### PR TITLE
Per-vertex color + perspective-correct attribute interpolation

### DIFF
--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -51,6 +51,19 @@ extern "C"
 
     bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2,
                                 sdl3d_color color);
+
+    /*
+     * Triangle with per-vertex colors. Colors are interpolated across the
+     * triangle with perspective correction: each attribute is linearly
+     * interpolated in screen space as (attribute / w) and divided by the
+     * linearly interpolated (1 / w) at each pixel, which reproduces the
+     * correct 3D-space blend even under heavy perspective foreshortening.
+     *
+     * When wireframe is enabled, edges use linear screen-space color
+     * interpolation between their endpoints.
+     */
+    bool sdl3d_draw_triangle_3d_ex(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2,
+                                   sdl3d_color c0, sdl3d_color c1, sdl3d_color c2);
     bool sdl3d_draw_line_3d(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, sdl3d_color color);
     bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl3d_color color);
 

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -285,6 +285,20 @@ bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_
     return true;
 }
 
+bool sdl3d_draw_triangle_3d_ex(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2,
+                               sdl3d_color c0, sdl3d_color c1, sdl3d_color c2)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_draw_triangle_3d_ex"))
+    {
+        return false;
+    }
+
+    sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
+    sdl3d_rasterize_triangle_colored(&framebuffer, context->model_view_projection, v0, v1, v2, c0, c1, c2,
+                                     context->backface_culling_enabled, context->wireframe_enabled);
+    return true;
+}
+
 bool sdl3d_draw_line_3d(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, sdl3d_color color)
 {
     if (!sdl3d_require_mode_3d(context, "sdl3d_draw_line_3d"))

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -667,6 +667,512 @@ void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sd
     }
 }
 
