### PR TITLE
M4-1/2/3: PBR lighting with directional, point, and spot lights

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,12 +82,14 @@ target_sources(
         src/fbx_loader.c
         src/gltf_loader.c
         src/image.c
+        src/lighting.c
         src/math.c
         src/model.c
         src/obj_loader.c
         src/rasterizer.c
         src/render_context.c
         src/sdl3d.c
+        src/shading.c
         src/shapes.c
         src/texture.c
         $<TARGET_OBJECTS:sdl3d_cgltf>

--- a/include/sdl3d/lighting.h
+++ b/include/sdl3d/lighting.h
@@ -1,0 +1,77 @@
+#ifndef SDL3D_LIGHTING_H
+#define SDL3D_LIGHTING_H
+
+#include <stdbool.h>
+
+#include "sdl3d/render_context.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SDL3D_MAX_LIGHTS 8
+
+    typedef enum sdl3d_light_type
+    {
+        SDL3D_LIGHT_DIRECTIONAL = 0,
+        SDL3D_LIGHT_POINT = 1,
+        SDL3D_LIGHT_SPOT = 2
+    } sdl3d_light_type;
+
+    /*
+     * Unified light descriptor. Fields used depend on `type`:
+     *
+     * DIRECTIONAL: direction, color, intensity.
+     * POINT:       position, color, intensity, range.
+     * SPOT:        position, direction, color, intensity, range,
+     *              inner_cutoff, outer_cutoff (cosines of half-angles).
+     */
+    typedef struct sdl3d_light
+    {
+        sdl3d_light_type type;
+        sdl3d_vec3 position;
+        sdl3d_vec3 direction;
+        float color[3];
+        float intensity;
+        float range;
+        float inner_cutoff;
+        float outer_cutoff;
+    } sdl3d_light;
+
+    /*
+     * Add a light to the scene. Up to SDL3D_MAX_LIGHTS may be active.
+     * Returns false if the light list is full or context is NULL.
+     */
+    bool sdl3d_add_light(sdl3d_render_context *context, const sdl3d_light *light);
+
+    /*
+     * Remove all lights from the scene.
+     */
+    bool sdl3d_clear_lights(sdl3d_render_context *context);
+
+    /*
+     * Enable or disable lighting. When disabled, DrawModel/DrawMesh
+     * use the existing unlit path (texture × tint). When enabled,
+     * per-fragment PBR shading is applied using the active lights
+     * and the mesh's material properties.
+     *
+     * Lighting is disabled by default.
+     */
+    bool sdl3d_set_lighting_enabled(sdl3d_render_context *context, bool enabled);
+
+    bool sdl3d_is_lighting_enabled(const sdl3d_render_context *context);
+
+    /*
+     * Set the scene ambient light color (linear RGB, default 0.03 each).
+     */
+    bool sdl3d_set_ambient_light(sdl3d_render_context *context, float r, float g, float b);
+
+    int sdl3d_get_light_count(const sdl3d_render_context *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -9,6 +9,7 @@
 #include "sdl3d/camera.h"
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/image.h"
+#include "sdl3d/lighting.h"
 #include "sdl3d/math.h"
 #include "sdl3d/model.h"
 #include "sdl3d/render_context.h"

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -7,6 +7,8 @@
 #include "render_context_internal.h"
 #include "texture_internal.h"
 
+#include "lighting_internal.h"
+
 static const int SDL3D_MODEL_STACK_INITIAL_CAPACITY = 8;
 
 static float sdl3d_clamp01(float value)
@@ -257,11 +259,19 @@ static sdl3d_vec2 sdl3d_mesh_uv(const sdl3d_mesh *mesh, unsigned int vertex_inde
     return out;
 }
 
+static sdl3d_vec3 sdl3d_mesh_normal(const sdl3d_mesh *mesh, unsigned int vertex_index)
+{
+    const float *n = &mesh->normals[(size_t)vertex_index * 3U];
+    return sdl3d_vec3_make(n[0], n[1], n[2]);
+}
+
 static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_mesh *mesh,
-                                     const sdl3d_texture2d *texture, sdl3d_vec4 base_modulate)
+                                     const sdl3d_texture2d *texture, sdl3d_vec4 base_modulate,
+                                     const sdl3d_lighting_params *lighting)
 {
     const bool indexed = mesh->indices != NULL;
     const int triangle_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
+    const bool lit = lighting != NULL && mesh->normals != NULL;
     sdl3d_framebuffer framebuffer;
 
     if (!sdl3d_require_mode_3d(context, "sdl3d_draw_mesh"))
@@ -319,11 +329,54 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
             uv2 = sdl3d_mesh_uv(mesh, i2);
         }
 
-        sdl3d_rasterize_triangle_textured(
-            &framebuffer, context->model_view_projection, sdl3d_mesh_position(mesh, i0), sdl3d_mesh_position(mesh, i1),
-            sdl3d_mesh_position(mesh, i2), uv0, uv1, uv2, sdl3d_mesh_vertex_modulate(mesh, i0, base_modulate),
-            sdl3d_mesh_vertex_modulate(mesh, i1, base_modulate), sdl3d_mesh_vertex_modulate(mesh, i2, base_modulate),
-            texture, context->backface_culling_enabled, context->wireframe_enabled);
+        if (lit)
+        {
+            /* Transform normals by upper-left 3x3 of model matrix. */
+            const sdl3d_mat4 m = context->model;
+            sdl3d_vec3 rn0, rn1, rn2;
+            sdl3d_vec3 on0 = sdl3d_mesh_normal(mesh, i0);
+            sdl3d_vec3 on1 = sdl3d_mesh_normal(mesh, i1);
+            sdl3d_vec3 on2 = sdl3d_mesh_normal(mesh, i2);
+            rn0.x = m.m[0] * on0.x + m.m[4] * on0.y + m.m[8] * on0.z;
+            rn0.y = m.m[1] * on0.x + m.m[5] * on0.y + m.m[9] * on0.z;
+            rn0.z = m.m[2] * on0.x + m.m[6] * on0.y + m.m[10] * on0.z;
+            rn1.x = m.m[0] * on1.x + m.m[4] * on1.y + m.m[8] * on1.z;
+            rn1.y = m.m[1] * on1.x + m.m[5] * on1.y + m.m[9] * on1.z;
+            rn1.z = m.m[2] * on1.x + m.m[6] * on1.y + m.m[10] * on1.z;
+            rn2.x = m.m[0] * on2.x + m.m[4] * on2.y + m.m[8] * on2.z;
+            rn2.y = m.m[1] * on2.x + m.m[5] * on2.y + m.m[9] * on2.z;
+            rn2.z = m.m[2] * on2.x + m.m[6] * on2.y + m.m[10] * on2.z;
+            rn0 = sdl3d_vec3_normalize(rn0);
+            rn1 = sdl3d_vec3_normalize(rn1);
+            rn2 = sdl3d_vec3_normalize(rn2);
+
+            /* Transform positions to world space. */
+            sdl3d_vec3 p0 = sdl3d_mesh_position(mesh, i0);
+            sdl3d_vec3 p1 = sdl3d_mesh_position(mesh, i1);
+            sdl3d_vec3 p2 = sdl3d_mesh_position(mesh, i2);
+            sdl3d_vec4 wp0_4 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(p0, 1.0f));
+            sdl3d_vec4 wp1_4 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(p1, 1.0f));
+            sdl3d_vec4 wp2_4 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(p2, 1.0f));
+            sdl3d_vec3 wp0 = sdl3d_vec3_make(wp0_4.x, wp0_4.y, wp0_4.z);
+            sdl3d_vec3 wp1 = sdl3d_vec3_make(wp1_4.x, wp1_4.y, wp1_4.z);
+            sdl3d_vec3 wp2 = sdl3d_vec3_make(wp2_4.x, wp2_4.y, wp2_4.z);
+
+            sdl3d_rasterize_triangle_lit(&framebuffer, context->model_view_projection, p0, p1, p2, uv0, uv1, uv2, rn0,
+                                         rn1, rn2, wp0, wp1, wp2, sdl3d_mesh_vertex_modulate(mesh, i0, base_modulate),
+                                         sdl3d_mesh_vertex_modulate(mesh, i1, base_modulate),
+                                         sdl3d_mesh_vertex_modulate(mesh, i2, base_modulate), texture, lighting,
+                                         context->backface_culling_enabled, context->wireframe_enabled);
+        }
+        else
+        {
+            sdl3d_rasterize_triangle_textured(&framebuffer, context->model_view_projection,
+                                              sdl3d_mesh_position(mesh, i0), sdl3d_mesh_position(mesh, i1),
+                                              sdl3d_mesh_position(mesh, i2), uv0, uv1, uv2,
+                                              sdl3d_mesh_vertex_modulate(mesh, i0, base_modulate),
+                                              sdl3d_mesh_vertex_modulate(mesh, i1, base_modulate),
+                                              sdl3d_mesh_vertex_modulate(mesh, i2, base_modulate), texture,
+                                              context->backface_culling_enabled, context->wireframe_enabled);
+        }
     }
 
     return true;
