### PR TITLE
M3 slice 2: textured mesh draw path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(
         src/render_context.c
         src/sdl3d.c
         src/shapes.c
+        src/texture.c
         $<TARGET_OBJECTS:sdl3d_cgltf>
         $<TARGET_OBJECTS:sdl3d_ufbx>
         $<TARGET_OBJECTS:sdl3d_stb>

--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -4,7 +4,9 @@
 #include <stdbool.h>
 
 #include "sdl3d/camera.h"
+#include "sdl3d/model.h"
 #include "sdl3d/render_context.h"
+#include "sdl3d/texture.h"
 #include "sdl3d/types.h"
 
 #ifdef __cplusplus
@@ -66,6 +68,35 @@ extern "C"
                                    sdl3d_color c0, sdl3d_color c1, sdl3d_color c2);
     bool sdl3d_draw_line_3d(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, sdl3d_color color);
     bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl3d_color color);
+
+    /*
+     * Draw a single mesh using the current model matrix stack. If `texture`
+     * is NULL, the mesh is rendered untextured and `tint` supplies the flat
+     * color. If `texture` is non-NULL, mesh UVs are interpreted as normalized
+     * coordinates with (0, 0) at the lower-left of the texture.
+     *
+     * Mesh vertex colors, when present, modulate the texture/tint.
+     */
+    bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
+                         sdl3d_color tint);
+
+    /*
+     * Draw every mesh in a model with a uniform translation + scale. Material
+     * albedo factors and albedo textures modulate the supplied tint. Texture
+     * paths are resolved relative to the model's source path and cached on
+     * the render context after first use.
+     */
+    bool sdl3d_draw_model(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position, float scale,
+                          sdl3d_color tint);
+
+    /*
+     * Same as sdl3d_draw_model, but applies translation, axis-angle rotation,
+     * and non-uniform scale before submitting the model. The transform
+     * composes with the current matrix stack.
+     */
+    bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position,
+                             sdl3d_vec3 rotation_axis, float rotation_angle_radians, sdl3d_vec3 scale,
+                             sdl3d_color tint);
 
     /*
      * Read a single pixel from the color backbuffer. Returns false if x or y

--- a/include/sdl3d/model.h
+++ b/include/sdl3d/model.h
@@ -16,8 +16,9 @@ extern "C"
      * their defaults so consumers never have to branch on the source
      * format.
      *
-     * Texture fields are file paths resolved relative to the model's
-     * source directory. Images are NOT decoded at load time — callers
+     * Texture fields are stored exactly as authored by the source asset
+     * (typically paths relative to the model's source directory). Images
+     * are NOT decoded at load time — callers
      * choose when to realize them into sdl3d_texture2d, so scenes can be
      * loaded without touching disk twice.
      */
@@ -43,6 +44,7 @@ extern "C"
      * Vertex attributes are de-interleaved: each pointer is an array of
      * `vertex_count` entries with the stride implied by its semantic
      * (3 floats for positions/normals, 2 for uvs, 4 for colors).
+     * Colors, when present, are RGBA floats in [0, 1].
      *
      * Indices are always 32-bit unsigned and index into this mesh's
      * vertex arrays. `material_index` is -1 when no material is bound.

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -13,6 +13,7 @@
 #include "sdl3d/model.h"
 #include "sdl3d/render_context.h"
 #include "sdl3d/shapes.h"
+#include "sdl3d/texture.h"
 #include "sdl3d/types.h"
 
 #ifdef __cplusplus

--- a/include/sdl3d/texture.h
+++ b/include/sdl3d/texture.h
@@ -1,0 +1,68 @@
+#ifndef SDL3D_TEXTURE_H
+#define SDL3D_TEXTURE_H
+
+#include <stdbool.h>
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/image.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum sdl3d_texture_filter
+    {
+        SDL3D_TEXTURE_FILTER_NEAREST = 0,
+        SDL3D_TEXTURE_FILTER_BILINEAR = 1
+    } sdl3d_texture_filter;
+
+    typedef enum sdl3d_texture_wrap
+    {
+        SDL3D_TEXTURE_WRAP_CLAMP = 0,
+        SDL3D_TEXTURE_WRAP_REPEAT = 1
+    } sdl3d_texture_wrap;
+
+    /*
+     * Software texture owned by SDL3D. Pixels are RGBA8, tightly packed,
+     * row-major, and stored top-down exactly like sdl3d_image.
+     *
+     * Defaults:
+     * - filter: bilinear
+     * - wrap_u / wrap_v: clamp
+     */
+    typedef struct sdl3d_texture2d
+    {
+        Uint8 *pixels;
+        int width;
+        int height;
+        sdl3d_texture_filter filter;
+        sdl3d_texture_wrap wrap_u;
+        sdl3d_texture_wrap wrap_v;
+    } sdl3d_texture2d;
+
+    /*
+     * Copy an RGBA8 image into a software texture.
+     */
+    bool sdl3d_create_texture_from_image(const sdl3d_image *image, sdl3d_texture2d *out);
+
+    /*
+     * Convenience helper: load an image from disk, then copy it into a
+     * software texture.
+     */
+    bool sdl3d_load_texture_from_file(const char *path, sdl3d_texture2d *out);
+
+    /*
+     * Release texture pixels. Safe on a zero-initialized struct.
+     */
+    void sdl3d_free_texture(sdl3d_texture2d *texture);
+
+    bool sdl3d_set_texture_filter(sdl3d_texture2d *texture, sdl3d_texture_filter filter);
+    bool sdl3d_set_texture_wrap(sdl3d_texture2d *texture, sdl3d_texture_wrap wrap_u, sdl3d_texture_wrap wrap_v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -5,8 +5,32 @@
 
 #include "rasterizer.h"
 #include "render_context_internal.h"
+#include "texture_internal.h"
 
 static const int SDL3D_MODEL_STACK_INITIAL_CAPACITY = 8;
+
+static float sdl3d_clamp01(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value >= 1.0f)
+    {
+        return 1.0f;
+    }
+    return value;
+}
+
+static sdl3d_vec4 sdl3d_color_to_modulate(sdl3d_color color)
+{
+    sdl3d_vec4 out;
+    out.x = (float)color.r / 255.0f;
+    out.y = (float)color.g / 255.0f;
+    out.z = (float)color.b / 255.0f;
+    out.w = (float)color.a / 255.0f;
+    return out;
+}
 
 static bool sdl3d_ensure_model_stack_capacity(sdl3d_render_context *context, int required_depth)
 {
@@ -189,6 +213,122 @@ static bool sdl3d_require_mode_3d(const sdl3d_render_context *context, const cha
     return true;
 }
 
+static bool sdl3d_validate_texture_for_draw(const sdl3d_texture2d *texture)
+{
+    if (texture == NULL)
+    {
+        return true;
+    }
+    if (texture->pixels == NULL || texture->width <= 0 || texture->height <= 0)
+    {
+        return SDL_SetError("Texture passed to draw call is empty.");
+    }
+    return true;
+}
+
+static sdl3d_vec4 sdl3d_mesh_vertex_modulate(const sdl3d_mesh *mesh, unsigned int vertex_index, sdl3d_vec4 base)
+{
+    sdl3d_vec4 out = base;
+
+    if (mesh->colors != NULL)
+    {
+        const float *color = &mesh->colors[(size_t)vertex_index * 4U];
+        out.x = sdl3d_clamp01(base.x * color[0]);
+        out.y = sdl3d_clamp01(base.y * color[1]);
+        out.z = sdl3d_clamp01(base.z * color[2]);
+        out.w = sdl3d_clamp01(base.w * color[3]);
+    }
+
+    return out;
+}
+
+static sdl3d_vec3 sdl3d_mesh_position(const sdl3d_mesh *mesh, unsigned int vertex_index)
+{
+    const float *position = &mesh->positions[(size_t)vertex_index * 3U];
+    return sdl3d_vec3_make(position[0], position[1], position[2]);
+}
+
+static sdl3d_vec2 sdl3d_mesh_uv(const sdl3d_mesh *mesh, unsigned int vertex_index)
+{
+    const float *uv = &mesh->uvs[(size_t)vertex_index * 2U];
+    sdl3d_vec2 out;
+    out.x = uv[0];
+    out.y = uv[1];
+    return out;
+}
+
+static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_mesh *mesh,
+                                     const sdl3d_texture2d *texture, sdl3d_vec4 base_modulate)
+{
+    const bool indexed = mesh->indices != NULL;
+    const int triangle_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
+    sdl3d_framebuffer framebuffer;
+
+    if (!sdl3d_require_mode_3d(context, "sdl3d_draw_mesh"))
+    {
+        return false;
+    }
+    if (mesh == NULL)
+    {
+        return SDL_InvalidParamError("mesh");
+    }
+    if (mesh->positions == NULL || mesh->vertex_count <= 0)
+    {
+        return SDL_SetError("Mesh must provide positions and at least one vertex.");
+    }
+    if (!sdl3d_validate_texture_for_draw(texture))
+    {
+        return false;
+    }
+    if (texture != NULL && mesh->uvs == NULL)
+    {
+        return SDL_SetError("Textured mesh draw requires UV coordinates.");
+    }
+    if (indexed)
+    {
+        if (mesh->index_count <= 0 || (mesh->index_count % 3) != 0)
+        {
+            return SDL_SetError("Indexed mesh draw requires index_count > 0 and divisible by 3.");
+        }
+    }
+    else if ((mesh->vertex_count % 3) != 0)
+    {
+        return SDL_SetError("Non-indexed mesh draw requires vertex_count divisible by 3.");
+    }
+
+    framebuffer = sdl3d_framebuffer_from_context(context);
+
+    for (int triangle = 0; triangle < triangle_count; ++triangle)
+    {
+        const unsigned int i0 = indexed ? mesh->indices[triangle * 3 + 0] : (unsigned int)(triangle * 3 + 0);
+        const unsigned int i1 = indexed ? mesh->indices[triangle * 3 + 1] : (unsigned int)(triangle * 3 + 1);
+        const unsigned int i2 = indexed ? mesh->indices[triangle * 3 + 2] : (unsigned int)(triangle * 3 + 2);
+        sdl3d_vec2 uv0 = {0.0f, 0.0f};
+        sdl3d_vec2 uv1 = {0.0f, 0.0f};
+        sdl3d_vec2 uv2 = {0.0f, 0.0f};
+
+        if ((int)i0 >= mesh->vertex_count || (int)i1 >= mesh->vertex_count || (int)i2 >= mesh->vertex_count)
+        {
+            return SDL_SetError("Mesh index out of range for vertex_count=%d.", mesh->vertex_count);
+        }
+
+        if (texture != NULL)
+        {
+            uv0 = sdl3d_mesh_uv(mesh, i0);
+            uv1 = sdl3d_mesh_uv(mesh, i1);
+            uv2 = sdl3d_mesh_uv(mesh, i2);
+        }
+
+        sdl3d_rasterize_triangle_textured(
+            &framebuffer, context->model_view_projection, sdl3d_mesh_position(mesh, i0), sdl3d_mesh_position(mesh, i1),
+            sdl3d_mesh_position(mesh, i2), uv0, uv1, uv2, sdl3d_mesh_vertex_modulate(mesh, i0, base_modulate),
+            sdl3d_mesh_vertex_modulate(mesh, i1, base_modulate), sdl3d_mesh_vertex_modulate(mesh, i2, base_modulate),
+            texture, context->backface_culling_enabled, context->wireframe_enabled);
+    }
+
+    return true;
+}
+
 bool sdl3d_push_matrix(sdl3d_render_context *context)
 {
     if (!sdl3d_require_mode_3d(context, "sdl3d_push_matrix"))
@@ -321,6 +461,104 @@ bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
     sdl3d_rasterize_point(&framebuffer, context->model_view_projection, position, color);
     return true;
+}
+
+bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
+                     sdl3d_color tint)
+{
+    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint));
+}
+
+bool sdl3d_draw_model(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position, float scale,
+                      sdl3d_color tint)
+{
+    return sdl3d_draw_model_ex(context, model, position, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f,
+                               sdl3d_vec3_make(scale, scale, scale), tint);
+}
+
+bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position,
+                         sdl3d_vec3 rotation_axis, float rotation_angle_radians, sdl3d_vec3 scale, sdl3d_color tint)
+{
+    const sdl3d_vec4 tint_modulate = sdl3d_color_to_modulate(tint);
+    bool ok = false;
+
+    if (!sdl3d_require_mode_3d(context, "sdl3d_draw_model_ex"))
+    {
+        return false;
+    }
+    if (model == NULL)
+    {
+        return SDL_InvalidParamError("model");
+    }
+    if (model->meshes == NULL || model->mesh_count <= 0)
+    {
+        return SDL_SetError("Model draw requires at least one mesh.");
+    }
+
+    if (!sdl3d_push_matrix(context))
+    {
+        return false;
+    }
+
+    ok = sdl3d_translate(context, position.x, position.y, position.z);
+    if (ok && rotation_angle_radians != 0.0f)
+    {
+        ok = sdl3d_rotate(context, rotation_axis, rotation_angle_radians);
+    }
+    if (ok)
+    {
+        ok = sdl3d_scale(context, scale.x, scale.y, scale.z);
+    }
+
+    for (int mesh_index = 0; ok && mesh_index < model->mesh_count; ++mesh_index)
+    {
+        const sdl3d_mesh *mesh = &model->meshes[mesh_index];
+        const sdl3d_texture2d *texture = NULL;
+        sdl3d_vec4 mesh_modulate = tint_modulate;
+
+        if (mesh->material_index < -1)
+        {
+            ok = SDL_SetError("Mesh material index %d is invalid.", mesh->material_index);
+            break;
+        }
+
+        if (mesh->material_index >= 0)
+        {
+            const sdl3d_material *material = NULL;
+
+            if (mesh->material_index >= model->material_count || model->materials == NULL)
+            {
+                ok = SDL_SetError("Mesh material index %d is outside material_count=%d.", mesh->material_index,
+                                  model->material_count);
+                break;
+            }
+
+            material = &model->materials[mesh->material_index];
+            mesh_modulate.x = sdl3d_clamp01(mesh_modulate.x * material->albedo[0]);
+            mesh_modulate.y = sdl3d_clamp01(mesh_modulate.y * material->albedo[1]);
+            mesh_modulate.z = sdl3d_clamp01(mesh_modulate.z * material->albedo[2]);
+            mesh_modulate.w = sdl3d_clamp01(mesh_modulate.w * material->albedo[3]);
+
+            if (material->albedo_map != NULL && material->albedo_map[0] != '\0')
+            {
+                ok = sdl3d_texture_cache_get_or_load(&context->texture_cache, model->source_path, material->albedo_map,
+                                                     &texture);
+                if (!ok)
+                {
+                    break;
+                }
+            }
+        }
+
+        ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate);
+    }
+
+    if (!sdl3d_pop_matrix(context))
+    {
+        return false;
+    }
+
+    return ok;
 }
 
 bool sdl3d_get_framebuffer_pixel(const sdl3d_render_context *context, int x, int y, sdl3d_color *out_color)

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -7,6 +7,8 @@
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_thread.h>
 
