### PR TITLE
Add immediate-mode model matrix stack

### DIFF
--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -29,6 +29,20 @@ extern "C"
     bool sdl3d_is_wireframe_enabled(const sdl3d_render_context *context);
 
     /*
+     * Matrix stack for immediate-mode model transforms. These functions are
+     * only valid between sdl3d_begin_mode_3d and sdl3d_end_mode_3d.
+     *
+     * The current model matrix starts as identity when 3D mode begins.
+     * Transform mutators post-multiply the current model matrix, so calling
+     * translate, then rotate, then scale produces Model = T * R * S.
+     */
+    bool sdl3d_push_matrix(sdl3d_render_context *context);
+    bool sdl3d_pop_matrix(sdl3d_render_context *context);
+    bool sdl3d_translate(sdl3d_render_context *context, float x, float y, float z);
+    bool sdl3d_rotate(sdl3d_render_context *context, sdl3d_vec3 axis, float angle_radians);
+    bool sdl3d_scale(sdl3d_render_context *context, float x, float y, float z);
+
+    /*
      * Override the depth planes used by sdl3d_begin_mode_3d. Must be called
      * before begin_mode_3d. near_plane and far_plane must satisfy 0 < near < far.
      * Defaults: near=0.01, far=1000.

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1,9 +1,55 @@
 #include "sdl3d/drawing3d.h"
 
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
 
 #include "rasterizer.h"
 #include "render_context_internal.h"
+
+static const int SDL3D_MODEL_STACK_INITIAL_CAPACITY = 8;
+
+static bool sdl3d_ensure_model_stack_capacity(sdl3d_render_context *context, int required_depth)
+{
+    if (context->model_stack_capacity >= required_depth)
+    {
+        return true;
+    }
+
+    int new_capacity = context->model_stack_capacity;
+    if (new_capacity <= 0)
+    {
+        new_capacity = SDL3D_MODEL_STACK_INITIAL_CAPACITY;
+    }
+
+    while (new_capacity < required_depth)
+    {
+        new_capacity *= 2;
+    }
+
+    sdl3d_mat4 *new_stack = (sdl3d_mat4 *)SDL_realloc(context->model_stack, (size_t)new_capacity * sizeof(*new_stack));
+    if (new_stack == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    context->model_stack = new_stack;
+    context->model_stack_capacity = new_capacity;
+    return true;
+}
+
+static void sdl3d_update_current_model_matrices(sdl3d_render_context *context)
+{
+    if (context->model_stack_depth <= 0)
+    {
+        context->model = sdl3d_mat4_identity();
+    }
+    else
+    {
+        context->model = context->model_stack[context->model_stack_depth - 1];
+    }
+
+    context->model_view_projection = sdl3d_mat4_multiply(context->view_projection, context->model);
+}
 
 bool sdl3d_begin_mode_3d(sdl3d_render_context *context, sdl3d_camera3d camera)
 {
@@ -24,6 +70,14 @@ bool sdl3d_begin_mode_3d(sdl3d_render_context *context, sdl3d_camera3d camera)
     }
 
     context->view_projection = sdl3d_mat4_multiply(context->projection, context->view);
+    if (!sdl3d_ensure_model_stack_capacity(context, 1))
+    {
+        return false;
+    }
+
+    context->model_stack_depth = 1;
+    context->model_stack[0] = sdl3d_mat4_identity();
+    sdl3d_update_current_model_matrices(context);
     context->in_mode_3d = true;
     return true;
 }
@@ -41,6 +95,9 @@ bool sdl3d_end_mode_3d(sdl3d_render_context *context)
     }
 
     context->in_mode_3d = false;
+    context->model_stack_depth = 0;
+    context->model = sdl3d_mat4_identity();
+    context->model_view_projection = context->view_projection;
     return true;
 }
 
@@ -132,6 +189,88 @@ static bool sdl3d_require_mode_3d(const sdl3d_render_context *context, const cha
     return true;
 }
 
+bool sdl3d_push_matrix(sdl3d_render_context *context)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_push_matrix"))
+    {
+        return false;
+    }
+
+    if (!sdl3d_ensure_model_stack_capacity(context, context->model_stack_depth + 1))
+    {
+        return false;
+    }
+
+    context->model_stack[context->model_stack_depth] = context->model_stack[context->model_stack_depth - 1];
+    context->model_stack_depth += 1;
+    sdl3d_update_current_model_matrices(context);
+    return true;
+}
+
+bool sdl3d_pop_matrix(sdl3d_render_context *context)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_pop_matrix"))
+    {
+        return false;
+    }
+
+    if (context->model_stack_depth <= 1)
+    {
+        return SDL_SetError("sdl3d_pop_matrix cannot pop the root model matrix.");
+    }
+
+    context->model_stack_depth -= 1;
+    sdl3d_update_current_model_matrices(context);
+    return true;
+}
+
+bool sdl3d_translate(sdl3d_render_context *context, float x, float y, float z)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_translate"))
+    {
+        return false;
+    }
+
+    const sdl3d_mat4 translation = sdl3d_mat4_translate(sdl3d_vec3_make(x, y, z));
+    context->model_stack[context->model_stack_depth - 1] =
+        sdl3d_mat4_multiply(context->model_stack[context->model_stack_depth - 1], translation);
+    sdl3d_update_current_model_matrices(context);
+    return true;
+}
+
+bool sdl3d_rotate(sdl3d_render_context *context, sdl3d_vec3 axis, float angle_radians)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_rotate"))
+    {
+        return false;
+    }
+
+    if (!(sdl3d_vec3_length_squared(axis) > 0.0f))
+    {
+        return SDL_SetError("sdl3d_rotate requires a non-zero rotation axis.");
+    }
+
+    const sdl3d_mat4 rotation = sdl3d_mat4_rotate(axis, angle_radians);
+    context->model_stack[context->model_stack_depth - 1] =
+        sdl3d_mat4_multiply(context->model_stack[context->model_stack_depth - 1], rotation);
+    sdl3d_update_current_model_matrices(context);
+    return true;
+}
+
+bool sdl3d_scale(sdl3d_render_context *context, float x, float y, float z)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_scale"))
+    {
+        return false;
+    }
+
+    const sdl3d_mat4 scale = sdl3d_mat4_scale(sdl3d_vec3_make(x, y, z));
+    context->model_stack[context->model_stack_depth - 1] =
+        sdl3d_mat4_multiply(context->model_stack[context->model_stack_depth - 1], scale);
+    sdl3d_update_current_model_matrices(context);
+    return true;
+}
+
 bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2,
                             sdl3d_color color)
 {
@@ -141,7 +280,7 @@ bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_
     }
 
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
-    sdl3d_rasterize_triangle(&framebuffer, context->view_projection, v0, v1, v2, color,
+    sdl3d_rasterize_triangle(&framebuffer, context->model_view_projection, v0, v1, v2, color,
                              context->backface_culling_enabled, context->wireframe_enabled);
     return true;
 }
@@ -154,7 +293,7 @@ bool sdl3d_draw_line_3d(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_v
     }
 
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
-    sdl3d_rasterize_line(&framebuffer, context->view_projection, start, end, color);
+    sdl3d_rasterize_line(&framebuffer, context->model_view_projection, start, end, color);
     return true;
 }
 
@@ -166,7 +305,7 @@ bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl
     }
 
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
-    sdl3d_rasterize_point(&framebuffer, context->view_projection, position, color);
+    sdl3d_rasterize_point(&framebuffer, context->model_view_projection, position, color);
     return true;
 }
 

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -258,13 +258,18 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     context->near_plane = SDL3D_DEFAULT_NEAR_PLANE;
     context->far_plane = SDL3D_DEFAULT_FAR_PLANE;
     context->in_mode_3d = false;
+    context->model_stack = NULL;
+    context->model_stack_depth = 0;
+    context->model_stack_capacity = 0;
     context->backface_culling_enabled = false;
     context->wireframe_enabled = false;
     context->scissor_enabled = false;
     context->scissor_rect = (SDL_Rect){0, 0, render_width, render_height};
+    context->model = sdl3d_mat4_identity();
     context->view = sdl3d_mat4_identity();
     context->projection = sdl3d_mat4_identity();
     context->view_projection = sdl3d_mat4_identity();
+    context->model_view_projection = sdl3d_mat4_identity();
     sdl3d_try_create_parallel_rasterizer(context);
 
     *out_context = context;
@@ -279,6 +284,7 @@ void sdl3d_destroy_render_context(sdl3d_render_context *context)
     }
 
     sdl3d_parallel_rasterizer_destroy(context->parallel_rasterizer);
+    SDL_free(context->model_stack);
     SDL_DestroyTexture(context->color_texture);
     SDL_free(context->color_buffer);
     SDL_free(context->depth_buffer);

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -32,13 +32,18 @@ struct sdl3d_render_context
     float far_plane;
 
     bool in_mode_3d;
+    sdl3d_mat4 *model_stack;
+    int model_stack_depth;
+    int model_stack_capacity;
     bool backface_culling_enabled;
     bool wireframe_enabled;
     bool scissor_enabled;
     SDL_Rect scissor_rect;
+    sdl3d_mat4 model;
     sdl3d_mat4 view;
     sdl3d_mat4 projection;
     sdl3d_mat4 view_projection;
+    sdl3d_mat4 model_view_projection;
 };
 
 static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_context *context)

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -81,6 +81,17 @@ sdl3d_camera3d MakeCamera(float fovy_degrees = 60.0f)
     return cam;
 }
 
+sdl3d_camera3d MakeOrthoCamera(float view_height = 4.0f)
+{
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(0.0f, 0.0f, 3.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = view_height;
+    cam.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
+    return cam;
+}
+
 bool PixelEquals(sdl3d_color a, sdl3d_color b)
 {
     return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
@@ -198,12 +209,47 @@ TEST(SDL3DDrawing3DNull, NullContextIsRejected)
     EXPECT_FALSE(sdl3d_begin_mode_3d(nullptr, MakeCamera()));
     EXPECT_FALSE(sdl3d_end_mode_3d(nullptr));
     EXPECT_FALSE(sdl3d_draw_point_3d(nullptr, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
+    EXPECT_FALSE(sdl3d_push_matrix(nullptr));
+    EXPECT_FALSE(sdl3d_pop_matrix(nullptr));
+    EXPECT_FALSE(sdl3d_translate(nullptr, 1.0f, 2.0f, 3.0f));
+    EXPECT_FALSE(sdl3d_rotate(nullptr, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), sdl3d_degrees_to_radians(45.0f)));
+    EXPECT_FALSE(sdl3d_scale(nullptr, 2.0f, 2.0f, 2.0f));
     EXPECT_FALSE(sdl3d_set_backface_culling_enabled(nullptr, true));
     EXPECT_FALSE(sdl3d_set_wireframe_enabled(nullptr, true));
     EXPECT_FALSE(sdl3d_set_depth_planes(nullptr, 0.1f, 100.0f));
     EXPECT_FALSE(sdl3d_is_in_mode_3d(nullptr));
     EXPECT_FALSE(sdl3d_is_backface_culling_enabled(nullptr));
     EXPECT_FALSE(sdl3d_is_wireframe_enabled(nullptr));
+}
+
+TEST_F(SDL3DDrawingFixture, MatrixStackMutatorsRejectedOutsideMode)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_push_matrix(ctx));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_pop_matrix(ctx));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_translate(ctx, 1.0f, 0.0f, 0.0f));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_rotate(ctx, sdl3d_vec3_make(0.0f, 0.0f, 1.0f), sdl3d_degrees_to_radians(90.0f)));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_scale(ctx, 2.0f, 1.0f, 1.0f));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    sdl3d_destroy_render_context(ctx);
 }
 
 /* --- Drawing / readback -------------------------------------------------- */