@@ -466,7 +519,7 @@ bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl
 bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
                      sdl3d_color tint)
 {
-    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint));
+    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint), NULL);
 }
 
 bool sdl3d_draw_model(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position, float scale,
@@ -514,6 +567,7 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
     {
         const sdl3d_mesh *mesh = &model->meshes[mesh_index];
         const sdl3d_texture2d *texture = NULL;
+        const sdl3d_material *material = NULL;
         sdl3d_vec4 mesh_modulate = tint_modulate;
 
         if (mesh->material_index < -1)
@@ -524,8 +578,6 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
 
         if (mesh->material_index >= 0)
         {
-            const sdl3d_material *material = NULL;
-
             if (mesh->material_index >= model->material_count || model->materials == NULL)
             {
                 ok = SDL_SetError("Mesh material index %d is outside material_count=%d.", mesh->material_index,
@@ -550,7 +602,54 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
             }
         }
 
-        ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate);
+        {
+            sdl3d_lighting_params lp_storage;
+            const sdl3d_lighting_params *lp_ptr = NULL;
+
+            if (context->lighting_enabled && context->light_count > 0)
+            {
+                lp_storage.lights = context->lights;
+                lp_storage.light_count = context->light_count;
+                lp_storage.ambient[0] = context->ambient[0];
+                lp_storage.ambient[1] = context->ambient[1];
+                lp_storage.ambient[2] = context->ambient[2];
+
+                /* Camera position: extract from the inverse of the view matrix.
+                 * For a look-at view matrix, the camera position is the negated
+                 * translation of the transpose of the upper-left 3x3 applied to
+                 * the translation column. Simpler: we stored it during begin_mode_3d
+                 * — but we didn't. Instead, recover from view matrix: the camera
+                 * world position is -(R^T * t) where R is upper-left 3x3 and t is
+                 * column 3. */
+                {
+                    const sdl3d_mat4 v = context->view;
+                    lp_storage.camera_pos.x = -(v.m[0] * v.m[12] + v.m[1] * v.m[13] + v.m[2] * v.m[14]);
+                    lp_storage.camera_pos.y = -(v.m[4] * v.m[12] + v.m[5] * v.m[13] + v.m[6] * v.m[14]);
+                    lp_storage.camera_pos.z = -(v.m[8] * v.m[12] + v.m[9] * v.m[13] + v.m[10] * v.m[14]);
+                }
+
+                if (material != NULL)
+                {
+                    lp_storage.metallic = material->metallic;
+                    lp_storage.roughness = material->roughness;
+                    lp_storage.emissive[0] = material->emissive[0];
+                    lp_storage.emissive[1] = material->emissive[1];
+                    lp_storage.emissive[2] = material->emissive[2];
+                }
+                else
+                {
+                    lp_storage.metallic = 0.0f;
+                    lp_storage.roughness = 1.0f;
+                    lp_storage.emissive[0] = 0.0f;
+                    lp_storage.emissive[1] = 0.0f;
+                    lp_storage.emissive[2] = 0.0f;
+                }
+
+                lp_ptr = &lp_storage;
+            }
+
+            ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate, lp_ptr);
+        }
     }
 
     if (!sdl3d_pop_matrix(context))

--- a/src/lighting.c
+++ b/src/lighting.c
@@ -1,0 +1,79 @@
+#include "sdl3d/lighting.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "render_context_internal.h"
+
+bool sdl3d_add_light(sdl3d_render_context *context, const sdl3d_light *light)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (light == NULL)
+    {
+        return SDL_InvalidParamError("light");
+    }
+    if (context->light_count >= SDL3D_MAX_LIGHTS)
+    {
+        return SDL_SetError("Light list is full (max %d).", SDL3D_MAX_LIGHTS);
+    }
+
+    context->lights[context->light_count] = *light;
+    context->light_count += 1;
+    return true;
+}
+
+bool sdl3d_clear_lights(sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    context->light_count = 0;
+    return true;
+}
+
+bool sdl3d_set_lighting_enabled(sdl3d_render_context *context, bool enabled)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    context->lighting_enabled = enabled;
+    return true;
+}
+
+bool sdl3d_is_lighting_enabled(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return false;
+    }
+    return context->lighting_enabled;
+}
+
+bool sdl3d_set_ambient_light(sdl3d_render_context *context, float r, float g, float b)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+
+    context->ambient[0] = r;
+    context->ambient[1] = g;
+    context->ambient[2] = b;
+    return true;
+}
+
+int sdl3d_get_light_count(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return 0;
+    }
+    return context->light_count;
+}

--- a/src/lighting_internal.h
+++ b/src/lighting_internal.h
@@ -1,0 +1,41 @@
+/*
+ * Internal lighting types and per-fragment PBR shading. Not part of
+ * the public SDL3D API.
+ */
+
+#ifndef SDL3D_INTERNAL_LIGHTING_H
+#define SDL3D_INTERNAL_LIGHTING_H
+
+#include "sdl3d/lighting.h"
+#include "sdl3d/math.h"
+
+/*
+ * Packed lighting parameters passed from drawing3d.c into the
+ * rasterizer so the fill loop can evaluate PBR shading per fragment.
+ */
+typedef struct sdl3d_lighting_params
+{
+    const sdl3d_light *lights;
+    int light_count;
+    float ambient[3];
+    sdl3d_vec3 camera_pos;
+    float metallic;
+    float roughness;
+    float emissive[3];
+} sdl3d_lighting_params;
+
+/*
+ * Evaluate PBR shading for a single fragment.
+ *
+ * `albedo` is the base color (texture × material factor) in linear RGB.
+ * `world_normal` must be normalized.
+ * `world_pos` is the fragment's world-space position.
+ *
+ * Writes the final lit linear RGB into out_r/g/b. Alpha is not affected
+ * by lighting.
+ */
+void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_r, float albedo_g, float albedo_b,
+                              float world_nx, float world_ny, float world_nz, float world_px, float world_py,
+                              float world_pz, float *out_r, float *out_g, float *out_b);
+
+#endif

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -9,6 +9,8 @@
 
 #include "texture_internal.h"
 
+#include "lighting_internal.h"
+
 /*
  * Subpixel precision: 8 bits (256 subpixel positions per pixel).
  * Sample point is pixel center at (x + 0.5, y + 0.5).
@@ -1689,6 +1691,413 @@ static void sdl3d_rasterize_screen_line(sdl3d_framebuffer *framebuffer, sdl3d_sc
         x += step_x;
         y += step_y;
         z += step_z;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Lit textured triangle: normals + world positions through clipping   */
