### PR TITLE
Add software renderer culling and scissor controls

### DIFF
--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -23,6 +23,10 @@ extern "C"
     bool sdl3d_end_mode_3d(sdl3d_render_context *context);
 
     bool sdl3d_is_in_mode_3d(const sdl3d_render_context *context);
+    bool sdl3d_set_backface_culling_enabled(sdl3d_render_context *context, bool enabled);
+    bool sdl3d_is_backface_culling_enabled(const sdl3d_render_context *context);
+    bool sdl3d_set_wireframe_enabled(sdl3d_render_context *context, bool enabled);
+    bool sdl3d_is_wireframe_enabled(const sdl3d_render_context *context);
 
     /*
      * Override the depth planes used by sdl3d_begin_mode_3d. Must be called

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -40,6 +40,10 @@ extern "C"
     int sdl3d_get_render_context_width(const sdl3d_render_context *context);
     int sdl3d_get_render_context_height(const sdl3d_render_context *context);
     bool sdl3d_clear_render_context(sdl3d_render_context *context, sdl3d_color color);
+    bool sdl3d_clear_render_context_rect(sdl3d_render_context *context, const SDL_Rect *rect, sdl3d_color color);
+    bool sdl3d_set_scissor_rect(sdl3d_render_context *context, const SDL_Rect *rect);
+    bool sdl3d_is_scissor_enabled(const sdl3d_render_context *context);
+    bool sdl3d_get_scissor_rect(const sdl3d_render_context *context, SDL_Rect *out_rect);
     bool sdl3d_present_render_context(sdl3d_render_context *context);
 
 #ifdef __cplusplus

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -53,6 +53,50 @@ bool sdl3d_is_in_mode_3d(const sdl3d_render_context *context)
     return context->in_mode_3d;
 }
 
+bool sdl3d_set_backface_culling_enabled(sdl3d_render_context *context, bool enabled)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    context->backface_culling_enabled = enabled;
+    return true;
+}
+
+bool sdl3d_is_backface_culling_enabled(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return false;
+    }
+
+    return context->backface_culling_enabled;
+}
+
+bool sdl3d_set_wireframe_enabled(sdl3d_render_context *context, bool enabled)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    context->wireframe_enabled = enabled;
+    return true;
+}
+
+bool sdl3d_is_wireframe_enabled(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return false;
+    }
+
+    return context->wireframe_enabled;
+}
+
 bool sdl3d_set_depth_planes(sdl3d_render_context *context, float near_plane, float far_plane)
 {
     if (context == NULL)
@@ -97,7 +141,8 @@ bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_
     }
 
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
-    sdl3d_rasterize_triangle(&framebuffer, context->view_projection, v0, v1, v2, color);
+    sdl3d_rasterize_triangle(&framebuffer, context->view_projection, v0, v1, v2, color,
+                             context->backface_culling_enabled, context->wireframe_enabled);
     return true;
 }
 

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -35,9 +35,26 @@ static int sdl3d_min_int(int a, int b)
     return (a < b) ? a : b;
 }
 
+static bool sdl3d_scissor_contains(const sdl3d_framebuffer *framebuffer, int x, int y)
+{
+    if (!framebuffer->scissor_enabled)
+    {
+        return true;
+    }
+
+    return (x >= framebuffer->scissor_rect.x) && (y >= framebuffer->scissor_rect.y) &&
+           (x < framebuffer->scissor_rect.x + framebuffer->scissor_rect.w) &&
+           (y < framebuffer->scissor_rect.y + framebuffer->scissor_rect.h);
+}
+
 static void sdl3d_write_pixel(sdl3d_framebuffer *framebuffer, int x, int y, float depth, sdl3d_color color)
 {
     const int index = (y * framebuffer->width) + x;
+
+    if (!sdl3d_scissor_contains(framebuffer, x, y))
+    {
+        return;
+    }
 
     if (depth > framebuffer->depth_pixels[index])
     {
@@ -229,6 +246,9 @@ typedef struct sdl3d_screen_vertex
     float y_px;
 } sdl3d_screen_vertex;
 
+static void sdl3d_rasterize_screen_line(sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex start,
+                                        sdl3d_screen_vertex end, sdl3d_color color);
+
 static sdl3d_screen_vertex sdl3d_viewport_transform(sdl3d_vec4 clip, int width, int height)
 {
     sdl3d_screen_vertex out;
@@ -260,6 +280,25 @@ static Sint64 sdl3d_edge_function(int ax, int ay, int bx, int by, int px, int py
     return (Sint64)(bx - ax) * (Sint64)(py - ay) - (Sint64)(by - ay) * (Sint64)(px - ax);
 }
 
+static Sint64 sdl3d_screen_triangle_signed_area(sdl3d_screen_vertex a, sdl3d_screen_vertex b, sdl3d_screen_vertex c)
+{
+    return sdl3d_edge_function(a.x_fx, a.y_fx, b.x_fx, b.y_fx, c.x_fx, c.y_fx);
+}
+
+static Sint64 sdl3d_screen_polygon_signed_area(const sdl3d_screen_vertex *vertices, int count)
+{
+    Sint64 area_twice = 0;
+
+    for (int i = 0; i < count; ++i)
+    {
+        const sdl3d_screen_vertex current = vertices[i];
+        const sdl3d_screen_vertex next = vertices[(i + 1) % count];
+        area_twice += ((Sint64)current.x_fx * (Sint64)next.y_fx) - ((Sint64)next.x_fx * (Sint64)current.y_fx);
+    }
+
+    return area_twice;
+}
+
 /*
  * D3D-style top-left fill rule. Assumes winding has been normalized so that
  * the triangle has positive 2x-area. Returns the bias to add to the edge
@@ -282,7 +321,7 @@ static void sdl3d_rasterize_screen_triangle(sdl3d_framebuffer *framebuffer, sdl3
                                             sdl3d_screen_vertex b, sdl3d_screen_vertex c, sdl3d_color color)
 {
     /* 2x signed area in fixed-point. If negative, swap winding. Zero means degenerate. */