@@ -251,6 +297,139 @@ TEST_F(SDL3DDrawingFixture, DrawTriangleFacingCameraPaintsPixels)
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, cx, cy, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, TranslateMovesPointUnderOrthographicCamera)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_translate(ctx, 1.0f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlack));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, RotateTransformsPointsAroundOrigin)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_rotate(ctx, sdl3d_vec3_make(0.0f, 0.0f, 1.0f), sdl3d_degrees_to_radians(90.0f)));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(1.0f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 16, &c));
+    EXPECT_TRUE(PixelEquals(c, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlack));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, ScaleTransformsPointsUnderOrthographicCamera)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_scale(ctx, 2.0f, 1.0f, 1.0f));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.5f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 40, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlack));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, PushPopRestoresPreviousTransform)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_translate(ctx, 0.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_push_matrix(ctx));
+    ASSERT_TRUE(sdl3d_translate(ctx, 0.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_pop_matrix(ctx));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color c{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 40, 32, &c));
+    EXPECT_TRUE(PixelEquals(c, kBlue));
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, MatrixStackGrowsDynamicallyAndRejectsRootPop)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    for (int i = 0; i < 40; ++i)
+    {
+        ASSERT_TRUE(sdl3d_push_matrix(ctx));
+    }
+    for (int i = 0; i < 40; ++i)
+    {
+        ASSERT_TRUE(sdl3d_pop_matrix(ctx));
+    }
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_pop_matrix(ctx));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DDrawingFixture, RotateRejectsZeroAxis)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_rotate(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_degrees_to_radians(45.0f)));
+    EXPECT_NE(*SDL_GetError(), '\0');
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
     sdl3d_destroy_render_context(ctx);
 }

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -139,6 +139,21 @@ SDL_Point ProjectPointToFramebuffer(const sdl3d_render_context *ctx, sdl3d_camer
     return out;
 }
 
