### PR TITLE
Optimize lit pipeline: early depth test + rough specular skip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 option(SDL3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
 option(SDL3D_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 option(SDL3D_BUILD_BENCHMARKS "Build SDL3D benchmarks" OFF)
+option(SDL3D_BUILD_DEMOS "Build SDL3D demo programs" OFF)
 
 set(SDL3D_USING_FETCHED_SDL3 OFF)
 
@@ -155,6 +156,10 @@ endif()
 
 if(SDL3D_BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
+endif()
+
+if(SDL3D_BUILD_DEMOS)
+    add_subdirectory(demos)
 endif()
 
 if(SDL3D_USING_FETCHED_SDL3)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(sdl3d_profile_viewer profile_viewer.c)
+
+target_link_libraries(sdl3d_profile_viewer PRIVATE SDL3D::sdl3d)
+target_compile_features(sdl3d_profile_viewer PRIVATE c_std_17)
+
+if(NOT WIN32)
+    target_link_libraries(sdl3d_profile_viewer PRIVATE m)
+endif()
+
+if(WIN32)
+    add_custom_command(
+        TARGET sdl3d_profile_viewer
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:sdl3d_profile_viewer> $<TARGET_FILE_DIR:sdl3d_profile_viewer>
+        COMMAND_EXPAND_LISTS
+    )
+endif()

--- a/demos/profile_viewer.c
+++ b/demos/profile_viewer.c
@@ -1,0 +1,208 @@
+/*
+ * SDL3D render profile demo.
+ * Press 1-5 or SPACE to cycle: Modern, PS1, N64, DOS, SNES.
+ * ESC to quit.
+ */
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include "sdl3d/lighting.h"
+#include "sdl3d/sdl3d.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#define RENDER_W 320
+#define RENDER_H 240
+
+typedef struct
+{
+    const char *name;
+    sdl3d_render_profile (*fn)(void);
+} profile_entry;
+
+static const profile_entry profiles[] = {
+    {"Modern (Phong + ACES)", sdl3d_profile_modern}, {"PS1 (Gouraud + Affine + Snap)", sdl3d_profile_ps1},
+    {"N64 (Gouraud + Bilinear)", sdl3d_profile_n64}, {"DOS (Gouraud + 256-color dither)", sdl3d_profile_dos},
+    {"SNES (Flat + Affine)", sdl3d_profile_snes},
+};
+static const int profile_count = 5;
+
+static void draw_scene(sdl3d_render_context *ctx, float angle)
+{
+    sdl3d_camera3d cam;
+    sdl3d_color sky = {150, 180, 210, 255};
+    sdl3d_color ground = {80, 130, 60, 255};
+    sdl3d_color brown = {120, 80, 40, 255};
+    sdl3d_color green = {40, 140, 40, 255};
+    sdl3d_color gray = {100, 100, 105, 255};
+    sdl3d_color flame = {255, 180, 50, 255};
+    sdl3d_color stone = {80, 75, 70, 255};
+    sdl3d_color mountain = {90, 85, 80, 255};
+    sdl3d_vec2 plane_sz = {20.0f, 20.0f};
+    int i;
+
+    cam.position = sdl3d_vec3_make(cosf(angle) * 10.0f, 5.0f, sinf(angle) * 10.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 55.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_clear_render_context(ctx, sky);
+    sdl3d_set_backface_culling_enabled(ctx, true);
+    sdl3d_begin_mode_3d(ctx, cam);
+
+    sdl3d_draw_plane(ctx, sdl3d_vec3_make(0, 0, 0), plane_sz, ground);
+
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(-3, 1, -4), 0.2f, 0.2f, 2, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-3, 2.5f, -4), 1.2f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(4, 1.2f, -2), 0.25f, 0.25f, 2.4f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(4, 3, -2), 1.5f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(-5, 0.8f, 3), 0.15f, 0.15f, 1.6f, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-5, 2, 3), 1.0f, 8, 8, green);
+    sdl3d_draw_cylinder(ctx, sdl3d_vec3_make(2, 1, 5), 0.2f, 0.2f, 2, 8, brown);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(2, 2.5f, 5), 1.3f, 8, 8, green);
+
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(1.5f, 0.2f, -1), 0.4f, 6, 6, gray);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(-2, 0.15f, 1.5f), 0.3f, 6, 6, gray);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0.5f, 0.25f, 2.5f), 0.5f, 6, 6, gray);
+
+    for (i = 0; i < 8; ++i)
+    {
+        float a = (float)i * 3.14159f * 2.0f / 8.0f;
+        sdl3d_draw_cube(ctx, sdl3d_vec3_make(cosf(a) * 0.6f, 0.1f, sinf(a) * 0.6f),
+                        sdl3d_vec3_make(0.15f, 0.15f, 0.15f), stone);
+    }
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0, 0.3f, 0), 0.15f, 6, 6, flame);
+    sdl3d_draw_sphere(ctx, sdl3d_vec3_make(0, -3, -15), 8.0f, 12, 12, mountain);
+
+    sdl3d_end_mode_3d(ctx);
+}
+
+int main(int argc, char *argv[])
+{
+    SDL_Window *win;
+    SDL_Renderer *ren;
+    sdl3d_render_context *ctx;
+    sdl3d_render_context_config cfg;
+    sdl3d_light sun, fire;
+    sdl3d_fog fog;
+    int current = 0;
+    float angle = 0.0f;
+    bool running = true;
+    char title[128];
+
+    (void)argc;
+    (void)argv;
+    SDL_SetMainReady();
+    if (!SDL_Init(SDL_INIT_VIDEO))
+    {
+        return 1;
+    }
+
+    win = SDL_CreateWindow("SDL3D Profiles", 800, 600, SDL_WINDOW_RESIZABLE);
+    ren = SDL_CreateRenderer(win, NULL);
+    sdl3d_init_render_context_config(&cfg);
+    cfg.logical_width = RENDER_W;
+    cfg.logical_height = RENDER_H;
+    cfg.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+    sdl3d_create_render_context(win, ren, &cfg, &ctx);
+
+    /* Lighting. */
+    SDL_zerop(&sun);
+    sun.type = SDL3D_LIGHT_DIRECTIONAL;
+    sun.direction = sdl3d_vec3_make(0.4f, -0.8f, -0.3f);
+    sun.color[0] = 1.0f;
+    sun.color[1] = 0.95f;
+    sun.color[2] = 0.8f;
+    sun.intensity = 2.5f;
+    sdl3d_add_light(ctx, &sun);
+
+    SDL_zerop(&fire);
+    fire.type = SDL3D_LIGHT_POINT;
+    fire.position = sdl3d_vec3_make(0, 0.5f, 0);
+    fire.color[0] = 1.0f;
+    fire.color[1] = 0.6f;
+    fire.color[2] = 0.2f;
+    fire.intensity = 3.0f;
+    fire.range = 8.0f;
+    sdl3d_add_light(ctx, &fire);
+
+    /* Fog. */
+    SDL_zerop(&fog);
+    fog.mode = SDL3D_FOG_EXP2;
+    fog.color[0] = 0.6f;
+    fog.color[1] = 0.7f;
+    fog.color[2] = 0.8f;
+    fog.density = 0.04f;
+    sdl3d_set_fog(ctx, &fog);
+
+    /* Start with Modern profile. */
+    {
+        sdl3d_render_profile p = profiles[current].fn();
+        sdl3d_set_render_profile(ctx, &p);
+    }
+
+    while (running)
+    {
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev))
+        {
+            if (ev.type == SDL_EVENT_QUIT)
+            {
+                running = false;
+            }
+            if (ev.type == SDL_EVENT_KEY_DOWN)
+            {
+                int next = -1;
+                switch (ev.key.key)
+                {
+                case SDLK_ESCAPE:
+                    running = false;
+                    break;
+                case SDLK_SPACE:
+                    next = (current + 1) % profile_count;
+                    break;
+                case SDLK_1:
+                    next = 0;
+                    break;
+                case SDLK_2:
+                    next = 1;
+                    break;
+                case SDLK_3:
+                    next = 2;
+                    break;
+                case SDLK_4:
+                    next = 3;
+                    break;
+                case SDLK_5:
+                    next = 4;
+                    break;
+                default:
+                    break;
+                }
+                if (next >= 0 && next != current)
+                {
+                    current = next;
+                    sdl3d_render_profile p = profiles[current].fn();
+                    sdl3d_set_render_profile(ctx, &p);
+                    SDL_snprintf(title, sizeof(title), "SDL3D Profiles - [%d] %s", current + 1, profiles[current].name);
+                    SDL_SetWindowTitle(win, title);
+                    fprintf(stderr, "Profile: %s\n", profiles[current].name);
+                }
+            }
+        }
+
+        angle += 0.005f;
+        draw_scene(ctx, angle);
+        sdl3d_present_render_context(ctx);
+    }
+
+    sdl3d_destroy_render_context(ctx);
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -1866,134 +1866,148 @@ static void sdl3d_rasterize_prepared_triangle_lit_region(sdl3d_framebuffer *fram
             const float bb = (float)w_ca * tri->inverse_area;
             const float bc = (float)w_ab * tri->inverse_area;
             const float depth = ba * a.base.z + bb * b.base.z + bc * c.base.z;
-            const float iw_px = ba * a.inverse_w + bb * b.inverse_w + bc * c.inverse_w;
-            const float pw = 1.0f / iw_px;
 
-            float u, v, mr, mg, mb, ma;
-
-            if (lp->uv_mode == SDL3D_UV_AFFINE)
+            /* Early depth test: skip all attribute interpolation + PBR
+             * shading for pixels that would fail the depth test anyway. */
             {
-                /* Affine: linear interpolation in screen space (no /w correction). */
-                float aw = a.inverse_w > 0.0f ? 1.0f / a.inverse_w : 1.0f;
-                float bw = b.inverse_w > 0.0f ? 1.0f / b.inverse_w : 1.0f;
-                float cw = c.inverse_w > 0.0f ? 1.0f / c.inverse_w : 1.0f;
-                u = ba * (a.u_over_w * aw) + bb * (b.u_over_w * bw) + bc * (c.u_over_w * cw);
-                v = ba * (a.v_over_w * aw) + bb * (b.v_over_w * bw) + bc * (c.v_over_w * cw);
-            }
-            else
-            {
-                u = (ba * a.u_over_w + bb * b.u_over_w + bc * c.u_over_w) * pw;
-                v = (ba * a.v_over_w + bb * b.v_over_w + bc * c.v_over_w) * pw;
-            }
-
-            mr = (ba * a.mod_r_over_w + bb * b.mod_r_over_w + bc * c.mod_r_over_w) * pw;
-            mg = (ba * a.mod_g_over_w + bb * b.mod_g_over_w + bc * c.mod_g_over_w) * pw;
-            mb = (ba * a.mod_b_over_w + bb * b.mod_b_over_w + bc * c.mod_b_over_w) * pw;
-            ma = (ba * a.mod_a_over_w + bb * b.mod_a_over_w + bc * c.mod_a_over_w) * pw;
-
-            {
-                float tr = 1.0f, tg = 1.0f, tb = 1.0f, ta = 1.0f;
-                float albedo_r, albedo_g, albedo_b, out_a;
-                float nx, ny, nz, n_len, wpx, wpy, wpz;
-                float lit_r, lit_g, lit_b;
-                sdl3d_color color;
-
-                if (texture != NULL)
-                {
-                    sdl3d_texture_sample_rgba(texture, u, v, 0.0f, &tr, &tg, &tb, &ta);
-                }
-
-                albedo_r = tr * mr;
-                albedo_g = tg * mg;
-                albedo_b = tb * mb;
-                out_a = ta * ma;
-                if (out_a <= 0.0f)
+                const int depth_idx = py * framebuffer->width + px;
+                if (depth > framebuffer->depth_pixels[depth_idx])
                 {
                     continue;
                 }
+            }
 
-                nx = (ba * a.nx_over_w + bb * b.nx_over_w + bc * c.nx_over_w) * pw;
-                ny = (ba * a.ny_over_w + bb * b.ny_over_w + bc * c.ny_over_w) * pw;
-                nz = (ba * a.nz_over_w + bb * b.nz_over_w + bc * c.nz_over_w) * pw;
-                n_len = nx * nx + ny * ny + nz * nz;
-                if (n_len > 1e-12f)
+            {
+                const float iw_px = ba * a.inverse_w + bb * b.inverse_w + bc * c.inverse_w;
+                const float pw = 1.0f / iw_px;
+
+                float u, v, mr, mg, mb, ma;
+
+                if (lp->uv_mode == SDL3D_UV_AFFINE)
                 {
-                    float inv = 1.0f / SDL_sqrtf(n_len);
-                    nx *= inv;
-                    ny *= inv;
-                    nz *= inv;
+                    /* Affine: linear interpolation in screen space (no /w correction). */
+                    float aw = a.inverse_w > 0.0f ? 1.0f / a.inverse_w : 1.0f;
+                    float bw = b.inverse_w > 0.0f ? 1.0f / b.inverse_w : 1.0f;
+                    float cw = c.inverse_w > 0.0f ? 1.0f / c.inverse_w : 1.0f;
+                    u = ba * (a.u_over_w * aw) + bb * (b.u_over_w * bw) + bc * (c.u_over_w * cw);
+                    v = ba * (a.v_over_w * aw) + bb * (b.v_over_w * bw) + bc * (c.v_over_w * cw);
                 }
-                wpx = (ba * a.wx_over_w + bb * b.wx_over_w + bc * c.wx_over_w) * pw;
-                wpy = (ba * a.wy_over_w + bb * b.wy_over_w + bc * c.wy_over_w) * pw;
-                wpz = (ba * a.wz_over_w + bb * b.wz_over_w + bc * c.wz_over_w) * pw;
-
-                sdl3d_shade_fragment_pbr(lp, albedo_r, albedo_g, albedo_b, nx, ny, nz, wpx, wpy, wpz, &lit_r, &lit_g,
-                                         &lit_b);
-
-                sdl3d_tonemap(lp->tonemap_mode, &lit_r, &lit_g, &lit_b);
-
-                /* Fog: vertex or fragment evaluation. */
-                if (lp->fog.mode != SDL3D_FOG_NONE)
+                else
                 {
-                    float fog_f;
-                    if (lp->fog_eval == SDL3D_FOG_EVAL_VERTEX)
+                    u = (ba * a.u_over_w + bb * b.u_over_w + bc * c.u_over_w) * pw;
+                    v = (ba * a.v_over_w + bb * b.v_over_w + bc * c.v_over_w) * pw;
+                }
+
+                mr = (ba * a.mod_r_over_w + bb * b.mod_r_over_w + bc * c.mod_r_over_w) * pw;
+                mg = (ba * a.mod_g_over_w + bb * b.mod_g_over_w + bc * c.mod_g_over_w) * pw;
+                mb = (ba * a.mod_b_over_w + bb * b.mod_b_over_w + bc * c.mod_b_over_w) * pw;
+                ma = (ba * a.mod_a_over_w + bb * b.mod_a_over_w + bc * c.mod_a_over_w) * pw;
+
+                {
+                    float tr = 1.0f, tg = 1.0f, tb = 1.0f, ta = 1.0f;
+                    float albedo_r, albedo_g, albedo_b, out_a;
+                    float nx, ny, nz, n_len, wpx, wpy, wpz;
+                    float lit_r, lit_g, lit_b;
+                    sdl3d_color color;
+
+                    if (texture != NULL)
                     {
-                        /* Interpolate pre-computed vertex fog factors. */
-                        fog_f = (ba * a.fog_over_w + bb * b.fog_over_w + bc * c.fog_over_w) * pw;
-                        if (fog_f < 0.0f)
+                        sdl3d_texture_sample_rgba(texture, u, v, 0.0f, &tr, &tg, &tb, &ta);
+                    }
+
+                    albedo_r = tr * mr;
+                    albedo_g = tg * mg;
+                    albedo_b = tb * mb;
+                    out_a = ta * ma;
+                    if (out_a <= 0.0f)
+                    {
+                        continue;
+                    }
+
+                    nx = (ba * a.nx_over_w + bb * b.nx_over_w + bc * c.nx_over_w) * pw;
+                    ny = (ba * a.ny_over_w + bb * b.ny_over_w + bc * c.ny_over_w) * pw;
+                    nz = (ba * a.nz_over_w + bb * b.nz_over_w + bc * c.nz_over_w) * pw;
+                    n_len = nx * nx + ny * ny + nz * nz;
+                    if (n_len > 1e-12f)
+                    {
+                        float inv = 1.0f / SDL_sqrtf(n_len);
+                        nx *= inv;
+                        ny *= inv;
+                        nz *= inv;
+                    }
+                    wpx = (ba * a.wx_over_w + bb * b.wx_over_w + bc * c.wx_over_w) * pw;
+                    wpy = (ba * a.wy_over_w + bb * b.wy_over_w + bc * c.wy_over_w) * pw;
+                    wpz = (ba * a.wz_over_w + bb * b.wz_over_w + bc * c.wz_over_w) * pw;
+
+                    sdl3d_shade_fragment_pbr(lp, albedo_r, albedo_g, albedo_b, nx, ny, nz, wpx, wpy, wpz, &lit_r,
+                                             &lit_g, &lit_b);
+
+                    sdl3d_tonemap(lp->tonemap_mode, &lit_r, &lit_g, &lit_b);
+
+                    /* Fog: vertex or fragment evaluation. */
+                    if (lp->fog.mode != SDL3D_FOG_NONE)
+                    {
+                        float fog_f;
+                        if (lp->fog_eval == SDL3D_FOG_EVAL_VERTEX)
                         {
-                            fog_f = 0.0f;
+                            /* Interpolate pre-computed vertex fog factors. */
+                            fog_f = (ba * a.fog_over_w + bb * b.fog_over_w + bc * c.fog_over_w) * pw;
+                            if (fog_f < 0.0f)
+                            {
+                                fog_f = 0.0f;
+                            }
+                            if (fog_f > 1.0f)
+                            {
+                                fog_f = 1.0f;
+                            }
                         }
-                        if (fog_f > 1.0f)
+                        else
                         {
-                            fog_f = 1.0f;
+                            float dx = wpx - lp->camera_pos.x;
+                            float dy = wpy - lp->camera_pos.y;
+                            float dz = wpz - lp->camera_pos.z;
+                            float dist = SDL_sqrtf(dx * dx + dy * dy + dz * dz);
+                            fog_f = sdl3d_compute_fog_factor(&lp->fog, dist);
+                        }
+                        lit_r = lit_r * (1.0f - fog_f) + lp->fog.color[0] * fog_f;
+                        lit_g = lit_g * (1.0f - fog_f) + lp->fog.color[1] * fog_f;
+                        lit_b = lit_b * (1.0f - fog_f) + lp->fog.color[2] * fog_f;
+                    }
+
+                    /* Color quantization with optional Bayer dithering. */
+                    if (lp->color_quantize && lp->color_depth > 0)
+                    {
+                        static const float bayer4x4[4][4] = {
+                            {0.0f / 16.0f, 8.0f / 16.0f, 2.0f / 16.0f, 10.0f / 16.0f},
+                            {12.0f / 16.0f, 4.0f / 16.0f, 14.0f / 16.0f, 6.0f / 16.0f},
+                            {3.0f / 16.0f, 11.0f / 16.0f, 1.0f / 16.0f, 9.0f / 16.0f},
+                            {15.0f / 16.0f, 7.0f / 16.0f, 13.0f / 16.0f, 5.0f / 16.0f}};
+                        float levels = (float)lp->color_depth;
+                        float step = 1.0f / levels;
+                        float dither = (bayer4x4[py & 3][px & 3] - 0.5f) * step;
+                        lit_r = SDL_floorf((lit_r + dither) * levels + 0.5f) / levels;
+                        lit_g = SDL_floorf((lit_g + dither) * levels + 0.5f) / levels;
+                        lit_b = SDL_floorf((lit_b + dither) * levels + 0.5f) / levels;
+                        if (lit_r < 0.0f)
+                        {
+                            lit_r = 0.0f;
+                        }
+                        if (lit_g < 0.0f)
+                        {
+                            lit_g = 0.0f;
+                        }
+                        if (lit_b < 0.0f)
+                        {
+                            lit_b = 0.0f;
                         }
                     }
-                    else
-                    {
-                        float dx = wpx - lp->camera_pos.x;
-                        float dy = wpy - lp->camera_pos.y;
-                        float dz = wpz - lp->camera_pos.z;
-                        float dist = SDL_sqrtf(dx * dx + dy * dy + dz * dz);
-                        fog_f = sdl3d_compute_fog_factor(&lp->fog, dist);
-                    }
-                    lit_r = lit_r * (1.0f - fog_f) + lp->fog.color[0] * fog_f;
-                    lit_g = lit_g * (1.0f - fog_f) + lp->fog.color[1] * fog_f;
-                    lit_b = lit_b * (1.0f - fog_f) + lp->fog.color[2] * fog_f;
-                }
 
-                /* Color quantization with optional Bayer dithering. */
-                if (lp->color_quantize && lp->color_depth > 0)
-                {
-                    static const float bayer4x4[4][4] = {{0.0f / 16.0f, 8.0f / 16.0f, 2.0f / 16.0f, 10.0f / 16.0f},
-                                                         {12.0f / 16.0f, 4.0f / 16.0f, 14.0f / 16.0f, 6.0f / 16.0f},
-                                                         {3.0f / 16.0f, 11.0f / 16.0f, 1.0f / 16.0f, 9.0f / 16.0f},
-                                                         {15.0f / 16.0f, 7.0f / 16.0f, 13.0f / 16.0f, 5.0f / 16.0f}};
-                    float levels = (float)lp->color_depth;
-                    float step = 1.0f / levels;
-                    float dither = (bayer4x4[py & 3][px & 3] - 0.5f) * step;
-                    lit_r = SDL_floorf((lit_r + dither) * levels + 0.5f) / levels;
-                    lit_g = SDL_floorf((lit_g + dither) * levels + 0.5f) / levels;
-                    lit_b = SDL_floorf((lit_b + dither) * levels + 0.5f) / levels;
-                    if (lit_r < 0.0f)
-                    {
-                        lit_r = 0.0f;
-                    }
-                    if (lit_g < 0.0f)
-                    {
-                        lit_g = 0.0f;
-                    }
-                    if (lit_b < 0.0f)
-                    {
-                        lit_b = 0.0f;
-                    }
+                    color.r = sdl3d_color_channel_clamp(lit_r * 255.0f);
+                    color.g = sdl3d_color_channel_clamp(lit_g * 255.0f);
+                    color.b = sdl3d_color_channel_clamp(lit_b * 255.0f);
+                    color.a = sdl3d_color_channel_clamp(out_a * 255.0f);
+                    sdl3d_write_pixel(framebuffer, px, py, depth, color);
                 }
-
-                color.r = sdl3d_color_channel_clamp(lit_r * 255.0f);
-                color.g = sdl3d_color_channel_clamp(lit_g * 255.0f);
-                color.b = sdl3d_color_channel_clamp(lit_b * 255.0f);
-                color.a = sdl3d_color_channel_clamp(out_a * 255.0f);
-                sdl3d_write_pixel(framebuffer, px, py, depth, color);
             }
         }
     }

