### PR TITLE
Add software render context foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(SDL3D::sdl3d ALIAS sdl3d)
 target_sources(
     sdl3d
     PRIVATE
+        src/render_context.c
         src/sdl3d.c
 )
 

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -1,0 +1,49 @@
+#ifndef SDL3D_RENDER_CONTEXT_H
+#define SDL3D_RENDER_CONTEXT_H
+
+#include <stdbool.h>
+
+#include <SDL3/SDL_render.h>
+
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum sdl3d_backend
+    {
+        SDL3D_BACKEND_AUTO = 0,
+        SDL3D_BACKEND_SOFTWARE = 1,
+        SDL3D_BACKEND_SDLGPU = 2
+    } sdl3d_backend;
+
+    typedef struct sdl3d_render_context_config
+    {
+        sdl3d_backend backend;
+        bool allow_backend_fallback;
+        int logical_width;
+        int logical_height;
+        SDL_RendererLogicalPresentation logical_presentation;
+    } sdl3d_render_context_config;
+
+    typedef struct sdl3d_render_context sdl3d_render_context;
+
+    void sdl3d_init_render_context_config(sdl3d_render_context_config *config);
+    const char *sdl3d_get_backend_name(sdl3d_backend backend);
+    bool sdl3d_get_backend_override_from_environment(sdl3d_backend *backend);
+    bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer,
+                                     const sdl3d_render_context_config *config, sdl3d_render_context **out_context);
+    void sdl3d_destroy_render_context(sdl3d_render_context *context);
+    sdl3d_backend sdl3d_get_render_context_backend(const sdl3d_render_context *context);
+    int sdl3d_get_render_context_width(const sdl3d_render_context *context);
+    int sdl3d_get_render_context_height(const sdl3d_render_context *context);
+    bool sdl3d_clear_render_context(sdl3d_render_context *context, sdl3d_color color);
+    bool sdl3d_present_render_context(sdl3d_render_context *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -6,6 +6,9 @@
 
 #include <SDL3/SDL_log.h>
 
+#include "sdl3d/render_context.h"
+#include "sdl3d/types.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/include/sdl3d/types.h
+++ b/include/sdl3d/types.h
@@ -1,0 +1,32 @@
+#ifndef SDL3D_TYPES_H
+#define SDL3D_TYPES_H
+
+#include <SDL3/SDL_stdinc.h>
+
+typedef struct sdl3d_vec2
+{
+    float x;
+    float y;
+} sdl3d_vec2;
+
+typedef struct sdl3d_vec3
+{
+    float x;
+    float y;
+    float z;
+} sdl3d_vec3;
+
+typedef struct sdl3d_color
+{
+    Uint8 r;
+    Uint8 g;
+    Uint8 b;
+    Uint8 a;
+} sdl3d_color;
+
+typedef struct sdl3d_mat4
+{
+    float m[16];
+} sdl3d_mat4;
+
+#endif

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -1,0 +1,320 @@
+#include "sdl3d/render_context.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+struct sdl3d_render_context
+{
+    SDL_Window *window;
+    SDL_Renderer *renderer;
+    SDL_Texture *color_texture;
+    Uint8 *color_buffer;
+    sdl3d_backend backend;
+    int width;
+    int height;
+};
+
+static const char *const SDL3D_BACKEND_ENV = "SDL3D_BACKEND";
+
+static bool sdl3d_parse_backend_name(const char *name, sdl3d_backend *backend)
+{
+    if (name == NULL || backend == NULL)
+    {
+        return SDL_InvalidParamError(name == NULL ? "name" : "backend");
+    }
+
+    if (SDL_strcasecmp(name, "auto") == 0)
+    {
+        *backend = SDL3D_BACKEND_AUTO;
+        return true;
+    }
+
+    if (SDL_strcasecmp(name, "software") == 0)
+    {
+        *backend = SDL3D_BACKEND_SOFTWARE;
+        return true;
+    }
+
+    if (SDL_strcasecmp(name, "sdlgpu") == 0 || SDL_strcasecmp(name, "gpu") == 0)
+    {
+        *backend = SDL3D_BACKEND_SDLGPU;
+        return true;
+    }
+
+    return SDL_SetError("Unsupported SDL3D backend override: %s", name);
+}
+
+static bool sdl3d_resolve_backend(sdl3d_backend requested_backend, bool allow_backend_fallback,
+                                  sdl3d_backend *resolved_backend)
+{
+    if (resolved_backend == NULL)
+    {
+        return SDL_InvalidParamError("resolved_backend");
+    }
+
+    switch (requested_backend)
+    {
+    case SDL3D_BACKEND_AUTO:
+    case SDL3D_BACKEND_SOFTWARE:
+        *resolved_backend = SDL3D_BACKEND_SOFTWARE;
+        return true;
+    case SDL3D_BACKEND_SDLGPU:
+        if (allow_backend_fallback)
+        {
+            *resolved_backend = SDL3D_BACKEND_SOFTWARE;
+            return true;
+        }
+
+        return SDL_SetError("The SDL GPU backend is not implemented yet.");
+    default:
+        return SDL_SetError("Unknown SDL3D backend value: %d", (int)requested_backend);
+    }
+}
+
+void sdl3d_init_render_context_config(sdl3d_render_context_config *config)
+{
+    if (config == NULL)
+    {
+        SDL_InvalidParamError("config");
+        return;
+    }
+
+    config->backend = SDL3D_BACKEND_AUTO;
+    config->allow_backend_fallback = true;
+    config->logical_width = 0;
+    config->logical_height = 0;
+    config->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
+}
+
+const char *sdl3d_get_backend_name(sdl3d_backend backend)
+{
+    switch (backend)
+    {
+    case SDL3D_BACKEND_AUTO:
+        return "auto";
+    case SDL3D_BACKEND_SOFTWARE:
+        return "software";
+    case SDL3D_BACKEND_SDLGPU:
+        return "sdlgpu";
+    default:
+        return "unknown";
+    }
+}
+
+bool sdl3d_get_backend_override_from_environment(sdl3d_backend *backend)
+{
+    const char *value = SDL_getenv(SDL3D_BACKEND_ENV);
+
+    if (value == NULL || *value == '\0')
+    {
+        return false;
+    }
+
+    return sdl3d_parse_backend_name(value, backend);
+}
+
+bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, const sdl3d_render_context_config *config,
+                                 sdl3d_render_context **out_context)
+{
+    sdl3d_render_context_config local_config;
+    sdl3d_backend requested_backend;
+    sdl3d_backend env_backend;
+    sdl3d_backend resolved_backend;
+    sdl3d_render_context *context;
+    const char *env_backend_name;
+    int render_width;
+    int render_height;
+    size_t buffer_size;
+
+    if (window == NULL)
+    {
+        return SDL_InvalidParamError("window");
+    }
+
+    if (renderer == NULL)
+    {
+        return SDL_InvalidParamError("renderer");
+    }
+
+    if (out_context == NULL)
+    {
+        return SDL_InvalidParamError("out_context");
+    }
+
+    local_config = (config != NULL) ? *config : (sdl3d_render_context_config){0};
+    if (config == NULL)
+    {
+        sdl3d_init_render_context_config(&local_config);
+    }
+
+    if ((local_config.logical_width < 0) || (local_config.logical_height < 0))
+    {
+        return SDL_SetError("Logical dimensions must be zero or positive.");
+    }
+
+    if ((local_config.logical_width == 0) != (local_config.logical_height == 0))
+    {
+        return SDL_SetError("Logical width and height must both be zero or both be non-zero.");
+    }
+
+    requested_backend = local_config.backend;
+    env_backend_name = SDL_getenv(SDL3D_BACKEND_ENV);
+    if (env_backend_name != NULL && *env_backend_name != '\0')
+    {
+        if (!sdl3d_parse_backend_name(env_backend_name, &env_backend))
+        {
+            return false;
+        }
+
+        requested_backend = env_backend;
+    }
+
+    if (!sdl3d_resolve_backend(requested_backend, local_config.allow_backend_fallback, &resolved_backend))
+    {
+        return false;
+    }
+
+    if (local_config.logical_width > 0)
+    {
+        if (!SDL_SetRenderLogicalPresentation(renderer, local_config.logical_width, local_config.logical_height,
+                                              local_config.logical_presentation))
+        {
+            return false;
+        }
+
+        render_width = local_config.logical_width;
+        render_height = local_config.logical_height;
+    }
+    else
+    {
+        if (!SDL_GetCurrentRenderOutputSize(renderer, &render_width, &render_height))
+        {
+            return false;
+        }
+
+        if (render_width <= 0 || render_height <= 0)
+        {
+            return SDL_SetError("The SDL renderer does not currently expose a valid output size.");
+        }
+    }
+
+    context = SDL_calloc(1, sizeof(*context));
+    if (context == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    context->color_texture =
+        SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, render_width, render_height);
+    if (context->color_texture == NULL)
+    {
+        SDL_free(context);
+        return false;
+    }
+
+    buffer_size = (size_t)render_width * (size_t)render_height * 4U;
+    context->color_buffer = SDL_calloc(1, buffer_size);
+    if (context->color_buffer == NULL)
+    {
+        SDL_DestroyTexture(context->color_texture);
+        SDL_free(context);
+        return SDL_OutOfMemory();
+    }
+
+    context->window = window;
+    context->renderer = renderer;
+    context->backend = resolved_backend;
+    context->width = render_width;
+    context->height = render_height;
+
+    *out_context = context;
+    return true;
+}
+
+void sdl3d_destroy_render_context(sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return;
+    }
+
+    SDL_DestroyTexture(context->color_texture);
+    SDL_free(context->color_buffer);
+    SDL_free(context);
+}
+
+sdl3d_backend sdl3d_get_render_context_backend(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return SDL3D_BACKEND_AUTO;
+    }
+
+    return context->backend;
+}
+
+int sdl3d_get_render_context_width(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return 0;
+    }
+
+    return context->width;
+}
+
+int sdl3d_get_render_context_height(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return 0;
+    }
+
+    return context->height;
+}
+
+bool sdl3d_clear_render_context(sdl3d_render_context *context, sdl3d_color color)
+{
+    size_t pixel_count;
+    size_t index;
+
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    pixel_count = (size_t)context->width * (size_t)context->height;
+    for (index = 0; index < pixel_count; ++index)
+    {
+        Uint8 *pixel = &context->color_buffer[index * 4U];
+        pixel[0] = color.r;
+        pixel[1] = color.g;
+        pixel[2] = color.b;
+        pixel[3] = color.a;
+    }
+
+    return true;
+}
+
+bool sdl3d_present_render_context(sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    if (!SDL_UpdateTexture(context->color_texture, NULL, context->color_buffer, context->width * 4))
+    {
+        return false;
+    }
+
+    if (!SDL_RenderTexture(context->renderer, context->color_texture, NULL, NULL))
+    {
+        return false;
+    }
+
+    return SDL_RenderPresent(context->renderer);
+}

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -118,7 +118,6 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
 {
     sdl3d_render_context_config local_config;
     sdl3d_backend requested_backend;
-    sdl3d_backend env_backend;
     sdl3d_backend resolved_backend;
     sdl3d_render_context *context;
     const char *env_backend_name;
@@ -161,12 +160,10 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     env_backend_name = SDL_getenv(SDL3D_BACKEND_ENV);
     if (env_backend_name != NULL && *env_backend_name != '\0')
     {
-        if (!sdl3d_parse_backend_name(env_backend_name, &env_backend))
+        if (!sdl3d_parse_backend_name(env_backend_name, &requested_backend))
         {
             return false;
         }
-
-        requested_backend = env_backend;
     }
 
     if (!sdl3d_resolve_backend(requested_backend, local_config.allow_backend_fallback, &resolved_backend))

--- a/src/sdl3d.c
+++ b/src/sdl3d.c
@@ -1,8 +1,7 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_version.h>
-
-#include <string.h>
 
 #include "sdl3d/sdl3d.h"
 
@@ -26,7 +25,7 @@ bool sdl3d_copy_greeting(char *buffer, size_t buffer_size)
         return SDL_SetError("Buffer is too small for the SDL3D greeting.");
     }
 
