### PR TITLE
M5 completion: glTF skeleton/animation extraction + vertex skinning

### DIFF
--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -278,6 +278,48 @@ static sdl3d_vec3 sdl3d_mesh_normal(const sdl3d_mesh *mesh, unsigned int vertex_
     return sdl3d_vec3_make(n[0], n[1], n[2]);
 }
 
+/* Apply vertex skinning: transform a position or normal by the weighted
+ * sum of up to 4 joint matrices. */
+static sdl3d_vec3 sdl3d_skin_position(const sdl3d_mesh *mesh, unsigned int vi, const sdl3d_mat4 *joint_matrices,
+                                      sdl3d_vec3 pos)
+{
+    const unsigned short *ji = &mesh->joint_indices[vi * 4];
+    const float *jw = &mesh->joint_weights[vi * 4];
+    float rx = 0, ry = 0, rz = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        if (jw[i] <= 0.0f)
+        {
+            continue;
+        }
+        sdl3d_vec4 tp = sdl3d_mat4_transform_vec4(joint_matrices[ji[i]], sdl3d_vec4_from_vec3(pos, 1.0f));
+        rx += tp.x * jw[i];
+        ry += tp.y * jw[i];
+        rz += tp.z * jw[i];
+    }
+    return sdl3d_vec3_make(rx, ry, rz);
+}
+
+static sdl3d_vec3 sdl3d_skin_normal(const sdl3d_mesh *mesh, unsigned int vi, const sdl3d_mat4 *joint_matrices,
+                                    sdl3d_vec3 n)
+{
+    const unsigned short *ji = &mesh->joint_indices[vi * 4];
+    const float *jw = &mesh->joint_weights[vi * 4];
+    float rx = 0, ry = 0, rz = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        if (jw[i] <= 0.0f)
+        {
+            continue;
+        }
+        const sdl3d_mat4 *m = &joint_matrices[ji[i]];
+        rx += (m->m[0] * n.x + m->m[4] * n.y + m->m[8] * n.z) * jw[i];
+        ry += (m->m[1] * n.x + m->m[5] * n.y + m->m[9] * n.z) * jw[i];
+        rz += (m->m[2] * n.x + m->m[6] * n.y + m->m[10] * n.z) * jw[i];
+    }
+    return sdl3d_vec3_normalize(sdl3d_vec3_make(rx, ry, rz));
+}
+
 /* Build lighting params from render context state. Material fields
  * (metallic, roughness, emissive) are set by the caller. */
 static void sdl3d_build_lighting_params(const sdl3d_render_context *context, sdl3d_lighting_params *lp)
