### PR TITLE
Add immediate-mode shape primitives (M2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ target_sources(
         src/rasterizer.c
         src/render_context.c
         src/sdl3d.c
+        src/shapes.c
 )
 
 target_compile_features(sdl3d PUBLIC c_std_17)

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -10,6 +10,7 @@
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/math.h"
 #include "sdl3d/render_context.h"
+#include "sdl3d/shapes.h"
 #include "sdl3d/types.h"
 
 #ifdef __cplusplus

--- a/include/sdl3d/shapes.h
+++ b/include/sdl3d/shapes.h
@@ -1,0 +1,99 @@
+#ifndef SDL3D_SHAPES_H
+#define SDL3D_SHAPES_H
+
+#include <stdbool.h>
+
+#include "sdl3d/render_context.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /*
+     * Immediate-mode shape primitives. Every function in this header must
+     * be called between sdl3d_begin_mode_3d and sdl3d_end_mode_3d, and
+     * every primitive is transformed by the current model matrix stack.
+     *
+     * Solid primitives emit triangles with counter-clockwise winding
+     * around the outward normal, so backface culling is safe to enable.
+     * Wire primitives emit lines and ignore the backface-culling flag.
+     *
+     * Tessellated primitives accept explicit subdivision counts rather
+     * than picking defaults for the caller. A slice count is the number
+     * of longitudinal segments around an axis; a ring count is the number
+     * of latitudinal segments along an axis. Both must be >= 3 where they
+     * define a closed loop, and >= 2 where they define an open fan.
+     */
+
+    /*
+     * Axis-aligned cube centered at `center` with per-axis extents given
+     * by `size`. Size components must be non-negative.
+     */
+    bool sdl3d_draw_cube(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+    bool sdl3d_draw_cube_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+
+    /*
+     * Planar quad in the local XZ plane, centered at `center`, with
+     * outward normal +Y. `size` gives the extent along local X and Z.
+     */
+    bool sdl3d_draw_plane(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color);
+
+    /*
+     * Grid in the local XZ plane centered at the origin. Draws
+     * `slices + 1` lines per axis. `slices` must be >= 1 and `spacing`
+     * must be positive.
+     */
+    bool sdl3d_draw_grid(sdl3d_render_context *context, int slices, float spacing, sdl3d_color color);
+
+    /*
+     * Line segment from ray.position to ray.position + ray.direction.
+     * The direction is drawn as-is; callers control the displayed length
+     * through its magnitude.
+     */
+    bool sdl3d_draw_ray(sdl3d_render_context *context, sdl3d_ray ray, sdl3d_color color);
+
+    /*
+     * Wireframe of an axis-aligned bounding box (12 edges). Requires
+     * box.min.x <= box.max.x, box.min.y <= box.max.y, box.min.z <= box.max.z.
+     */
+    bool sdl3d_draw_bounding_box(sdl3d_render_context *context, sdl3d_bounding_box box, sdl3d_color color);
+
+    /*
+     * UV sphere centered at `center` with the given radius. `rings` is
+     * the number of latitudinal bands between the poles (must be >= 2),
+     * `slices` the number of longitudinal divisions (must be >= 3).
+     */
+    bool sdl3d_draw_sphere(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                           sdl3d_color color);
+    bool sdl3d_draw_sphere_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                                 sdl3d_color color);
+
+    /*
+     * Cylinder (or truncated cone when top and bottom radii differ)
+     * aligned with the local +Y axis, centered vertically at `center`.
+     * `slices` must be >= 3. Both radii must be non-negative; a zero
+     * radius produces a cone endpoint. `height` must be non-negative.
+     */
+    bool sdl3d_draw_cylinder(sdl3d_render_context *context, sdl3d_vec3 center, float radius_top, float radius_bottom,
+                             float height, int slices, sdl3d_color color);
+    bool sdl3d_draw_cylinder_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius_top,
+                                   float radius_bottom, float height, int slices, sdl3d_color color);
+
+    /*
+     * Capsule: a cylinder between `start` and `end` capped by two
+     * hemispheres of `radius`. `slices` must be >= 3, `rings` must be
+     * >= 1 (rings per hemisphere). If start == end, the capsule
+     * collapses to a sphere.
+     */
+    bool sdl3d_draw_capsule(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius, int slices,
+                            int rings, sdl3d_color color);
+    bool sdl3d_draw_capsule_wires(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius,
+                                  int slices, int rings, sdl3d_color color);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/types.h
+++ b/include/sdl3d/types.h
@@ -42,4 +42,25 @@ typedef struct sdl3d_mat4
     float m[16];
 } sdl3d_mat4;
 