+/* --- Colored triangle rasterization -------------------------------------- */
+
+/*
+ * Clip-space vertex carrying per-vertex color as a float RGBA attribute.
+ * Colors are in [0, 255] (matching sdl3d_color) so no separate scale is
+ * needed when converting back to the framebuffer. During Sutherland-Hodgman
+ * clipping the color is interpolated linearly in the clip-space edge
+ * parameter `t`, which is the same parameter used for positions.
+ */
+typedef struct sdl3d_clip_vertex_colored
+{
+    sdl3d_vec4 position;
+    float r;
+    float g;
+    float b;
+    float a;
+} sdl3d_clip_vertex_colored;
+
+static sdl3d_clip_vertex_colored sdl3d_clip_vertex_colored_lerp(sdl3d_clip_vertex_colored a,
+                                                                sdl3d_clip_vertex_colored b, float t)
+{
+    sdl3d_clip_vertex_colored out;
+    out.position = sdl3d_vec4_lerp(a.position, b.position, t);
+    out.r = a.r + (b.r - a.r) * t;
+    out.g = a.g + (b.g - a.g) * t;
+    out.b = a.b + (b.b - a.b) * t;
+    out.a = a.a + (b.a - a.a) * t;
+    return out;
+}
+
+static int sdl3d_clip_polygon_against_plane_colored(const sdl3d_clip_vertex_colored *in, int count_in,
+                                                    sdl3d_clip_vertex_colored *out, sdl3d_clip_plane plane)
+{
+    if (count_in < 3)
+    {
+        return 0;
+    }
+
+    int count_out = 0;
+    sdl3d_clip_vertex_colored prev = in[count_in - 1];
+    float prev_distance = sdl3d_clip_distance(prev.position, plane);
+
+    for (int i = 0; i < count_in; ++i)
+    {
+        const sdl3d_clip_vertex_colored curr = in[i];
+        const float curr_distance = sdl3d_clip_distance(curr.position, plane);
+
+        const bool prev_inside = prev_distance >= 0.0f;
+        const bool curr_inside = curr_distance >= 0.0f;
+
+        if (prev_inside != curr_inside)
+        {
+            const float t = prev_distance / (prev_distance - curr_distance);
+            if (count_out < SDL3D_CLIP_MAX_VERTICES)
+            {
+                out[count_out++] = sdl3d_clip_vertex_colored_lerp(prev, curr, t);
+            }
+        }
+
+        if (curr_inside)
+        {
+            if (count_out < SDL3D_CLIP_MAX_VERTICES)
+            {
+                out[count_out++] = curr;
+            }
+        }
+
+        prev = curr;
+        prev_distance = curr_distance;
+    }
+
+    return count_out;
+}
+
+static int sdl3d_clip_triangle_colored(sdl3d_clip_vertex_colored v0, sdl3d_clip_vertex_colored v1,
+                                       sdl3d_clip_vertex_colored v2, sdl3d_clip_vertex_colored *out)
+{
+    sdl3d_clip_vertex_colored buffer_a[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_clip_vertex_colored buffer_b[SDL3D_CLIP_MAX_VERTICES];
+
+    buffer_a[0] = v0;
+    buffer_a[1] = v1;
+    buffer_a[2] = v2;
+    int count = 3;
+
+    sdl3d_clip_vertex_colored *src = buffer_a;
+    sdl3d_clip_vertex_colored *dst = buffer_b;
+
+    for (int plane = 0; plane < 6; ++plane)
+    {
+        count = sdl3d_clip_polygon_against_plane_colored(src, count, dst, (sdl3d_clip_plane)plane);
+        if (count == 0)
+        {
+            return 0;
+        }
+        sdl3d_clip_vertex_colored *swap = src;
+        src = dst;
+        dst = swap;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        out[i] = src[i];
+    }
+    return count;
+}
+
+/*
+ * Screen vertex augmented for perspective-correct attribute interpolation.
+ * `inverse_w` is 1/w at the vertex; `r_over_w` etc. are the per-vertex color
+ * pre-divided by w. Linear barycentric interpolation of these quantities in
+ * screen space, followed by division by the interpolated 1/w, yields the
+ * perspective-correct attribute at each pixel.
+ */
+typedef struct sdl3d_screen_vertex_colored
+{
+    sdl3d_screen_vertex base;
+    float inverse_w;
+    float r_over_w;
+    float g_over_w;
+    float b_over_w;
+    float a_over_w;
+} sdl3d_screen_vertex_colored;
+
+static sdl3d_screen_vertex_colored sdl3d_viewport_transform_colored(sdl3d_clip_vertex_colored v, int width, int height)
+{
+    sdl3d_screen_vertex_colored out;
+    out.base = sdl3d_viewport_transform(v.position, width, height);
+    const float inv_w = 1.0f / v.position.w;
+    out.inverse_w = inv_w;
+    out.r_over_w = v.r * inv_w;
+    out.g_over_w = v.g * inv_w;
+    out.b_over_w = v.b * inv_w;
+    out.a_over_w = v.a * inv_w;
+    return out;
+}
+
+typedef struct sdl3d_prepared_triangle_colored
+{
+    sdl3d_screen_vertex_colored a;
+    sdl3d_screen_vertex_colored b;
+    sdl3d_screen_vertex_colored c;
+    Sint64 area;
+    int bias_ab;
+    int bias_bc;
+    int bias_ca;
+    float inverse_area;
+    sdl3d_triangle_bounds bounds;
+} sdl3d_prepared_triangle_colored;
+
+typedef struct sdl3d_parallel_triangle_colored_job
+{
+    sdl3d_framebuffer *framebuffer;
+    sdl3d_prepared_triangle_colored triangle;
+    int first_tile_x;
+    int first_tile_y;
+    int tiles_w;
+} sdl3d_parallel_triangle_colored_job;
+
+static bool sdl3d_prepare_screen_triangle_colored(const sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex_colored a,
+                                                  sdl3d_screen_vertex_colored b, sdl3d_screen_vertex_colored c,
+                                                  sdl3d_prepared_triangle_colored *out_triangle)
+{
+    Sint64 area = sdl3d_screen_triangle_signed_area(a.base, b.base, c.base);
+    if (area == 0)
+    {
+        return false;
+    }
+    if (area < 0)
+    {
+        sdl3d_screen_vertex_colored tmp = b;
+        b = c;
+        c = tmp;
+        area = -area;
+    }
+
+    const int min_fx = sdl3d_min_int(a.base.x_fx, sdl3d_min_int(b.base.x_fx, c.base.x_fx));
+    const int max_fx = sdl3d_max_int(a.base.x_fx, sdl3d_max_int(b.base.x_fx, c.base.x_fx));
+    const int min_fy = sdl3d_min_int(a.base.y_fx, sdl3d_min_int(b.base.y_fx, c.base.y_fx));
+    const int max_fy = sdl3d_max_int(a.base.y_fx, sdl3d_max_int(b.base.y_fx, c.base.y_fx));
+
+    const int min_px_x = sdl3d_max_int(0, min_fx >> SDL3D_SUBPIXEL_BITS);
+    const int max_px_x = sdl3d_min_int(framebuffer->width - 1, (max_fx - 1) >> SDL3D_SUBPIXEL_BITS);
+    const int min_px_y = sdl3d_max_int(0, min_fy >> SDL3D_SUBPIXEL_BITS);
+    const int max_px_y = sdl3d_min_int(framebuffer->height - 1, (max_fy - 1) >> SDL3D_SUBPIXEL_BITS);
+
+    if (min_px_x > max_px_x || min_px_y > max_px_y)
+    {
+        return false;
+    }
+
+    out_triangle->a = a;
+    out_triangle->b = b;
+    out_triangle->c = c;
+    out_triangle->area = area;
+    out_triangle->bias_ab = sdl3d_fill_bias(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx);
+    out_triangle->bias_bc = sdl3d_fill_bias(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx);
+    out_triangle->bias_ca = sdl3d_fill_bias(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx);
+    out_triangle->inverse_area = 1.0f / (float)area;
+    out_triangle->bounds.min_px_x = min_px_x;
+    out_triangle->bounds.max_px_x = max_px_x;
+    out_triangle->bounds.min_px_y = min_px_y;
+    out_triangle->bounds.max_px_y = max_px_y;
+    return true;
+}
+
+static Uint8 sdl3d_color_channel_clamp(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0;
+    }
+    if (value >= 255.0f)
+    {
+        return 255;
+    }
+    return (Uint8)SDL_lroundf(value);
+}
+
+static void sdl3d_rasterize_prepared_triangle_colored_region(sdl3d_framebuffer *framebuffer,
+                                                             const sdl3d_prepared_triangle_colored *triangle,
+                                                             int min_px_x, int max_px_x, int min_px_y, int max_px_y)
+{
+    const sdl3d_screen_vertex_colored a = triangle->a;
+    const sdl3d_screen_vertex_colored b = triangle->b;
+    const sdl3d_screen_vertex_colored c = triangle->c;
+
+    for (int py = min_px_y; py <= max_px_y; ++py)
+    {
+        const int sample_y = (py << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+        for (int px = min_px_x; px <= max_px_x; ++px)
+        {
+            const int sample_x = (px << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+
+            const Sint64 w_ab =
+                sdl3d_edge_function(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx, sample_x, sample_y) +
+                triangle->bias_ab;
+            const Sint64 w_bc =
+                sdl3d_edge_function(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx, sample_x, sample_y) +
+                triangle->bias_bc;
+            const Sint64 w_ca =
+                sdl3d_edge_function(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx, sample_x, sample_y) +
+                triangle->bias_ca;
+
+            if ((w_ab | w_bc | w_ca) < 0)
+            {
+                continue;
+            }
+
+            const float bary_a = (float)w_bc * triangle->inverse_area;
+            const float bary_b = (float)w_ca * triangle->inverse_area;
+            const float bary_c = (float)w_ab * triangle->inverse_area;
+            const float depth = (bary_a * a.base.z) + (bary_b * b.base.z) + (bary_c * c.base.z);
+
+            const float inverse_w_pixel = (bary_a * a.inverse_w) + (bary_b * b.inverse_w) + (bary_c * c.inverse_w);
+            /*
+             * Post-clip w is strictly positive (both near and far planes are
+             * one-sided so v.w >= max(|v.z|, 0)), so dividing by the
+             * barycentric blend of 1/w is safe inside a covered pixel.
+             */
+            const float w_pixel = 1.0f / inverse_w_pixel;
+            const float r = ((bary_a * a.r_over_w) + (bary_b * b.r_over_w) + (bary_c * c.r_over_w)) * w_pixel;
+            const float g = ((bary_a * a.g_over_w) + (bary_b * b.g_over_w) + (bary_c * c.g_over_w)) * w_pixel;
+            const float blue = ((bary_a * a.b_over_w) + (bary_b * b.b_over_w) + (bary_c * c.b_over_w)) * w_pixel;
+            const float alpha = ((bary_a * a.a_over_w) + (bary_b * b.a_over_w) + (bary_c * c.a_over_w)) * w_pixel;
+
+            sdl3d_color color;
+            color.r = sdl3d_color_channel_clamp(r);
+            color.g = sdl3d_color_channel_clamp(g);
+            color.b = sdl3d_color_channel_clamp(blue);
+            color.a = sdl3d_color_channel_clamp(alpha);
+
+            sdl3d_write_pixel(framebuffer, px, py, depth, color);
+        }
+    }
+}
+
+static void sdl3d_parallel_triangle_colored_job_run_tile(void *userdata, int tile_index)
+{
+    sdl3d_parallel_triangle_colored_job *job = (sdl3d_parallel_triangle_colored_job *)userdata;
+    const int tile_x = job->first_tile_x + (tile_index % job->tiles_w);
+    const int tile_y = job->first_tile_y + (tile_index / job->tiles_w);
+
+    const int tile_min_px_x = sdl3d_max_int(job->triangle.bounds.min_px_x, tile_x * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_x = sdl3d_min_int(job->triangle.bounds.max_px_x, ((tile_x + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+    const int tile_min_px_y = sdl3d_max_int(job->triangle.bounds.min_px_y, tile_y * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_y = sdl3d_min_int(job->triangle.bounds.max_px_y, ((tile_y + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+
+    if (tile_min_px_x > tile_max_px_x || tile_min_px_y > tile_max_px_y)
+    {
+        return;
+    }
+
+    sdl3d_rasterize_prepared_triangle_colored_region(job->framebuffer, &job->triangle, tile_min_px_x, tile_max_px_x,
+                                                     tile_min_px_y, tile_max_px_y);
+}
+
+static bool sdl3d_try_rasterize_prepared_triangle_colored_parallel(sdl3d_framebuffer *framebuffer,
+                                                                   const sdl3d_prepared_triangle_colored *triangle)
+{
+    if (framebuffer->parallel_rasterizer == NULL)
+    {
+        return false;
+    }
+
+    const int first_tile_x = triangle->bounds.min_px_x / SDL3D_RASTER_TILE_SIZE;
+    const int last_tile_x = triangle->bounds.max_px_x / SDL3D_RASTER_TILE_SIZE;
+    const int first_tile_y = triangle->bounds.min_px_y / SDL3D_RASTER_TILE_SIZE;
+    const int last_tile_y = triangle->bounds.max_px_y / SDL3D_RASTER_TILE_SIZE;
+    const int tiles_w = last_tile_x - first_tile_x + 1;
+    const int tiles_h = last_tile_y - first_tile_y + 1;
+    const int tile_count = tiles_w * tiles_h;
+
+    if (tile_count <= 1)
+    {
+        return false;
+    }
+
+    sdl3d_parallel_triangle_colored_job triangle_job;
+    triangle_job.framebuffer = framebuffer;
+    triangle_job.triangle = *triangle;
+    triangle_job.first_tile_x = first_tile_x;
+    triangle_job.first_tile_y = first_tile_y;
+    triangle_job.tiles_w = tiles_w;
+
+    sdl3d_parallel_job job;
+    job.run_tile = sdl3d_parallel_triangle_colored_job_run_tile;
+    job.userdata = &triangle_job;
+    job.tile_count = tile_count;
+    SDL_SetAtomicInt(&job.next_tile_index, 0);
+
+    sdl3d_parallel_rasterizer_execute(framebuffer->parallel_rasterizer, &job);
+    return true;
+}
+
+static void sdl3d_rasterize_screen_triangle_colored(sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex_colored a,
+                                                    sdl3d_screen_vertex_colored b, sdl3d_screen_vertex_colored c)
+{
+    sdl3d_prepared_triangle_colored triangle;
+    if (!sdl3d_prepare_screen_triangle_colored(framebuffer, a, b, c, &triangle))
+    {
+        return;
+    }
+
+    if (sdl3d_try_rasterize_prepared_triangle_colored_parallel(framebuffer, &triangle))
+    {
+        return;
+    }
+
+    sdl3d_rasterize_prepared_triangle_colored_region(framebuffer, &triangle, triangle.bounds.min_px_x,
+                                                     triangle.bounds.max_px_x, triangle.bounds.min_px_y,
+                                                     triangle.bounds.max_px_y);
+}
+
+/*
+ * Colored line rasterizer for wireframe edges of a vertex-colored triangle.
+ * Linear interpolation along the screen-space segment; not perspective
+ * correct (lines have no meaningful barycentric area), which is acceptable
+ * for wireframe visualization.
+ */
+static void sdl3d_rasterize_screen_line_colored(sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex_colored start,
+                                                sdl3d_screen_vertex_colored end)
+{
+    const float dx = end.base.x_px - start.base.x_px;
+    const float dy = end.base.y_px - start.base.y_px;
+    const float abs_dx = SDL_fabsf(dx);
+    const float abs_dy = SDL_fabsf(dy);
+    const float length = (abs_dx > abs_dy) ? abs_dx : abs_dy;
+
+    if (length <= 0.0f)
+    {
+        const int px = (int)SDL_lroundf(start.base.x_px);
+        const int py = (int)SDL_lroundf(start.base.y_px);
+        if (px >= 0 && px < framebuffer->width && py >= 0 && py < framebuffer->height)
+        {
+            const float w_start = 1.0f / start.inverse_w;
+            sdl3d_color color;
+            color.r = sdl3d_color_channel_clamp(start.r_over_w * w_start);
+            color.g = sdl3d_color_channel_clamp(start.g_over_w * w_start);
+            color.b = sdl3d_color_channel_clamp(start.b_over_w * w_start);
+            color.a = sdl3d_color_channel_clamp(start.a_over_w * w_start);
+            sdl3d_write_pixel(framebuffer, px, py, start.base.z, color);
+        }
+        return;
+    }
+
+    const int steps = (int)length + 1;
+    const float inverse_steps = 1.0f / (float)steps;
+
+    const float start_w = 1.0f / start.inverse_w;
+    const float end_w = 1.0f / end.inverse_w;
+    const float start_r = start.r_over_w * start_w;
+    const float start_g = start.g_over_w * start_w;
+    const float start_b = start.b_over_w * start_w;
+    const float start_a = start.a_over_w * start_w;
+    const float end_r = end.r_over_w * end_w;
+    const float end_g = end.g_over_w * end_w;
+    const float end_b = end.b_over_w * end_w;
+    const float end_a = end.a_over_w * end_w;
+
+    const float step_x = dx * inverse_steps;
+    const float step_y = dy * inverse_steps;
+    const float step_z = (end.base.z - start.base.z) * inverse_steps;
+    const float step_r = (end_r - start_r) * inverse_steps;
+    const float step_g = (end_g - start_g) * inverse_steps;
+    const float step_b = (end_b - start_b) * inverse_steps;
+    const float step_a = (end_a - start_a) * inverse_steps;
+
+    float x = start.base.x_px;
+    float y = start.base.y_px;
+    float z = start.base.z;
+    float r = start_r;
+    float g = start_g;
+    float blue = start_b;
+    float alpha = start_a;
+
+    for (int i = 0; i <= steps; ++i)
+    {
+        const int px = (int)SDL_lroundf(x);
+        const int py = (int)SDL_lroundf(y);
+        if (px >= 0 && px < framebuffer->width && py >= 0 && py < framebuffer->height)
+        {
+            sdl3d_color color;
+            color.r = sdl3d_color_channel_clamp(r);
+            color.g = sdl3d_color_channel_clamp(g);
+            color.b = sdl3d_color_channel_clamp(blue);
+            color.a = sdl3d_color_channel_clamp(alpha);
+            sdl3d_write_pixel(framebuffer, px, py, z, color);
+        }
+        x += step_x;
+        y += step_y;
+        z += step_z;
+        r += step_r;
+        g += step_g;
+        blue += step_b;
+        alpha += step_a;
+    }
+}
+
+void sdl3d_rasterize_triangle_colored(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                      sdl3d_vec3 v2, sdl3d_color c0, sdl3d_color c1, sdl3d_color c2,
+                                      bool backface_culling_enabled, bool wireframe_enabled)
+{
+    if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL)
+    {
+        return;
+    }
+
+    sdl3d_clip_vertex_colored clip[3];
+    clip[0].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v0, 1.0f));
+    clip[0].r = (float)c0.r;
+    clip[0].g = (float)c0.g;
+    clip[0].b = (float)c0.b;
+    clip[0].a = (float)c0.a;
+    clip[1].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v1, 1.0f));
+    clip[1].r = (float)c1.r;
+    clip[1].g = (float)c1.g;
+    clip[1].b = (float)c1.b;
+    clip[1].a = (float)c1.a;
+    clip[2].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v2, 1.0f));
+    clip[2].r = (float)c2.r;
+    clip[2].g = (float)c2.g;
+    clip[2].b = (float)c2.b;
+    clip[2].a = (float)c2.a;
+
+    sdl3d_clip_vertex_colored clipped[SDL3D_CLIP_MAX_VERTICES];
+    const int clipped_count = sdl3d_clip_triangle_colored(clip[0], clip[1], clip[2], clipped);
+    if (clipped_count < 3)
+    {
+        return;
+    }
+
+    sdl3d_screen_vertex_colored screen[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_screen_vertex screen_positions[SDL3D_CLIP_MAX_VERTICES];
+    for (int i = 0; i < clipped_count; ++i)
+    {
+        screen[i] = sdl3d_viewport_transform_colored(clipped[i], framebuffer->width, framebuffer->height);
+        screen_positions[i] = screen[i].base;
+    }
+
+    const Sint64 polygon_area = sdl3d_screen_polygon_signed_area(screen_positions, clipped_count);
+    if (polygon_area == 0)
+    {
+        return;
+    }
+
+    if (backface_culling_enabled && polygon_area >= 0)
+    {
+        return;
+    }
+
+    if (wireframe_enabled)
+    {
+        for (int i = 0; i < clipped_count; ++i)
+        {
+            sdl3d_rasterize_screen_line_colored(framebuffer, screen[i], screen[(i + 1) % clipped_count]);
+        }
+        return;
+    }
+
+    for (int i = 1; i + 1 < clipped_count; ++i)
+    {
+        sdl3d_rasterize_screen_triangle_colored(framebuffer, screen[0], screen[i], screen[i + 1]);
+    }
+}
+
 /* --- Line rasterization -------------------------------------------------- */
 
 static void sdl3d_rasterize_screen_line(sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex start,

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -56,6 +56,16 @@ bool sdl3d_framebuffer_get_depth(const sdl3d_framebuffer *framebuffer, int x, in
 void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
                               sdl3d_vec3 v2, sdl3d_color color, bool backface_culling_enabled, bool wireframe_enabled);
 
+/*
+ * Triangle with per-vertex RGBA colors. Attributes are interpolated with
+ * perspective correction in the fill loop (attr/w linearly in screen space,
+ * divided by the linearly interpolated 1/w per pixel). Wireframe edges use
+ * linear (screen-space) color interpolation along each edge.
+ */
+void sdl3d_rasterize_triangle_colored(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                      sdl3d_vec3 v2, sdl3d_color c0, sdl3d_color c1, sdl3d_color c2,
+                                      bool backface_culling_enabled, bool wireframe_enabled);
+
 void sdl3d_rasterize_line(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 start, sdl3d_vec3 end,
                           sdl3d_color color);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SDL3D_TEST_SOURCES
     test_drawing3d.cpp
     test_render_loop.cpp
     test_shapes.cpp
+    test_vertex_color.cpp
 )
 
 if(ANDROID)
@@ -135,4 +136,5 @@ else()
     sdl3d_add_test(sdl3d_drawing3d_test test_drawing3d.cpp render)
     sdl3d_add_test(sdl3d_render_loop_test test_render_loop.cpp render)
     sdl3d_add_test(sdl3d_shapes_test test_shapes.cpp render)
+    sdl3d_add_test(sdl3d_vertex_color_test test_vertex_color.cpp render)
 endif()

--- a/tests/test_vertex_color.cpp
+++ b/tests/test_vertex_color.cpp
@@ -183,9 +183,15 @@ TEST_F(SDL3DVertexColorFixture, CornersTakeVertexColorsUnderOrtho)
     const sdl3d_camera3d cam = MakeOrtho(4.0f);
     ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
 
-    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.0f, -1.0f, 0.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.0f, -1.0f, 0.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    /*
+     * Keep the triangle well inside half-width even on steeply portrait
+     * framebuffers (Android emulators hand us device aspect, not the 1:1 we
+     * ask for). half-width = half-height * aspect = 2 * aspect; coords in
+     * [-0.6, 0.6] stay visible for aspect >= 0.3.
+     */
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-0.6f, -0.6f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(0.6f, -0.6f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.6f, 0.0f);
     ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlue));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
@@ -229,9 +235,9 @@ TEST_F(SDL3DVertexColorFixture, OrthoMidpointIsLinearBlend)
      * collapses to linear screen-space interpolation. The midpoint of the
      * bottom edge (v0 red, v1 green) should be close to (127, 127, 0).
      */
-    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.6f, 0.0f);
     ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlack));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