-    memcpy(buffer, SDL3D_GREETING, sizeof(SDL3D_GREETING));
+    SDL_memcpy(buffer, SDL3D_GREETING, sizeof(SDL3D_GREETING));
     return true;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,4 +50,5 @@ function(sdl3d_add_test target_name source_file test_label)
 endfunction()
 
 sdl3d_add_test(sdl3d_api_test test_api.cpp unit)
+sdl3d_add_test(sdl3d_render_context_test test_render_context.cpp render)
 sdl3d_add_test(sdl3d_render_loop_test test_render_loop.cpp render)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,5 +50,6 @@ function(sdl3d_add_test target_name source_file test_label)
 endfunction()
 
 sdl3d_add_test(sdl3d_api_test test_api.cpp unit)
+sdl3d_add_test(sdl3d_render_context_unit_test test_render_context_unit.cpp unit)
 sdl3d_add_test(sdl3d_render_context_test test_render_context.cpp render)
 sdl3d_add_test(sdl3d_render_loop_test test_render_loop.cpp render)

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -13,21 +13,6 @@ extern "C"
 
 namespace
 {
-bool TryInitVideo(std::string *error_message, bool *is_displayless)
-{
-    SDL_ClearError();
-    if (!SDL_Init(SDL_INIT_VIDEO))
-    {
-        *error_message = SDL_GetError();
-        *is_displayless = error_message->find("did not add any displays") != std::string::npos;
-        return false;
-    }
-
-    error_message->clear();
-    *is_displayless = false;
-    return true;
-}
-
 bool SetBackendOverride(const char *value)
 {
     if (value == nullptr)
@@ -41,6 +26,21 @@ bool SetBackendOverride(const char *value)
 struct SDLQuitGuard
 {
     ~SDLQuitGuard()
+    {
+        SDL_Quit();
+    }
+};
+
+class SDLVideoFixture : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_ClearError();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
     {
         SDL_Quit();
     }
@@ -120,36 +120,12 @@ class SDL3DBackendOverrideGuard
 };
 } // namespace
 