+/* ------------------------------------------------------------------ */
+
+typedef struct sdl3d_clip_vertex_lit
+{
+    sdl3d_vec4 position;
+    float u, v;
+    float mod_r, mod_g, mod_b, mod_a;
+    float nx, ny, nz;
+    float wx, wy, wz;
+} sdl3d_clip_vertex_lit;
+
+static sdl3d_clip_vertex_lit sdl3d_clip_vertex_lit_lerp(sdl3d_clip_vertex_lit a, sdl3d_clip_vertex_lit b, float t)
+{
+    sdl3d_clip_vertex_lit out;
+    out.position = sdl3d_vec4_lerp(a.position, b.position, t);
+    out.u = a.u + (b.u - a.u) * t;
+    out.v = a.v + (b.v - a.v) * t;
+    out.mod_r = a.mod_r + (b.mod_r - a.mod_r) * t;
+    out.mod_g = a.mod_g + (b.mod_g - a.mod_g) * t;
+    out.mod_b = a.mod_b + (b.mod_b - a.mod_b) * t;
+    out.mod_a = a.mod_a + (b.mod_a - a.mod_a) * t;
+    out.nx = a.nx + (b.nx - a.nx) * t;
+    out.ny = a.ny + (b.ny - a.ny) * t;
+    out.nz = a.nz + (b.nz - a.nz) * t;
+    out.wx = a.wx + (b.wx - a.wx) * t;
+    out.wy = a.wy + (b.wy - a.wy) * t;
+    out.wz = a.wz + (b.wz - a.wz) * t;
+    return out;
+}
+
+static int sdl3d_clip_polygon_against_plane_lit(const sdl3d_clip_vertex_lit *in_verts, int in_count,
+                                                sdl3d_clip_vertex_lit *out_verts, sdl3d_clip_plane plane)
+{
+    int out_count = 0;
+    if (in_count < 1)
+    {
+        return 0;
+    }
+    sdl3d_clip_vertex_lit prev = in_verts[in_count - 1];
+    float prev_dist = sdl3d_clip_distance(prev.position, plane);
+    for (int i = 0; i < in_count; ++i)
+    {
+        sdl3d_clip_vertex_lit curr = in_verts[i];
+        float curr_dist = sdl3d_clip_distance(curr.position, plane);
+        if (prev_dist >= 0.0f)
+        {
+            if (curr_dist >= 0.0f)
+            {
+                out_verts[out_count++] = curr;
+            }
+            else
+            {
+                float t = prev_dist / (prev_dist - curr_dist);
+                out_verts[out_count++] = sdl3d_clip_vertex_lit_lerp(prev, curr, t);
+            }
+        }
+        else if (curr_dist >= 0.0f)
+        {
+            float t = prev_dist / (prev_dist - curr_dist);
+            out_verts[out_count++] = sdl3d_clip_vertex_lit_lerp(prev, curr, t);
+            out_verts[out_count++] = curr;
+        }
+        prev = curr;
+        prev_dist = curr_dist;
+    }
+    return out_count;
+}
+
+static int sdl3d_clip_triangle_lit(sdl3d_clip_vertex_lit *verts)
+{
+    sdl3d_clip_vertex_lit buf_a[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_clip_vertex_lit buf_b[SDL3D_CLIP_MAX_VERTICES];
+    int count = 3;
+    sdl3d_clip_vertex_lit *src = verts;
+    sdl3d_clip_vertex_lit *dst = buf_a;
+    for (int p = 0; p < 6; ++p)
+    {
+        count = sdl3d_clip_polygon_against_plane_lit(src, count, dst, (sdl3d_clip_plane)p);
+        if (count < 3)
+        {
+            return 0;
+        }
+        src = dst;
+        dst = (src == buf_a) ? buf_b : buf_a;
+    }
+    if (src != verts)
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            verts[i] = src[i];
+        }
+    }
+    return count;
+}
+
+typedef struct sdl3d_screen_vertex_lit
+{
+    sdl3d_screen_vertex base;
+    float inverse_w;
+    float u_over_w, v_over_w;
+    float mod_r_over_w, mod_g_over_w, mod_b_over_w, mod_a_over_w;
+    float nx_over_w, ny_over_w, nz_over_w;
+    float wx_over_w, wy_over_w, wz_over_w;
+} sdl3d_screen_vertex_lit;
+
+static sdl3d_screen_vertex_lit sdl3d_viewport_transform_lit(sdl3d_clip_vertex_lit v, int width, int height)
+{
+    sdl3d_screen_vertex_lit out;
+    float iw = 1.0f / v.position.w;
+    out.base = sdl3d_viewport_transform(v.position, width, height);
+    out.inverse_w = iw;
+    out.u_over_w = v.u * iw;
+    out.v_over_w = v.v * iw;
+    out.mod_r_over_w = v.mod_r * iw;
+    out.mod_g_over_w = v.mod_g * iw;
+    out.mod_b_over_w = v.mod_b * iw;
+    out.mod_a_over_w = v.mod_a * iw;
+    out.nx_over_w = v.nx * iw;
+    out.ny_over_w = v.ny * iw;
+    out.nz_over_w = v.nz * iw;
+    out.wx_over_w = v.wx * iw;
+    out.wy_over_w = v.wy * iw;
+    out.wz_over_w = v.wz * iw;
+    return out;
+}
+
+typedef struct sdl3d_prepared_triangle_lit
+{
+    sdl3d_screen_vertex_lit a, b, c;
+    Sint64 area;
+    int bias_ab, bias_bc, bias_ca;
+    float inverse_area;
+    sdl3d_triangle_bounds bounds;
+} sdl3d_prepared_triangle_lit;
+
+static void sdl3d_rasterize_prepared_triangle_lit_region(sdl3d_framebuffer *framebuffer,
+                                                         const sdl3d_prepared_triangle_lit *tri,
+                                                         const sdl3d_texture2d *texture,
+                                                         const sdl3d_lighting_params *lp, int min_px_x, int max_px_x,
+                                                         int min_px_y, int max_px_y)
+{
+    const sdl3d_screen_vertex_lit a = tri->a;
+    const sdl3d_screen_vertex_lit b = tri->b;
+    const sdl3d_screen_vertex_lit c = tri->c;
+
+    for (int py = min_px_y; py <= max_px_y; ++py)
+    {
+        const int sy = (py << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+        for (int px = min_px_x; px <= max_px_x; ++px)
+        {
+            const int sx = (px << SDL3D_SUBPIXEL_BITS) + SDL3D_SUBPIXEL_HALF;
+            const Sint64 w_ab =
+                sdl3d_edge_function(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx, sx, sy) + tri->bias_ab;
+            const Sint64 w_bc =
+                sdl3d_edge_function(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx, sx, sy) + tri->bias_bc;
+            const Sint64 w_ca =
+                sdl3d_edge_function(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx, sx, sy) + tri->bias_ca;
+            if ((w_ab | w_bc | w_ca) < 0)
+            {
+                continue;
+            }
+
+            const float ba = (float)w_bc * tri->inverse_area;
+            const float bb = (float)w_ca * tri->inverse_area;
+            const float bc = (float)w_ab * tri->inverse_area;
+            const float depth = ba * a.base.z + bb * b.base.z + bc * c.base.z;
+            const float iw_px = ba * a.inverse_w + bb * b.inverse_w + bc * c.inverse_w;
+            const float pw = 1.0f / iw_px;
+
+            const float u = (ba * a.u_over_w + bb * b.u_over_w + bc * c.u_over_w) * pw;
+            const float v = (ba * a.v_over_w + bb * b.v_over_w + bc * c.v_over_w) * pw;
+            const float mr = (ba * a.mod_r_over_w + bb * b.mod_r_over_w + bc * c.mod_r_over_w) * pw;
+            const float mg = (ba * a.mod_g_over_w + bb * b.mod_g_over_w + bc * c.mod_g_over_w) * pw;
+            const float mb = (ba * a.mod_b_over_w + bb * b.mod_b_over_w + bc * c.mod_b_over_w) * pw;
+            const float ma = (ba * a.mod_a_over_w + bb * b.mod_a_over_w + bc * c.mod_a_over_w) * pw;
+
+            float tr = 1.0f, tg = 1.0f, tb = 1.0f, ta = 1.0f;
+            if (texture != NULL)
+            {
+                sdl3d_texture_sample_rgba(texture, u, v, 0.0f, &tr, &tg, &tb, &ta);
+            }
+
+            float albedo_r = tr * mr;
+            float albedo_g = tg * mg;
+            float albedo_b = tb * mb;
+            float out_a = ta * ma;
+            if (out_a <= 0.0f)
+            {
+                continue;
+            }
+
+            /* Interpolate and normalize world normal + world position. */
+            float nx = (ba * a.nx_over_w + bb * b.nx_over_w + bc * c.nx_over_w) * pw;
+            float ny = (ba * a.ny_over_w + bb * b.ny_over_w + bc * c.ny_over_w) * pw;
+            float nz = (ba * a.nz_over_w + bb * b.nz_over_w + bc * c.nz_over_w) * pw;
+            float n_len = nx * nx + ny * ny + nz * nz;
+            if (n_len > 1e-12f)
+            {
+                float inv = 1.0f / SDL_sqrtf(n_len);
+                nx *= inv;
+                ny *= inv;
+                nz *= inv;
+            }
+            float wpx = (ba * a.wx_over_w + bb * b.wx_over_w + bc * c.wx_over_w) * pw;
+            float wpy = (ba * a.wy_over_w + bb * b.wy_over_w + bc * c.wy_over_w) * pw;
+            float wpz = (ba * a.wz_over_w + bb * b.wz_over_w + bc * c.wz_over_w) * pw;
+
+            float lit_r, lit_g, lit_b;
+            sdl3d_shade_fragment_pbr(lp, albedo_r, albedo_g, albedo_b, nx, ny, nz, wpx, wpy, wpz, &lit_r, &lit_g,
+                                     &lit_b);
+
+            sdl3d_color color;
+            color.r = sdl3d_color_channel_clamp(lit_r * 255.0f);
+            color.g = sdl3d_color_channel_clamp(lit_g * 255.0f);
+            color.b = sdl3d_color_channel_clamp(lit_b * 255.0f);
+            color.a = sdl3d_color_channel_clamp(out_a * 255.0f);
+            sdl3d_write_pixel(framebuffer, px, py, depth, color);
+        }
+    }
+}
+
+static bool sdl3d_prepare_triangle_lit(sdl3d_screen_vertex_lit sv0, sdl3d_screen_vertex_lit sv1,
+                                       sdl3d_screen_vertex_lit sv2, sdl3d_framebuffer *framebuffer,
+                                       sdl3d_prepared_triangle_lit *out)
+{
+    sdl3d_screen_vertex_lit a = sv0, b = sv1, c = sv2;
+    Sint64 area = sdl3d_edge_function(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx);
+    int min_fx, max_fx, min_fy, max_fy;
+    int min_px_x, max_px_x, min_px_y, max_px_y;
+
+    if (area < 0)
+    {
+        sdl3d_screen_vertex_lit tmp = b;
+        b = c;
+        c = tmp;
+        area = -area;
+    }
+    if (area == 0)
+    {
+        return false;
+    }
+
+    min_fx = sdl3d_min_int(a.base.x_fx, sdl3d_min_int(b.base.x_fx, c.base.x_fx));
+    max_fx = sdl3d_max_int(a.base.x_fx, sdl3d_max_int(b.base.x_fx, c.base.x_fx));
+    min_fy = sdl3d_min_int(a.base.y_fx, sdl3d_min_int(b.base.y_fx, c.base.y_fx));
+    max_fy = sdl3d_max_int(a.base.y_fx, sdl3d_max_int(b.base.y_fx, c.base.y_fx));
+
+    if (framebuffer->scissor_enabled)
+    {
+        const SDL_Rect *sr = &framebuffer->scissor_rect;
+        min_fx = sdl3d_max_int(min_fx, sr->x << SDL3D_SUBPIXEL_BITS);
+        max_fx = sdl3d_min_int(max_fx, ((sr->x + sr->w) << SDL3D_SUBPIXEL_BITS) - 1);
+        min_fy = sdl3d_max_int(min_fy, sr->y << SDL3D_SUBPIXEL_BITS);
+        max_fy = sdl3d_min_int(max_fy, ((sr->y + sr->h) << SDL3D_SUBPIXEL_BITS) - 1);
+    }
+
+    min_px_x = sdl3d_max_int(0, min_fx >> SDL3D_SUBPIXEL_BITS);
+    max_px_x = sdl3d_min_int(framebuffer->width - 1, (max_fx - 1) >> SDL3D_SUBPIXEL_BITS);
+    min_px_y = sdl3d_max_int(0, min_fy >> SDL3D_SUBPIXEL_BITS);
+    max_px_y = sdl3d_min_int(framebuffer->height - 1, (max_fy - 1) >> SDL3D_SUBPIXEL_BITS);
+
+    if (min_px_x > max_px_x || min_px_y > max_px_y)
+    {
+        return false;
+    }
+
+    out->a = a;
+    out->b = b;
+    out->c = c;
+    out->area = area;
+    out->inverse_area = 1.0f / (float)area;
+    out->bias_ab = sdl3d_fill_bias(a.base.x_fx, a.base.y_fx, b.base.x_fx, b.base.y_fx);
+    out->bias_bc = sdl3d_fill_bias(b.base.x_fx, b.base.y_fx, c.base.x_fx, c.base.y_fx);
+    out->bias_ca = sdl3d_fill_bias(c.base.x_fx, c.base.y_fx, a.base.x_fx, a.base.y_fx);
+    out->bounds.min_px_x = min_px_x;
+    out->bounds.max_px_x = max_px_x;
+    out->bounds.min_px_y = min_px_y;
+    out->bounds.max_px_y = max_px_y;
+    return true;
+}
+
+void sdl3d_rasterize_triangle_lit(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                  sdl3d_vec3 v2, sdl3d_vec2 uv0, sdl3d_vec2 uv1, sdl3d_vec2 uv2, sdl3d_vec3 n0,
+                                  sdl3d_vec3 n1, sdl3d_vec3 n2, sdl3d_vec3 wp0, sdl3d_vec3 wp1, sdl3d_vec3 wp2,
+                                  sdl3d_vec4 modulate0, sdl3d_vec4 modulate1, sdl3d_vec4 modulate2,
+                                  const sdl3d_texture2d *texture, const sdl3d_lighting_params *lighting_params,
+                                  bool backface_culling_enabled, bool wireframe_enabled)
+{
+    sdl3d_clip_vertex_lit clip[SDL3D_CLIP_MAX_VERTICES];
+    sdl3d_screen_vertex_lit screen[SDL3D_CLIP_MAX_VERTICES];
+    int count;
+    Sint64 signed_area;
+
+    if (framebuffer == NULL || framebuffer->color_pixels == NULL || framebuffer->depth_pixels == NULL)
+    {
+        return;
+    }
+
+    /* Build clip vertices with all attributes. */
+    sdl3d_vec4 p0 = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v0, 1.0f));
+    sdl3d_vec4 p1 = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v1, 1.0f));
+    sdl3d_vec4 p2 = sdl3d_mat4_transform_vec4(mvp, sdl3d_vec4_from_vec3(v2, 1.0f));
+
+    clip[0].position = p0;
+    clip[0].u = uv0.x;
+    clip[0].v = uv0.y;
+    clip[0].mod_r = modulate0.x;
+    clip[0].mod_g = modulate0.y;
+    clip[0].mod_b = modulate0.z;
+    clip[0].mod_a = modulate0.w;
+    clip[0].nx = n0.x;
+    clip[0].ny = n0.y;
+    clip[0].nz = n0.z;
+    clip[0].wx = wp0.x;
+    clip[0].wy = wp0.y;
+    clip[0].wz = wp0.z;
+
+    clip[1].position = p1;
+    clip[1].u = uv1.x;
+    clip[1].v = uv1.y;
+    clip[1].mod_r = modulate1.x;
+    clip[1].mod_g = modulate1.y;
+    clip[1].mod_b = modulate1.z;
+    clip[1].mod_a = modulate1.w;
+    clip[1].nx = n1.x;
+    clip[1].ny = n1.y;
+    clip[1].nz = n1.z;
+    clip[1].wx = wp1.x;
+    clip[1].wy = wp1.y;
+    clip[1].wz = wp1.z;
+
+    clip[2].position = p2;
+    clip[2].u = uv2.x;
+    clip[2].v = uv2.y;
+    clip[2].mod_r = modulate2.x;
+    clip[2].mod_g = modulate2.y;
+    clip[2].mod_b = modulate2.z;
+    clip[2].mod_a = modulate2.w;
+    clip[2].nx = n2.x;
+    clip[2].ny = n2.y;
+    clip[2].nz = n2.z;
+    clip[2].wx = wp2.x;
+    clip[2].wy = wp2.y;
+    clip[2].wz = wp2.z;
+
+    count = sdl3d_clip_triangle_lit(clip);
+    if (count < 3)
+    {
+        return;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        screen[i] = sdl3d_viewport_transform_lit(clip[i], framebuffer->width, framebuffer->height);
+    }
+
+    /* Backface culling on the first sub-triangle. */
+    signed_area = sdl3d_edge_function(screen[0].base.x_fx, screen[0].base.y_fx, screen[1].base.x_fx,
+                                      screen[1].base.y_fx, screen[2].base.x_fx, screen[2].base.y_fx);
+    if (backface_culling_enabled && signed_area <= 0)
+    {
+        return;
+    }
+
+    if (wireframe_enabled)
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            int j = (i + 1) % count;
+            float iw_i = screen[i].inverse_w > 0.0f ? screen[i].inverse_w : 1.0f;
+            float iw_j = screen[j].inverse_w > 0.0f ? screen[j].inverse_w : 1.0f;
+            sdl3d_screen_vertex_colored sa, sb;
+            sa.base = screen[i].base;
+            sa.inverse_w = screen[i].inverse_w;
+            sa.r_over_w = screen[i].mod_r_over_w;
+            sa.g_over_w = screen[i].mod_g_over_w;
+            sa.b_over_w = screen[i].mod_b_over_w;
+            sa.a_over_w = screen[i].mod_a_over_w;
+            sb.base = screen[j].base;
+            sb.inverse_w = screen[j].inverse_w;
+            sb.r_over_w = screen[j].mod_r_over_w;
+            sb.g_over_w = screen[j].mod_g_over_w;
+            sb.b_over_w = screen[j].mod_b_over_w;
+            sb.a_over_w = screen[j].mod_a_over_w;
+            (void)iw_i;
+            (void)iw_j;
+            sdl3d_rasterize_screen_line_colored(framebuffer, sa, sb);
+        }
+        return;
+    }
+
+    /* Fan-triangulate and rasterize. */
+    for (int i = 1; i + 1 < count; ++i)
+    {
+        sdl3d_prepared_triangle_lit prepared;
+        if (!sdl3d_prepare_triangle_lit(screen[0], screen[i], screen[i + 1], framebuffer, &prepared))
+        {
+            continue;
+        }
+        sdl3d_rasterize_prepared_triangle_lit_region(framebuffer, &prepared, texture, lighting_params,
+                                                     prepared.bounds.min_px_x, prepared.bounds.max_px_x,
+                                                     prepared.bounds.min_px_y, prepared.bounds.max_px_y);
     }
 }
 

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -32,6 +32,7 @@
 #include "sdl3d/types.h"
 
 typedef struct sdl3d_parallel_rasterizer sdl3d_parallel_rasterizer;
