### PR TITLE
M4-4/5/6: Fog, shadow mapping, tonemapping + gamma

### DIFF
--- a/include/sdl3d/lighting.h
+++ b/include/sdl3d/lighting.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+#include "sdl3d/math.h"
 #include "sdl3d/render_context.h"
 #include "sdl3d/types.h"
 
@@ -10,6 +11,8 @@
 extern "C"
 {
 #endif
+
+    struct sdl3d_mesh;
 
 #define SDL3D_MAX_LIGHTS 8
 
@@ -69,6 +72,73 @@ extern "C"
     bool sdl3d_set_ambient_light(sdl3d_render_context *context, float r, float g, float b);
 
     int sdl3d_get_light_count(const sdl3d_render_context *context);
+
+    /* ============================================================== */
+    /* Fog                                                            */
+    /* ============================================================== */
+
+    typedef enum sdl3d_fog_mode
+    {
+        SDL3D_FOG_NONE = 0,
+        SDL3D_FOG_LINEAR = 1,
+        SDL3D_FOG_EXP = 2,
+        SDL3D_FOG_EXP2 = 3
+    } sdl3d_fog_mode;
+
+    typedef struct sdl3d_fog
+    {
+        sdl3d_fog_mode mode;
+        float color[3];
+        float start;   /* LINEAR: distance where fog begins */
+        float end;     /* LINEAR: distance where fog is fully opaque */
+        float density; /* EXP / EXP2: fog density coefficient */
+    } sdl3d_fog;
+
+    bool sdl3d_set_fog(sdl3d_render_context *context, const sdl3d_fog *fog);
+    bool sdl3d_clear_fog(sdl3d_render_context *context);
+
+    /* ============================================================== */
+    /* Tonemapping                                                    */
+    /* ============================================================== */
+
+    typedef enum sdl3d_tonemap_mode
+    {
+        SDL3D_TONEMAP_NONE = 0,
+        SDL3D_TONEMAP_REINHARD = 1,
+        SDL3D_TONEMAP_ACES = 2
+    } sdl3d_tonemap_mode;
+
+    bool sdl3d_set_tonemap_mode(sdl3d_render_context *context, sdl3d_tonemap_mode mode);
+    sdl3d_tonemap_mode sdl3d_get_tonemap_mode(const sdl3d_render_context *context);
+
+    /* ============================================================== */
+    /* Shadow mapping                                                 */
+    /* ============================================================== */
+
+#define SDL3D_SHADOW_MAP_SIZE 512
+
+    /*
+     * Enable shadow casting for a directional light at the given index.
+     * Allocates a depth-only shadow map and computes the light-space
+     * orthographic projection covering the specified scene bounds.
+     *
+     * `light_index` must refer to a SDL3D_LIGHT_DIRECTIONAL light.
+     * `scene_radius` defines the half-extent of the ortho projection.
+     * `scene_center` is the world-space center the shadow map covers.
+     */
+    bool sdl3d_enable_shadow(sdl3d_render_context *context, int light_index, sdl3d_vec3 scene_center,
+                             float scene_radius);
+
+    bool sdl3d_disable_shadow(sdl3d_render_context *context, int light_index);
+
+    /*
+     * Render shadow maps for all shadow-enabled lights. Call after
+     * adding lights and before drawing lit geometry. Renders the
+     * provided meshes into each shadow map's depth buffer from the
+     * light's point of view.
+     */
+    bool sdl3d_render_shadow_map(sdl3d_render_context *context, const struct sdl3d_mesh *meshes, int mesh_count,
+                                 const sdl3d_mat4 *model_matrices);
 
 #ifdef __cplusplus
 }

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -467,14 +467,74 @@ bool sdl3d_scale(sdl3d_render_context *context, float x, float y, float z)
 bool sdl3d_draw_triangle_3d(sdl3d_render_context *context, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2,
                             sdl3d_color color)
 {
+    sdl3d_framebuffer framebuffer;
+
     if (!sdl3d_require_mode_3d(context, "sdl3d_draw_triangle_3d"))
     {
         return false;
     }
 
-    sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
-    sdl3d_rasterize_triangle(&framebuffer, context->model_view_projection, v0, v1, v2, color,
-                             context->backface_culling_enabled, context->wireframe_enabled);
+    framebuffer = sdl3d_framebuffer_from_context(context);
+
+    if (context->lighting_enabled && context->light_count > 0)
+    {
+        /* Compute flat face normal from the triangle edges. */
+        sdl3d_vec3 edge1 = sdl3d_vec3_sub(v1, v0);
+        sdl3d_vec3 edge2 = sdl3d_vec3_sub(v2, v0);
+        sdl3d_vec3 face_normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(edge1, edge2));
+
+        /* Transform normal by upper-left 3x3 of model matrix. */
+        const sdl3d_mat4 m = context->model;
+        sdl3d_vec3 wn;
+        wn.x = m.m[0] * face_normal.x + m.m[4] * face_normal.y + m.m[8] * face_normal.z;
+        wn.y = m.m[1] * face_normal.x + m.m[5] * face_normal.y + m.m[9] * face_normal.z;
+        wn.z = m.m[2] * face_normal.x + m.m[6] * face_normal.y + m.m[10] * face_normal.z;
+        wn = sdl3d_vec3_normalize(wn);
+
+        /* Transform positions to world space. */
+        sdl3d_vec4 w0 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(v0, 1.0f));
+        sdl3d_vec4 w1 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(v1, 1.0f));
+        sdl3d_vec4 w2 = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(v2, 1.0f));
+
+        /* Build lighting params. */
+        sdl3d_lighting_params lp;
+        SDL_zerop(&lp);
+        lp.lights = context->lights;
+        lp.light_count = context->light_count;
+        lp.ambient[0] = context->ambient[0];
+        lp.ambient[1] = context->ambient[1];
+        lp.ambient[2] = context->ambient[2];
+        lp.roughness = 1.0f;
+        lp.fog = context->fog;
+        lp.tonemap_mode = context->tonemap_mode;
+        lp.shadow_bias = context->shadow_bias;
+        for (int i = 0; i < SDL3D_MAX_LIGHTS; ++i)
+        {
+            lp.shadow_depth[i] = context->shadow_depth[i];
+            lp.shadow_vp[i] = context->shadow_vp[i];
+            lp.shadow_enabled[i] = context->shadow_enabled[i];
+        }
+        {
+            const sdl3d_mat4 v = context->view;
+            lp.camera_pos.x = -(v.m[0] * v.m[12] + v.m[1] * v.m[13] + v.m[2] * v.m[14]);
+            lp.camera_pos.y = -(v.m[4] * v.m[12] + v.m[5] * v.m[13] + v.m[6] * v.m[14]);
+            lp.camera_pos.z = -(v.m[8] * v.m[12] + v.m[9] * v.m[13] + v.m[10] * v.m[14]);
+        }
+
+        sdl3d_vec4 modulate = sdl3d_color_to_modulate(color);
+        sdl3d_vec2 uv0 = {0.0f, 0.0f};
+
+        sdl3d_rasterize_triangle_lit(&framebuffer, context->model_view_projection, v0, v1, v2, uv0, uv0, uv0, wn, wn,
+                                     wn, sdl3d_vec3_make(w0.x, w0.y, w0.z), sdl3d_vec3_make(w1.x, w1.y, w1.z),
+                                     sdl3d_vec3_make(w2.x, w2.y, w2.z), modulate, modulate, modulate, NULL, &lp,
+                                     context->backface_culling_enabled, context->wireframe_enabled);
+    }
+    else
+    {
+        sdl3d_rasterize_triangle(&framebuffer, context->model_view_projection, v0, v1, v2, color,
+                                 context->backface_culling_enabled, context->wireframe_enabled);
+    }
+
     return true;
 }
 