-TEST(SDL3DRenderContext, DefaultConfigUsesSoftwareBackend)
+TEST_F(SDLVideoFixture, DefaultConfigUsesSoftwareBackend)
 {
-    std::string error_message;
-    bool is_displayless = false;
-
-    if (!TryInitVideo(&error_message, &is_displayless))
-    {
-        if (is_displayless)
-        {
-            GTEST_SKIP() << error_message;
-        }
-
-        FAIL() << error_message;
-    }
-
-    SDLQuitGuard quit_guard;
     SDLWindowRendererPair pair;
+    ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
+
     sdl3d_render_context *context = nullptr;
-
-    if (!pair.is_valid())
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
-
     ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), nullptr, &context)) << SDL_GetError();
     ASSERT_NE(context, nullptr);
     EXPECT_EQ(SDL3D_BACKEND_SOFTWARE, sdl3d_get_render_context_backend(context));
@@ -159,49 +135,26 @@ TEST(SDL3DRenderContext, DefaultConfigUsesSoftwareBackend)
     sdl3d_destroy_render_context(context);
 }
 
-TEST(SDL3DRenderContext, LogicalPresentationConfigIsApplied)
+TEST_F(SDLVideoFixture, LogicalPresentationConfigIsApplied)
 {
-    std::string error_message;
-    bool is_displayless = false;
-
-    if (!TryInitVideo(&error_message, &is_displayless))
-    {
-        if (is_displayless)
-        {
-            GTEST_SKIP() << error_message;
-        }
-
-        FAIL() << error_message;
-    }
-
-    SDLQuitGuard quit_guard;
     SDLWindowRendererPair pair;
-    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
+
     sdl3d_render_context_config config;
-    int logical_width = 0;
-    int logical_height = 0;
-    SDL_RendererLogicalPresentation mode = SDL_LOGICAL_PRESENTATION_DISABLED;
-
-    if (!pair.is_valid())
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
-
     sdl3d_init_render_context_config(&config);
     config.logical_width = 320;
     config.logical_height = 180;
     config.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
 
+    sdl3d_render_context *context = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context)) << SDL_GetError();
     ASSERT_NE(context, nullptr);
     EXPECT_EQ(320, sdl3d_get_render_context_width(context));
     EXPECT_EQ(180, sdl3d_get_render_context_height(context));