+struct sdl3d_lighting_params;
 
 typedef struct sdl3d_framebuffer
 {
@@ -72,6 +73,18 @@ void sdl3d_rasterize_triangle_textured(sdl3d_framebuffer *framebuffer, sdl3d_mat
                                        sdl3d_vec4 modulate0, sdl3d_vec4 modulate1, sdl3d_vec4 modulate2,
                                        const sdl3d_texture2d *texture, bool backface_culling_enabled,
                                        bool wireframe_enabled);
+
+/*
+ * Lit textured triangle. Carries per-vertex world-space normals and
+ * world-space positions through clipping for per-fragment PBR shading.
+ * Falls back to the unlit textured path when lighting_params is NULL.
+ */
+void sdl3d_rasterize_triangle_lit(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 v0, sdl3d_vec3 v1,
+                                  sdl3d_vec3 v2, sdl3d_vec2 uv0, sdl3d_vec2 uv1, sdl3d_vec2 uv2, sdl3d_vec3 n0,
+                                  sdl3d_vec3 n1, sdl3d_vec3 n2, sdl3d_vec3 wp0, sdl3d_vec3 wp1, sdl3d_vec3 wp2,
+                                  sdl3d_vec4 modulate0, sdl3d_vec4 modulate1, sdl3d_vec4 modulate2,
+                                  const sdl3d_texture2d *texture, const struct sdl3d_lighting_params *lighting_params,
+                                  bool backface_culling_enabled, bool wireframe_enabled);
 
 void sdl3d_rasterize_line(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp, sdl3d_vec3 start, sdl3d_vec3 end,
                           sdl3d_color color);

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -286,6 +286,11 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     context->projection = sdl3d_mat4_identity();
     context->view_projection = sdl3d_mat4_identity();
     context->model_view_projection = sdl3d_mat4_identity();
+    context->lighting_enabled = false;
+    context->light_count = 0;
+    context->ambient[0] = 0.03f;
+    context->ambient[1] = 0.03f;
+    context->ambient[2] = 0.03f;
     sdl3d_try_create_parallel_rasterizer(context);
 
     *out_context = context;

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -13,6 +13,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "rasterizer.h"
+#include "sdl3d/lighting.h"
 #include "sdl3d/math.h"
 #include "sdl3d/render_context.h"
 
@@ -45,6 +46,11 @@ struct sdl3d_render_context
     sdl3d_mat4 projection;
     sdl3d_mat4 view_projection;
     sdl3d_mat4 model_view_projection;
+
+    bool lighting_enabled;
+    sdl3d_light lights[SDL3D_MAX_LIGHTS];
+    int light_count;
+    float ambient[3];
 };
 
 static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_context *context)