+/*
+ * Ray defined by an origin and a direction. The direction is drawn at
+ * the magnitude the caller supplies; it is not normalized.
+ */
+typedef struct sdl3d_ray
+{
+    sdl3d_vec3 position;
+    sdl3d_vec3 direction;
+} sdl3d_ray;
+
+/*
+ * Axis-aligned bounding box in the coordinate frame where it is drawn.
+ * The current model matrix is applied, so an AABB in local space can be
+ * rendered in any world orientation.
+ */
+typedef struct sdl3d_bounding_box
+{
+    sdl3d_vec3 min;
+    sdl3d_vec3 max;
+} sdl3d_bounding_box;
+
 #endif

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -1,0 +1,604 @@
+#include "sdl3d/shapes.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/drawing3d.h"
+#include "sdl3d/math.h"
+
+static const float SDL3D_SHAPES_PI = 3.14159265358979323846f;
+
+static bool sdl3d_shape_require_finite(float value, const char *label, const char *function)
+{
+    if (!SDL_isinf(value) && !SDL_isnan(value))
+    {
+        return true;
+    }
+    return SDL_SetError("%s requires a finite %s.", function, label);
+}
+
+static bool sdl3d_shape_require_nonnegative(float value, const char *label, const char *function)
+{
+    if (!sdl3d_shape_require_finite(value, label, function))
+    {
+        return false;
+    }
+    if (value < 0.0f)
+    {
+        return SDL_SetError("%s requires %s >= 0.", function, label);
+    }
+    return true;
+}
+
+static bool sdl3d_shape_require_positive(float value, const char *label, const char *function)
+{
+    if (!sdl3d_shape_require_finite(value, label, function))
+    {
+        return false;
+    }
+    if (!(value > 0.0f))
+    {
+        return SDL_SetError("%s requires %s > 0.", function, label);
+    }
+    return true;
+}
+
+/*
+ * Build a right-handed orthonormal basis {tangent, bitangent, axis}
+ * from a unit axis. `axis` must be normalized. The tangent direction is
+ * arbitrary but stable; capsules only need a consistent cross-section
+ * frame, not any particular texture orientation.
+ */
+static void sdl3d_shape_basis_from_axis(sdl3d_vec3 axis, sdl3d_vec3 *out_tangent, sdl3d_vec3 *out_bitangent)
+{
+    sdl3d_vec3 reference = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    if (SDL_fabsf(axis.y) > 0.9f)
+    {
+        reference = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    }
+    sdl3d_vec3 tangent = sdl3d_vec3_normalize(sdl3d_vec3_cross(reference, axis));
+    sdl3d_vec3 bitangent = sdl3d_vec3_cross(axis, tangent);
+    *out_tangent = tangent;
+    *out_bitangent = bitangent;
+}
+
+static sdl3d_vec3 sdl3d_shape_circle_point(sdl3d_vec3 center, sdl3d_vec3 tangent, sdl3d_vec3 bitangent, float radius,
+                                           float angle_radians)
+{
+    const float c = SDL_cosf(angle_radians);
+    const float s = SDL_sinf(angle_radians);
+    sdl3d_vec3 result = center;
+    result = sdl3d_vec3_add(result, sdl3d_vec3_scale(tangent, c * radius));
+    result = sdl3d_vec3_add(result, sdl3d_vec3_scale(bitangent, s * radius));
+    return result;
+}
+
+bool sdl3d_draw_cube(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_cube") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_cube") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_cube"))
+    {
+        return false;
+    }
+
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float hz = size.z * 0.5f;
+
+    /*
+     * Corner indices encoded as bit patterns: bit 0 = +X, bit 1 = +Y,
+     * bit 2 = +Z. Every quad below lists the four corners in CCW order
+     * when viewed from outside along the face normal. The faces are
+     * expanded into two triangles each.
+     */
+    const sdl3d_vec3 c[8] = {
+        {center.x - hx, center.y - hy, center.z - hz}, {center.x + hx, center.y - hy, center.z - hz},
+        {center.x - hx, center.y + hy, center.z - hz}, {center.x + hx, center.y + hy, center.z - hz},
+        {center.x - hx, center.y - hy, center.z + hz}, {center.x + hx, center.y - hy, center.z + hz},
+        {center.x - hx, center.y + hy, center.z + hz}, {center.x + hx, center.y + hy, center.z + hz},
+    };
+
+    static const int faces[6][4] = {
+        {4, 5, 7, 6}, /* +Z */
+        {1, 0, 2, 3}, /* -Z */
+        {5, 1, 3, 7}, /* +X */
+        {0, 4, 6, 2}, /* -X */
+        {6, 7, 3, 2}, /* +Y */
+        {0, 1, 5, 4}, /* -Y */
+    };
+
+    for (int f = 0; f < 6; ++f)
+    {
+        const sdl3d_vec3 a = c[faces[f][0]];
+        const sdl3d_vec3 b = c[faces[f][1]];
+        const sdl3d_vec3 d = c[faces[f][2]];
+        const sdl3d_vec3 e = c[faces[f][3]];
+        if (!sdl3d_draw_triangle_3d(context, a, b, d, color))
+        {
+            return false;
+        }
+        if (!sdl3d_draw_triangle_3d(context, a, d, e, color))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_cube_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_cube_wires") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_cube_wires") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_cube_wires"))
+    {
+        return false;
+    }
+
+    sdl3d_bounding_box box;
+    box.min = sdl3d_vec3_make(center.x - size.x * 0.5f, center.y - size.y * 0.5f, center.z - size.z * 0.5f);
+    box.max = sdl3d_vec3_make(center.x + size.x * 0.5f, center.y + size.y * 0.5f, center.z + size.z * 0.5f);
+    return sdl3d_draw_bounding_box(context, box, color);
+}
+
+bool sdl3d_draw_plane(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_plane") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_plane"))
+    {
+        return false;
+    }
+
+    const float hx = size.x * 0.5f;
+    const float hz = size.y * 0.5f;
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(center.x - hx, center.y, center.z + hz);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(center.x + hx, center.y, center.z + hz);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(center.x + hx, center.y, center.z - hz);
+    const sdl3d_vec3 v3 = sdl3d_vec3_make(center.x - hx, center.y, center.z - hz);
+
+    if (!sdl3d_draw_triangle_3d(context, v0, v1, v2, color))
+    {
+        return false;
+    }
+    return sdl3d_draw_triangle_3d(context, v0, v2, v3, color);
+}
+
+bool sdl3d_draw_grid(sdl3d_render_context *context, int slices, float spacing, sdl3d_color color)
+{
+    if (slices < 1)
+    {
+        return SDL_SetError("sdl3d_draw_grid requires slices >= 1.");
+    }
+    if (!sdl3d_shape_require_positive(spacing, "spacing", "sdl3d_draw_grid"))
+    {
+        return false;
+    }
+
+    const float half = (float)slices * spacing * 0.5f;
+    for (int i = 0; i <= slices; ++i)
+    {
+        const float offset = -half + (float)i * spacing;
+        const sdl3d_vec3 a = sdl3d_vec3_make(-half, 0.0f, offset);
+        const sdl3d_vec3 b = sdl3d_vec3_make(half, 0.0f, offset);
+        const sdl3d_vec3 c = sdl3d_vec3_make(offset, 0.0f, -half);
+        const sdl3d_vec3 d = sdl3d_vec3_make(offset, 0.0f, half);
+        if (!sdl3d_draw_line_3d(context, a, b, color))
+        {
+            return false;
+        }
+        if (!sdl3d_draw_line_3d(context, c, d, color))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_ray(sdl3d_render_context *context, sdl3d_ray ray, sdl3d_color color)
+{
+    const sdl3d_vec3 end = sdl3d_vec3_add(ray.position, ray.direction);
+    return sdl3d_draw_line_3d(context, ray.position, end, color);
+}
+
+bool sdl3d_draw_bounding_box(sdl3d_render_context *context, sdl3d_bounding_box box, sdl3d_color color)
+{
+    if (!(box.min.x <= box.max.x) || !(box.min.y <= box.max.y) || !(box.min.z <= box.max.z))
+    {
+        return SDL_SetError("sdl3d_draw_bounding_box requires min <= max componentwise.");
+    }
+
+    const sdl3d_vec3 corners[8] = {
+        {box.min.x, box.min.y, box.min.z}, {box.max.x, box.min.y, box.min.z}, {box.min.x, box.max.y, box.min.z},
+        {box.max.x, box.max.y, box.min.z}, {box.min.x, box.min.y, box.max.z}, {box.max.x, box.min.y, box.max.z},
+        {box.min.x, box.max.y, box.max.z}, {box.max.x, box.max.y, box.max.z},
+    };
+
+    /* Each edge lists the two corner indices it connects. */
+    static const int edges[12][2] = {
+        {0, 1}, {2, 3}, {4, 5}, {6, 7}, /* X-aligned */
+        {0, 2}, {1, 3}, {4, 6}, {5, 7}, /* Y-aligned */
+        {0, 4}, {1, 5}, {2, 6}, {3, 7}, /* Z-aligned */
+    };
+
+    for (int i = 0; i < 12; ++i)
+    {
+        if (!sdl3d_draw_line_3d(context, corners[edges[i][0]], corners[edges[i][1]], color))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static sdl3d_vec3 sdl3d_sphere_point(sdl3d_vec3 center, float radius, float theta, float phi)
+{
+    const float sin_t = SDL_sinf(theta);
+    const float cos_t = SDL_cosf(theta);
+    const float sin_p = SDL_sinf(phi);
+    const float cos_p = SDL_cosf(phi);
+    return sdl3d_vec3_make(center.x + radius * sin_t * cos_p, center.y + radius * cos_t,
+                           center.z + radius * sin_t * sin_p);
+}
+
+bool sdl3d_draw_sphere(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                       sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_sphere"))
+    {
+        return false;
+    }
+    if (rings < 2)
+    {
+        return SDL_SetError("sdl3d_draw_sphere requires rings >= 2.");
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_sphere requires slices >= 3.");
+    }
+
+    for (int i = 0; i < rings; ++i)
+    {
+        const float theta1 = SDL3D_SHAPES_PI * (float)i / (float)rings;
+        const float theta2 = SDL3D_SHAPES_PI * (float)(i + 1) / (float)rings;
+        for (int j = 0; j < slices; ++j)
+        {
+            const float phi1 = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+            const float phi2 = 2.0f * SDL3D_SHAPES_PI * (float)(j + 1) / (float)slices;
+
+            const sdl3d_vec3 v00 = sdl3d_sphere_point(center, radius, theta1, phi1);
+            const sdl3d_vec3 v01 = sdl3d_sphere_point(center, radius, theta1, phi2);
+            const sdl3d_vec3 v10 = sdl3d_sphere_point(center, radius, theta2, phi1);
+            const sdl3d_vec3 v11 = sdl3d_sphere_point(center, radius, theta2, phi2);
+
+            if (!sdl3d_draw_triangle_3d(context, v00, v01, v11, color))
+            {
+                return false;
+            }
+            if (!sdl3d_draw_triangle_3d(context, v00, v11, v10, color))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_sphere_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                             sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_sphere_wires"))
+    {
+        return false;
+    }
+    if (rings < 2)
+    {
+        return SDL_SetError("sdl3d_draw_sphere_wires requires rings >= 2.");
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_sphere_wires requires slices >= 3.");
+    }
+
+    /* Interior latitude rings (excluding the degenerate poles). */
+    for (int i = 1; i < rings; ++i)
+    {
+        const float theta = SDL3D_SHAPES_PI * (float)i / (float)rings;
+        sdl3d_vec3 previous = sdl3d_sphere_point(center, radius, theta, 0.0f);
+        for (int j = 1; j <= slices; ++j)
+        {
+            const float phi = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+            const sdl3d_vec3 next = sdl3d_sphere_point(center, radius, theta, phi);
+            if (!sdl3d_draw_line_3d(context, previous, next, color))
+            {
+                return false;
+            }
+            previous = next;
+        }
+    }
+
+    /* Meridians from north to south pole. */
+    for (int j = 0; j < slices; ++j)
+    {
+        const float phi = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+        sdl3d_vec3 previous = sdl3d_sphere_point(center, radius, 0.0f, phi);
+        for (int i = 1; i <= rings; ++i)
+        {
+            const float theta = SDL3D_SHAPES_PI * (float)i / (float)rings;
+            const sdl3d_vec3 next = sdl3d_sphere_point(center, radius, theta, phi);
+            if (!sdl3d_draw_line_3d(context, previous, next, color))
+            {
+                return false;
+            }
+            previous = next;
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_cylinder(sdl3d_render_context *context, sdl3d_vec3 center, float radius_top, float radius_bottom,
+                         float height, int slices, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius_top, "radius_top", "sdl3d_draw_cylinder") ||
+        !sdl3d_shape_require_nonnegative(radius_bottom, "radius_bottom", "sdl3d_draw_cylinder") ||
+        !sdl3d_shape_require_nonnegative(height, "height", "sdl3d_draw_cylinder"))
+    {
+        return false;
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_cylinder requires slices >= 3.");
+    }
+
+    const float hh = height * 0.5f;
+    const sdl3d_vec3 top_center = sdl3d_vec3_make(center.x, center.y + hh, center.z);
+    const sdl3d_vec3 bottom_center = sdl3d_vec3_make(center.x, center.y - hh, center.z);
+    const sdl3d_vec3 tangent = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 bitangent = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
+
+    for (int j = 0; j < slices; ++j)
+    {
+        const float phi1 = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+        const float phi2 = 2.0f * SDL3D_SHAPES_PI * (float)(j + 1) / (float)slices;
+
+        const sdl3d_vec3 top1 = sdl3d_shape_circle_point(top_center, tangent, bitangent, radius_top, phi1);
+        const sdl3d_vec3 top2 = sdl3d_shape_circle_point(top_center, tangent, bitangent, radius_top, phi2);
+        const sdl3d_vec3 bot1 = sdl3d_shape_circle_point(bottom_center, tangent, bitangent, radius_bottom, phi1);
+        const sdl3d_vec3 bot2 = sdl3d_shape_circle_point(bottom_center, tangent, bitangent, radius_bottom, phi2);
+
+        /* Side: outward-facing, CCW from outside. */
+        if (!sdl3d_draw_triangle_3d(context, bot1, top1, top2, color))
+        {
+            return false;
+        }
+        if (!sdl3d_draw_triangle_3d(context, bot1, top2, bot2, color))
+        {
+            return false;
+        }
+
+        /* Top cap (+Y outward): CCW from +Y requires order (center, v_{j+1}, v_j). */
+        if (radius_top > 0.0f)
+        {
+            if (!sdl3d_draw_triangle_3d(context, top_center, top2, top1, color))
+            {
+                return false;
+            }
+        }
+        /* Bottom cap (-Y outward): opposite winding. */
+        if (radius_bottom > 0.0f)
+        {
+            if (!sdl3d_draw_triangle_3d(context, bottom_center, bot1, bot2, color))
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_cylinder_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius_top, float radius_bottom,
+                               float height, int slices, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius_top, "radius_top", "sdl3d_draw_cylinder_wires") ||
+        !sdl3d_shape_require_nonnegative(radius_bottom, "radius_bottom", "sdl3d_draw_cylinder_wires") ||
+        !sdl3d_shape_require_nonnegative(height, "height", "sdl3d_draw_cylinder_wires"))
+    {
+        return false;
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_cylinder_wires requires slices >= 3.");
+    }
+
+    const float hh = height * 0.5f;
+    const sdl3d_vec3 top_center = sdl3d_vec3_make(center.x, center.y + hh, center.z);
+    const sdl3d_vec3 bottom_center = sdl3d_vec3_make(center.x, center.y - hh, center.z);
+    const sdl3d_vec3 tangent = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 bitangent = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
+
+    for (int j = 0; j < slices; ++j)
+    {
+        const float phi1 = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+        const float phi2 = 2.0f * SDL3D_SHAPES_PI * (float)(j + 1) / (float)slices;
+
+        const sdl3d_vec3 top1 = sdl3d_shape_circle_point(top_center, tangent, bitangent, radius_top, phi1);
+        const sdl3d_vec3 top2 = sdl3d_shape_circle_point(top_center, tangent, bitangent, radius_top, phi2);
+        const sdl3d_vec3 bot1 = sdl3d_shape_circle_point(bottom_center, tangent, bitangent, radius_bottom, phi1);
+        const sdl3d_vec3 bot2 = sdl3d_shape_circle_point(bottom_center, tangent, bitangent, radius_bottom, phi2);
+
+        if (radius_top > 0.0f && !sdl3d_draw_line_3d(context, top1, top2, color))
+        {
+            return false;
+        }
+        if (radius_bottom > 0.0f && !sdl3d_draw_line_3d(context, bot1, bot2, color))
+        {
+            return false;
+        }
+        if (!sdl3d_draw_line_3d(context, bot1, top1, color))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/*
+ * A capsule is a tube of `rings+1` ring samples up each hemisphere with
+ * a single quad band connecting the two equators (which collapses to a
+ * seam when start == end). Ring index 0 is the pole near `end`; ring
+ * index 2*rings+1 is the pole near `start`. Rings 0..rings live on the
+ * `end` hemisphere, rings rings+1..2*rings+1 live on the `start`
+ * hemisphere, and the quad band between ring `rings` and ring `rings+1`
+ * forms the cylindrical side.
+ */
+static bool sdl3d_draw_capsule_solid(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius,
+                                     int slices, int rings, sdl3d_color color, bool wireframe)
+{
+    sdl3d_vec3 axis_vec = sdl3d_vec3_sub(end, start);
+    const float length = sdl3d_vec3_length(axis_vec);
+    sdl3d_vec3 axis;
+    if (length > 0.0f)
+    {
+        axis = sdl3d_vec3_scale(axis_vec, 1.0f / length);
+    }
+    else
+    {
+        axis = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    }
+
+    sdl3d_vec3 tangent;
+    sdl3d_vec3 bitangent;
+    sdl3d_shape_basis_from_axis(axis, &tangent, &bitangent);
+
+    const int total_rings = 2 * rings + 2; /* ring samples, 0..total_rings-1 */
+    for (int i = 0; i + 1 < total_rings; ++i)
+    {
+        float r_this;
+        float along_this;
+        sdl3d_vec3 center_this;
+        float r_next;
+        float along_next;
+        sdl3d_vec3 center_next;
+
+        /*
+         * Evaluate ring `k`: returns its circle radius around the axis
+         * and a center point in world space. Rings 0..rings ride on
+         * `end`; rings rings+1..2*rings+1 ride on `start`.
+         */
+        for (int pass = 0; pass < 2; ++pass)
+        {
+            const int k = i + pass;
+            float r;
+            float along;
+            sdl3d_vec3 c;
+            if (k <= rings)
+            {
+                const float hemisphere_t = (float)k / (float)rings; /* 0 at pole, 1 at equator */
+                const float theta_h = SDL3D_SHAPES_PI * 0.5f * hemisphere_t;
+                r = radius * SDL_sinf(theta_h);
+                along = radius * SDL_cosf(theta_h);
+                c = sdl3d_vec3_add(end, sdl3d_vec3_scale(axis, along));
+            }
+            else
+            {
+                const int kb = k - (rings + 1);                      /* 0 at start equator, rings at start pole */
+                const float hemisphere_t = (float)kb / (float)rings; /* 0..1 */
+                const float theta_h = SDL3D_SHAPES_PI * 0.5f * hemisphere_t;
+                r = radius * SDL_cosf(theta_h);
+                along = -radius * SDL_sinf(theta_h);
+                c = sdl3d_vec3_add(start, sdl3d_vec3_scale(axis, along));
+            }
+            if (pass == 0)
+            {
+                r_this = r;
+                along_this = along;
+                center_this = c;
+            }
+            else
+            {
+                r_next = r;
+                along_next = along;
+                center_next = c;
+            }
+        }
+        (void)along_this;
+        (void)along_next;
+
+        for (int j = 0; j < slices; ++j)
+        {
+            const float phi1 = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)slices;
+            const float phi2 = 2.0f * SDL3D_SHAPES_PI * (float)(j + 1) / (float)slices;
+
+            const sdl3d_vec3 v00 = sdl3d_shape_circle_point(center_this, tangent, bitangent, r_this, phi1);
+            const sdl3d_vec3 v01 = sdl3d_shape_circle_point(center_this, tangent, bitangent, r_this, phi2);
+            const sdl3d_vec3 v10 = sdl3d_shape_circle_point(center_next, tangent, bitangent, r_next, phi1);
+            const sdl3d_vec3 v11 = sdl3d_shape_circle_point(center_next, tangent, bitangent, r_next, phi2);
+
+            if (wireframe)
+            {
+                if (r_this > 0.0f && !sdl3d_draw_line_3d(context, v00, v01, color))
+                {
+                    return false;
+                }
+                if (!sdl3d_draw_line_3d(context, v00, v10, color))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                /*
+                 * sdl3d_shape_basis_from_axis orients phi so that rotation is
+                 * CCW when viewed from +axis, which is opposite to the sphere
+                 * parameterization used above. Swap v01 and v10 so the
+                 * outward normal matches the capsule's exterior.
+                 */
+                if (!sdl3d_draw_triangle_3d(context, v00, v10, v11, color))
+                {
+                    return false;
+                }
+                if (!sdl3d_draw_triangle_3d(context, v00, v11, v01, color))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+bool sdl3d_draw_capsule(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius, int slices,
+                        int rings, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_capsule"))
+    {
+        return false;
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_capsule requires slices >= 3.");
+    }
+    if (rings < 1)
+    {
+        return SDL_SetError("sdl3d_draw_capsule requires rings >= 1.");
+    }
+    return sdl3d_draw_capsule_solid(context, start, end, radius, slices, rings, color, false);
+}
+
+bool sdl3d_draw_capsule_wires(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius, int slices,
+                              int rings, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_capsule_wires"))
+    {
+        return false;
+    }
+    if (slices < 3)
+    {
+        return SDL_SetError("sdl3d_draw_capsule_wires requires slices >= 3.");
+    }
+    if (rings < 1)
+    {
+        return SDL_SetError("sdl3d_draw_capsule_wires requires rings >= 1.");
+    }
+    return sdl3d_draw_capsule_solid(context, start, end, radius, slices, rings, color, true);
+}

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -469,59 +469,44 @@ static bool sdl3d_draw_capsule_solid(sdl3d_render_context *context, sdl3d_vec3 s
     sdl3d_vec3 bitangent;
     sdl3d_shape_basis_from_axis(axis, &tangent, &bitangent);
 
-    const int total_rings = 2 * rings + 2; /* ring samples, 0..total_rings-1 */
+    /*
+     * Ring `k` sits on `end` for k in [0, rings] and on `start` for k in
+     * [rings+1, 2*rings+1]. The quad band between ring `rings` and ring
+     * `rings+1` forms the cylindrical side; it collapses to a seam when
+     * start == end.
+     */
+    struct ring_sample
+    {
+        float radius;
+        sdl3d_vec3 center;
+    };
+    const int total_rings = 2 * rings + 2;
     for (int i = 0; i + 1 < total_rings; ++i)
     {
-        float r_this;
-        float along_this;
-        sdl3d_vec3 center_this;
-        float r_next;
-        float along_next;
-        sdl3d_vec3 center_next;
-
-        /*
-         * Evaluate ring `k`: returns its circle radius around the axis
-         * and a center point in world space. Rings 0..rings ride on
-         * `end`; rings rings+1..2*rings+1 ride on `start`.
-         */
+        struct ring_sample samples[2] = {0};
         for (int pass = 0; pass < 2; ++pass)
         {
             const int k = i + pass;
-            float r;
-            float along;
-            sdl3d_vec3 c;
             if (k <= rings)
             {
                 const float hemisphere_t = (float)k / (float)rings; /* 0 at pole, 1 at equator */
                 const float theta_h = SDL3D_SHAPES_PI * 0.5f * hemisphere_t;
-                r = radius * SDL_sinf(theta_h);
-                along = radius * SDL_cosf(theta_h);
-                c = sdl3d_vec3_add(end, sdl3d_vec3_scale(axis, along));
+                samples[pass].radius = radius * SDL_sinf(theta_h);
+                samples[pass].center = sdl3d_vec3_add(end, sdl3d_vec3_scale(axis, radius * SDL_cosf(theta_h)));
             }
             else
             {
-                const int kb = k - (rings + 1);                      /* 0 at start equator, rings at start pole */
+                const int kb = k - (rings + 1);                      /* 0 at start equator, rings at pole */
                 const float hemisphere_t = (float)kb / (float)rings; /* 0..1 */
                 const float theta_h = SDL3D_SHAPES_PI * 0.5f * hemisphere_t;
-                r = radius * SDL_cosf(theta_h);
-                along = -radius * SDL_sinf(theta_h);
-                c = sdl3d_vec3_add(start, sdl3d_vec3_scale(axis, along));
-            }
-            if (pass == 0)
-            {
-                r_this = r;
-                along_this = along;
-                center_this = c;
-            }
-            else
-            {
-                r_next = r;
-                along_next = along;
-                center_next = c;
+                samples[pass].radius = radius * SDL_cosf(theta_h);
+                samples[pass].center = sdl3d_vec3_add(start, sdl3d_vec3_scale(axis, -radius * SDL_sinf(theta_h)));
             }
         }
-        (void)along_this;
-        (void)along_next;
+        const float r_this = samples[0].radius;
+        const float r_next = samples[1].radius;
+        const sdl3d_vec3 center_this = samples[0].center;
+        const sdl3d_vec3 center_next = samples[1].center;
 
         for (int j = 0; j < slices; ++j)
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SDL3D_TEST_SOURCES
     test_render_context.cpp
     test_drawing3d.cpp
     test_render_loop.cpp
+    test_shapes.cpp
 )
 
 if(ANDROID)
@@ -133,4 +134,5 @@ else()
     sdl3d_add_test(sdl3d_render_context_test test_render_context.cpp render)
     sdl3d_add_test(sdl3d_drawing3d_test test_drawing3d.cpp render)
     sdl3d_add_test(sdl3d_render_loop_test test_render_loop.cpp render)
+    sdl3d_add_test(sdl3d_shapes_test test_shapes.cpp render)
 endif()

--- a/tests/test_shapes.cpp
+++ b/tests/test_shapes.cpp
@@ -1,0 +1,594 @@
+/*
+ * Integration tests for the immediate-mode shape primitives. Each
+ * primitive renders to a real SDL render context and we check
+ * coverage/visibility, winding correctness under backface culling, and
+ * composition with the model matrix stack.
+ */
+
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <cmath>
+#include <memory>
+
+namespace
+{
+class SDL3DShapesFixture : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        SDL_ClearError();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        SDL_Quit();
+    }
+};
+
+class WindowRenderer
+{
+  public:
+    WindowRenderer(int width = 128, int height = 128)
+        : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *w = nullptr;
+        SDL_Renderer *r = nullptr;
+        if (!SDL_CreateWindowAndRenderer("SDL3D Shapes Test", width, height, 0, &w, &r))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+        window_.reset(w);
+        renderer_.reset(r);
+    }
+
+    bool ok() const
+    {
+        return window_ && renderer_;
+    }
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+constexpr sdl3d_color kBlack = {0, 0, 0, 255};
+constexpr sdl3d_color kRed = {255, 0, 0, 255};
+constexpr sdl3d_color kGreen = {0, 255, 0, 255};
+constexpr sdl3d_color kBlue = {0, 0, 255, 255};
+
+bool PixelEquals(sdl3d_color a, sdl3d_color b)
+{
+    return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+}
+
+int CountColor(sdl3d_render_context *ctx, sdl3d_color c)
+{
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    int n = 0;
+    for (int y = 0; y < h; ++y)
+    {
+        for (int x = 0; x < w; ++x)
+        {
+            sdl3d_color px{};
+            if (sdl3d_get_framebuffer_pixel(ctx, x, y, &px) && PixelEquals(px, c))
+            {
+                ++n;
+            }
+        }
+    }
+    return n;
+}
+
+sdl3d_camera3d MakeCamera(sdl3d_vec3 eye = {0.0f, 0.0f, 4.0f})
+{
+    sdl3d_camera3d cam{};
+    cam.position = eye;
+    cam.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return cam;
+}
+
+struct ContextOwner
+{
+    sdl3d_render_context *ctx = nullptr;
+    ~ContextOwner()
+    {
+        if (ctx)
+        {
+            sdl3d_destroy_render_context(ctx);
+        }
+    }
+};
+} // namespace
+
+/* --- Argument validation ------------------------------------------------- */
+
+TEST_F(SDL3DShapesFixture, RejectsNegativeCubeSize)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(-1, 1, 1), kRed));
+    EXPECT_NE(*SDL_GetError(), '\0');
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+}
+
+TEST_F(SDL3DShapesFixture, RejectsBadSphereTessellation)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    EXPECT_FALSE(sdl3d_draw_sphere(c.ctx, sdl3d_vec3_make(0, 0, 0), 1.0f, 1, 8, kRed));
+    EXPECT_FALSE(sdl3d_draw_sphere(c.ctx, sdl3d_vec3_make(0, 0, 0), 1.0f, 4, 2, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+}
+
+TEST_F(SDL3DShapesFixture, RejectsInvertedBoundingBox)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    sdl3d_bounding_box bad{sdl3d_vec3_make(1, 0, 0), sdl3d_vec3_make(0, 1, 1)};
+    EXPECT_FALSE(sdl3d_draw_bounding_box(c.ctx, bad, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+}
+
+TEST_F(SDL3DShapesFixture, RejectsOutsideMode3d)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1, 1, 1), kRed));
+    EXPECT_NE(*SDL_GetError(), '\0');
+}
+
+/* --- Cube ---------------------------------------------------------------- */
+
+TEST_F(SDL3DShapesFixture, SolidCubeCoversCenter)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kRed));
+    EXPECT_GT(CountColor(c.ctx, kRed), 100);
+}
+
+TEST_F(SDL3DShapesFixture, CubeFacesAreOutwardUnderBackfaceCulling)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    /* With culling on and all faces outward, the front face is still visible. */
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kRed));
+}
+
+TEST_F(SDL3DShapesFixture, CubeFacesAreOutwardFromEachDirection)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+
+    /*
+     * Orbit the camera around each of the six cardinal directions. With
+     * all faces outward-CCW, every direction must leave the center pixel
+     * covered by the cube. If any face were inverted this would fail
+     * from exactly one direction.
+     */
+    const sdl3d_vec3 eyes[] = {
+        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4), sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(-4, 0, 0), sdl3d_vec3_make(0, 4, 0.001f), sdl3d_vec3_make(0, -4, 0.001f),
+    };
+    for (const auto &eye : eyes)
+    {
+        ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+        ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera(eye)));
+        ASSERT_TRUE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f), kRed));
+        ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+        const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+        const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+        sdl3d_color p{};
+        ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+        EXPECT_TRUE(PixelEquals(p, kRed))
+            << "Eye (" << eye.x << ", " << eye.y << ", " << eye.z << ") shows the cube as missing.";
+    }
+}
+
+TEST_F(SDL3DShapesFixture, CubeWiresLeaveInteriorBlank)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_cube_wires(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f), kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    EXPECT_GT(CountColor(c.ctx, kGreen), 0);
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kBlack));
+}
+
+/* --- Plane / grid / ray -------------------------------------------------- */
+
+TEST_F(SDL3DShapesFixture, PlaneVisibleFromAbove)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+
+    sdl3d_camera3d cam = MakeCamera(sdl3d_vec3_make(0, 4, 0.001f));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, cam));
+    sdl3d_vec2 size{2.0f, 2.0f};
+    ASSERT_TRUE(sdl3d_draw_plane(c.ctx, sdl3d_vec3_make(0, 0, 0), size, kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kBlue));
+}
+
+TEST_F(SDL3DShapesFixture, PlaneCulledFromBelow)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+
+    sdl3d_camera3d cam = MakeCamera(sdl3d_vec3_make(0, -4, 0.001f));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, cam));
+    sdl3d_vec2 size{2.0f, 2.0f};
+    ASSERT_TRUE(sdl3d_draw_plane(c.ctx, sdl3d_vec3_make(0, 0, 0), size, kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    EXPECT_EQ(CountColor(c.ctx, kBlue), 0);
+}
+
+TEST_F(SDL3DShapesFixture, GridDrawsLines)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    sdl3d_camera3d cam = MakeCamera(sdl3d_vec3_make(0, 3, 3));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, cam));
+    ASSERT_TRUE(sdl3d_draw_grid(c.ctx, 10, 0.5f, kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    EXPECT_GT(CountColor(c.ctx, kGreen), 20);
+}
+
+TEST_F(SDL3DShapesFixture, GridRejectsBadArguments)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    EXPECT_FALSE(sdl3d_draw_grid(c.ctx, 0, 1.0f, kGreen));
+    EXPECT_FALSE(sdl3d_draw_grid(c.ctx, 4, 0.0f, kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+}
+
+TEST_F(SDL3DShapesFixture, RayDrawsLineSegment)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    sdl3d_ray ray{sdl3d_vec3_make(-0.6f, 0.0f, 0.0f), sdl3d_vec3_make(1.2f, 0.0f, 0.0f)};
+    ASSERT_TRUE(sdl3d_draw_ray(c.ctx, ray, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    EXPECT_GT(CountColor(c.ctx, kRed), 10);
+}
+
+TEST_F(SDL3DShapesFixture, BoundingBoxDrawsTwelveEdges)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    sdl3d_bounding_box box{sdl3d_vec3_make(-0.5f, -0.5f, -0.5f), sdl3d_vec3_make(0.5f, 0.5f, 0.5f)};
+    ASSERT_TRUE(sdl3d_draw_bounding_box(c.ctx, box, kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    EXPECT_GT(CountColor(c.ctx, kGreen), 0);
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kBlack));
+}
+
+/* --- Sphere / cylinder / capsule ---------------------------------------- */
+
+TEST_F(SDL3DShapesFixture, SolidSphereHasOutwardFaces)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    const sdl3d_vec3 eyes[] = {
+        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4), sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(-4, 0, 0), sdl3d_vec3_make(0, 4, 0.001f),
+    };
+    for (const auto &eye : eyes)
+    {
+        ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+        ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera(eye)));
+        ASSERT_TRUE(sdl3d_draw_sphere(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.7f, 10, 18, kRed));
+        ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+        const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+        const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+        sdl3d_color p{};
+        ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+        EXPECT_TRUE(PixelEquals(p, kRed))
+            << "Eye (" << eye.x << ", " << eye.y << ", " << eye.z << ") shows the sphere as missing.";
+    }
+}
+
+TEST_F(SDL3DShapesFixture, SphereWiresDrawWithoutFilling)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_sphere_wires(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.7f, 6, 12, kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int total = sdl3d_get_render_context_width(c.ctx) * sdl3d_get_render_context_height(c.ctx);
+    const int green = CountColor(c.ctx, kGreen);
+    EXPECT_GT(green, 0);
+    EXPECT_LT(green, total / 2);
+}
+
+TEST_F(SDL3DShapesFixture, SolidCylinderHasOutwardFaces)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+
+    const sdl3d_vec3 eyes[] = {
+        sdl3d_vec3_make(0, 0, 4),
+        sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(0, 4, 0.001f),
+        sdl3d_vec3_make(0, -4, 0.001f),
+    };
+    for (const auto &eye : eyes)
+    {
+        ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+        ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera(eye)));
+        ASSERT_TRUE(sdl3d_draw_cylinder(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 0.5f, 1.2f, 16, kRed));
+        ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+        const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+        const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+        sdl3d_color p{};
+        ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+        EXPECT_TRUE(PixelEquals(p, kRed))
+            << "Eye (" << eye.x << ", " << eye.y << ", " << eye.z << ") shows the cylinder as missing.";
+    }
+}
+
+TEST_F(SDL3DShapesFixture, ConeDrawsAsTruncatedCylinder)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    /* Cone: top radius 0, bottom radius 0.6. */
+    ASSERT_TRUE(sdl3d_draw_cylinder(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.0f, 0.6f, 1.2f, 16, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kRed));
+}
+
+TEST_F(SDL3DShapesFixture, SolidCapsuleHasOutwardFaces)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+
+    const sdl3d_vec3 eyes[] = {
+        sdl3d_vec3_make(0, 0, 4),
+        sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(0, 4, 0.001f),
+        sdl3d_vec3_make(0, -4, 0.001f),
+    };
+    for (const auto &eye : eyes)
+    {
+        ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+        ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera(eye)));
+        ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(0.0f, -0.4f, 0.0f),
+                                       sdl3d_vec3_make(0.0f, 0.4f, 0.0f), 0.35f, 16, 6, kRed));
+        ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+        const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+        const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+        sdl3d_color p{};
+        ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+        EXPECT_TRUE(PixelEquals(p, kRed))
+            << "Eye (" << eye.x << ", " << eye.y << ", " << eye.z << ") shows the capsule as missing.";
+    }
+}
+
+TEST_F(SDL3DShapesFixture, CapsuleCollapsesToSphereWhenStartEqualsEnd)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    const sdl3d_vec3 p0 = sdl3d_vec3_make(0, 0, 0);
+    ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, p0, p0, 0.6f, 16, 6, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kRed));
+}
+
+TEST_F(SDL3DShapesFixture, CapsuleAcceptsArbitraryAxis)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    /* Capsule along X axis, in front of camera. */
+    ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(-0.5f, 0.0f, 0.0f),
+                                   sdl3d_vec3_make(0.5f, 0.0f, 0.0f), 0.3f, 16, 6, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kRed));
+}
+
+/* --- Matrix-stack composition ------------------------------------------- */
+
+TEST_F(SDL3DShapesFixture, CubeHonorsModelMatrixStack)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+
+    /* Shift a small cube off-origin via the matrix stack and confirm it
+     * no longer covers the screen center. */
+    ASSERT_TRUE(sdl3d_push_matrix(c.ctx));
+    ASSERT_TRUE(sdl3d_translate(c.ctx, 1.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(0.4f, 0.4f, 0.4f), kRed));
+    ASSERT_TRUE(sdl3d_pop_matrix(c.ctx));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
+    const int cy = sdl3d_get_render_context_height(c.ctx) / 2;
+    sdl3d_color p{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(c.ctx, cx, cy, &p));
+    EXPECT_TRUE(PixelEquals(p, kBlack));
+
+    /* But the cube is drawn somewhere. */
+    EXPECT_GT(CountColor(c.ctx, kRed), 10);
+}

