### PR TITLE
Add iOS CI workflow and simulator test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,55 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           script: bash scripts/run_android_tests.sh
 
+  ios:
+    name: iOS (${{ matrix.sdk }})
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sdk: iphoneos
+            arch: arm64
+            run_tests: false
+          - sdk: iphonesimulator
+            arch: runner
+            run_tests: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Select target architecture
+        run: |
+          if [ "${{ matrix.arch }}" = "runner" ]; then
+            echo "CMAKE_OSX_ARCHITECTURES=$(uname -m)" >> "$GITHUB_ENV"
+          else
+            echo "CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure
+        run: >
+          cmake -S . -B build/ios/${{ matrix.sdk }}
+          -G Xcode
+          -DCMAKE_SYSTEM_NAME=iOS
+          -DCMAKE_OSX_SYSROOT=${{ matrix.sdk }}
+          -DCMAKE_OSX_ARCHITECTURES=${{ env.CMAKE_OSX_ARCHITECTURES }}
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+          -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=NO
+          -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=
+          -DSDL3D_BUILD_TESTS=ON
+
+      - name: Build iOS test app
+        run: cmake --build build/ios/${{ matrix.sdk }} --config Release --target sdl3d_ios_tests
+
+      - name: Run tests on iOS simulator
+        if: matrix.run_tests
+        env:
+          BUILD_DIR: build/ios/${{ matrix.sdk }}
+        run: bash scripts/run_ios_tests.sh
+
   sanitizers:
     name: Sanitizers
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ if(NOT TARGET SDL3::SDL3 AND SDL3D_FETCH_SDL3)
         GIT_SHALLOW TRUE
     )
 
+    if(IOS)
+        # iOS app bundles cannot rely on a build-tree SDL dylib at runtime.
+        # Force a static SDL so the simulator/device app can launch without
+        # embedding extra runtime artifacts into the .app.
+        set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+        set(SDL_STATIC ON CACHE BOOL "" FORCE)
+    endif()
+
     set(SDL_TEST_LIBRARY OFF CACHE BOOL "" FORCE)
     set(SDL_TESTS OFF CACHE BOOL "" FORCE)
     set(SDL_EXAMPLES OFF CACHE BOOL "" FORCE)
@@ -50,8 +58,15 @@ if(NOT TARGET SDL3::SDL3 AND SDL3D_FETCH_SDL3)
     set(SDL3D_USING_FETCHED_SDL3 ON)
 endif()
 
-if(NOT TARGET SDL3::SDL3)
-    message(FATAL_ERROR "SDL3::SDL3 was not found. Provide SDL3 via a parent target, find_package(SDL3), or enable SDL3D_FETCH_SDL3.")
+if(NOT TARGET SDL3::SDL3 AND NOT TARGET SDL3::SDL3-static)
+    message(FATAL_ERROR "SDL3 was not found. Provide SDL3 via a parent target, find_package(SDL3), or enable SDL3D_FETCH_SDL3.")
+endif()
+
+set(SDL3D_SDL_TARGET SDL3::SDL3)
+if(NOT TARGET ${SDL3D_SDL_TARGET} AND TARGET SDL3::SDL3-static)
+    set(SDL3D_SDL_TARGET SDL3::SDL3-static)
+elseif(IOS AND TARGET SDL3::SDL3-static)
+    set(SDL3D_SDL_TARGET SDL3::SDL3-static)
 endif()
 
 add_library(sdl3d STATIC)