-    Sint64 area = sdl3d_edge_function(a.x_fx, a.y_fx, b.x_fx, b.y_fx, c.x_fx, c.y_fx);
+    Sint64 area = sdl3d_screen_triangle_signed_area(a, b, c);
     if (area == 0)
     {
         return;
@@ -352,7 +391,8 @@ static void sdl3d_rasterize_screen_triangle(sdl3d_framebuffer *framebuffer, sdl3
 /* --- Public: triangle, line, point --------------------------------------- */
 
 void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
-                              sdl3d_vec3 v2, sdl3d_color color)
+                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled,
+                              bool wireframe_enabled)
 {
     if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL)
     {
@@ -374,6 +414,26 @@ void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sd
     for (int i = 0; i < clipped_count; ++i)
     {
         screen[i] = sdl3d_viewport_transform(clipped[i], framebuffer->width, framebuffer->height);
+    }
+
+    const Sint64 polygon_area = sdl3d_screen_polygon_signed_area(screen, clipped_count);
+    if (polygon_area == 0)
+    {
+        return;
+    }
+
+    if (backface_culling_enabled && polygon_area >= 0)
+    {
+        return;
+    }
+
+    if (wireframe_enabled)
+    {
+        for (int i = 0; i < clipped_count; ++i)
+        {
+            sdl3d_rasterize_screen_line(framebuffer, screen[i], screen[(i + 1) % clipped_count], color);
+        }
+        return;
     }
 
     /* Fan-triangulate the clipped polygon around vertex 0. */
@@ -509,6 +569,55 @@ void sdl3d_framebuffer_clear(sdl3d_framebuffer *framebuffer, sdl3d_color color, 
         pixel[2] = color.b;
         pixel[3] = color.a;
         framebuffer->depth_pixels[i] = depth;
+    }
+}
+
+void sdl3d_framebuffer_clear_rect(sdl3d_framebuffer *framebuffer, const SDL_Rect *rect, sdl3d_color color, float depth)
+{
+    if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL || rect == NULL)
+    {
+        return;
+    }
+
+    Sint64 min_x = rect->x;
+    Sint64 min_y = rect->y;
+    Sint64 max_x = (Sint64)rect->x + (Sint64)rect->w;
+    Sint64 max_y = (Sint64)rect->y + (Sint64)rect->h;
+
+    if (min_x < 0)
+    {
+        min_x = 0;
+    }
+    if (min_y < 0)
+    {
+        min_y = 0;
+    }
+    if (max_x > framebuffer->width)
+    {
+        max_x = framebuffer->width;
+    }
+    if (max_y > framebuffer->height)
+    {
+        max_y = framebuffer->height;
+    }
+
+    if (min_x >= max_x || min_y >= max_y)
+    {
+        return;
+    }
+
+    for (int y = (int)min_y; y < (int)max_y; ++y)
+    {
+        for (int x = (int)min_x; x < (int)max_x; ++x)
+        {
+            const int index = (y * framebuffer->width) + x;
+            Uint8 *pixel = &framebuffer->color_pixels[index * 4];
+            pixel[0] = color.r;
+            pixel[1] = color.g;
+            pixel[2] = color.b;
+            pixel[3] = color.a;
+            framebuffer->depth_pixels[index] = depth;
+        }
     }
 }
 

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -391,8 +391,7 @@ static void sdl3d_rasterize_screen_triangle(sdl3d_framebuffer *framebuffer, sdl3
 /* --- Public: triangle, line, point --------------------------------------- */
 
 void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
-                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled,
-                              bool wireframe_enabled)
+                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled, bool wireframe_enabled)
 {
     if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL)
     {

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 
+#include <SDL3/SDL_rect.h>
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/math.h"
@@ -35,15 +36,19 @@ typedef struct sdl3d_framebuffer
     float *depth_pixels; /* width * height floats in [-1, 1] */
     int width;
     int height;
+    bool scissor_enabled;
+    SDL_Rect scissor_rect;
 } sdl3d_framebuffer;
 
 void sdl3d_framebuffer_clear(sdl3d_framebuffer *framebuffer, sdl3d_color color, float depth);
