### PR TITLE
Cleanup pass: fix bugs, stale comments, consistency

### DIFF
--- a/include/sdl3d/model.h
+++ b/include/sdl3d/model.h
@@ -103,8 +103,8 @@ extern "C"
     /*
      * Dispatching entry point. Picks a loader by file extension:
      *   .obj            -> in-house OBJ + MTL parser
-     *   .gltf / .glb    -> cgltf (reserved; returns error until M3 slice)
-     *   .fbx            -> ufbx (reserved; returns error until M3 slice)
+     *   .gltf / .glb    -> cgltf
+     *   .fbx            -> ufbx
      *
      * Returns false with SDL_GetError populated on any failure.
      */

--- a/include/sdl3d/types.h
+++ b/include/sdl3d/types.h
@@ -3,64 +3,73 @@
 
 #include <SDL3/SDL_stdinc.h>
 
-typedef struct sdl3d_vec2
+#ifdef __cplusplus
+extern "C"
 {
-    float x;
-    float y;
-} sdl3d_vec2;
+#endif
 
-typedef struct sdl3d_vec3
-{
-    float x;
-    float y;
-    float z;
-} sdl3d_vec3;
+    typedef struct sdl3d_vec2
+    {
+        float x;
+        float y;
+    } sdl3d_vec2;
 
-typedef struct sdl3d_vec4
-{
-    float x;
-    float y;
-    float z;
-    float w;
-} sdl3d_vec4;
+    typedef struct sdl3d_vec3
+    {
+        float x;
+        float y;
+        float z;
+    } sdl3d_vec3;
 
-typedef struct sdl3d_color
-{
-    Uint8 r;
-    Uint8 g;
-    Uint8 b;
-    Uint8 a;
-} sdl3d_color;
+    typedef struct sdl3d_vec4
+    {
+        float x;
+        float y;
+        float z;
+        float w;
+    } sdl3d_vec4;
 
-/*
- * Column-major storage. m[0..3] is column 0 (the first basis vector).
- * Translation components live in m[12], m[13], m[14]. A matrix-vector
- * multiply treats the vector as a column: out = M * v.
- */
-typedef struct sdl3d_mat4
-{
-    float m[16];
-} sdl3d_mat4;
+    typedef struct sdl3d_color
+    {
+        Uint8 r;
+        Uint8 g;
+        Uint8 b;
+        Uint8 a;
+    } sdl3d_color;
 
-/*
- * Ray defined by an origin and a direction. The direction is drawn at
- * the magnitude the caller supplies; it is not normalized.
- */
-typedef struct sdl3d_ray
-{
-    sdl3d_vec3 position;
-    sdl3d_vec3 direction;
-} sdl3d_ray;
+    /*
+     * Column-major storage. m[0..3] is column 0 (the first basis vector).
+     * Translation components live in m[12], m[13], m[14]. A matrix-vector
+     * multiply treats the vector as a column: out = M * v.
+     */
+    typedef struct sdl3d_mat4
+    {
+        float m[16];
+    } sdl3d_mat4;
 
-/*
- * Axis-aligned bounding box in the coordinate frame where it is drawn.
- * The current model matrix is applied, so an AABB in local space can be
- * rendered in any world orientation.
- */
-typedef struct sdl3d_bounding_box
-{
-    sdl3d_vec3 min;
-    sdl3d_vec3 max;
-} sdl3d_bounding_box;
+    /*
+     * Ray defined by an origin and a direction. The direction is drawn at
+     * the magnitude the caller supplies; it is not normalized.
+     */
+    typedef struct sdl3d_ray
+    {
+        sdl3d_vec3 position;
+        sdl3d_vec3 direction;
+    } sdl3d_ray;
+
+    /*
+     * Axis-aligned bounding box in the coordinate frame where it is drawn.
+     * The current model matrix is applied, so an AABB in local space can be
+     * rendered in any world orientation.
+     */
+    typedef struct sdl3d_bounding_box
+    {
+        sdl3d_vec3 min;
+        sdl3d_vec3 max;
+    } sdl3d_bounding_box;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/animation.c
+++ b/src/animation.c
@@ -8,15 +8,13 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
 