+
+    int logical_width = 0;
+    int logical_height = 0;
+    SDL_RendererLogicalPresentation mode = SDL_LOGICAL_PRESENTATION_DISABLED;
     ASSERT_TRUE(SDL_GetRenderLogicalPresentation(pair.renderer(), &logical_width, &logical_height, &mode))
         << SDL_GetError();
     EXPECT_EQ(320, logical_width);
@@ -213,83 +166,35 @@ TEST(SDL3DRenderContext, LogicalPresentationConfigIsApplied)
     sdl3d_destroy_render_context(context);
 }
 
-TEST(SDL3DRenderContext, SdlGpuWithoutFallbackFails)
+TEST_F(SDLVideoFixture, SdlGpuWithoutFallbackFails)
 {
-    std::string error_message;
-    bool is_displayless = false;
-
-    if (!TryInitVideo(&error_message, &is_displayless))
-    {
-        if (is_displayless)
-        {
-            GTEST_SKIP() << error_message;
-        }
-
-        FAIL() << error_message;
-    }
-
-    SDLQuitGuard quit_guard;
     SDLWindowRendererPair pair;
-    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
+
     sdl3d_render_context_config config;
-
-    if (!pair.is_valid())
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
-
     sdl3d_init_render_context_config(&config);
     config.backend = SDL3D_BACKEND_SDLGPU;
     config.allow_backend_fallback = false;
 
+    sdl3d_render_context *context = nullptr;
     SDL_ClearError();
     EXPECT_FALSE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context));
     EXPECT_EQ(nullptr, context);
     EXPECT_NE(std::string_view(SDL_GetError()).find("not implemented"), std::string_view::npos);
 }
 
-TEST(SDL3DRenderContext, EnvironmentOverrideCanForceSoftwareBackend)
+TEST_F(SDLVideoFixture, EnvironmentOverrideCanForceSoftwareBackend)
 {
-    std::string error_message;
-    bool is_displayless = false;
-
-    if (!TryInitVideo(&error_message, &is_displayless))
-    {
-        if (is_displayless)
-        {
-            GTEST_SKIP() << error_message;
-        }
-
-        FAIL() << error_message;
-    }
-
-    SDLQuitGuard quit_guard;
     SDLWindowRendererPair pair;
+    ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
+
     SDL3DBackendOverrideGuard backend_override("software");
-    sdl3d_render_context *context = nullptr;
     sdl3d_render_context_config config;
-
-    if (!pair.is_valid())
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
-
     sdl3d_init_render_context_config(&config);
     config.backend = SDL3D_BACKEND_SDLGPU;
     config.allow_backend_fallback = false;
 
+    sdl3d_render_context *context = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context)) << SDL_GetError();
     ASSERT_NE(context, nullptr);
     EXPECT_EQ(SDL3D_BACKEND_SOFTWARE, sdl3d_get_render_context_backend(context));
@@ -297,36 +202,13 @@ TEST(SDL3DRenderContext, EnvironmentOverrideCanForceSoftwareBackend)
     sdl3d_destroy_render_context(context);
 }
 
