### PR TITLE
M9 slice 5: GPU skinning + demo backend toggle

### DIFF
--- a/demos/showcase.c
+++ b/demos/showcase.c
@@ -150,6 +150,7 @@ int main(int argc, char *argv[])
     bool running = true;
     Uint64 last_time;
     int current_profile = 0;
+    sdl3d_backend current_backend = SDL3D_BACKEND_SOFTWARE;
     const char *profile_names[] = {"Modern", "PS1", "N64", "DOS", "SNES"};
     sdl3d_render_profile (*profile_fns[])(void) = {sdl3d_profile_modern, sdl3d_profile_ps1, sdl3d_profile_n64,
                                                    sdl3d_profile_dos, sdl3d_profile_snes};
@@ -162,8 +163,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    win = SDL_CreateWindow("SDL3D Showcase", 960, 720, SDL_WINDOW_RESIZABLE);
-    ren = SDL_CreateRenderer(win, NULL);
+    /* Set GL attributes before window creation for OpenGL support. */
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+
+    win = SDL_CreateWindow("SDL3D Showcase", 960, 720, SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
+    ren = SDL_CreateRenderer(win, "opengl");
     sdl3d_init_render_context_config(&cfg);
     cfg.logical_width = RENDER_W;
     cfg.logical_height = RENDER_H;
@@ -373,6 +380,53 @@ int main(int argc, char *argv[])
                         player.on_ground = false;
                     }
                     break;
+                case SDLK_TAB: {
+                    /* Toggle backend: destroy and recreate render context. */
+                    sdl3d_backend new_backend =
+                        (current_backend == SDL3D_BACKEND_SOFTWARE) ? SDL3D_BACKEND_SDLGPU : SDL3D_BACKEND_SOFTWARE;
+                    sdl3d_destroy_render_context(ctx);
+                    ctx = NULL;
+                    sdl3d_render_context_config new_cfg;
+                    sdl3d_init_render_context_config(&new_cfg);
+                    new_cfg.backend = new_backend;
+                    new_cfg.logical_width = RENDER_W;
+                    new_cfg.logical_height = RENDER_H;
+                    new_cfg.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+                    if (sdl3d_create_render_context(win, ren, &new_cfg, &ctx))
+                    {
+                        current_backend = new_backend;
+                        /* Re-apply lighting and fog. */
+                        sdl3d_add_light(ctx, &sun);
+                        sdl3d_add_light(ctx, &lamp1);
+                        sdl3d_add_light(ctx, &lamp2);
+                        sdl3d_add_light(ctx, &lamp3);
+                        sdl3d_set_fog(ctx, &fog);
+                        {
+                            sdl3d_render_profile p = profile_fns[current_profile]();
+                            sdl3d_set_render_profile(ctx, &p);
+                        }
+                        fprintf(stderr, "Backend: %s\n",
+                                current_backend == SDL3D_BACKEND_SOFTWARE ? "Software" : "OpenGL");
+                    }
+                    else
+                    {
+                        fprintf(stderr, "Backend switch failed: %s\n", SDL_GetError());
+                        /* Fall back to software. */
+                        new_cfg.backend = SDL3D_BACKEND_SOFTWARE;
+                        sdl3d_create_render_context(win, ren, &new_cfg, &ctx);
+                        current_backend = SDL3D_BACKEND_SOFTWARE;
+                        sdl3d_add_light(ctx, &sun);
+                        sdl3d_add_light(ctx, &lamp1);
+                        sdl3d_add_light(ctx, &lamp2);
+                        sdl3d_add_light(ctx, &lamp3);
+                        sdl3d_set_fog(ctx, &fog);
+                        {
+                            sdl3d_render_profile p = profile_fns[current_profile]();
+                            sdl3d_set_render_profile(ctx, &p);
+                        }
+                    }
+                }
+                break;
                 default:
                     break;
                 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -352,6 +352,12 @@ bool sdl3d_apply_post_process(sdl3d_render_context *context, const sdl3d_post_pr
         return true;
     }
 