+#include "texture_internal.h"
+
 /*
  * Subpixel precision: 8 bits (256 subpixel positions per pixel).
  * Sample point is pixel center at (x + 0.5, y + 0.5).
@@ -1170,6 +1172,472 @@ void sdl3d_rasterize_triangle_colored(sdl3d_framebuffer *framebuffer, sdl3d_mat4
     for (int i = 1; i + 1 < clipped_count; ++i)
     {
         sdl3d_rasterize_screen_triangle_colored(framebuffer, screen[0], screen[i], screen[i + 1]);
+    }
+}
+
+/* --- Textured triangle rasterization ------------------------------------ */
+
+typedef struct sdl3d_clip_vertex_textured
+{
+    sdl3d_vec4 position;
+    float u;
+    float v;
+    float modulate_r;
+    float modulate_g;
+    float modulate_b;
+    float modulate_a;
+} sdl3d_clip_vertex_textured;
+
+static sdl3d_clip_vertex_textured sdl3d_clip_vertex_textured_lerp(sdl3d_clip_vertex_textured a,
+                                                                  sdl3d_clip_vertex_textured b, float t)
+{
+    sdl3d_clip_vertex_textured out;
+    out.position = sdl3d_vec4_lerp(a.position, b.position, t);
+    out.u = a.u + (b.u - a.u) * t;
+    out.v = a.v + (b.v - a.v) * t;
+    out.modulate_r = a.modulate_r + (b.modulate_r - a.modulate_r) * t;
+    out.modulate_g = a.modulate_g + (b.modulate_g - a.modulate_g) * t;
+    out.modulate_b = a.modulate_b + (b.modulate_b - a.modulate_b) * t;
+    out.modulate_a = a.modulate_a + (b.modulate_a - a.modulate_a) * t;
+    return out;
+}
+
+static int sdl3d_clip_polygon_against_plane_textured(const sdl3d_clip_vertex_textured *in, int count_in,
+                                                     sdl3d_clip_vertex_textured *out, sdl3d_clip_plane plane)
+{
+    if (count_in < 3)
+    {
+        return 0;
+    }
+
+    int count_out = 0;
+    sdl3d_clip_vertex_textured prev = in[count_in - 1];
+    float prev_distance = sdl3d_clip_distance(prev.position, plane);
+
+    for (int i = 0; i < count_in; ++i)
+    {
+        const sdl3d_clip_vertex_textured curr = in[i];
+        const float curr_distance = sdl3d_clip_distance(curr.position, plane);
+        const bool prev_inside = prev_distance >= 0.0f;
+        const bool curr_inside = curr_distance >= 0.0f;
+
+        if (prev_inside != curr_inside)
+        {
+            const float t = prev_distance / (prev_distance - curr_distance);
+            if (count_out < SDL3D_CLIP_MAX_VERTICES)
+            {
+                out[count_out++] = sdl3d_clip_vertex_textured_lerp(prev, curr, t);
+            }
+        }
+
+        if (curr_inside)
+        {
+            if (count_out < SDL3D_CLIP_MAX_VERTICES)
+            {
+                out[count_out++] = curr;
+            }
+        }
+
+        prev = curr;
+        prev_distance = curr_distance;
+    }
+
+    return count_out;
+}
+
+static int sdl3d_clip_triangle_textured(sdl3d_clip_vertex_textured v0, sdl3d_clip_vertex_textured v1,
+                                        sdl3d_clip_vertex_textured v2, sdl3d_clip_vertex_textured *out)
+{
+    sdl3d_clip_vertex_textured buffer_a[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_clip_vertex_textured buffer_b[SDL3D_CLIP_MAX_VERTICES];
+
+    buffer_a[0] = v0;
+    buffer_a[1] = v1;
+    buffer_a[2] = v2;
+    int count = 3;
+
+    sdl3d_clip_vertex_textured *src = buffer_a;
+    sdl3d_clip_vertex_textured *dst = buffer_b;
+
+    for (int plane = 0; plane < 6; ++plane)
+    {
+        count = sdl3d_clip_polygon_against_plane_textured(src, count, dst, (sdl3d_clip_plane)plane);
+        if (count == 0)
+        {
+            return 0;
+        }
+        sdl3d_clip_vertex_textured *swap = src;
+        src = dst;
+        dst = swap;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        out[i] = src[i];
+    }
+    return count;
+}
+
+typedef struct sdl3d_screen_vertex_textured
+{
+    sdl3d_screen_vertex base;
+    float inverse_w;
+    float u_over_w;
+    float v_over_w;
+    float modulate_r_over_w;
+    float modulate_g_over_w;
+    float modulate_b_over_w;
+    float modulate_a_over_w;
+} sdl3d_screen_vertex_textured;
+
+static sdl3d_screen_vertex_textured sdl3d_viewport_transform_textured(sdl3d_clip_vertex_textured v, int width,
+                                                                      int height)
+{
+    sdl3d_screen_vertex_textured out;
+    const float inverse_w = 1.0f / v.position.w;
+
+    out.base = sdl3d_viewport_transform(v.position, width, height);
+    out.inverse_w = inverse_w;
+    out.u_over_w = v.u * inverse_w;
+    out.v_over_w = v.v * inverse_w;
+    out.modulate_r_over_w = v.modulate_r * inverse_w;
+    out.modulate_g_over_w = v.modulate_g * inverse_w;
+    out.modulate_b_over_w = v.modulate_b * inverse_w;
+    out.modulate_a_over_w = v.modulate_a * inverse_w;
+    return out;
+}
+
+typedef struct sdl3d_prepared_triangle_textured
+{
+    sdl3d_screen_vertex_textured a;
+    sdl3d_screen_vertex_textured b;
+    sdl3d_screen_vertex_textured c;
+    Sint64 area;
+    int bias_ab;
+    int bias_bc;
+    int bias_ca;
+    float inverse_area;
+    sdl3d_triangle_bounds bounds;
+} sdl3d_prepared_triangle_textured;
+
+typedef struct sdl3d_parallel_triangle_textured_job
+{
+    sdl3d_framebuffer *framebuffer;
+    sdl3d_prepared_triangle_textured triangle;
+    const sdl3d_texture2d *texture;
+    int first_tile_x;
+    int first_tile_y;
+    int tiles_w;
+} sdl3d_parallel_triangle_textured_job;
+
+static bool sdl3d_prepare_screen_triangle_textured(const sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex_textured a,
+                                                   sdl3d_screen_vertex_textured b, sdl3d_screen_vertex_textured c,
+                                                   sdl3d_prepared_triangle_textured *out_triangle)
+{
+    Sint64 area = sdl3d_screen_triangle_signed_area(a.base, b.base, c.base);
+    if (area == 0)
+    {
+        return false;
+    }
+    if (area < 0)
+    {
+        sdl3d_screen_vertex_textured tmp = b;
+        b = c;
+        c = tmp;
+        area = -area;
+    }
+
+    const int min_fx = sdl3d_min_int(a.base.x_fx, sdl3d_min_int(b.base.x_fx, c.base.x_fx));
+    const int max_fx = sdl3d_max_int(a.base.x_fx, sdl3d_max_int(b.base.x_fx, c.base.x_fx));
+    const int min_fy = sdl3d_min_int(a.base.y_fx, sdl3d_min_int(b.base.y_fx, c.base.y_fx));
+    const int max_fy = sdl3d_max_int(a.base.y_fx, sdl3d_max_int(b.base.y_fx, c.base.y_fx));
+
+    const int min_px_x = sdl3d_max_int(0, min_fx >> SDL3D_SUBPIXEL_BITS);
+    const int max_px_x = sdl3d_min_int(framebuffer->width - 1, (max_fx - 1) >> SDL3D_SUBPIXEL_BITS);
+    const int min_px_y = sdl3d_max_int(0, min_fy >> SDL3D_SUBPIXEL_BITS);
+    const int max_px_y = sdl3d_min_int(framebuffer->height - 1, (max_fy - 1) >> SDL3D_SUBPIXEL_BITS);
+
+    if (min_px_x > max_px_x || min_px_y > max_px_y)
+    {
+        return false;
+    }
+
+    out_triangle->a = a;
+    out_triangle->b = b;
+    out_triangle->c = c;
+    out_triangle->area = area;
+    out_triangle->bias_ab = sdl3d_fill_bias(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx);
+    out_triangle->bias_bc = sdl3d_fill_bias(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx);
+    out_triangle->bias_ca = sdl3d_fill_bias(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx);
+    out_triangle->inverse_area = 1.0f / (float)area;
+    out_triangle->bounds.min_px_x = min_px_x;
+    out_triangle->bounds.max_px_x = max_px_x;
+    out_triangle->bounds.min_px_y = min_px_y;
+    out_triangle->bounds.max_px_y = max_px_y;
+    return true;
+}
+
+static void sdl3d_rasterize_prepared_triangle_textured_region(sdl3d_framebuffer *framebuffer,
+                                                              const sdl3d_prepared_triangle_textured *triangle,
+                                                              const sdl3d_texture2d *texture, int min_px_x,
+                                                              int max_px_x, int min_px_y, int max_px_y)
+{
+    const sdl3d_screen_vertex_textured a = triangle->a;
+    const sdl3d_screen_vertex_textured b = triangle->b;
+    const sdl3d_screen_vertex_textured c = triangle->c;
+
+    for (int py = min_px_y; py <= max_px_y; ++py)
+    {
+        const int sample_y = (py << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+        for (int px = min_px_x; px <= max_px_x; ++px)
+        {
+            float texture_r = 1.0f;
+            float texture_g = 1.0f;
+            float texture_b = 1.0f;
+            float texture_a = 1.0f;
+            float output_r = 0.0f;
+            float output_g = 0.0f;
+            float output_b = 0.0f;
+            float output_a = 0.0f;
+
+            const int sample_x = (px << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+            const Sint64 w_ab =
+                sdl3d_edge_function(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx, sample_x, sample_y) +
+                triangle->bias_ab;
+            const Sint64 w_bc =
+                sdl3d_edge_function(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx, sample_x, sample_y) +
+                triangle->bias_bc;
+            const Sint64 w_ca =
+                sdl3d_edge_function(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx, sample_x, sample_y) +
+                triangle->bias_ca;
+
+            if ((w_ab | w_bc | w_ca) < 0)
+            {
+                continue;
+            }
+
+            const float bary_a = (float)w_bc * triangle->inverse_area;
+            const float bary_b = (float)w_ca * triangle->inverse_area;
+            const float bary_c = (float)w_ab * triangle->inverse_area;
+            const float depth = (bary_a * a.base.z) + (bary_b * b.base.z) + (bary_c * c.base.z);
+            const float inverse_w_pixel = (bary_a * a.inverse_w) + (bary_b * b.inverse_w) + (bary_c * c.inverse_w);
+            const float pixel_w = 1.0f / inverse_w_pixel;
+            const float u = ((bary_a * a.u_over_w) + (bary_b * b.u_over_w) + (bary_c * c.u_over_w)) * pixel_w;
+            const float v = ((bary_a * a.v_over_w) + (bary_b * b.v_over_w) + (bary_c * c.v_over_w)) * pixel_w;
+            const float modulate_r =
+                ((bary_a * a.modulate_r_over_w) + (bary_b * b.modulate_r_over_w) + (bary_c * c.modulate_r_over_w)) *
+                pixel_w;
+            const float modulate_g =
+                ((bary_a * a.modulate_g_over_w) + (bary_b * b.modulate_g_over_w) + (bary_c * c.modulate_g_over_w)) *
+                pixel_w;
+            const float modulate_b =
+                ((bary_a * a.modulate_b_over_w) + (bary_b * b.modulate_b_over_w) + (bary_c * c.modulate_b_over_w)) *
+                pixel_w;
+            const float modulate_a =
+                ((bary_a * a.modulate_a_over_w) + (bary_b * b.modulate_a_over_w) + (bary_c * c.modulate_a_over_w)) *
+                pixel_w;
+
+            if (texture != NULL)
+            {
+                sdl3d_texture_sample_rgba(texture, u, v, &texture_r, &texture_g, &texture_b, &texture_a);
+            }
+
+            output_r = texture_r * modulate_r;
+            output_g = texture_g * modulate_g;
+            output_b = texture_b * modulate_b;
+            output_a = texture_a * modulate_a;
+
+            if (output_a <= 0.0f)
+            {
+                continue;
+            }
+
+            sdl3d_color color;
+            color.r = sdl3d_color_channel_clamp(output_r * 255.0f);
+            color.g = sdl3d_color_channel_clamp(output_g * 255.0f);
+            color.b = sdl3d_color_channel_clamp(output_b * 255.0f);
+            color.a = sdl3d_color_channel_clamp(output_a * 255.0f);
+
+            sdl3d_write_pixel(framebuffer, px, py, depth, color);
+        }
+    }
+}
+
+static void sdl3d_parallel_triangle_textured_job_run_tile(void *userdata, int tile_index)
+{
+    sdl3d_parallel_triangle_textured_job *job = (sdl3d_parallel_triangle_textured_job *)userdata;
+    const int tile_x = job->first_tile_x + (tile_index % job->tiles_w);
+    const int tile_y = job->first_tile_y + (tile_index / job->tiles_w);
+
+    const int tile_min_px_x = sdl3d_max_int(job->triangle.bounds.min_px_x, tile_x * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_x = sdl3d_min_int(job->triangle.bounds.max_px_x, ((tile_x + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+    const int tile_min_px_y = sdl3d_max_int(job->triangle.bounds.min_px_y, tile_y * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_y = sdl3d_min_int(job->triangle.bounds.max_px_y, ((tile_y + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+
+    if (tile_min_px_x > tile_max_px_x || tile_min_px_y > tile_max_px_y)
+    {
+        return;
+    }
+
+    sdl3d_rasterize_prepared_triangle_textured_region(job->framebuffer, &job->triangle, job->texture, tile_min_px_x,
+                                                      tile_max_px_x, tile_min_px_y, tile_max_px_y);
+}
+
+static bool sdl3d_try_rasterize_prepared_triangle_textured_parallel(sdl3d_framebuffer *framebuffer,
+                                                                    const sdl3d_prepared_triangle_textured *triangle,
+                                                                    const sdl3d_texture2d *texture)
+{
+    if (framebuffer->parallel_rasterizer == NULL)
+    {
+        return false;
+    }
+
+    const int first_tile_x = triangle->bounds.min_px_x / SDL3D_RASTER_TILE_SIZE;
+    const int last_tile_x = triangle->bounds.max_px_x / SDL3D_RASTER_TILE_SIZE;
+    const int first_tile_y = triangle->bounds.min_px_y / SDL3D_RASTER_TILE_SIZE;
+    const int last_tile_y = triangle->bounds.max_px_y / SDL3D_RASTER_TILE_SIZE;
+    const int tiles_w = last_tile_x - first_tile_x + 1;
+    const int tiles_h = last_tile_y - first_tile_y + 1;
+    const int tile_count = tiles_w * tiles_h;
+
+    if (tile_count <= 1)
+    {
+        return false;
+    }
+
+    sdl3d_parallel_triangle_textured_job triangle_job;
+    triangle_job.framebuffer = framebuffer;
+    triangle_job.triangle = *triangle;
+    triangle_job.texture = texture;
+    triangle_job.first_tile_x = first_tile_x;
+    triangle_job.first_tile_y = first_tile_y;
+    triangle_job.tiles_w = tiles_w;
+
+    sdl3d_parallel_job job;
+    job.run_tile = sdl3d_parallel_triangle_textured_job_run_tile;
+    job.userdata = &triangle_job;
+    job.tile_count = tile_count;
+    SDL_SetAtomicInt(&job.next_tile_index, 0);
+
+    sdl3d_parallel_rasterizer_execute(framebuffer->parallel_rasterizer, &job);
+    return true;
+}
+
+static void sdl3d_rasterize_screen_triangle_textured(sdl3d_framebuffer *framebuffer, sdl3d_screen_vertex_textured a,
+                                                     sdl3d_screen_vertex_textured b, sdl3d_screen_vertex_textured c,
+                                                     const sdl3d_texture2d *texture)
+{
+    sdl3d_prepared_triangle_textured triangle;
+    if (!sdl3d_prepare_screen_triangle_textured(framebuffer, a, b, c, &triangle))
+    {
+        return;
+    }
+
+    if (sdl3d_try_rasterize_prepared_triangle_textured_parallel(framebuffer, &triangle, texture))
+    {
+        return;
+    }
+
+    sdl3d_rasterize_prepared_triangle_textured_region(framebuffer, &triangle, texture, triangle.bounds.min_px_x,
+                                                      triangle.bounds.max_px_x, triangle.bounds.min_px_y,
+                                                      triangle.bounds.max_px_y);
+}
+
+void sdl3d_rasterize_triangle_textured(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                       sdl3d_vec3 v2, sdl3d_vec2 uv0, sdl3d_vec2 uv1, sdl3d_vec2 uv2,
+                                       sdl3d_vec4 modulate0, sdl3d_vec4 modulate1, sdl3d_vec4 modulate2,
+                                       const sdl3d_texture2d *texture, bool backface_culling_enabled,
+                                       bool wireframe_enabled)
+{
+    if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL)
+    {
+        return;
+    }
+
+    sdl3d_clip_vertex_textured clip[3];
+    clip[0].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v0, 1.0f));
+    clip[0].u = uv0.x;
+    clip[0].v = uv0.y;
+    clip[0].modulate_r = modulate0.x;
+    clip[0].modulate_g = modulate0.y;
+    clip[0].modulate_b = modulate0.z;
+    clip[0].modulate_a = modulate0.w;
+    clip[1].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v1, 1.0f));
+    clip[1].u = uv1.x;
+    clip[1].v = uv1.y;
+    clip[1].modulate_r = modulate1.x;
+    clip[1].modulate_g = modulate1.y;
+    clip[1].modulate_b = modulate1.z;
+    clip[1].modulate_a = modulate1.w;
+    clip[2].position = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v2, 1.0f));
+    clip[2].u = uv2.x;
+    clip[2].v = uv2.y;
+    clip[2].modulate_r = modulate2.x;
+    clip[2].modulate_g = modulate2.y;
+    clip[2].modulate_b = modulate2.z;
+    clip[2].modulate_a = modulate2.w;
+
+    sdl3d_clip_vertex_textured clipped[SDL3D_CLIP_MAX_VERTICES];
+    const int clipped_count = sdl3d_clip_triangle_textured(clip[0], clip[1], clip[2], clipped);
+    if (clipped_count < 3)
+    {
+        return;
+    }
+
+    sdl3d_screen_vertex_textured screen[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_screen_vertex screen_positions[SDL3D_CLIP_MAX_VERTICES];
+    for (int i = 0; i < clipped_count; ++i)
+    {
+        screen[i] = sdl3d_viewport_transform_textured(clipped[i], framebuffer->width, framebuffer->height);
+        screen_positions[i] = screen[i].base;
+    }
+
+    const Sint64 polygon_area = sdl3d_screen_polygon_signed_area(screen_positions, clipped_count);
+    if (polygon_area == 0)
+    {
+        return;
+    }
+
+    if (backface_culling_enabled && polygon_area >= 0)
+    {
+        return;
+    }
+
+    if (wireframe_enabled)
+    {
+        for (int i = 0; i < clipped_count; ++i)
+        {
+            sdl3d_screen_vertex_colored line_start;
+            sdl3d_screen_vertex_colored line_end;
+            const float start_w = 1.0f / screen[i].inverse_w;
+            const float end_w = 1.0f / screen[(i + 1) % clipped_count].inverse_w;
+
+            line_start.base = screen[i].base;
+            line_start.inverse_w = screen[i].inverse_w;
+            line_start.r_over_w = (screen[i].modulate_r_over_w * start_w) * screen[i].inverse_w * 255.0f;
+            line_start.g_over_w = (screen[i].modulate_g_over_w * start_w) * screen[i].inverse_w * 255.0f;
+            line_start.b_over_w = (screen[i].modulate_b_over_w * start_w) * screen[i].inverse_w * 255.0f;
+            line_start.a_over_w = (screen[i].modulate_a_over_w * start_w) * screen[i].inverse_w * 255.0f;
+
+            line_end.base = screen[(i + 1) % clipped_count].base;
+            line_end.inverse_w = screen[(i + 1) % clipped_count].inverse_w;
+            line_end.r_over_w = (screen[(i + 1) % clipped_count].modulate_r_over_w * end_w) *
+                                screen[(i + 1) % clipped_count].inverse_w * 255.0f;
+            line_end.g_over_w = (screen[(i + 1) % clipped_count].modulate_g_over_w * end_w) *
+                                screen[(i + 1) % clipped_count].inverse_w * 255.0f;
+            line_end.b_over_w = (screen[(i + 1) % clipped_count].modulate_b_over_w * end_w) *
+                                screen[(i + 1) % clipped_count].inverse_w * 255.0f;
+            line_end.a_over_w = (screen[(i + 1) % clipped_count].modulate_a_over_w * end_w) *
+                                screen[(i + 1) % clipped_count].inverse_w * 255.0f;
+
+            sdl3d_rasterize_screen_line_colored(framebuffer, line_start, line_end);
+        }
+        return;
+    }
+
+    for (int i = 1; i + 1 < clipped_count; ++i)
+    {
+        sdl3d_rasterize_screen_triangle_textured(framebuffer, screen[0], screen[i], screen[i + 1], texture);
     }
 }
 

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -28,6 +28,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/math.h"
+#include "sdl3d/texture.h"
 #include "sdl3d/types.h"
 
 typedef struct sdl3d_parallel_rasterizer sdl3d_parallel_rasterizer;
@@ -65,6 +66,12 @@ void sdl3d_rasterize_triangle(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sd
 void sdl3d_rasterize_triangle_colored(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
                                       sdl3d_vec3 v2, sdl3d_color c0, sdl3d_color c1, sdl3d_color c2,
                                       bool backface_culling_enabled, bool wireframe_enabled);
+
+void sdl3d_rasterize_triangle_textured(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                       sdl3d_vec3 v2, sdl3d_vec2 uv0, sdl3d_vec2 uv1, sdl3d_vec2 uv2,
+                                       sdl3d_vec4 modulate0, sdl3d_vec4 modulate1, sdl3d_vec4 modulate2,
+                                       const sdl3d_texture2d *texture, bool backface_culling_enabled,
+                                       bool wireframe_enabled);
 
 void sdl3d_rasterize_line(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 start, sdl3d_vec3 end,
                           sdl3d_color color);

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -6,6 +6,7 @@
 
 #include "rasterizer.h"
 #include "render_context_internal.h"
+#include "texture_internal.h"
 
 static const char *const SDL3D_BACKEND_ENV = "SDL3D_BACKEND";
 static const float SDL3D_DEFAULT_NEAR_PLANE = 0.01f;
@@ -251,6 +252,7 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
 
     context->window = window;
     context->renderer = renderer;
+    context->texture_cache = NULL;
     context->parallel_rasterizer = NULL;
     context->backend = resolved_backend;
     context->width = render_width;
@@ -284,6 +286,7 @@ void sdl3d_destroy_render_context(sdl3d_render_context *context)
     }
 
     sdl3d_parallel_rasterizer_destroy(context->parallel_rasterizer);
+    sdl3d_texture_cache_destroy(context->texture_cache);
     SDL_free(context->model_stack);
     SDL_DestroyTexture(context->color_texture);
     SDL_free(context->color_buffer);

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -21,6 +21,7 @@ struct sdl3d_render_context
     SDL_Window *window;
     SDL_Renderer *renderer;
     SDL_Texture *color_texture;
+    struct sdl3d_texture_cache_entry *texture_cache;
     Uint8 *color_buffer;
     float *depth_buffer;
     sdl3d_parallel_rasterizer *parallel_rasterizer;

--- a/src/texture.c
+++ b/src/texture.c
@@ -1,0 +1,464 @@
+#include "sdl3d/texture.h"
+
+#include <stddef.h>
+
+#include <SDL3/SDL_assert.h>
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "texture_internal.h"
+
+static bool sdl3d_texture_filter_valid(sdl3d_texture_filter filter)
+{
+    return filter == SDL3D_TEXTURE_FILTER_NEAREST || filter == SDL3D_TEXTURE_FILTER_BILINEAR;
+}
+
+static bool sdl3d_texture_wrap_valid(sdl3d_texture_wrap wrap)
+{
+    return wrap == SDL3D_TEXTURE_WRAP_CLAMP || wrap == SDL3D_TEXTURE_WRAP_REPEAT;
+}
+
+static float sdl3d_texture_lerp(float a, float b, float t)
+{
+    return a + (b - a) * t;
+}
+
+static char *sdl3d_texture_strdup(const char *text)
+{
+    const size_t length = SDL_strlen(text);
+    char *copy = (char *)SDL_malloc(length + 1);
+    if (copy == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    SDL_memcpy(copy, text, length);
+    copy[length] = '\0';
+    return copy;
+}
+
+static bool sdl3d_texture_set_defaults(sdl3d_texture2d *texture)
+{
+    if (texture == NULL)
+    {
+        return SDL_InvalidParamError("texture");
+    }
+
+    texture->filter = SDL3D_TEXTURE_FILTER_BILINEAR;
+    texture->wrap_u = SDL3D_TEXTURE_WRAP_CLAMP;
+    texture->wrap_v = SDL3D_TEXTURE_WRAP_CLAMP;
+    return true;
+}
+
+bool sdl3d_create_texture_from_image(const sdl3d_image *image, sdl3d_texture2d *out)
+{
+    size_t bytes = 0;
+
+    if (image == NULL)
+    {
+        return SDL_InvalidParamError("image");
+    }
+    if (out == NULL)
+    {
+        return SDL_InvalidParamError("out");
+    }
+    if (image->pixels == NULL || image->width <= 0 || image->height <= 0)
+    {
+        return SDL_SetError("sdl3d_create_texture_from_image requires a populated RGBA8 image.");
+    }
+
+    SDL_zerop(out);
+    if (!sdl3d_texture_set_defaults(out))
+    {
+        return false;
+    }
+
+    bytes = (size_t)image->width * (size_t)image->height * 4U;
+    out->pixels = (Uint8 *)SDL_malloc(bytes);
+    if (out->pixels == NULL)
+    {
+        SDL_zerop(out);
+        return SDL_OutOfMemory();
+    }
+
+    SDL_memcpy(out->pixels, image->pixels, bytes);
+    out->width = image->width;
+    out->height = image->height;
+    return true;
+}
+
+bool sdl3d_load_texture_from_file(const char *path, sdl3d_texture2d *out)
+{
+    sdl3d_image image;
+    bool ok = false;
+
+    if (path == NULL)
+    {
+        return SDL_InvalidParamError("path");
+    }
+    if (out == NULL)
+    {
+        return SDL_InvalidParamError("out");
+    }
+
+    SDL_zerop(&image);
+    if (!sdl3d_load_image_from_file(path, &image))
+    {
+        return false;
+    }
+
+    ok = sdl3d_create_texture_from_image(&image, out);
+    sdl3d_free_image(&image);
+    return ok;
+}
+
+void sdl3d_free_texture(sdl3d_texture2d *texture)
+{
+    if (texture == NULL)
+    {
+        return;
+    }
+
+    SDL_free(texture->pixels);
+    SDL_zerop(texture);
+}
+
+bool sdl3d_set_texture_filter(sdl3d_texture2d *texture, sdl3d_texture_filter filter)
+{
+    if (texture == NULL)
+    {
+        return SDL_InvalidParamError("texture");
+    }
+    if (!sdl3d_texture_filter_valid(filter))
+    {
+        return SDL_SetError("Unknown texture filter value: %d.", (int)filter);
+    }
+
+    texture->filter = filter;
+    return true;
+}
+
+bool sdl3d_set_texture_wrap(sdl3d_texture2d *texture, sdl3d_texture_wrap wrap_u, sdl3d_texture_wrap wrap_v)
+{
+    if (texture == NULL)
+    {
+        return SDL_InvalidParamError("texture");
+    }
+    if (!sdl3d_texture_wrap_valid(wrap_u) || !sdl3d_texture_wrap_valid(wrap_v))
+    {
+        return SDL_SetError("Unknown texture wrap value: (%d, %d).", (int)wrap_u, (int)wrap_v);
+    }
+
+    texture->wrap_u = wrap_u;
+    texture->wrap_v = wrap_v;
+    return true;
+}
+
+static float sdl3d_texture_clamp01(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value >= 1.0f)
+    {
+        return 1.0f;
+    }
+    return value;
+}
+
+static float sdl3d_texture_wrap_coord(float value, sdl3d_texture_wrap wrap)
+{
+    if (wrap == SDL3D_TEXTURE_WRAP_REPEAT)
+    {
+        const float floored = SDL_floorf(value);
+        value -= floored;
+        if (value < 0.0f)
+        {
+            value += 1.0f;
+        }
+        return value;
+    }
+
+    return sdl3d_texture_clamp01(value);
+}
+
+static int sdl3d_texture_resolve_index(int coord, int extent, sdl3d_texture_wrap wrap)
+{
+    if (extent <= 0)
+    {
+        return 0;
+    }
+
+    if (wrap == SDL3D_TEXTURE_WRAP_REPEAT)
+    {
+        int wrapped = coord % extent;
+        if (wrapped < 0)
+        {
+            wrapped += extent;
+        }
+        return wrapped;
+    }
+
+    if (coord < 0)
+    {
+        return 0;
+    }
+    if (coord >= extent)
+    {
+        return extent - 1;
+    }
+    return coord;
+}
+
+static void sdl3d_texture_fetch_rgba(const sdl3d_texture2d *texture, int x, int y, float *out_r, float *out_g,
+                                     float *out_b, float *out_a)
+{
+    const int ix = sdl3d_texture_resolve_index(x, texture->width, texture->wrap_u);
+    const int iy = sdl3d_texture_resolve_index(y, texture->height, texture->wrap_v);
+    const Uint8 *pixel = &texture->pixels[((iy * texture->width) + ix) * 4];
+
+    *out_r = (float)pixel[0] / 255.0f;
+    *out_g = (float)pixel[1] / 255.0f;
+    *out_b = (float)pixel[2] / 255.0f;
+    *out_a = (float)pixel[3] / 255.0f;
+}
+
+void sdl3d_texture_sample_rgba(const sdl3d_texture2d *texture, float u, float v, float *out_r, float *out_g,
+                               float *out_b, float *out_a)
+{
+    float sample_u;
+    float sample_v;
+    float texel_x;
+    float texel_y;
+
+    SDL_assert(texture != NULL);
+    SDL_assert(texture->pixels != NULL);
+    SDL_assert(texture->width > 0);
+    SDL_assert(texture->height > 0);
+    SDL_assert(out_r != NULL);
+    SDL_assert(out_g != NULL);
+    SDL_assert(out_b != NULL);
+    SDL_assert(out_a != NULL);
+
+    sample_u = sdl3d_texture_wrap_coord(u, texture->wrap_u);
+    sample_v = sdl3d_texture_wrap_coord(v, texture->wrap_v);
+
+    /*
+     * Texture coordinates follow the common 3D convention where (0, 0) is
+     * the lower-left corner of the texture. Pixels are stored top-down, so
+     * the Y mapping flips here.
+     */
+    texel_x = (sample_u * (float)texture->width) - 0.5f;
+    texel_y = ((1.0f - sample_v) * (float)texture->height) - 0.5f;
+
+    if (texture->filter == SDL3D_TEXTURE_FILTER_NEAREST)
+    {
+        const int ix = (int)SDL_floorf(texel_x + 0.5f);
+        const int iy = (int)SDL_floorf(texel_y + 0.5f);
+        sdl3d_texture_fetch_rgba(texture, ix, iy, out_r, out_g, out_b, out_a);
+        return;
+    }
+
+    const int x0 = (int)SDL_floorf(texel_x);
+    const int y0 = (int)SDL_floorf(texel_y);
+    const int x1 = x0 + 1;
+    const int y1 = y0 + 1;
+    const float tx = texel_x - (float)x0;
+    const float ty = texel_y - (float)y0;
+
+    float c00_r = 0.0f, c00_g = 0.0f, c00_b = 0.0f, c00_a = 0.0f;
+    float c10_r = 0.0f, c10_g = 0.0f, c10_b = 0.0f, c10_a = 0.0f;
+    float c01_r = 0.0f, c01_g = 0.0f, c01_b = 0.0f, c01_a = 0.0f;
+    float c11_r = 0.0f, c11_g = 0.0f, c11_b = 0.0f, c11_a = 0.0f;
+
+    sdl3d_texture_fetch_rgba(texture, x0, y0, &c00_r, &c00_g, &c00_b, &c00_a);
+    sdl3d_texture_fetch_rgba(texture, x1, y0, &c10_r, &c10_g, &c10_b, &c10_a);
+    sdl3d_texture_fetch_rgba(texture, x0, y1, &c01_r, &c01_g, &c01_b, &c01_a);
+    sdl3d_texture_fetch_rgba(texture, x1, y1, &c11_r, &c11_g, &c11_b, &c11_a);
+
+    *out_r = sdl3d_texture_lerp(sdl3d_texture_lerp(c00_r, c10_r, tx), sdl3d_texture_lerp(c01_r, c11_r, tx), ty);
+    *out_g = sdl3d_texture_lerp(sdl3d_texture_lerp(c00_g, c10_g, tx), sdl3d_texture_lerp(c01_g, c11_g, tx), ty);
+    *out_b = sdl3d_texture_lerp(sdl3d_texture_lerp(c00_b, c10_b, tx), sdl3d_texture_lerp(c01_b, c11_b, tx), ty);
+    *out_a = sdl3d_texture_lerp(sdl3d_texture_lerp(c00_a, c10_a, tx), sdl3d_texture_lerp(c01_a, c11_a, tx), ty);
+}
+
+static bool sdl3d_texture_path_is_absolute(const char *path)
+{
+    const char c0 = path[0];
+    const char c1 = path[1];
+    const char c2 = path[2];
+
+    if (c0 == '/' || c0 == '\\')
+    {
+        return true;
+    }
+
+    if (((c0 >= 'A' && c0 <= 'Z') || (c0 >= 'a' && c0 <= 'z')) && c1 == ':' && (c2 == '/' || c2 == '\\'))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+static char *sdl3d_texture_dirname_dup(const char *path)
+{
+    const char *slash = NULL;
+
+    for (const char *cursor = path; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor == '/' || *cursor == '\\')
+        {
+            slash = cursor;
+        }
+    }
+
+    if (slash == NULL)
+    {
+        char *empty = (char *)SDL_malloc(1);
+        if (empty == NULL)
+        {
+            SDL_OutOfMemory();
+            return NULL;
+        }
+        empty[0] = '\0';
+        return empty;
+    }
+
+    const size_t length = (size_t)(slash - path + 1);
+    char *dirname = (char *)SDL_malloc(length + 1);
+    if (dirname == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    SDL_memcpy(dirname, path, length);
+    dirname[length] = '\0';
+    return dirname;
+}
+
+static bool sdl3d_texture_resolve_path(const char *source_path, const char *texture_path, char **out_path)
+{
+    char *dirname = NULL;
+    size_t dirname_length = 0;
+    size_t texture_length = 0;
+    char *resolved = NULL;
+
+    if (texture_path == NULL)
+    {
+        return SDL_InvalidParamError("texture_path");
+    }
+    if (out_path == NULL)
+    {
+        return SDL_InvalidParamError("out_path");
+    }
+
+    if (sdl3d_texture_path_is_absolute(texture_path))
+    {
+        resolved = sdl3d_texture_strdup(texture_path);
+        if (resolved == NULL)
+        {
+            return false;
+        }
+        *out_path = resolved;
+        return true;
+    }
+
+    if (source_path == NULL || *source_path == '\0')
+    {
+        return SDL_SetError("Cannot resolve relative texture path '%s' without a model source path.", texture_path);
+    }
+
+    dirname = sdl3d_texture_dirname_dup(source_path);
+    if (dirname == NULL)
+    {
+        return false;
+    }
+
+    dirname_length = SDL_strlen(dirname);
+    texture_length = SDL_strlen(texture_path);
+    resolved = (char *)SDL_malloc(dirname_length + texture_length + 1);
+    if (resolved == NULL)
+    {
+        SDL_free(dirname);
+        return SDL_OutOfMemory();
+    }
+
+    SDL_memcpy(resolved, dirname, dirname_length);
+    SDL_memcpy(resolved + dirname_length, texture_path, texture_length);
+    resolved[dirname_length + texture_length] = '\0';
+
+    SDL_free(dirname);
+    *out_path = resolved;
+    return true;
+}
+
+void sdl3d_texture_cache_destroy(sdl3d_texture_cache_entry *cache)
+{
+    while (cache != NULL)
+    {
+        sdl3d_texture_cache_entry *next = cache->next;
+        SDL_free(cache->path);
+        sdl3d_free_texture(&cache->texture);
+        SDL_free(cache);
+        cache = next;
+    }
+}
+
+bool sdl3d_texture_cache_get_or_load(sdl3d_texture_cache_entry **cache, const char *source_path,
+                                     const char *texture_path, const sdl3d_texture2d **out_texture)
+{
+    sdl3d_texture_cache_entry *entry = NULL;
+    char *resolved_path = NULL;
+
+    if (cache == NULL)
+    {
+        return SDL_InvalidParamError("cache");
+    }
+    if (texture_path == NULL)
+    {
+        return SDL_InvalidParamError("texture_path");
+    }
+    if (out_texture == NULL)
+    {
+        return SDL_InvalidParamError("out_texture");
+    }
+
+    if (!sdl3d_texture_resolve_path(source_path, texture_path, &resolved_path))
+    {
+        return false;
+    }
+
+    for (entry = *cache; entry != NULL; entry = entry->next)
+    {
+        if (SDL_strcmp(entry->path, resolved_path) == 0)
+        {
+            SDL_free(resolved_path);
+            *out_texture = &entry->texture;
+            return true;
+        }
+    }
+
+    entry = (sdl3d_texture_cache_entry *)SDL_calloc(1, sizeof(*entry));
+    if (entry == NULL)
+    {
+        SDL_free(resolved_path);
+        return SDL_OutOfMemory();
+    }
+
+    if (!sdl3d_load_texture_from_file(resolved_path, &entry->texture))
+    {
+        SDL_free(entry);
+        SDL_free(resolved_path);
+        return false;
+    }
+
+    entry->path = resolved_path;
+    entry->next = *cache;
+    *cache = entry;
+    *out_texture = &entry->texture;
+    return true;
+}

--- a/src/texture_internal.h
+++ b/src/texture_internal.h
@@ -1,0 +1,19 @@
+#ifndef SDL3D_TEXTURE_INTERNAL_H
+#define SDL3D_TEXTURE_INTERNAL_H
+
+#include "sdl3d/texture.h"
+
+typedef struct sdl3d_texture_cache_entry
+{
+    char *path;
+    sdl3d_texture2d texture;
+    struct sdl3d_texture_cache_entry *next;
+} sdl3d_texture_cache_entry;
+
+void sdl3d_texture_sample_rgba(const sdl3d_texture2d *texture, float u, float v, float *out_r, float *out_g,
+                               float *out_b, float *out_a);
+void sdl3d_texture_cache_destroy(sdl3d_texture_cache_entry *cache);
+bool sdl3d_texture_cache_get_or_load(sdl3d_texture_cache_entry **cache, const char *source_path,
+                                     const char *texture_path, const sdl3d_texture2d **out_texture);
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ set(SDL3D_TEST_SOURCES
     test_render_loop.cpp
     test_shapes.cpp
     test_vertex_color.cpp
+    test_texture.cpp
+    test_textured_rendering.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -150,6 +152,8 @@ else()
     sdl3d_add_test(sdl3d_render_loop_test test_render_loop.cpp render)
     sdl3d_add_test(sdl3d_shapes_test test_shapes.cpp render)
     sdl3d_add_test(sdl3d_vertex_color_test test_vertex_color.cpp render)
+    sdl3d_add_test(sdl3d_texture_test test_texture.cpp unit)
+    sdl3d_add_test(sdl3d_textured_rendering_test test_textured_rendering.cpp render)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)

--- a/tests/test_image.cpp
+++ b/tests/test_image.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_filesystem.h>
 
 #include "sdl3d/image.h"
 
@@ -14,8 +15,21 @@ namespace
 
 std::string make_temp_path(const char *leaf)
 {
-    std::filesystem::path tmp = std::filesystem::temp_directory_path() / leaf;
-    return tmp.string();
+    std::filesystem::path root;
+    char *pref_path = SDL_GetPrefPath("bluesentinelsec", "SDL3DTests");
+    if (pref_path != nullptr)
+    {
+        root = pref_path;
+        SDL_free(pref_path);
+    }
+    else
+    {
+        SDL_ClearError();
+        root = std::filesystem::temp_directory_path();
+    }
+
+    std::filesystem::create_directories(root);
+    return (root / leaf).string();
 }
 
 } // namespace

--- a/tests/test_rasterizer.cpp
+++ b/tests/test_rasterizer.cpp
@@ -16,6 +16,7 @@ extern "C"
 #include "sdl3d/types.h"
 }
 
+#include <cmath>
 #include <cstring>
 #include <vector>
 
@@ -79,6 +80,59 @@ constexpr sdl3d_color kRed = {255, 0, 0, 255};
 constexpr sdl3d_color kGreen = {0, 255, 0, 255};
 constexpr sdl3d_color kBlue = {0, 0, 255, 255};
 constexpr sdl3d_color kBlack = {0, 0, 0, 0};
+
+sdl3d_texture2d MakeTextureFromPixels(const std::vector<Uint8> &pixels, int width, int height)
+{
+    sdl3d_image image{};
+    image.pixels = const_cast<Uint8 *>(pixels.data());
+    image.width = width;
+    image.height = height;
+
+    sdl3d_texture2d texture{};
+    EXPECT_TRUE(sdl3d_create_texture_from_image(&image, &texture));
+    return texture;
+}
+
+bool PixelNear(sdl3d_color actual, sdl3d_color expected, int tolerance = 12)
+{
+    return std::abs((int)actual.r - (int)expected.r) <= tolerance &&
+           std::abs((int)actual.g - (int)expected.g) <= tolerance &&
+           std::abs((int)actual.b - (int)expected.b) <= tolerance &&
+           std::abs((int)actual.a - (int)expected.a) <= tolerance;
+}
+
+bool SampleNearColor(const Framebuffer &f, int cx, int cy, int window, sdl3d_color expected)
+{
+    for (int dy = -window; dy <= window; ++dy)
+    {
+        for (int dx = -window; dx <= window; ++dx)
+        {
+            const int x = cx + dx;
+            const int y = cy + dy;
+            if (x < 0 || x >= f.fb.width || y < 0 || y >= f.fb.height)
+            {
+                continue;
+            }
+            if (PixelNear(f.GetPixel(x, y), expected))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+SDL_Point ProjectToFramebuffer(const sdl3d_mat4 &mvp, int width, int height, sdl3d_vec3 point)
+{
+    const sdl3d_vec4 clip = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(point, 1.0f));
+    const float inverse_w = 1.0f / clip.w;
+    const float ndc_x = clip.x * inverse_w;
+    const float ndc_y = clip.y * inverse_w;
+    SDL_Point out{};
+    out.x = (int)std::lround((ndc_x + 1.0f) * 0.5f * (float)width);
+    out.y = (int)std::lround((1.0f - ndc_y) * 0.5f * (float)height);
+    return out;
+}
 } // namespace
 
 /* --- Framebuffer clear --------------------------------------------------- */
@@ -357,6 +411,102 @@ TEST(SDL3DRasterizeTriangle, WireframeDrawsEdgesWithoutFillingInterior)
 
     EXPECT_GT(CountPixelsEqual(f, kRed), 0);
     EXPECT_TRUE(PixelEquals(f.GetPixel(kW / 2, kH / 2), kBlack));
+}
+
+TEST(SDL3DRasterizeTriangle, TexturedNearestMapsQuadrantsCorrectly)
+{
+    Framebuffer f(32, 32);
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+
+    const std::vector<Uint8> pixels = {
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
+    };
+    sdl3d_texture2d texture = MakeTextureFromPixels(pixels, 2, 2);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_NEAREST));
+    ASSERT_TRUE(sdl3d_set_texture_wrap(&texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP));
+
+    const sdl3d_mat4 id = sdl3d_mat4_identity();
+    const sdl3d_vec4 modulate = {1.0f, 1.0f, 1.0f, 1.0f};
+
+    sdl3d_rasterize_triangle_textured(&f.fb, id, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f),
+                                      sdl3d_vec3_make(1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, 1.0f, 0.0f),
+                                      sdl3d_vec2{0.0f, 0.0f}, sdl3d_vec2{1.0f, 0.0f}, sdl3d_vec2{1.0f, 1.0f}, modulate,
+                                      modulate, modulate, &texture, false, false);
+    sdl3d_rasterize_triangle_textured(&f.fb, id, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, 1.0f, 0.0f),
+                                      sdl3d_vec3_make(-1.0f, 1.0f, 0.0f), sdl3d_vec2{0.0f, 0.0f},
+                                      sdl3d_vec2{1.0f, 1.0f}, sdl3d_vec2{0.0f, 1.0f}, modulate, modulate, modulate,
+                                      &texture, false, false);
+
+    EXPECT_TRUE(PixelNear(f.GetPixel(8, 8), kRed));
+    EXPECT_TRUE(PixelNear(f.GetPixel(24, 8), kGreen));
+    EXPECT_TRUE(PixelNear(f.GetPixel(8, 24), kBlue));
+    EXPECT_TRUE(PixelNear(f.GetPixel(24, 24), sdl3d_color{255, 255, 0, 255}));
+
+    sdl3d_free_texture(&texture);
+}
+
+TEST(SDL3DRasterizeTriangle, TexturedBilinearBlendsAtCenter)
+{
+    Framebuffer f(32, 32);
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+
+    const std::vector<Uint8> pixels = {
+        0, 0, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255,
+    };
+    sdl3d_texture2d texture = MakeTextureFromPixels(pixels, 2, 2);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_BILINEAR));
+
+    const sdl3d_mat4 id = sdl3d_mat4_identity();
+    const sdl3d_vec4 modulate = {1.0f, 1.0f, 1.0f, 1.0f};
+
+    sdl3d_rasterize_triangle_textured(&f.fb, id, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f),
+                                      sdl3d_vec3_make(1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, 1.0f, 0.0f),
+                                      sdl3d_vec2{0.0f, 0.0f}, sdl3d_vec2{1.0f, 0.0f}, sdl3d_vec2{1.0f, 1.0f}, modulate,
+                                      modulate, modulate, &texture, false, false);
+    sdl3d_rasterize_triangle_textured(&f.fb, id, sdl3d_vec3_make(-1.0f, -1.0f, 0.0f), sdl3d_vec3_make(1.0f, 1.0f, 0.0f),
+                                      sdl3d_vec3_make(-1.0f, 1.0f, 0.0f), sdl3d_vec2{0.0f, 0.0f},
+                                      sdl3d_vec2{1.0f, 1.0f}, sdl3d_vec2{0.0f, 1.0f}, modulate, modulate, modulate,
+                                      &texture, false, false);
+
+    const sdl3d_color center = f.GetPixel(16, 16);
+    EXPECT_NEAR((int)center.r, 64, 20);
+    EXPECT_NEAR((int)center.g, 64, 20);
+    EXPECT_NEAR((int)center.b, 64, 20);
+
+    sdl3d_free_texture(&texture);
+}
+
+TEST(SDL3DRasterizeTriangle, TexturedPerspectiveCorrectNearTexelDominates)
+{
+    Framebuffer f(64, 64);
+    sdl3d_framebuffer_clear(&f.fb, kBlack, 1.0f);
+
+    const std::vector<Uint8> pixels = {
+        255, 0, 0, 255, 0, 255, 0, 255,
+    };
+    sdl3d_texture2d texture = MakeTextureFromPixels(pixels, 2, 1);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_NEAREST));
+
+    sdl3d_mat4 proj;
+    ASSERT_TRUE(sdl3d_mat4_perspective(sdl3d_degrees_to_radians(60.0f), 1.0f, 0.01f, 100.0f, &proj));
+
+    const sdl3d_vec4 modulate = {1.0f, 1.0f, 1.0f, 1.0f};
+    const sdl3d_vec3 v0 = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
+    const sdl3d_vec3 v1 = sdl3d_vec3_make(2.0f, 0.0f, -10.0f);
+    const sdl3d_vec3 v2 = sdl3d_vec3_make(0.0f, 2.0f, -10.0f);
+
+    sdl3d_rasterize_triangle_textured(&f.fb, proj, v0, v1, v2, sdl3d_vec2{0.0f, 0.0f}, sdl3d_vec2{1.0f, 0.0f},
+                                      sdl3d_vec2{1.0f, 1.0f}, modulate, modulate, modulate, &texture, false, false);
+
+    const SDL_Point p0 = ProjectToFramebuffer(proj, f.fb.width, f.fb.height, v0);
+    const SDL_Point p1 = ProjectToFramebuffer(proj, f.fb.width, f.fb.height, v1);
+    const SDL_Point p2 = ProjectToFramebuffer(proj, f.fb.width, f.fb.height, v2);
+    const int cx = (p0.x + p1.x + p2.x) / 3;
+    const int cy = (p0.y + p1.y + p2.y) / 3;
+
+    EXPECT_TRUE(SampleNearColor(f, cx, cy, 2, kRed));
+
+    sdl3d_free_texture(&texture);
 }
 
 TEST(SDL3DRasterizeTriangle, ScissorClipsTriangleCoverage)