+void sdl3d_framebuffer_clear_rect(sdl3d_framebuffer *framebuffer, const SDL_Rect *rect, sdl3d_color color, float depth);
 
 bool sdl3d_framebuffer_get_pixel(const sdl3d_framebuffer *framebuffer, int x, int y, sdl3d_color *out_color);
 bool sdl3d_framebuffer_get_depth(const sdl3d_framebuffer *framebuffer, int x, int y, float *out_depth);
 
 void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
-                              sdl3d_vec3 v2, sdl3d_color color);
+                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled,
+                              bool wireframe_enabled);
 
 void sdl3d_rasterize_line(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 start, sdl3d_vec3 end,
                           sdl3d_color color);

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -47,8 +47,7 @@ bool sdl3d_framebuffer_get_pixel(const sdl3d_framebuffer *framebuffer, int x, in
 bool sdl3d_framebuffer_get_depth(const sdl3d_framebuffer *framebuffer, int x, int y, float *out_depth);
 
 void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
-                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled,
-                              bool wireframe_enabled);
+                              sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled, bool wireframe_enabled);
 
 void sdl3d_rasterize_line(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 start, sdl3d_vec3 end,
                           sdl3d_color color);

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -237,6 +237,10 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     context->near_plane = SDL3D_DEFAULT_NEAR_PLANE;
     context->far_plane = SDL3D_DEFAULT_FAR_PLANE;
     context->in_mode_3d = false;
+    context->backface_culling_enabled = false;
+    context->wireframe_enabled = false;
+    context->scissor_enabled = false;
+    context->scissor_rect = (SDL_Rect){0, 0, render_width, render_height};
     context->view = sdl3d_mat4_identity();
     context->projection = sdl3d_mat4_identity();
     context->view_projection = sdl3d_mat4_identity();