+float FramebufferAspect(const sdl3d_render_context *ctx)
+{
+    return (float)sdl3d_get_render_context_width(ctx) / (float)sdl3d_get_render_context_height(ctx);
+}
+
+float OrthoHalfHeight(sdl3d_camera3d camera)
+{
+    return camera.fovy * 0.5f;
+}
+
+float OrthoHalfWidth(const sdl3d_render_context *ctx, sdl3d_camera3d camera)
+{
+    return OrthoHalfHeight(camera) * FramebufferAspect(ctx);
+}
+
 constexpr sdl3d_color kBlack = {0, 0, 0, 255};
 constexpr sdl3d_color kRed = {255, 0, 0, 255};
 constexpr sdl3d_color kBlue = {0, 0, 255, 255};
@@ -330,15 +345,17 @@ TEST_F(SDL3DDrawingFixture, TranslateMovesPointUnderOrthographicCamera)
     ASSERT_TRUE(wr.ok());
     sdl3d_render_context *ctx = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+    const sdl3d_camera3d camera = MakeOrthoCamera();
+    const float translate_x = OrthoHalfWidth(ctx, camera) * 0.5f;
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
-    ASSERT_TRUE(sdl3d_translate(ctx, 1.0f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, camera));
+    ASSERT_TRUE(sdl3d_translate(ctx, translate_x, 0.0f, 0.0f));
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    const SDL_Point translated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
-    const SDL_Point origin = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const SDL_Point translated = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(translate_x, 0.0f, 0.0f));
+    const SDL_Point origin = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
 
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, translated.x, translated.y, &c));
@@ -355,15 +372,17 @@ TEST_F(SDL3DDrawingFixture, RotateTransformsPointsAroundOrigin)
     ASSERT_TRUE(wr.ok());
     sdl3d_render_context *ctx = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+    const sdl3d_camera3d camera = MakeOrthoCamera();