--- a/src/shading.c
+++ b/src/shading.c
@@ -1,0 +1,251 @@
+/*
+ * Per-fragment PBR shading: simplified Cook-Torrance BRDF.
+ *
+ * - GGX (Trowbridge-Reitz) normal distribution
+ * - Schlick-GGX geometry (Smith method, k = (roughness+1)^2 / 8)
+ * - Schlick Fresnel approximation
+ * - Lambertian diffuse
+ *
+ * Supports directional, point, and spot lights.
+ */
+
+#include "lighting_internal.h"
+
+#include <math.h>
+
+static const float SDL3D_PI = 3.14159265358979323846f;
+
+static float sdl3d_maxf(float a, float b)
+{
+    return a > b ? a : b;
+}
+
+static float sdl3d_clampf(float v, float lo, float hi)
+{
+    if (v < lo)
+    {
+        return lo;
+    }
+    if (v > hi)
+    {
+        return hi;
+    }
+    return v;
+}
+
+/* GGX / Trowbridge-Reitz normal distribution function. */
+static float sdl3d_distribution_ggx(float n_dot_h, float roughness)
+{
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float denom = n_dot_h * n_dot_h * (a2 - 1.0f) + 1.0f;
+    return a2 / (SDL3D_PI * denom * denom + 1e-7f);
+}
+
+/* Schlick-GGX geometry function (one direction). */
+static float sdl3d_geometry_schlick_ggx(float n_dot_v, float roughness)
+{
+    float r = roughness + 1.0f;
+    float k = (r * r) / 8.0f;
+    return n_dot_v / (n_dot_v * (1.0f - k) + k + 1e-7f);
+}
+
+/* Smith geometry: product of two Schlick-GGX terms. */
+static float sdl3d_geometry_smith(float n_dot_v, float n_dot_l, float roughness)
+{
+    return sdl3d_geometry_schlick_ggx(n_dot_v, roughness) * sdl3d_geometry_schlick_ggx(n_dot_l, roughness);
+}
+
+/* Schlick Fresnel approximation. */
+static void sdl3d_fresnel_schlick(float cos_theta, float f0_r, float f0_g, float f0_b, float *out_r, float *out_g,
+                                  float *out_b)
+{
+    float t = 1.0f - cos_theta;
+    float t2 = t * t;
+    float t5 = t2 * t2 * t;
+    *out_r = f0_r + (1.0f - f0_r) * t5;
+    *out_g = f0_g + (1.0f - f0_g) * t5;
+    *out_b = f0_b + (1.0f - f0_b) * t5;
+}
+
+static float sdl3d_vec3_dot_raw(float ax, float ay, float az, float bx, float by, float bz)
+{
+    return ax * bx + ay * by + az * bz;
+}
+
+static float sdl3d_vec3_length_raw(float x, float y, float z)
+{
+    return sqrtf(x * x + y * y + z * z);
+}
+
+/*
+ * Compute the light's radiance contribution and the light direction
+ * (pointing FROM the fragment TOWARD the light).
+ */
+static bool sdl3d_compute_light_contribution(const sdl3d_light *light, float px, float py, float pz, float *out_lx,
+                                             float *out_ly, float *out_lz, float *out_rad_r, float *out_rad_g,
+                                             float *out_rad_b)
+{
+    float attenuation = 1.0f;
+
+    if (light->type == SDL3D_LIGHT_DIRECTIONAL)
+    {
+        float len = sdl3d_vec3_length_raw(light->direction.x, light->direction.y, light->direction.z);
+        if (len < 1e-7f)
+        {
+            return false;
+        }
+        float inv = 1.0f / len;
+        *out_lx = -light->direction.x * inv;
+        *out_ly = -light->direction.y * inv;
+        *out_lz = -light->direction.z * inv;
+    }
+    else
+    {
+        /* Point or spot: direction from fragment to light. */
+        float dx = light->position.x - px;
+        float dy = light->position.y - py;
+        float dz = light->position.z - pz;
+        float dist = sdl3d_vec3_length_raw(dx, dy, dz);
+        if (dist < 1e-7f)
+        {
+            return false;
+        }
+        float inv = 1.0f / dist;
+        *out_lx = dx * inv;
+        *out_ly = dy * inv;
+        *out_lz = dz * inv;
+
+        /* Distance attenuation. */
+        if (light->range > 0.0f)
+        {
+            float ratio = dist / light->range;
+            attenuation = sdl3d_maxf(1.0f - ratio * ratio, 0.0f);
+            attenuation *= attenuation;
+        }
+        else
+        {
+            attenuation = 1.0f / (dist * dist + 1e-4f);
+        }
+
+        /* Spot cone falloff. */
+        if (light->type == SDL3D_LIGHT_SPOT)
+        {
+            float spot_dir_len = sdl3d_vec3_length_raw(light->direction.x, light->direction.y, light->direction.z);
+            if (spot_dir_len < 1e-7f)
+            {
+                return false;
+            }
+            float inv_sd = 1.0f / spot_dir_len;
+            float sdx = light->direction.x * inv_sd;
+            float sdy = light->direction.y * inv_sd;
+            float sdz = light->direction.z * inv_sd;
+            float cos_angle = sdl3d_vec3_dot_raw(-(*out_lx), -(*out_ly), -(*out_lz), sdx, sdy, sdz);
+            float epsilon = light->inner_cutoff - light->outer_cutoff;
+            if (fabsf(epsilon) < 1e-7f)
+            {
+                attenuation *= (cos_angle >= light->outer_cutoff) ? 1.0f : 0.0f;
+            }
+            else
+            {
+                float spot_intensity = sdl3d_clampf((cos_angle - light->outer_cutoff) / epsilon, 0.0f, 1.0f);
+                attenuation *= spot_intensity;
+            }
+        }
+    }
+
+    float scale = light->intensity * attenuation;
+    *out_rad_r = light->color[0] * scale;
+    *out_rad_g = light->color[1] * scale;
+    *out_rad_b = light->color[2] * scale;
+    return true;
+}
+
+void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_r, float albedo_g, float albedo_b,
+                              float world_nx, float world_ny, float world_nz, float world_px, float world_py,
+                              float world_pz, float *out_r, float *out_g, float *out_b)
+{
+    /* F0: base reflectance. Dielectrics ~0.04, metals use albedo. */
+    float f0_r = 0.04f + (albedo_r - 0.04f) * params->metallic;
+    float f0_g = 0.04f + (albedo_g - 0.04f) * params->metallic;
+    float f0_b = 0.04f + (albedo_b - 0.04f) * params->metallic;
+
+    /* View direction: from fragment toward camera. */
+    float vx = params->camera_pos.x - world_px;
+    float vy = params->camera_pos.y - world_py;
+    float vz = params->camera_pos.z - world_pz;
+    float v_len = sdl3d_vec3_length_raw(vx, vy, vz);
+    if (v_len > 1e-7f)
+    {
+        float inv = 1.0f / v_len;
+        vx *= inv;
+        vy *= inv;
+        vz *= inv;
+    }
+
+    float n_dot_v = sdl3d_maxf(sdl3d_vec3_dot_raw(world_nx, world_ny, world_nz, vx, vy, vz), 0.0f);
+
+    /* Accumulate light contributions. */
+    float lo_r = 0.0f, lo_g = 0.0f, lo_b = 0.0f;
+
+    for (int i = 0; i < params->light_count; ++i)
+    {
+        float lx, ly, lz;
+        float rad_r, rad_g, rad_b;
+
+        if (!sdl3d_compute_light_contribution(&params->lights[i], world_px, world_py, world_pz, &lx, &ly, &lz, &rad_r,
+                                              &rad_g, &rad_b))
+        {
+            continue;
+        }
+
+        float n_dot_l = sdl3d_maxf(sdl3d_vec3_dot_raw(world_nx, world_ny, world_nz, lx, ly, lz), 0.0f);
+        if (n_dot_l <= 0.0f)
+        {
+            continue;
+        }
+
+        /* Half vector. */
+        float hx = lx + vx;
+        float hy = ly + vy;
+        float hz = lz + vz;
+        float h_len = sdl3d_vec3_length_raw(hx, hy, hz);
+        if (h_len > 1e-7f)
+        {
+            float inv = 1.0f / h_len;
+            hx *= inv;
+            hy *= inv;
+            hz *= inv;
+        }
+
+        float n_dot_h = sdl3d_maxf(sdl3d_vec3_dot_raw(world_nx, world_ny, world_nz, hx, hy, hz), 0.0f);
+        float h_dot_v = sdl3d_maxf(sdl3d_vec3_dot_raw(hx, hy, hz, vx, vy, vz), 0.0f);
+
+        /* Cook-Torrance specular BRDF. */
+        float ndf = sdl3d_distribution_ggx(n_dot_h, params->roughness);
+        float geo = sdl3d_geometry_smith(n_dot_v, n_dot_l, params->roughness);
+        float fr, fg, fb;
+        sdl3d_fresnel_schlick(h_dot_v, f0_r, f0_g, f0_b, &fr, &fg, &fb);
+
+        float denom = 4.0f * n_dot_v * n_dot_l + 1e-4f;
+        float spec_scale = ndf * geo / denom;
+        float spec_r = fr * spec_scale;
+        float spec_g = fg * spec_scale;
+        float spec_b = fb * spec_scale;
+
+        /* Energy-conserving diffuse: kD = (1 - F) * (1 - metallic). */
+        float kd = (1.0f - params->metallic);
+        float diff_r = (1.0f - fr) * kd * albedo_r / SDL3D_PI;
+        float diff_g = (1.0f - fg) * kd * albedo_g / SDL3D_PI;
+        float diff_b = (1.0f - fb) * kd * albedo_b / SDL3D_PI;
+
+        lo_r += (diff_r + spec_r) * rad_r * n_dot_l;
+        lo_g += (diff_g + spec_g) * rad_g * n_dot_l;
+        lo_b += (diff_b + spec_b) * rad_b * n_dot_l;
+    }
+
+    /* Ambient + emissive. */
+    *out_r = params->ambient[0] * albedo_r + lo_r + params->emissive[0];
+    *out_g = params->ambient[1] * albedo_g + lo_g + params->emissive[1];
+    *out_b = params->ambient[2] * albedo_b + lo_b + params->emissive[2];
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SDL3D_TEST_SOURCES
     test_vertex_color.cpp
     test_texture.cpp
     test_textured_rendering.cpp
+    test_lighting.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -155,6 +156,8 @@ else()
     sdl3d_add_test(sdl3d_vertex_color_test test_vertex_color.cpp render)
     sdl3d_add_test(sdl3d_texture_test test_texture.cpp unit)
     sdl3d_add_test(sdl3d_textured_rendering_test test_textured_rendering.cpp render)
+    sdl3d_add_test(sdl3d_lighting_test test_lighting.cpp render)
+    target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -1,0 +1,391 @@
+/*
+ * Comprehensive tests for M4-1/2/3: lighting API, PBR shading,
+ * directional/point/spot lights.
+ */
+
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_main.h>
+
+#include <cmath>
+
+extern "C"
+{
+#include "lighting_internal.h"
+#include "sdl3d/lighting.h"
+#include "sdl3d/sdl3d.h"
+}
+
+/* ================================================================== */
+/* Lighting API tests (unit, no SDL video)                            */
+/* ================================================================== */
+
+/* Fixture that creates a real render context for API testing. */
+class SDL3DLightingFixture : public ::testing::Test
+{
+  protected:
+    SDL_Window *window = nullptr;
+    SDL_Renderer *renderer = nullptr;
+    sdl3d_render_context *ctx = nullptr;
+
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO));
+        window = SDL_CreateWindow("test", 64, 64, SDL_WINDOW_HIDDEN);
+        ASSERT_NE(window, nullptr);
+        renderer = SDL_CreateRenderer(window, NULL);
+        ASSERT_NE(renderer, nullptr);
+        sdl3d_render_context_config config;
+        sdl3d_init_render_context_config(&config);
+        ASSERT_TRUE(sdl3d_create_render_context(window, renderer, &config, &ctx));
+    }
+
+    void TearDown() override
+    {
+        sdl3d_destroy_render_context(ctx);
+        if (renderer)
+            SDL_DestroyRenderer(renderer);
+        if (window)
+            SDL_DestroyWindow(window);
+        SDL_Quit();
+    }
+};
+
+TEST_F(SDL3DLightingFixture, DefaultState)
+{
+    EXPECT_FALSE(sdl3d_is_lighting_enabled(ctx));
+    EXPECT_EQ(sdl3d_get_light_count(ctx), 0);
+}
+
+TEST_F(SDL3DLightingFixture, EnableDisable)
+{
+    ASSERT_TRUE(sdl3d_set_lighting_enabled(ctx, true));
+    EXPECT_TRUE(sdl3d_is_lighting_enabled(ctx));
+    ASSERT_TRUE(sdl3d_set_lighting_enabled(ctx, false));
+    EXPECT_FALSE(sdl3d_is_lighting_enabled(ctx));
+}
+
+TEST_F(SDL3DLightingFixture, AddAndClearLights)
+{
+    sdl3d_light light{};
+    light.type = SDL3D_LIGHT_DIRECTIONAL;
+    light.direction = {0.0f, -1.0f, 0.0f};
+    light.color[0] = light.color[1] = light.color[2] = 1.0f;
+    light.intensity = 1.0f;
+
+    ASSERT_TRUE(sdl3d_add_light(ctx, &light));
+    EXPECT_EQ(sdl3d_get_light_count(ctx), 1);
+
+    ASSERT_TRUE(sdl3d_add_light(ctx, &light));
+    EXPECT_EQ(sdl3d_get_light_count(ctx), 2);
+
+    ASSERT_TRUE(sdl3d_clear_lights(ctx));
+    EXPECT_EQ(sdl3d_get_light_count(ctx), 0);
+}
+
+TEST_F(SDL3DLightingFixture, MaxLightsEnforced)
+{
+    sdl3d_light light{};
+    light.type = SDL3D_LIGHT_POINT;
+    light.intensity = 1.0f;
+
+    for (int i = 0; i < SDL3D_MAX_LIGHTS; ++i)
+    {
+        ASSERT_TRUE(sdl3d_add_light(ctx, &light)) << "light " << i;
+    }
+    EXPECT_EQ(sdl3d_get_light_count(ctx), SDL3D_MAX_LIGHTS);
+    EXPECT_FALSE(sdl3d_add_light(ctx, &light));
+    EXPECT_EQ(sdl3d_get_light_count(ctx), SDL3D_MAX_LIGHTS);
+}
+
+TEST_F(SDL3DLightingFixture, SetAmbientLight)
+{
+    ASSERT_TRUE(sdl3d_set_ambient_light(ctx, 0.1f, 0.2f, 0.3f));
+}
+
+/* ================================================================== */
+/* Null context rejection                                             */
+/* ================================================================== */
+
+struct NullCtxCase
+{
+    const char *label;
+};
+
+TEST(SDL3DLightingNullCtx, AllFunctionsRejectNull)
+{
+    sdl3d_light light{};
+    EXPECT_FALSE(sdl3d_add_light(nullptr, &light));
+    EXPECT_FALSE(sdl3d_add_light(nullptr, nullptr));
+    EXPECT_FALSE(sdl3d_clear_lights(nullptr));
+    EXPECT_FALSE(sdl3d_set_lighting_enabled(nullptr, true));
+    EXPECT_FALSE(sdl3d_is_lighting_enabled(nullptr));
+    EXPECT_EQ(sdl3d_get_light_count(nullptr), 0);
+    EXPECT_FALSE(sdl3d_set_ambient_light(nullptr, 0, 0, 0));
+}
+
+/* ================================================================== */
+/* PBR shading unit tests (sdl3d_shade_fragment_pbr)                  */
+/* ================================================================== */
+
+static sdl3d_lighting_params make_params(float metallic, float roughness)
+{
+    sdl3d_lighting_params p{};
+    p.lights = nullptr;
+    p.light_count = 0;
+    p.ambient[0] = p.ambient[1] = p.ambient[2] = 0.0f;
+    p.camera_pos = {0.0f, 0.0f, 5.0f};
+    p.metallic = metallic;
+    p.roughness = roughness;
+    p.emissive[0] = p.emissive[1] = p.emissive[2] = 0.0f;
+    return p;
+}
+
+static sdl3d_light make_directional(float dx, float dy, float dz, float intensity)
+{
+    sdl3d_light l{};
+    l.type = SDL3D_LIGHT_DIRECTIONAL;
+    l.direction = {dx, dy, dz};
+    l.color[0] = l.color[1] = l.color[2] = 1.0f;
+    l.intensity = intensity;
+    return l;
+}
+
+static sdl3d_light make_point(float px, float py, float pz, float intensity, float range)
+{
+    sdl3d_light l{};
+    l.type = SDL3D_LIGHT_POINT;
+    l.position = {px, py, pz};
+    l.color[0] = l.color[1] = l.color[2] = 1.0f;
+    l.intensity = intensity;
+    l.range = range;
+    return l;
+}
+
+static sdl3d_light make_spot(float px, float py, float pz, float dx, float dy, float dz, float intensity, float range,
+                             float inner_cos, float outer_cos)
+{
+    sdl3d_light l{};
+    l.type = SDL3D_LIGHT_SPOT;
+    l.position = {px, py, pz};
+    l.direction = {dx, dy, dz};
+    l.color[0] = l.color[1] = l.color[2] = 1.0f;
+    l.intensity = intensity;
+    l.range = range;
+    l.inner_cutoff = inner_cos;
+    l.outer_cutoff = outer_cos;
+    return l;
+}
+
+TEST(SDL3DPBRShading, NoLightsNoAmbientProducesBlack)
+{
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.0f, 0.001f);
+    EXPECT_NEAR(g, 0.0f, 0.001f);
+    EXPECT_NEAR(b, 0.0f, 0.001f);
+}
+
+TEST(SDL3DPBRShading, AmbientOnlyProducesAmbientTimesAlbedo)
+{
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.ambient[0] = 0.1f;
+    p.ambient[1] = 0.2f;
+    p.ambient[2] = 0.3f;
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 0.5f, 0.5f, 0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.05f, 0.001f);
+    EXPECT_NEAR(g, 0.10f, 0.001f);
+    EXPECT_NEAR(b, 0.15f, 0.001f);
+}
+
+TEST(SDL3DPBRShading, EmissiveAddsToOutput)
+{
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.emissive[0] = 0.5f;
+    p.emissive[1] = 0.0f;
+    p.emissive[2] = 0.0f;
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.5f, 0.001f);
+    EXPECT_NEAR(g, 0.0f, 0.001f);
+    EXPECT_NEAR(b, 0.0f, 0.001f);
+}
+
+TEST(SDL3DPBRShading, DirectionalLightFacingNormalProducesLight)
+{
+    sdl3d_light dl = make_directional(0.0f, -1.0f, 0.0f, 1.0f);
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &dl;
+    p.light_count = 1;
+
+    float r, g, b;
+    /* Normal pointing up, light pointing down → N·L = 1. */
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_GT(r, 0.1f);
+    EXPECT_GT(g, 0.1f);
+    EXPECT_GT(b, 0.1f);
+}
+
+TEST(SDL3DPBRShading, DirectionalLightBackfaceProducesNoLight)
+{
+    sdl3d_light dl = make_directional(0.0f, 1.0f, 0.0f, 1.0f);
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &dl;
+    p.light_count = 1;
+
+    float r, g, b;
+    /* Normal pointing up, light pointing up → N·L = -1 → clamped to 0. */
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.0f, 0.001f);
+}
+
+TEST(SDL3DPBRShading, PointLightAttenuatesWithDistance)
+{
+    sdl3d_light pl = make_point(0.0f, 2.0f, 0.0f, 1.0f, 10.0f);
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &pl;
+    p.light_count = 1;
+
+    float r_near, g_near, b_near;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r_near, &g_near, &b_near);
+
+    /* Move fragment far away. */
+    float r_far, g_far, b_far;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, -8.0f, 0.0f, &r_far, &g_far, &b_far);
+
+    EXPECT_GT(r_near, r_far);
+}
+
+TEST(SDL3DPBRShading, PointLightOutOfRangeProducesNoLight)
+{
+    sdl3d_light pl = make_point(0.0f, 2.0f, 0.0f, 1.0f, 1.0f);
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &pl;
+    p.light_count = 1;
+
+    float r, g, b;
+    /* Fragment at origin, light at y=2, range=1 → distance > range. */
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.0f, 0.01f);
+}
+
+TEST(SDL3DPBRShading, SpotLightInsideConeProducesLight)
+{
+    /* Spot at y=2 pointing down, fragment at origin with normal up. */
+    sdl3d_light sl = make_spot(0.0f, 2.0f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 10.0f, cosf(0.3f), cosf(0.5f));
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &sl;
+    p.light_count = 1;
+
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_GT(r, 0.05f);
+}
+
+TEST(SDL3DPBRShading, SpotLightOutsideConeProducesNoLight)
+{
+    /* Spot at y=2 pointing down, fragment far to the side. */
+    sdl3d_light sl = make_spot(0.0f, 2.0f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 100.0f, cosf(0.1f), cosf(0.2f));
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &sl;
+    p.light_count = 1;
+
+    float r, g, b;
+    /* Fragment at x=100, well outside the narrow cone. */
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 100.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_NEAR(r, 0.0f, 0.01f);
+}
+
+TEST(SDL3DPBRShading, MetallicSurfaceHasNoLambertianDiffuse)
+{
+    sdl3d_light dl = make_directional(0.0f, -1.0f, 0.0f, 1.0f);
+    sdl3d_lighting_params p_metal = make_params(1.0f, 0.5f);
+    p_metal.lights = &dl;
+    p_metal.light_count = 1;
+
+    sdl3d_lighting_params p_dielectric = make_params(0.0f, 0.5f);
+    p_dielectric.lights = &dl;
+    p_dielectric.light_count = 1;
+
+    float rm, gm, bm;
+    float rd, gd, bd;
+    sdl3d_shade_fragment_pbr(&p_metal, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rm, &gm, &bm);
+    sdl3d_shade_fragment_pbr(&p_dielectric, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rd, &gd, &bd);
+
+    /* Metal should have less red (no diffuse) but more specular. The green
+     * channel should be near zero for both since albedo green is 0. */
+    EXPECT_NEAR(gm, 0.0f, 0.05f);
+    EXPECT_NEAR(gd, 0.0f, 0.05f);
+}
+
+TEST(SDL3DPBRShading, MultipleLightsAccumulate)
+{
+    sdl3d_light lights[2];
+    lights[0] = make_directional(0.0f, -1.0f, 0.0f, 1.0f);
+    lights[1] = make_directional(0.0f, -1.0f, 0.0f, 1.0f);
+
+    sdl3d_lighting_params p1 = make_params(0.0f, 1.0f);
+    p1.lights = lights;
+    p1.light_count = 1;
+
+    sdl3d_lighting_params p2 = make_params(0.0f, 1.0f);
+    p2.lights = lights;
+    p2.light_count = 2;
+
+    float r1, g1, b1, r2, g2, b2;
+    sdl3d_shade_fragment_pbr(&p1, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r1, &g1, &b1);
+    sdl3d_shade_fragment_pbr(&p2, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r2, &g2, &b2);
+
+    /* Two identical lights should produce roughly double the output. */
+    EXPECT_NEAR(r2, r1 * 2.0f, 0.01f);
+}
+
+TEST(SDL3DPBRShading, ColoredLightTintsOutput)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = 1.0f;
+    dl.color[1] = 0.0f;
+    dl.color[2] = 0.0f;
+    dl.intensity = 1.0f;
+
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &dl;
+    p.light_count = 1;
+
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+    EXPECT_GT(r, 0.1f);
+    EXPECT_NEAR(g, 0.0f, 0.001f);
+    EXPECT_NEAR(b, 0.0f, 0.001f);
+}
+
+TEST(SDL3DPBRShading, RoughnessAffectsSpecular)
+{
+    sdl3d_light dl = make_directional(0.0f, -1.0f, 0.0f, 1.0f);
+
+    sdl3d_lighting_params p_smooth = make_params(0.0f, 0.1f);
+    p_smooth.lights = &dl;
+    p_smooth.light_count = 1;
+
+    sdl3d_lighting_params p_rough = make_params(0.0f, 1.0f);
+    p_rough.lights = &dl;
+    p_rough.light_count = 1;
+
+    float rs, gs, bs, rr, gr, br;
+    /* View from directly above → specular highlight should be stronger for smooth. */
+    p_smooth.camera_pos = (sdl3d_vec3){0.0f, 5.0f, 0.0f};
+    p_rough.camera_pos = (sdl3d_vec3){0.0f, 5.0f, 0.0f};
+    sdl3d_shade_fragment_pbr(&p_smooth, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rs, &gs, &bs);
+    sdl3d_shade_fragment_pbr(&p_rough, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rr, &gr, &br);
+
+    /* Smooth surface should have higher total output due to specular peak. */
+    EXPECT_GT(rs, rr);
+}