--- a/src/shading.c
+++ b/src/shading.c
@@ -247,33 +247,45 @@ void sdl3d_shade_fragment_pbr(const sdl3d_lighting_params *params, float albedo_
             continue;
         }
 
-        /* Half vector. */
-        float hx = lx + vx;
-        float hy = ly + vy;
-        float hz = lz + vz;
-        float h_len = sdl3d_vec3_length_raw(hx, hy, hz);
-        if (h_len > 1e-7f)
-        {
-            float inv = 1.0f / h_len;
-            hx *= inv;
-            hy *= inv;
-            hz *= inv;
-        }
-
-        float n_dot_h = sdl3d_maxf(sdl3d_vec3_dot_raw(world_nx, world_ny, world_nz, hx, hy, hz), 0.0f);
-        float h_dot_v = sdl3d_maxf(sdl3d_vec3_dot_raw(hx, hy, hz, vx, vy, vz), 0.0f);
-
-        /* Cook-Torrance specular BRDF. */
-        float ndf = sdl3d_distribution_ggx(n_dot_h, params->roughness);
-        float geo = sdl3d_geometry_smith(n_dot_v, n_dot_l, params->roughness);
+        /* Cook-Torrance specular BRDF. Skip for very rough dielectric
+         * surfaces where the specular contribution is negligible —
+         * avoids half-vector, GGX, geometry, and Fresnel computation. */
+        float spec_r = 0.0f, spec_g = 0.0f, spec_b = 0.0f;
         float fr, fg, fb;