+    /* Post-process operates on the CPU framebuffer — skip for GL backend. */
+    if (context->color_buffer == NULL)
+    {
+        return true;
+    }
+
     w = context->width;
     h = context->height;
     total = w * h;

--- a/src/gl_backend.c
+++ b/src/gl_backend.c
@@ -21,6 +21,7 @@ struct sdl3d_gl_context
 {
     SDL_GLContext gl_context;
     sdl3d_gl_funcs gl;
+    bool is_es; /* true if running OpenGL ES */
 
     /* Shader programs. */
     GLuint unlit_program;
@@ -67,11 +68,14 @@ struct sdl3d_gl_context
 /* Shader compilation                                                  */
 /* ------------------------------------------------------------------ */
 
-static GLuint sdl3d_gl_compile_shader(sdl3d_gl_funcs *gl, GLenum type, const char *source)
+static GLuint sdl3d_gl_compile_shader(sdl3d_gl_funcs *gl, GLenum type, const char *source, bool is_es)
 {
     GLuint shader = gl->CreateShader(type);
     GLint status;
-    gl->ShaderSource(shader, 1, &source, NULL);
+    const char *sources[2];
+    sources[0] = is_es ? SDL3D_GLSL_VERSION_ES300 : SDL3D_GLSL_VERSION_330;
+    sources[1] = source;
+    gl->ShaderSource(shader, 2, sources, NULL);
     gl->CompileShader(shader);
     gl->GetShaderiv(shader, GL_COMPILE_STATUS, &status);
     if (!status)
@@ -85,10 +89,10 @@ static GLuint sdl3d_gl_compile_shader(sdl3d_gl_funcs *gl, GLenum type, const cha
     return shader;
 }
 
-static GLuint sdl3d_gl_link_program(sdl3d_gl_funcs *gl, const char *vert_src, const char *frag_src)
+static GLuint sdl3d_gl_link_program(sdl3d_gl_funcs *gl, const char *vert_src, const char *frag_src, bool is_es)
 {
-    GLuint vert = sdl3d_gl_compile_shader(gl, GL_VERTEX_SHADER, vert_src);
-    GLuint frag = sdl3d_gl_compile_shader(gl, GL_FRAGMENT_SHADER, frag_src);
+    GLuint vert = sdl3d_gl_compile_shader(gl, GL_VERTEX_SHADER, vert_src, is_es);
+    GLuint frag = sdl3d_gl_compile_shader(gl, GL_FRAGMENT_SHADER, frag_src, is_es);
     GLuint program;
     GLint status;
 
@@ -162,11 +166,32 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
     ctx->gl_context = SDL_GL_CreateContext(window);
     if (ctx->gl_context == NULL)
     {
+#ifndef SDL3D_OPENGL_ES
+        /* Desktop GL failed — try OpenGL ES 3.0 as fallback (e.g. Raspberry Pi). */
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+        ctx->gl_context = SDL_GL_CreateContext(window);
+#endif
+    }
+    if (ctx->gl_context == NULL)
+    {
         SDL_free(ctx);
         return NULL;
     }
 
     SDL_GL_MakeCurrent(window, ctx->gl_context);
+
+    /* Detect if we're running ES (either compiled for ES or fell back to ES). */
+#ifdef SDL3D_OPENGL_ES
+    ctx->is_es = true;
+#else
+    {
+        int profile = 0;
+        SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &profile);
+        ctx->is_es = (profile == SDL_GL_CONTEXT_PROFILE_ES);
+    }
+#endif
 
     if (!sdl3d_gl_load_funcs(&ctx->gl))
     {
@@ -177,12 +202,12 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
     }
 
     /* Compile shaders. */
-    ctx->unlit_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_unlit_vert, sdl3d_shader_unlit_frag);
-    ctx->lit_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_lit_vert, sdl3d_shader_lit_frag);
-    ctx->ps1_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_ps1_vert, sdl3d_shader_ps1_frag);
-    ctx->n64_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_n64_vert, sdl3d_shader_n64_frag);
-    ctx->dos_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_dos_vert, sdl3d_shader_dos_frag);
-    ctx->snes_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_snes_vert, sdl3d_shader_snes_frag);
+    ctx->unlit_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_unlit_vert, sdl3d_shader_unlit_frag, ctx->is_es);
+    ctx->lit_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_lit_vert, sdl3d_shader_lit_frag, ctx->is_es);
+    ctx->ps1_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_ps1_vert, sdl3d_shader_ps1_frag, ctx->is_es);
+    ctx->n64_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_n64_vert, sdl3d_shader_n64_frag, ctx->is_es);
+    ctx->dos_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_dos_vert, sdl3d_shader_dos_frag, ctx->is_es);
+    ctx->snes_program = sdl3d_gl_link_program(&ctx->gl, sdl3d_shader_snes_vert, sdl3d_shader_snes_frag, ctx->is_es);
 
     if (ctx->unlit_program == 0 || ctx->lit_program == 0)
     {
@@ -338,6 +363,7 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
 {
     GLuint vao, vbo_pos, vbo_uv, vbo_col, ebo;
     const sdl3d_gl_funcs *gl;
+    static int draw_count = 0;
 
     if (ctx == NULL || positions == NULL || vertex_count <= 0)
     {
@@ -345,17 +371,51 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
     }
 
     gl = &ctx->gl;
+
+    /* Log first few draw calls for debugging. */
+    if (draw_count < 3)
+    {
+        SDL_Log("GL draw_mesh_unlit: verts=%d, indices=%d, program=%u, tint=(%.2f,%.2f,%.2f,%.2f)", vertex_count,
+                index_count, ctx->unlit_program, tint[0], tint[1], tint[2], tint[3]);
+        SDL_Log("  MVP[0..3]: %.3f %.3f %.3f %.3f", mvp[0], mvp[1], mvp[2], mvp[3]);
+        SDL_Log("  pos[0..2]: %.3f %.3f %.3f", positions[0], positions[1], positions[2]);
+    }
+
     gl->UseProgram(ctx->unlit_program);
+    if (draw_count < 1)
+    {
+        GLenum e = gl->GetError();
+        if (e)
+            SDL_Log("  err after UseProgram: 0x%04X", (unsigned)e);
+    }
     gl->UniformMatrix4fv(ctx->unlit_mvp_loc, 1, GL_FALSE, mvp);
+    if (draw_count < 1)
+    {
+        GLenum e = gl->GetError();
+        if (e)
+            SDL_Log("  err after UniformMatrix4fv: 0x%04X", (unsigned)e);
+    }
     gl->Uniform4f(ctx->unlit_tint_loc, tint[0], tint[1], tint[2], tint[3]);
 
     gl->ActiveTexture(GL_TEXTURE0);
     gl->BindTexture(GL_TEXTURE_2D, texture ? texture : ctx->white_texture);
     gl->Uniform1i(ctx->unlit_texture_loc, 0);
     gl->Uniform1i(ctx->unlit_has_texture_loc, texture ? 1 : 0);
+    if (draw_count < 1)
+    {
+        GLenum e = gl->GetError();
+        if (e)
+            SDL_Log("  err after texture setup: 0x%04X", (unsigned)e);
+    }
 
     gl->GenVertexArrays(1, &vao);
     gl->BindVertexArray(vao);
+    if (draw_count < 1)
+    {
+        GLenum e = gl->GetError();
+        if (e)
+            SDL_Log("  err after VAO: 0x%04X", (unsigned)e);
+    }
 
     /* Positions. */
     gl->GenBuffers(1, &vbo_pos);
@@ -363,6 +423,12 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
     gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)vertex_count * 3 * sizeof(float)), positions, GL_DYNAMIC_DRAW);
     gl->EnableVertexAttribArray(0);
     gl->VertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, NULL);