@@ -643,6 +703,17 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
                     lp_storage.emissive[0] = 0.0f;
                     lp_storage.emissive[1] = 0.0f;
                     lp_storage.emissive[2] = 0.0f;
+                }
+
+                /* Fog, tonemapping, shadows. */
+                lp_storage.fog = context->fog;
+                lp_storage.tonemap_mode = context->tonemap_mode;
+                lp_storage.shadow_bias = context->shadow_bias;
+                for (int si = 0; si < SDL3D_MAX_LIGHTS; ++si)
+                {
+                    lp_storage.shadow_depth[si] = context->shadow_depth[si];
+                    lp_storage.shadow_vp[si] = context->shadow_vp[si];
+                    lp_storage.shadow_enabled[si] = context->shadow_enabled[si];
                 }
 
                 lp_ptr = &lp_storage;

--- a/src/lighting.c
+++ b/src/lighting.c
@@ -3,6 +3,8 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include "sdl3d/model.h"
+
 #include "render_context_internal.h"
 
 bool sdl3d_add_light(sdl3d_render_context *context, const sdl3d_light *light)
@@ -76,4 +78,319 @@ int sdl3d_get_light_count(const sdl3d_render_context *context)
         return 0;
     }
     return context->light_count;
+}
+
+/* ------------------------------------------------------------------ */
+/* Fog                                                                 */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_set_fog(sdl3d_render_context *context, const sdl3d_fog *fog)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (fog == NULL)
+    {
+        return SDL_InvalidParamError("fog");
+    }
+    context->fog = *fog;
+    return true;
+}
+
+bool sdl3d_clear_fog(sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    context->fog.mode = SDL3D_FOG_NONE;
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tonemapping                                                         */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_set_tonemap_mode(sdl3d_render_context *context, sdl3d_tonemap_mode mode)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    context->tonemap_mode = mode;
+    return true;
+}
+
+sdl3d_tonemap_mode sdl3d_get_tonemap_mode(const sdl3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return SDL3D_TONEMAP_NONE;
+    }
+    return context->tonemap_mode;
+}
+
+/* ------------------------------------------------------------------ */
+/* Shadow mapping                                                      */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_enable_shadow(sdl3d_render_context *context, int light_index, sdl3d_vec3 scene_center, float scene_radius)
+{
+    sdl3d_mat4 light_view;
+    sdl3d_mat4 light_proj;
+    sdl3d_vec3 light_pos;
+    sdl3d_vec3 light_dir;
+    float len;
+    size_t map_bytes;
+
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (light_index < 0 || light_index >= context->light_count)
+    {
+        return SDL_SetError("Light index %d out of range (count=%d).", light_index, context->light_count);
+    }
+    if (context->lights[light_index].type != SDL3D_LIGHT_DIRECTIONAL)
+    {
+        return SDL_SetError("Shadow mapping is only supported for directional lights.");
+    }
+    if (scene_radius <= 0.0f)
+    {
+        return SDL_SetError("Scene radius must be positive.");
+    }
+
+    /* Allocate shadow depth buffer if not already allocated. */
+    if (context->shadow_depth[light_index] == NULL)
+    {
+        map_bytes = (size_t)SDL3D_SHADOW_MAP_SIZE * SDL3D_SHADOW_MAP_SIZE * sizeof(float);
+        context->shadow_depth[light_index] = (float *)SDL_malloc(map_bytes);
+        if (context->shadow_depth[light_index] == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+    }
+
+    /* Compute light-space view-projection matrix. */
+    light_dir = context->lights[light_index].direction;
+    len = SDL_sqrtf(light_dir.x * light_dir.x + light_dir.y * light_dir.y + light_dir.z * light_dir.z);
+    if (len < 1e-7f)
+    {
+        return SDL_SetError("Directional light has zero-length direction.");
+    }
+    light_dir.x /= len;
+    light_dir.y /= len;
+    light_dir.z /= len;
+
+    /* Place the light camera behind the scene center, looking along the light direction. */
+    light_pos.x = scene_center.x - light_dir.x * scene_radius * 2.0f;
+    light_pos.y = scene_center.y - light_dir.y * scene_radius * 2.0f;
+    light_pos.z = scene_center.z - light_dir.z * scene_radius * 2.0f;
+
+    if (!sdl3d_mat4_look_at(light_pos, scene_center, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), &light_view))
+    {
+        /* If up is parallel to direction, try a different up vector. */
+        if (!sdl3d_mat4_look_at(light_pos, scene_center, sdl3d_vec3_make(1.0f, 0.0f, 0.0f), &light_view))
+        {
+            return SDL_SetError("Cannot compute light view matrix.");
+        }
+    }
+
+    if (!sdl3d_mat4_orthographic(-scene_radius, scene_radius, -scene_radius, scene_radius, 0.01f, scene_radius * 4.0f,
+                                 &light_proj))
+    {
+        return SDL_SetError("Cannot compute light projection matrix.");
+    }
+
+    context->shadow_vp[light_index] = sdl3d_mat4_multiply(light_proj, light_view);
+    context->shadow_enabled[light_index] = true;
+    return true;
+}
+
+bool sdl3d_disable_shadow(sdl3d_render_context *context, int light_index)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (light_index < 0 || light_index >= SDL3D_MAX_LIGHTS)
+    {
+        return SDL_SetError("Light index %d out of range.", light_index);
+    }
+    context->shadow_enabled[light_index] = false;
+    SDL_free(context->shadow_depth[light_index]);
+    context->shadow_depth[light_index] = NULL;
+    return true;
+}
+
+bool sdl3d_render_shadow_map(sdl3d_render_context *context, const sdl3d_mesh *meshes, int mesh_count,
+                             const sdl3d_mat4 *model_matrices)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (meshes == NULL && mesh_count > 0)
+    {
+        return SDL_InvalidParamError("meshes");
+    }
+
+    for (int li = 0; li < context->light_count; ++li)
+    {
+        float *depth_buf;
+        size_t map_pixels;
+        sdl3d_mat4 light_mvp;
+
+        if (!context->shadow_enabled[li] || context->shadow_depth[li] == NULL)
+        {
+            continue;
+        }
+
+        depth_buf = context->shadow_depth[li];
+        map_pixels = (size_t)SDL3D_SHADOW_MAP_SIZE * SDL3D_SHADOW_MAP_SIZE;
+
+        /* Clear shadow depth buffer to 1.0 (far). */
+        for (size_t p = 0; p < map_pixels; ++p)
+        {
+            depth_buf[p] = 1.0f;
+        }
+
+        /* Render each mesh into the shadow map. */
+        for (int mi = 0; mi < mesh_count; ++mi)
+        {
+            const sdl3d_mesh *mesh = &meshes[mi];
+            sdl3d_mat4 model_mat = (model_matrices != NULL) ? model_matrices[mi] : sdl3d_mat4_identity();
+            light_mvp = sdl3d_mat4_multiply(context->shadow_vp[li], model_mat);
+
+            if (mesh->positions == NULL || mesh->vertex_count <= 0)
+            {
+                continue;
+            }
+
+            {
+                const bool indexed = mesh->indices != NULL;
+                const int tri_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
+
+                for (int t = 0; t < tri_count; ++t)
+                {
+                    const unsigned int i0 = indexed ? mesh->indices[t * 3 + 0] : (unsigned int)(t * 3 + 0);
+                    const unsigned int i1 = indexed ? mesh->indices[t * 3 + 1] : (unsigned int)(t * 3 + 1);
+                    const unsigned int i2 = indexed ? mesh->indices[t * 3 + 2] : (unsigned int)(t * 3 + 2);
+
+                    if ((int)i0 >= mesh->vertex_count || (int)i1 >= mesh->vertex_count || (int)i2 >= mesh->vertex_count)
+                    {
+                        continue;
+                    }
+
+                    {
+                        const float *p0 = &mesh->positions[i0 * 3];
+                        const float *p1 = &mesh->positions[i1 * 3];
+                        const float *p2 = &mesh->positions[i2 * 3];
+
+                        sdl3d_vec4 c0 =
+                            sdl3d_mat4_transform_vec4(light_mvp, sdl3d_vec4_make(p0[0], p0[1], p0[2], 1.0f));
+                        sdl3d_vec4 c1 =
+                            sdl3d_mat4_transform_vec4(light_mvp, sdl3d_vec4_make(p1[0], p1[1], p1[2], 1.0f));
+                        sdl3d_vec4 c2 =
+                            sdl3d_mat4_transform_vec4(light_mvp, sdl3d_vec4_make(p2[0], p2[1], p2[2], 1.0f));
+
+                        /* Perspective divide → NDC. */
+                        if (c0.w <= 0.0f || c1.w <= 0.0f || c2.w <= 0.0f)
+                        {
+                            continue;
+                        }
+
+                        {
+                            float ndc[3][3];
+                            int sx[3], sy[3];
+                            float sz[3];
+                            int min_x, max_x, min_y, max_y;
+
+                            ndc[0][0] = c0.x / c0.w;
+                            ndc[0][1] = c0.y / c0.w;
+                            ndc[0][2] = c0.z / c0.w;
+                            ndc[1][0] = c1.x / c1.w;
+                            ndc[1][1] = c1.y / c1.w;
+                            ndc[1][2] = c1.z / c1.w;
+                            ndc[2][0] = c2.x / c2.w;
+                            ndc[2][1] = c2.y / c2.w;
+                            ndc[2][2] = c2.z / c2.w;
+
+                            for (int v = 0; v < 3; ++v)
+                            {
+                                sx[v] = (int)((ndc[v][0] * 0.5f + 0.5f) * (float)SDL3D_SHADOW_MAP_SIZE);
+                                sy[v] = (int)((ndc[v][1] * 0.5f + 0.5f) * (float)SDL3D_SHADOW_MAP_SIZE);
+                                sz[v] = ndc[v][2] * 0.5f + 0.5f;
+                            }
+
+                            /* Simple bounding-box rasterization for the shadow map. */
+                            min_x = sx[0] < sx[1] ? sx[0] : sx[1];
+                            min_x = min_x < sx[2] ? min_x : sx[2];
+                            max_x = sx[0] > sx[1] ? sx[0] : sx[1];
+                            max_x = max_x > sx[2] ? max_x : sx[2];
+                            min_y = sy[0] < sy[1] ? sy[0] : sy[1];
+                            min_y = min_y < sy[2] ? min_y : sy[2];
+                            max_y = sy[0] > sy[1] ? sy[0] : sy[1];
+                            max_y = max_y > sy[2] ? max_y : sy[2];
+
+                            if (min_x < 0)
+                            {
+                                min_x = 0;
+                            }
+                            if (min_y < 0)
+                            {
+                                min_y = 0;
+                            }
+                            if (max_x >= SDL3D_SHADOW_MAP_SIZE)
+                            {
+                                max_x = SDL3D_SHADOW_MAP_SIZE - 1;
+                            }
+                            if (max_y >= SDL3D_SHADOW_MAP_SIZE)
+                            {
+                                max_y = SDL3D_SHADOW_MAP_SIZE - 1;
+                            }
+
+                            for (int py = min_y; py <= max_y; ++py)
+                            {
+                                for (int px = min_x; px <= max_x; ++px)
+                                {
+                                    /* Barycentric test. */
+                                    float w0, w1, w2, area, depth;
+                                    w0 = (float)(sx[1] - sx[2]) * (float)(py - sy[2]) -
+                                         (float)(sy[1] - sy[2]) * (float)(px - sx[2]);
+                                    w1 = (float)(sx[2] - sx[0]) * (float)(py - sy[0]) -
+                                         (float)(sy[2] - sy[0]) * (float)(px - sx[0]);
+                                    w2 = (float)(sx[0] - sx[1]) * (float)(py - sy[1]) -
+                                         (float)(sy[0] - sy[1]) * (float)(px - sx[1]);
+                                    area = w0 + w1 + w2;
+                                    if (area <= 0.0f)
+                                    {
+                                        continue;
+                                    }
+                                    w0 /= area;
+                                    w1 /= area;
+                                    w2 /= area;
+                                    if (w0 < 0.0f || w1 < 0.0f || w2 < 0.0f)
+                                    {
+                                        continue;
+                                    }
+                                    depth = w0 * sz[0] + w1 * sz[1] + w2 * sz[2];
+                                    {
+                                        int idx = py * SDL3D_SHADOW_MAP_SIZE + px;
+                                        if (depth < depth_buf[idx])
+                                        {
+                                            depth_buf[idx] = depth;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
 }

--- a/src/lighting_internal.h
+++ b/src/lighting_internal.h
@@ -22,6 +22,18 @@ typedef struct sdl3d_lighting_params
     float metallic;
     float roughness;
     float emissive[3];
+
+    /* Shadow maps (per-light, NULL when no shadow for that light). */
+    const float *shadow_depth[SDL3D_MAX_LIGHTS];
+    sdl3d_mat4 shadow_vp[SDL3D_MAX_LIGHTS];
+    bool shadow_enabled[SDL3D_MAX_LIGHTS];
+    float shadow_bias;
+
+    /* Fog. */
+    sdl3d_fog fog;
+
+    /* Tonemapping. */
+    sdl3d_tonemap_mode tonemap_mode;
 } sdl3d_lighting_params;
 
 /*
@@ -37,5 +49,15 @@ typedef struct sdl3d_lighting_params
 void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_r, float albedo_g, float albedo_b,
                               float world_nx, float world_ny, float world_nz, float world_px, float world_py,
                               float world_pz, float *out_r, float *out_g, float *out_b);
+
+/*
+ * Apply tonemapping to HDR linear RGB. Modifies values in-place.
+ */
+void sdl3d_tonemap(sdl3d_tonemap_mode mode, float *r, float *g, float *b);
+
+/*
+ * Compute fog factor in [0,1] where 0 = no fog, 1 = fully fogged.
+ */
+float sdl3d_compute_fog_factor(const sdl3d_fog *fog, float distance);
 
 #endif

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -1907,6 +1907,22 @@ static void sdl3d_rasterize_prepared_triangle_lit_region(sdl3d_framebuffer *fram
             sdl3d_shade_fragment_pbr(lp, albedo_r, albedo_g, albedo_b, nx, ny, nz, wpx, wpy, wpz, &lit_r, &lit_g,
                                      &lit_b);
 
+            /* Tonemapping: HDR → LDR + sRGB gamma. */
+            sdl3d_tonemap(lp->tonemap_mode, &lit_r, &lit_g, &lit_b);
+
+            /* Fog: blend toward fog color based on distance from camera. */
+            if (lp->fog.mode != SDL3D_FOG_NONE)
+            {
+                float dx = wpx - lp->camera_pos.x;
+                float dy = wpy - lp->camera_pos.y;
+                float dz = wpz - lp->camera_pos.z;
+                float dist = SDL_sqrtf(dx * dx + dy * dy + dz * dz);
+                float fog_f = sdl3d_compute_fog_factor(&lp->fog, dist);
+                lit_r = lit_r * (1.0f - fog_f) + lp->fog.color[0] * fog_f;
+                lit_g = lit_g * (1.0f - fog_f) + lp->fog.color[1] * fog_f;
+                lit_b = lit_b * (1.0f - fog_f) + lp->fog.color[2] * fog_f;
+            }
+
             sdl3d_color color;
             color.r = sdl3d_color_channel_clamp(lit_r * 255.0f);
             color.g = sdl3d_color_channel_clamp(lit_g * 255.0f);
@@ -1974,6 +1990,82 @@ static bool sdl3d_prepare_triangle_lit(sdl3d_screen_vertex_lit sv0, sdl3d_screen
     out->bounds.max_px_x = max_px_x;
     out->bounds.min_px_y = min_px_y;
     out->bounds.max_px_y = max_px_y;
+    return true;
+}
+
+typedef struct sdl3d_parallel_triangle_lit_job
+{
+    sdl3d_framebuffer *framebuffer;
+    sdl3d_prepared_triangle_lit triangle;
+    const sdl3d_texture2d *texture;
+    const sdl3d_lighting_params *lp;
+    int first_tile_x;
+    int first_tile_y;
+    int tiles_w;
+} sdl3d_parallel_triangle_lit_job;
+
+static void sdl3d_parallel_triangle_lit_job_run_tile(void *userdata, int tile_index)
+{
+    sdl3d_parallel_triangle_lit_job *job = (sdl3d_parallel_triangle_lit_job *)userdata;
+    const int tile_x = job->first_tile_x + (tile_index % job->tiles_w);
+    const int tile_y = job->first_tile_y + (tile_index / job->tiles_w);
+
+    const int tile_min_px_x = sdl3d_max_int(job->triangle.bounds.min_px_x, tile_x * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_x = sdl3d_min_int(job->triangle.bounds.max_px_x, ((tile_x + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+    const int tile_min_px_y = sdl3d_max_int(job->triangle.bounds.min_px_y, tile_y * SDL3D_RASTER_TILE_SIZE);
+    const int tile_max_px_y = sdl3d_min_int(job->triangle.bounds.max_px_y, ((tile_y + 1) * SDL3D_RASTER_TILE_SIZE) - 1);
+
+    if (tile_min_px_x > tile_max_px_x || tile_min_px_y > tile_max_px_y)
+    {
+        return;
+    }
+
+    sdl3d_rasterize_prepared_triangle_lit_region(job->framebuffer, &job->triangle, job->texture, job->lp, tile_min_px_x,
+                                                 tile_max_px_x, tile_min_px_y, tile_max_px_y);
+}
+
+static bool sdl3d_try_rasterize_prepared_triangle_lit_parallel(sdl3d_framebuffer *framebuffer,
+                                                               const sdl3d_prepared_triangle_lit *triangle,
+                                                               const sdl3d_texture2d *texture,
+                                                               const sdl3d_lighting_params *lp)
+{
+    int first_tile_x, last_tile_x, first_tile_y, last_tile_y;
+    int tiles_w, tiles_h, tile_count;
+    sdl3d_parallel_triangle_lit_job triangle_job;
+    sdl3d_parallel_job job;
+
+    if (framebuffer->parallel_rasterizer == NULL)
+    {
+        return false;
+    }
+
+    first_tile_x = triangle->bounds.min_px_x / SDL3D_RASTER_TILE_SIZE;
+    last_tile_x = triangle->bounds.max_px_x / SDL3D_RASTER_TILE_SIZE;
+    first_tile_y = triangle->bounds.min_px_y / SDL3D_RASTER_TILE_SIZE;
+    last_tile_y = triangle->bounds.max_px_y / SDL3D_RASTER_TILE_SIZE;
+    tiles_w = last_tile_x - first_tile_x + 1;
+    tiles_h = last_tile_y - first_tile_y + 1;
+    tile_count = tiles_w * tiles_h;
+
+    if (tile_count <= 1)
+    {
+        return false;
+    }
+
+    triangle_job.framebuffer = framebuffer;
+    triangle_job.triangle = *triangle;
+    triangle_job.texture = texture;
+    triangle_job.lp = lp;
+    triangle_job.first_tile_x = first_tile_x;
+    triangle_job.first_tile_y = first_tile_y;
+    triangle_job.tiles_w = tiles_w;
+
+    job.run_tile = sdl3d_parallel_triangle_lit_job_run_tile;
+    job.userdata = &triangle_job;
+    job.tile_count = tile_count;
+    SDL_SetAtomicInt(&job.next_tile_index, 0);
+
+    sdl3d_parallel_rasterizer_execute(framebuffer->parallel_rasterizer, &job);
     return true;
 }
 
@@ -2052,10 +2144,14 @@ void sdl3d_rasterize_triangle_lit(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp
         screen[i] = sdl3d_viewport_transform_lit(clip[i], framebuffer->width, framebuffer->height);
     }
 
-    /* Backface culling on the first sub-triangle. */
+    /* Backface culling: positive signed area = CW screen winding = backface. */
     signed_area = sdl3d_edge_function(screen[0].base.x_fx, screen[0].base.y_fx, screen[1].base.x_fx,
                                       screen[1].base.y_fx, screen[2].base.x_fx, screen[2].base.y_fx);
-    if (backface_culling_enabled && signed_area <= 0)
+    if (signed_area == 0)
+    {
+        return;
+    }
+    if (backface_culling_enabled && signed_area >= 0)
     {
         return;
     }
@@ -2095,9 +2191,12 @@ void sdl3d_rasterize_triangle_lit(sdl3d_framebuffer *framebuffer, sdl3d_mat4 mvp
         {
             continue;
         }
-        sdl3d_rasterize_prepared_triangle_lit_region(framebuffer, &prepared, texture, lighting_params,
-                                                     prepared.bounds.min_px_x, prepared.bounds.max_px_x,
-                                                     prepared.bounds.min_px_y, prepared.bounds.max_px_y);
+        if (!sdl3d_try_rasterize_prepared_triangle_lit_parallel(framebuffer, &prepared, texture, lighting_params))
+        {
+            sdl3d_rasterize_prepared_triangle_lit_region(framebuffer, &prepared, texture, lighting_params,
+                                                         prepared.bounds.min_px_x, prepared.bounds.max_px_x,
+                                                         prepared.bounds.min_px_y, prepared.bounds.max_px_y);
+        }
     }
 }
 

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -291,6 +291,11 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     context->ambient[0] = 0.03f;
     context->ambient[1] = 0.03f;
     context->ambient[2] = 0.03f;
+    context->fog.mode = SDL3D_FOG_NONE;
+    context->tonemap_mode = SDL3D_TONEMAP_NONE;
+    SDL_memset(context->shadow_depth, 0, sizeof(context->shadow_depth));
+    SDL_memset(context->shadow_enabled, 0, sizeof(context->shadow_enabled));
+    context->shadow_bias = 0.005f;
     sdl3d_try_create_parallel_rasterizer(context);
 
     *out_context = context;
@@ -310,6 +315,10 @@ void sdl3d_destroy_render_context(sdl3d_render_context *context)
     SDL_DestroyTexture(context->color_texture);
     SDL_free(context->color_buffer);
     SDL_free(context->depth_buffer);
+    for (int i = 0; i < SDL3D_MAX_LIGHTS; ++i)
+    {
+        SDL_free(context->shadow_depth[i]);
+    }
     SDL_free(context);
 }
 

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -51,6 +51,15 @@ struct sdl3d_render_context
     sdl3d_light lights[SDL3D_MAX_LIGHTS];
     int light_count;
     float ambient[3];
+
+    sdl3d_fog fog;
+    sdl3d_tonemap_mode tonemap_mode;
+
+    /* Per-light shadow maps (only directional lights supported). */
+    float *shadow_depth[SDL3D_MAX_LIGHTS];
+    sdl3d_mat4 shadow_vp[SDL3D_MAX_LIGHTS];
+    bool shadow_enabled[SDL3D_MAX_LIGHTS];
+    float shadow_bias;
 };
 
 static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_context *context)

--- a/src/shading.c
+++ b/src/shading.c
@@ -161,6 +161,48 @@ static bool sdl3d_compute_light_contribution(const sdl3d_light *light, float px,
     return true;
 }
 
+static float sdl3d_sample_shadow(const sdl3d_lighting_params *params, int light_index, float wpx, float wpy, float wpz)
+{
+    sdl3d_vec4 lp;
+    float ndc_x, ndc_y, ndc_z;
+    int sx, sy, idx;
+    float map_depth;
+
+    if (!params->shadow_enabled[light_index] || params->shadow_depth[light_index] == NULL)
+    {
+        return 1.0f;
+    }
+
+    /* Transform world position to light clip space. */
+    lp = sdl3d_mat4_transform_vec4(params->shadow_vp[light_index], sdl3d_vec4_make(wpx, wpy, wpz, 1.0f));
+    if (lp.w <= 0.0f)
+    {
+        return 1.0f;
+    }
+
+    ndc_x = lp.x / lp.w;
+    ndc_y = lp.y / lp.w;
+    ndc_z = lp.z / lp.w;
+
+    /* Map NDC [-1,1] to [0, shadow_map_size). */
+    sx = (int)((ndc_x * 0.5f + 0.5f) * (float)SDL3D_SHADOW_MAP_SIZE);
+    sy = (int)((ndc_y * 0.5f + 0.5f) * (float)SDL3D_SHADOW_MAP_SIZE);
+
+    if (sx < 0 || sx >= SDL3D_SHADOW_MAP_SIZE || sy < 0 || sy >= SDL3D_SHADOW_MAP_SIZE)
+    {
+        return 1.0f; /* Outside shadow map → lit. */
+    }
+
+    idx = sy * SDL3D_SHADOW_MAP_SIZE + sx;
+    map_depth = params->shadow_depth[light_index][idx];
+
+    /* Fragment depth in [0,1] range. */
+    {
+        float frag_depth = ndc_z * 0.5f + 0.5f;
+        return (frag_depth - params->shadow_bias > map_depth) ? 0.0f : 1.0f;
+    }
+}
+
 void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_r, float albedo_g, float albedo_b,
                               float world_nx, float world_ny, float world_nz, float world_px, float world_py,
                               float world_pz, float *out_r, float *out_g, float *out_b)
@@ -239,13 +281,87 @@ void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_
         float diff_g = (1.0f - fg) * kd * albedo_g / SDL3D_PI;
         float diff_b = (1.0f - fb) * kd * albedo_b / SDL3D_PI;
 
-        lo_r += (diff_r + spec_r) * rad_r * n_dot_l;
-        lo_g += (diff_g + spec_g) * rad_g * n_dot_l;
-        lo_b += (diff_b + spec_b) * rad_b * n_dot_l;
+        {
+            float shadow = sdl3d_sample_shadow(params, i, world_px, world_py, world_pz);
+            lo_r += (diff_r + spec_r) * rad_r * n_dot_l * shadow;
+            lo_g += (diff_g + spec_g) * rad_g * n_dot_l * shadow;
+            lo_b += (diff_b + spec_b) * rad_b * n_dot_l * shadow;
+        }
     }
 
     /* Ambient + emissive. */
     *out_r = params->ambient[0] * albedo_r + lo_r + params->emissive[0];
     *out_g = params->ambient[1] * albedo_g + lo_g + params->emissive[1];
     *out_b = params->ambient[2] * albedo_b + lo_b + params->emissive[2];
+}
+
+/* ------------------------------------------------------------------ */
+/* Tonemapping                                                         */
+/* ------------------------------------------------------------------ */
+
+static float sdl3d_tonemap_reinhard(float x)
+{
+    return x / (1.0f + x);
+}
+
+void sdl3d_tonemap(sdl3d_tonemap_mode mode, float *r, float *g, float *b)
+{
+    if (mode == SDL3D_TONEMAP_REINHARD)
+    {
+        *r = sdl3d_tonemap_reinhard(*r);
+        *g = sdl3d_tonemap_reinhard(*g);
+        *b = sdl3d_tonemap_reinhard(*b);
+    }
+    else if (mode == SDL3D_TONEMAP_ACES)
+    {
+        /* ACES filmic approximation (Narkowicz 2015). */
+        float a = 2.51f, bt = 0.03f, c = 2.43f, d = 0.59f, e = 0.14f;
+        float ri = *r, gi = *g, bi = *b;
+        *r = sdl3d_clampf((ri * (a * ri + bt)) / (ri * (c * ri + d) + e), 0.0f, 1.0f);
+        *g = sdl3d_clampf((gi * (a * gi + bt)) / (gi * (c * gi + d) + e), 0.0f, 1.0f);
+        *b = sdl3d_clampf((bi * (a * bi + bt)) / (bi * (c * bi + d) + e), 0.0f, 1.0f);
+    }
+
+    /* Apply sRGB gamma curve when any tonemapping is active. */
+    if (mode != SDL3D_TONEMAP_NONE)
+    {
+        float inv_gamma = 1.0f / 2.2f;
+        *r = powf(sdl3d_clampf(*r, 0.0f, 1.0f), inv_gamma);
+        *g = powf(sdl3d_clampf(*g, 0.0f, 1.0f), inv_gamma);
+        *b = powf(sdl3d_clampf(*b, 0.0f, 1.0f), inv_gamma);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Fog                                                                 */
+/* ------------------------------------------------------------------ */
+
+float sdl3d_compute_fog_factor(const sdl3d_fog *fog, float distance)
+{
+    if (fog->mode == SDL3D_FOG_NONE)
+    {
+        return 0.0f;
+    }
+
+    if (fog->mode == SDL3D_FOG_LINEAR)
+    {
+        if (fog->end <= fog->start)
+        {
+            return 0.0f;
+        }
+        return sdl3d_clampf((distance - fog->start) / (fog->end - fog->start), 0.0f, 1.0f);
+    }
+
+    if (fog->mode == SDL3D_FOG_EXP)
+    {
+        float f = expf(-fog->density * distance);
+        return sdl3d_clampf(1.0f - f, 0.0f, 1.0f);
+    }
+
+    /* SDL3D_FOG_EXP2 */
+    {
+        float d = fog->density * distance;
+        float f = expf(-d * d);
+        return sdl3d_clampf(1.0f - f, 0.0f, 1.0f);
+    }
 }

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -389,3 +389,275 @@ TEST(SDL3DPBRShading, RoughnessAffectsSpecular)
     /* Smooth surface should have higher total output due to specular peak. */
     EXPECT_GT(rs, rr);
 }
+
+/* ================================================================== */
+/* Fog computation tests                                              */
+/* ================================================================== */
+
+struct FogFactorCase
+{
+    const char *label;
+    sdl3d_fog_mode mode;
+    float start;
+    float end;
+    float density;
+    float distance;
+    float expected_min;
+    float expected_max;
+};
+
+class SDL3DFogFactor : public ::testing::TestWithParam<FogFactorCase>
+{
+};
+
+TEST_P(SDL3DFogFactor, ComputesExpectedRange)
+{
+    const auto &c = GetParam();
+    sdl3d_fog fog{};
+    fog.mode = c.mode;
+    fog.start = c.start;
+    fog.end = c.end;
+    fog.density = c.density;
+    float f = sdl3d_compute_fog_factor(&fog, c.distance);
+    EXPECT_GE(f, c.expected_min) << c.label;
+    EXPECT_LE(f, c.expected_max) << c.label;
+}
+
+INSTANTIATE_TEST_SUITE_P(Fog, SDL3DFogFactor,
+                         ::testing::Values(
+                             /* No fog → always 0. */
+                             FogFactorCase{"none d=0", SDL3D_FOG_NONE, 0, 0, 0, 0.0f, 0.0f, 0.0f},
+                             FogFactorCase{"none d=100", SDL3D_FOG_NONE, 0, 0, 0, 100.0f, 0.0f, 0.0f},
+
+                             /* Linear fog. */
+                             FogFactorCase{"linear before start", SDL3D_FOG_LINEAR, 10, 50, 0, 5.0f, 0.0f, 0.0f},
+                             FogFactorCase{"linear at start", SDL3D_FOG_LINEAR, 10, 50, 0, 10.0f, 0.0f, 0.001f},
+                             FogFactorCase{"linear midpoint", SDL3D_FOG_LINEAR, 10, 50, 0, 30.0f, 0.49f, 0.51f},
+                             FogFactorCase{"linear at end", SDL3D_FOG_LINEAR, 10, 50, 0, 50.0f, 0.99f, 1.0f},
+                             FogFactorCase{"linear past end", SDL3D_FOG_LINEAR, 10, 50, 0, 100.0f, 1.0f, 1.0f},
+                             FogFactorCase{"linear start==end", SDL3D_FOG_LINEAR, 10, 10, 0, 10.0f, 0.0f, 0.0f},
+
+                             /* Exponential fog. */
+                             FogFactorCase{"exp d=0", SDL3D_FOG_EXP, 0, 0, 0.1f, 0.0f, 0.0f, 0.001f},
+                             FogFactorCase{"exp d=10", SDL3D_FOG_EXP, 0, 0, 0.1f, 10.0f, 0.5f, 0.7f},
+                             FogFactorCase{"exp d=100", SDL3D_FOG_EXP, 0, 0, 0.1f, 100.0f, 0.99f, 1.0f},
+
+                             /* Exponential squared fog. */
+                             FogFactorCase{"exp2 d=0", SDL3D_FOG_EXP2, 0, 0, 0.1f, 0.0f, 0.0f, 0.001f},
+                             FogFactorCase{"exp2 d=5", SDL3D_FOG_EXP2, 0, 0, 0.1f, 5.0f, 0.15f, 0.30f},
+                             FogFactorCase{"exp2 d=50", SDL3D_FOG_EXP2, 0, 0, 0.1f, 50.0f, 0.99f, 1.0f}));
+
+TEST_F(SDL3DLightingFixture, SetAndClearFog)
+{
+    sdl3d_fog fog{};
+    fog.mode = SDL3D_FOG_LINEAR;
+    fog.color[0] = 0.5f;
+    fog.color[1] = 0.5f;
+    fog.color[2] = 0.5f;
+    fog.start = 10.0f;
+    fog.end = 100.0f;
+    ASSERT_TRUE(sdl3d_set_fog(ctx, &fog));
+    ASSERT_TRUE(sdl3d_clear_fog(ctx));
+}
+
+TEST(SDL3DFogAPI, NullContextRejected)
+{
+    sdl3d_fog fog{};
+    EXPECT_FALSE(sdl3d_set_fog(nullptr, &fog));
+    EXPECT_FALSE(sdl3d_clear_fog(nullptr));
+}
+
+TEST(SDL3DFogAPI, NullFogRejected)
+{
+    /* Can't test without a context, but we can verify the null fog param. */
+    EXPECT_FALSE(sdl3d_set_fog(nullptr, nullptr));
+}
+
+/* ================================================================== */
+/* Tonemapping tests                                                  */
+/* ================================================================== */
+
+struct TonemapCase
+{
+    const char *label;
+    sdl3d_tonemap_mode mode;
+    float in_r, in_g, in_b;
+    float expect_min_r, expect_max_r;
+};
+
+class SDL3DTonemapTable : public ::testing::TestWithParam<TonemapCase>
+{
+};
+
+TEST_P(SDL3DTonemapTable, OutputInExpectedRange)
+{
+    const auto &c = GetParam();
+    float r = c.in_r, g = c.in_g, b = c.in_b;
+    sdl3d_tonemap(c.mode, &r, &g, &b);
+    EXPECT_GE(r, c.expect_min_r) << c.label;
+    EXPECT_LE(r, c.expect_max_r) << c.label;
+    EXPECT_GE(g, 0.0f) << c.label;
+    /* Tonemapped modes clamp to [0,1]; NONE is passthrough. */
+    if (c.mode != SDL3D_TONEMAP_NONE)
+    {
+        EXPECT_LE(b, 1.01f) << c.label;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(Tonemap, SDL3DTonemapTable,
+                         ::testing::Values(
+                             /* None: passthrough. */
+                             TonemapCase{"none 0", SDL3D_TONEMAP_NONE, 0.0f, 0.0f, 0.0f, 0.0f, 0.001f},
+                             TonemapCase{"none 1", SDL3D_TONEMAP_NONE, 1.0f, 1.0f, 1.0f, 1.0f, 1.001f},
+                             TonemapCase{"none HDR", SDL3D_TONEMAP_NONE, 5.0f, 5.0f, 5.0f, 5.0f, 5.001f},
+
+                             /* Reinhard: x/(1+x), then gamma. */
+                             TonemapCase{"reinhard 0", SDL3D_TONEMAP_REINHARD, 0.0f, 0.0f, 0.0f, 0.0f, 0.001f},
+                             TonemapCase{"reinhard 1", SDL3D_TONEMAP_REINHARD, 1.0f, 1.0f, 1.0f, 0.5f, 0.8f},
+                             TonemapCase{"reinhard HDR", SDL3D_TONEMAP_REINHARD, 10.0f, 10.0f, 10.0f, 0.9f, 1.0f},
+
+                             /* ACES: should compress HDR to [0,1]. */
+                             TonemapCase{"aces 0", SDL3D_TONEMAP_ACES, 0.0f, 0.0f, 0.0f, 0.0f, 0.01f},
+                             TonemapCase{"aces 1", SDL3D_TONEMAP_ACES, 1.0f, 1.0f, 1.0f, 0.5f, 1.0f},
+                             TonemapCase{"aces HDR", SDL3D_TONEMAP_ACES, 10.0f, 10.0f, 10.0f, 0.9f, 1.0f}));
+
+TEST_F(SDL3DLightingFixture, SetAndGetTonemapMode)
+{
+    EXPECT_EQ(sdl3d_get_tonemap_mode(ctx), SDL3D_TONEMAP_NONE);
+    ASSERT_TRUE(sdl3d_set_tonemap_mode(ctx, SDL3D_TONEMAP_REINHARD));
+    EXPECT_EQ(sdl3d_get_tonemap_mode(ctx), SDL3D_TONEMAP_REINHARD);
+    ASSERT_TRUE(sdl3d_set_tonemap_mode(ctx, SDL3D_TONEMAP_ACES));
+    EXPECT_EQ(sdl3d_get_tonemap_mode(ctx), SDL3D_TONEMAP_ACES);
+    ASSERT_TRUE(sdl3d_set_tonemap_mode(ctx, SDL3D_TONEMAP_NONE));
+    EXPECT_EQ(sdl3d_get_tonemap_mode(ctx), SDL3D_TONEMAP_NONE);
+}
+
+TEST(SDL3DTonemapAPI, NullContextRejected)
+{
+    EXPECT_FALSE(sdl3d_set_tonemap_mode(nullptr, SDL3D_TONEMAP_REINHARD));
+    EXPECT_EQ(sdl3d_get_tonemap_mode(nullptr), SDL3D_TONEMAP_NONE);
+}
+
+/* ================================================================== */
+/* Shadow mapping tests                                               */
+/* ================================================================== */
+
+TEST_F(SDL3DLightingFixture, EnableShadowOnDirectionalLight)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = dl.color[1] = dl.color[2] = 1.0f;
+    dl.intensity = 1.0f;
+    ASSERT_TRUE(sdl3d_add_light(ctx, &dl));
+
+    ASSERT_TRUE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+    ASSERT_TRUE(sdl3d_disable_shadow(ctx, 0));
+}
+
+TEST_F(SDL3DLightingFixture, ShadowRejectsNonDirectionalLight)
+{
+    sdl3d_light pl{};
+    pl.type = SDL3D_LIGHT_POINT;
+    pl.intensity = 1.0f;
+    ASSERT_TRUE(sdl3d_add_light(ctx, &pl));
+
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+}
+
+TEST_F(SDL3DLightingFixture, ShadowRejectsInvalidLightIndex)
+{
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, -1, sdl3d_vec3_make(0, 0, 0), 10.0f));
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, 99, sdl3d_vec3_make(0, 0, 0), 10.0f));
+}
+
+TEST_F(SDL3DLightingFixture, ShadowRejectsZeroRadius)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.intensity = 1.0f;
+    ASSERT_TRUE(sdl3d_add_light(ctx, &dl));
+
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 0.0f));
+    EXPECT_FALSE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), -1.0f));
+}
+
+TEST(SDL3DShadowAPI, NullContextRejected)
+{
+    EXPECT_FALSE(sdl3d_enable_shadow(nullptr, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+    EXPECT_FALSE(sdl3d_disable_shadow(nullptr, 0));
+    EXPECT_FALSE(sdl3d_render_shadow_map(nullptr, nullptr, 0, nullptr));
+}
+
+TEST_F(SDL3DLightingFixture, RenderShadowMapWithNoMeshes)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = dl.color[1] = dl.color[2] = 1.0f;
+    dl.intensity = 1.0f;
+    ASSERT_TRUE(sdl3d_add_light(ctx, &dl));
+    ASSERT_TRUE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+
+    /* Rendering with zero meshes should succeed (no-op). */
+    ASSERT_TRUE(sdl3d_render_shadow_map(ctx, nullptr, 0, nullptr));
+
+    sdl3d_disable_shadow(ctx, 0);
+}
+
+TEST(SDL3DPBRShading, ShadowOccludesLight)
+{
+    /* Create a shadow map that is all zeros (everything at depth 0 = near).
+     * Any fragment behind depth 0 should be in shadow. */
+    const size_t map_size = (size_t)SDL3D_SHADOW_MAP_SIZE * SDL3D_SHADOW_MAP_SIZE;
+    std::vector<float> shadow_depth(map_size, 0.0f);
+
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = dl.color[1] = dl.color[2] = 1.0f;
+    dl.intensity = 1.0f;
+
+    sdl3d_lighting_params p{};
+    p.lights = &dl;
+    p.light_count = 1;
+    p.camera_pos = {0.0f, 0.0f, 5.0f};
+    p.roughness = 1.0f;
+    p.shadow_depth[0] = shadow_depth.data();
+    p.shadow_enabled[0] = true;
+    p.shadow_bias = 0.005f;
+    /* Identity VP → fragment at origin maps to NDC (0,0,0) → depth 0.5. */
+    p.shadow_vp[0] = sdl3d_mat4_identity();
+
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+
+    /* Fragment should be in shadow → no direct light contribution. */
+    EXPECT_NEAR(r, 0.0f, 0.01f);
+    EXPECT_NEAR(g, 0.0f, 0.01f);
+    EXPECT_NEAR(b, 0.0f, 0.01f);
+}
+
+TEST(SDL3DPBRShading, NoShadowWhenDisabled)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = dl.color[1] = dl.color[2] = 1.0f;
+    dl.intensity = 1.0f;
+
+    sdl3d_lighting_params p{};
+    p.lights = &dl;
+    p.light_count = 1;
+    p.camera_pos = {0.0f, 0.0f, 5.0f};
+    p.roughness = 1.0f;
+    /* shadow_enabled[0] defaults to false. */
+
+    float r, g, b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
+
+    /* Should be lit (no shadow). */
+    EXPECT_GT(r, 0.1f);
+}