--- a/tests/test_texture.cpp
+++ b/tests/test_texture.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_filesystem.h>
 
 #include "sdl3d/texture.h"
 
@@ -13,9 +14,22 @@ namespace
 
 std::filesystem::path make_temp_dir(const char *leaf)
 {
+    std::filesystem::path root;
+    char *pref_path = SDL_GetPrefPath("bluesentinelsec", "SDL3DTests");
+    if (pref_path != nullptr)
+    {
+        root = pref_path;
+        SDL_free(pref_path);
+    }
+    else
+    {
+        SDL_ClearError();
+        root = std::filesystem::temp_directory_path();
+    }
+
     const auto unique =
         std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
-    std::filesystem::path dir = std::filesystem::temp_directory_path() / (std::string(leaf) + "_" + unique);
+    std::filesystem::path dir = root / (std::string(leaf) + "_" + unique);
     std::filesystem::create_directories(dir);
     return dir;
 }

--- a/tests/test_texture.cpp
+++ b/tests/test_texture.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <SDL3/SDL_error.h>
+
+#include "sdl3d/texture.h"
+
+namespace
+{
+
+std::filesystem::path make_temp_dir(const char *leaf)
+{
+    const auto unique =
+        std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / (std::string(leaf) + "_" + unique);
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+} // namespace
+
+TEST(SDL3DTexture, CreateFromImageCopiesPixelsAndDefaultsSampler)
+{
+    std::vector<Uint8> pixels = {
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
+    };
+
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = 2;
+    image.height = 2;
+
+    sdl3d_texture2d texture{};
+    ASSERT_TRUE(sdl3d_create_texture_from_image(&image, &texture)) << SDL_GetError();
+
+    EXPECT_EQ(2, texture.width);
+    EXPECT_EQ(2, texture.height);
+    EXPECT_EQ(SDL3D_TEXTURE_FILTER_BILINEAR, texture.filter);
+    EXPECT_EQ(SDL3D_TEXTURE_WRAP_CLAMP, texture.wrap_u);
+    EXPECT_EQ(SDL3D_TEXTURE_WRAP_CLAMP, texture.wrap_v);
+    ASSERT_NE(nullptr, texture.pixels);
+
+    pixels[0] = 17;
+    EXPECT_EQ(255, texture.pixels[0]);
+
+    sdl3d_free_texture(&texture);
+}
+
+TEST(SDL3DTexture, LoadFromFileRoundTrip)
+{
+    constexpr int w = 2;
+    constexpr int h = 2;
+    const std::filesystem::path dir = make_temp_dir("texture_roundtrip");
+    const std::filesystem::path png_path = dir / "roundtrip.png";
+
+    std::vector<Uint8> pixels = {
+        10, 20, 30, 255, 40, 50, 60, 255, 70, 80, 90, 255, 100, 110, 120, 255,
+    };
+
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = w;
+    image.height = h;
+
+    ASSERT_TRUE(sdl3d_save_image_png(&image, png_path.string().c_str())) << SDL_GetError();
+
+    sdl3d_texture2d texture{};
+    ASSERT_TRUE(sdl3d_load_texture_from_file(png_path.string().c_str(), &texture)) << SDL_GetError();
+
+    EXPECT_EQ(w, texture.width);
+    EXPECT_EQ(h, texture.height);
+    ASSERT_NE(nullptr, texture.pixels);
+
+    for (size_t i = 0; i < pixels.size(); ++i)
+    {
+        EXPECT_EQ(pixels[i], texture.pixels[i]) << "byte " << i;
+    }
+
+    sdl3d_free_texture(&texture);
+}
+
+TEST(SDL3DTexture, SamplerStateMutatorsValidateEnums)
+{
+    std::vector<Uint8> pixels(4, 255);
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = 1;
+    image.height = 1;
+
+    sdl3d_texture2d texture{};
+    ASSERT_TRUE(sdl3d_create_texture_from_image(&image, &texture));
+
+    EXPECT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_NEAREST));
+    EXPECT_EQ(SDL3D_TEXTURE_FILTER_NEAREST, texture.filter);
+
+    EXPECT_TRUE(sdl3d_set_texture_wrap(&texture, SDL3D_TEXTURE_WRAP_REPEAT, SDL3D_TEXTURE_WRAP_CLAMP));
+    EXPECT_EQ(SDL3D_TEXTURE_WRAP_REPEAT, texture.wrap_u);
+    EXPECT_EQ(SDL3D_TEXTURE_WRAP_CLAMP, texture.wrap_v);
+
+    EXPECT_FALSE(sdl3d_set_texture_filter(&texture, (sdl3d_texture_filter)99));
+    EXPECT_FALSE(sdl3d_set_texture_wrap(&texture, (sdl3d_texture_wrap)88, SDL3D_TEXTURE_WRAP_CLAMP));
+
+    sdl3d_free_texture(&texture);
+}
+
+TEST(SDL3DTexture, FreeIsIdempotent)
+{
+    sdl3d_texture2d texture{};
+    sdl3d_free_texture(&texture);
+    sdl3d_free_texture(&texture);
+}