@@ -300,6 +304,123 @@ bool sdl3d_clear_render_context(sdl3d_render_context *context, sdl3d_color color
 
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
     sdl3d_framebuffer_clear(&framebuffer, color, 1.0f);
+    return true;
+}
+
+bool sdl3d_clear_render_context_rect(sdl3d_render_context *context, const SDL_Rect *rect, sdl3d_color color)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (rect == NULL)
+    {
+        return SDL_InvalidParamError("rect");
+    }
+    if (rect->w < 0 || rect->h < 0)
+    {
+        return SDL_SetError("Clear rect dimensions must be non-negative.");
+    }
+
+    sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
+    sdl3d_framebuffer_clear_rect(&framebuffer, rect, color, 1.0f);
+    return true;
+}
+
+bool sdl3d_set_scissor_rect(sdl3d_render_context *context, const SDL_Rect *rect)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    if (rect == NULL)
+    {
+        context->scissor_enabled = false;
+        context->scissor_rect = (SDL_Rect){0, 0, context->width, context->height};
+        return true;
+    }
+
+    if (rect->w < 0 || rect->h < 0)
+    {
+        return SDL_SetError("Scissor rect dimensions must be non-negative.");
+    }
+
+    Sint64 x = rect->x;
+    Sint64 y = rect->y;
+    Sint64 w = rect->w;
+    Sint64 h = rect->h;
+
+    if (x < 0)
+    {
+        w += x;
+        x = 0;
+    }
+    if (y < 0)
+    {
+        h += y;
+        y = 0;
+    }
+
+    if (x > context->width)
+    {
+        x = context->width;
+    }
+    if (y > context->height)
+    {
+        y = context->height;
+    }
+
+    if (w > context->width - x)
+    {
+        w = context->width - x;
+    }
+    if (h > context->height - y)
+    {
+        h = context->height - y;
+    }
+
+    if (w < 0)
+    {
+        w = 0;
+    }
+    if (h < 0)
+    {
+        h = 0;
+    }
+
+    context->scissor_enabled = true;
+    context->scissor_rect = (SDL_Rect){(int)x, (int)y, (int)w, (int)h};
+    return true;
+}
+
+bool sdl3d_is_scissor_enabled(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        SDL_InvalidParamError("context");
+        return false;
+    }
+
+    return context->scissor_enabled;
+}
+
+bool sdl3d_get_scissor_rect(const sdl3d_render_context *context, SDL_Rect *out_rect)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (out_rect == NULL)
+    {
+        return SDL_InvalidParamError("out_rect");
+    }
+    if (!context->scissor_enabled)
+    {
+        return SDL_SetError("Scissor is not enabled on this render context.");
+    }
+
+    *out_rect = context->scissor_rect;
     return true;
 }
 

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -31,6 +31,10 @@ struct sdl3d_render_context
     float far_plane;
 
     bool in_mode_3d;
+    bool backface_culling_enabled;
+    bool wireframe_enabled;
+    bool scissor_enabled;
+    SDL_Rect scissor_rect;
     sdl3d_mat4 view;
     sdl3d_mat4 projection;
     sdl3d_mat4 view_projection;
@@ -43,6 +47,8 @@ static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_cont
     framebuffer.depth_pixels = context->depth_buffer;
     framebuffer.width = context->width;
     framebuffer.height = context->height;
+    framebuffer.scissor_enabled = context->scissor_enabled;
+    framebuffer.scissor_rect = context->scissor_rect;
     return framebuffer;
 }
 

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -345,7 +345,7 @@ TEST_F(SDL3DDrawingFixture, ClearResetsDepthBuffer)
     sdl3d_destroy_render_context(ctx);
 }
 