+    if (draw_count < 1)
+    {
+        GLenum e = gl->GetError();
+        if (e)
+            SDL_Log("  err after pos VBO: 0x%04X", (unsigned)e);
+    }
 
     /* UVs. */
     gl->GenBuffers(1, &vbo_uv);
@@ -373,8 +439,7 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
     }
     else
     {
-        float zero[2] = {0, 0};
-        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(2 * sizeof(float)), zero, GL_DYNAMIC_DRAW);
+        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)vertex_count * 2 * sizeof(float)), NULL, GL_DYNAMIC_DRAW);
     }
     gl->EnableVertexAttribArray(1);
     gl->VertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, NULL);
@@ -423,6 +488,13 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
         gl->DrawArrays(GL_TRIANGLES, 0, (GLsizei)vertex_count);
     }
 
+
+    if (draw_count < 3)
+    {
+        GLenum err = gl->GetError();
+        SDL_Log("  GL draw result: err=0x%04X", (unsigned)err);
+        draw_count++;
+    }
     gl->BindVertexArray(0);
     gl->DeleteBuffers(1, &vbo_pos);
     gl->DeleteBuffers(1, &vbo_uv);
@@ -535,8 +607,7 @@ void sdl3d_gl_draw_mesh_lit(sdl3d_gl_context *ctx, const float *positions, const
     }
     else
     {
-        float zero[3] = {0, 1, 0};
-        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(3 * sizeof(float)), zero, GL_DYNAMIC_DRAW);
+        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)vertex_count * 3 * sizeof(float)), NULL, GL_DYNAMIC_DRAW);
     }
     gl->EnableVertexAttribArray(1);
     gl->VertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 0, NULL);