--- a/tests/test_textured_rendering.cpp
+++ b/tests/test_textured_rendering.cpp
@@ -1,0 +1,402 @@
+/*
+ * Integration tests for textured mesh/model drawing. Covers software texture
+ * sampling modes, perspective-correct UV interpolation, model texture path
+ * resolution, cache reuse, and logical-presentation interop.
+ */
+
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+class SDL3DTexturedFixture : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        SDL_ClearError();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        SDL_Quit();
+    }
+};
+
+class WindowRenderer
+{
+  public:
+    WindowRenderer(int width = 128, int height = 128)
+        : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *window = nullptr;
+        SDL_Renderer *renderer = nullptr;
+        if (!SDL_CreateWindowAndRenderer("SDL3D Textured Test", width, height, 0, &window, &renderer))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+        window_.reset(window);
+        renderer_.reset(renderer);
+    }
+
+    bool ok() const
+    {
+        return window_ && renderer_;
+    }
+
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+std::filesystem::path make_temp_dir(const char *leaf)
+{
+    const auto unique =
+        std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / (std::string(leaf) + "_" + unique);
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+sdl3d_camera3d make_ortho(float view_height = 4.0f)
+{
+    sdl3d_camera3d camera{};
+    camera.position = sdl3d_vec3_make(0.0f, 0.0f, 3.0f);
+    camera.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.fovy = view_height;
+    camera.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
+    return camera;
+}
+
+sdl3d_camera3d make_perspective(sdl3d_vec3 eye, sdl3d_vec3 target, float fovy_degrees = 60.0f)
+{
+    sdl3d_camera3d camera{};
+    camera.position = eye;
+    camera.target = target;
+    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.fovy = fovy_degrees;
+    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return camera;
+}
+
+constexpr sdl3d_color kBlack = {0, 0, 0, 255};
+constexpr sdl3d_color kWhite = {255, 255, 255, 255};
+constexpr sdl3d_color kRed = {255, 0, 0, 255};
+constexpr sdl3d_color kGreen = {0, 255, 0, 255};
+constexpr sdl3d_color kBlue = {0, 0, 255, 255};
+constexpr sdl3d_color kYellow = {255, 255, 0, 255};
+constexpr sdl3d_color kMauve = {180, 90, 140, 255};
+
+bool pixel_near(sdl3d_color actual, sdl3d_color expected, int tolerance = 12)
+{
+    return std::abs((int)actual.r - (int)expected.r) <= tolerance &&
+           std::abs((int)actual.g - (int)expected.g) <= tolerance &&
+           std::abs((int)actual.b - (int)expected.b) <= tolerance &&
+           std::abs((int)actual.a - (int)expected.a) <= tolerance;
+}
+
+sdl3d_texture2d make_texture_from_pixels(const std::vector<Uint8> &pixels, int width, int height)
+{
+    sdl3d_image image{};
+    image.pixels = const_cast<Uint8 *>(pixels.data());
+    image.width = width;
+    image.height = height;
+
+    sdl3d_texture2d texture{};
+    EXPECT_TRUE(sdl3d_create_texture_from_image(&image, &texture)) << SDL_GetError();
+    return texture;
+}
+
+sdl3d_mesh make_textured_quad_mesh()
+{
+    sdl3d_mesh mesh{};
+
+    static float positions[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 1.0f, 1.0f, 0.0f, -1.0f, 1.0f, 0.0f,
+    };
+    static float uvs[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f,
+    };
+    static unsigned int indices[] = {
+        0, 1, 2, 0, 2, 3,
+    };
+
+    mesh.positions = positions;
+    mesh.uvs = uvs;
+    mesh.vertex_count = 4;
+    mesh.indices = indices;
+    mesh.index_count = 6;
+    mesh.material_index = -1;
+    return mesh;
+}
+
+SDL_Point project_to_screen(const sdl3d_render_context *context, sdl3d_camera3d camera, sdl3d_vec3 point)
+{
+    sdl3d_mat4 view{};
+    sdl3d_mat4 projection{};
+    EXPECT_TRUE(sdl3d_camera3d_compute_matrices(&camera, sdl3d_get_render_context_width(context),
+                                                sdl3d_get_render_context_height(context), 0.01f, 1000.0f, &view,
+                                                &projection));
+
+    const sdl3d_mat4 vp = sdl3d_mat4_multiply(projection, view);
+    const sdl3d_vec4 clip = sdl3d_mat4_transform_vec4(vp, sdl3d_vec4_from_vec3(point, 1.0f));
+    const float inverse_w = 1.0f / clip.w;
+
+    SDL_Point out{};
+    out.x = (int)std::lround((clip.x * inverse_w + 1.0f) * 0.5f * (float)sdl3d_get_render_context_width(context));
+    out.y = (int)std::lround((1.0f - clip.y * inverse_w) * 0.5f * (float)sdl3d_get_render_context_height(context));
+    return out;
+}
+
+void write_text_file(const std::filesystem::path &path, const std::string &contents)
+{
+    std::ofstream out(path, std::ios::binary);
+    ASSERT_TRUE(out.is_open());
+    out << contents;
+    ASSERT_TRUE(out.good());
+}
+
+std::filesystem::path write_model_fixture(const std::filesystem::path &dir, sdl3d_color texture_color)
+{
+    const std::filesystem::path texture_path = dir / "albedo.png";
+    const std::filesystem::path mtl_path = dir / "quad.mtl";
+    const std::filesystem::path obj_path = dir / "quad.obj";
+
+    std::vector<Uint8> pixels = {
+        texture_color.r,
+        texture_color.g,
+        texture_color.b,
+        texture_color.a,
+    };
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = 1;
+    image.height = 1;
+    if (!sdl3d_save_image_png(&image, texture_path.string().c_str()))
+    {
+        ADD_FAILURE() << SDL_GetError();
+    }
+
+    write_text_file(mtl_path, "newmtl QuadMat\nKd 1.0 1.0 1.0\nmap_Kd albedo.png\n");
+    write_text_file(obj_path, "mtllib quad.mtl\n"
+                              "o Quad\n"
+                              "v -1.0 -1.0 0.0\n"
+                              "v  1.0 -1.0 0.0\n"
+                              "v  1.0  1.0 0.0\n"
+                              "v -1.0  1.0 0.0\n"
+                              "vt 0.0 0.0\n"
+                              "vt 1.0 0.0\n"
+                              "vt 1.0 1.0\n"
+                              "vt 0.0 1.0\n"
+                              "usemtl QuadMat\n"
+                              "f 1/1 2/2 3/3 4/4\n");
+
+    return obj_path;
+}
+
+} // namespace
+
+TEST(SDL3DTexturedNull, NullContextRejected)
+{
+    sdl3d_mesh mesh{};
+    EXPECT_FALSE(sdl3d_draw_mesh(nullptr, &mesh, nullptr, kWhite));
+}
+
+TEST_F(SDL3DTexturedFixture, DrawMeshOutsideModeRejected)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &context));
+
+    const sdl3d_mesh mesh = make_textured_quad_mesh();
+    EXPECT_FALSE(sdl3d_draw_mesh(context, &mesh, nullptr, kWhite));
+
+    sdl3d_destroy_render_context(context);
+}
+
+TEST_F(SDL3DTexturedFixture, NearestClampSamplerMapsQuadrantsCorrectly)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &context));
+
+    const std::vector<Uint8> pixels = {
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
+    };
+    sdl3d_texture2d texture = make_texture_from_pixels(pixels, 2, 2);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_NEAREST));
+    ASSERT_TRUE(sdl3d_set_texture_wrap(&texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP));
+
+    const sdl3d_mesh mesh = make_textured_quad_mesh();
+
+    ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, make_ortho()));
+    ASSERT_TRUE(sdl3d_draw_mesh(context, &mesh, &texture, kWhite)) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_end_mode_3d(context));
+
+    sdl3d_color sample{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 40, &sample));
+    EXPECT_TRUE(pixel_near(sample, kBlue));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 40, &sample));
+    EXPECT_TRUE(pixel_near(sample, kYellow));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 88, &sample));
+    EXPECT_TRUE(pixel_near(sample, kRed));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 88, &sample));
+    EXPECT_TRUE(pixel_near(sample, kGreen));
+
+    sdl3d_free_texture(&texture);
+    sdl3d_destroy_render_context(context);
+}
+
+TEST_F(SDL3DTexturedFixture, BilinearSamplerBlendsTexelsAtCenter)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &context));
+
+    const std::vector<Uint8> pixels = {
+        0, 0, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255,
+    };
+    sdl3d_texture2d texture = make_texture_from_pixels(pixels, 2, 2);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_BILINEAR));
+
+    const sdl3d_mesh mesh = make_textured_quad_mesh();
+
+    ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, make_ortho()));
+    ASSERT_TRUE(sdl3d_draw_mesh(context, &mesh, &texture, kWhite)) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_end_mode_3d(context));
+
+    sdl3d_color center{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 64, 64, &center));
+    EXPECT_NEAR((int)center.r, 64, 20);
+    EXPECT_NEAR((int)center.g, 64, 20);
+    EXPECT_NEAR((int)center.b, 64, 20);
+
+    sdl3d_free_texture(&texture);
+    sdl3d_destroy_render_context(context);
+}
+
+TEST_F(SDL3DTexturedFixture, PerspectiveCorrectUvInterpolationKeepsNearTexelDominant)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &context));
+
+    const std::vector<Uint8> pixels = {
+        255, 0, 0, 255, 0, 255, 0, 255,
+    };
+    sdl3d_texture2d texture = make_texture_from_pixels(pixels, 2, 1);
+    ASSERT_TRUE(sdl3d_set_texture_filter(&texture, SDL3D_TEXTURE_FILTER_NEAREST));
+
+    const float positions[] = {
+        0.0f, 0.0f, -1.0f, 2.0f, 0.0f, -10.0f, 0.0f, 2.0f, -10.0f,
+    };
+    const float uvs[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f,
+    };
+    const unsigned int indices[] = {0, 1, 2};
+    sdl3d_mesh mesh{};
+    mesh.positions = const_cast<float *>(positions);
+    mesh.uvs = const_cast<float *>(uvs);
+    mesh.vertex_count = 3;
+    mesh.indices = const_cast<unsigned int *>(indices);
+    mesh.index_count = 3;
+    mesh.material_index = -1;
+
+    const sdl3d_camera3d camera =
+        make_perspective(sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(0.0f, 0.0f, -1.0f), 60.0f);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, camera));
+    ASSERT_TRUE(sdl3d_draw_mesh(context, &mesh, &texture, kWhite)) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_end_mode_3d(context));
+
+    const SDL_Point p0 = project_to_screen(context, camera, sdl3d_vec3_make(0.0f, 0.0f, -1.0f));
+    const SDL_Point p1 = project_to_screen(context, camera, sdl3d_vec3_make(2.0f, 0.0f, -10.0f));
+    const SDL_Point p2 = project_to_screen(context, camera, sdl3d_vec3_make(0.0f, 2.0f, -10.0f));
+    const int cx = (p0.x + p1.x + p2.x) / 3;
+    const int cy = (p0.y + p1.y + p2.y) / 3;
+
+    sdl3d_color sample{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, cx, cy, &sample));
+    EXPECT_TRUE(pixel_near(sample, kRed));
+
+    sdl3d_free_texture(&texture);
+    sdl3d_destroy_render_context(context);
+}
+
+TEST_F(SDL3DTexturedFixture, DrawModelResolvesRelativeTexturePathAndUsesLogicalSize)
+{
+    WindowRenderer wr(320, 240);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context_config config;
+    sdl3d_init_render_context_config(&config);
+    config.logical_width = 64;
+    config.logical_height = 64;
+    config.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), &config, &context)) << SDL_GetError();
+    ASSERT_EQ(64, sdl3d_get_render_context_width(context));
+    ASSERT_EQ(64, sdl3d_get_render_context_height(context));
+
+    const std::filesystem::path dir = make_temp_dir("textured_model");
+    const std::filesystem::path obj_path = write_model_fixture(dir, kMauve);
+
+    sdl3d_model model{};
+    ASSERT_TRUE(sdl3d_load_model_from_file(obj_path.string().c_str(), &model)) << SDL_GetError();
+
+    ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, make_ortho()));
+    ASSERT_TRUE(sdl3d_draw_model(context, &model, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 1.0f, kWhite)) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_end_mode_3d(context));
+
+    sdl3d_color center{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 32, 32, &center));
+    EXPECT_TRUE(pixel_near(center, kMauve));
+
+    ASSERT_TRUE(sdl3d_present_render_context(context)) << SDL_GetError();
+
+    sdl3d_free_model(&model);
+    sdl3d_destroy_render_context(context);
+}