-TEST_F(SDL3DDrawingFixture, ScissorRestrictsRasterizationToClippedRegion)
+TEST_F(SDL3DDrawingFixture, ScissorRestrictsDrawingToClippedRegion)
 {
     WindowRenderer wr(64, 64);
     ASSERT_TRUE(wr.ok());
@@ -365,14 +365,15 @@ TEST_F(SDL3DDrawingFixture, ScissorRestrictsRasterizationToClippedRegion)
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
-    ASSERT_TRUE(sdl3d_draw_triangle_3d(ctx, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, -1.0f, 0.0f),
-                                       sdl3d_vec3_make(0.0f, 1.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
     EXPECT_EQ(CountColor(ctx, kRed), 1);
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 31, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlack));
 
     ASSERT_TRUE(sdl3d_set_scissor_rect(ctx, nullptr));
     EXPECT_FALSE(sdl3d_is_scissor_enabled(ctx));

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -198,8 +198,12 @@ TEST(SDL3DDrawing3DNull, NullContextIsRejected)
     EXPECT_FALSE(sdl3d_begin_mode_3d(nullptr, MakeCamera()));
     EXPECT_FALSE(sdl3d_end_mode_3d(nullptr));
     EXPECT_FALSE(sdl3d_draw_point_3d(nullptr, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
+    EXPECT_FALSE(sdl3d_set_backface_culling_enabled(nullptr, true));
+    EXPECT_FALSE(sdl3d_set_wireframe_enabled(nullptr, true));
     EXPECT_FALSE(sdl3d_set_depth_planes(nullptr, 0.1f, 100.0f));
     EXPECT_FALSE(sdl3d_is_in_mode_3d(nullptr));
+    EXPECT_FALSE(sdl3d_is_backface_culling_enabled(nullptr));
+    EXPECT_FALSE(sdl3d_is_wireframe_enabled(nullptr));
 }
 
 /* --- Drawing / readback -------------------------------------------------- */
@@ -251,6 +255,55 @@ TEST_F(SDL3DDrawingFixture, DrawTriangleFacingCameraPaintsPixels)
     sdl3d_destroy_render_context(ctx);
 }
 
+TEST_F(SDL3DDrawingFixture, BackfaceCullingRejectsBackfacingTriangle)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    EXPECT_FALSE(sdl3d_is_backface_culling_enabled(ctx));
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(ctx, true));
+    EXPECT_TRUE(sdl3d_is_backface_culling_enabled(ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_triangle_3d(ctx, sdl3d_vec3_make(0.0f, 0.5f, 0.0f), sdl3d_vec3_make(0.5f, -0.5f, 0.0f),
+                                       sdl3d_vec3_make(-0.5f, -0.5f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    EXPECT_EQ(CountColor(ctx, kRed), 0);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, WireframeLeavesTriangleInteriorUntouched)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_set_wireframe_enabled(ctx, true));
+    EXPECT_TRUE(sdl3d_is_wireframe_enabled(ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_triangle_3d(ctx, sdl3d_vec3_make(-0.5f, -0.5f, 0.0f), sdl3d_vec3_make(0.5f, -0.5f, 0.0f),
+                                       sdl3d_vec3_make(0.0f, 0.5f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    EXPECT_GT(CountColor(ctx, kRed), 0);
+
+    const int cx = sdl3d_get_render_context_width(ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(ctx) / 2;
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, cx, cy, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlack));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
 TEST_F(SDL3DDrawingFixture, DepthOrderingNearOverFar)
 {
     WindowRenderer wr(64, 64);
@@ -288,6 +341,71 @@ TEST_F(SDL3DDrawingFixture, ClearResetsDepthBuffer)
     float d = 0.0f;
     ASSERT_TRUE(sdl3d_get_framebuffer_depth(ctx, 0, 0, &d));
     EXPECT_FLOAT_EQ(d, 1.0f);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, ScissorRestrictsRasterizationToClippedRegion)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    const SDL_Rect scissor = {32, 32, 1, 1};
+    ASSERT_TRUE(sdl3d_set_scissor_rect(ctx, &scissor));
+    EXPECT_TRUE(sdl3d_is_scissor_enabled(ctx));
+
+    SDL_Rect queried{};
+    ASSERT_TRUE(sdl3d_get_scissor_rect(ctx, &queried));
+    EXPECT_EQ(queried.x, scissor.x);
+    EXPECT_EQ(queried.y, scissor.y);
+    EXPECT_EQ(queried.w, scissor.w);
+    EXPECT_EQ(queried.h, scissor.h);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_triangle_3d(ctx, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, -1.0f, 0.0f),
+                                       sdl3d_vec3_make(0.0f, 1.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    EXPECT_EQ(CountColor(ctx, kRed), 1);
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kRed));
+
+    ASSERT_TRUE(sdl3d_set_scissor_rect(ctx, nullptr));
+    EXPECT_FALSE(sdl3d_is_scissor_enabled(ctx));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, ClearRectClearsOnlyRequestedRegionAndResetsDepth)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    const SDL_Rect rect = {28, 28, 8, 8};
+    ASSERT_TRUE(sdl3d_clear_render_context_rect(ctx, &rect, kBlue));
+
+    sdl3d_color cleared{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &cleared));
+    EXPECT_TRUE(PixelEquals(cleared, kBlue));
+
+    sdl3d_color untouched{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 4, 4, &untouched));
+    EXPECT_TRUE(PixelEquals(untouched, kBlack));
+
+    float depth = 0.0f;
+    ASSERT_TRUE(sdl3d_get_framebuffer_depth(ctx, 32, 32, &depth));
+    EXPECT_FLOAT_EQ(depth, 1.0f);
 
     sdl3d_destroy_render_context(ctx);
 }

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -352,7 +352,9 @@ TEST_F(SDL3DDrawingFixture, ScissorRestrictsDrawingToClippedRegion)
     sdl3d_render_context *ctx = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
 
