### PR TITLE
M8: Scene graph and actor system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(
         src/obj_loader.c
         src/rasterizer.c
         src/render_context.c
+        src/scene.c
         src/sdl3d.c
         src/shading.c
         src/shapes.c

--- a/include/sdl3d/scene.h
+++ b/include/sdl3d/scene.h
@@ -1,0 +1,77 @@
+#ifndef SDL3D_SCENE_H
+#define SDL3D_SCENE_H
+
+#include <stdbool.h>
+
+#include "sdl3d/model.h"
+#include "sdl3d/render_context.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct sdl3d_actor sdl3d_actor;
+    typedef struct sdl3d_scene sdl3d_scene;
+
+    /* ============================================================== */
+    /* Scene lifecycle                                                 */
+    /* ============================================================== */
+
+    sdl3d_scene *sdl3d_create_scene(void);
+    void sdl3d_destroy_scene(sdl3d_scene *scene);
+
+    /* ============================================================== */
+    /* Actor management                                               */
+    /* ============================================================== */
+
+    /*
+     * Add an actor to the scene referencing the given model. The model
+     * must outlive the actor. Returns NULL on failure.
+     */
+    sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model);
+
+    /*
+     * Remove and free an actor from the scene. Safe with NULL.
+     */
+    void sdl3d_scene_remove_actor(sdl3d_scene *scene, sdl3d_actor *actor);
+
+    int sdl3d_scene_get_actor_count(const sdl3d_scene *scene);
+
+    /* ============================================================== */
+    /* Actor properties                                               */
+    /* ============================================================== */
+
+    void sdl3d_actor_set_position(sdl3d_actor *actor, sdl3d_vec3 position);
+    sdl3d_vec3 sdl3d_actor_get_position(const sdl3d_actor *actor);
+
+    void sdl3d_actor_set_rotation(sdl3d_actor *actor, sdl3d_vec3 axis, float angle_radians);
+
+    void sdl3d_actor_set_scale(sdl3d_actor *actor, sdl3d_vec3 scale);
+    sdl3d_vec3 sdl3d_actor_get_scale(const sdl3d_actor *actor);
+
+    void sdl3d_actor_set_visible(sdl3d_actor *actor, bool visible);
+    bool sdl3d_actor_is_visible(const sdl3d_actor *actor);
+
+    void sdl3d_actor_set_tint(sdl3d_actor *actor, sdl3d_color tint);
+
+    const sdl3d_model *sdl3d_actor_get_model(const sdl3d_actor *actor);
+
+    /* ============================================================== */
+    /* Drawing                                                        */
+    /* ============================================================== */
+
+    /*
+     * Draw all visible actors in the scene. Must be called between
+     * sdl3d_begin_mode_3d and sdl3d_end_mode_3d. The caller owns the
+     * camera, lighting, and render profile — this function simply
+     * iterates actors and calls sdl3d_draw_model_ex for each.
+     */
+    bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -13,6 +13,7 @@
 #include "sdl3d/math.h"
 #include "sdl3d/model.h"
 #include "sdl3d/render_context.h"
+#include "sdl3d/scene.h"
 #include "sdl3d/shapes.h"
 #include "sdl3d/texture.h"
 #include "sdl3d/types.h"