--- a/tests/test_textured_rendering.cpp
+++ b/tests/test_textured_rendering.cpp
@@ -270,13 +270,13 @@ TEST_F(SDL3DTexturedFixture, NearestClampSamplerMapsQuadrantsCorrectly)
 
     sdl3d_color sample{};
     ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 40, &sample));
-    EXPECT_TRUE(pixel_near(sample, kBlue));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 40, &sample));
-    EXPECT_TRUE(pixel_near(sample, kYellow));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 88, &sample));
     EXPECT_TRUE(pixel_near(sample, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 88, &sample));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 40, &sample));
     EXPECT_TRUE(pixel_near(sample, kGreen));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 88, &sample));
+    EXPECT_TRUE(pixel_near(sample, kBlue));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 88, &sample));
+    EXPECT_TRUE(pixel_near(sample, kYellow));
 
     sdl3d_free_texture(&texture);
     sdl3d_destroy_render_context(context);

--- a/tests/test_textured_rendering.cpp
+++ b/tests/test_textured_rendering.cpp
@@ -7,8 +7,8 @@
 #include <gtest/gtest.h>
 
 #define SDL_MAIN_HANDLED
-#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL.h>
+#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_main.h>
 
 extern "C"

--- a/tests/test_textured_rendering.cpp
+++ b/tests/test_textured_rendering.cpp
@@ -264,18 +264,23 @@ TEST_F(SDL3DTexturedFixture, NearestClampSamplerMapsQuadrantsCorrectly)
     const sdl3d_mesh mesh = make_textured_quad_mesh();
 
     ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(context, make_ortho()));