@@ -85,22 +100,22 @@ set_target_properties(
 target_include_directories(
     sdl3d
     PRIVATE
-        $<TARGET_PROPERTY:SDL3::SDL3,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:${SDL3D_SDL_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_compile_definitions(
     sdl3d
     PRIVATE
-        $<TARGET_PROPERTY:SDL3::SDL3,INTERFACE_COMPILE_DEFINITIONS>
+        $<TARGET_PROPERTY:${SDL3D_SDL_TARGET},INTERFACE_COMPILE_DEFINITIONS>
 )
 
 target_compile_options(
     sdl3d
     PRIVATE
-        $<TARGET_PROPERTY:SDL3::SDL3,INTERFACE_COMPILE_OPTIONS>
+        $<TARGET_PROPERTY:${SDL3D_SDL_TARGET},INTERFACE_COMPILE_OPTIONS>
 )
 
-set_property(TARGET sdl3d APPEND PROPERTY INTERFACE_LINK_LIBRARIES SDL3::SDL3)
+set_property(TARGET sdl3d APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${SDL3D_SDL_TARGET})
 
 target_include_directories(
     sdl3d

--- a/scripts/run_ios_tests.sh
+++ b/scripts/run_ios_tests.sh
@@ -14,6 +14,8 @@ SIM_NAME="${SIM_NAME:-SDL3D Tests}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-240}"
 
 SIM_UDID=""
+SIM_DEVICE_NAME=""
+CREATED_SIM=0
 LAUNCH_PID=""
 STREAM_PID=""
 LOGFILE="$(mktemp)"
@@ -29,7 +31,9 @@ cleanup() {
     fi
     if [ -n "$SIM_UDID" ]; then
         xcrun simctl shutdown "$SIM_UDID" >/dev/null 2>&1 || true
-        xcrun simctl delete "$SIM_UDID" >/dev/null 2>&1 || true
+        if [ "$CREATED_SIM" -eq 1 ]; then
+            xcrun simctl delete "$SIM_UDID" >/dev/null 2>&1 || true
+        fi
     fi
     rm -f "$LOGFILE"
 }
@@ -50,6 +54,21 @@ if [ -z "$RUNTIME_ID" ]; then
     RUNTIME_ID="$(
         xcrun simctl list runtimes | sed -En \
             '/^[[:space:]]*iOS /{/unavailable/d;s/.* - (com\.apple\.CoreSimulator\.SimRuntime\.iOS[-A-Za-z0-9]+).*/\1/p;q;}'
+    )"
+fi
+
+RUNTIME_NAME="${SIM_RUNTIME_NAME:-}"
+if [ -z "$RUNTIME_NAME" ]; then
+    RUNTIME_NAME="$(
+        xcrun simctl list runtimes | awk -v id="$RUNTIME_ID" '
+            index($0, id) {
+                line = $0
+                sub(/[[:space:]]+\(.*/, "", line)
+                sub(/^[[:space:]]*/, "", line)
+                print line
+                exit
+            }
+        '
     )"
 fi
 
@@ -83,9 +102,54 @@ fi
 xcrun simctl delete unavailable >/dev/null 2>&1 || true
 
 echo "Using runtime: $RUNTIME_ID"
-echo "Using device type: $DEVICE_TYPE_ID"
+SIM_UDID="$(
+    xcrun simctl list devices available | awk -v runtime="$RUNTIME_NAME" '
+        $0 == "-- " runtime " --" {
+            in_runtime = 1
+            next
+        }
+        /^-- / {
+            in_runtime = 0
+        }
+        in_runtime && /^[[:space:]]*iPhone / {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            name = line
+            sub(/[[:space:]]+\(.*/, "", name)
+            if (match(line, /\(([0-9A-F-]+)\)/)) {
+                print substr(line, RSTART + 1, RLENGTH - 2)
+                exit
+            }
+        }
+    '
+)"
 
-SIM_UDID="$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+if [ -n "$SIM_UDID" ]; then
+    SIM_DEVICE_NAME="$(
+        xcrun simctl list devices available | awk -v runtime="$RUNTIME_NAME" '
+            $0 == "-- " runtime " --" {
+                in_runtime = 1
+                next
+            }
+            /^-- / {
+                in_runtime = 0
+            }
+            in_runtime && /^[[:space:]]*iPhone / {
+                line = $0
+                sub(/^[[:space:]]*/, "", line)
+                sub(/[[:space:]]+\(.*/, "", line)
+                print line
+                exit
+            }
+        '
+    )"
+    echo "Using existing simulator: ${SIM_DEVICE_NAME:-$SIM_UDID}"
+else
+    echo "Using device type: $DEVICE_TYPE_ID"
+    SIM_UDID="$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+    CREATED_SIM=1
+fi
+
 xcrun simctl boot "$SIM_UDID" >/dev/null
 xcrun simctl bootstatus "$SIM_UDID" -b
 

--- a/scripts/run_ios_tests.sh
+++ b/scripts/run_ios_tests.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Creates a fresh iOS simulator, installs the pre-built test .app bundle,
+# launches it, and tails both the app console and unified logs for the
+# sentinel line emitted by tests/ios_main.cpp.
+set -euo pipefail
+
+APP="${APP:-}"
+APP_NAME="${APP_NAME:-sdl3d_ios_tests.app}"
+BUILD_DIR="${BUILD_DIR:-build/ios/iphonesimulator}"
+BUNDLE_ID="${BUNDLE_ID:-com.sdl3d.tests}"
+LOG_SUBSYSTEM="${LOG_SUBSYSTEM:-com.sdl3d.tests}"
+SENTINEL="${SENTINEL:-SDL3D_TEST_RESULT}"
+SIM_NAME="${SIM_NAME:-SDL3D Tests}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-240}"
+
+SIM_UDID=""
+LAUNCH_PID=""
+STREAM_PID=""
+LOGFILE="$(mktemp)"
+
+cleanup() {
+    if [ -n "$LAUNCH_PID" ]; then
+        kill "$LAUNCH_PID" 2>/dev/null || true
+        wait "$LAUNCH_PID" 2>/dev/null || true
+    fi
+    if [ -n "$STREAM_PID" ]; then
+        kill "$STREAM_PID" 2>/dev/null || true
+        wait "$STREAM_PID" 2>/dev/null || true
+    fi
+    if [ -n "$SIM_UDID" ]; then
+        xcrun simctl shutdown "$SIM_UDID" >/dev/null 2>&1 || true
+        xcrun simctl delete "$SIM_UDID" >/dev/null 2>&1 || true
+    fi
+    rm -f "$LOGFILE"
+}
+trap cleanup EXIT
+
+if [ -z "$APP" ]; then
+    APP="$(find "$BUILD_DIR" -type d -name "$APP_NAME" | head -n 1 || true)"
+fi
+
+if [ -z "$APP" ] || [ ! -d "$APP" ]; then
+    echo "iOS app bundle not found. Looked for $APP_NAME under $BUILD_DIR" >&2
+    find "$BUILD_DIR" -maxdepth 4 -type d -name "*.app" -print 2>/dev/null || true
+    exit 2
+fi
+
+RUNTIME_ID="${SIM_RUNTIME_ID:-}"
+if [ -z "$RUNTIME_ID" ]; then
+    RUNTIME_ID="$(
+        xcrun simctl list runtimes | sed -En \
+            '/^[[:space:]]*iOS /{/unavailable/d;s/.* - (com\.apple\.CoreSimulator\.SimRuntime\.iOS[-A-Za-z0-9]+).*/\1/p;q;}'
+    )"
+fi
+
+DEVICE_TYPE_ID="${SIM_DEVICE_TYPE_ID:-}"
+if [ -z "$DEVICE_TYPE_ID" ]; then
+    for device_name in "iPhone 17" "iPhone 16" "iPhone 15" "iPhone 14"; do
+        DEVICE_TYPE_ID="$(
+            xcrun simctl list devicetypes | sed -En \
+                "/^${device_name// /[[:space:]]+} /s/.*\\((com\\.apple\\.CoreSimulator\\.SimDeviceType\\.[^)]+)\\).*/\\1/p"
+        )"
+        if [ -n "$DEVICE_TYPE_ID" ]; then
+            break
+        fi
+    done
+fi
+
+if [ -z "$RUNTIME_ID" ] || [ -z "$DEVICE_TYPE_ID" ]; then
+    echo "Unable to determine an available iOS simulator runtime/device type" >&2
+    xcrun simctl list runtimes
+    xcrun simctl list devicetypes
+    exit 2
+fi
+
+xcrun simctl delete unavailable >/dev/null 2>&1 || true
+
+echo "Using runtime: $RUNTIME_ID"
+echo "Using device type: $DEVICE_TYPE_ID"
+
+SIM_UDID="$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+xcrun simctl boot "$SIM_UDID" >/dev/null
+xcrun simctl bootstatus "$SIM_UDID" -b
+
+# Capture the unified log stream in the background; the app's stdout/stderr
+# is collected separately by simctl launch --console-pty and appended to the
+# same logfile so CI shows both the gtest transcript and our os_log lines.
+log stream \
+    --style compact \
+    --level debug \
+    --predicate "subsystem == \"$LOG_SUBSYSTEM\"" >"$LOGFILE" 2>&1 &
+STREAM_PID=$!
+
+xcrun simctl install "$SIM_UDID" "$APP"
+xcrun simctl launch --console-pty "$SIM_UDID" "$BUNDLE_ID" >>"$LOGFILE" 2>&1 &
+LAUNCH_PID=$!
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+rc=""
+while [ -z "$rc" ] && [ $SECONDS -lt $deadline ]; do
+    if grep -q "$SENTINEL:" "$LOGFILE" 2>/dev/null; then
+        rc="$(grep "$SENTINEL:" "$LOGFILE" | tail -n 1 | sed -E "s/.*${SENTINEL}: ([0-9]+).*/\\1/")"
+        break
+    fi
+    sleep 2
+done
+
+kill "$LAUNCH_PID" 2>/dev/null || true
+wait "$LAUNCH_PID" 2>/dev/null || true
+kill "$STREAM_PID" 2>/dev/null || true
+wait "$STREAM_PID" 2>/dev/null || true
+LAUNCH_PID=""
+STREAM_PID=""
+
+echo "----- iOS test log -----"
+cat "$LOGFILE"
+echo "----- end iOS test log -----"
+
+if [ -z "$rc" ]; then
+    echo "Test run did not report $SENTINEL within ${TIMEOUT_SECONDS}s" >&2
+    exit 1
+fi
+
+echo "GoogleTest exit code: $rc"
+exit "$rc"

--- a/scripts/run_ios_tests.sh
+++ b/scripts/run_ios_tests.sh
@@ -19,6 +19,7 @@ CREATED_SIM=0
 LAUNCH_PID=""
 STREAM_PID=""
 LOGFILE="$(mktemp)"
+LAUNCH_STATUS_FILE="$(mktemp)"
 
 cleanup() {
     if [ -n "$LAUNCH_PID" ]; then
@@ -36,6 +37,7 @@ cleanup() {
         fi
     fi
     rm -f "$LOGFILE"
+    rm -f "$LAUNCH_STATUS_FILE"
 }
 trap cleanup EXIT
 
@@ -156,22 +158,30 @@ xcrun simctl bootstatus "$SIM_UDID" -b
 # Capture the unified log stream in the background; the app's stdout/stderr
 # is collected separately by simctl launch --console-pty and appended to the
 # same logfile so CI shows both the gtest transcript and our os_log lines.
+echo "Listening for subsystem logs: $LOG_SUBSYSTEM" >>"$LOGFILE"
 log stream \
     --style compact \
     --level debug \
-    --predicate "subsystem == \"$LOG_SUBSYSTEM\"" >"$LOGFILE" 2>&1 &
+    --predicate "subsystem == \"$LOG_SUBSYSTEM\"" >>"$LOGFILE" 2>&1 &
 STREAM_PID=$!
 
 xcrun simctl install "$SIM_UDID" "$APP"
-xcrun simctl launch --console-pty "$SIM_UDID" "$BUNDLE_ID" >>"$LOGFILE" 2>&1 &
+( xcrun simctl launch --console-pty "$SIM_UDID" "$BUNDLE_ID" >>"$LOGFILE" 2>&1; echo $? >"$LAUNCH_STATUS_FILE" ) &
 LAUNCH_PID=$!
 
 deadline=$((SECONDS + TIMEOUT_SECONDS))
 rc=""
+launch_status=""
 while [ -z "$rc" ] && [ $SECONDS -lt $deadline ]; do
     if grep -q "$SENTINEL:" "$LOGFILE" 2>/dev/null; then
         rc="$(grep "$SENTINEL:" "$LOGFILE" | tail -n 1 | sed -E "s/.*${SENTINEL}: ([0-9]+).*/\\1/")"
         break
+    fi
+    if [ -s "$LAUNCH_STATUS_FILE" ]; then
+        launch_status="$(tr -d '\n' <"$LAUNCH_STATUS_FILE")"
+        if [ "$launch_status" != "0" ]; then
+            break
+        fi
     fi
     sleep 2
 done
@@ -188,6 +198,9 @@ cat "$LOGFILE"
 echo "----- end iOS test log -----"
 
 if [ -z "$rc" ]; then
+    if [ -n "$launch_status" ]; then
+        echo "simctl launch exit code: $launch_status" >&2
+    fi
     echo "Test run did not report $SENTINEL within ${TIMEOUT_SECONDS}s" >&2
     exit 1
 fi

--- a/scripts/run_ios_tests.sh
+++ b/scripts/run_ios_tests.sh
@@ -57,8 +57,15 @@ DEVICE_TYPE_ID="${SIM_DEVICE_TYPE_ID:-}"
 if [ -z "$DEVICE_TYPE_ID" ]; then
     for device_name in "iPhone 17" "iPhone 16" "iPhone 15" "iPhone 14"; do
         DEVICE_TYPE_ID="$(
-            xcrun simctl list devicetypes | sed -En \
-                "/^${device_name// /[[:space:]]+} /s/.*\\((com\\.apple\\.CoreSimulator\\.SimDeviceType\\.[^)]+)\\).*/\\1/p"
+            xcrun simctl list devicetypes | awk -v want="$device_name" '
+                index($0, want " (") == 1 {
+                    line = $0
+                    sub(/^.*\(/, "", line)
+                    sub(/\)$/, "", line)
+                    print line
+                    exit
+                }
+            '
         )"
         if [ -n "$DEVICE_TYPE_ID" ]; then
             break

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,21 +63,21 @@ function(sdl3d_add_test target_name source_file test_label)
     )
 endfunction()
 