### PR DESCRIPTION
## Summary

Implements M4 slices 1-3 from the roadmap in #4: PBR material evaluation, directional lights, point lights, and spot lights in the software rasterizer.

### What changed

**Public API** (include/sdl3d/lighting.h)
- `sdl3d_light` struct: directional, point, and spot light types
- `sdl3d_add_light` / `sdl3d_clear_lights` — manage up to SDL3D_MAX_LIGHTS (8)
- `sdl3d_set_lighting_enabled` / `sdl3d_is_lighting_enabled` — toggle per-fragment PBR shading
- `sdl3d_set_ambient_light` — scene ambient color
- `sdl3d_get_light_count` — query active light count

**PBR shading** (src/shading.c)
- Cook-Torrance specular BRDF: GGX normal distribution, Schlick-GGX geometry (Smith method), Schlick Fresnel
- Lambertian diffuse with energy conservation (kD = (1-F)(1-metallic))
- Point light: smooth distance attenuation with configurable range
- Spot light: inner/outer cone falloff (cosine half-angles)
- Directional light: no attenuation

**Lit rasterizer** (src/rasterizer.c)
- New `sdl3d_rasterize_triangle_lit`: carries per-vertex world-space normals and positions through Sutherland-Hodgman clipping with perspective-correct interpolation
- Per-fragment normal recovery, normalization, and PBR evaluation
- Wireframe fallback for lit triangles

**Integration** (src/drawing3d.c)
- `DrawModel`/`DrawModelEx` builds `sdl3d_lighting_params` from context state + material properties when lighting enabled
- Normal matrix: upper-left 3x3 of model matrix (correct for uniform scale)
- Camera position extracted from view matrix inverse
- Falls back to existing unlit textured path when lighting disabled — zero behavior change for existing code

### What was tested

19 new tests:
- **PBR shading unit tests** (14): no lights/ambient/emissive, directional facing/backface, point attenuation/out-of-range, spot inside/outside cone, metallic vs dielectric, multiple lights accumulate, colored light tinting, roughness affects specular
- **Lighting API render tests** (5): default state, enable/disable, add/clear, max lights enforcement, ambient setting, null context rejection

167 existing unit tests unaffected. clang-format clean.

### No new dependencies

Pure C17. No external libraries added.