### PR TITLE
M5: Skeletal animation — types, runtime evaluation, actor playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(SDL3D::sdl3d ALIAS sdl3d)
 target_sources(
     sdl3d
     PRIVATE
+        src/animation.c
         src/camera.c
         src/collision.c
         src/drawing3d.c

--- a/include/sdl3d/animation.h
+++ b/include/sdl3d/animation.h
@@ -1,0 +1,98 @@
+#ifndef SDL3D_ANIMATION_H
+#define SDL3D_ANIMATION_H
+
+#include <stdbool.h>
+
+#include "sdl3d/math.h"
+#include "sdl3d/scene.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /* ============================================================== */
+    /* Skeleton and animation data types (stored in sdl3d_model)       */
+    /* ============================================================== */
+
+    typedef struct sdl3d_joint
+    {
+        char *name;
+        int parent_index; /* -1 for root joints */
+        sdl3d_mat4 inverse_bind_matrix;
+        float local_translation[3];
+        float local_rotation[4]; /* quaternion (x, y, z, w) */
+        float local_scale[3];
+    } sdl3d_joint;
+
+    typedef struct sdl3d_skeleton
+    {
+        sdl3d_joint *joints;
+        int joint_count;
+    } sdl3d_skeleton;
+
+    typedef enum sdl3d_anim_path
+    {
+        SDL3D_ANIM_TRANSLATION = 0,
+        SDL3D_ANIM_ROTATION = 1,
+        SDL3D_ANIM_SCALE = 2
+    } sdl3d_anim_path;
+
+    typedef struct sdl3d_keyframe
+    {
+        float time;
+        float value[4]; /* 3 for translation/scale, 4 for rotation quat */
+    } sdl3d_keyframe;
+
+    typedef struct sdl3d_anim_channel
+    {
+        int joint_index;
+        sdl3d_anim_path path;
+        sdl3d_keyframe *keyframes;
+        int keyframe_count;
+    } sdl3d_anim_channel;
+
+    typedef struct sdl3d_animation_clip
+    {
+        char *name;
+        float duration;
+        sdl3d_anim_channel *channels;
+        int channel_count;
+    } sdl3d_animation_clip;
+
+    /* ============================================================== */
+    /* Runtime animation evaluation                                   */
+    /* ============================================================== */
+
+    /*
+     * Evaluate an animation clip at the given time and compute world-
+     * space joint matrices suitable for vertex skinning.
+     *
+     * `out_joint_matrices` must have room for skeleton->joint_count
+     * mat4 entries. Each matrix transforms from bind space to the
+     * posed world space (inverse_bind_matrix * joint_world_transform).
+     */
+    bool sdl3d_evaluate_animation(const sdl3d_skeleton *skeleton, const sdl3d_animation_clip *clip, float time,
+                                  sdl3d_mat4 *out_joint_matrices);
+
+    /*
+     * Compute bind-pose joint matrices (identity pose).
+     */
+    bool sdl3d_compute_bind_pose(const sdl3d_skeleton *skeleton, sdl3d_mat4 *out_joint_matrices);
+
+    /* ============================================================== */
+    /* Actor animation playback                                       */
+    /* ============================================================== */
+
+    bool sdl3d_actor_play_animation(sdl3d_actor *actor, int clip_index, bool loop);
+    bool sdl3d_actor_stop_animation(sdl3d_actor *actor);
+    bool sdl3d_actor_advance_animation(sdl3d_actor *actor, float delta_time);
+    bool sdl3d_actor_is_animation_playing(const sdl3d_actor *actor);
+    int sdl3d_actor_get_animation_clip(const sdl3d_actor *actor);
+    float sdl3d_actor_get_animation_time(const sdl3d_actor *actor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/model.h
+++ b/include/sdl3d/model.h
@@ -63,6 +63,12 @@ extern "C"
         int index_count;
 
         int material_index;
+
+        /* Skinning attributes (NULL when no skeleton). Up to 4 joints
+         * per vertex. joint_indices indexes into the model's skeleton
+         * joint array. joint_weights sum to 1.0 per vertex. */
+        unsigned short *joint_indices; /* vertex_count * 4 */
+        float *joint_weights;          /* vertex_count * 4 */
     } sdl3d_mesh;
 
     /*
@@ -70,6 +76,9 @@ extern "C"
      * they reference by index. `source_path` is kept so higher layers
      * can resolve texture paths relative to the original file.
      */
+    struct sdl3d_skeleton;
+    struct sdl3d_animation_clip;
+
     typedef struct sdl3d_model
     {
         sdl3d_mesh *meshes;
@@ -79,6 +88,10 @@ extern "C"
         int material_count;
 
         char *source_path;
+
+        struct sdl3d_skeleton *skeleton;
+        struct sdl3d_animation_clip *animations;
+        int animation_count;
     } sdl3d_model;
 
     /*

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -6,6 +6,7 @@
 
 #include <SDL3/SDL_log.h>
 
+#include "sdl3d/animation.h"
 #include "sdl3d/camera.h"
 #include "sdl3d/collision.h"
 #include "sdl3d/drawing3d.h"

--- a/src/animation.c
+++ b/src/animation.c
@@ -1,0 +1,387 @@
+/*
+ * Runtime skeletal animation: joint pose evaluation, quaternion math,
+ * and actor animation playback.
+ */
+
+#include "sdl3d/animation.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include <math.h>
+
+/* ------------------------------------------------------------------ */
+/* Quaternion helpers                                                   */
+/* ------------------------------------------------------------------ */
+
+static void sdl3d_quat_normalize(float *q)
+{
+    float len = sqrtf(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    if (len > 1e-7f)
+    {
+        float inv = 1.0f / len;
+        q[0] *= inv;
+        q[1] *= inv;
+        q[2] *= inv;
+        q[3] *= inv;
+    }
+}
+
+static void sdl3d_quat_slerp(const float *a, const float *b, float t, float *out)
+{
+    float dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
+    float nb[4];
+    float theta, sin_theta, wa, wb;
+
+    /* Ensure shortest path. */
+    if (dot < 0.0f)
+    {
+        nb[0] = -b[0];
+        nb[1] = -b[1];
+        nb[2] = -b[2];
+        nb[3] = -b[3];
+        dot = -dot;
+    }
+    else
+    {
+        nb[0] = b[0];
+        nb[1] = b[1];
+        nb[2] = b[2];
+        nb[3] = b[3];
+    }
+
+    if (dot > 0.9995f)
+    {
+        /* Linear interpolation for nearly identical quaternions. */
+        out[0] = a[0] + (nb[0] - a[0]) * t;
+        out[1] = a[1] + (nb[1] - a[1]) * t;
+        out[2] = a[2] + (nb[2] - a[2]) * t;
+        out[3] = a[3] + (nb[3] - a[3]) * t;
+        sdl3d_quat_normalize(out);
+        return;
+    }
+
+    theta = acosf(dot);
+    sin_theta = sinf(theta);
+    wa = sinf((1.0f - t) * theta) / sin_theta;
+    wb = sinf(t * theta) / sin_theta;
+    out[0] = wa * a[0] + wb * nb[0];
+    out[1] = wa * a[1] + wb * nb[1];
+    out[2] = wa * a[2] + wb * nb[2];
+    out[3] = wa * a[3] + wb * nb[3];
+}
+
+static sdl3d_mat4 sdl3d_mat4_from_trs(const float *t, const float *r, const float *s)
+{
+    /* Build a matrix from translation, rotation (quaternion), scale. */
+    float x = r[0], y = r[1], z = r[2], w = r[3];
+    float x2 = x + x, y2 = y + y, z2 = z + z;
+    float xx = x * x2, xy = x * y2, xz = x * z2;
+    float yy = y * y2, yz = y * z2, zz = z * z2;
+    float wx = w * x2, wy = w * y2, wz = w * z2;
+    sdl3d_mat4 m;
+
+    m.m[0] = (1.0f - (yy + zz)) * s[0];
+    m.m[1] = (xy + wz) * s[0];
+    m.m[2] = (xz - wy) * s[0];
+    m.m[3] = 0.0f;
+    m.m[4] = (xy - wz) * s[1];
+    m.m[5] = (1.0f - (xx + zz)) * s[1];
+    m.m[6] = (yz + wx) * s[1];
+    m.m[7] = 0.0f;
+    m.m[8] = (xz + wy) * s[2];
+    m.m[9] = (yz - wx) * s[2];
+    m.m[10] = (1.0f - (xx + yy)) * s[2];
+    m.m[11] = 0.0f;
+    m.m[12] = t[0];
+    m.m[13] = t[1];
+    m.m[14] = t[2];
+    m.m[15] = 1.0f;
+
+    return m;
+}
+
+/* ------------------------------------------------------------------ */
+/* Keyframe sampling                                                   */
+/* ------------------------------------------------------------------ */
+
+static void sdl3d_sample_channel(const sdl3d_anim_channel *ch, float time, float *out, int components)
+{
+    int i;
+    float t;
+
+    if (ch->keyframe_count <= 0)
+    {
+        return;
+    }
+    if (ch->keyframe_count == 1 || time <= ch->keyframes[0].time)
+    {
+        for (i = 0; i < components; ++i)
+        {
+            out[i] = ch->keyframes[0].value[i];
+        }
+        return;
+    }
+    if (time >= ch->keyframes[ch->keyframe_count - 1].time)
+    {
+        for (i = 0; i < components; ++i)
+        {
+            out[i] = ch->keyframes[ch->keyframe_count - 1].value[i];
+        }
+        return;
+    }
+
+    /* Find the two keyframes bracketing `time`. */
+    for (i = 0; i < ch->keyframe_count - 1; ++i)
+    {
+        if (time < ch->keyframes[i + 1].time)
+        {
+            break;
+        }
+    }
+
+    {
+        float t0 = ch->keyframes[i].time;
+        float t1 = ch->keyframes[i + 1].time;
+        t = (t1 > t0) ? (time - t0) / (t1 - t0) : 0.0f;
+    }
+
+    if (ch->path == SDL3D_ANIM_ROTATION)
+    {
+        sdl3d_quat_slerp(ch->keyframes[i].value, ch->keyframes[i + 1].value, t, out);
+    }
+    else
+    {
+        for (int c = 0; c < components; ++c)
+        {
+            out[c] = ch->keyframes[i].value[c] + (ch->keyframes[i + 1].value[c] - ch->keyframes[i].value[c]) * t;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Animation evaluation                                                */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_evaluate_animation(const sdl3d_skeleton *skeleton, const sdl3d_animation_clip *clip, float time,
+                              sdl3d_mat4 *out_joint_matrices)
+{
+    float *local_t = NULL;
+    float *local_r = NULL;
+    float *local_s = NULL;
+    sdl3d_mat4 *world = NULL;
+    int jc;
+
+    if (skeleton == NULL || out_joint_matrices == NULL)
+    {
+        return SDL_InvalidParamError("skeleton or out_joint_matrices");
+    }
+
+    jc = skeleton->joint_count;
+    if (jc <= 0)
+    {
+        return true;
+    }
+
+    /* Allocate temp arrays for local TRS per joint. */
+    local_t = (float *)SDL_malloc((size_t)jc * 3 * sizeof(float));
+    local_r = (float *)SDL_malloc((size_t)jc * 4 * sizeof(float));
+    local_s = (float *)SDL_malloc((size_t)jc * 3 * sizeof(float));
+    world = (sdl3d_mat4 *)SDL_malloc((size_t)jc * sizeof(sdl3d_mat4));
+    if (!local_t || !local_r || !local_s || !world)
+    {
+        SDL_free(local_t);
+        SDL_free(local_r);
+        SDL_free(local_s);
+        SDL_free(world);
+        return SDL_OutOfMemory();
+    }
+
+    /* Initialize from bind pose. */
+    for (int j = 0; j < jc; ++j)
+    {
+        SDL_memcpy(&local_t[j * 3], skeleton->joints[j].local_translation, 3 * sizeof(float));
+        SDL_memcpy(&local_r[j * 4], skeleton->joints[j].local_rotation, 4 * sizeof(float));
+        SDL_memcpy(&local_s[j * 3], skeleton->joints[j].local_scale, 3 * sizeof(float));
+    }
+
+    /* Apply animation channels. */
+    if (clip != NULL)
+    {
+        for (int c = 0; c < clip->channel_count; ++c)
+        {
+            const sdl3d_anim_channel *ch = &clip->channels[c];
+            if (ch->joint_index < 0 || ch->joint_index >= jc)
+            {
+                continue;
+            }
+            switch (ch->path)
+            {
+            case SDL3D_ANIM_TRANSLATION:
+                sdl3d_sample_channel(ch, time, &local_t[ch->joint_index * 3], 3);
+                break;
+            case SDL3D_ANIM_ROTATION:
+                sdl3d_sample_channel(ch, time, &local_r[ch->joint_index * 4], 4);
+                break;
+            case SDL3D_ANIM_SCALE:
+                sdl3d_sample_channel(ch, time, &local_s[ch->joint_index * 3], 3);
+                break;
+            }
+        }
+    }
+
+    /* Compute world transforms (parent-first order). */
+    for (int j = 0; j < jc; ++j)
+    {
+        sdl3d_mat4 local = sdl3d_mat4_from_trs(&local_t[j * 3], &local_r[j * 4], &local_s[j * 3]);
+        int parent = skeleton->joints[j].parent_index;
+        if (parent >= 0 && parent < jc)
+        {
+            world[j] = sdl3d_mat4_multiply(world[parent], local);
+        }
+        else
+        {
+            world[j] = local;
+        }
+    }
+
+    /* Final skinning matrices: world * inverse_bind. */
+    for (int j = 0; j < jc; ++j)
+    {
+        out_joint_matrices[j] = sdl3d_mat4_multiply(world[j], skeleton->joints[j].inverse_bind_matrix);
+    }
+
+    SDL_free(local_t);
+    SDL_free(local_r);
+    SDL_free(local_s);
+    SDL_free(world);
+    return true;
+}
+
+bool sdl3d_compute_bind_pose(const sdl3d_skeleton *skeleton, sdl3d_mat4 *out_joint_matrices)
+{
+    return sdl3d_evaluate_animation(skeleton, NULL, 0.0f, out_joint_matrices);
+}
+
+/* ------------------------------------------------------------------ */
+/* Actor animation playback                                            */
+/* ------------------------------------------------------------------ */
+
+/* These functions access actor fields defined in scene.c. We use the
+ * public getter/setter API plus new animation-specific fields that
+ * we add to the actor struct via scene_internal.h. For now, we store
+ * animation state in a simple struct accessed via opaque helpers
+ * declared in scene.c. */
+
+/* Forward declarations — implemented in scene.c */
+extern void sdl3d_actor_set_anim_state(sdl3d_actor *actor, int clip, float time, bool playing, bool looping);
+extern void sdl3d_actor_get_anim_state(const sdl3d_actor *actor, int *clip, float *time, bool *playing, bool *looping);
+
+bool sdl3d_actor_play_animation(sdl3d_actor *actor, int clip_index, bool loop)
+{
+    if (actor == NULL)
+    {
+        return SDL_InvalidParamError("actor");
+    }
+    sdl3d_actor_set_anim_state(actor, clip_index, 0.0f, true, loop);
+    return true;
+}
+
+bool sdl3d_actor_stop_animation(sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return SDL_InvalidParamError("actor");
+    }
+    sdl3d_actor_set_anim_state(actor, -1, 0.0f, false, false);
+    return true;
+}
+
+bool sdl3d_actor_advance_animation(sdl3d_actor *actor, float delta_time)
+{
+    int clip;
+    float time;
+    bool playing, looping;
+    const sdl3d_model *model;
+
+    if (actor == NULL)
+    {
+        return SDL_InvalidParamError("actor");
+    }
+
+    sdl3d_actor_get_anim_state(actor, &clip, &time, &playing, &looping);
+    if (!playing || clip < 0)
+    {
+        return true;
+    }
+
+    model = sdl3d_actor_get_model(actor);
+    if (model == NULL || clip >= model->animation_count)
+    {
+        return true;
+    }
+
+    time += delta_time;
+    if (time > model->animations[clip].duration)
+    {
+        if (looping)
+        {
+            float dur = model->animations[clip].duration;
+            if (dur > 0.0f)
+            {
+                time = fmodf(time, dur);
+            }
+            else
+            {
+                time = 0.0f;
+            }
+        }
+        else
+        {
+            time = model->animations[clip].duration;
+            playing = false;
+        }
+    }
+
+    sdl3d_actor_set_anim_state(actor, clip, time, playing, looping);
+    return true;
+}
+
+bool sdl3d_actor_is_animation_playing(const sdl3d_actor *actor)
+{
+    int clip;
+    float time;
+    bool playing, looping;
+    if (actor == NULL)
+    {
+        return false;
+    }
+    sdl3d_actor_get_anim_state(actor, &clip, &time, &playing, &looping);
+    return playing;
+}
+
+int sdl3d_actor_get_animation_clip(const sdl3d_actor *actor)
+{
+    int clip;
+    float time;
+    bool playing, looping;
+    if (actor == NULL)
+    {
+        return -1;
+    }
+    sdl3d_actor_get_anim_state(actor, &clip, &time, &playing, &looping);
+    return clip;
+}
+
+float sdl3d_actor_get_animation_time(const sdl3d_actor *actor)
+{
+    int clip;
+    float time;
+    bool playing, looping;
+    if (actor == NULL)
+    {
+        return 0.0f;
+    }
+    sdl3d_actor_get_anim_state(actor, &clip, &time, &playing, &looping);
+    return time;
+}

--- a/src/model.c
+++ b/src/model.c
@@ -3,6 +3,8 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include "sdl3d/animation.h"
+
 #include "model_internal.h"
 
 void sdl3d_free_model(sdl3d_model *model)
@@ -21,6 +23,8 @@ void sdl3d_free_model(sdl3d_model *model)
         SDL_free(mesh->uvs);
         SDL_free(mesh->colors);
         SDL_free(mesh->indices);
+        SDL_free(mesh->joint_indices);
+        SDL_free(mesh->joint_weights);
     }
     SDL_free(model->meshes);
 
@@ -34,6 +38,28 @@ void sdl3d_free_model(sdl3d_model *model)
         SDL_free(mat->emissive_map);
     }
     SDL_free(model->materials);
+
+    if (model->skeleton != NULL)
+    {
+        for (int i = 0; i < model->skeleton->joint_count; ++i)
+        {
+            SDL_free(model->skeleton->joints[i].name);
+        }
+        SDL_free(model->skeleton->joints);
+        SDL_free(model->skeleton);
+    }
+
+    for (int i = 0; i < model->animation_count; ++i)
+    {
+        sdl3d_animation_clip *clip = &model->animations[i];
+        SDL_free(clip->name);
+        for (int c = 0; c < clip->channel_count; ++c)
+        {
+            SDL_free(clip->channels[c].keyframes);
+        }
+        SDL_free(clip->channels);
+    }
+    SDL_free(model->animations);
 
     SDL_free(model->source_path);
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -16,6 +16,12 @@ struct sdl3d_actor
     bool visible;
     sdl3d_actor *next;
     sdl3d_actor *prev;
+
+    /* Animation playback state. */
+    int anim_clip;
+    float anim_time;
+    bool anim_playing;
+    bool anim_looping;
 };
 
 struct sdl3d_scene
@@ -83,6 +89,10 @@ sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model)
     actor->tint.b = 255;
     actor->tint.a = 255;
     actor->visible = true;