+    const float radius = std::fmin(OrthoHalfWidth(ctx, camera), OrthoHalfHeight(camera)) * 0.5f;
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, camera));
     ASSERT_TRUE(sdl3d_rotate(ctx, sdl3d_vec3_make(0.0f, 0.0f, 1.0f), sdl3d_degrees_to_radians(90.0f)));
-    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(1.0f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(radius, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    const SDL_Point rotated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.0f, 1.0f, 0.0f));
-    const SDL_Point unrotated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    const SDL_Point rotated = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(0.0f, radius, 0.0f));
+    const SDL_Point unrotated = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(radius, 0.0f, 0.0f));
 
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, rotated.x, rotated.y, &c));
@@ -380,15 +399,18 @@ TEST_F(SDL3DDrawingFixture, ScaleTransformsPointsUnderOrthographicCamera)
     ASSERT_TRUE(wr.ok());
     sdl3d_render_context *ctx = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+    const sdl3d_camera3d camera = MakeOrthoCamera();
+    const float scaled_x = OrthoHalfWidth(ctx, camera) * 0.5f;
+    const float local_x = scaled_x * 0.5f;
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, camera));
     ASSERT_TRUE(sdl3d_scale(ctx, 2.0f, 1.0f, 1.0f));
-    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.5f, 0.0f, 0.0f), kRed));
+    ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(local_x, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    const SDL_Point scaled = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
-    const SDL_Point unscaled = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.5f, 0.0f, 0.0f));
+    const SDL_Point scaled = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(scaled_x, 0.0f, 0.0f));
+    const SDL_Point unscaled = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(local_x, 0.0f, 0.0f));
 
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, scaled.x, scaled.y, &c));
@@ -405,19 +427,22 @@ TEST_F(SDL3DDrawingFixture, PushPopRestoresPreviousTransform)
     ASSERT_TRUE(wr.ok());
     sdl3d_render_context *ctx = nullptr;
     ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+    const sdl3d_camera3d camera = MakeOrthoCamera();
