### PR TITLE
Add profiling CI job and headless rendering benchmark

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,63 @@
+name: Profile
+
+on:
+  pull_request:
+
+jobs:
+  profile:
+    name: perf profile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq linux-tools-common linux-tools-$(uname -r) || true
+          # Fallback: install linux-tools-generic if kernel-specific package unavailable
+          sudo apt-get install -y -qq linux-tools-generic || true
+
+      - name: Setup SDL3
+        uses: libsdl-org/setup-sdl@main
+        with:
+          version: 3-latest
+          build-type: Release
+
+      - name: Configure
+        run: >
+          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DSDL3D_BUILD_TESTS=OFF
+          -DSDL3D_BUILD_BENCHMARKS=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Benchmark (timing)
+        run: |
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=dummy
+          ./build/benchmarks/sdl3d_bench 120
+
+      - name: Profile (perf stat)
+        run: |
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=dummy
+          sudo sysctl -w kernel.perf_event_paranoid=-1 || true
+          perf stat -d ./build/benchmarks/sdl3d_bench 120 2>&1 | tee build/perf_stat.txt
+
+      - name: Profile (perf record + report)
+        run: |
+          export SDL_VIDEODRIVER=dummy
+          export SDL_AUDIODRIVER=dummy
+          sudo sysctl -w kernel.perf_event_paranoid=-1 || true
+          perf record -g --call-graph dwarf -o build/perf.data ./build/benchmarks/sdl3d_bench 120
+          perf report -i build/perf.data --stdio --no-children --percent-limit 1.0 2>&1 | tee build/perf_report.txt
+
+      - name: Upload profile artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: profile-report
+          path: |
+            build/perf_stat.txt
+            build/perf_report.txt
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 option(SDL3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
 option(SDL3D_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
+option(SDL3D_BUILD_BENCHMARKS "Build SDL3D benchmarks" OFF)
 
 set(SDL3D_USING_FETCHED_SDL3 OFF)
 
@@ -150,6 +151,10 @@ endif()
 
 if(SDL3D_BUILD_TESTS)
     add_subdirectory(tests)
+endif()
+
+if(SDL3D_BUILD_BENCHMARKS)
+    add_subdirectory(benchmarks)
 endif()
 
 if(SDL3D_USING_FETCHED_SDL3)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(sdl3d_bench bench_render.c)
+
+target_link_libraries(sdl3d_bench PRIVATE SDL3D::sdl3d)
+
+if(NOT WIN32)
+    target_link_libraries(sdl3d_bench PRIVATE m)
+endif()
+target_compile_features(sdl3d_bench PRIVATE c_std_17)
+
+if(WIN32)
+    add_custom_command(
+        TARGET sdl3d_bench
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:sdl3d_bench> $<TARGET_FILE_DIR:sdl3d_bench>
+        COMMAND_EXPAND_LISTS
+    )
+endif()

--- a/benchmarks/bench_render.c
+++ b/benchmarks/bench_render.c
@@ -1,0 +1,208 @@
+/*
+ * Headless rendering benchmark for profiling the software 3D pipeline.
+ *
+ * Renders a fixed scene (ground plane, shapes with PBR lighting, fog,
+ * tonemapping) for a configurable number of frames without presenting
+ * to a window. Designed to run under perf or other profilers in CI.
+ *
+ * Usage: sdl3d_bench [frame_count]   (default: 60)
+ */
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include "sdl3d/lighting.h"
+#include "sdl3d/sdl3d.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Fog and tonemap may not be available until M4-4/5/6 lands. */
+#ifdef SDL3D_FOG_LINEAR
+#define BENCH_HAS_FOG 1
+#else
+#define BENCH_HAS_FOG 0
+#endif
+
+#ifdef SDL3D_TONEMAP_REINHARD
+#define BENCH_HAS_TONEMAP 1
+#else
+#define BENCH_HAS_TONEMAP 0
+#endif
+
+#define BENCH_WIDTH 320
+#define BENCH_HEIGHT 240
+
+static void draw_scene(sdl3d_render_context *ctx, float angle)
+{
+    sdl3d_camera3d camera;
+    sdl3d_color sky = {150, 180, 210, 255};
+    sdl3d_color ground = {80, 130, 60, 255};
+    sdl3d_color brown = {120, 80, 40, 255};
+    sdl3d_color green = {40, 140, 40, 255};
+    sdl3d_color gray = {100, 100, 105, 255};
+    sdl3d_color flame = {255, 180, 50, 255};
+    sdl3d_vec2 plane_size = {20.0f, 20.0f};
+    int i;
+
+    camera.position = sdl3d_vec3_make(cosf(angle) * 10.0f, 5.0f, sinf(angle) * 10.0f);
+    camera.target = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.fovy = 55.0f;
+    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_clear_render_context(ctx, sky);
+    sdl3d_set_backface_culling_enabled(ctx, true);
+    sdl3d_begin_mode_3d(ctx, camera);
+
+    /* Ground. */
+    sdl3d_draw_plane(ctx, sdl3d_vec3_make(0, 0, 0), plane_size, ground);
+
+    /* Trees: trunk + canopy. */
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(-3, 1.0f, -4), 0.2f, 0.2f, 2.0f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-3, 2.5f, -4), 1.2f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(4, 1.2f, -2), 0.25f, 0.25f, 2.4f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(4, 3.0f, -2), 1.5f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(-5, 0.8f, 3), 0.15f, 0.15f, 1.6f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-5, 2.0f, 3), 1.0f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(2, 1.0f, 5), 0.2f, 0.2f, 2.0f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(2, 2.5f, 5), 1.3f, 8, 8, green);
+
+    /* Rocks. */
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(1.5f, 0.2f, -1), 0.4f, 6, 6, gray);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-2, 0.15f, 1.5f), 0.3f, 6, 6, gray);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0.5f, 0.25f, 2.5f), 0.5f, 6, 6, gray);
+
+    /* Campfire ring. */
+    for (i = 0; i < 8; ++i)
+    {
+        float a = (float)i * 3.14159f * 2.0f / 8.0f;
+        sdl3d_color stone = {80, 75, 70, 255};
+        sdl3d_draw_cube(ctx, sdl3d_vec3_make(cosf(a) * 0.6f, 0.1f, sinf(a) * 0.6f),
+                        sdl3d_vec3_make(0.15f, 0.15f, 0.15f), stone);
+    }
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0, 0.3f, 0), 0.15f, 6, 6, flame);
+
+    /* Distant mountain. */
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0, -3, -15), 8.0f, 12, 12, gray);
+
+    sdl3d_end_mode_3d(ctx);
+}
+
+int main(int argc, char *argv[])
+{
+    SDL_Window *window = NULL;
+    SDL_Renderer *renderer = NULL;
+    sdl3d_render_context *ctx = NULL;
+    sdl3d_render_context_config config;
+    sdl3d_light sun, campfire;
+#if BENCH_HAS_FOG
+    sdl3d_fog fog;
+#else
+    int fog;
+#endif
+    int frame_count = 60;
+    int frame;
+    Uint64 start_ticks, end_ticks;
+    float elapsed_ms;
+
+    if (argc > 1)
+    {
+        frame_count = atoi(argv[1]);
+        if (frame_count <= 0)
+        {
+            frame_count = 60;
+        }
+    }
+
+    SDL_SetMainReady();
+    if (!SDL_Init(SDL_INIT_VIDEO))
+    {
+        fprintf(stderr, "SDL_Init: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    window = SDL_CreateWindow("bench", BENCH_WIDTH, BENCH_HEIGHT, SDL_WINDOW_HIDDEN);
+    if (!window)
+    {
+        fprintf(stderr, "Window: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    renderer = SDL_CreateRenderer(window, NULL);
+    if (!renderer)
+    {
+        fprintf(stderr, "Renderer: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    sdl3d_init_render_context_config(&config);
+    if (!sdl3d_create_render_context(window, renderer, &config, &ctx))
+    {
+        fprintf(stderr, "Context: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    /* Lighting. */
+    sdl3d_set_lighting_enabled(ctx, true);
+    sdl3d_set_ambient_light(ctx, 0.15f, 0.18f, 0.25f);
+
+    SDL_zerop(&sun);
+    sun.type = SDL3D_LIGHT_DIRECTIONAL;
+    sun.direction = sdl3d_vec3_make(0.4f, -0.8f, -0.3f);
+    sun.color[0] = 1.0f;
+    sun.color[1] = 0.95f;
+    sun.color[2] = 0.8f;
+    sun.intensity = 2.5f;
+    sdl3d_add_light(ctx, &sun);
+
+    SDL_zerop(&campfire);
+    campfire.type = SDL3D_LIGHT_POINT;
+    campfire.position = sdl3d_vec3_make(0, 0.5f, 0);
+    campfire.color[0] = 1.0f;
+    campfire.color[1] = 0.6f;
+    campfire.color[2] = 0.2f;
+    campfire.intensity = 3.0f;
+    campfire.range = 8.0f;
+    sdl3d_add_light(ctx, &campfire);
+
+    /* Fog + tonemap. */
+#if BENCH_HAS_FOG
+    SDL_zerop(&fog);
+    fog.mode = SDL3D_FOG_EXP2;
+    fog.color[0] = 0.6f;
+    fog.color[1] = 0.7f;
+    fog.color[2] = 0.8f;
+    fog.density = 0.04f;
+    sdl3d_set_fog(ctx, &fog);
+#else
+    (void)fog;
+#endif
+#if BENCH_HAS_TONEMAP
+    sdl3d_set_tonemap_mode(ctx, SDL3D_TONEMAP_ACES);
+#endif
+
+    /* Benchmark loop. */
+    fprintf(stderr, "Rendering %d frames at %dx%d...\n", frame_count, BENCH_WIDTH, BENCH_HEIGHT);
+    start_ticks = SDL_GetPerformanceCounter();
+
+    for (frame = 0; frame < frame_count; ++frame)
+    {
+        draw_scene(ctx, (float)frame * 0.05f);
+        /* No present — headless. */
+    }
+
+    end_ticks = SDL_GetPerformanceCounter();
+    elapsed_ms = (float)(end_ticks - start_ticks) / (float)SDL_GetPerformanceFrequency() * 1000.0f;
+
+    fprintf(stderr, "Done: %.1f ms total, %.2f ms/frame, %.1f FPS\n", elapsed_ms, elapsed_ms / (float)frame_count,
+            (float)frame_count / (elapsed_ms / 1000.0f));
+
+    sdl3d_destroy_render_context(ctx);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds a data-driven profiling pipeline to identify optimization targets in the software 3D renderer.

### What's included

**Headless benchmark** (`benchmarks/bench_render.c`)
- Renders a fixed outdoor scene (ground, trees, rocks, campfire, mountain) with PBR lighting for N frames
- No window presentation — runs headless with `SDL_VIDEODRIVER=dummy`
- Reports total time, ms/frame, and FPS to stderr
- Compile-time guards for fog/tonemap APIs (graceful degradation on current main)
- Gated by `SDL3D_BUILD_BENCHMARKS=ON` CMake option

**Profiling CI job** (`.github/workflows/profile.yml`)
- Triggers on `pull_request` (same as existing CI jobs)
- Builds with `RelWithDebInfo` for optimized code with debug symbols
- Runs `perf stat -d` for high-level metrics (cycles, IPC, cache misses)
- Runs `perf record -g` + `perf report --stdio` for per-function hotspot analysis
- Uploads `perf_stat.txt` and `perf_report.txt` as downloadable artifacts (30-day retention)

### Usage

After CI runs, download the `profile-report` artifact from the Actions tab. The `perf_report.txt` shows the hottest functions with call-graph percentages — this tells us exactly where to optimize.

Local usage:
```sh
cmake -B build/bench -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSDL3D_BUILD_BENCHMARKS=ON
cmake --build build/bench
perf record -g ./build/bench/benchmarks/sdl3d_bench 120
perf report
```