-    const SDL_Rect scissor = {32, 32, 1, 1};
+    const int cx = sdl3d_get_render_context_width(ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(ctx) / 2;
+    const SDL_Rect scissor = {cx, cy, 1, 1};
     ASSERT_TRUE(sdl3d_set_scissor_rect(ctx, &scissor));
     EXPECT_TRUE(sdl3d_is_scissor_enabled(ctx));
 
@@ -370,9 +372,9 @@ TEST_F(SDL3DDrawingFixture, ScissorRestrictsDrawingToClippedRegion)
 
     EXPECT_EQ(CountColor(ctx, kRed), 1);
     sdl3d_color c{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, cx, cy, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 31, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, cx - 1, cy, &c));
     EXPECT_TRUE(PixelEquals(c, kBlack));
 
     ASSERT_TRUE(sdl3d_set_scissor_rect(ctx, nullptr));

--- a/tests/test_rasterizer.cpp
+++ b/tests/test_rasterizer.cpp
@@ -106,6 +106,25 @@ TEST(SDL3DFramebuffer, AccessorsRejectOutOfBounds)
     EXPECT_FALSE(sdl3d_framebuffer_get_depth(&f.fb, kW, 0, &d));
 }
 
+TEST(SDL3DFramebuffer, ClearRectOnlyTouchesRequestedPixels)
+{
+    Framebuffer f;
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+
+    const SDL_Rect rect = {4, 5, 3, 2};
+    sdl3d_framebuffer_clear_rect(&f.fb, &rect, kBlue, 0.25f);
+
+    for (int y = 0; y < kH; ++y)
+    {
+        for (int x = 0; x < kW; ++x)
+        {
+            const bool in_rect = (x >= rect.x) && (x < rect.x + rect.w) && (y >= rect.y) && (y < rect.y + rect.h);
+            EXPECT_TRUE(PixelEquals(f.GetPixel(x, y), in_rect ? kBlue : kBlack));
+            EXPECT_FLOAT_EQ(f.GetDepth(x, y), in_rect ? 0.25f : 1.0f);
+        }
+    }
+}
+
 /* --- Triangle coverage --------------------------------------------------- */
 
 TEST(SDL3DRasterizeTriangle, FullscreenTriangleCoversAllPixels)
@@ -115,7 +134,7 @@ TEST(SDL3DRasterizeTriangle, FullscreenTriangleCoversAllPixels)
     const sdl3d_mat4 id = sdl3d_mat4_identity();
     // Oversized triangle (NDC) that covers the whole viewport [-1, 1]^2.
     sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, 0.0f), sdl3d_vec3_make(3.0f, -1.0f, 0.0f),
-                             sdl3d_vec3_make(0.0f, 3.0f, 0.0f), kRed);
+                             sdl3d_vec3_make(0.0f, 3.0f, 0.0f), kRed, false, false);
     EXPECT_EQ(CountPixelsEqual(f, kRed), kW * kH);
 }
 
@@ -126,7 +145,7 @@ TEST(SDL3DRasterizeTriangle, BehindNearPlaneProducesNoPixels)
     const sdl3d_mat4 id = sdl3d_mat4_identity();
     // z = -2 in NDC means clip-space z < -w, entirely behind near plane.
     sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-1.0f, -1.0f, -2.0f), sdl3d_vec3_make(1.0f, -1.0f, -2.0f),
-                             sdl3d_vec3_make(0.0f, 1.0f, -2.0f), kRed);
+                             sdl3d_vec3_make(0.0f, 1.0f, -2.0f), kRed, false, false);
     EXPECT_EQ(CountPixelsEqual(f, kRed), 0);
 }
 