+    const float base_x = OrthoHalfWidth(ctx, camera) * 0.25f;
+    const float pushed_x = base_x * 2.0f;
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeOrthoCamera()));
-    ASSERT_TRUE(sdl3d_translate(ctx, 0.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, camera));
+    ASSERT_TRUE(sdl3d_translate(ctx, base_x, 0.0f, 0.0f));
     ASSERT_TRUE(sdl3d_push_matrix(ctx));
-    ASSERT_TRUE(sdl3d_translate(ctx, 0.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_translate(ctx, base_x, 0.0f, 0.0f));
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_pop_matrix(ctx));
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kBlue));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    const SDL_Point red_point = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
-    const SDL_Point blue_point = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.5f, 0.0f, 0.0f));
+    const SDL_Point red_point = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(pushed_x, 0.0f, 0.0f));
+    const SDL_Point blue_point = ProjectPointToFramebuffer(ctx, camera, sdl3d_vec3_make(base_x, 0.0f, 0.0f));
 
     sdl3d_color c{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, red_point.x, red_point.y, &c));

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -15,6 +15,7 @@ extern "C"
 #include "sdl3d/sdl3d.h"
 }
 
+#include <cmath>
 #include <memory>
 
 namespace
@@ -114,6 +115,28 @@ int CountColor(sdl3d_render_context *ctx, sdl3d_color c)
         }
     }
     return n;