+    const sdl3d_camera3d camera = make_ortho();
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, camera));
     ASSERT_TRUE(sdl3d_draw_mesh(context, &mesh, &texture, kWhite)) << SDL_GetError();
     ASSERT_TRUE(sdl3d_end_mode_3d(context));
 
     sdl3d_color sample{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 40, &sample));
+    SDL_Point probe = project_to_screen(context, camera, sdl3d_vec3_make(-0.5f, 0.5f, 0.0f));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, probe.x, probe.y, &sample));
     EXPECT_TRUE(pixel_near(sample, kRed));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 40, &sample));
+    probe = project_to_screen(context, camera, sdl3d_vec3_make(0.5f, 0.5f, 0.0f));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, probe.x, probe.y, &sample));
     EXPECT_TRUE(pixel_near(sample, kGreen));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 40, 88, &sample));
+    probe = project_to_screen(context, camera, sdl3d_vec3_make(-0.5f, -0.5f, 0.0f));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, probe.x, probe.y, &sample));
     EXPECT_TRUE(pixel_near(sample, kBlue));
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 88, 88, &sample));
+    probe = project_to_screen(context, camera, sdl3d_vec3_make(0.5f, -0.5f, 0.0f));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, probe.x, probe.y, &sample));
     EXPECT_TRUE(pixel_near(sample, kYellow));
 
     sdl3d_free_texture(&texture);