@@ -137,7 +156,7 @@ TEST(SDL3DRasterizeTriangle, DegenerateTriangleProducesNoPixels)
     const sdl3d_mat4 id = sdl3d_mat4_identity();
     // Collinear vertices: zero area.
     sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-0.5f, -0.5f, 0.0f), sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
-                             sdl3d_vec3_make(0.5f, 0.5f, 0.0f), kRed);
+                             sdl3d_vec3_make(0.5f, 0.5f, 0.0f), kRed, false, false);
     EXPECT_EQ(CountPixelsEqual(f, kRed), 0);
 }
 
@@ -148,9 +167,9 @@ TEST(SDL3DRasterizeTriangle, DepthTestNearHidesFar)
     const sdl3d_mat4 id = sdl3d_mat4_identity();
     // Far triangle first (z = 0.5), then near (z = -0.5). Near must win.
     sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, 0.5f), sdl3d_vec3_make(3.0f, -1.0f, 0.5f),
-                             sdl3d_vec3_make(0.0f, 3.0f, 0.5f), kBlue);
+                             sdl3d_vec3_make(0.0f, 3.0f, 0.5f), kBlue, false, false);
     sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, -0.5f), sdl3d_vec3_make(3.0f, -1.0f, -0.5f),
-                             sdl3d_vec3_make(0.0f, 3.0f, -0.5f), kRed);
+                             sdl3d_vec3_make(0.0f, 3.0f, -0.5f), kRed, false, false);
     EXPECT_EQ(CountPixelsEqual(f, kRed), kW * kH);
     EXPECT_EQ(CountPixelsEqual(f, kBlue), 0);
 
@@ -158,9 +177,9 @@ TEST(SDL3DRasterizeTriangle, DepthTestNearHidesFar)
     Framebuffer g;
     sdl3d_framebuffer_clear(&g.fb, kBlack, 1.0f);
     sdl3d_rasterize_triangle(&g.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, -0.5f), sdl3d_vec3_make(3.0f, -1.0f, -0.5f),
-                             sdl3d_vec3_make(0.0f, 3.0f, -0.5f), kRed);
+                             sdl3d_vec3_make(0.0f, 3.0f, -0.5f), kRed, false, false);
     sdl3d_rasterize_triangle(&g.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, 0.5f), sdl3d_vec3_make(3.0f, -1.0f, 0.5f),
-                             sdl3d_vec3_make(0.0f, 3.0f, 0.5f), kBlue);
+                             sdl3d_vec3_make(0.0f, 3.0f, 0.5f), kBlue, false, false);
     EXPECT_EQ(CountPixelsEqual(g, kRed), kW * kH);
     EXPECT_EQ(CountPixelsEqual(g, kBlue), 0);
 }
@@ -179,11 +198,11 @@ TEST(SDL3DRasterizeTriangle, AdjacentTrianglesNoGapsNoOverlap)
     const sdl3d_vec3 bl = sdl3d_vec3_make(-1.0f, -1.0f, 0.0f);
 
     // First triangle: tl, tr, br. Uses kRed. Writes depth 0.
-    sdl3d_rasterize_triangle(&f.fb, id, tl, tr, br, kRed);
+    sdl3d_rasterize_triangle(&f.fb, id, tl, tr, br, kRed, false, false);
     // Second triangle: tl, br, bl. Uses kBlue. Due to depth test (<=)
     // pixels shared across the diagonal go to whichever writes first;
     // the fill rule ensures no pixel is actually shared.
-    sdl3d_rasterize_triangle(&f.fb, id, tl, br, bl, kBlue);
+    sdl3d_rasterize_triangle(&f.fb, id, tl, br, bl, kBlue, false, false);
 
     const int red = CountPixelsEqual(f, kRed);
     const int blue = CountPixelsEqual(f, kBlue);
@@ -311,6 +330,45 @@ TEST(SDL3DRasterizeTriangle, TriangleStraddlingNearPlaneRenders)
     const sdl3d_vec3 v1 = sdl3d_vec3_make(-1.0f, -1.0f, -0.3f);
     const sdl3d_vec3 v2 = sdl3d_vec3_make(1.0f, -1.0f, -0.3f);
 