### PR DESCRIPTION
## Summary

Completes M4 (Lighting and Materials) from the roadmap in #4.

### Fog (M4-4)
- Linear, exponential, and exponential-squared modes
- Configurable fog color, start/end distance (linear), density (exp/exp2)
- Applied post-lighting as distance-based blend toward fog color
- API: `sdl3d_set_fog`, `sdl3d_clear_fog`

### Shadow Mapping (M4-5)
- 512x512 depth buffer per directional light
- Orthographic projection from light POV covering configurable scene bounds
- Barycentric rasterization for depth-only shadow pass
- Per-fragment shadow test with bias in the PBR per-light loop
- API: `sdl3d_enable_shadow`, `sdl3d_disable_shadow`, `sdl3d_render_shadow_map`

### Tonemapping + Gamma (M4-6)
- Reinhard and ACES filmic (Narkowicz 2015) tonemapping modes
- sRGB gamma curve (1/2.2) applied when tonemapping is active
- NONE mode is passthrough (no gamma, preserving existing behavior)
- API: `sdl3d_set_tonemap_mode`, `sdl3d_get_tonemap_mode`

### Pipeline Order
PBR shading -> shadow factor (per-light) -> tonemapping (HDR->LDR + gamma) -> fog (distance blend) -> pixel write

### Testing
29 new tests:
- Fog factor computation: 14 table-driven cases (none/linear/exp/exp2 at various distances)
- Tonemapping: 9 table-driven cases (none/reinhard/aces at 0, 1, HDR values)
- Shadow mapping: enable/disable, reject non-directional, reject invalid index/radius, render with no meshes, shadow occlusion verification, no-shadow-when-disabled
- API null rejection for all new functions
- Fog/tonemap set/get/clear via render context fixture

167 existing unit tests + 43 non-fixture lighting tests all passing. clang-format clean. No new dependencies.