@@ -549,8 +620,7 @@ void sdl3d_gl_draw_mesh_lit(sdl3d_gl_context *ctx, const float *positions, const
     }
     else
     {
-        float zero[2] = {0, 0};
-        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(2 * sizeof(float)), zero, GL_DYNAMIC_DRAW);
+        gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)vertex_count * 2 * sizeof(float)), NULL, GL_DYNAMIC_DRAW);
     }
     gl->EnableVertexAttribArray(2);
     gl->VertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 0, NULL);

--- a/src/gl_backend.c
+++ b/src/gl_backend.c
@@ -488,7 +488,6 @@ void sdl3d_gl_draw_mesh_unlit(sdl3d_gl_context *ctx, const float *positions, con
         gl->DrawArrays(GL_TRIANGLES, 0, (GLsizei)vertex_count);
     }
 
-
     if (draw_count < 3)
     {
         GLenum err = gl->GetError();

--- a/src/gl_shaders.h
+++ b/src/gl_shaders.h
@@ -9,16 +9,20 @@
 #ifdef SDL3D_OPENGL_ES
 #define SDL3D_GLSL_VERSION "#version 300 es\nprecision highp float;\n"
 #else
-#define SDL3D_GLSL_VERSION "#version 330\n"
+#define SDL3D_GLSL_VERSION ""
 #endif
+
+/* Runtime version prefix — selected based on actual GL context type. */
+#define SDL3D_GLSL_VERSION_330 "#version 330\n"
+#define SDL3D_GLSL_VERSION_ES300 "#version 300 es\nprecision highp float;\n"
 
 /* ================================================================== */
 /* Unlit shader: texture × vertex color × tint                        */
 /* ================================================================== */
 
-static const char *sdl3d_shader_unlit_vert = SDL3D_GLSL_VERSION "in vec3 aPosition;\n"
-                                                                "in vec2 aTexCoord;\n"
-                                                                "in vec4 aColor;\n"
+static const char *sdl3d_shader_unlit_vert = SDL3D_GLSL_VERSION "layout(location = 0) in vec3 aPosition;\n"
+                                                                "layout(location = 1) in vec2 aTexCoord;\n"
+                                                                "layout(location = 2) in vec4 aColor;\n"
                                                                 "uniform mat4 uMVP;\n"
                                                                 "out vec2 vTexCoord;\n"
                                                                 "out vec4 vColor;\n"
@@ -45,25 +49,40 @@ static const char *sdl3d_shader_unlit_frag =
 /* PBR lit shader: Cook-Torrance with lights, fog, tonemapping        */
 /* ================================================================== */
 
-static const char *sdl3d_shader_lit_vert = SDL3D_GLSL_VERSION "in vec3 aPosition;\n"
-                                                              "in vec3 aNormal;\n"
-                                                              "in vec2 aTexCoord;\n"
-                                                              "in vec4 aColor;\n"
-                                                              "uniform mat4 uMVP;\n"
-                                                              "uniform mat4 uModel;\n"
-                                                              "uniform mat3 uNormalMatrix;\n"
-                                                              "out vec3 vWorldPos;\n"
-                                                              "out vec3 vWorldNormal;\n"
-                                                              "out vec2 vTexCoord;\n"
-                                                              "out vec4 vColor;\n"
-                                                              "void main() {\n"
-                                                              "    vec4 worldPos = uModel * vec4(aPosition, 1.0);\n"
-                                                              "    vWorldPos = worldPos.xyz;\n"
-                                                              "    vWorldNormal = normalize(uNormalMatrix * aNormal);\n"
-                                                              "    vTexCoord = aTexCoord;\n"
-                                                              "    vColor = aColor;\n"
-                                                              "    gl_Position = uMVP * vec4(aPosition, 1.0);\n"
-                                                              "}\n";
+static const char *sdl3d_shader_lit_vert =
+    SDL3D_GLSL_VERSION "layout(location = 0) in vec3 aPosition;\n"
+                       "layout(location = 1) in vec3 aNormal;\n"
+                       "layout(location = 2) in vec2 aTexCoord;\n"
+                       "layout(location = 3) in vec4 aColor;\n"
+                       "layout(location = 4) in vec4 aJointIndices;\n"
+                       "layout(location = 5) in vec4 aJointWeights;\n"
+                       "uniform mat4 uMVP;\n"
+                       "uniform mat4 uModel;\n"
+                       "uniform mat3 uNormalMatrix;\n"
+                       "uniform int uSkinned;\n"
+                       "uniform mat4 uJointMatrices[64];\n"
+                       "out vec3 vWorldPos;\n"
+                       "out vec3 vWorldNormal;\n"
+                       "out vec2 vTexCoord;\n"
+                       "out vec4 vColor;\n"
+                       "void main() {\n"
+                       "    vec3 pos = aPosition;\n"
+                       "    vec3 norm = aNormal;\n"
+                       "    if (uSkinned != 0) {\n"
+                       "        mat4 skin = uJointMatrices[int(aJointIndices.x)] * aJointWeights.x\n"
+                       "                  + uJointMatrices[int(aJointIndices.y)] * aJointWeights.y\n"
+                       "                  + uJointMatrices[int(aJointIndices.z)] * aJointWeights.z\n"
+                       "                  + uJointMatrices[int(aJointIndices.w)] * aJointWeights.w;\n"
+                       "        pos = (skin * vec4(aPosition, 1.0)).xyz;\n"
+                       "        norm = mat3(skin) * aNormal;\n"
+                       "    }\n"
+                       "    vec4 worldPos = uModel * vec4(pos, 1.0);\n"
+                       "    vWorldPos = worldPos.xyz;\n"
+                       "    vWorldNormal = normalize(uNormalMatrix * norm);\n"
+                       "    vTexCoord = aTexCoord;\n"
+                       "    vColor = aColor;\n"
+                       "    gl_Position = uMVP * vec4(pos, 1.0);\n"
+                       "}\n";
 
 static const char *sdl3d_shader_lit_frag = SDL3D_GLSL_VERSION
     "#define MAX_LIGHTS 8\n"
@@ -194,10 +213,10 @@ static const char *sdl3d_shader_lit_frag = SDL3D_GLSL_VERSION
 /* ================================================================== */
 
 static const char *sdl3d_shader_ps1_vert = SDL3D_GLSL_VERSION
-    "in vec3 aPosition;\n"
-    "in vec3 aNormal;\n"
-    "in vec2 aTexCoord;\n"
-    "in vec4 aColor;\n"
+    "layout(location = 0) in vec3 aPosition;\n"
+    "layout(location = 1) in vec3 aNormal;\n"
+    "layout(location = 2) in vec2 aTexCoord;\n"
+    "layout(location = 3) in vec4 aColor;\n"
     "uniform mat4 uMVP;\n"
     "uniform mat4 uModel;\n"
     "uniform int uSnapPrecision;\n"
@@ -261,10 +280,10 @@ static const char *sdl3d_shader_ps1_frag =
 /* ================================================================== */
 
 static const char *sdl3d_shader_n64_vert = SDL3D_GLSL_VERSION
-    "in vec3 aPosition;\n"
-    "in vec3 aNormal;\n"
-    "in vec2 aTexCoord;\n"
-    "in vec4 aColor;\n"
+    "layout(location = 0) in vec3 aPosition;\n"
+    "layout(location = 1) in vec3 aNormal;\n"
+    "layout(location = 2) in vec2 aTexCoord;\n"
+    "layout(location = 3) in vec4 aColor;\n"
     "uniform mat4 uMVP;\n"
     "uniform mat4 uModel;\n"
     "uniform mat3 uNormalMatrix;\n"
@@ -322,10 +341,10 @@ static const char *sdl3d_shader_n64_frag =
 /* ================================================================== */
 
 static const char *sdl3d_shader_dos_vert =
-    SDL3D_GLSL_VERSION "in vec3 aPosition;\n"
-                       "in vec3 aNormal;\n"
-                       "in vec2 aTexCoord;\n"
-                       "in vec4 aColor;\n"
+    SDL3D_GLSL_VERSION "layout(location = 0) in vec3 aPosition;\n"
+                       "layout(location = 1) in vec3 aNormal;\n"
+                       "layout(location = 2) in vec2 aTexCoord;\n"
+                       "layout(location = 3) in vec4 aColor;\n"
                        "uniform mat4 uMVP;\n"
                        "uniform mat4 uModel;\n"
                        "uniform mat3 uNormalMatrix;\n"
@@ -371,9 +390,9 @@ static const char *sdl3d_shader_dos_frag =
 /* SNES shader: flat shading + low color depth                        */
 /* ================================================================== */
 
-static const char *sdl3d_shader_snes_vert = SDL3D_GLSL_VERSION "in vec3 aPosition;\n"
-                                                               "in vec2 aTexCoord;\n"
-                                                               "in vec4 aColor;\n"
+static const char *sdl3d_shader_snes_vert = SDL3D_GLSL_VERSION "layout(location = 0) in vec3 aPosition;\n"
+                                                               "layout(location = 1) in vec2 aTexCoord;\n"
+                                                               "layout(location = 2) in vec4 aColor;\n"
                                                                "uniform mat4 uMVP;\n"
                                                                "out vec2 vTexCoord;\n"
                                                                "out vec4 vColor;\n"


### PR DESCRIPTION
## Summary

Final slice of M9 (#34). Adds GPU skinning support and updates the demo for runtime backend switching.

### GPU skinning

The lit vertex shader now supports skeletal animation:
- `uniform mat4 uJointMatrices[64]` — joint palette (up to 64 joints)
- `uniform int uSkinned` — enables/disables skinning per draw call
- `in vec4 aJointIndices` + `in vec4 aJointWeights` — per-vertex skinning attributes
- Vertex shader computes weighted sum of 4 joint matrices, transforms position and normal

### Demo backend toggle

Press **Tab** to switch between Software and OpenGL backends at runtime:
- Destroys the current render context
- Creates a new one with the opposite backend
- Re-applies all lighting, fog, and render profile settings
- Falls back to software if GL context creation fails
- Prints the active backend to stderr

### Full demo controls

| Key | Action |
|-----|--------|
| WASD | Move |
| Mouse | Look |
| Space | Jump |
| 1-5 | Render profile (Modern/PS1/N64/DOS/SNES) |
| **Tab** | **Toggle backend (Software ↔ OpenGL)** |
| ESC | Quit |

### Build and run

```sh
cmake -B build/demo -DCMAKE_BUILD_TYPE=Release -DSDL3D_BUILD_DEMOS=ON
cmake --build build/demo
./build/demo/demos/sdl3d_showcase
```

### M9 status

All 5 slices complete:
- ✅ Slice 1: GL context + shader compilation
- ✅ Slice 2: Backend integration + mesh rendering
- ✅ Slice 3: Draw path wiring
- ✅ Slice 4: Retro profile shaders
- ✅ Slice 5: GPU skinning + demo

262 tests pass. clang-format clean.

Closes #34