-    sdl3d_rasterize_triangle(&f.fb, proj, v0, v1, v2, kRed);
+    sdl3d_rasterize_triangle(&f.fb, proj, v0, v1, v2, kRed, false, false);
     EXPECT_GT(CountPixelsEqual(f, kRed), 0);
+}
+
+TEST(SDL3DRasterizeTriangle, BackfaceCullingRejectsClockwiseScreenFaces)
+{
+    Framebuffer f;
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+    const sdl3d_mat4 id = sdl3d_mat4_identity();
+
+    sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(0.0f, 0.5f, 0.0f), sdl3d_vec3_make(0.5f, -0.5f, 0.0f),
+                             sdl3d_vec3_make(-0.5f, -0.5f, 0.0f), kRed, true, false);
+    EXPECT_EQ(CountPixelsEqual(f, kRed), 0);
+}
+
+TEST(SDL3DRasterizeTriangle, WireframeDrawsEdgesWithoutFillingInterior)
+{
+    Framebuffer f;
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+    const sdl3d_mat4 id = sdl3d_mat4_identity();
+
+    sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-0.5f, -0.5f, 0.0f), sdl3d_vec3_make(0.5f, -0.5f, 0.0f),
+                             sdl3d_vec3_make(0.0f, 0.5f, 0.0f), kRed, false, true);
+
+    EXPECT_GT(CountPixelsEqual(f, kRed), 0);
+    EXPECT_TRUE(PixelEquals(f.GetPixel(kW / 2, kH / 2), kBlack));
+}
+
+TEST(SDL3DRasterizeTriangle, ScissorClipsTriangleCoverage)
+{
+    Framebuffer f;
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+    f.fb.scissor_enabled = true;
+    f.fb.scissor_rect = SDL_Rect{8, 8, 1, 1};
+
+    const sdl3d_mat4 id = sdl3d_mat4_identity();
+    sdl3d_rasterize_triangle(&f.fb, id, sdl3d_vec3_make(-3.0f, -1.0f, 0.0f), sdl3d_vec3_make(3.0f, -1.0f, 0.0f),
+                             sdl3d_vec3_make(0.0f, 3.0f, 0.0f), kRed, false, false);
+
+    EXPECT_EQ(CountPixelsEqual(f, kRed), 1);
+    EXPECT_TRUE(PixelEquals(f.GetPixel(8, 8), kRed));
 }

--- a/tests/test_render_context_unit.cpp
+++ b/tests/test_render_context_unit.cpp
@@ -84,6 +84,15 @@ TEST(SDL3DRenderContextConfig, InitRenderContextConfigRejectsNull)
     EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'config' is invalid"), std::string_view::npos);
 }
 
+TEST(SDL3DRenderContextState, NullStateAccessorsAreRejected)
+{
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_set_scissor_rect(nullptr, nullptr));
+    EXPECT_FALSE(sdl3d_is_scissor_enabled(nullptr));
+    EXPECT_FALSE(sdl3d_get_scissor_rect(nullptr, reinterpret_cast<SDL_Rect *>(0x1)));
+    EXPECT_FALSE(sdl3d_clear_render_context_rect(nullptr, reinterpret_cast<const SDL_Rect *>(0x1), sdl3d_color{}));
+}
+
 TEST(SDL3DBackendName, MapsKnownBackendsToStableStrings)
 {
     EXPECT_EQ(std::string_view("auto"), sdl3d_get_backend_name(SDL3D_BACKEND_AUTO));


### PR DESCRIPTION
## Summary
- add software-renderer state for backface culling, wireframe mode, scissor rects, and clear-rect operations
- teach the rasterizer to apply culling and wireframe on the clipped polygon so frustum-clipped primitives still render correctly
- add direct rasterizer coverage for the new controls plus public API tests for the new renderer state

## Validation
- cmake --preset default
- cmake --build --preset default
- ctest --preset default -R '^(SDL3DFramebuffer|SDL3DRasterizeTriangle|SDL3DRasterizeLine|SDL3DRasterizePoint|SDL3DRenderContextState|SDL3DDrawing3DNull)\\.' --output-on-failure

## Notes
- SDL window-backed tests could not run in this local macOS session because SDL video init failed with "The video driver did not add any displays."
- The pure software rasterizer and null-guard/unit coverage for this slice passed locally.