--- a/tests/test_shapes.cpp
+++ b/tests/test_shapes.cpp
@@ -237,7 +237,7 @@ TEST_F(SDL3DShapesFixture, CubeFacesAreOutwardFromEachDirection)
      * from exactly one direction.
      */
     const sdl3d_vec3 eyes[] = {
-        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4), sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4),     sdl3d_vec3_make(4, 0, 0),
         sdl3d_vec3_make(-4, 0, 0), sdl3d_vec3_make(0, 4, 0.001f), sdl3d_vec3_make(0, -4, 0.001f),
     };
     for (const auto &eye : eyes)
@@ -399,7 +399,7 @@ TEST_F(SDL3DShapesFixture, SolidSphereHasOutwardFaces)
 
     ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
     const sdl3d_vec3 eyes[] = {
-        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4), sdl3d_vec3_make(4, 0, 0),
+        sdl3d_vec3_make(0, 0, 4),  sdl3d_vec3_make(0, 0, -4),     sdl3d_vec3_make(4, 0, 0),
         sdl3d_vec3_make(-4, 0, 0), sdl3d_vec3_make(0, 4, 0.001f),
     };
     for (const auto &eye : eyes)
@@ -507,8 +507,8 @@ TEST_F(SDL3DShapesFixture, SolidCapsuleHasOutwardFaces)
     {
         ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
         ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera(eye)));
