### PR TITLE
Bootstrap C17 CMake project scaffold

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,192 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,30 @@ jobs:
 
       - name: Test
         run: ctest --preset release
+
+  sanitizers:
+    name: Sanitizers
+    runs-on: ubuntu-latest
+
+    env:
+      CC: clang
+      ASAN_OPTIONS: detect_leaks=1
+      UBSAN_OPTIONS: print_stacktrace=1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang ninja-build
+
+      - name: Configure
+        run: cmake --preset sanitizers
+
+      - name: Build
+        run: cmake --build --preset sanitizers
+
+      - name: Test
+        run: ctest --preset sanitizers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure
+        run: cmake --preset release
+
+      - name: Build
+        run: cmake --build --preset release
+
+      - name: Test
+        run: ctest --preset release

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,21 @@
+name: Clang Format
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang-format
+
+      - name: Verify formatting
+        run: ./scripts/check_clang_format.sh

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,7 +1,6 @@
 name: Clang Format
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,21 @@ dkms.conf
 build/
 build-*/
 
+# CMake generated files
+CMakeCache.txt
+CMakeFiles/
+CTestTestfile.cmake
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+Makefile
+build.ninja
+.ninja_deps
+.ninja_log
+Testing/
+
+# Local CMake presets
+CMakeUserPresets.json
+
 # Platform cruft
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,12 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
-# debug information files
+# Debug information files
 *.dwo