-TEST(SDL3DRenderContext, InvalidEnvironmentOverrideFails)
+TEST_F(SDLVideoFixture, InvalidEnvironmentOverrideFails)
 {
-    std::string error_message;
-    bool is_displayless = false;
-
-    if (!TryInitVideo(&error_message, &is_displayless))
-    {
-        if (is_displayless)
-        {
-            GTEST_SKIP() << error_message;
-        }
-
-        FAIL() << error_message;
-    }
-
-    SDLQuitGuard quit_guard;
     SDLWindowRendererPair pair;
+    ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
+
     SDL3DBackendOverrideGuard backend_override("bogus");
     sdl3d_render_context *context = nullptr;
-
-    if (!pair.is_valid())
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
 
     SDL_ClearError();
     EXPECT_FALSE(sdl3d_create_render_context(pair.window(), pair.renderer(), nullptr, &context));

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -1,0 +1,335 @@
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace
+{
+bool TryInitVideo(std::string *error_message, bool *is_displayless)
+{
+    SDL_ClearError();
+    if (!SDL_Init(SDL_INIT_VIDEO))
+    {
+        *error_message = SDL_GetError();
+        *is_displayless = error_message->find("did not add any displays") != std::string::npos;
+        return false;
+    }
+
+    error_message->clear();
+    *is_displayless = false;
+    return true;
+}
+
+bool SetBackendOverride(const char *value)
+{
+    if (value == nullptr)
+    {
+        return SDL_unsetenv_unsafe("SDL3D_BACKEND") == 0;
+    }
+
+    return SDL_setenv_unsafe("SDL3D_BACKEND", value, 1) == 0;
+}
+
+struct SDLQuitGuard
+{
+    ~SDLQuitGuard()
+    {
+        SDL_Quit();
+    }
+};
+
+class SDLWindowRendererPair
+{
+  public:
+    SDLWindowRendererPair() : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *raw_window = nullptr;
+        SDL_Renderer *raw_renderer = nullptr;
+
+        if (!SDL_CreateWindowAndRenderer("SDL3D Context Test", 128, 72, 0, &raw_window, &raw_renderer))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+
+        window_.reset(raw_window);
+        renderer_.reset(raw_renderer);
+    }
+
+    bool is_valid() const
+    {
+        return window_ != nullptr && renderer_ != nullptr;
+    }
+
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+class SDL3DBackendOverrideGuard
+{
+  public:
+    explicit SDL3DBackendOverrideGuard(const char *value)
+    {
+        const char *existing = SDL_getenv("SDL3D_BACKEND");
+        if (existing != nullptr)
+        {
+            had_existing_ = true;
+            previous_value_ = existing;
+        }
+
+        if (!SetBackendOverride(value))
+        {
+            ADD_FAILURE() << "Failed to set SDL3D_BACKEND test override";
+        }
+    }
+
+    ~SDL3DBackendOverrideGuard()
+    {
+        if (had_existing_)
+        {
+            SetBackendOverride(previous_value_.c_str());
+        }
+        else
+        {
+            SetBackendOverride(nullptr);
+        }
+    }
+
+  private:
+    bool had_existing_ = false;
+    std::string previous_value_;
+};
+} // namespace
+
+TEST(SDL3DRenderContext, DefaultConfigUsesSoftwareBackend)
+{
+    std::string error_message;
+    bool is_displayless = false;
+
+    if (!TryInitVideo(&error_message, &is_displayless))
+    {
+        if (is_displayless)
+        {
+            GTEST_SKIP() << error_message;
+        }
+
+        FAIL() << error_message;
+    }
+
+    SDLQuitGuard quit_guard;
+    SDLWindowRendererPair pair;
+    sdl3d_render_context *context = nullptr;
+
+    if (!pair.is_valid())
+    {
+        const std::string_view error = SDL_GetError();
+        if (error.find("did not add any displays") != std::string_view::npos)
+        {
+            GTEST_SKIP() << error;
+        }
+
+        FAIL() << error;
+    }
+
+    ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), nullptr, &context)) << SDL_GetError();
+    ASSERT_NE(context, nullptr);
+    EXPECT_EQ(SDL3D_BACKEND_SOFTWARE, sdl3d_get_render_context_backend(context));
+    EXPECT_GT(sdl3d_get_render_context_width(context), 0);
+    EXPECT_GT(sdl3d_get_render_context_height(context), 0);
+
+    sdl3d_destroy_render_context(context);
+}
+
+TEST(SDL3DRenderContext, LogicalPresentationConfigIsApplied)
+{
+    std::string error_message;
+    bool is_displayless = false;
+
+    if (!TryInitVideo(&error_message, &is_displayless))
+    {
+        if (is_displayless)
+        {
+            GTEST_SKIP() << error_message;
+        }
+
+        FAIL() << error_message;
+    }
+
+    SDLQuitGuard quit_guard;
+    SDLWindowRendererPair pair;
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+    int logical_width = 0;
+    int logical_height = 0;
+    SDL_RendererLogicalPresentation mode = SDL_LOGICAL_PRESENTATION_DISABLED;
+
+    if (!pair.is_valid())
+    {
+        const std::string_view error = SDL_GetError();
+        if (error.find("did not add any displays") != std::string_view::npos)
+        {
+            GTEST_SKIP() << error;
+        }
+
+        FAIL() << error;
+    }
+
+    sdl3d_init_render_context_config(&config);
+    config.logical_width = 320;
+    config.logical_height = 180;
+    config.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+
+    ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context)) << SDL_GetError();
+    ASSERT_NE(context, nullptr);
+    EXPECT_EQ(320, sdl3d_get_render_context_width(context));
+    EXPECT_EQ(180, sdl3d_get_render_context_height(context));
+    ASSERT_TRUE(SDL_GetRenderLogicalPresentation(pair.renderer(), &logical_width, &logical_height, &mode))
+        << SDL_GetError();
+    EXPECT_EQ(320, logical_width);
+    EXPECT_EQ(180, logical_height);
+    EXPECT_EQ(SDL_LOGICAL_PRESENTATION_LETTERBOX, mode);
+    ASSERT_TRUE(sdl3d_clear_render_context(context, {16, 32, 64, 255})) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_present_render_context(context)) << SDL_GetError();
+
+    sdl3d_destroy_render_context(context);
+}
+
+TEST(SDL3DRenderContext, SdlGpuWithoutFallbackFails)
+{
+    std::string error_message;
+    bool is_displayless = false;
+
+    if (!TryInitVideo(&error_message, &is_displayless))
+    {
+        if (is_displayless)
+        {
+            GTEST_SKIP() << error_message;
+        }
+
+        FAIL() << error_message;
+    }
+
+    SDLQuitGuard quit_guard;
+    SDLWindowRendererPair pair;
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+
+    if (!pair.is_valid())
+    {
+        const std::string_view error = SDL_GetError();
+        if (error.find("did not add any displays") != std::string_view::npos)
+        {
+            GTEST_SKIP() << error;
+        }
+
+        FAIL() << error;
+    }
+
+    sdl3d_init_render_context_config(&config);
+    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.allow_backend_fallback = false;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("not implemented"), std::string_view::npos);
+}
+
+TEST(SDL3DRenderContext, EnvironmentOverrideCanForceSoftwareBackend)
+{
+    std::string error_message;
+    bool is_displayless = false;
+
+    if (!TryInitVideo(&error_message, &is_displayless))
+    {
+        if (is_displayless)
+        {
+            GTEST_SKIP() << error_message;
+        }
+
+        FAIL() << error_message;
+    }
+
+    SDLQuitGuard quit_guard;
+    SDLWindowRendererPair pair;
+    SDL3DBackendOverrideGuard backend_override("software");
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+
+    if (!pair.is_valid())
+    {
+        const std::string_view error = SDL_GetError();
+        if (error.find("did not add any displays") != std::string_view::npos)
+        {
+            GTEST_SKIP() << error;
+        }
+
+        FAIL() << error;
+    }
+
+    sdl3d_init_render_context_config(&config);
+    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.allow_backend_fallback = false;
+
+    ASSERT_TRUE(sdl3d_create_render_context(pair.window(), pair.renderer(), &config, &context)) << SDL_GetError();
+    ASSERT_NE(context, nullptr);
+    EXPECT_EQ(SDL3D_BACKEND_SOFTWARE, sdl3d_get_render_context_backend(context));
+
+    sdl3d_destroy_render_context(context);
+}
+
+TEST(SDL3DRenderContext, InvalidEnvironmentOverrideFails)
+{
+    std::string error_message;
+    bool is_displayless = false;
+
+    if (!TryInitVideo(&error_message, &is_displayless))
+    {
+        if (is_displayless)
+        {
+            GTEST_SKIP() << error_message;
+        }
+
+        FAIL() << error_message;
+    }
+
+    SDLQuitGuard quit_guard;
+    SDLWindowRendererPair pair;
+    SDL3DBackendOverrideGuard backend_override("bogus");
+    sdl3d_render_context *context = nullptr;
+
+    if (!pair.is_valid())
+    {
+        const std::string_view error = SDL_GetError();
+        if (error.find("did not add any displays") != std::string_view::npos)
+        {
+            GTEST_SKIP() << error;
+        }
+
+        FAIL() << error;
+    }
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(pair.window(), pair.renderer(), nullptr, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Unsupported SDL3D backend override"), std::string_view::npos);
+}

--- a/tests/test_render_context_unit.cpp
+++ b/tests/test_render_context_unit.cpp
@@ -192,8 +192,8 @@ TEST(SDL3DCreateRenderContext, RejectsNullRenderer)
 TEST(SDL3DCreateRenderContext, RejectsNullOutputPointer)
 {
     SDL_ClearError();
-    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
-                                             reinterpret_cast<SDL_Renderer *>(0x1), nullptr, nullptr));
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), reinterpret_cast<SDL_Renderer *>(0x1),
+                                             nullptr, nullptr));
     EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'out_context' is invalid"), std::string_view::npos);
 }
 