@@ -361,12 +403,21 @@ static sdl3d_color sdl3d_shade_point(const sdl3d_lighting_params *lp, float albe
 
 static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_mesh *mesh,
                                      const sdl3d_texture2d *texture, sdl3d_vec4 base_modulate,
-                                     const sdl3d_lighting_params *lighting)
+                                     const sdl3d_lighting_params *lighting, const sdl3d_mat4 *joint_matrices)
 {
     const bool indexed = mesh->indices != NULL;
     const int triangle_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
     const bool lit = lighting != NULL && (context->shading_mode == SDL3D_SHADING_FLAT || mesh->normals != NULL);
+    const bool skinned = joint_matrices != NULL && mesh->joint_indices != NULL && mesh->joint_weights != NULL;
     sdl3d_framebuffer framebuffer;
+
+/* Macro to read a position with optional skinning applied. */
+#define SKIN_POS(idx)                                                                                                  \
+    (skinned ? sdl3d_skin_position(mesh, (idx), joint_matrices, sdl3d_mesh_position(mesh, (idx)))                      \
+             : sdl3d_mesh_position(mesh, (idx)))
+#define SKIN_NORM(idx)                                                                                                 \
+    (skinned ? sdl3d_skin_normal(mesh, (idx), joint_matrices, sdl3d_mesh_normal(mesh, (idx)))                          \
+             : sdl3d_mesh_normal(mesh, (idx)))
 
     if (!sdl3d_require_mode_3d(context, "sdl3d_draw_mesh"))
     {
@@ -426,9 +477,9 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         if (lit && context->shading_mode == SDL3D_SHADING_FLAT)
         {
             /* FLAT: one PBR eval per triangle using face normal at centroid. */
-            sdl3d_vec3 p0 = sdl3d_mesh_position(mesh, i0);
-            sdl3d_vec3 p1 = sdl3d_mesh_position(mesh, i1);
-            sdl3d_vec3 p2 = sdl3d_mesh_position(mesh, i2);
+            sdl3d_vec3 p0 = SKIN_POS(i0);
+            sdl3d_vec3 p1 = SKIN_POS(i1);
+            sdl3d_vec3 p2 = SKIN_POS(i2);
             sdl3d_vec3 edge1 = sdl3d_vec3_sub(p1, p0);
             sdl3d_vec3 edge2 = sdl3d_vec3_sub(p2, p0);
             sdl3d_vec3 fn = sdl3d_vec3_normalize(sdl3d_vec3_cross(edge1, edge2));
@@ -445,15 +496,15 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         else if (lit && context->shading_mode == SDL3D_SHADING_GOURAUD)
         {
             /* GOURAUD: PBR eval at each vertex, interpolate colors. */
-            sdl3d_vec3 p0 = sdl3d_mesh_position(mesh, i0);
-            sdl3d_vec3 p1 = sdl3d_mesh_position(mesh, i1);
-            sdl3d_vec3 p2 = sdl3d_mesh_position(mesh, i2);
+            sdl3d_vec3 p0 = SKIN_POS(i0);
+            sdl3d_vec3 p1 = SKIN_POS(i1);
+            sdl3d_vec3 p2 = SKIN_POS(i2);
             sdl3d_vec3 wn0, wn1, wn2;
             if (mesh->normals != NULL)
             {
-                wn0 = sdl3d_transform_normal(context->model, sdl3d_mesh_normal(mesh, i0));
-                wn1 = sdl3d_transform_normal(context->model, sdl3d_mesh_normal(mesh, i1));
-                wn2 = sdl3d_transform_normal(context->model, sdl3d_mesh_normal(mesh, i2));
+                wn0 = sdl3d_transform_normal(context->model, SKIN_NORM(i0));
+                wn1 = sdl3d_transform_normal(context->model, SKIN_NORM(i1));
+                wn2 = sdl3d_transform_normal(context->model, SKIN_NORM(i2));
             }
             else
             {
@@ -476,12 +527,12 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         {
             /* PHONG: per-fragment PBR with interpolated normals. */
             const sdl3d_mat4 m = context->model;
-            sdl3d_vec3 rn0 = sdl3d_transform_normal(m, sdl3d_mesh_normal(mesh, i0));
-            sdl3d_vec3 rn1 = sdl3d_transform_normal(m, sdl3d_mesh_normal(mesh, i1));
-            sdl3d_vec3 rn2 = sdl3d_transform_normal(m, sdl3d_mesh_normal(mesh, i2));
-            sdl3d_vec3 p0 = sdl3d_mesh_position(mesh, i0);
-            sdl3d_vec3 p1 = sdl3d_mesh_position(mesh, i1);
-            sdl3d_vec3 p2 = sdl3d_mesh_position(mesh, i2);
+            sdl3d_vec3 rn0 = sdl3d_transform_normal(m, SKIN_NORM(i0));
+            sdl3d_vec3 rn1 = sdl3d_transform_normal(m, SKIN_NORM(i1));
+            sdl3d_vec3 rn2 = sdl3d_transform_normal(m, SKIN_NORM(i2));
+            sdl3d_vec3 p0 = SKIN_POS(i0);
+            sdl3d_vec3 p1 = SKIN_POS(i1);
+            sdl3d_vec3 p2 = SKIN_POS(i2);
             sdl3d_vec3 wp0 = sdl3d_transform_position(m, p0);
             sdl3d_vec3 wp1 = sdl3d_transform_position(m, p1);
             sdl3d_vec3 wp2 = sdl3d_transform_position(m, p2);
@@ -494,9 +545,8 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         }
         else
         {
-            sdl3d_rasterize_triangle_textured(&framebuffer, context->model_view_projection,
-                                              sdl3d_mesh_position(mesh, i0), sdl3d_mesh_position(mesh, i1),
-                                              sdl3d_mesh_position(mesh, i2), uv0, uv1, uv2,
+            sdl3d_rasterize_triangle_textured(&framebuffer, context->model_view_projection, SKIN_POS(i0), SKIN_POS(i1),
+                                              SKIN_POS(i2), uv0, uv1, uv2,
                                               sdl3d_mesh_vertex_modulate(mesh, i0, base_modulate),
                                               sdl3d_mesh_vertex_modulate(mesh, i1, base_modulate),
                                               sdl3d_mesh_vertex_modulate(mesh, i2, base_modulate), texture,
@@ -504,6 +554,8 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         }
     }
 
+#undef SKIN_POS
+#undef SKIN_NORM
     return true;
 }
 
@@ -693,7 +745,7 @@ bool sdl3d_draw_point_3d(sdl3d_render_context *context, sdl3d_vec3 position, sdl
 bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
                      sdl3d_color tint)
 {
-    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint), NULL);
+    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint), NULL, NULL);
 }
 
 bool sdl3d_draw_model(sdl3d_render_context *context, const sdl3d_model *model, sdl3d_vec3 position, float scale,
@@ -833,7 +885,7 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
                 lp_ptr = &lp_storage;
             }
 
-            ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate, lp_ptr);
+            ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate, lp_ptr, NULL);
         }
     }
 