-#include <math.h>
-
 /* ------------------------------------------------------------------ */
 /* Quaternion helpers                                                   */
 /* ------------------------------------------------------------------ */
 
 static void sdl3d_quat_normalize(float *q)
 {
-    float len = sqrtf(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+    float len = SDL_sqrtf(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
     if (len > 1e-7f)
     {
         float inv = 1.0f / len;
@@ -61,10 +59,10 @@ static void sdl3d_quat_slerp(const float *a, const float *b, float t, float *out
         return;
     }
 
-    theta = acosf(dot);
-    sin_theta = sinf(theta);
-    wa = sinf((1.0f - t) * theta) / sin_theta;
-    wb = sinf(t * theta) / sin_theta;
+    theta = SDL_acosf(dot);
+    sin_theta = SDL_sinf(theta);
+    wa = SDL_sinf((1.0f - t) * theta) / sin_theta;
+    wb = SDL_sinf(t * theta) / sin_theta;
     out[0] = wa * a[0] + wb * nb[0];
     out[1] = wa * a[1] + wb * nb[1];
     out[2] = wa * a[2] + wb * nb[2];
@@ -329,7 +327,7 @@ bool sdl3d_actor_advance_animation(sdl3d_actor *actor, float delta_time)
             float dur = model->animations[clip].duration;
             if (dur > 0.0f)
             {
-                time = fmodf(time, dur);
+                time = SDL_fmodf(time, dur);
             }
             else
             {

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -875,25 +875,7 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
 
             if (context->shading_mode != SDL3D_SHADING_UNLIT && context->light_count > 0)
             {
-                lp_storage.lights = context->lights;
-                lp_storage.light_count = context->light_count;
-                lp_storage.ambient[0] = context->ambient[0];
-                lp_storage.ambient[1] = context->ambient[1];
-                lp_storage.ambient[2] = context->ambient[2];
-
-                /* Camera position: extract from the inverse of the view matrix.
-                 * For a look-at view matrix, the camera position is the negated
-                 * translation of the transpose of the upper-left 3x3 applied to
-                 * the translation column. Simpler: we stored it during begin_mode_3d
-                 * — but we didn't. Instead, recover from view matrix: the camera
-                 * world position is -(R^T * t) where R is upper-left 3x3 and t is
-                 * column 3. */
-                {
-                    const sdl3d_mat4 v = context->view;
-                    lp_storage.camera_pos.x = -(v.m[0] * v.m[12] + v.m[1] * v.m[13] + v.m[2] * v.m[14]);
-                    lp_storage.camera_pos.y = -(v.m[4] * v.m[12] + v.m[5] * v.m[13] + v.m[6] * v.m[14]);
-                    lp_storage.camera_pos.z = -(v.m[8] * v.m[12] + v.m[9] * v.m[13] + v.m[10] * v.m[14]);
-                }
+                sdl3d_build_lighting_params(context, &lp_storage);
 
                 if (material != NULL)
                 {
@@ -905,22 +887,7 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
                 }
                 else
                 {
-                    lp_storage.metallic = 0.0f;
                     lp_storage.roughness = 1.0f;
-                    lp_storage.emissive[0] = 0.0f;
-                    lp_storage.emissive[1] = 0.0f;
-                    lp_storage.emissive[2] = 0.0f;
-                }
-
-                /* Fog, tonemapping, shadows. */
-                lp_storage.fog = context->fog;
-                lp_storage.tonemap_mode = context->tonemap_mode;
-                lp_storage.shadow_bias = context->shadow_bias;
-                for (int si = 0; si < SDL3D_MAX_LIGHTS; ++si)
-                {
-                    lp_storage.shadow_depth[si] = context->shadow_depth[si];
-                    lp_storage.shadow_vp[si] = context->shadow_vp[si];
-                    lp_storage.shadow_enabled[si] = context->shadow_enabled[si];
                 }
 
                 lp_ptr = &lp_storage;
@@ -985,8 +952,21 @@ bool sdl3d_draw_model_skinned(sdl3d_render_context *context, const sdl3d_model *
         const sdl3d_material *material = NULL;
         sdl3d_vec4 mesh_modulate = tint_modulate;
 
-        if (mesh->material_index >= 0 && mesh->material_index < model->material_count && model->materials != NULL)
+        if (mesh->material_index < -1)
         {
+            ok = SDL_SetError("Mesh material index %d is invalid.", mesh->material_index);
+            break;
+        }
+
+        if (mesh->material_index >= 0)
+        {
+            if (mesh->material_index >= model->material_count || model->materials == NULL)
+            {
+                ok = SDL_SetError("Mesh material index %d is outside material_count=%d.", mesh->material_index,
+                                  model->material_count);
+                break;
+            }
+
             material = &model->materials[mesh->material_index];
             mesh_modulate.x = sdl3d_clamp01(mesh_modulate.x * material->albedo[0]);
             mesh_modulate.y = sdl3d_clamp01(mesh_modulate.y * material->albedo[1]);

--- a/src/effects.c
+++ b/src/effects.c
@@ -3,8 +3,6 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
 
-#include <math.h>
-
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/math.h"
 #include "sdl3d/shapes.h"
@@ -112,18 +110,18 @@ static void sdl3d_emit_one(sdl3d_particle_emitter *em)
         float speed = sdl3d_randf_range(em->config.speed_min, em->config.speed_max);
         float theta = sdl3d_randf() * 6.28318f;
         float phi = sdl3d_randf() * em->config.spread;
-        float sp = sinf(phi);
+        float sp = SDL_sinf(phi);
 
         sdl3d_vec3 dir = sdl3d_vec3_normalize(em->config.direction);
         /* Build a random direction within the cone. */
-        sdl3d_vec3 up = (fabsf(dir.y) < 0.99f) ? sdl3d_vec3_make(0, 1, 0) : sdl3d_vec3_make(1, 0, 0);
+        sdl3d_vec3 up = (SDL_fabsf(dir.y) < 0.99f) ? sdl3d_vec3_make(0, 1, 0) : sdl3d_vec3_make(1, 0, 0);
         sdl3d_vec3 right = sdl3d_vec3_normalize(sdl3d_vec3_cross(up, dir));
         sdl3d_vec3 fwd = sdl3d_vec3_cross(dir, right);
 
         sdl3d_vec3 offset;
-        offset.x = dir.x * cosf(phi) + right.x * sp * cosf(theta) + fwd.x * sp * sinf(theta);
-        offset.y = dir.y * cosf(phi) + right.y * sp * cosf(theta) + fwd.y * sp * sinf(theta);
-        offset.z = dir.z * cosf(phi) + right.z * sp * cosf(theta) + fwd.z * sp * sinf(theta);
+        offset.x = dir.x * SDL_cosf(phi) + right.x * sp * SDL_cosf(theta) + fwd.x * sp * SDL_sinf(theta);
+        offset.y = dir.y * SDL_cosf(phi) + right.y * sp * SDL_cosf(theta) + fwd.y * sp * SDL_sinf(theta);
+        offset.z = dir.z * SDL_cosf(phi) + right.z * sp * SDL_cosf(theta) + fwd.z * sp * SDL_sinf(theta);
 
         p->position = em->config.position;
         p->velocity = sdl3d_vec3_scale(offset, speed);
@@ -272,10 +270,10 @@ bool sdl3d_draw_skybox_gradient(sdl3d_render_context *context, sdl3d_color top_c
         float t1 = (float)(r + 1) / (float)rings;
         float phi0 = t0 * 3.14159265f;
         float phi1 = t1 * 3.14159265f;
-        float y0 = cosf(phi0) * radius;
-        float y1 = cosf(phi1) * radius;
-        float r0 = sinf(phi0) * radius;
-        float r1 = sinf(phi1) * radius;
+        float y0 = SDL_cosf(phi0) * radius;
+        float y1 = SDL_cosf(phi1) * radius;
+        float r0 = SDL_sinf(phi0) * radius;
+        float r1 = SDL_sinf(phi1) * radius;
 
         /* Interpolate color from top to bottom. */
         sdl3d_color c0, c1;
@@ -300,10 +298,10 @@ bool sdl3d_draw_skybox_gradient(sdl3d_render_context *context, sdl3d_color top_c
             float theta0 = (float)s / (float)slices * 6.28318f;
             float theta1 = (float)(s + 1) / (float)slices * 6.28318f;
 
-            sdl3d_vec3 v00 = sdl3d_vec3_make(cosf(theta0) * r0, y0, sinf(theta0) * r0);
-            sdl3d_vec3 v10 = sdl3d_vec3_make(cosf(theta1) * r0, y0, sinf(theta1) * r0);
-            sdl3d_vec3 v01 = sdl3d_vec3_make(cosf(theta0) * r1, y1, sinf(theta0) * r1);
-            sdl3d_vec3 v11 = sdl3d_vec3_make(cosf(theta1) * r1, y1, sinf(theta1) * r1);
+            sdl3d_vec3 v00 = sdl3d_vec3_make(SDL_cosf(theta0) * r0, y0, SDL_sinf(theta0) * r0);
+            sdl3d_vec3 v10 = sdl3d_vec3_make(SDL_cosf(theta1) * r0, y0, SDL_sinf(theta1) * r0);
+            sdl3d_vec3 v01 = sdl3d_vec3_make(SDL_cosf(theta0) * r1, y1, SDL_sinf(theta0) * r1);
+            sdl3d_vec3 v11 = sdl3d_vec3_make(SDL_cosf(theta1) * r1, y1, SDL_sinf(theta1) * r1);
 
             /* Inward-facing triangles (we're inside the sphere). */
             sdl3d_draw_triangle_3d(context, v00, v01, v10, avg);
@@ -412,14 +410,14 @@ bool sdl3d_apply_post_process(sdl3d_render_context *context, const sdl3d_post_pr
     {
         float cx = (float)w * 0.5f;
         float cy = (float)h * 0.5f;
-        float max_dist = sqrtf(cx * cx + cy * cy);
+        float max_dist = SDL_sqrtf(cx * cx + cy * cy);
         for (int y = 0; y < h; ++y)
         {
             for (int x = 0; x < w; ++x)
             {
                 float dx = (float)x - cx;
                 float dy = (float)y - cy;
-                float dist = sqrtf(dx * dx + dy * dy) / max_dist;
+                float dist = SDL_sqrtf(dx * dx + dy * dy) / max_dist;
                 float factor = 1.0f - dist * dist * config->vignette_intensity;
                 if (factor < 0.0f)
                 {

--- a/src/shading.c
+++ b/src/shading.c
@@ -11,8 +11,6 @@
 
 #include "lighting_internal.h"
 
-#include <math.h>
-
 static const float SDL3D_PI = 3.14159265358979323846f;
 
 static float sdl3d_maxf(float a, float b)
@@ -75,7 +73,7 @@ static float sdl3d_vec3_dot_raw(float ax, float ay, float az, float bx, float by
 
 static float sdl3d_vec3_length_raw(float x, float y, float z)
 {
-    return sqrtf(x * x + y * y + z * z);
+    return SDL_sqrtf(x * x + y * y + z * z);
 }
 
 /*
@@ -142,7 +140,7 @@ static bool sdl3d_compute_light_contribution(const sdl3d_light *light, float px,
             float sdz = light->direction.z * inv_sd;
             float cos_angle = sdl3d_vec3_dot_raw(-(*out_lx), -(*out_ly), -(*out_lz), sdx, sdy, sdz);
             float epsilon = light->inner_cutoff - light->outer_cutoff;
-            if (fabsf(epsilon) < 1e-7f)
+            if (SDL_fabsf(epsilon) < 1e-7f)
             {
                 attenuation *= (cos_angle >= light->outer_cutoff) ? 1.0f : 0.0f;
             }
@@ -338,9 +336,9 @@ void sdl3d_tonemap(sdl3d_tonemap_mode mode, float *r, float *g, float *b)
      * outputting linear values produces incorrect (too dark) colors. */
     {
         float inv_gamma = 1.0f / 2.2f;
-        *r = powf(sdl3d_clampf(*r, 0.0f, 1.0f), inv_gamma);
-        *g = powf(sdl3d_clampf(*g, 0.0f, 1.0f), inv_gamma);
-        *b = powf(sdl3d_clampf(*b, 0.0f, 1.0f), inv_gamma);
+        *r = SDL_powf(sdl3d_clampf(*r, 0.0f, 1.0f), inv_gamma);
+        *g = SDL_powf(sdl3d_clampf(*g, 0.0f, 1.0f), inv_gamma);
+        *b = SDL_powf(sdl3d_clampf(*b, 0.0f, 1.0f), inv_gamma);
     }
 }
 
@@ -366,14 +364,14 @@ float sdl3d_compute_fog_factor(const sdl3d_fog *fog, float distance)
 
     if (fog->mode == SDL3D_FOG_EXP)
     {
-        float f = expf(-fog->density * distance);
+        float f = SDL_expf(-fog->density * distance);
         return sdl3d_clampf(1.0f - f, 0.0f, 1.0f);
     }
 
     /* SDL3D_FOG_EXP2 */
     {
         float d = fog->density * distance;
-        float f = expf(-d * d);
+        float f = SDL_expf(-d * d);
         return sdl3d_clampf(1.0f - f, 0.0f, 1.0f);
     }
 }


### PR DESCRIPTION
## Summary

Pre-GPU-backend cleanup pass. Fixes bugs, removes stale comments, and improves consistency across the codebase.

### Bug fixes

**draw_model_ex uninitialized lighting_params (HIGH)**
- 6 fields in `sdl3d_lighting_params` (uv_mode, fog_eval, vertex_snap, vertex_snap_precision, color_quantize, color_depth) were left as stack garbage because the manual construction didn't set them. Replaced with `sdl3d_build_lighting_params()` which zero-initializes first, matching what `draw_model_skinned` and `draw_triangle_3d` already do.

**draw_model_skinned missing material validation (MEDIUM)**
- Silently ignored invalid material indices while `draw_model_ex` returned errors for the same condition. Added matching validation: reject `material_index < -1` and `>= material_count` with `SDL_SetError`.

### Stale comments
- model.h: removed 'reserved; returns error until M3 slice' from glTF/FBX loader descriptions

### Consistency
- types.h: added `extern C` guards matching all other public headers
- effects.c, animation.c, shading.c: replaced bare `math.h` functions with SDL wrappers (`SDL_sinf`, `SDL_cosf`, `SDL_sqrtf`, etc.), removed `#include <math.h>`

### Not addressed (deferred to M10 polish)
- 63 public API functions without doc comments — these should be documented as part of the API reference pass

262 tests pass. clang-format clean.