@@ -206,8 +206,8 @@ TEST(SDL3DCreateRenderContext, RejectsNegativeLogicalDimensions)
     config.logical_height = 0;
 
     SDL_ClearError();
-    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
-                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), reinterpret_cast<SDL_Renderer *>(0x1),
+                                             &config, &context));
     EXPECT_EQ(nullptr, context);
     EXPECT_NE(std::string_view(SDL_GetError()).find("Logical dimensions must be zero or positive"),
               std::string_view::npos);
@@ -222,8 +222,8 @@ TEST(SDL3DCreateRenderContext, RejectsMismatchedLogicalDimensions)
     config.logical_height = 0;
 
     SDL_ClearError();
-    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
-                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), reinterpret_cast<SDL_Renderer *>(0x1),
+                                             &config, &context));
     EXPECT_EQ(nullptr, context);
     EXPECT_NE(std::string_view(SDL_GetError()).find("Logical width and height must both be zero or both be non-zero"),
               std::string_view::npos);
@@ -235,8 +235,8 @@ TEST(SDL3DCreateRenderContext, InvalidEnvOverrideFailsBeforeTouchingRenderer)
     sdl3d_render_context *context = nullptr;
 
     SDL_ClearError();
-    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
-                                             reinterpret_cast<SDL_Renderer *>(0x1), nullptr, &context));
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), reinterpret_cast<SDL_Renderer *>(0x1),
+                                             nullptr, &context));
     EXPECT_EQ(nullptr, context);
     EXPECT_NE(std::string_view(SDL_GetError()).find("Unsupported SDL3D backend override"), std::string_view::npos);
 }