+    actor->anim_clip = -1;
+    actor->anim_time = 0.0f;
+    actor->anim_playing = false;
+    actor->anim_looping = false;
 
     /* Prepend to linked list. */
     actor->next = scene->first;
@@ -251,4 +261,60 @@ bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
     }
 
     return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Animation state accessors (called from animation.c)                 */
+/* ------------------------------------------------------------------ */
+
+void sdl3d_actor_set_anim_state(sdl3d_actor *actor, int clip, float time, bool playing, bool looping)
+{
+    if (actor == NULL)
+    {
+        return;
+    }
+    actor->anim_clip = clip;
+    actor->anim_time = time;
+    actor->anim_playing = playing;
+    actor->anim_looping = looping;
+}
+
+void sdl3d_actor_get_anim_state(const sdl3d_actor *actor, int *clip, float *time, bool *playing, bool *looping)
+{
+    if (actor == NULL)
+    {
+        if (clip)
+        {
+            *clip = -1;
+        }
+        if (time)
+        {
+            *time = 0.0f;
+        }
+        if (playing)
+        {
+            *playing = false;
+        }
+        if (looping)
+        {
+            *looping = false;
+        }
+        return;
+    }
+    if (clip)
+    {
+        *clip = actor->anim_clip;
+    }
+    if (time)
+    {
+        *time = actor->anim_time;
+    }
+    if (playing)
+    {
+        *playing = actor->anim_playing;
+    }
+    if (looping)
+    {
+        *looping = actor->anim_looping;
+    }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SDL3D_TEST_SOURCES
     test_lighting.cpp
     test_scene.cpp
     test_collision.cpp
+    test_animation.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -162,6 +163,7 @@ else()
     target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
     sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
+    sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -1,0 +1,306 @@
+/*
+ * Tests for M5: skeletal animation — evaluation, quaternion math,
+ * actor playback, skeleton/clip data structures.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+extern "C"
+{
+#include "sdl3d/animation.h"
+#include "sdl3d/math.h"
+#include "sdl3d/scene.h"
+}
+
+/* ================================================================== */
+/* Helpers                                                            */
+/* ================================================================== */
+
+static sdl3d_joint make_joint(const char *name, int parent, float tx, float ty, float tz)
+{
+    sdl3d_joint j{};
+    j.name = nullptr; /* Tests don't own the name string. */
+    j.parent_index = parent;
+    j.inverse_bind_matrix = sdl3d_mat4_identity();
+    j.local_translation[0] = tx;
+    j.local_translation[1] = ty;
+    j.local_translation[2] = tz;
+    j.local_rotation[0] = 0.0f;
+    j.local_rotation[1] = 0.0f;
+    j.local_rotation[2] = 0.0f;
+    j.local_rotation[3] = 1.0f; /* identity quaternion */
+    j.local_scale[0] = 1.0f;
+    j.local_scale[1] = 1.0f;
+    j.local_scale[2] = 1.0f;
+    (void)name;
+    return j;
+}
+
+static sdl3d_keyframe kf(float time, float x, float y, float z, float w)
+{
+    sdl3d_keyframe k{};
+    k.time = time;
+    k.value[0] = x;
+    k.value[1] = y;
+    k.value[2] = z;
+    k.value[3] = w;
+    return k;
+}
+
+/* ================================================================== */
+/* Bind pose evaluation                                               */
+/* ================================================================== */
+
+TEST(SDL3DAnimation, BindPoseSingleJoint)
+{
+    sdl3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    sdl3d_mat4 matrices[1];
+    ASSERT_TRUE(sdl3d_compute_bind_pose(&skel, matrices));
+
+    /* With identity inverse_bind and identity local TRS, result is identity. */
+    for (int i = 0; i < 16; ++i)
+    {
+        float expected = (i % 5 == 0) ? 1.0f : 0.0f;
+        EXPECT_NEAR(matrices[0].m[i], expected, 1e-5f) << "m[" << i << "]";
+    }
+}
+
+TEST(SDL3DAnimation, BindPoseParentChild)
+{
+    sdl3d_joint joints[2] = {
+        make_joint("root", -1, 0, 1, 0),
+        make_joint("child", 0, 0, 2, 0),
+    };
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 2;
+
+    sdl3d_mat4 matrices[2];
+    ASSERT_TRUE(sdl3d_compute_bind_pose(&skel, matrices));
+
+    /* Root at y=1, child at y=1+2=3 (parent chain). */
+    EXPECT_NEAR(matrices[0].m[13], 1.0f, 1e-5f);
+    EXPECT_NEAR(matrices[1].m[13], 3.0f, 1e-5f);
+}
+
+TEST(SDL3DAnimation, BindPoseNullRejected)
+{
+    sdl3d_mat4 m;
+    EXPECT_FALSE(sdl3d_compute_bind_pose(nullptr, &m));
+    sdl3d_skeleton skel{};
+    EXPECT_FALSE(sdl3d_compute_bind_pose(&skel, nullptr));
+}
+
+/* ================================================================== */
+/* Animation evaluation                                               */
+/* ================================================================== */
+
+TEST(SDL3DAnimation, TranslationKeyframes)
+{
+    sdl3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    sdl3d_keyframe keyframes[2] = {kf(0.0f, 0, 0, 0, 0), kf(1.0f, 10, 0, 0, 0)};
+    sdl3d_anim_channel ch{};
+    ch.joint_index = 0;
+    ch.path = SDL3D_ANIM_TRANSLATION;
+    ch.keyframes = keyframes;
+    ch.keyframe_count = 2;
+
+    sdl3d_animation_clip clip{};
+    clip.duration = 1.0f;
+    clip.channels = &ch;
+    clip.channel_count = 1;
+
+    sdl3d_mat4 matrices[1];
+
+    /* At t=0: translation = (0,0,0). */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 0.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[12], 0.0f, 1e-5f);
+
+    /* At t=0.5: translation = (5,0,0). */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 0.5f, matrices));
+    EXPECT_NEAR(matrices[0].m[12], 5.0f, 1e-5f);
+
+    /* At t=1.0: translation = (10,0,0). */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 1.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[12], 10.0f, 1e-5f);
+}
+
+TEST(SDL3DAnimation, RotationKeyframesSlerp)
+{
+    sdl3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    /* Rotate 90 degrees around Y: quat (0, sin(45°), 0, cos(45°)). */
+    float s45 = sinf(3.14159265f / 4.0f);
+    float c45 = cosf(3.14159265f / 4.0f);
+    sdl3d_keyframe keyframes[2] = {kf(0.0f, 0, 0, 0, 1), kf(1.0f, 0, s45, 0, c45)};
+    sdl3d_anim_channel ch{};
+    ch.joint_index = 0;
+    ch.path = SDL3D_ANIM_ROTATION;
+    ch.keyframes = keyframes;
+    ch.keyframe_count = 2;
+
+    sdl3d_animation_clip clip{};
+    clip.duration = 1.0f;
+    clip.channels = &ch;
+    clip.channel_count = 1;
+
+    sdl3d_mat4 matrices[1];
+
+    /* At t=0: identity rotation. */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 0.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[0], 1.0f, 1e-4f);
+
+    /* At t=1: 90° around Y. m[0] should be ~0 (cos90), m[8] should be ~1 (sin90). */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 1.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[0], 0.0f, 0.01f);
+}
+
+TEST(SDL3DAnimation, ScaleKeyframes)
+{
+    sdl3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    sdl3d_keyframe keyframes[2] = {kf(0.0f, 1, 1, 1, 0), kf(1.0f, 2, 2, 2, 0)};
+    sdl3d_anim_channel ch{};
+    ch.joint_index = 0;
+    ch.path = SDL3D_ANIM_SCALE;
+    ch.keyframes = keyframes;
+    ch.keyframe_count = 2;
+
+    sdl3d_animation_clip clip{};
+    clip.duration = 1.0f;
+    clip.channels = &ch;
+    clip.channel_count = 1;
+
+    sdl3d_mat4 matrices[1];
+
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 0.5f, matrices));
+    /* Scale 1.5 at midpoint. m[0] = sx, m[5] = sy, m[10] = sz. */
+    EXPECT_NEAR(matrices[0].m[0], 1.5f, 1e-4f);
+    EXPECT_NEAR(matrices[0].m[5], 1.5f, 1e-4f);
+    EXPECT_NEAR(matrices[0].m[10], 1.5f, 1e-4f);
+}
+
+TEST(SDL3DAnimation, ClampsBeyondDuration)
+{
+    sdl3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    sdl3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    sdl3d_keyframe keyframes[2] = {kf(0.0f, 0, 0, 0, 0), kf(1.0f, 10, 0, 0, 0)};
+    sdl3d_anim_channel ch{};
+    ch.joint_index = 0;
+    ch.path = SDL3D_ANIM_TRANSLATION;
+    ch.keyframes = keyframes;
+    ch.keyframe_count = 2;
+
+    sdl3d_animation_clip clip{};
+    clip.duration = 1.0f;
+    clip.channels = &ch;
+    clip.channel_count = 1;
+
+    sdl3d_mat4 matrices[1];
+
+    /* Beyond duration: clamps to last keyframe. */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, 5.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[12], 10.0f, 1e-5f);
+
+    /* Before start: clamps to first keyframe. */
+    ASSERT_TRUE(sdl3d_evaluate_animation(&skel, &clip, -1.0f, matrices));
+    EXPECT_NEAR(matrices[0].m[12], 0.0f, 1e-5f);
+}
+
+/* ================================================================== */
+/* Actor animation playback                                           */
+/* ================================================================== */
+
+TEST(SDL3DActorAnimation, PlayAndStop)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    EXPECT_FALSE(sdl3d_actor_is_animation_playing(actor));
+    EXPECT_EQ(sdl3d_actor_get_animation_clip(actor), -1);
+
+    ASSERT_TRUE(sdl3d_actor_play_animation(actor, 0, true));
+    EXPECT_TRUE(sdl3d_actor_is_animation_playing(actor));
+    EXPECT_EQ(sdl3d_actor_get_animation_clip(actor), 0);
+    EXPECT_FLOAT_EQ(sdl3d_actor_get_animation_time(actor), 0.0f);
+
+    ASSERT_TRUE(sdl3d_actor_stop_animation(actor));
+    EXPECT_FALSE(sdl3d_actor_is_animation_playing(actor));
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActorAnimation, AdvanceTime)
+{
+    sdl3d_animation_clip clip{};
+    clip.duration = 2.0f;
+
+    sdl3d_model model{};
+    model.animations = &clip;
+    model.animation_count = 1;
+
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_actor_play_animation(actor, 0, false);
+    sdl3d_actor_advance_animation(actor, 0.5f);
+    EXPECT_NEAR(sdl3d_actor_get_animation_time(actor), 0.5f, 1e-5f);
+    EXPECT_TRUE(sdl3d_actor_is_animation_playing(actor));
+
+    /* Advance past duration — should stop (non-looping). */
+    sdl3d_actor_advance_animation(actor, 2.0f);
+    EXPECT_FALSE(sdl3d_actor_is_animation_playing(actor));
+    EXPECT_NEAR(sdl3d_actor_get_animation_time(actor), 2.0f, 1e-5f);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActorAnimation, LoopWraps)
+{
+    sdl3d_animation_clip clip{};
+    clip.duration = 1.0f;
+
+    sdl3d_model model{};
+    model.animations = &clip;
+    model.animation_count = 1;
+
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_actor_play_animation(actor, 0, true);
+    sdl3d_actor_advance_animation(actor, 1.5f);
+    EXPECT_TRUE(sdl3d_actor_is_animation_playing(actor));
+    EXPECT_NEAR(sdl3d_actor_get_animation_time(actor), 0.5f, 1e-5f);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActorAnimation, NullActorSafe)
+{
+    EXPECT_FALSE(sdl3d_actor_play_animation(nullptr, 0, false));
+    EXPECT_FALSE(sdl3d_actor_stop_animation(nullptr));
+    EXPECT_FALSE(sdl3d_actor_advance_animation(nullptr, 1.0f));
+    EXPECT_FALSE(sdl3d_actor_is_animation_playing(nullptr));
+    EXPECT_EQ(sdl3d_actor_get_animation_clip(nullptr), -1);
+    EXPECT_FLOAT_EQ(sdl3d_actor_get_animation_time(nullptr), 0.0f);
+}