@@ -299,12 +304,14 @@ TEST_F(SDL3DTexturedFixture, BilinearSamplerBlendsTexelsAtCenter)
     const sdl3d_mesh mesh = make_textured_quad_mesh();
 
     ASSERT_TRUE(sdl3d_clear_render_context(context, kBlack));
-    ASSERT_TRUE(sdl3d_begin_mode_3d(context, make_ortho()));
+    const sdl3d_camera3d camera = make_ortho();
+    ASSERT_TRUE(sdl3d_begin_mode_3d(context, camera));
     ASSERT_TRUE(sdl3d_draw_mesh(context, &mesh, &texture, kWhite)) << SDL_GetError();
     ASSERT_TRUE(sdl3d_end_mode_3d(context));
 
     sdl3d_color center{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, 64, 64, &center));
+    const SDL_Point center_probe = project_to_screen(context, camera, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(context, center_probe.x, center_probe.y, &center));
     EXPECT_NEAR((int)center.r, 64, 20);
     EXPECT_NEAR((int)center.g, 64, 20);
     EXPECT_NEAR((int)center.b, 64, 20);

--- a/tests/test_textured_rendering.cpp
+++ b/tests/test_textured_rendering.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #define SDL_MAIN_HANDLED
+#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 
@@ -80,9 +81,22 @@ class WindowRenderer
 
 std::filesystem::path make_temp_dir(const char *leaf)
 {
+    std::filesystem::path root;
+    char *pref_path = SDL_GetPrefPath("bluesentinelsec", "SDL3DTests");
+    if (pref_path != nullptr)
+    {
+        root = pref_path;
+        SDL_free(pref_path);
+    }
+    else
+    {
+        SDL_ClearError();
+        root = std::filesystem::temp_directory_path();
+    }
+
     const auto unique =
         std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
-    std::filesystem::path dir = std::filesystem::temp_directory_path() / (std::string(leaf) + "_" + unique);
+    std::filesystem::path dir = root / (std::string(leaf) + "_" + unique);
     std::filesystem::create_directories(dir);
     return dir;
 }