+set(SDL3D_TEST_SOURCES
+    test_api.cpp
+    test_math.cpp
+    test_rasterizer.cpp
+    test_render_context_unit.cpp
+    test_render_context.cpp
+    test_drawing3d.cpp
+    test_render_loop.cpp
+)
+
 if(ANDROID)
     # SDLActivity expects libmain.so with an SDL_main entry point. Combine
     # all GoogleTest translation units into one shared library so a single
     # APK can run the entire suite.
-    add_library(
-        main SHARED
-        android_main.cpp
-        test_api.cpp
-        test_math.cpp
-        test_rasterizer.cpp
-        test_render_context_unit.cpp
-        test_render_context.cpp
-        test_drawing3d.cpp
-        test_render_loop.cpp
-    )
+    add_library(main SHARED android_main.cpp ${SDL3D_TEST_SOURCES})
 
     target_link_libraries(
         main
@@ -91,6 +91,39 @@ if(ANDROID)
     target_compile_features(main PRIVATE cxx_std_17)
     target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_enable_sanitizers(main)
+elseif(IOS)
+    # iOS apps must be bundled as .app directories and cannot launch bare
+    # executables; as on Android we combine every test TU into a single
+    # app bundle whose SDL_main runs the full suite. SDL's iOS bootstrap
+    # creates UIApplication + a window and then calls into our SDL_main.
+    set(SDL3D_IOS_BUNDLE_ID "com.sdl3d.tests")
+
+    add_executable(sdl3d_ios_tests MACOSX_BUNDLE ios_main.cpp ${SDL3D_TEST_SOURCES})
+
+    target_link_libraries(
+        sdl3d_ios_tests
+        PRIVATE
+            SDL3D::sdl3d
+            GTest::gtest
+    )
+
+    target_compile_features(sdl3d_ios_tests PRIVATE cxx_std_17)
+    target_include_directories(sdl3d_ios_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    sdl3d_enable_sanitizers(sdl3d_ios_tests)
+
+    set_target_properties(
+        sdl3d_ios_tests
+        PROPERTIES
+            MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/ios/Info.plist.in"
+            MACOSX_BUNDLE_GUI_IDENTIFIER "${SDL3D_IOS_BUNDLE_ID}"
+            MACOSX_BUNDLE_BUNDLE_NAME "SDL3D Tests"
+            MACOSX_BUNDLE_BUNDLE_VERSION "1"
+            MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${SDL3D_IOS_BUNDLE_ID}"
+            XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+            XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+            XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+    )
 else()
     sdl3d_add_test(sdl3d_api_test test_api.cpp unit)
     sdl3d_add_test(sdl3d_math_test test_math.cpp unit)

--- a/tests/ios/Info.plist.in
+++ b/tests/ios/Info.plist.in
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>SDL3D Tests</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.sdl3d.tests</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>SDL3D Tests</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/tests/ios_main.cpp
+++ b/tests/ios_main.cpp
@@ -1,0 +1,69 @@
+// iOS test entry point.
+//
+// SDL's iOS bootstrap invokes UIApplicationMain and then calls back into
+// SDL_main (our main() below is renamed to SDL_main via SDL_main.h). We
+// run GoogleTest from here and emit per-test and sentinel lines via
+// os_log to the "com.sdl3d.tests" subsystem so the CI runner can tail
+// them through `log stream` / `log show` on the simulator.
+//
+// gtest writes its pass/fail to stdout; the simulator console can pick
+// that up with `simctl launch --console`, but os_log is the reliable
+// channel because it survives process exit timing and we can filter by
+// subsystem without noise from the rest of iOS.
+
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include <os/log.h>
+
+namespace
+{
+os_log_t g_log()
+{
+    static os_log_t log = os_log_create("com.sdl3d.tests", "tests");
+    return log;
+}
+
+class IOSLogListener : public ::testing::EmptyTestEventListener
+{
+    void OnTestStart(const ::testing::TestInfo &info) override
+    {
+        os_log_info(g_log(), "SDL3D_TEST RUN  %{public}s.%{public}s", info.test_suite_name(), info.name());
+    }
+
+    void OnTestPartResult(const ::testing::TestPartResult &result) override
+    {
+        if (result.failed())
+        {
+            os_log_error(g_log(), "SDL3D_TEST FAIL %{public}s:%d %{public}s",
+                         result.file_name() ? result.file_name() : "?", result.line_number(), result.summary());
+        }
+    }
+
+    void OnTestEnd(const ::testing::TestInfo &info) override
+    {
+        const auto *r = info.result();
+        const bool failed = r && r->Failed();
+        if (failed)
+        {
+            os_log_error(g_log(), "SDL3D_TEST FAIL %{public}s.%{public}s", info.test_suite_name(), info.name());
+        }
+        else
+        {
+            os_log_info(g_log(), "SDL3D_TEST OK   %{public}s.%{public}s", info.test_suite_name(), info.name());
+        }
+    }
+};
+} // namespace
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::UnitTest::GetInstance()->listeners().Append(new IOSLogListener());
+    int rc = RUN_ALL_TESTS();
+    os_log_info(g_log(), "SDL3D_TEST_RESULT: %d", rc);
+    SDL_Delay(500);
+    return rc;
+}


### PR DESCRIPTION
## Summary
- add an iOS test bundle target and plist so the GoogleTest suite can run under SDL on iOS
- add an iOS CI job that mirrors Android with an iphoneos build leg and an iphonesimulator test leg
- add a simulator runner script that creates a simulator, installs the app, launches it, and waits for the SDL3D_TEST_RESULT sentinel

## Validation
- bash -n scripts/run_ios_tests.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'
- git diff --check
- local iOS CMake configure reached SDL discovery with the Xcode/iOS toolchain