+
+# Build directories
+build/
+build-*/
+
+# Platform cruft
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(
+    SDL3D
+    VERSION 0.1.0
+    DESCRIPTION "High-level 3D graphics API powered by SDL3 GPU"
+    LANGUAGES C
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+option(SDL3D_BUILD_TESTS "Build SDL3D tests" ON)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(SDL3DCompilerWarnings)
+
+add_library(sdl3d)
+add_library(SDL3D::sdl3d ALIAS sdl3d)
+
+target_sources(
+    sdl3d
+    PRIVATE
+        src/sdl3d.c
+)
+
+target_compile_features(sdl3d PUBLIC c_std_17)
+
+set_target_properties(
+    sdl3d
+    PROPERTIES
+        C_STANDARD 17
+        C_STANDARD_REQUIRED YES
+        C_EXTENSIONS NO
+        POSITION_INDEPENDENT_CODE ON
+        EXPORT_NAME sdl3d
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+target_include_directories(
+    sdl3d
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+sdl3d_enable_warnings(sdl3d)
+
+if(MSVC)
+    target_compile_options(sdl3d PRIVATE /permissive-)
+endif()
+
+if(SDL3D_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+configure_package_config_file(
+    cmake/SDL3DConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/SDL3DConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL3D"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/SDL3DConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    TARGETS sdl3d
+    EXPORT SDL3DTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    EXPORT SDL3DTargets
+    FILE SDL3DTargets.cmake
+    NAMESPACE SDL3D::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL3D"
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/SDL3DConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/SDL3DConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL3D"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,13 @@ project(
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CTest)
 
-option(SDL3D_BUILD_TESTS "Build SDL3D tests" ON)
+if(PROJECT_IS_TOP_LEVEL)
+    option(SDL3D_BUILD_TESTS "Build SDL3D tests" ${BUILD_TESTING})
+else()
+    option(SDL3D_BUILD_TESTS "Build SDL3D tests" OFF)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SDL3DCompilerWarnings)
@@ -52,7 +57,6 @@ if(MSVC)
 endif()
 
 if(SDL3D_BUILD_TESTS)
-    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,11 @@ if(PROJECT_IS_TOP_LEVEL)
 else()
     option(SDL3D_BUILD_TESTS "Build SDL3D tests" OFF)
 endif()
+option(SDL3D_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SDL3DCompilerWarnings)
+include(SDL3DSanitizers)
 
 add_library(sdl3d)
 add_library(SDL3D::sdl3d ALIAS sdl3d)
@@ -51,6 +53,7 @@ target_include_directories(
 )
 
 sdl3d_enable_warnings(sdl3d)
+sdl3d_enable_sanitizers(sdl3d)
 
 if(MSVC)
     target_compile_options(sdl3d PRIVATE /permissive-)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,55 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SDL3D_BUILD_TESTS": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build/release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "release",
+            "configurePreset": "release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,6 +24,16 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
+        },
+        {
+            "name": "sanitizers",
+            "displayName": "Sanitizers",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build/sanitizers",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "SDL3D_ENABLE_SANITIZERS": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -34,6 +44,10 @@
         {
             "name": "release",
             "configurePreset": "release"
+        },
+        {
+            "name": "sanitizers",
+            "configurePreset": "sanitizers"
         }
     ],
     "testPresets": [
@@ -47,6 +61,13 @@
         {
             "name": "release",
             "configurePreset": "release",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "sanitizers",
+            "configurePreset": "sanitizers",
             "output": {
                 "outputOnFailure": true
             }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# SDL_3D
-An easy-to-use 3D API powered by SDL
+# SDL3D
+
+SDL3D is an idiomatic C17 project scaffold for a high-level 3D graphics API powered by SDL3's GPU API.
+
+## Layout
+
+- `include/` public headers
+- `src/` library sources
+- `tests/` executable tests registered with CTest
+- `cmake/` reusable CMake modules and package configuration templates
+- `scripts/` repository maintenance scripts
+
+## Build
+
+```sh
+cmake --preset default
+cmake --build --preset default
+ctest --preset default
+```
+
+For an optimized build:
+
+```sh
+cmake --preset release
+cmake --build --preset release
+ctest --preset release
+```
+
+## Install
+
+```sh
+cmake --install build/release
+```
+
+## Formatting
+
+```sh
+./scripts/check_clang_format.sh
+```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ cmake --build --preset release
 ctest --preset release
 ```
 
+For a sanitizer-enabled build with AddressSanitizer and UndefinedBehaviorSanitizer:
+
+```sh
+CC=clang cmake --preset sanitizers
+cmake --build --preset sanitizers
+ctest --preset sanitizers
+```
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ ctest --preset release
 cmake --install build/release
 ```
 
+## Consume With FetchContent
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    SDL3D
+    GIT_REPOSITORY git@github.com:bluesentinelsec/SDL_3D.git
+    GIT_TAG main
+)
+
+FetchContent_MakeAvailable(SDL3D)
+
+target_link_libraries(your_target PRIVATE SDL3D::sdl3d)
+```
+
+When SDL3D is consumed as a subproject, its tests default to `OFF` so it behaves cleanly inside a parent build. To force them on, set `SDL3D_BUILD_TESTS=ON` before `FetchContent_MakeAvailable`.
+
 ## Formatting
 
 ```sh

--- a/cmake/SDL3DCompilerWarnings.cmake
+++ b/cmake/SDL3DCompilerWarnings.cmake
@@ -1,0 +1,21 @@
+function(sdl3d_enable_warnings target_name)
+    if(MSVC)
+        target_compile_options(
+            ${target_name}
+            PRIVATE
+                /W4
+                /WX
+        )
+    else()
+        target_compile_options(
+            ${target_name}
+            PRIVATE
+                -Wall
+                -Wextra
+                -Wpedantic
+                -Wconversion
+                -Wshadow
+                -Werror
+        )
+    endif()
+endfunction()

--- a/cmake/SDL3DConfig.cmake.in
+++ b/cmake/SDL3DConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/SDL3DTargets.cmake")
+
+check_required_components(SDL3D)

--- a/cmake/SDL3DSanitizers.cmake
+++ b/cmake/SDL3DSanitizers.cmake
@@ -1,0 +1,26 @@
+function(sdl3d_enable_sanitizers target_name)
+    if(NOT SDL3D_ENABLE_SANITIZERS)
+        return()
+    endif()
+
+    if(MSVC)
+        message(FATAL_ERROR "SDL3D_ENABLE_SANITIZERS is not supported with MSVC.")
+    endif()
+
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+        message(FATAL_ERROR "SDL3D_ENABLE_SANITIZERS requires Clang or GCC.")
+    endif()
+
+    target_compile_options(
+        ${target_name}
+        PRIVATE
+            -fsanitize=address,undefined
+            -fno-omit-frame-pointer
+    )
+
+    target_link_options(
+        ${target_name}
+        PRIVATE
+            -fsanitize=address,undefined
+    )
+endfunction()

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -1,0 +1,15 @@
+#ifndef SDL3D_SDL3D_H
+#define SDL3D_SDL3D_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    const char *sdl3d_greet(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/scripts/check_clang_format.sh
+++ b/scripts/check_clang_format.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+files=()
+
+while IFS= read -r file; do
+    files+=("${file}")
+done < <(git ls-files --cached --others --exclude-standard -- '*.c' '*.h')
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "No C source files tracked by git."
+    exit 0
+fi
+
+clang-format --dry-run --Werror "${files[@]}"

--- a/src/sdl3d.c
+++ b/src/sdl3d.c
@@ -1,0 +1,6 @@
+#include "sdl3d/sdl3d.h"
+
+const char *sdl3d_greet(void)
+{
+    return "Hello from SDL3D.";
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,6 @@ add_executable(test_greet test_greet.c)
 
 target_link_libraries(test_greet PRIVATE SDL3D::sdl3d)
 
+sdl3d_enable_sanitizers(test_greet)
+
 add_test(NAME sdl3d.test_greet COMMAND test_greet)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(test_greet test_greet.c)
+
+target_link_libraries(test_greet PRIVATE SDL3D::sdl3d)
+
+add_test(NAME sdl3d.test_greet COMMAND test_greet)

--- a/tests/test_greet.c
+++ b/tests/test_greet.c
@@ -1,0 +1,18 @@
+#include "sdl3d/sdl3d.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+    const char *greeting = sdl3d_greet();
+
+    if (strcmp(greeting, "Hello from SDL3D.") != 0)
+    {
+        fprintf(stderr, "unexpected greeting: %s\n", greeting);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- add a scalable C17/CMake library scaffold with install/export support
- add a trivial public API and CTest-based smoke test
- add GitHub Actions for cross-platform builds and clang-format verification

## Testing
- cmake --preset default
- cmake --build --preset default
- ctest --preset default
- ./scripts/check_clang_format.sh