@@ -259,9 +265,9 @@ TEST_F(SDL3DVertexColorFixture, FlatColorMatchesFlatPath)
 
     const sdl3d_color mauve = {180, 90, 140, 255};
     const sdl3d_camera3d cam = MakeOrtho(4.0f);
-    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.0f, -0.8f, 0.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.0f, -0.8f, 0.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.8f, 0.0f);
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.5f, 0.0f);
 
     ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
@@ -325,9 +331,15 @@ TEST_F(SDL3DVertexColorFixture, PerspectiveCorrectNearVertexDominates)
         MakePerspective(sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(0.0f, 0.0f, -1.0f), 60.0f);
     ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
 
+    /*
+     * v1/v2 at z=-10 project to screen-x = (x / 10) / tan(fov_h/2); keep
+     * x=2 so the vertex stays inside the horizontal frustum even on a
+     * portrait aspect (~0.56 on Android), where horizontal half-FOV shrinks
+     * relative to vertical.
+     */
     const sdl3d_vec3 v0 = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(3.0f, 0.0f, -10.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 3.0f, -10.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(2.0f, 0.0f, -10.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 2.0f, -10.0f);
     ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kGreen));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
@@ -367,9 +379,9 @@ TEST_F(SDL3DVertexColorFixture, AlphaInterpolates)
 
     const sdl3d_color red_opaque = {255, 0, 0, 255};
     const sdl3d_color red_transparent = {255, 0, 0, 0};