-        ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(0.0f, -0.4f, 0.0f),
-                                       sdl3d_vec3_make(0.0f, 0.4f, 0.0f), 0.35f, 16, 6, kRed));
+        ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(0.0f, -0.4f, 0.0f), sdl3d_vec3_make(0.0f, 0.4f, 0.0f),
+                                       0.35f, 16, 6, kRed));
         ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
 
         const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
@@ -552,8 +552,8 @@ TEST_F(SDL3DShapesFixture, CapsuleAcceptsArbitraryAxis)
     ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
     ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
     /* Capsule along X axis, in front of camera. */
-    ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(-0.5f, 0.0f, 0.0f),
-                                   sdl3d_vec3_make(0.5f, 0.0f, 0.0f), 0.3f, 16, 6, kRed));
+    ASSERT_TRUE(sdl3d_draw_capsule(c.ctx, sdl3d_vec3_make(-0.5f, 0.0f, 0.0f), sdl3d_vec3_make(0.5f, 0.0f, 0.0f), 0.3f,
+                                   16, 6, kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
 
     const int cx = sdl3d_get_render_context_width(c.ctx) / 2;
@@ -575,10 +575,14 @@ TEST_F(SDL3DShapesFixture, CubeHonorsModelMatrixStack)
     ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
     ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
 
-    /* Shift a small cube off-origin via the matrix stack and confirm it
-     * no longer covers the screen center. */
+    /*
+     * Shift a small cube off-origin via the matrix stack and confirm it
+     * no longer covers the screen center. Y-axis translation is aspect-
+     * independent under a perspective camera, so the test is portable
+     * across portrait/landscape window sizes we may encounter in CI.
+     */
     ASSERT_TRUE(sdl3d_push_matrix(c.ctx));
-    ASSERT_TRUE(sdl3d_translate(c.ctx, 1.5f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_translate(c.ctx, 0.0f, 0.8f, 0.0f));
     ASSERT_TRUE(sdl3d_draw_cube(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(0.4f, 0.4f, 0.4f), kRed));
     ASSERT_TRUE(sdl3d_pop_matrix(c.ctx));
     ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));


### PR DESCRIPTION
## Summary
- Implements the M2 roadmap primitive set: `sdl3d_draw_cube`/`_wires`, `sdl3d_draw_plane`, `sdl3d_draw_grid`, `sdl3d_draw_ray`, `sdl3d_draw_bounding_box`, `sdl3d_draw_sphere`/`_wires`, `sdl3d_draw_cylinder`/`_wires` (cones via asymmetric radii), and `sdl3d_draw_capsule`/`_wires`.
- Adds `sdl3d_ray` and `sdl3d_bounding_box` value types.
- Every primitive funnels through the existing `sdl3d_draw_triangle_3d` / `sdl3d_draw_line_3d` pipeline, so the matrix stack, scissor, culling, and wireframe flags compose unchanged.

## Design notes
- Solid triangle winding is CCW around the outward normal on every face. Backface culling is therefore a free optimization for callers, not a correctness hazard.
- Tessellation counts (`slices`, `rings`) are explicit rather than defaulted; the library does not pick a quality level for the caller.
- Capsule handles the cylinder seam between hemispheres explicitly, so `end == start` collapses to a sphere and off-axis capsules stay closed.
- All argument-range violations go through `SDL_SetError` and return `false`, matching the rest of the immediate-mode API.

## Test plan
- [x] `ctest` (`default` preset): 123/123 pass, including 22 new shape tests.
- [x] `ctest` (`sanitizers` preset, ASan+UBSan): 123/123 pass.
- [x] Winding is validated by orbiting the camera around each solid primitive under backface culling and confirming the silhouette remains on the center pixel — a single inverted face would fail exactly one eye position.
- [x] Wire-primitive tests confirm lines are drawn and the interior stays unshaded.
- [x] Matrix-stack composition is exercised through `sdl3d_push_matrix` + `sdl3d_translate` around a cube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)