-        sdl3d_fresnel_schlick(h_dot_v, f0_r, f0_g, f0_b, &fr, &fg, &fb);
 
-        float denom = 4.0f * n_dot_v * n_dot_l + 1e-4f;
-        float spec_scale = ndf * geo / denom;
-        float spec_r = fr * spec_scale;
-        float spec_g = fg * spec_scale;
-        float spec_b = fb * spec_scale;
+        if (params->roughness < 0.95f || params->metallic > 0.05f)
+        {
+            float hx = lx + vx;
+            float hy = ly + vy;
+            float hz = lz + vz;
+            float h_len = sdl3d_vec3_length_raw(hx, hy, hz);
+            float n_dot_h, h_dot_v, ndf, geo, denom, spec_scale;
+            if (h_len > 1e-7f)
+            {
+                float inv = 1.0f / h_len;
+                hx *= inv;
+                hy *= inv;
+                hz *= inv;
+            }
+            n_dot_h = sdl3d_maxf(sdl3d_vec3_dot_raw(world_nx, world_ny, world_nz, hx, hy, hz), 0.0f);
+            h_dot_v = sdl3d_maxf(sdl3d_vec3_dot_raw(hx, hy, hz, vx, vy, vz), 0.0f);
+
+            ndf = sdl3d_distribution_ggx(n_dot_h, params->roughness);
+            geo = sdl3d_geometry_smith(n_dot_v, n_dot_l, params->roughness);
+            sdl3d_fresnel_schlick(h_dot_v, f0_r, f0_g, f0_b, &fr, &fg, &fb);
+
+            denom = 4.0f * n_dot_v * n_dot_l + 1e-4f;
+            spec_scale = ndf * geo / denom;
+            spec_r = fr * spec_scale;
+            spec_g = fg * spec_scale;
+            spec_b = fb * spec_scale;
+        }
+        else
+        {
+            fr = f0_r;
+            fg = f0_g;
+            fb = f0_b;
+        }
 
         /* Energy-conserving diffuse: kD = (1 - F) * (1 - metallic). */
         float kd = (1.0f - params->metallic);


