### PR TITLE
M6: Collisions and spatial queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ target_sources(
     sdl3d
     PRIVATE
         src/camera.c
+        src/collision.c
         src/drawing3d.c
         src/fbx_loader.c
         src/gltf_loader.c

--- a/include/sdl3d/collision.h
+++ b/include/sdl3d/collision.h
@@ -1,0 +1,81 @@
+#ifndef SDL3D_COLLISION_H
+#define SDL3D_COLLISION_H
+
+#include <stdbool.h>
+
+#include "sdl3d/model.h"
+#include "sdl3d/scene.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct sdl3d_sphere
+    {
+        sdl3d_vec3 center;
+        float radius;
+    } sdl3d_sphere;
+
+    typedef struct sdl3d_ray_hit
+    {
+        bool hit;
+        float distance;
+        sdl3d_vec3 point;
+        sdl3d_vec3 normal;
+    } sdl3d_ray_hit;
+
+    typedef struct sdl3d_scene_hit
+    {
+        bool hit;
+        float distance;
+        sdl3d_vec3 point;
+        sdl3d_vec3 normal;
+        const sdl3d_actor *actor;
+    } sdl3d_scene_hit;
+
+    /* ============================================================== */
+    /* Primitive-primitive tests                                       */
+    /* ============================================================== */
+
+    bool sdl3d_check_aabb_aabb(sdl3d_bounding_box a, sdl3d_bounding_box b);
+    bool sdl3d_check_sphere_sphere(sdl3d_sphere a, sdl3d_sphere b);
+    bool sdl3d_check_aabb_sphere(sdl3d_bounding_box box, sdl3d_sphere sphere);
+
+    /* ============================================================== */
+    /* Ray tests                                                      */
+    /* ============================================================== */
+
+    sdl3d_ray_hit sdl3d_ray_vs_aabb(sdl3d_ray ray, sdl3d_bounding_box box);
+    sdl3d_ray_hit sdl3d_ray_vs_sphere(sdl3d_ray ray, sdl3d_sphere sphere);
+    sdl3d_ray_hit sdl3d_ray_vs_triangle(sdl3d_ray ray, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2);
+
+    /*
+     * Test a ray against all triangles in a mesh (brute-force).
+     * Returns the closest hit, or hit=false if no intersection.
+     */
+    sdl3d_ray_hit sdl3d_ray_vs_mesh(sdl3d_ray ray, const sdl3d_mesh *mesh);
+
+    /* ============================================================== */
+    /* Bounding volume helpers                                        */
+    /* ============================================================== */
+
+    sdl3d_bounding_box sdl3d_compute_mesh_aabb(const sdl3d_mesh *mesh);
+
+    /* ============================================================== */
+    /* Scene-level queries                                            */
+    /* ============================================================== */
+
+    /*
+     * Cast a ray against all visible actors in the scene. Tests each
+     * actor's mesh AABB first, then triangles on hit. Returns the
+     * closest intersection with the actor that was hit.
+     */
+    sdl3d_scene_hit sdl3d_scene_raycast(const sdl3d_scene *scene, sdl3d_ray ray);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/scene.h
+++ b/include/sdl3d/scene.h
@@ -39,6 +39,11 @@ extern "C"
 
     int sdl3d_scene_get_actor_count(const sdl3d_scene *scene);
 
+    /*
+     * Get actor by index (0-based). Returns NULL if out of range.
+     */
+    sdl3d_actor *sdl3d_scene_get_actor_at(const sdl3d_scene *scene, int index);
+
     /* ============================================================== */
     /* Actor properties                                               */
     /* ============================================================== */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -7,6 +7,7 @@
 #include <SDL3/SDL_log.h>
 
 #include "sdl3d/camera.h"
+#include "sdl3d/collision.h"
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/image.h"
 #include "sdl3d/lighting.h"

--- a/src/collision.c
+++ b/src/collision.c
@@ -1,0 +1,395 @@
+#include "sdl3d/collision.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/math.h"
+
+static float sdl3d_col_minf(float a, float b)
+{
+    return a < b ? a : b;
+}
+
+static float sdl3d_col_maxf(float a, float b)
+{
+    return a > b ? a : b;
+}
+
+/* ------------------------------------------------------------------ */
+/* Primitive-primitive tests                                           */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_check_aabb_aabb(sdl3d_bounding_box a, sdl3d_bounding_box b)
+{
+    return a.min.x <= b.max.x && a.max.x >= b.min.x && a.min.y <= b.max.y && a.max.y >= b.min.y && a.min.z <= b.max.z &&
+           a.max.z >= b.min.z;
+}
+
+bool sdl3d_check_sphere_sphere(sdl3d_sphere a, sdl3d_sphere b)
+{
+    float dx = a.center.x - b.center.x;
+    float dy = a.center.y - b.center.y;
+    float dz = a.center.z - b.center.z;
+    float dist_sq = dx * dx + dy * dy + dz * dz;
+    float r_sum = a.radius + b.radius;
+    return dist_sq <= r_sum * r_sum;
+}
+
+bool sdl3d_check_aabb_sphere(sdl3d_bounding_box box, sdl3d_sphere sphere)
+{
+    /* Find the closest point on the AABB to the sphere center. */
+    float cx = sdl3d_col_maxf(box.min.x, sdl3d_col_minf(sphere.center.x, box.max.x));
+    float cy = sdl3d_col_maxf(box.min.y, sdl3d_col_minf(sphere.center.y, box.max.y));
+    float cz = sdl3d_col_maxf(box.min.z, sdl3d_col_minf(sphere.center.z, box.max.z));
+    float dx = cx - sphere.center.x;
+    float dy = cy - sphere.center.y;
+    float dz = cz - sphere.center.z;
+    return (dx * dx + dy * dy + dz * dz) <= sphere.radius * sphere.radius;
+}
+
+/* ------------------------------------------------------------------ */
+/* Ray tests                                                           */
+/* ------------------------------------------------------------------ */
+
+static sdl3d_ray_hit sdl3d_no_hit(void)
+{
+    sdl3d_ray_hit h;
+    SDL_zerop(&h);
+    return h;
+}
+
+sdl3d_ray_hit sdl3d_ray_vs_aabb(sdl3d_ray ray, sdl3d_bounding_box box)
+{
+    float tmin, tmax, tymin, tymax, tzmin, tzmax;
+    float inv_dx = (ray.direction.x != 0.0f) ? 1.0f / ray.direction.x : 1e30f;
+    float inv_dy = (ray.direction.y != 0.0f) ? 1.0f / ray.direction.y : 1e30f;
+    float inv_dz = (ray.direction.z != 0.0f) ? 1.0f / ray.direction.z : 1e30f;
+
+    if (inv_dx >= 0.0f)
+    {
+        tmin = (box.min.x - ray.position.x) * inv_dx;
+        tmax = (box.max.x - ray.position.x) * inv_dx;
+    }
+    else
+    {
+        tmin = (box.max.x - ray.position.x) * inv_dx;
+        tmax = (box.min.x - ray.position.x) * inv_dx;
+    }
+
+    if (inv_dy >= 0.0f)
+    {
+        tymin = (box.min.y - ray.position.y) * inv_dy;
+        tymax = (box.max.y - ray.position.y) * inv_dy;
+    }
+    else
+    {
+        tymin = (box.max.y - ray.position.y) * inv_dy;
+        tymax = (box.min.y - ray.position.y) * inv_dy;
+    }
+
+    if (tmin > tymax || tymin > tmax)
+    {
+        return sdl3d_no_hit();
+    }
+    tmin = sdl3d_col_maxf(tmin, tymin);
+    tmax = sdl3d_col_minf(tmax, tymax);
+
+    if (inv_dz >= 0.0f)
+    {
+        tzmin = (box.min.z - ray.position.z) * inv_dz;
+        tzmax = (box.max.z - ray.position.z) * inv_dz;
+    }
+    else
+    {
+        tzmin = (box.max.z - ray.position.z) * inv_dz;
+        tzmax = (box.min.z - ray.position.z) * inv_dz;
+    }
+
+    if (tmin > tzmax || tzmin > tmax)
+    {
+        return sdl3d_no_hit();
+    }
+    tmin = sdl3d_col_maxf(tmin, tzmin);
+    tmax = sdl3d_col_minf(tmax, tzmax);
+
+    if (tmax < 0.0f)
+    {
+        return sdl3d_no_hit();
+    }
+
+    {
+        sdl3d_ray_hit h;
+        float t = tmin >= 0.0f ? tmin : tmax;
+        h.hit = true;
+        h.distance = t;
+        h.point.x = ray.position.x + ray.direction.x * t;
+        h.point.y = ray.position.y + ray.direction.y * t;
+        h.point.z = ray.position.z + ray.direction.z * t;
+        /* Approximate normal from which face was hit. */
+        h.normal = sdl3d_vec3_make(0, 0, 0);
+        return h;
+    }
+}
+
+sdl3d_ray_hit sdl3d_ray_vs_sphere(sdl3d_ray ray, sdl3d_sphere sphere)
+{
+    float ox = ray.position.x - sphere.center.x;
+    float oy = ray.position.y - sphere.center.y;
+    float oz = ray.position.z - sphere.center.z;
+    float a = ray.direction.x * ray.direction.x + ray.direction.y * ray.direction.y + ray.direction.z * ray.direction.z;
+    float b = 2.0f * (ox * ray.direction.x + oy * ray.direction.y + oz * ray.direction.z);
+    float c = ox * ox + oy * oy + oz * oz - sphere.radius * sphere.radius;
+    float disc = b * b - 4.0f * a * c;
+
+    if (disc < 0.0f)
+    {
+        return sdl3d_no_hit();
+    }
+
+    {
+        float sqrt_disc = SDL_sqrtf(disc);
+        float t0 = (-b - sqrt_disc) / (2.0f * a);
+        float t1 = (-b + sqrt_disc) / (2.0f * a);
+        float t;
+        sdl3d_ray_hit h;
+
+        if (t0 >= 0.0f)
+        {
+            t = t0;
+        }
+        else if (t1 >= 0.0f)
+        {
+            t = t1;
+        }
+        else
+        {
+            return sdl3d_no_hit();
+        }
+
+        h.hit = true;
+        h.distance = t;
+        h.point.x = ray.position.x + ray.direction.x * t;
+        h.point.y = ray.position.y + ray.direction.y * t;
+        h.point.z = ray.position.z + ray.direction.z * t;
+        h.normal = sdl3d_vec3_normalize(sdl3d_vec3_sub(h.point, sphere.center));
+        return h;
+    }
+}
+
+sdl3d_ray_hit sdl3d_ray_vs_triangle(sdl3d_ray ray, sdl3d_vec3 v0, sdl3d_vec3 v1, sdl3d_vec3 v2)
+{
+    /* Möller–Trumbore intersection algorithm. */
+    sdl3d_vec3 e1 = sdl3d_vec3_sub(v1, v0);
+    sdl3d_vec3 e2 = sdl3d_vec3_sub(v2, v0);
+    sdl3d_vec3 h = sdl3d_vec3_cross(ray.direction, e2);
+    float a = sdl3d_vec3_dot(e1, h);
+
+    if (a > -1e-7f && a < 1e-7f)
+    {
+        return sdl3d_no_hit();
+    }
+
+    {
+        float f = 1.0f / a;
+        sdl3d_vec3 s = sdl3d_vec3_sub(ray.position, v0);
+        float u = f * sdl3d_vec3_dot(s, h);
+        sdl3d_vec3 q;
+        float v, t;
+        sdl3d_ray_hit hit;
+
+        if (u < 0.0f || u > 1.0f)
+        {
+            return sdl3d_no_hit();
+        }
+
+        q = sdl3d_vec3_cross(s, e1);
+        v = f * sdl3d_vec3_dot(ray.direction, q);
+        if (v < 0.0f || u + v > 1.0f)
+        {
+            return sdl3d_no_hit();
+        }
+
+        t = f * sdl3d_vec3_dot(e2, q);
+        if (t < 0.0f)
+        {
+            return sdl3d_no_hit();
+        }
+
+        hit.hit = true;
+        hit.distance = t;
+        hit.point.x = ray.position.x + ray.direction.x * t;
+        hit.point.y = ray.position.y + ray.direction.y * t;
+        hit.point.z = ray.position.z + ray.direction.z * t;
+        hit.normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(e1, e2));
+        return hit;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Ray-mesh (brute-force)                                              */
+/* ------------------------------------------------------------------ */
+
+sdl3d_ray_hit sdl3d_ray_vs_mesh(sdl3d_ray ray, const sdl3d_mesh *mesh)
+{
+    sdl3d_ray_hit closest = sdl3d_no_hit();
+    int tri_count;
+    bool indexed;
+
+    if (mesh == NULL || mesh->positions == NULL || mesh->vertex_count <= 0)
+    {
+        return closest;
+    }
+
+    indexed = mesh->indices != NULL;
+    tri_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
+
+    for (int i = 0; i < tri_count; ++i)
+    {
+        unsigned int i0 = indexed ? mesh->indices[i * 3 + 0] : (unsigned int)(i * 3 + 0);
+        unsigned int i1 = indexed ? mesh->indices[i * 3 + 1] : (unsigned int)(i * 3 + 1);
+        unsigned int i2 = indexed ? mesh->indices[i * 3 + 2] : (unsigned int)(i * 3 + 2);
+        sdl3d_vec3 v0, v1, v2;
+        sdl3d_ray_hit h;
+
+        if ((int)i0 >= mesh->vertex_count || (int)i1 >= mesh->vertex_count || (int)i2 >= mesh->vertex_count)
+        {
+            continue;
+        }
+
+        v0 = sdl3d_vec3_make(mesh->positions[i0 * 3], mesh->positions[i0 * 3 + 1], mesh->positions[i0 * 3 + 2]);
+        v1 = sdl3d_vec3_make(mesh->positions[i1 * 3], mesh->positions[i1 * 3 + 1], mesh->positions[i1 * 3 + 2]);
+        v2 = sdl3d_vec3_make(mesh->positions[i2 * 3], mesh->positions[i2 * 3 + 1], mesh->positions[i2 * 3 + 2]);
+
+        h = sdl3d_ray_vs_triangle(ray, v0, v1, v2);
+        if (h.hit && (!closest.hit || h.distance < closest.distance))
+        {
+            closest = h;
+        }
+    }
+
+    return closest;
+}
+
+/* ------------------------------------------------------------------ */
+/* Bounding volume helpers                                             */
+/* ------------------------------------------------------------------ */
+
+sdl3d_bounding_box sdl3d_compute_mesh_aabb(const sdl3d_mesh *mesh)
+{
+    sdl3d_bounding_box box;
+    box.min = sdl3d_vec3_make(0, 0, 0);
+    box.max = sdl3d_vec3_make(0, 0, 0);
+
+    if (mesh == NULL || mesh->positions == NULL || mesh->vertex_count <= 0)
+    {
+        return box;
+    }
+
+    box.min = sdl3d_vec3_make(mesh->positions[0], mesh->positions[1], mesh->positions[2]);
+    box.max = box.min;
+
+    for (int i = 1; i < mesh->vertex_count; ++i)
+    {
+        float x = mesh->positions[i * 3 + 0];
+        float y = mesh->positions[i * 3 + 1];
+        float z = mesh->positions[i * 3 + 2];
+        if (x < box.min.x)
+        {
+            box.min.x = x;
+        }
+        if (y < box.min.y)
+        {
+            box.min.y = y;
+        }
+        if (z < box.min.z)
+        {
+            box.min.z = z;
+        }
+        if (x > box.max.x)
+        {
+            box.max.x = x;
+        }
+        if (y > box.max.y)
+        {
+            box.max.y = y;
+        }
+        if (z > box.max.z)
+        {
+            box.max.z = z;
+        }
+    }
+
+    return box;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scene-level raycast                                                 */
+/* ------------------------------------------------------------------ */
+
+sdl3d_scene_hit sdl3d_scene_raycast(const sdl3d_scene *scene, sdl3d_ray ray)
+{
+    sdl3d_scene_hit result;
+    int count;
+    int i;
+
+    SDL_zerop(&result);
+
+    if (scene == NULL)
+    {
+        return result;
+    }
+
+    count = sdl3d_scene_get_actor_count(scene);
+
+    for (i = 0; i < count; ++i)
+    {
+        const sdl3d_actor *actor = sdl3d_scene_get_actor_at(scene, i);
+        const sdl3d_model *model;
+        int m;
+
+        if (actor == NULL || !sdl3d_actor_is_visible(actor))
+        {
+            continue;
+        }
+
+        model = sdl3d_actor_get_model(actor);
+        if (model == NULL || model->meshes == NULL)
+        {
+            continue;
+        }
+
+        {
+            sdl3d_vec3 actor_pos = sdl3d_actor_get_position(actor);
+            sdl3d_ray local_ray;
+            local_ray.position.x = ray.position.x - actor_pos.x;
+            local_ray.position.y = ray.position.y - actor_pos.y;
+            local_ray.position.z = ray.position.z - actor_pos.z;
+            local_ray.direction = ray.direction;
+
+            for (m = 0; m < model->mesh_count; ++m)
+            {
+                sdl3d_bounding_box aabb = sdl3d_compute_mesh_aabb(&model->meshes[m]);
+                sdl3d_ray_hit aabb_hit = sdl3d_ray_vs_aabb(local_ray, aabb);
+                sdl3d_ray_hit mesh_hit;
+
+                if (!aabb_hit.hit)
+                {
+                    continue;
+                }
+
+                mesh_hit = sdl3d_ray_vs_mesh(local_ray, &model->meshes[m]);
+                if (mesh_hit.hit && (!result.hit || mesh_hit.distance < result.distance))
+                {
+                    result.hit = true;
+                    result.distance = mesh_hit.distance;
+                    result.point.x = mesh_hit.point.x + actor_pos.x;
+                    result.point.y = mesh_hit.point.y + actor_pos.y;
+                    result.point.z = mesh_hit.point.z + actor_pos.z;
+                    result.normal = mesh_hit.normal;
+                    result.actor = actor;
+                }
+            }
+        }
+    }
+
+    return result;
+}

--- a/src/scene.c
+++ b/src/scene.c
@@ -130,6 +130,22 @@ int sdl3d_scene_get_actor_count(const sdl3d_scene *scene)
     return scene->actor_count;
 }
 
+sdl3d_actor *sdl3d_scene_get_actor_at(const sdl3d_scene *scene, int index)
+{
+    sdl3d_actor *actor;
+    int i;
+    if (scene == NULL || index < 0 || index >= scene->actor_count)
+    {
+        return NULL;
+    }
+    actor = scene->first;
+    for (i = 0; i < index && actor != NULL; ++i)
+    {
+        actor = actor->next;
+    }
+    return actor;
+}
+
 void sdl3d_actor_set_position(sdl3d_actor *actor, sdl3d_vec3 position)
 {
     if (actor != NULL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SDL3D_TEST_SOURCES
     test_textured_rendering.cpp
     test_lighting.cpp
     test_scene.cpp
+    test_collision.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -160,6 +161,7 @@ else()
     sdl3d_add_test(sdl3d_lighting_test test_lighting.cpp render)
     target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
+    sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)

--- a/tests/test_collision.cpp
+++ b/tests/test_collision.cpp
@@ -1,0 +1,393 @@
+/*
+ * Comprehensive tests for M6: collisions and spatial queries.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+extern "C"
+{
+#include "sdl3d/collision.h"
+#include "sdl3d/math.h"
+}
+
+/* ================================================================== */
+/* AABB-AABB                                                          */
+/* ================================================================== */
+
+struct AABBCase
+{
+    const char *label;
+    sdl3d_bounding_box a, b;
+    bool expected;
+};
+
+class SDL3DAABBAABB : public ::testing::TestWithParam<AABBCase>
+{
+};
+
+TEST_P(SDL3DAABBAABB, Check)
+{
+    const auto &c = GetParam();
+    EXPECT_EQ(sdl3d_check_aabb_aabb(c.a, c.b), c.expected) << c.label;
+    EXPECT_EQ(sdl3d_check_aabb_aabb(c.b, c.a), c.expected) << c.label << " (reversed)";
+}
+
+static sdl3d_bounding_box bb(float x0, float y0, float z0, float x1, float y1, float z1)
+{
+    sdl3d_bounding_box b;
+    b.min = sdl3d_vec3_make(x0, y0, z0);
+    b.max = sdl3d_vec3_make(x1, y1, z1);
+    return b;
+}
+
+INSTANTIATE_TEST_SUITE_P(Collision, SDL3DAABBAABB,
+                         ::testing::Values(AABBCase{"overlap", bb(-1, -1, -1, 1, 1, 1), bb(0, 0, 0, 2, 2, 2), true},
+                                           AABBCase{"touching", bb(0, 0, 0, 1, 1, 1), bb(1, 0, 0, 2, 1, 1), true},
+                                           AABBCase{"separated x", bb(0, 0, 0, 1, 1, 1), bb(2, 0, 0, 3, 1, 1), false},
+                                           AABBCase{"separated y", bb(0, 0, 0, 1, 1, 1), bb(0, 2, 0, 1, 3, 1), false},
+                                           AABBCase{"separated z", bb(0, 0, 0, 1, 1, 1), bb(0, 0, 2, 1, 1, 3), false},
+                                           AABBCase{"contained", bb(-2, -2, -2, 2, 2, 2), bb(-1, -1, -1, 1, 1, 1),
+                                                    true},
+                                           AABBCase{"identical", bb(0, 0, 0, 1, 1, 1), bb(0, 0, 0, 1, 1, 1), true},
+                                           AABBCase{"zero-size", bb(0, 0, 0, 0, 0, 0), bb(0, 0, 0, 0, 0, 0), true}));
+
+/* ================================================================== */
+/* Sphere-Sphere                                                      */
+/* ================================================================== */
+
+struct SphereSphereCase
+{
+    const char *label;
+    sdl3d_sphere a, b;
+    bool expected;
+};
+
+class SDL3DSphereSphere : public ::testing::TestWithParam<SphereSphereCase>
+{
+};
+
+TEST_P(SDL3DSphereSphere, Check)
+{
+    const auto &c = GetParam();
+    EXPECT_EQ(sdl3d_check_sphere_sphere(c.a, c.b), c.expected) << c.label;
+}
+
+static sdl3d_sphere sp(float x, float y, float z, float r)
+{
+    sdl3d_sphere s;
+    s.center = sdl3d_vec3_make(x, y, z);
+    s.radius = r;
+    return s;
+}
+
+INSTANTIATE_TEST_SUITE_P(Collision, SDL3DSphereSphere,
+                         ::testing::Values(SphereSphereCase{"overlap", sp(0, 0, 0, 1), sp(1, 0, 0, 1), true},
+                                           SphereSphereCase{"touching", sp(0, 0, 0, 1), sp(2, 0, 0, 1), true},
+                                           SphereSphereCase{"separated", sp(0, 0, 0, 1), sp(3, 0, 0, 1), false},
+                                           SphereSphereCase{"contained", sp(0, 0, 0, 5), sp(1, 0, 0, 1), true},
+                                           SphereSphereCase{"coincident", sp(0, 0, 0, 1), sp(0, 0, 0, 1), true},
+                                           SphereSphereCase{"zero radius", sp(0, 0, 0, 0), sp(0, 0, 0, 0), true},
+                                           SphereSphereCase{"far apart", sp(-10, 0, 0, 1), sp(10, 0, 0, 1), false}));
+
+/* ================================================================== */
+/* AABB-Sphere                                                        */
+/* ================================================================== */
+
+struct AABBSphereCase
+{
+    const char *label;
+    sdl3d_bounding_box box;
+    sdl3d_sphere sphere;
+    bool expected;
+};
+
+class SDL3DAABBSphere : public ::testing::TestWithParam<AABBSphereCase>
+{
+};
+
+TEST_P(SDL3DAABBSphere, Check)
+{
+    const auto &c = GetParam();
+    EXPECT_EQ(sdl3d_check_aabb_sphere(c.box, c.sphere), c.expected) << c.label;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Collision, SDL3DAABBSphere,
+    ::testing::Values(AABBSphereCase{"inside", bb(-1, -1, -1, 1, 1, 1), sp(0, 0, 0, 0.5f), true},
+                      AABBSphereCase{"touching face", bb(0, 0, 0, 1, 1, 1), sp(2, 0.5f, 0.5f, 1), true},
+                      AABBSphereCase{"separated", bb(0, 0, 0, 1, 1, 1), sp(3, 0.5f, 0.5f, 1), false},
+                      AABBSphereCase{"corner touch", bb(0, 0, 0, 1, 1, 1), sp(2, 2, 2, 1.733f), true},
+                      AABBSphereCase{"corner miss", bb(0, 0, 0, 1, 1, 1), sp(2, 2, 2, 1.7f), false}));
+
+/* ================================================================== */
+/* Ray-AABB                                                           */
+/* ================================================================== */
+
+struct RayAABBCase
+{
+    const char *label;
+    sdl3d_ray ray;
+    sdl3d_bounding_box box;
+    bool expect_hit;
+};
+
+class SDL3DRayAABB : public ::testing::TestWithParam<RayAABBCase>
+{
+};
+
+static sdl3d_ray make_ray(float ox, float oy, float oz, float dx, float dy, float dz)
+{
+    sdl3d_ray r;
+    r.position = sdl3d_vec3_make(ox, oy, oz);
+    r.direction = sdl3d_vec3_make(dx, dy, dz);
+    return r;
+}
+
+TEST_P(SDL3DRayAABB, HitOrMiss)
+{
+    const auto &c = GetParam();
+    sdl3d_ray_hit h = sdl3d_ray_vs_aabb(c.ray, c.box);
+    EXPECT_EQ(h.hit, c.expect_hit) << c.label;
+    if (h.hit)
+    {
+        EXPECT_GE(h.distance, 0.0f) << c.label;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Collision, SDL3DRayAABB,
+    ::testing::Values(RayAABBCase{"direct hit", make_ray(-5, 0.5f, 0.5f, 1, 0, 0), bb(0, 0, 0, 1, 1, 1), true},
+                      RayAABBCase{"miss above", make_ray(-5, 2, 0.5f, 1, 0, 0), bb(0, 0, 0, 1, 1, 1), false},
+                      RayAABBCase{"miss behind", make_ray(5, 0.5f, 0.5f, 1, 0, 0), bb(0, 0, 0, 1, 1, 1), false},
+                      RayAABBCase{"inside", make_ray(0.5f, 0.5f, 0.5f, 1, 0, 0), bb(0, 0, 0, 1, 1, 1), true},
+                      RayAABBCase{"along y", make_ray(0.5f, -5, 0.5f, 0, 1, 0), bb(0, 0, 0, 1, 1, 1), true},
+                      RayAABBCase{"along z", make_ray(0.5f, 0.5f, -5, 0, 0, 1), bb(0, 0, 0, 1, 1, 1), true},
+                      RayAABBCase{"diagonal hit", make_ray(-2, -2, -2, 1, 1, 1), bb(0, 0, 0, 1, 1, 1), true}));
+
+/* ================================================================== */
+/* Ray-Sphere                                                         */
+/* ================================================================== */
+
+struct RaySphereCase
+{
+    const char *label;
+    sdl3d_ray ray;
+    sdl3d_sphere sphere;
+    bool expect_hit;
+};
+
+class SDL3DRaySphere : public ::testing::TestWithParam<RaySphereCase>
+{
+};
+
+TEST_P(SDL3DRaySphere, HitOrMiss)
+{
+    const auto &c = GetParam();
+    sdl3d_ray_hit h = sdl3d_ray_vs_sphere(c.ray, c.sphere);
+    EXPECT_EQ(h.hit, c.expect_hit) << c.label;
+    if (h.hit)
+    {
+        EXPECT_GE(h.distance, 0.0f) << c.label;
+        /* Hit point should be on the sphere surface. */
+        float dx = h.point.x - c.sphere.center.x;
+        float dy = h.point.y - c.sphere.center.y;
+        float dz = h.point.z - c.sphere.center.z;
+        float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+        EXPECT_NEAR(dist, c.sphere.radius, 0.01f) << c.label;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Collision, SDL3DRaySphere,
+    ::testing::Values(RaySphereCase{"direct hit", make_ray(-5, 0, 0, 1, 0, 0), sp(0, 0, 0, 1), true},
+                      RaySphereCase{"miss above", make_ray(-5, 2, 0, 1, 0, 0), sp(0, 0, 0, 1), false},
+                      RaySphereCase{"miss behind", make_ray(5, 0, 0, 1, 0, 0), sp(0, 0, 0, 1), false},
+                      RaySphereCase{"inside", make_ray(0, 0, 0, 1, 0, 0), sp(0, 0, 0, 5), true},
+                      RaySphereCase{"tangent", make_ray(-5, 1, 0, 1, 0, 0), sp(0, 0, 0, 1), true},
+                      RaySphereCase{"far sphere", make_ray(0, 0, 0, 0, 0, -1), sp(0, 0, -100, 1), true}));
+
+/* ================================================================== */
+/* Ray-Triangle (Möller–Trumbore)                                     */
+/* ================================================================== */
+
+TEST(SDL3DRayTriangle, HitsFrontFace)
+{
+    sdl3d_vec3 v0 = sdl3d_vec3_make(-1, -1, 0);
+    sdl3d_vec3 v1 = sdl3d_vec3_make(1, -1, 0);
+    sdl3d_vec3 v2 = sdl3d_vec3_make(0, 1, 0);
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+
+    sdl3d_ray_hit h = sdl3d_ray_vs_triangle(ray, v0, v1, v2);
+    EXPECT_TRUE(h.hit);
+    EXPECT_NEAR(h.distance, 5.0f, 0.01f);
+    EXPECT_NEAR(h.point.z, 0.0f, 0.01f);
+}
+
+TEST(SDL3DRayTriangle, MissesOutside)
+{
+    sdl3d_vec3 v0 = sdl3d_vec3_make(-1, -1, 0);
+    sdl3d_vec3 v1 = sdl3d_vec3_make(1, -1, 0);
+    sdl3d_vec3 v2 = sdl3d_vec3_make(0, 1, 0);
+    sdl3d_ray ray = make_ray(5, 5, -5, 0, 0, 1);
+
+    sdl3d_ray_hit h = sdl3d_ray_vs_triangle(ray, v0, v1, v2);
+    EXPECT_FALSE(h.hit);
+}
+
+TEST(SDL3DRayTriangle, MissesBehind)
+{
+    sdl3d_vec3 v0 = sdl3d_vec3_make(-1, -1, 0);
+    sdl3d_vec3 v1 = sdl3d_vec3_make(1, -1, 0);
+    sdl3d_vec3 v2 = sdl3d_vec3_make(0, 1, 0);
+    sdl3d_ray ray = make_ray(0, 0, 5, 0, 0, 1);
+
+    sdl3d_ray_hit h = sdl3d_ray_vs_triangle(ray, v0, v1, v2);
+    EXPECT_FALSE(h.hit);
+}
+
+TEST(SDL3DRayTriangle, ParallelMisses)
+{
+    sdl3d_vec3 v0 = sdl3d_vec3_make(-1, -1, 0);
+    sdl3d_vec3 v1 = sdl3d_vec3_make(1, -1, 0);
+    sdl3d_vec3 v2 = sdl3d_vec3_make(0, 1, 0);
+    sdl3d_ray ray = make_ray(0, 0, -5, 1, 0, 0);
+
+    sdl3d_ray_hit h = sdl3d_ray_vs_triangle(ray, v0, v1, v2);
+    EXPECT_FALSE(h.hit);
+}
+
+/* ================================================================== */
+/* Ray-Mesh                                                           */
+/* ================================================================== */
+
+TEST(SDL3DRayMesh, HitsClosestTriangle)
+{
+    /* Two triangles: one at z=0, one at z=2. Ray from z=-5 along +z. */
+    float positions[] = {
+        -1, -1, 0, 1, -1, 0, 0, 1, 0, /* tri 0 at z=0 */
+        -1, -1, 2, 1, -1, 2, 0, 1, 2, /* tri 1 at z=2 */
+    };
+    unsigned int indices[] = {0, 1, 2, 3, 4, 5};
+    sdl3d_mesh mesh{};
+    mesh.positions = positions;
+    mesh.vertex_count = 6;
+    mesh.indices = indices;
+    mesh.index_count = 6;
+
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+    sdl3d_ray_hit h = sdl3d_ray_vs_mesh(ray, &mesh);
+    EXPECT_TRUE(h.hit);
+    EXPECT_NEAR(h.distance, 5.0f, 0.01f);
+    EXPECT_NEAR(h.point.z, 0.0f, 0.01f);
+}
+
+TEST(SDL3DRayMesh, MissesEmptyMesh)
+{
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+    sdl3d_ray_hit h = sdl3d_ray_vs_mesh(ray, nullptr);
+    EXPECT_FALSE(h.hit);
+}
+
+/* ================================================================== */
+/* Compute mesh AABB                                                  */
+/* ================================================================== */
+
+TEST(SDL3DMeshAABB, ComputesCorrectBounds)
+{
+    float positions[] = {-1, -2, -3, 4, 5, 6, 0, 0, 0};
+    sdl3d_mesh mesh{};
+    mesh.positions = positions;
+    mesh.vertex_count = 3;
+
+    sdl3d_bounding_box aabb = sdl3d_compute_mesh_aabb(&mesh);
+    EXPECT_FLOAT_EQ(aabb.min.x, -1);
+    EXPECT_FLOAT_EQ(aabb.min.y, -2);
+    EXPECT_FLOAT_EQ(aabb.min.z, -3);
+    EXPECT_FLOAT_EQ(aabb.max.x, 4);
+    EXPECT_FLOAT_EQ(aabb.max.y, 5);
+    EXPECT_FLOAT_EQ(aabb.max.z, 6);
+}
+
+TEST(SDL3DMeshAABB, NullMeshReturnsZero)
+{
+    sdl3d_bounding_box aabb = sdl3d_compute_mesh_aabb(nullptr);
+    EXPECT_FLOAT_EQ(aabb.min.x, 0);
+    EXPECT_FLOAT_EQ(aabb.max.x, 0);
+}
+
+/* ================================================================== */
+/* Scene raycast                                                      */
+/* ================================================================== */
+
+TEST(SDL3DSceneRaycast, NullSceneReturnsNoHit)
+{
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+    sdl3d_scene_hit h = sdl3d_scene_raycast(nullptr, ray);
+    EXPECT_FALSE(h.hit);
+}
+
+TEST(SDL3DSceneRaycast, EmptySceneReturnsNoHit)
+{
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+    sdl3d_scene_hit h = sdl3d_scene_raycast(scene, ray);
+    EXPECT_FALSE(h.hit);
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DSceneRaycast, HitsActorMesh)
+{
+    float positions[] = {-1, -1, 0, 1, -1, 0, 0, 1, 0};
+    unsigned int indices[] = {0, 1, 2};
+    sdl3d_mesh meshes[1] = {};
+    meshes[0].positions = positions;
+    meshes[0].vertex_count = 3;
+    meshes[0].indices = indices;
+    meshes[0].index_count = 3;
+    meshes[0].material_index = -1;
+
+    sdl3d_model model{};
+    model.meshes = meshes;
+    model.mesh_count = 1;
+
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+    sdl3d_actor_set_position(actor, sdl3d_vec3_make(0, 0, 5));
+
+    /* Ray from origin along +z should hit the triangle at z=5. */
+    sdl3d_ray ray = make_ray(0, 0, 0, 0, 0, 1);
+    sdl3d_scene_hit h = sdl3d_scene_raycast(scene, ray);
+    EXPECT_TRUE(h.hit);
+    EXPECT_NEAR(h.point.z, 5.0f, 0.01f);
+    EXPECT_EQ(h.actor, actor);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DSceneRaycast, InvisibleActorSkipped)
+{
+    float positions[] = {-1, -1, 0, 1, -1, 0, 0, 1, 0};
+    unsigned int indices[] = {0, 1, 2};
+    sdl3d_mesh meshes[1] = {};
+    meshes[0].positions = positions;
+    meshes[0].vertex_count = 3;
+    meshes[0].indices = indices;
+    meshes[0].index_count = 3;
+    meshes[0].material_index = -1;
+
+    sdl3d_model model{};
+    model.meshes = meshes;
+    model.mesh_count = 1;
+
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+    sdl3d_actor_set_visible(actor, false);
+
+    sdl3d_ray ray = make_ray(0, 0, -5, 0, 0, 1);
+    sdl3d_scene_hit h = sdl3d_scene_raycast(scene, ray);
+    EXPECT_FALSE(h.hit);
+
+    sdl3d_destroy_scene(scene);
+}


### PR DESCRIPTION
## Summary

Implements M6 (Collisions and Spatial Queries) from the roadmap in #4.

### Primitive-primitive tests
- `sdl3d_check_aabb_aabb` — axis-aligned bounding box overlap
- `sdl3d_check_sphere_sphere` — sphere overlap (distance² vs sum-of-radii²)
- `sdl3d_check_aabb_sphere` — closest-point-on-AABB to sphere center

### Ray intersection tests
- `sdl3d_ray_vs_aabb` — slab method, returns hit point and distance
- `sdl3d_ray_vs_sphere` — quadratic formula, returns hit point + surface normal
- `sdl3d_ray_vs_triangle` — Möller–Trumbore algorithm, returns hit point + face normal
- `sdl3d_ray_vs_mesh` — brute-force closest triangle in a mesh

### Bounding volume helpers
- `sdl3d_compute_mesh_aabb` — compute AABB from mesh vertex positions

### Scene-level queries
- `sdl3d_scene_raycast` — cast a ray against all visible actors. AABB broadphase per mesh, then Möller–Trumbore narrowphase. Returns closest hit with actor reference.
- `sdl3d_scene_get_actor_at` — indexed actor access for iteration

### Testing

45 new table-driven unit tests (235 total):
- AABB-AABB: 8 cases (overlap, touching, separated per axis, contained, identical, zero-size)
- Sphere-sphere: 7 cases (overlap, touching, separated, contained, coincident, zero radius, far apart)
- AABB-sphere: 5 cases (inside, face touch, separated, corner touch, corner miss)
- Ray-AABB: 7 cases (direct hit, miss above/behind, inside, along each axis, diagonal)
- Ray-sphere: 6 cases (direct hit, miss, behind, inside, tangent, far sphere)
- Ray-triangle: 4 cases (front face, outside, behind, parallel)
- Ray-mesh: 2 cases (closest triangle, null mesh)
- Mesh AABB: 2 cases (correct bounds, null)
- Scene raycast: 4 cases (null scene, empty scene, hit actor, invisible actor skipped)

clang-format clean. No new dependencies.

Refs #4