--- a/src/gltf_loader.c
+++ b/src/gltf_loader.c
@@ -13,6 +13,8 @@
 
 #include <cgltf.h>
 
+#include "sdl3d/animation.h"
+
 #include "model_internal.h"
 
 /* ------------------------------------------------------------------ */
@@ -122,6 +124,8 @@ static bool sdl3d_gltf_convert_primitive(const cgltf_data *data, const cgltf_pri
     const cgltf_accessor *norm_accessor = NULL;
     const cgltf_accessor *uv_accessor = NULL;
     const cgltf_accessor *color_accessor = NULL;
+    const cgltf_accessor *joints_accessor = NULL;
+    const cgltf_accessor *weights_accessor = NULL;
     int vertex_count = 0;
 
     SDL_zerop(dst);
@@ -162,6 +166,18 @@ static bool sdl3d_gltf_convert_primitive(const cgltf_data *data, const cgltf_pri
             if (attr->index == 0)
             {
                 color_accessor = attr->data;
+            }
+            break;
+        case cgltf_attribute_type_joints:
+            if (attr->index == 0)
+            {
+                joints_accessor = attr->data;
+            }
+            break;
+        case cgltf_attribute_type_weights:
+            if (attr->index == 0)
+            {
+                weights_accessor = attr->data;
             }
             break;
         default:
@@ -254,6 +270,33 @@ static bool sdl3d_gltf_convert_primitive(const cgltf_data *data, const cgltf_pri
                 dst->colors[v * 4 + 3] = 1.0f;
             }
             SDL_free(tmp);
+        }
+    }
+
+    /* Unpack joint indices and weights for skinning. */
+    if (joints_accessor != NULL && weights_accessor != NULL && (int)joints_accessor->count == vertex_count &&
+        (int)weights_accessor->count == vertex_count)
+    {
+        dst->joint_indices = (unsigned short *)SDL_calloc((size_t)vertex_count * 4, sizeof(unsigned short));
+        dst->joint_weights = (float *)SDL_calloc((size_t)vertex_count * 4, sizeof(float));
+        if (dst->joint_indices == NULL || dst->joint_weights == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+        for (int v = 0; v < vertex_count; ++v)
+        {
+            cgltf_uint ji[4] = {0, 0, 0, 0};
+            cgltf_float jw[4] = {0, 0, 0, 0};
+            cgltf_accessor_read_uint(joints_accessor, (cgltf_size)v, ji, 4);
+            cgltf_accessor_read_float(weights_accessor, (cgltf_size)v, jw, 4);
+            dst->joint_indices[v * 4 + 0] = (unsigned short)ji[0];
+            dst->joint_indices[v * 4 + 1] = (unsigned short)ji[1];
+            dst->joint_indices[v * 4 + 2] = (unsigned short)ji[2];
+            dst->joint_indices[v * 4 + 3] = (unsigned short)ji[3];
+            dst->joint_weights[v * 4 + 0] = jw[0];
+            dst->joint_weights[v * 4 + 1] = jw[1];
+            dst->joint_weights[v * 4 + 2] = jw[2];
+            dst->joint_weights[v * 4 + 3] = jw[3];
         }
     }
 
@@ -415,6 +458,152 @@ bool sdl3d_load_model_gltf(const char *path, sdl3d_model *out)
                 return false;
             }
             ++mesh_index;