### PR DESCRIPTION
## Summary
Implements the second M3 slice: textured mesh drawing on the software backend.

This PR adds:
- `sdl3d_texture2d` with load/create/free, nearest/bilinear filtering, and clamp/repeat wrap.
- `sdl3d_draw_mesh`, `sdl3d_draw_model`, and `sdl3d_draw_model_ex`.
- A perspective-correct textured triangle path in the software rasterizer.
- Render-context texture caching for model albedo maps resolved relative to `model->source_path`.
- Headless rasterizer tests for nearest sampling, bilinear sampling, and perspective-correct UV interpolation.
- Integration tests for textured model drawing and logical-size interop.

Behavioral notes:
- The textured path reuses the existing clip/depth/fixed-point triangle pipeline instead of adding a separate affine sampler path.
- UVs are sampled with the usual 3D convention `(0,0) == lower-left`, while image storage remains top-down.
- Logical-size behavior remains driven by the render-context backbuffer dimensions, so `SDL_SetRenderLogicalPresentation` / logical size interop is preserved.

## Testing
Passed locally:
- `./scripts/check_clang_format.sh`
- `cmake --build build/default`
- `./tests/sdl3d_texture_test`
- `./tests/sdl3d_rasterizer_test`
- `./tests/sdl3d_obj_loader_test`
- `./tests/sdl3d_render_context_unit_test`

Compiled but not executable in this displayless sandbox:
- `./tests/sdl3d_textured_rendering_test`

The local SDL renderer integration tests could not run here because `SDL_Init(SDL_INIT_VIDEO)` reported no displays, and the offscreen path failed to initialize a renderer. The core textured pipeline is still covered locally by the headless rasterizer tests.

Closes roadmap slice tracked from #4.