-    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.6f, 0.0f);
     ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, red_opaque, red_transparent, red_opaque));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
@@ -399,9 +411,9 @@ TEST_F(SDL3DVertexColorFixture, WireframeInterpolatesAlongEdges)
     const sdl3d_camera3d cam = MakeOrtho(4.0f);
     ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
 
-    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
-    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(0.6f, -0.5f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.6f, 0.0f);
     ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlack));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
     ASSERT_TRUE(sdl3d_set_wireframe_enabled(ctx, false));

--- a/tests/test_vertex_color.cpp
+++ b/tests/test_vertex_color.cpp
@@ -1,0 +1,437 @@
+/*
+ * Integration tests for per-vertex color triangles and perspective-correct
+ * attribute interpolation. Exercises the sdl3d_draw_triangle_3d_ex path:
+ * corner colors, linear (orthographic) midpoint blend, perspective
+ * correctness under heavy foreshortening, wireframe color interpolation,
+ * and argument validation.
+ */
+
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <cmath>
+#include <memory>
+
+namespace
+{
+class SDL3DVertexColorFixture : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        SDL_ClearError();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        SDL_Quit();
+    }
+};
+
+class WindowRenderer
+{
+  public:
+    WindowRenderer(int width = 128, int height = 128)
+        : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *w = nullptr;
+        SDL_Renderer *r = nullptr;
+        if (!SDL_CreateWindowAndRenderer("SDL3D VertexColor Test", width, height, 0, &w, &r))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+        window_.reset(w);
+        renderer_.reset(r);
+    }
+
+    bool ok() const
+    {
+        return window_ && renderer_;
+    }
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+sdl3d_camera3d MakePerspective(sdl3d_vec3 eye, sdl3d_vec3 target, float fovy_degrees = 60.0f)
+{
+    sdl3d_camera3d cam{};
+    cam.position = eye;
+    cam.target = target;
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = fovy_degrees;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return cam;
+}
+
+sdl3d_camera3d MakeOrtho(float view_height = 4.0f)
+{
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(0.0f, 0.0f, 3.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = view_height;
+    cam.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
+    return cam;
+}
+
+constexpr sdl3d_color kBlack = {0, 0, 0, 255};
+constexpr sdl3d_color kRed = {255, 0, 0, 255};
+constexpr sdl3d_color kGreen = {0, 255, 0, 255};
+constexpr sdl3d_color kBlue = {0, 0, 255, 255};
+
+SDL_Point ProjectToScreen(const sdl3d_render_context *ctx, sdl3d_camera3d camera, sdl3d_vec3 point)
+{
+    sdl3d_mat4 view{};
+    sdl3d_mat4 projection{};
+    EXPECT_TRUE(sdl3d_camera3d_compute_matrices(&camera, sdl3d_get_render_context_width(ctx),
+                                                sdl3d_get_render_context_height(ctx), 0.01f, 1000.0f, &view,
+                                                &projection));
+    const sdl3d_mat4 vp = sdl3d_mat4_multiply(projection, view);
+    const sdl3d_vec4 clip = sdl3d_mat4_transform_vec4(vp, sdl3d_vec4_from_vec3(point, 1.0f));
+    const float inv_w = 1.0f / clip.w;
+    const float ndc_x = clip.x * inv_w;
+    const float ndc_y = clip.y * inv_w;
+    SDL_Point out{};
+    out.x = (int)std::lround((ndc_x + 1.0f) * 0.5f * (float)sdl3d_get_render_context_width(ctx));
+    out.y = (int)std::lround((1.0f - ndc_y) * 0.5f * (float)sdl3d_get_render_context_height(ctx));
+    return out;
+}
+
+/*
+ * Read the first covered pixel within a small square window around (cx, cy).
+ * Used to sample colors near a projected vertex without having to know the
+ * exact rasterization seam placement.
+ */
+bool SampleNear(const sdl3d_render_context *ctx, int cx, int cy, int window, sdl3d_color *out)
+{
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    for (int dy = -window; dy <= window; ++dy)
+    {
+        for (int dx = -window; dx <= window; ++dx)
+        {
+            const int x = cx + dx;
+            const int y = cy + dy;
+            if (x < 0 || x >= w || y < 0 || y >= h)
+            {
+                continue;
+            }
+            sdl3d_color c{};
+            if (sdl3d_get_framebuffer_pixel(ctx, x, y, &c) && !(c.r == 0 && c.g == 0 && c.b == 0))
+            {
+                *out = c;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+TEST_F(SDL3DVertexColorFixture, DrawOutsideModeRejected)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_draw_triangle_3d_ex(ctx, sdl3d_vec3_make(-1, -1, 0), sdl3d_vec3_make(1, -1, 0),
+                                           sdl3d_vec3_make(0, 1, 0), kRed, kGreen, kBlue));
+    EXPECT_NE(*SDL_GetError(), '\0');
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST(SDL3DVertexColorNull, NullContextRejected)
+{
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_draw_triangle_3d_ex(nullptr, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1, 0, 0),
+                                           sdl3d_vec3_make(0, 1, 0), kRed, kGreen, kBlue));
+}
+
+TEST_F(SDL3DVertexColorFixture, CornersTakeVertexColorsUnderOrtho)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    const sdl3d_camera3d cam = MakeOrtho(4.0f);
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.0f, -1.0f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.0f, -1.0f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    const SDL_Point p0 = ProjectToScreen(ctx, cam, v0);
+    const SDL_Point p1 = ProjectToScreen(ctx, cam, v1);
+    const SDL_Point p2 = ProjectToScreen(ctx, cam, v2);
+
+    sdl3d_color near_v0{}, near_v1{}, near_v2{};
+    ASSERT_TRUE(SampleNear(ctx, p0.x, p0.y, 3, &near_v0));
+    ASSERT_TRUE(SampleNear(ctx, p1.x, p1.y, 3, &near_v1));
+    ASSERT_TRUE(SampleNear(ctx, p2.x, p2.y, 3, &near_v2));
+
+    EXPECT_GT(near_v0.r, 200);
+    EXPECT_LT(near_v0.g, 60);
+    EXPECT_LT(near_v0.b, 60);
+
+    EXPECT_LT(near_v1.r, 60);
+    EXPECT_GT(near_v1.g, 200);
+    EXPECT_LT(near_v1.b, 60);
+
+    EXPECT_LT(near_v2.r, 60);
+    EXPECT_LT(near_v2.g, 60);
+    EXPECT_GT(near_v2.b, 200);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DVertexColorFixture, OrthoMidpointIsLinearBlend)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    const sdl3d_camera3d cam = MakeOrtho(4.0f);
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+
+    /*
+     * Orthographic has constant w, so perspective-correct interpolation
+     * collapses to linear screen-space interpolation. The midpoint of the
+     * bottom edge (v0 red, v1 green) should be close to (127, 127, 0).
+     */
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlack));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    const SDL_Point p0 = ProjectToScreen(ctx, cam, v0);
+    const SDL_Point p1 = ProjectToScreen(ctx, cam, v1);
+    const int mid_x = (p0.x + p1.x) / 2;
+    const int mid_y = (p0.y + p1.y) / 2 - 1; /* one row above the edge so we sample filled interior */
+
+    sdl3d_color mid{};
+    ASSERT_TRUE(SampleNear(ctx, mid_x, mid_y, 2, &mid));
+
+    EXPECT_NEAR((int)mid.r, 127, 20);
+    EXPECT_NEAR((int)mid.g, 127, 20);
+    EXPECT_LT(mid.b, 20);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DVertexColorFixture, FlatColorMatchesFlatPath)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    const sdl3d_color mauve = {180, 90, 140, 255};
+    const sdl3d_camera3d cam = MakeOrtho(4.0f);
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.0f, -0.8f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.0f, -0.8f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 0.8f, 0.0f);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, mauve, mauve, mauve));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    int matches = 0;
+    int covered = 0;
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    for (int y = 0; y < h; ++y)
+    {
+        for (int x = 0; x < w; ++x)
+        {
+            sdl3d_color px{};
+            if (!sdl3d_get_framebuffer_pixel(ctx, x, y, &px))
+            {
+                continue;
+            }
+            if (px.r == kBlack.r && px.g == kBlack.g && px.b == kBlack.b)
+            {
+                continue;
+            }
+            ++covered;
+            /*
+             * A 1 ULP drift in the perspective-correct path vs. a flat
+             * write is acceptable; all three channels should round-trip
+             * within one unit of the input color.
+             */
+            if (std::abs((int)px.r - (int)mauve.r) <= 1 && std::abs((int)px.g - (int)mauve.g) <= 1 &&
+                std::abs((int)px.b - (int)mauve.b) <= 1)
+            {
+                ++matches;
+            }
+        }
+    }
+
+    EXPECT_GT(covered, 100);
+    EXPECT_EQ(matches, covered);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DVertexColorFixture, PerspectiveCorrectNearVertexDominates)
+{
+    /*
+     * Heavy-foreshortening triangle: v0 near the camera with 1/w large,
+     * v1/v2 far with 1/w small. All three vertices project into the frame.
+     * With perspective-correct interpolation, the near vertex color
+     * dominates a much larger fraction of the triangle's screen area than
+     * a screen-space-linear blend would predict; we assert the center of
+     * the screen-projected triangle is strongly red-weighted.
+     */
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    const sdl3d_camera3d cam =
+        MakePerspective(sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(0.0f, 0.0f, -1.0f), 60.0f);
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(3.0f, 0.0f, -10.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 3.0f, -10.0f);
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    /*
+     * Sample the screen centroid of the three projected vertices. Under
+     * perspective correctness the red channel at this point is ~182
+     * (worked out from clip-w's ~1 / ~10 / ~10). A screen-linear blend
+     * would give red ~85, so we require red > 140 and green < 120 to
+     * confirm the pipeline is PC rather than linear.
+     */
+    const SDL_Point p0 = ProjectToScreen(ctx, cam, v0);
+    const SDL_Point p1 = ProjectToScreen(ctx, cam, v1);
+    const SDL_Point p2 = ProjectToScreen(ctx, cam, v2);
+    const int cx = (p0.x + p1.x + p2.x) / 3;
+    const int cy = (p0.y + p1.y + p2.y) / 3;
+
+    sdl3d_color center{};
+    ASSERT_TRUE(SampleNear(ctx, cx, cy, 2, &center));
+
+    EXPECT_GT((int)center.r, 140);
+    EXPECT_LT((int)center.g, 120);
+    EXPECT_LT((int)center.b, 20);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DVertexColorFixture, AlphaInterpolates)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    const sdl3d_camera3d cam = MakeOrtho(4.0f);
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+
+    const sdl3d_color red_opaque = {255, 0, 0, 255};
+    const sdl3d_color red_transparent = {255, 0, 0, 0};
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, red_opaque, red_transparent, red_opaque));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    const SDL_Point p0 = ProjectToScreen(ctx, cam, v0);
+    const SDL_Point p1 = ProjectToScreen(ctx, cam, v1);
+    const int mid_x = (p0.x + p1.x) / 2;
+    const int mid_y = (p0.y + p1.y) / 2 - 1;
+
+    sdl3d_color mid{};
+    ASSERT_TRUE(SampleNear(ctx, mid_x, mid_y, 2, &mid));
+
+    EXPECT_GT((int)mid.r, 200);
+    EXPECT_NEAR((int)mid.a, 127, 30);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(SDL3DVertexColorFixture, WireframeInterpolatesAlongEdges)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_set_wireframe_enabled(ctx, true));
+    const sdl3d_camera3d cam = MakeOrtho(4.0f);
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(-1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(1.5f, -1.0f, 0.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 1.5f, 0.0f);
+    ASSERT_TRUE(sdl3d_draw_triangle_3d_ex(ctx, v0, v1, v2, kRed, kGreen, kBlack));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+    ASSERT_TRUE(sdl3d_set_wireframe_enabled(ctx, false));
+
+    int red_pixels = 0;
+    int green_pixels = 0;
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    for (int y = 0; y < h; ++y)
+    {
+        for (int x = 0; x < w; ++x)
+        {
+            sdl3d_color px{};
+            if (!sdl3d_get_framebuffer_pixel(ctx, x, y, &px))
+            {
+                continue;
+            }
+            if (px.r > 200 && px.g < 40)
+            {
+                ++red_pixels;
+            }
+            if (px.g > 200 && px.r < 40)
+            {
+                ++green_pixels;
+            }
+        }
+    }
+
+    EXPECT_GT(red_pixels, 0);
+    EXPECT_GT(green_pixels, 0);
+
+    sdl3d_destroy_render_context(ctx);
+}