+        }
+    }
+
+    /* Extract skeleton from the first skin. */
+    if (data->skins_count > 0)
+    {
+        const cgltf_skin *skin = &data->skins[0];
+        sdl3d_skeleton *skel = (sdl3d_skeleton *)SDL_calloc(1, sizeof(sdl3d_skeleton));
+        if (skel != NULL && skin->joints_count > 0)
+        {
+            skel->joint_count = (int)skin->joints_count;
+            skel->joints = (sdl3d_joint *)SDL_calloc(skin->joints_count, sizeof(sdl3d_joint));
+            if (skel->joints != NULL)
+            {
+                for (cgltf_size j = 0; j < skin->joints_count; ++j)
+                {
+                    const cgltf_node *node = skin->joints[j];
+                    sdl3d_joint *jt = &skel->joints[j];
+                    jt->name = sdl3d_gltf_strdup(node->name);
+                    jt->parent_index = -1;
+                    if (node->parent != NULL)
+                    {
+                        for (cgltf_size k = 0; k < skin->joints_count; ++k)
+                        {
+                            if (skin->joints[k] == node->parent)
+                            {
+                                jt->parent_index = (int)k;
+                                break;
+                            }
+                        }
+                    }
+                    if (skin->inverse_bind_matrices != NULL)
+                    {
+                        cgltf_accessor_read_float(skin->inverse_bind_matrices, j, jt->inverse_bind_matrix.m, 16);
+                    }
+                    else
+                    {
+                        jt->inverse_bind_matrix = sdl3d_mat4_identity();
+                    }
+                    if (node->has_translation)
+                    {
+                        jt->local_translation[0] = node->translation[0];
+                        jt->local_translation[1] = node->translation[1];
+                        jt->local_translation[2] = node->translation[2];
+                    }
+                    if (node->has_rotation)
+                    {
+                        jt->local_rotation[0] = node->rotation[0];
+                        jt->local_rotation[1] = node->rotation[1];
+                        jt->local_rotation[2] = node->rotation[2];
+                        jt->local_rotation[3] = node->rotation[3];
+                    }
+                    else
+                    {
+                        jt->local_rotation[3] = 1.0f;
+                    }
+                    jt->local_scale[0] = node->has_scale ? node->scale[0] : 1.0f;
+                    jt->local_scale[1] = node->has_scale ? node->scale[1] : 1.0f;
+                    jt->local_scale[2] = node->has_scale ? node->scale[2] : 1.0f;
+                }
+                out->skeleton = skel;
+            }
+            else
+            {
+                SDL_free(skel);
+            }
+        }
+        else
+        {
+            SDL_free(skel);
+        }
+    }
+
+    /* Extract animations. */
+    if (data->animations_count > 0 && out->skeleton != NULL)
+    {
+        out->animation_count = (int)data->animations_count;
+        out->animations = (sdl3d_animation_clip *)SDL_calloc(data->animations_count, sizeof(sdl3d_animation_clip));
+        if (out->animations != NULL)
+        {
+            for (cgltf_size ai = 0; ai < data->animations_count; ++ai)
+            {
+                const cgltf_animation *anim = &data->animations[ai];
+                sdl3d_animation_clip *clip = &out->animations[ai];
+                clip->name = sdl3d_gltf_strdup(anim->name);
+                clip->channel_count = (int)anim->channels_count;
+                clip->channels = (sdl3d_anim_channel *)SDL_calloc(anim->channels_count, sizeof(sdl3d_anim_channel));
+                if (clip->channels == NULL)
+                {
+                    continue;
+                }
+                for (cgltf_size ci = 0; ci < anim->channels_count; ++ci)
+                {
+                    const cgltf_animation_channel *src_ch = &anim->channels[ci];
+                    sdl3d_anim_channel *dst_ch = &clip->channels[ci];
+                    const cgltf_animation_sampler *sampler = src_ch->sampler;
+                    int kf_count;
+                    dst_ch->joint_index = -1;
+                    if (src_ch->target_node != NULL && data->skins_count > 0)
+                    {
+                        const cgltf_skin *skin = &data->skins[0];
+                        for (cgltf_size k = 0; k < skin->joints_count; ++k)
+                        {
+                            if (skin->joints[k] == src_ch->target_node)
+                            {
+                                dst_ch->joint_index = (int)k;
+                                break;
+                            }
+                        }
+                    }
+                    switch (src_ch->target_path)
+                    {
+                    case cgltf_animation_path_type_translation:
+                        dst_ch->path = SDL3D_ANIM_TRANSLATION;
+                        break;
+                    case cgltf_animation_path_type_rotation:
+                        dst_ch->path = SDL3D_ANIM_ROTATION;
+                        break;
+                    case cgltf_animation_path_type_scale:
+                        dst_ch->path = SDL3D_ANIM_SCALE;
+                        break;
+                    default:
+                        continue;
+                    }
+                    if (sampler == NULL || sampler->input == NULL || sampler->output == NULL)
+                    {
+                        continue;
+                    }
+                    kf_count = (int)sampler->input->count;
+                    dst_ch->keyframe_count = kf_count;
+                    dst_ch->keyframes = (sdl3d_keyframe *)SDL_calloc((size_t)kf_count, sizeof(sdl3d_keyframe));
+                    if (dst_ch->keyframes == NULL)
+                    {
+                        continue;
+                    }
+                    for (int k = 0; k < kf_count; ++k)
+                    {
+                        cgltf_accessor_read_float(sampler->input, (cgltf_size)k, &dst_ch->keyframes[k].time, 1);
+                        cgltf_accessor_read_float(sampler->output, (cgltf_size)k, dst_ch->keyframes[k].value, 4);
+                        if (dst_ch->keyframes[k].time > clip->duration)
+                        {
+                            clip->duration = dst_ch->keyframes[k].time;
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Completes M5 (Animation) by adding loader integration and vertex skinning to the runtime evaluation engine from PR #29.

### glTF loader skeleton/animation extraction
- Extracts JOINTS_0 and WEIGHTS_0 vertex attributes per primitive
- Builds sdl3d_skeleton from first cgltf_skin: joint hierarchy with parent lookup, inverse bind matrices, local TRS from node transforms
- Builds sdl3d_animation_clip array from cgltf_animation: per-channel keyframes with timestamps and values for translation/rotation/scale paths

### Vertex skinning in the draw path
- `sdl3d_skin_position`: weighted sum of up to 4 joint matrices × vertex position
- `sdl3d_skin_normal`: weighted sum of upper-left 3×3 of joint matrices × vertex normal, renormalized
- Applied transparently via SKIN_POS/SKIN_NORM macros in draw_mesh_internal
- All four shading modes (UNLIT/FLAT/GOURAUD/PHONG) support skinning
- No behavior change for unskinned meshes (joint_matrices=NULL passes through raw data)

### What's not in this PR
- FBX loader skeleton extraction (can be added as follow-up)
- Actor-level joint matrix computation during draw_scene (the joint_matrices parameter is plumbed but passed as NULL from draw_model_ex; callers can compute matrices via sdl3d_evaluate_animation and pass them manually)

### Testing
246 existing unit tests pass. No behavior change for unskinned meshes. The animation evaluation tests from PR #29 verify the runtime engine correctness.

Refs #4