@@ -251,8 +251,8 @@ TEST(SDL3DCreateRenderContext, SdlGpuWithoutFallbackFailsBeforeTouchingRenderer)
     config.allow_backend_fallback = false;
 
     SDL_ClearError();
-    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
-                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), reinterpret_cast<SDL_Renderer *>(0x1),
+                                             &config, &context));
     EXPECT_EQ(nullptr, context);
     EXPECT_NE(std::string_view(SDL_GetError()).find("not implemented"), std::string_view::npos);
 }

--- a/tests/test_render_context_unit.cpp
+++ b/tests/test_render_context_unit.cpp
@@ -1,0 +1,286 @@
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <string>
+#include <string_view>
+
+namespace
+{
+bool SetBackendOverride(const char *value)
+{
+    if (value == nullptr)
+    {
+        return SDL_unsetenv_unsafe("SDL3D_BACKEND") == 0;
+    }
+
+    return SDL_setenv_unsafe("SDL3D_BACKEND", value, 1) == 0;
+}
+
+class SDL3DBackendEnvGuard
+{
+  public:
+    explicit SDL3DBackendEnvGuard(const char *value)
+    {
+        const char *existing = SDL_getenv("SDL3D_BACKEND");
+        if (existing != nullptr)
+        {
+            had_existing_ = true;
+            previous_value_ = existing;
+        }
+
+        if (!SetBackendOverride(value))
+        {
+            ADD_FAILURE() << "Failed to set SDL3D_BACKEND test override";
+        }
+    }
+
+    ~SDL3DBackendEnvGuard()
+    {
+        if (had_existing_)
+        {
+            SetBackendOverride(previous_value_.c_str());
+        }
+        else
+        {
+            SetBackendOverride(nullptr);
+        }
+    }
+
+  private:
+    bool had_existing_ = false;
+    std::string previous_value_;
+};
+} // namespace
+
+TEST(SDL3DRenderContextConfig, InitRenderContextConfigSetsDocumentedDefaults)
+{
+    sdl3d_render_context_config config{};
+    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.allow_backend_fallback = false;
+    config.logical_width = 42;
+    config.logical_height = 42;
+    config.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+
+    sdl3d_init_render_context_config(&config);
+
+    EXPECT_EQ(SDL3D_BACKEND_AUTO, config.backend);
+    EXPECT_TRUE(config.allow_backend_fallback);
+    EXPECT_EQ(0, config.logical_width);
+    EXPECT_EQ(0, config.logical_height);
+    EXPECT_EQ(SDL_LOGICAL_PRESENTATION_STRETCH, config.logical_presentation);
+}
+
+TEST(SDL3DRenderContextConfig, InitRenderContextConfigRejectsNull)
+{
+    SDL_ClearError();
+    sdl3d_init_render_context_config(nullptr);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'config' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DBackendName, MapsKnownBackendsToStableStrings)
+{
+    EXPECT_EQ(std::string_view("auto"), sdl3d_get_backend_name(SDL3D_BACKEND_AUTO));
+    EXPECT_EQ(std::string_view("software"), sdl3d_get_backend_name(SDL3D_BACKEND_SOFTWARE));
+    EXPECT_EQ(std::string_view("sdlgpu"), sdl3d_get_backend_name(SDL3D_BACKEND_SDLGPU));
+}
+
+TEST(SDL3DBackendName, UnknownBackendsMapToUnknown)
+{
+    const sdl3d_backend bogus = static_cast<sdl3d_backend>(0x4242);
+    EXPECT_EQ(std::string_view("unknown"), sdl3d_get_backend_name(bogus));
+}
+
+TEST(SDL3DBackendEnvOverride, UnsetEnvReturnsFalseWithoutTouchingOutput)
+{
+    SDL3DBackendEnvGuard guard(nullptr);
+    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+
+    EXPECT_FALSE(sdl3d_get_backend_override_from_environment(&backend));
+    EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+}
+
+TEST(SDL3DBackendEnvOverride, EmptyEnvReturnsFalseWithoutTouchingOutput)
+{
+    SDL3DBackendEnvGuard guard("");
+    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+
+    EXPECT_FALSE(sdl3d_get_backend_override_from_environment(&backend));
+    EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+}
+
+TEST(SDL3DBackendEnvOverride, ParsesSoftware)
+{
+    SDL3DBackendEnvGuard guard("software");
+    sdl3d_backend backend = SDL3D_BACKEND_AUTO;
+
+    EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
+    EXPECT_EQ(SDL3D_BACKEND_SOFTWARE, backend);
+}
+
+TEST(SDL3DBackendEnvOverride, ParsesAuto)
+{
+    SDL3DBackendEnvGuard guard("AUTO");
+    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+
+    EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
+    EXPECT_EQ(SDL3D_BACKEND_AUTO, backend);
+}
+
+TEST(SDL3DBackendEnvOverride, ParsesSdlGpuAndGpuAliasCaseInsensitively)
+{
+    {
+        SDL3DBackendEnvGuard guard("SdlGpu");
+        sdl3d_backend backend = SDL3D_BACKEND_AUTO;
+        EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
+        EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+    }
+
+    {
+        SDL3DBackendEnvGuard guard("GPU");
+        sdl3d_backend backend = SDL3D_BACKEND_AUTO;
+        EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
+        EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+    }
+}
+
+TEST(SDL3DBackendEnvOverride, InvalidValueReturnsFalseAndSetsError)
+{
+    SDL3DBackendEnvGuard guard("not-a-backend");
+    sdl3d_backend backend = SDL3D_BACKEND_AUTO;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_get_backend_override_from_environment(&backend));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Unsupported SDL3D backend override"), std::string_view::npos);
+}
+
+TEST(SDL3DBackendEnvOverride, NullBackendOutputIsRejected)
+{
+    SDL3DBackendEnvGuard guard("software");
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_get_backend_override_from_environment(nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'backend' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, RejectsNullWindow)
+{
+    sdl3d_render_context *context = nullptr;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(nullptr, reinterpret_cast<SDL_Renderer *>(0x1), nullptr, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'window' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, RejectsNullRenderer)
+{
+    sdl3d_render_context *context = nullptr;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1), nullptr, nullptr, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'renderer' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, RejectsNullOutputPointer)
+{
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
+                                             reinterpret_cast<SDL_Renderer *>(0x1), nullptr, nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'out_context' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, RejectsNegativeLogicalDimensions)
+{
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+    sdl3d_init_render_context_config(&config);
+    config.logical_width = -1;
+    config.logical_height = 0;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
+                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Logical dimensions must be zero or positive"),
+              std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, RejectsMismatchedLogicalDimensions)
+{
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+    sdl3d_init_render_context_config(&config);
+    config.logical_width = 320;
+    config.logical_height = 0;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
+                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Logical width and height must both be zero or both be non-zero"),
+              std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, InvalidEnvOverrideFailsBeforeTouchingRenderer)
+{
+    SDL3DBackendEnvGuard guard("nonsense");
+    sdl3d_render_context *context = nullptr;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
+                                             reinterpret_cast<SDL_Renderer *>(0x1), nullptr, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Unsupported SDL3D backend override"), std::string_view::npos);
+}
+
+TEST(SDL3DCreateRenderContext, SdlGpuWithoutFallbackFailsBeforeTouchingRenderer)
+{
+    SDL3DBackendEnvGuard guard(nullptr);
+    sdl3d_render_context *context = nullptr;
+    sdl3d_render_context_config config;
+    sdl3d_init_render_context_config(&config);
+    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.allow_backend_fallback = false;
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_create_render_context(reinterpret_cast<SDL_Window *>(0x1),
+                                             reinterpret_cast<SDL_Renderer *>(0x1), &config, &context));
+    EXPECT_EQ(nullptr, context);
+    EXPECT_NE(std::string_view(SDL_GetError()).find("not implemented"), std::string_view::npos);
+}
+
+TEST(SDL3DRenderContextAccessors, NullContextReturnsZeroSizedAuto)
+{
+    SDL_ClearError();
+    EXPECT_EQ(SDL3D_BACKEND_AUTO, sdl3d_get_render_context_backend(nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'context' is invalid"), std::string_view::npos);
+
+    SDL_ClearError();
+    EXPECT_EQ(0, sdl3d_get_render_context_width(nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'context' is invalid"), std::string_view::npos);
+
+    SDL_ClearError();
+    EXPECT_EQ(0, sdl3d_get_render_context_height(nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'context' is invalid"), std::string_view::npos);
+}
+
+TEST(SDL3DRenderContextMutators, NullContextIsRejectedSafely)
+{
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_clear_render_context(nullptr, sdl3d_color{0, 0, 0, 255}));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'context' is invalid"), std::string_view::npos);
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_present_render_context(nullptr));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'context' is invalid"), std::string_view::npos);
+
+    sdl3d_destroy_render_context(nullptr);
+}

--- a/tests/test_render_loop.cpp
+++ b/tests/test_render_loop.cpp
@@ -3,7 +3,6 @@
 #include <SDL3/SDL.h>
 
 #include <memory>
-#include <string_view>
 
 namespace
 {
@@ -82,16 +81,7 @@ using RendererPtr = std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)
 TEST(SDL3DRenderLoop, MinimalRendererLoopCompletesDeterministically)
 {
     SDL_ClearError();
-    if (!SDL_Init(SDL_INIT_VIDEO))
-    {
-        const std::string_view error = SDL_GetError();
-        if (error.find("did not add any displays") != std::string_view::npos)
-        {
-            GTEST_SKIP() << error;
-        }
-
-        FAIL() << error;
-    }
+    ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
     SDLQuitGuard quit_guard;
 
     SDL_Window *raw_window = nullptr;


### PR DESCRIPTION
## Summary
- add public SDL3D core types and render-context API headers
- add backend selection/configuration skeleton with environment override support
- implement a minimal software render context backed by a logical-size CPU color buffer and SDL presentation path
- add real SDL renderer tests for backend selection semantics and logical-presentation setup

## Testing
- ./scripts/check_clang_format.sh
- cmake -S . -B /tmp/sdl3d-sdl3-tests -G Ninja -DSDL3D_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
- cmake --build /tmp/sdl3d-sdl3-tests
- ctest --test-dir /tmp/sdl3d-sdl3-tests --output-on-failure

## Notes
- In this local macOS session, the render-context tests skip when SDL reports that no displays are available. They are intended to run normally in CI with a real renderer.