--- a/src/scene.c
+++ b/src/scene.c
@@ -1,0 +1,238 @@
+#include "sdl3d/scene.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/drawing3d.h"
+
+struct sdl3d_actor
+{
+    const sdl3d_model *model;
+    sdl3d_vec3 position;
+    sdl3d_vec3 rotation_axis;
+    float rotation_angle;
+    sdl3d_vec3 scale;
+    sdl3d_color tint;
+    bool visible;
+    sdl3d_actor *next;
+    sdl3d_actor *prev;
+};
+
+struct sdl3d_scene
+{
+    sdl3d_actor *first;
+    int actor_count;
+};
+
+sdl3d_scene *sdl3d_create_scene(void)
+{
+    sdl3d_scene *scene = (sdl3d_scene *)SDL_calloc(1, sizeof(sdl3d_scene));
+    if (scene == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+    return scene;
+}
+
+void sdl3d_destroy_scene(sdl3d_scene *scene)
+{
+    sdl3d_actor *actor;
+    if (scene == NULL)
+    {
+        return;
+    }
+    actor = scene->first;
+    while (actor != NULL)
+    {
+        sdl3d_actor *next = actor->next;
+        SDL_free(actor);
+        actor = next;
+    }
+    SDL_free(scene);
+}
+
+sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model)
+{
+    sdl3d_actor *actor;
+    if (scene == NULL)
+    {
+        SDL_InvalidParamError("scene");
+        return NULL;
+    }
+    if (model == NULL)
+    {
+        SDL_InvalidParamError("model");
+        return NULL;
+    }
+
+    actor = (sdl3d_actor *)SDL_calloc(1, sizeof(sdl3d_actor));
+    if (actor == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    actor->model = model;
+    actor->position = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    actor->rotation_axis = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    actor->rotation_angle = 0.0f;
+    actor->scale = sdl3d_vec3_make(1.0f, 1.0f, 1.0f);
+    actor->tint.r = 255;
+    actor->tint.g = 255;
+    actor->tint.b = 255;
+    actor->tint.a = 255;
+    actor->visible = true;
+
+    /* Prepend to linked list. */
+    actor->next = scene->first;
+    actor->prev = NULL;
+    if (scene->first != NULL)
+    {
+        scene->first->prev = actor;
+    }
+    scene->first = actor;
+    scene->actor_count += 1;
+
+    return actor;
+}
+
+void sdl3d_scene_remove_actor(sdl3d_scene *scene, sdl3d_actor *actor)
+{
+    if (scene == NULL || actor == NULL)
+    {
+        return;
+    }
+
+    if (actor->prev != NULL)
+    {
+        actor->prev->next = actor->next;
+    }
+    else
+    {
+        scene->first = actor->next;
+    }
+    if (actor->next != NULL)
+    {
+        actor->next->prev = actor->prev;
+    }
+
+    scene->actor_count -= 1;
+    SDL_free(actor);
+}
+
+int sdl3d_scene_get_actor_count(const sdl3d_scene *scene)
+{
+    if (scene == NULL)
+    {
+        return 0;
+    }
+    return scene->actor_count;
+}
+
+void sdl3d_actor_set_position(sdl3d_actor *actor, sdl3d_vec3 position)
+{
+    if (actor != NULL)
+    {
+        actor->position = position;
+    }
+}
+
+sdl3d_vec3 sdl3d_actor_get_position(const sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    }
+    return actor->position;
+}
+
+void sdl3d_actor_set_rotation(sdl3d_actor *actor, sdl3d_vec3 axis, float angle_radians)
+{
+    if (actor != NULL)
+    {
+        actor->rotation_axis = axis;
+        actor->rotation_angle = angle_radians;
+    }
+}
+
+void sdl3d_actor_set_scale(sdl3d_actor *actor, sdl3d_vec3 scale)
+{
+    if (actor != NULL)
+    {
+        actor->scale = scale;
+    }
+}
+
+sdl3d_vec3 sdl3d_actor_get_scale(const sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return sdl3d_vec3_make(1.0f, 1.0f, 1.0f);
+    }
+    return actor->scale;
+}
+
+void sdl3d_actor_set_visible(sdl3d_actor *actor, bool visible)
+{
+    if (actor != NULL)
+    {
+        actor->visible = visible;
+    }
+}
+
+bool sdl3d_actor_is_visible(const sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return false;
+    }
+    return actor->visible;
+}
+
+void sdl3d_actor_set_tint(sdl3d_actor *actor, sdl3d_color tint)
+{
+    if (actor != NULL)
+    {
+        actor->tint = tint;
+    }
+}
+
+const sdl3d_model *sdl3d_actor_get_model(const sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return NULL;
+    }
+    return actor->model;
+}
+
+bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
+{
+    const sdl3d_actor *actor;
+
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (scene == NULL)
+    {
+        return SDL_InvalidParamError("scene");
+    }
+
+    for (actor = scene->first; actor != NULL; actor = actor->next)
+    {
+        if (!actor->visible || actor->model == NULL)
+        {
+            continue;
+        }
+
+        if (!sdl3d_draw_model_ex(context, actor->model, actor->position, actor->rotation_axis, actor->rotation_angle,
+                                 actor->scale, actor->tint))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SDL3D_TEST_SOURCES
     test_texture.cpp
     test_textured_rendering.cpp
     test_lighting.cpp
+    test_scene.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -158,6 +159,7 @@ else()
     sdl3d_add_test(sdl3d_textured_rendering_test test_textured_rendering.cpp render)
     sdl3d_add_test(sdl3d_lighting_test test_lighting.cpp render)
     target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)

--- a/tests/test_scene.cpp
+++ b/tests/test_scene.cpp
@@ -1,0 +1,272 @@
+/*
+ * Tests for the scene graph and actor system.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+extern "C"
+{
+#include "sdl3d/math.h"
+#include "sdl3d/scene.h"
+}
+
+/* ================================================================== */
+/* Scene lifecycle                                                    */
+/* ================================================================== */
+
+TEST(SDL3DScene, CreateAndDestroy)
+{
+    sdl3d_scene *scene = sdl3d_create_scene();
+    ASSERT_NE(scene, nullptr);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 0);
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, DestroyNullIsSafe)
+{
+    sdl3d_destroy_scene(nullptr);
+}
+
+TEST(SDL3DScene, DestroyWithActors)
+{
+    sdl3d_model model{};
+    model.mesh_count = 0;
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_scene_add_actor(scene, &model);
+    sdl3d_scene_add_actor(scene, &model);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 2);
+    sdl3d_destroy_scene(scene); /* Must free all actors. */
+}
+
+/* ================================================================== */
+/* Actor management                                                   */
+/* ================================================================== */
+
+TEST(SDL3DScene, AddActorReturnsHandle)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+    ASSERT_NE(actor, nullptr);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 1);
+    EXPECT_EQ(sdl3d_actor_get_model(actor), &model);
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, AddMultipleActors)
+{
+    sdl3d_model m1{}, m2{}, m3{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *a1 = sdl3d_scene_add_actor(scene, &m1);
+    sdl3d_actor *a2 = sdl3d_scene_add_actor(scene, &m2);
+    sdl3d_actor *a3 = sdl3d_scene_add_actor(scene, &m3);
+    ASSERT_NE(a1, nullptr);
+    ASSERT_NE(a2, nullptr);
+    ASSERT_NE(a3, nullptr);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 3);
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, RemoveActor)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *a1 = sdl3d_scene_add_actor(scene, &model);
+    sdl3d_actor *a2 = sdl3d_scene_add_actor(scene, &model);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 2);
+
+    sdl3d_scene_remove_actor(scene, a1);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 1);
+
+    sdl3d_scene_remove_actor(scene, a2);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 0);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, RemoveMiddleActor)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_scene_add_actor(scene, &model);
+    sdl3d_actor *mid = sdl3d_scene_add_actor(scene, &model);
+    sdl3d_scene_add_actor(scene, &model);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 3);
+
+    sdl3d_scene_remove_actor(scene, mid);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 2);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, RemoveNullIsSafe)
+{
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_scene_remove_actor(scene, nullptr);
+    sdl3d_scene_remove_actor(nullptr, nullptr);
+    EXPECT_EQ(sdl3d_scene_get_actor_count(scene), 0);
+    sdl3d_destroy_scene(scene);
+}
+
+/* ================================================================== */
+/* Null rejection                                                     */
+/* ================================================================== */
+
+TEST(SDL3DScene, AddActorNullSceneReturnsNull)
+{
+    sdl3d_model model{};
+    EXPECT_EQ(sdl3d_scene_add_actor(nullptr, &model), nullptr);
+}
+
+TEST(SDL3DScene, AddActorNullModelReturnsNull)
+{
+    sdl3d_scene *scene = sdl3d_create_scene();
+    EXPECT_EQ(sdl3d_scene_add_actor(scene, nullptr), nullptr);
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, GetActorCountNullReturnsZero)
+{
+    EXPECT_EQ(sdl3d_scene_get_actor_count(nullptr), 0);
+}
+
+TEST(SDL3DScene, DrawSceneNullContextFails)
+{
+    sdl3d_scene *scene = sdl3d_create_scene();
+    EXPECT_FALSE(sdl3d_draw_scene(nullptr, scene));
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DScene, DrawSceneNullSceneFails)
+{
+    EXPECT_FALSE(sdl3d_draw_scene(nullptr, nullptr));
+}
+
+/* ================================================================== */
+/* Actor properties — defaults                                        */
+/* ================================================================== */
+
+TEST(SDL3DActor, DefaultProperties)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_vec3 pos = sdl3d_actor_get_position(actor);
+    EXPECT_FLOAT_EQ(pos.x, 0.0f);
+    EXPECT_FLOAT_EQ(pos.y, 0.0f);
+    EXPECT_FLOAT_EQ(pos.z, 0.0f);
+
+    sdl3d_vec3 scale = sdl3d_actor_get_scale(actor);
+    EXPECT_FLOAT_EQ(scale.x, 1.0f);
+    EXPECT_FLOAT_EQ(scale.y, 1.0f);
+    EXPECT_FLOAT_EQ(scale.z, 1.0f);
+
+    EXPECT_TRUE(sdl3d_actor_is_visible(actor));
+    EXPECT_EQ(sdl3d_actor_get_model(actor), &model);
+
+    sdl3d_destroy_scene(scene);
+}
+
+/* ================================================================== */
+/* Actor properties — set/get                                         */
+/* ================================================================== */
+
+struct PositionCase
+{
+    const char *label;
+    float x, y, z;
+};
+
+class SDL3DActorPosition : public ::testing::TestWithParam<PositionCase>
+{
+};
+
+TEST_P(SDL3DActorPosition, SetAndGet)
+{
+    const auto &c = GetParam();
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_actor_set_position(actor, sdl3d_vec3_make(c.x, c.y, c.z));
+    sdl3d_vec3 pos = sdl3d_actor_get_position(actor);
+    EXPECT_FLOAT_EQ(pos.x, c.x) << c.label;
+    EXPECT_FLOAT_EQ(pos.y, c.y) << c.label;
+    EXPECT_FLOAT_EQ(pos.z, c.z) << c.label;
+
+    sdl3d_destroy_scene(scene);
+}
+
+INSTANTIATE_TEST_SUITE_P(Actor, SDL3DActorPosition,
+                         ::testing::Values(PositionCase{"origin", 0, 0, 0}, PositionCase{"positive", 1, 2, 3},
+                                           PositionCase{"negative", -5, -10, -15},
+                                           PositionCase{"large", 1000, 2000, 3000},
+                                           PositionCase{"fractional", 0.5f, 0.25f, 0.125f}));
+
+TEST(SDL3DActor, SetScale)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_actor_set_scale(actor, sdl3d_vec3_make(2.0f, 3.0f, 4.0f));
+    sdl3d_vec3 s = sdl3d_actor_get_scale(actor);
+    EXPECT_FLOAT_EQ(s.x, 2.0f);
+    EXPECT_FLOAT_EQ(s.y, 3.0f);
+    EXPECT_FLOAT_EQ(s.z, 4.0f);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActor, SetVisibility)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    EXPECT_TRUE(sdl3d_actor_is_visible(actor));
+    sdl3d_actor_set_visible(actor, false);
+    EXPECT_FALSE(sdl3d_actor_is_visible(actor));
+    sdl3d_actor_set_visible(actor, true);
+    EXPECT_TRUE(sdl3d_actor_is_visible(actor));
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActor, SetTint)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_color red = {255, 0, 0, 255};
+    sdl3d_actor_set_tint(actor, red);
+    /* No getter for tint — just verify it doesn't crash. */
+
+    sdl3d_destroy_scene(scene);
+}
+
+/* ================================================================== */
+/* Null actor property access                                         */
+/* ================================================================== */
+
+TEST(SDL3DActor, NullActorPropertyAccessIsSafe)
+{
+    sdl3d_actor_set_position(nullptr, sdl3d_vec3_make(1, 2, 3));
+    sdl3d_actor_set_rotation(nullptr, sdl3d_vec3_make(0, 1, 0), 1.0f);
+    sdl3d_actor_set_scale(nullptr, sdl3d_vec3_make(1, 1, 1));
+    sdl3d_actor_set_visible(nullptr, true);
+    sdl3d_actor_set_tint(nullptr, (sdl3d_color){255, 255, 255, 255});
+
+    sdl3d_vec3 pos = sdl3d_actor_get_position(nullptr);
+    EXPECT_FLOAT_EQ(pos.x, 0.0f);
+
+    sdl3d_vec3 scale = sdl3d_actor_get_scale(nullptr);
+    EXPECT_FLOAT_EQ(scale.x, 1.0f);
+
+    EXPECT_FALSE(sdl3d_actor_is_visible(nullptr));
+    EXPECT_EQ(sdl3d_actor_get_model(nullptr), nullptr);
+}