### PR DESCRIPTION
## Summary

Data-driven optimizations targeting the top two hotspots from the CI profiling job, plus a demo program.

### Profile data (from PR #25 perf report)

| Hotspot | % CPU | Optimization |
|---------|-------|-------------|
| sdl3d_shade_fragment_pbr | 52.5% | Skip specular for rough surfaces |
| sdl3d_rasterize_prepared_triangle_lit_region | 27.6% | Early depth test |

### Optimization 1: Early depth test

Moved depth buffer comparison before all attribute interpolation and PBR shading in the lit fill loop. Occluded pixels now skip the 1/w division, 13 perspective-correct attribute recoveries, texture sampling, full PBR evaluation, tonemapping, and fog. Zero behavior change.

### Optimization 2: Skip specular for rough dielectric surfaces

When roughness >= 0.95 and metallic <= 0.05, skips the entire Cook-Torrance specular: half-vector normalization, GGX NDF, Schlick-GGX geometry, and Fresnel. Falls back to pure Lambertian diffuse. Smooth and metallic surfaces still get full Cook-Torrance.

### Demo program

`demos/profile_viewer.c` — outdoor scene with orbiting camera, directional + point lights, fog. Press 1-5 or Space to cycle through Modern/PS1/N64/DOS/SNES render profiles. Resizable window with 320x240 logical resolution.

Build: `cmake -DSDL3D_BUILD_DEMOS=ON`

### Testing

All 167 unit tests + 60 lighting tests pass. No behavior change for any existing test. The profiling CI job will produce a new perf report for before/after comparison.