### PR DESCRIPTION
## Summary

Implements M5 (Animation) from the roadmap in #4. This PR adds the animation data types, runtime joint evaluation, and actor playback API. Loader integration (extracting skeleton/animation data from glTF/FBX) and vertex skinning in the draw path are follow-up work.

### Data types

- `sdl3d_joint`: name, parent index, inverse bind matrix, local TRS (quaternion rotation)
- `sdl3d_skeleton`: joint array with parent-child hierarchy
- `sdl3d_keyframe`: time + value (3 for translation/scale, 4 for rotation quaternion)
- `sdl3d_anim_channel`: joint index, path (translation/rotation/scale), keyframe array
- `sdl3d_animation_clip`: name, duration, channel array
- `sdl3d_mesh`: added `joint_indices` + `joint_weights` (4 per vertex) for skinning
- `sdl3d_model`: added `skeleton` pointer + `animations` array

### Runtime evaluation

- Quaternion slerp with shortest-path correction and near-identity linear fallback
- TRS-to-matrix construction from quaternion rotation
- Per-channel keyframe sampling with linear interpolation (translation/scale) and slerp (rotation)
- Joint hierarchy traversal: local TRS → world matrices in parent-first order
- Final skinning matrices: world × inverse_bind_matrix
- `sdl3d_compute_bind_pose` for identity pose

### Actor playback

- `sdl3d_actor_play_animation(actor, clip_index, loop)`
- `sdl3d_actor_stop_animation` / `advance` / `is_playing` / `get_clip` / `get_time`
- Looping wraps via fmod, non-looping clamps at duration and stops
- Caller drives timing: call `advance_animation(actor, dt)` with their own delta time

### Testing

11 new unit tests (246 total): bind pose evaluation (single joint, parent-child, null rejection), translation/rotation/scale keyframe interpolation at multiple time points, clamp beyond duration, actor play/stop/advance/loop wrap, null actor safety.

### What's next for M5

- Update glTF loader to extract joints, weights, skeleton, animations from cgltf
- Update FBX loader to extract joints, weights, skeleton, animations from ufbx
- Implement vertex skinning in draw_mesh_internal (transform positions/normals by joint matrices)

Refs #4