### PR DESCRIPTION
## Summary

Implements M8 (Actor / Scene API) from the roadmap in #4.

### Design principles

- **Data container, not game loop owner** — the scene is a flat list of actors with transforms. The caller drives everything: event handling, frame timing, when to update actors, when to draw.
- **Purely opt-in** — callers who prefer manual `sdl3d_draw_model_ex` calls keep doing that. The scene API is layered on top.
- **No hidden updates** — no automatic animation, physics, or collision. When M5 (animation) lands, the caller will call `sdl3d_actor_advance_animation(actor, dt)` explicitly.

### API

```c
// Scene lifecycle
sdl3d_scene *sdl3d_create_scene(void);
void sdl3d_destroy_scene(sdl3d_scene *scene);

// Actor management
sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model);
void sdl3d_scene_remove_actor(sdl3d_scene *scene, sdl3d_actor *actor);

// Actor properties
void sdl3d_actor_set_position/rotation/scale/visible/tint(actor, ...);
sdl3d_vec3 sdl3d_actor_get_position/scale(actor);

// Draw all visible actors
bool sdl3d_draw_scene(sdl3d_render_context *ctx, const sdl3d_scene *scene);
```

### Implementation

- Actors stored as a doubly-linked list for O(1) add/remove
- `sdl3d_draw_scene` iterates visible actors and calls `sdl3d_draw_model_ex` — inherits all lighting, fog, tonemapping, and render profile settings from the context
- Destroy frees all actors automatically

### Testing

23 new unit tests: create/destroy, add/remove (single, multiple, middle, null), null rejection for all APIs, default properties, set/get position (5 table-driven cases), scale, visibility toggle, tint, null actor safety.

190 total unit tests, all passing. clang-format clean. No new dependencies.

Refs #4