+}
+
+SDL_Point ProjectPointToFramebuffer(const sdl3d_render_context *ctx, sdl3d_camera3d camera, sdl3d_vec3 point)
+{
+    sdl3d_mat4 view{};
+    sdl3d_mat4 projection{};
+    EXPECT_TRUE(sdl3d_camera3d_compute_matrices(&camera, sdl3d_get_render_context_width(ctx),
+                                                sdl3d_get_render_context_height(ctx), 0.01f, 1000.0f, &view,
+                                                &projection));
+
+    const sdl3d_mat4 view_projection = sdl3d_mat4_multiply(projection, view);
+    const sdl3d_vec4 clip = sdl3d_mat4_transform_vec4(view_projection, sdl3d_vec4_from_vec3(point, 1.0f));
+    const float inverse_w = 1.0f / clip.w;
+    const float ndc_x = clip.x * inverse_w;
+    const float ndc_y = clip.y * inverse_w;
+    const float screen_x = (ndc_x + 1.0f) * 0.5f * (float)sdl3d_get_render_context_width(ctx);
+    const float screen_y = (1.0f - ndc_y) * 0.5f * (float)sdl3d_get_render_context_height(ctx);
+
+    SDL_Point out{};
+    out.x = (int)std::lround(screen_x);
+    out.y = (int)std::lround(screen_y);
+    return out;
 }
 
 constexpr sdl3d_color kBlack = {0, 0, 0, 255};
@@ -314,10 +337,13 @@ TEST_F(SDL3DDrawingFixture, TranslateMovesPointUnderOrthographicCamera)
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
+    const SDL_Point translated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    const SDL_Point origin = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+
     sdl3d_color c{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, translated.x, translated.y, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, origin.x, origin.y, &c));
     EXPECT_TRUE(PixelEquals(c, kBlack));
 
     sdl3d_destroy_render_context(ctx);
@@ -336,10 +362,13 @@ TEST_F(SDL3DDrawingFixture, RotateTransformsPointsAroundOrigin)
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(1.0f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
+    const SDL_Point rotated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.0f, 1.0f, 0.0f));
+    const SDL_Point unrotated = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+
     sdl3d_color c{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 16, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, rotated.x, rotated.y, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, unrotated.x, unrotated.y, &c));
     EXPECT_TRUE(PixelEquals(c, kBlack));
 
     sdl3d_destroy_render_context(ctx);
@@ -358,10 +387,13 @@ TEST_F(SDL3DDrawingFixture, ScaleTransformsPointsUnderOrthographicCamera)
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.5f, 0.0f, 0.0f), kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
+    const SDL_Point scaled = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    const SDL_Point unscaled = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.5f, 0.0f, 0.0f));
+
     sdl3d_color c{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, scaled.x, scaled.y, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 40, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, unscaled.x, unscaled.y, &c));
     EXPECT_TRUE(PixelEquals(c, kBlack));
 
     sdl3d_destroy_render_context(ctx);
@@ -384,10 +416,13 @@ TEST_F(SDL3DDrawingFixture, PushPopRestoresPreviousTransform)
     ASSERT_TRUE(sdl3d_draw_point_3d(ctx, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), kBlue));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
+    const SDL_Point red_point = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    const SDL_Point blue_point = ProjectPointToFramebuffer(ctx, MakeOrthoCamera(), sdl3d_vec3_make(0.5f, 0.0f, 0.0f));
+
     sdl3d_color c{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, red_point.x, red_point.y, &c));
     EXPECT_TRUE(PixelEquals(c, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 40, 32, &c));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, blue_point.x, blue_point.y, &c));
     EXPECT_TRUE(PixelEquals(c, kBlue));
 
     sdl3d_destroy_render_context(ctx);


### PR DESCRIPTION
## Summary
- add a dynamic immediate-mode model matrix stack with `sdl3d_push_matrix`, `sdl3d_pop_matrix`, `sdl3d_translate`, `sdl3d_rotate`, and `sdl3d_scale`
- apply the current model transform to every 3D draw call through a cached `view_projection * model` matrix on the render context
- add integration coverage for translate, rotate, scale, push/pop restoration, dynamic stack growth, outside-mode rejection, and zero-axis rotate rejection

## Validation
- ./scripts/check_clang_format.sh
- cmake --build --preset default
- ctest --preset default -L unit --output-on-failure
- ./build/default/tests/sdl3d_drawing3d_test '--gtest_filter=SDL3DDrawing3DNull.*'

## Notes
- The new transform behavior tests live in `tests/test_drawing3d.cpp`, but they could not be run end-to-end in this local macOS session because SDL video init fails here with "The video driver did not add any displays." CI covers those window-backed tests.