### PR DESCRIPTION
## Summary
- Adds `sdl3d_draw_triangle_3d_ex` — triangles with per-vertex RGBA colors, interpolated with true perspective correction (attr/w linearly in screen space, divided by the interpolated 1/w per pixel).
- Sutherland-Hodgman clipping now has a parallel color-carrying path so attributes survive near/far/side-plane trimming with the same `t` used for positions.
- Shared plumbing (clip vertex, screen vertex with `1/w` + attr-over-w, colored prepare / fill / parallel tile dispatch) sets up the next roadmap item: texture sampling.
- Flat-color path is untouched, so existing byte-identical rasterizer output is preserved.

Part of the roadmap in #4.

## Test plan
- [x] `ctest` — 131/131 passing locally on macOS (8 new tests in `sdl3d_vertex_color_test`).
- [x] `clang-format --dry-run --Werror` clean on all touched files.
- [x] Corners take their vertex colors (ortho).
- [x] Edge midpoint equals the linear blend under ortho (no perspective effect).
- [x] Flat-color input (c0==c1==c2) round-trips exactly — every covered pixel matches input within 1 ULP per channel.
- [x] Perspective-correct test: near-red / far-green triangle yields a red-dominant screen centroid (~180 red), well above the 85 that screen-linear would give.
- [x] Alpha interpolates independently.
- [x] Wireframe edges interpolate colors along each screen segment.
- [ ] CI to confirm Ubuntu / Android / iOS / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)