### PR TITLE
perf: chunk levels by sector and frustum-cull world meshes

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -10,8 +10,6 @@
 #include "sdl3d/lighting.h"
 #include "sdl3d/sdl3d.h"
 
-#include <math.h>
-
 #define WINDOW_W 1280
 #define WINDOW_H 720
 #define MOVE_SPEED 12.0f
@@ -64,7 +62,7 @@ static void advance_projectile(const sdl3d_sector *sectors, int sector_count, fl
         return;
 
     float travel = PROJ_SPEED * dt;
-    int steps = (int)ceilf(travel / 0.25f);
+    int steps = (int)SDL_ceilf(travel / 0.25f);
     if (steps < 1)
         steps = 1;
     float step_dist = travel / (float)steps;
@@ -218,8 +216,21 @@ int main(int argc, char *argv[])
     }
     bool use_baked = true;
 
-    /* ---- Lighting ---- */
-    /* Start simple: unlit to verify geometry, then add lighting. */
+    SDL_Log("Portals detected: %d", level_lit.portal_count);
+    for (int i = 0; i < level_lit.portal_count; i++)
+    {
+        const sdl3d_level_portal *p = &level_lit.portals[i];
+        SDL_Log("  portal %d: sector %d <-> %d  x[%.1f,%.1f] z[%.1f,%.1f] y[%.2f,%.2f]", i, p->sector_a, p->sector_b,
+                p->min_x, p->max_x, p->min_z, p->max_z, p->floor_y, p->ceil_y);
+    }
+
+    /* Visibility state. */
+    bool sector_visible[13];
+    sdl3d_visibility_result vis;
+    vis.sector_visible = sector_visible;
+    vis.visible_count = 0;
+    bool show_debug = false;
+    bool portal_culling = true;
 
     /* Player */
     float px = 5, py = 1.6f, pz = 4;
@@ -246,6 +257,16 @@ int main(int argc, char *argv[])
                 running = false;
             if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_L)
                 use_baked = !use_baked;
+            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F1)
+            {
+                show_debug = !show_debug;
+                SDL_Log("Debug stats: %s", show_debug ? "ON" : "OFF");
+            }
+            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F2)
+            {
+                portal_culling = !portal_culling;
+                SDL_Log("Portal culling: %s", portal_culling ? "ON" : "OFF");
+            }
             if (ev.type == SDL_EVENT_MOUSE_MOTION && mouse_init)
             {
                 yaw += ev.motion.xrel * MOUSE_SENS;
@@ -263,9 +284,9 @@ int main(int argc, char *argv[])
                 proj_x = px;
                 proj_y = py;
                 proj_z = pz;
-                proj_dx = sinf(yaw) * cosf(pitch);
-                proj_dy = sinf(pitch);
-                proj_dz = -cosf(yaw) * cosf(pitch);
+                proj_dx = SDL_sinf(yaw) * SDL_cosf(pitch);
+                proj_dy = SDL_sinf(pitch);
+                proj_dz = -SDL_cosf(yaw) * SDL_cosf(pitch);
                 proj_life = PROJ_LIFETIME;
             }
         }
@@ -275,15 +296,15 @@ int main(int argc, char *argv[])
         last = now;
 
         /* Look direction (for camera target). */
-        float fx = sinf(yaw) * cosf(pitch);
-        float fz = -cosf(yaw) * cosf(pitch);
+        float fx = SDL_sinf(yaw) * SDL_cosf(pitch);
+        float fz = -SDL_cosf(yaw) * SDL_cosf(pitch);
 
         /* Doom-style movement: accumulate wish direction on XZ plane,
          * normalize so diagonal isn't faster, constant speed regardless of pitch. */
-        float fwd_x = sinf(yaw);
-        float fwd_z = -cosf(yaw);
-        float right_x = cosf(yaw);
-        float right_z = sinf(yaw);
+        float fwd_x = SDL_sinf(yaw);
+        float fwd_z = -SDL_cosf(yaw);
+        float right_x = SDL_cosf(yaw);
+        float right_z = SDL_sinf(yaw);
         float wish_x = 0, wish_z = 0;
 
         const Uint8 *keys = (const Uint8 *)SDL_GetKeyboardState(NULL);
@@ -309,7 +330,7 @@ int main(int argc, char *argv[])
         }
 
         /* Normalize wish direction. */
-        float wish_len = sqrtf(wish_x * wish_x + wish_z * wish_z);
+        float wish_len = SDL_sqrtf(wish_x * wish_x + wish_z * wish_z);
         if (wish_len > 0.001f)
         {
             wish_x /= wish_len;
@@ -320,7 +341,7 @@ int main(int argc, char *argv[])
 
         sdl3d_camera3d cam;
         cam.position = sdl3d_vec3_make(px, py, pz);
-        cam.target = sdl3d_vec3_make(px + fx, py + sinf(pitch), pz + fz);
+        cam.target = sdl3d_vec3_make(px + fx, py + SDL_sinf(pitch), pz + fz);
         cam.up = sdl3d_vec3_make(0, 1, 0);
         cam.fovy = 75.0f;
         cam.projection = SDL3D_CAMERA_PERSPECTIVE;
@@ -328,6 +349,11 @@ int main(int argc, char *argv[])
         /* Update projectile. */
         advance_projectile(sectors, sector_count, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
                            proj_dz, &proj_life);
+
+        /* Compute portal visibility. */
+        sdl3d_level *active_level = use_baked ? &level_lit : &level_unlit;
+        int current_sector = sdl3d_level_find_sector(active_level, sectors, px, pz);
+        sdl3d_vec3 cam_dir = sdl3d_vec3_make(fx, SDL_sinf(pitch), fz);
 
         sdl3d_clear_lights(ctx);
         if (proj_active)
@@ -345,12 +371,70 @@ int main(int argc, char *argv[])
 
         sdl3d_clear_render_context(ctx, (sdl3d_color){10, 10, 15, 255});
 
-        /* The level uses baked lighting as its static term, then runtime
-         * point lights are added per-pixel in the shader. */
         sdl3d_begin_mode_3d(ctx, cam);
 
-        sdl3d_draw_model(ctx, use_baked ? &level_lit.model : &level_unlit.model, sdl3d_vec3_make(0, 0, 0), 1.0f,
-                         (sdl3d_color){255, 255, 255, 255});
+        /* Compute visibility using cached frustum planes from begin_mode_3d.
+         * We pass the frustum planes through to the visibility system. */
+        if (portal_culling)
+        {
+            sdl3d_mat4 vview, vproj;
+            sdl3d_camera3d_compute_matrices(&cam, WINDOW_W, WINDOW_H, 0.01f, 1000.0f, &vview, &vproj);
+            sdl3d_mat4 vp = sdl3d_mat4_multiply(vproj, vview);
+            const float *m = vp.m;
+
+            /* Gribb/Hartmann frustum plane extraction: left, right, bottom, top, near, far. */
+            float fp[6][4];
+            float raw[6][4] = {
+                {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
+                {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
+                {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
+                {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
+                {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
+                {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
+            };
+            for (int i = 0; i < 6; i++)
+            {
+                float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
+                if (len > 0.000001f)
+                {
+                    fp[i][0] = raw[i][0] / len;
+                    fp[i][1] = raw[i][1] / len;
+                    fp[i][2] = raw[i][2] / len;
+                    fp[i][3] = raw[i][3] / len;
+                }
+                else
+                {
+                    fp[i][0] = fp[i][1] = fp[i][2] = 0.0f;
+                    fp[i][3] = raw[i][3];
+                }
+            }
+
+            sdl3d_level_compute_visibility(active_level, current_sector, cam.position, cam_dir, fp, &vis);
+        }
+        else
+        {
+            for (int i = 0; i < sector_count; i++)
+                sector_visible[i] = true;
+            vis.visible_count = sector_count;
+        }
+
+        /* Count visible mesh chunks for debug stats. */
+        int visible_meshes = 0;
+        if (portal_culling)
+        {
+            for (int i = 0; i < active_level->model.mesh_count; i++)
+            {
+                int sid = active_level->mesh_sector_ids[i];
+                if (sid >= 0 && sid < sector_count && vis.sector_visible[sid])
+                    visible_meshes++;
+            }
+        }
+        else
+        {
+            visible_meshes = active_level->model.mesh_count;
+        }
+
+        sdl3d_draw_level(ctx, active_level, portal_culling ? &vis : NULL, (sdl3d_color){255, 255, 255, 255});
 
         /* Projectile sphere. */
         if (proj_active)
@@ -364,7 +448,7 @@ int main(int argc, char *argv[])
         /* Crosshair. */
         {
             float chx = px + fx * 0.4f;
-            float chy = py + sinf(pitch) * 0.4f;
+            float chy = py + SDL_sinf(pitch) * 0.4f;
             float chz = pz + fz * 0.4f;
             sdl3d_set_emissive(ctx, 8, 8, 8);
             sdl3d_draw_cube(ctx, sdl3d_vec3_make(chx, chy, chz), sdl3d_vec3_make(0.003f, 0.003f, 0.003f),
@@ -374,6 +458,14 @@ int main(int argc, char *argv[])
 
         sdl3d_end_mode_3d(ctx);
         sdl3d_present_render_context(ctx);
+
+        /* Debug stats to log. */
+        if (show_debug)
+        {
+            SDL_Log("[VIS] sector=%d  visible=%d/%d sectors  meshes=%d/%d  portals=%d  culling=%s", current_sector,
+                    vis.visible_count, sector_count, visible_meshes, active_level->model.mesh_count,
+                    active_level->portal_count, portal_culling ? "ON" : "OFF");
+        }
     }
 
     sdl3d_free_level(&level_lit);

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -56,8 +56,9 @@ static bool point_in_any_sector(const sdl3d_sector *sectors, int sector_count, f
     return false;
 }
 
-static void advance_projectile(const sdl3d_sector *sectors, int sector_count, float dt, bool *proj_active, float *proj_x,
-                               float *proj_y, float *proj_z, float proj_dx, float proj_dy, float proj_dz, float *proj_life)
+static void advance_projectile(const sdl3d_sector *sectors, int sector_count, float dt, bool *proj_active,
+                               float *proj_x, float *proj_y, float *proj_z, float proj_dx, float proj_dy, float proj_dz,
+                               float *proj_life)
 {
     if (!*proj_active)
         return;
@@ -187,18 +188,18 @@ int main(int argc, char *argv[])
     };
 
     sdl3d_level_light lights[] = {
-        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 4.4f, 11.0f},   /* Start room — warm tungsten */
-        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 2.6f, 8.0f},   /* South corridor — amber */
-        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 4.0f, 14.0f},  /* Nukage basin — red */
-        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.8f, 9.0f}, /* West alcove — toxic green */
-        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 2.4f, 8.0f},     /* Upper hall — cold white */
-        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.8f, 12.0f},  /* Computer core — cyan */
-        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 2.4f, 7.0f},   /* Security bend — sodium */
-        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 5.0f, 18.0f},/* Courtyard — moonlight */
-        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 3.0f, 12.0f},  /* Storage — magenta */
-        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 3.8f, 8.0f},    /* Exit — green */
-        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 3.4f, 13.0f}, /* Reactor hall — violet */
-        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 2.5f, 8.0f},  /* Secret annex — orange */
+        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 4.4f, 11.0f},    /* Start room — warm tungsten */
+        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 2.6f, 8.0f},    /* South corridor — amber */
+        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 4.0f, 14.0f},   /* Nukage basin — red */
+        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.8f, 9.0f},  /* West alcove — toxic green */
+        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 2.4f, 8.0f},      /* Upper hall — cold white */
+        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.8f, 12.0f},   /* Computer core — cyan */
+        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 2.4f, 7.0f},    /* Security bend — sodium */
+        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 5.0f, 18.0f}, /* Courtyard — moonlight */
+        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 3.0f, 12.0f},   /* Storage — magenta */
+        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 3.8f, 8.0f},     /* Exit — green */
+        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 3.4f, 13.0f},  /* Reactor hall — violet */
+        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 2.5f, 8.0f},   /* Secret annex — orange */
     };
     const int sector_count = (int)SDL_arraysize(sectors);
     const int light_count = (int)SDL_arraysize(lights);
@@ -326,8 +327,7 @@ int main(int argc, char *argv[])
 
         /* Update projectile. */
         advance_projectile(sectors, sector_count, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
-                           proj_dz,
-                           &proj_life);
+                           proj_dz, &proj_life);
 
         sdl3d_clear_lights(ctx);
         if (proj_active)

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -1,6 +1,6 @@
 /*
  * Doom-style level demo — sector-based level builder.
- * 6 connected rooms built from 2D floor plans.
+ * Expanded E1M1-scale-ish layout with multiple wings and color accents.
  */
 #define SDL_MAIN_HANDLED
 #include <SDL3/SDL.h>
@@ -143,49 +143,74 @@ int main(int argc, char *argv[])
         {{1, 1, 1, 1}, 0, 0.9f, SDL3D_MEDIA_DIR "/textures/rock_floor.jpg", 4},    /* 5: rock floor alt */
     };
 
-    /* ---- Sector definitions (E1M1-inspired) ---- */
+    /* ---- Sector definitions (expanded E1M1-inspired layout) ---- */
     /*
      * Layout (top-down, Z increases downward):
      *
-     *   [0] Start Room (10x8)
-     *        |  (doorway 3..7)
-     *   [1] Corridor (4x8)
-     *        |  (doorway 3..7)
-     *   [2] Nukage Room (12x10) ---[3] Side Passage (6x4)---[4] Outdoor Area (12x10)
-     *                                                              |
-     *                                                         [5] Exit Room (8x6)
+     *   [7] Upper Hall -------- [8] Computer Core
+     *      |                          |
+     *   [0] Start Room                [9] Security Bend
+     *      |                               |
+     *   [1] South Corridor                 |
+     *      |                               |
+     *   [2] Nukage Basin -- [3] East Passage -- [4] Courtyard -- [10] Storage -- [12] Secret Annex
+     *      |                                       |
+     *   [6] West Alcove                           [5] Exit Room -- [11] Reactor Hall
      */
     sdl3d_sector sectors[] = {
         /* 0: Starting room */
         {{{0, 0}, {10, 0}, {10, 8}, {0, 8}}, 4, 0.0f, 4.0f, 0, 1, 2},
-        /* 1: Corridor */
+        /* 1: South corridor */
         {{{3, 8}, {7, 8}, {7, 16}, {3, 16}}, 4, 0.0f, 3.5f, 5, 1, 4},
-        /* 2: Nukage room (lower floor) */
+        /* 2: Nukage basin */
         {{{-2, 16}, {10, 16}, {10, 26}, {-2, 26}}, 4, -0.5f, 4.5f, 3, 1, 2},
-        /* 3: Side passage */
+        /* 3: East passage */
         {{{10, 18}, {16, 18}, {16, 22}, {10, 22}}, 4, 0.0f, 3.5f, 0, 1, 4},
-        /* 4: Outdoor area */
+        /* 4: Courtyard */
         {{{16, 14}, {28, 14}, {28, 26}, {16, 26}}, 4, 0.0f, 8.0f, 0, 1, 2},
         /* 5: Exit room */
         {{{20, 26}, {28, 26}, {28, 32}, {20, 32}}, 4, 0.0f, 3.0f, 5, 1, 4},
+        /* 6: West alcove off nukage */
+        {{{-10, 18}, {-2, 18}, {-2, 24}, {-10, 24}}, 4, -0.5f, 3.5f, 5, 1, 4},
+        /* 7: Upper hall off start */
+        {{{10, 2}, {18, 2}, {18, 6}, {10, 6}}, 4, 0.0f, 3.5f, 5, 1, 4},
+        /* 8: Computer core */
+        {{{18, 0}, {30, 0}, {30, 8}, {18, 8}}, 4, 0.0f, 4.0f, 0, 1, 2},
+        /* 9: Security bend linking core to courtyard */
+        {{{22, 8}, {26, 8}, {26, 14}, {22, 14}}, 4, 0.0f, 3.2f, 5, 1, 4},
+        /* 10: Storage annex */
+        {{{28, 12}, {38, 12}, {38, 24}, {28, 24}}, 4, 0.0f, 4.0f, 0, 1, 2},
+        /* 11: Reactor hall beyond exit */
+        {{{18, 32}, {30, 32}, {30, 44}, {18, 44}}, 4, 0.0f, 5.5f, 5, 1, 4},
+        /* 12: Secret annex behind storage */
+        {{{32, 24}, {40, 24}, {40, 30}, {32, 30}}, 4, 0.0f, 3.0f, 0, 1, 2},
     };
 
     sdl3d_level_light lights[] = {
-        {{5, 3.5f, 4}, {1.0f, 0.85f, 0.6f}, 5.0f, 12.0f},  /* Start room — warm */
-        {{5, 3.0f, 12}, {1.0f, 0.7f, 0.3f}, 3.0f, 8.0f},   /* Corridor — amber */
-        {{4, 1.0f, 21}, {1.0f, 0.15f, 0.1f}, 4.0f, 14.0f}, /* Lava — red */
-        {{22, 7.0f, 20}, {0.4f, 0.5f, 0.8f}, 6.0f, 18.0f}, /* Outdoor — moonlight */
-        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 4.0f, 8.0f},  /* Exit — green */
+        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 4.4f, 11.0f},   /* Start room — warm tungsten */
+        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 2.6f, 8.0f},   /* South corridor — amber */
+        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 4.0f, 14.0f},  /* Nukage basin — red */
+        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.8f, 9.0f}, /* West alcove — toxic green */
+        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 2.4f, 8.0f},     /* Upper hall — cold white */
+        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.8f, 12.0f},  /* Computer core — cyan */
+        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 2.4f, 7.0f},   /* Security bend — sodium */
+        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 5.0f, 18.0f},/* Courtyard — moonlight */
+        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 3.0f, 12.0f},  /* Storage — magenta */
+        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 3.8f, 8.0f},    /* Exit — green */
+        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 3.4f, 13.0f}, /* Reactor hall — violet */
+        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 2.5f, 8.0f},  /* Secret annex — orange */
     };
+    const int sector_count = (int)SDL_arraysize(sectors);
+    const int light_count = (int)SDL_arraysize(lights);
 
     /* Build two versions: baked lighting and raw materials. */
     sdl3d_level level_lit, level_unlit;
-    if (!sdl3d_build_level(sectors, 6, mats, 6, lights, 5, &level_lit))
+    if (!sdl3d_build_level(sectors, sector_count, mats, 6, lights, light_count, &level_lit))
     {
         SDL_Log("Level build failed: %s", SDL_GetError());
         return 1;
     }
-    if (!sdl3d_build_level(sectors, 6, mats, 6, NULL, 0, &level_unlit))
+    if (!sdl3d_build_level(sectors, sector_count, mats, 6, NULL, 0, &level_unlit))
     {
         SDL_Log("Level build failed: %s", SDL_GetError());
         return 1;
@@ -300,7 +325,8 @@ int main(int argc, char *argv[])
         cam.projection = SDL3D_CAMERA_PERSPECTIVE;
 
         /* Update projectile. */
-        advance_projectile(sectors, 6, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy, proj_dz,
+        advance_projectile(sectors, sector_count, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
+                           proj_dz,
                            &proj_life);
 
         sdl3d_clear_lights(ctx);

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -33,11 +33,11 @@ extern "C"
 
     typedef struct sdl3d_level_material
     {
-        float albedo[4];       /* RGBA; default {1,1,1,1} */
-        float metallic;        /* [0,1]; default 0 */
-        float roughness;       /* [0,1]; default 1 */
-        const char *texture;   /* path to diffuse texture, or NULL */
-        float tex_scale;       /* UV scale (units per repeat); 0 = default (4) */
+        float albedo[4];     /* RGBA; default {1,1,1,1} */
+        float metallic;      /* [0,1]; default 0 */
+        float roughness;     /* [0,1]; default 1 */
+        const char *texture; /* path to diffuse texture, or NULL */
+        float tex_scale;     /* UV scale (units per repeat); 0 = default (4) */
     } sdl3d_level_material;
 
     typedef struct sdl3d_sector
@@ -72,10 +72,8 @@ extern "C"
      * Pass NULL/0 for lights to use raw material colors.
      * Returns false with SDL_GetError on failure.
      */
-    bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count,
-                           const sdl3d_level_material *materials, int material_count,
-                           const sdl3d_level_light *lights, int light_count,
-                           sdl3d_level *out);
+    bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3d_level_material *materials,
+                           int material_count, const sdl3d_level_light *lights, int light_count, sdl3d_level *out);
 
     void sdl3d_free_level(sdl3d_level *level);
 

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -31,6 +31,8 @@ extern "C"
 
 #define SDL3D_SECTOR_MAX_POINTS 32
 
+    struct sdl3d_render_context;
+
     typedef struct sdl3d_level_material
     {
         float albedo[4];     /* RGBA; default {1,1,1,1} */
@@ -54,7 +56,36 @@ extern "C"
     typedef struct sdl3d_level
     {
         sdl3d_model model;
+
+        /* Runtime sector/portal metadata populated by sdl3d_build_level. */
+        int sector_count;
+
+        /* Per-mesh sector ownership: mesh_sector_ids[mesh_index] = sector index.
+         * Length = model.mesh_count. */
+        int *mesh_sector_ids;
+
+        /* Portal adjacency graph. */
+        int portal_count;
+        struct sdl3d_level_portal *portals;
     } sdl3d_level;
+
+    /* A portal connecting two adjacent sectors through a shared edge opening. */
+    typedef struct sdl3d_level_portal
+    {
+        int sector_a;
+        int sector_b;
+        float min_x, max_x; /* XZ span of the opening */
+        float min_z, max_z;
+        float floor_y;      /* opening bottom */
+        float ceil_y;       /* opening top */
+    } sdl3d_level_portal;
+
+    /* Visibility query result. */
+    typedef struct sdl3d_visibility_result
+    {
+        bool *sector_visible;  /* caller-provided array[sector_count] */
+        int visible_count;     /* number of visible sectors */
+    } sdl3d_visibility_result;
 
     typedef struct sdl3d_level_light
     {
@@ -76,6 +107,37 @@ extern "C"
                            int material_count, const sdl3d_level_light *lights, int light_count, sdl3d_level *out);
 
     void sdl3d_free_level(sdl3d_level *level);
+
+    /*
+     * Find which sector contains the given XZ point, or -1 if outside all
+     * sectors. Uses 2D point-in-polygon on the sector floor plans.
+     */
+    int sdl3d_level_find_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z);
+
+    /*
+     * Compute which sectors are visible from the camera's current sector
+     * by traversing the portal graph. Portals behind the camera or outside
+     * the frustum are rejected. The caller must provide sector_visible as
+     * a bool array of at least level->sector_count elements.
+     *
+     * camera_pos/camera_dir: world-space camera position and forward vector.
+     * frustum_planes: 6 normalized frustum planes as float[6][4] (a,b,c,d),
+     *                 or NULL to skip frustum rejection (all reachable sectors
+     *                 are marked visible).
+     *
+     * Returns the number of visible sectors via result->visible_count.
+     */
+    void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector, sdl3d_vec3 camera_pos,
+                                        sdl3d_vec3 camera_dir, const float frustum_planes[6][4],
+                                        sdl3d_visibility_result *result);
+
+    /*
+     * Draw a built level, skipping meshes whose sector is not marked visible.
+     * If vis is NULL, all meshes are drawn (equivalent to sdl3d_draw_model).
+     * Frustum culling still applies per-mesh as a second stage.
+     */
+    bool sdl3d_draw_level(struct sdl3d_render_context *context, const sdl3d_level *level,
+                          const sdl3d_visibility_result *vis, sdl3d_color tint);
 
 #ifdef __cplusplus
 }

--- a/include/sdl3d/model.h
+++ b/include/sdl3d/model.h
@@ -68,6 +68,8 @@ extern "C"
         int index_count;
 
         int material_index;
+        bool has_local_bounds;
+        sdl3d_bounding_box local_bounds;
 
         /* Skinning attributes (NULL when no skeleton). Up to 4 joints
          * per vertex. joint_indices indexes into the model's skeleton

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
+#include <math.h>
 
 #include "rasterizer.h"
 #include "render_context_internal.h"
@@ -371,6 +372,113 @@ static sdl3d_vec3 sdl3d_transform_position(sdl3d_mat4 m, sdl3d_vec3 p)
 {
     sdl3d_vec4 w = sdl3d_mat4_transform_vec4(m, sdl3d_vec4_from_vec3(p, 1.0f));
     return sdl3d_vec3_make(w.x, w.y, w.z);
+}
+
+typedef struct
+{
+    float a;
+    float b;
+    float c;
+    float d;
+} sdl3d_frustum_plane;
+
+static sdl3d_frustum_plane sdl3d_make_frustum_plane(float a, float b, float c, float d)
+{
+    const float len = sqrtf(a * a + b * b + c * c);
+    sdl3d_frustum_plane plane;
+    if (len <= 0.000001f)
+    {
+        plane.a = 0.0f;
+        plane.b = 0.0f;
+        plane.c = 0.0f;
+        plane.d = d;
+        return plane;
+    }
+    plane.a = a / len;
+    plane.b = b / len;
+    plane.c = c / len;
+    plane.d = d / len;
+    return plane;
+}
+
+static void sdl3d_extract_frustum_planes(sdl3d_frustum_plane planes[6], sdl3d_mat4 view_projection)
+{
+    const float *m = view_projection.m;
+    planes[0] = sdl3d_make_frustum_plane(m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]);
+    planes[1] = sdl3d_make_frustum_plane(m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]);
+    planes[2] = sdl3d_make_frustum_plane(m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]);
+    planes[3] = sdl3d_make_frustum_plane(m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]);
+    planes[4] = sdl3d_make_frustum_plane(m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]);
+    planes[5] = sdl3d_make_frustum_plane(m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]);
+}
+
+static sdl3d_bounding_box sdl3d_transform_bounding_box(sdl3d_mat4 transform, sdl3d_bounding_box local_bounds)
+{
+    const sdl3d_vec3 corners[8] = {
+        sdl3d_vec3_make(local_bounds.min.x, local_bounds.min.y, local_bounds.min.z),
+        sdl3d_vec3_make(local_bounds.min.x, local_bounds.min.y, local_bounds.max.z),
+        sdl3d_vec3_make(local_bounds.min.x, local_bounds.max.y, local_bounds.min.z),
+        sdl3d_vec3_make(local_bounds.min.x, local_bounds.max.y, local_bounds.max.z),
+        sdl3d_vec3_make(local_bounds.max.x, local_bounds.min.y, local_bounds.min.z),
+        sdl3d_vec3_make(local_bounds.max.x, local_bounds.min.y, local_bounds.max.z),
+        sdl3d_vec3_make(local_bounds.max.x, local_bounds.max.y, local_bounds.min.z),
+        sdl3d_vec3_make(local_bounds.max.x, local_bounds.max.y, local_bounds.max.z),
+    };
+    sdl3d_bounding_box world_bounds;
+    sdl3d_vec3 p = sdl3d_transform_position(transform, corners[0]);
+    world_bounds.min = p;
+    world_bounds.max = p;
+
+    for (int i = 1; i < 8; ++i)
+    {
+        p = sdl3d_transform_position(transform, corners[i]);
+        if (p.x < world_bounds.min.x)
+            world_bounds.min.x = p.x;
+        if (p.y < world_bounds.min.y)
+            world_bounds.min.y = p.y;
+        if (p.z < world_bounds.min.z)
+            world_bounds.min.z = p.z;
+        if (p.x > world_bounds.max.x)
+            world_bounds.max.x = p.x;
+        if (p.y > world_bounds.max.y)
+            world_bounds.max.y = p.y;
+        if (p.z > world_bounds.max.z)
+            world_bounds.max.z = p.z;
+    }
+
+    return world_bounds;
+}
+
+static bool sdl3d_box_intersects_frustum(sdl3d_bounding_box bounds, const sdl3d_frustum_plane planes[6])
+{
+    for (int i = 0; i < 6; ++i)
+    {
+        const sdl3d_frustum_plane plane = planes[i];
+        const float px = plane.a >= 0.0f ? bounds.max.x : bounds.min.x;
+        const float py = plane.b >= 0.0f ? bounds.max.y : bounds.min.y;
+        const float pz = plane.c >= 0.0f ? bounds.max.z : bounds.min.z;
+        const float distance = plane.a * px + plane.b * py + plane.c * pz + plane.d;
+        if (distance < 0.0f)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool sdl3d_mesh_is_visible(const sdl3d_render_context *context, const sdl3d_mesh *mesh)
+{
+    sdl3d_frustum_plane planes[6];
+    sdl3d_bounding_box world_bounds;
+
+    if (context == NULL || mesh == NULL || !mesh->has_local_bounds)
+    {
+        return true;
+    }
+
+    sdl3d_extract_frustum_planes(planes, context->view_projection);
+    world_bounds = sdl3d_transform_bounding_box(context->model, mesh->local_bounds);
+    return sdl3d_box_intersects_frustum(world_bounds, planes);
 }
 
 /* Evaluate PBR shading at a single point and return the result as an sdl3d_color.
@@ -1175,6 +1283,11 @@ static bool sdl3d_draw_model_mesh(sdl3d_render_context *context, const sdl3d_mod
     const sdl3d_material *material = NULL;
     sdl3d_vec4 mesh_modulate = tint_modulate;
     bool ok = true;
+
+    if (!sdl3d_mesh_is_visible(context, mesh))
+    {
+        return true;
+    }
 
     if (mesh->material_index < -1)
     {

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -2,13 +2,13 @@
 
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_stdinc.h>
-#include <math.h>
 
 #include "rasterizer.h"
 #include "render_context_internal.h"
 #include "texture_internal.h"
 
 #include "lighting_internal.h"
+#include "sdl3d/level.h"
 
 static const int SDL3D_MODEL_STACK_INITIAL_CAPACITY = 8;
 
@@ -118,6 +118,39 @@ bool sdl3d_begin_mode_3d(sdl3d_render_context *context, sdl3d_camera3d camera)
     context->model_stack_depth = 1;
     context->model_stack[0] = sdl3d_mat4_identity();
     sdl3d_update_current_model_matrices(context);
+
+    /* Cache frustum planes once per frame so per-mesh culling is cheap. */
+    {
+        const float *m = context->view_projection.m;
+        float raw[6][4] = {
+            {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
+            {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
+            {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
+            {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
+            {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
+            {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
+        };
+        for (int i = 0; i < 6; ++i)
+        {
+            float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
+            if (len > 0.000001f)
+            {
+                context->frustum_planes[i][0] = raw[i][0] / len;
+                context->frustum_planes[i][1] = raw[i][1] / len;
+                context->frustum_planes[i][2] = raw[i][2] / len;
+                context->frustum_planes[i][3] = raw[i][3] / len;
+            }
+            else
+            {
+                context->frustum_planes[i][0] = 0.0f;
+                context->frustum_planes[i][1] = 0.0f;
+                context->frustum_planes[i][2] = 0.0f;
+                context->frustum_planes[i][3] = raw[i][3];
+            }
+        }
+        context->frustum_planes_valid = true;
+    }
+
     context->in_mode_3d = true;
     return true;
 }
@@ -135,6 +168,7 @@ bool sdl3d_end_mode_3d(sdl3d_render_context *context)
     }
 
     context->in_mode_3d = false;
+    context->frustum_planes_valid = false;
     context->model_stack_depth = 0;
     context->model = sdl3d_mat4_identity();
     context->model_view_projection = context->view_projection;
@@ -382,36 +416,6 @@ typedef struct
     float d;
 } sdl3d_frustum_plane;
 
-static sdl3d_frustum_plane sdl3d_make_frustum_plane(float a, float b, float c, float d)
-{
-    const float len = sqrtf(a * a + b * b + c * c);
-    sdl3d_frustum_plane plane;
-    if (len <= 0.000001f)
-    {
-        plane.a = 0.0f;
-        plane.b = 0.0f;
-        plane.c = 0.0f;
-        plane.d = d;
-        return plane;
-    }
-    plane.a = a / len;
-    plane.b = b / len;
-    plane.c = c / len;
-    plane.d = d / len;
-    return plane;
-}
-
-static void sdl3d_extract_frustum_planes(sdl3d_frustum_plane planes[6], sdl3d_mat4 view_projection)
-{
-    const float *m = view_projection.m;
-    planes[0] = sdl3d_make_frustum_plane(m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]);
-    planes[1] = sdl3d_make_frustum_plane(m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]);
-    planes[2] = sdl3d_make_frustum_plane(m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]);
-    planes[3] = sdl3d_make_frustum_plane(m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]);
-    planes[4] = sdl3d_make_frustum_plane(m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]);
-    planes[5] = sdl3d_make_frustum_plane(m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]);
-}
-
 static sdl3d_bounding_box sdl3d_transform_bounding_box(sdl3d_mat4 transform, sdl3d_bounding_box local_bounds)
 {
     const sdl3d_vec3 corners[8] = {
@@ -468,7 +472,6 @@ static bool sdl3d_box_intersects_frustum(sdl3d_bounding_box bounds, const sdl3d_
 
 static bool sdl3d_mesh_is_visible(const sdl3d_render_context *context, const sdl3d_mesh *mesh)
 {
-    sdl3d_frustum_plane planes[6];
     sdl3d_bounding_box world_bounds;
 
     if (context == NULL || mesh == NULL || !mesh->has_local_bounds)
@@ -476,7 +479,20 @@ static bool sdl3d_mesh_is_visible(const sdl3d_render_context *context, const sdl
         return true;
     }
 
-    sdl3d_extract_frustum_planes(planes, context->view_projection);
+    if (!context->frustum_planes_valid)
+    {
+        return true;
+    }
+
+    sdl3d_frustum_plane planes[6];
+    for (int i = 0; i < 6; ++i)
+    {
+        planes[i].a = context->frustum_planes[i][0];
+        planes[i].b = context->frustum_planes[i][1];
+        planes[i].c = context->frustum_planes[i][2];
+        planes[i].d = context->frustum_planes[i][3];
+    }
+
     world_bounds = sdl3d_transform_bounding_box(context->model, mesh->local_bounds);
     return sdl3d_box_intersects_frustum(world_bounds, planes);
 }
@@ -1611,4 +1627,38 @@ bool sdl3d_get_framebuffer_depth(const sdl3d_render_context *context, int x, int
 
     *out_depth = context->depth_buffer[(y * context->width) + x];
     return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Level drawing with portal visibility                                */
+/* ------------------------------------------------------------------ */
+
+bool sdl3d_draw_level(sdl3d_render_context *context, const sdl3d_level *level, const sdl3d_visibility_result *vis,
+                      sdl3d_color tint)
+{
+    if (!sdl3d_require_mode_3d(context, "sdl3d_draw_level"))
+        return false;
+    if (!level)
+        return SDL_InvalidParamError("level");
+
+    const sdl3d_model *model = &level->model;
+    if (!model->meshes || model->mesh_count <= 0)
+        return SDL_SetError("Level has no meshes.");
+
+    const sdl3d_vec4 tint_modulate = sdl3d_color_to_modulate(tint);
+    bool ok = true;
+
+    for (int i = 0; ok && i < model->mesh_count; ++i)
+    {
+        /* Portal visibility: skip meshes in hidden sectors. */
+        if (vis && vis->sector_visible && level->mesh_sector_ids)
+        {
+            int sid = level->mesh_sector_ids[i];
+            if (sid >= 0 && sid < level->sector_count && !vis->sector_visible[sid])
+                continue;
+        }
+        ok = sdl3d_draw_model_mesh(context, model, i, tint_modulate, NULL);
+    }
+
+    return ok;
 }

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -244,9 +244,9 @@ struct sdl3d_gl_context
     sdl3d_render_context *current_ctx;
 
     /* IBL (Image-Based Lighting) */
-    GLuint ibl_irradiance_map;  /* diffuse irradiance cubemap */
-    GLuint ibl_prefilter_map;   /* specular prefiltered cubemap */
-    GLuint ibl_brdf_lut;        /* 2D BRDF integration LUT */
+    GLuint ibl_irradiance_map; /* diffuse irradiance cubemap */
+    GLuint ibl_prefilter_map;  /* specular prefiltered cubemap */
+    GLuint ibl_brdf_lut;       /* 2D BRDF integration LUT */
     GLint pbr_irradiance_map_loc;
     GLint pbr_prefilter_map_loc;
     GLint pbr_brdf_lut_loc;
@@ -315,88 +315,89 @@ static const char k_pbr_vert[] = "layout(location = 0) in vec3 aPosition;\n"
                                  "    gl_Position = uViewProjection * worldPos;\n"
                                  "}\n";
 
-static const char k_pbr_frag_decl[] = "#define MAX_LIGHTS 8\n"
-                                      "#define PI 3.14159265\n"
-                                      "\n"
-                                      "struct Light {\n"
-                                      "    int type;\n"
-                                      "    vec3 position;\n"
-                                      "    vec3 direction;\n"
-                                      "    vec3 color;\n"
-                                      "    float intensity;\n"
-                                      "    float range;\n"
-                                      "    float innerCutoff;\n"
-                                      "    float outerCutoff;\n"
-                                      "};\n"
-                                      "\n"
-                                      "layout(std140) uniform SceneUBO {\n"
-                                      "    mat4 uViewProjection;\n"
-                                      "    vec3 uCameraPos;\n"
-                                      "    float _pad0;\n"
-                                      "    vec3 uAmbient;\n"
-                                      "    int uLightCount;\n"
-                                      "    Light uLights[MAX_LIGHTS];\n"
-                                      "    int uFogMode;\n"
-                                      "    float uFogStart;\n"
-                                      "    float uFogEnd;\n"
-                                      "    float uFogDensity;\n"
-                                      "    vec3 uFogColor;\n"
-                                      "    int uTonemapMode;\n"
-                                      "};\n"
-                                      "\n"
-                                      "in vec3 vWorldPos;\n"
-                                      "in vec3 vWorldNormal;\n"
-                                      "in vec2 vTexCoord;\n"
-                                      "in vec4 vColor;\n"
-                                      "\n"
-                                      "uniform sampler2D uTexture;\n"
-                                      "uniform int uHasTexture;\n"
-                                      "uniform vec4 uTint;\n"
-                                      "uniform float uMetallic;\n"
-                                      "uniform float uRoughness;\n"
-                                      "uniform vec3 uEmissive;\n"
-                                      "uniform int uBakedLightMode;\n"
-                                      "\n"
-                                      "uniform sampler2DArray uShadowMap;\n"
-                                      "uniform mat4 uShadowVP;\n"
-                                      "uniform int uShadowEnabled;\n"
-                                      "uniform float uShadowBias;\n"
-                                      "uniform mat4 uCSMVP[4];\n"
-                                      "uniform float uCSMSplits[4];\n"
-                                      "uniform mat4 uViewMatrix;\n"
-                                      "uniform int uCSMEnabled;\n"
-                                      "\n"
-                                      "uniform samplerCube uPointShadowMap[2];\n"
-                                      "uniform vec3 uPointShadowLightPos[2];\n"
-                                      "uniform float uPointShadowFar[2];\n"
-                                      "uniform int uPointShadowCount;\n"
-                                      "\n"
-                                      "uniform samplerCube uIrradianceMap;\n"
-                                      "uniform samplerCube uPrefilterMap;\n"
-                                      "uniform sampler2D uBrdfLUT;\n"
-                                      "uniform int uIBLEnabled;\n"
-                                      "uniform float uMaxReflectionLod;\n"
-                                      "\n"
-                                      "out vec4 fragColor;\n"
-                                      "\n"
-                                      "float DistributionGGX(float NdotH, float r) {\n"
-                                      "    float a = r * r;\n"
-                                      "    float a2 = a * a;\n"
-                                      "    float d = NdotH * NdotH * (a2 - 1.0) + 1.0;\n"
-                                      "    return a2 / (PI * d * d + 0.0001);\n"
-                                      "}\n"
-                                      "\n"
-                                      "float GeometrySchlickGGX(float NdotV, float r) {\n"
-                                      "    float k = (r + 1.0) * (r + 1.0) / 8.0;\n"
-                                      "    return NdotV / (NdotV * (1.0 - k) + k + 0.0001);\n"
-                                      "}\n"
-                                      "\n"
-                                      "vec3 FresnelSchlick(float cosTheta, vec3 F0) {\n"
-                                      "    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);\n"
-                                      "}\n"
-                                      "vec3 FresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness) {\n"
-                                      "    return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);\n"
-                                      "}\n";
+static const char k_pbr_frag_decl[] =
+    "#define MAX_LIGHTS 8\n"
+    "#define PI 3.14159265\n"
+    "\n"
+    "struct Light {\n"
+    "    int type;\n"
+    "    vec3 position;\n"
+    "    vec3 direction;\n"
+    "    vec3 color;\n"
+    "    float intensity;\n"
+    "    float range;\n"
+    "    float innerCutoff;\n"
+    "    float outerCutoff;\n"
+    "};\n"
+    "\n"
+    "layout(std140) uniform SceneUBO {\n"
+    "    mat4 uViewProjection;\n"
+    "    vec3 uCameraPos;\n"
+    "    float _pad0;\n"
+    "    vec3 uAmbient;\n"
+    "    int uLightCount;\n"
+    "    Light uLights[MAX_LIGHTS];\n"
+    "    int uFogMode;\n"
+    "    float uFogStart;\n"
+    "    float uFogEnd;\n"
+    "    float uFogDensity;\n"
+    "    vec3 uFogColor;\n"
+    "    int uTonemapMode;\n"
+    "};\n"
+    "\n"
+    "in vec3 vWorldPos;\n"
+    "in vec3 vWorldNormal;\n"
+    "in vec2 vTexCoord;\n"
+    "in vec4 vColor;\n"
+    "\n"
+    "uniform sampler2D uTexture;\n"
+    "uniform int uHasTexture;\n"
+    "uniform vec4 uTint;\n"
+    "uniform float uMetallic;\n"
+    "uniform float uRoughness;\n"
+    "uniform vec3 uEmissive;\n"
+    "uniform int uBakedLightMode;\n"
+    "\n"
+    "uniform sampler2DArray uShadowMap;\n"
+    "uniform mat4 uShadowVP;\n"
+    "uniform int uShadowEnabled;\n"
+    "uniform float uShadowBias;\n"
+    "uniform mat4 uCSMVP[4];\n"
+    "uniform float uCSMSplits[4];\n"
+    "uniform mat4 uViewMatrix;\n"
+    "uniform int uCSMEnabled;\n"
+    "\n"
+    "uniform samplerCube uPointShadowMap[2];\n"
+    "uniform vec3 uPointShadowLightPos[2];\n"
+    "uniform float uPointShadowFar[2];\n"
+    "uniform int uPointShadowCount;\n"
+    "\n"
+    "uniform samplerCube uIrradianceMap;\n"
+    "uniform samplerCube uPrefilterMap;\n"
+    "uniform sampler2D uBrdfLUT;\n"
+    "uniform int uIBLEnabled;\n"
+    "uniform float uMaxReflectionLod;\n"
+    "\n"
+    "out vec4 fragColor;\n"
+    "\n"
+    "float DistributionGGX(float NdotH, float r) {\n"
+    "    float a = r * r;\n"
+    "    float a2 = a * a;\n"
+    "    float d = NdotH * NdotH * (a2 - 1.0) + 1.0;\n"
+    "    return a2 / (PI * d * d + 0.0001);\n"
+    "}\n"
+    "\n"
+    "float GeometrySchlickGGX(float NdotV, float r) {\n"
+    "    float k = (r + 1.0) * (r + 1.0) / 8.0;\n"
+    "    return NdotV / (NdotV * (1.0 - k) + k + 0.0001);\n"
+    "}\n"
+    "\n"
+    "vec3 FresnelSchlick(float cosTheta, vec3 F0) {\n"
+    "    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);\n"
+    "}\n"
+    "vec3 FresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness) {\n"
+    "    return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);\n"
+    "}\n";
 
 static const char k_pbr_frag_main[] =
     "void main() {\n"
@@ -837,29 +838,27 @@ static GLuint link_program(sdl3d_gl_funcs *gl, GLuint vert, GLuint frag)
 /* IBL shader sources                                                  */
 /* ------------------------------------------------------------------ */
 
-static const char k_cube_vert[] =
-    "layout(location = 0) in vec3 aPosition;\n"
-    "out vec3 vLocalPos;\n"
-    "uniform mat4 uProjection;\n"
-    "uniform mat4 uView;\n"
-    "void main() {\n"
-    "    vLocalPos = aPosition;\n"
-    "    gl_Position = uProjection * uView * vec4(aPosition, 1.0);\n"
-    "}\n";
+static const char k_cube_vert[] = "layout(location = 0) in vec3 aPosition;\n"
+                                  "out vec3 vLocalPos;\n"
+                                  "uniform mat4 uProjection;\n"
+                                  "uniform mat4 uView;\n"
+                                  "void main() {\n"
+                                  "    vLocalPos = aPosition;\n"
+                                  "    gl_Position = uProjection * uView * vec4(aPosition, 1.0);\n"
+                                  "}\n";
 
-static const char k_equirect_to_cube_frag[] =
-    "in vec3 vLocalPos;\n"
-    "out vec4 fragColor;\n"
-    "uniform sampler2D uEquirectMap;\n"
-    "const vec2 invAtan = vec2(0.1591, 0.3183);\n"
-    "void main() {\n"
-    "    vec3 d = normalize(vLocalPos);\n"
-    "    vec2 uv = vec2(atan(d.z, d.x), asin(d.y));\n"
-    "    uv *= invAtan;\n"
-    "    uv += 0.5;\n"
-    "    vec3 color = texture(uEquirectMap, uv).rgb;\n"
-    "    fragColor = vec4(color, 1.0);\n"
-    "}\n";
+static const char k_equirect_to_cube_frag[] = "in vec3 vLocalPos;\n"
+                                              "out vec4 fragColor;\n"
+                                              "uniform sampler2D uEquirectMap;\n"
+                                              "const vec2 invAtan = vec2(0.1591, 0.3183);\n"
+                                              "void main() {\n"
+                                              "    vec3 d = normalize(vLocalPos);\n"
+                                              "    vec2 uv = vec2(atan(d.z, d.x), asin(d.y));\n"
+                                              "    uv *= invAtan;\n"
+                                              "    uv += 0.5;\n"
+                                              "    vec3 color = texture(uEquirectMap, uv).rgb;\n"
+                                              "    fragColor = vec4(color, 1.0);\n"
+                                              "}\n";
 
 static const char k_irradiance_frag[] =
     "in vec3 vLocalPos;\n"
@@ -886,63 +885,61 @@ static const char k_irradiance_frag[] =
     "    fragColor = vec4(irradiance, 1.0);\n"
     "}\n";
 
-static const char k_prefilter_frag[] =
-    "in vec3 vLocalPos;\n"
-    "out vec4 fragColor;\n"
-    "uniform samplerCube uEnvironmentMap;\n"
-    "uniform float uRoughness;\n"
-    "const float PI = 3.14159265;\n"
-    "float RadicalInverse_VdC(uint bits) {\n"
-    "    bits = (bits << 16u) | (bits >> 16u);\n"
-    "    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);\n"
-    "    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);\n"
-    "    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);\n"
-    "    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);\n"
-    "    return float(bits) * 2.3283064365386963e-10;\n"
-    "}\n"
-    "vec2 Hammersley(uint i, uint N) {\n"
-    "    return vec2(float(i)/float(N), RadicalInverse_VdC(i));\n"
-    "}\n"
-    "vec3 ImportanceSampleGGX(vec2 Xi, vec3 N, float roughness) {\n"
-    "    float a = roughness * roughness;\n"
-    "    float phi = 2.0 * PI * Xi.x;\n"
-    "    float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a*a - 1.0) * Xi.y));\n"
-    "    float sinTheta = sqrt(1.0 - cosTheta*cosTheta);\n"
-    "    vec3 H = vec3(cos(phi)*sinTheta, sin(phi)*sinTheta, cosTheta);\n"
-    "    vec3 up = abs(N.z) < 0.999 ? vec3(0,0,1) : vec3(1,0,0);\n"
-    "    vec3 tangent = normalize(cross(up, N));\n"
-    "    vec3 bitangent = cross(N, tangent);\n"
-    "    return tangent * H.x + bitangent * H.y + N * H.z;\n"
-    "}\n"
-    "void main() {\n"
-    "    vec3 N = normalize(vLocalPos);\n"
-    "    vec3 R = N;\n"
-    "    vec3 V = R;\n"
-    "    const uint SAMPLE_COUNT = 1024u;\n"
-    "    float totalWeight = 0.0;\n"
-    "    vec3 prefilteredColor = vec3(0.0);\n"
-    "    for (uint i = 0u; i < SAMPLE_COUNT; ++i) {\n"
-    "        vec2 Xi = Hammersley(i, SAMPLE_COUNT);\n"
-    "        vec3 H = ImportanceSampleGGX(Xi, N, uRoughness);\n"
-    "        vec3 L = normalize(2.0 * dot(V, H) * H - V);\n"
-    "        float NdotL = max(dot(N, L), 0.0);\n"
-    "        if (NdotL > 0.0) {\n"
-    "            prefilteredColor += texture(uEnvironmentMap, L).rgb * NdotL;\n"
-    "            totalWeight += NdotL;\n"
-    "        }\n"
-    "    }\n"
-    "    prefilteredColor /= totalWeight;\n"
-    "    fragColor = vec4(prefilteredColor, 1.0);\n"
-    "}\n";
+static const char k_prefilter_frag[] = "in vec3 vLocalPos;\n"
+                                       "out vec4 fragColor;\n"
+                                       "uniform samplerCube uEnvironmentMap;\n"
+                                       "uniform float uRoughness;\n"
+                                       "const float PI = 3.14159265;\n"
+                                       "float RadicalInverse_VdC(uint bits) {\n"
+                                       "    bits = (bits << 16u) | (bits >> 16u);\n"
+                                       "    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);\n"
+                                       "    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);\n"
+                                       "    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);\n"
+                                       "    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);\n"
+                                       "    return float(bits) * 2.3283064365386963e-10;\n"
+                                       "}\n"
+                                       "vec2 Hammersley(uint i, uint N) {\n"
+                                       "    return vec2(float(i)/float(N), RadicalInverse_VdC(i));\n"
+                                       "}\n"
+                                       "vec3 ImportanceSampleGGX(vec2 Xi, vec3 N, float roughness) {\n"
+                                       "    float a = roughness * roughness;\n"
+                                       "    float phi = 2.0 * PI * Xi.x;\n"
+                                       "    float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a*a - 1.0) * Xi.y));\n"
+                                       "    float sinTheta = sqrt(1.0 - cosTheta*cosTheta);\n"
+                                       "    vec3 H = vec3(cos(phi)*sinTheta, sin(phi)*sinTheta, cosTheta);\n"
+                                       "    vec3 up = abs(N.z) < 0.999 ? vec3(0,0,1) : vec3(1,0,0);\n"
+                                       "    vec3 tangent = normalize(cross(up, N));\n"
+                                       "    vec3 bitangent = cross(N, tangent);\n"
+                                       "    return tangent * H.x + bitangent * H.y + N * H.z;\n"
+                                       "}\n"
+                                       "void main() {\n"
+                                       "    vec3 N = normalize(vLocalPos);\n"
+                                       "    vec3 R = N;\n"
+                                       "    vec3 V = R;\n"
+                                       "    const uint SAMPLE_COUNT = 1024u;\n"
+                                       "    float totalWeight = 0.0;\n"
+                                       "    vec3 prefilteredColor = vec3(0.0);\n"
+                                       "    for (uint i = 0u; i < SAMPLE_COUNT; ++i) {\n"
+                                       "        vec2 Xi = Hammersley(i, SAMPLE_COUNT);\n"
+                                       "        vec3 H = ImportanceSampleGGX(Xi, N, uRoughness);\n"
+                                       "        vec3 L = normalize(2.0 * dot(V, H) * H - V);\n"
+                                       "        float NdotL = max(dot(N, L), 0.0);\n"
+                                       "        if (NdotL > 0.0) {\n"
+                                       "            prefilteredColor += texture(uEnvironmentMap, L).rgb * NdotL;\n"
+                                       "            totalWeight += NdotL;\n"
+                                       "        }\n"
+                                       "    }\n"
+                                       "    prefilteredColor /= totalWeight;\n"
+                                       "    fragColor = vec4(prefilteredColor, 1.0);\n"
+                                       "}\n";
 
-static const char k_brdf_vert[] =
-    "layout(location = 0) in vec3 aPosition;\n"
-    "layout(location = 2) in vec2 aTexCoord;\n"
-    "out vec2 vTexCoord;\n"
-    "void main() {\n"
-    "    vTexCoord = aTexCoord;\n"
-    "    gl_Position = vec4(aPosition, 1.0);\n"
-    "}\n";
+static const char k_brdf_vert[] = "layout(location = 0) in vec3 aPosition;\n"
+                                  "layout(location = 2) in vec2 aTexCoord;\n"
+                                  "out vec2 vTexCoord;\n"
+                                  "void main() {\n"
+                                  "    vTexCoord = aTexCoord;\n"
+                                  "    gl_Position = vec4(aPosition, 1.0);\n"
+                                  "}\n";
 
 static const char k_brdf_frag[] =
     "in vec2 vTexCoord;\n"
@@ -1012,12 +1009,10 @@ static const char k_brdf_frag[] =
 
 /* Unit cube vertices for cubemap rendering. */
 static const float k_cube_vertices[] = {
-    -1, -1, -1,  1, -1, -1,  1,  1, -1, -1,  1, -1,
-    -1, -1,  1,  1, -1,  1,  1,  1,  1, -1,  1,  1,
+    -1, -1, -1, 1, -1, -1, 1, 1, -1, -1, 1, -1, -1, -1, 1, 1, -1, 1, 1, 1, 1, -1, 1, 1,
 };
 static const unsigned int k_cube_indices[] = {
-    0,1,2, 2,3,0, 1,5,6, 6,2,1, 5,4,7, 7,6,5,
-    4,0,3, 3,7,4, 3,2,6, 6,7,3, 4,5,1, 1,0,4,
+    0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 5, 4, 7, 7, 6, 5, 4, 0, 3, 3, 7, 4, 3, 2, 6, 6, 7, 3, 4, 5, 1, 1, 0, 4,
 };
 
 static GLuint build_program(sdl3d_gl_funcs *gl, const char *version, const char *vert_body, const char *frag_body)
@@ -1852,8 +1847,7 @@ bool sdl3d_gl_load_environment_map(sdl3d_gl_context *ctx, const char *hdr_path)
     GLuint hdr_tex;
     gl->GenTextures(1, &hdr_tex);
     gl->BindTexture(GL_TEXTURE_2D, hdr_tex);
-    gl->TexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, w, h, 0,
-                   nc == 4 ? GL_RGBA : GL_RGB, GL_FLOAT, data);
+    gl->TexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, w, h, 0, nc == 4 ? GL_RGBA : GL_RGB, GL_FLOAT, data);
     gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, 0x812F /* GL_CLAMP_TO_EDGE */);
     gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, 0x812F);
     gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -1888,8 +1882,8 @@ bool sdl3d_gl_load_environment_map(sdl3d_gl_context *ctx, const char *hdr_path)
         SDL_memcpy(cap_proj, pm.m, sizeof(cap_proj));
     }
     sdl3d_vec3 o = {0, 0, 0};
-    sdl3d_vec3 tgts[6] = {{1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}};
-    sdl3d_vec3 ups[6] = {{0,-1,0},{0,-1,0},{0,0,1},{0,0,-1},{0,-1,0},{0,-1,0}};
+    sdl3d_vec3 tgts[6] = {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}};
+    sdl3d_vec3 ups[6] = {{0, -1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}, {0, -1, 0}, {0, -1, 0}};
     float cap_views[6][16];
     for (int i = 0; i < 6; i++)
     {
@@ -1929,8 +1923,8 @@ bool sdl3d_gl_load_environment_map(sdl3d_gl_context *ctx, const char *hdr_path)
     for (int i = 0; i < 6; i++)
     {
         gl->UniformMatrix4fv(eq_view_loc, 1, GL_FALSE, cap_views[i]);
-        gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                 GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i, env_cubemap, 0);
+        gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i,
+                                 env_cubemap, 0);
         gl->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         ibl_render_cube(gl, cube_vao);
     }
@@ -1959,8 +1953,8 @@ bool sdl3d_gl_load_environment_map(sdl3d_gl_context *ctx, const char *hdr_path)
     for (int i = 0; i < 6; i++)
     {
         gl->UniformMatrix4fv(irr_view_loc, 1, GL_FALSE, cap_views[i]);
-        gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                 GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i, ctx->ibl_irradiance_map, 0);
+        gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i,
+                                 ctx->ibl_irradiance_map, 0);
         gl->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         ibl_render_cube(gl, cube_vao);
     }
@@ -1995,8 +1989,8 @@ bool sdl3d_gl_load_environment_map(sdl3d_gl_context *ctx, const char *hdr_path)
         for (int i = 0; i < 6; i++)
         {
             gl->UniformMatrix4fv(pf_view_loc, 1, GL_FALSE, cap_views[i]);
-            gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                     GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i, ctx->ibl_prefilter_map, mip);
+            gl->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + (GLenum)i,
+                                     ctx->ibl_prefilter_map, mip);
             gl->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             ibl_render_cube(gl, cube_vao);
         }

--- a/src/level.c
+++ b/src/level.c
@@ -59,6 +59,8 @@ typedef struct
     unsigned int *idx;
     int vc, vc_cap;
     int ic, ic_cap;
+    bool has_bounds;
+    sdl3d_bounding_box bounds;
 } macc;
 
 static bool macc_grow_v(macc *a, int n)
@@ -115,6 +117,31 @@ static int macc_vert(macc *a, float x, float y, float z, float nx, float ny, flo
     a->col[i * 4 + 3] = rgba[3];
     a->uvs[i * 2] = u;
     a->uvs[i * 2 + 1] = v;
+    if (!a->has_bounds)
+    {
+        a->bounds.min.x = x;
+        a->bounds.min.y = y;
+        a->bounds.min.z = z;
+        a->bounds.max.x = x;
+        a->bounds.max.y = y;
+        a->bounds.max.z = z;
+        a->has_bounds = true;
+    }
+    else
+    {
+        if (x < a->bounds.min.x)
+            a->bounds.min.x = x;
+        if (y < a->bounds.min.y)
+            a->bounds.min.y = y;
+        if (z < a->bounds.min.z)
+            a->bounds.min.z = z;
+        if (x > a->bounds.max.x)
+            a->bounds.max.x = x;
+        if (y > a->bounds.max.y)
+            a->bounds.max.y = y;
+        if (z > a->bounds.max.z)
+            a->bounds.max.z = z;
+    }
     return i;
 }
 
@@ -231,22 +258,14 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         }
     }
 
-    /* Per-material mesh accumulators. */
-    macc *accs = SDL_calloc((size_t)material_count, sizeof(macc));
+    /* Per-sector/per-material mesh accumulators so hidden rooms can be culled
+     * independently without changing the current baked-light look. */
+    const int acc_count = sector_count * material_count;
+    macc *accs = SDL_calloc((size_t)acc_count, sizeof(macc));
     if (!accs)
     {
         SDL_free(edges);
         return SDL_OutOfMemory();
-    }
-    for (int m = 0; m < material_count; m++)
-    {
-        accs[m].vc_cap = 64;
-        accs[m].ic_cap = 128;
-        accs[m].pos = SDL_malloc((size_t)accs[m].vc_cap * 3 * sizeof(float));
-        accs[m].nrm = SDL_malloc((size_t)accs[m].vc_cap * 3 * sizeof(float));
-        accs[m].col = SDL_malloc((size_t)accs[m].vc_cap * 4 * sizeof(float));
-        accs[m].uvs = SDL_malloc((size_t)accs[m].vc_cap * 2 * sizeof(float));
-        accs[m].idx = SDL_malloc((size_t)accs[m].ic_cap * sizeof(unsigned int));
     }
 
     for (int s = 0; s < sector_count; s++)
@@ -255,9 +274,12 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         int fi = sec->floor_material < material_count ? sec->floor_material : 0;
         int ci = sec->ceil_material < material_count ? sec->ceil_material : 0;
         int wi = sec->wall_material < material_count ? sec->wall_material : 0;
+        macc *floor_acc = &accs[s * material_count + fi];
+        macc *ceil_acc = &accs[s * material_count + ci];
+        macc *wall_acc = &accs[s * material_count + wi];
 
-        add_floor_ceil(&accs[fi], sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale);
-        add_floor_ceil(&accs[ci], sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale);
+        add_floor_ceil(floor_acc, sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale);
+        add_floor_ceil(ceil_acc, sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale);
 
         for (int e = 0; e < total_edges; e++)
         {
@@ -300,7 +322,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
             if (novl == 0)
             {
-                add_wall(&accs[wi], ax, az, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                add_wall(wall_acc, ax, az, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
                          materials[wi].tex_scale);
             }
             else
@@ -321,23 +343,23 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                     {
                         float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
                         float wx1 = ax + (bx - ax) * overlaps[oi].t0, wz1 = az + (bz - az) * overlaps[oi].t0;
-                        add_wall(&accs[wi], wx0, wz0, wx1, wz1, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                        add_wall(wall_acc, wx0, wz0, wx1, wz1, sec->floor_y, sec->ceil_y, materials[wi].albedo,
                                  materials[wi].tex_scale);
                     }
                     float ox0 = ax + (bx - ax) * overlaps[oi].t0, oz0 = az + (bz - az) * overlaps[oi].t0;
                     float ox1 = ax + (bx - ax) * overlaps[oi].t1, oz1 = az + (bz - az) * overlaps[oi].t1;
                     if (sec->floor_y < overlaps[oi].other_floor - 0.001f)
-                        add_wall(&accs[wi], ox0, oz0, ox1, oz1, sec->floor_y, overlaps[oi].other_floor,
+                        add_wall(wall_acc, ox0, oz0, ox1, oz1, sec->floor_y, overlaps[oi].other_floor,
                                  materials[wi].albedo, materials[wi].tex_scale);
                     if (sec->ceil_y > overlaps[oi].other_ceil + 0.001f)
-                        add_wall(&accs[wi], ox0, oz0, ox1, oz1, overlaps[oi].other_ceil, sec->ceil_y,
+                        add_wall(wall_acc, ox0, oz0, ox1, oz1, overlaps[oi].other_ceil, sec->ceil_y,
                                  materials[wi].albedo, materials[wi].tex_scale);
                     cursor = overlaps[oi].t1;
                 }
                 if (cursor < 1.0f - 0.001f)
                 {
                     float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
-                    add_wall(&accs[wi], wx0, wz0, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                    add_wall(wall_acc, wx0, wz0, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
                              materials[wi].tex_scale);
                 }
             }
@@ -349,9 +371,9 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
     /* ---- Bake vertex lighting per material ---- */
     if (lights && light_count > 0)
     {
-        for (int m = 0; m < material_count; m++)
+        for (int ai = 0; ai < acc_count; ai++)
         {
-            macc *a = &accs[m];
+            macc *a = &accs[ai];
             for (int v = 0; v < a->vc; v++)
             {
                 float px = a->pos[v * 3], py = a->pos[v * 3 + 1], pz = a->pos[v * 3 + 2];
@@ -389,52 +411,61 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         }
     }
 
-    /* ---- Package: one mesh + one material per level material ---- */
+    /* ---- Package: one mesh per sector/material chunk ---- */
     int num_meshes = 0;
-    for (int m = 0; m < material_count; m++)
-        if (accs[m].ic > 0)
+    for (int ai = 0; ai < acc_count; ai++)
+        if (accs[ai].ic > 0)
             num_meshes++;
 
     sdl3d_mesh *meshes = SDL_calloc((size_t)num_meshes, sizeof(sdl3d_mesh));
-    sdl3d_material *out_mats = SDL_calloc((size_t)num_meshes, sizeof(sdl3d_material));
+    sdl3d_material *out_mats = SDL_calloc((size_t)material_count, sizeof(sdl3d_material));
     if (!meshes || !out_mats)
     {
-        for (int m = 0; m < material_count; m++)
-            macc_free(&accs[m]);
+        for (int ai = 0; ai < acc_count; ai++)
+            macc_free(&accs[ai]);
         SDL_free(accs);
         SDL_free(meshes);
         SDL_free(out_mats);
         return SDL_OutOfMemory();
     }
 
-    int mi = 0;
-    int total_verts = 0, total_tris = 0;
     for (int m = 0; m < material_count; m++)
     {
-        if (accs[m].ic == 0)
-        {
-            macc_free(&accs[m]);
-            continue;
-        }
-        meshes[mi].vertex_count = accs[m].vc;
-        meshes[mi].index_count = accs[m].ic;
-        meshes[mi].positions = accs[m].pos;
-        meshes[mi].normals = accs[m].nrm;
-        meshes[mi].colors = accs[m].col;
-        meshes[mi].colors_are_baked_light = (lights != NULL && light_count > 0);
-        meshes[mi].uvs = accs[m].uvs;
-        meshes[mi].indices = accs[m].idx;
-        meshes[mi].material_index = mi;
-
-        out_mats[mi].albedo[0] = out_mats[mi].albedo[1] = out_mats[mi].albedo[2] = out_mats[mi].albedo[3] = 1.0f;
-        out_mats[mi].roughness = materials[m].roughness;
-        out_mats[mi].metallic = materials[m].metallic;
+        out_mats[m].albedo[0] = out_mats[m].albedo[1] = out_mats[m].albedo[2] = out_mats[m].albedo[3] = 1.0f;
+        out_mats[m].roughness = materials[m].roughness;
+        out_mats[m].metallic = materials[m].metallic;
         if (materials[m].texture)
-            out_mats[mi].albedo_map = SDL_strdup(materials[m].texture);
+            out_mats[m].albedo_map = SDL_strdup(materials[m].texture);
+    }
 
-        total_verts += accs[m].vc;
-        total_tris += accs[m].ic / 3;
-        mi++;
+    int mi = 0;
+    int total_verts = 0, total_tris = 0;
+    for (int s = 0; s < sector_count; s++)
+    {
+        for (int m = 0; m < material_count; m++)
+        {
+            macc *a = &accs[s * material_count + m];
+            if (a->ic == 0)
+            {
+                macc_free(a);
+                continue;
+            }
+            meshes[mi].vertex_count = a->vc;
+            meshes[mi].index_count = a->ic;
+            meshes[mi].positions = a->pos;
+            meshes[mi].normals = a->nrm;
+            meshes[mi].colors = a->col;
+            meshes[mi].colors_are_baked_light = (lights != NULL && light_count > 0);
+            meshes[mi].uvs = a->uvs;
+            meshes[mi].indices = a->idx;
+            meshes[mi].material_index = m;
+            meshes[mi].has_local_bounds = a->has_bounds;
+            meshes[mi].local_bounds = a->bounds;
+
+            total_verts += a->vc;
+            total_tris += a->ic / 3;
+            mi++;
+        }
     }
     SDL_free(accs);
 
@@ -451,7 +482,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
     out->model.meshes = meshes;
     out->model.mesh_count = num_meshes;
     out->model.materials = out_mats;
-    out->model.material_count = num_meshes;
+    out->model.material_count = material_count;
 
     SDL_Log("SDL3D level: %d verts, %d tris, %d meshes from %d sectors", total_verts, total_tris, num_meshes,
             sector_count);

--- a/src/level.c
+++ b/src/level.c
@@ -11,7 +11,6 @@
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
-#include <math.h>
 
 /* ------------------------------------------------------------------ */
 /* Edge overlap detection                                              */
@@ -28,7 +27,7 @@ static bool edges_collinear(float ax, float az, float bx, float bz, float cx, fl
     float eps = 0.01f;
     float cross1 = (bx - ax) * (cz - az) - (bz - az) * (cx - ax);
     float cross2 = (bx - ax) * (dz - az) - (bz - az) * (dx - ax);
-    return fabsf(cross1) < eps && fabsf(cross2) < eps;
+    return SDL_fabsf(cross1) < eps && SDL_fabsf(cross2) < eps;
 }
 
 static float project_onto_edge(float px, float pz, float ax, float az, float bx, float bz)
@@ -44,6 +43,7 @@ typedef struct
 {
     float t0, t1;
     float other_floor, other_ceil;
+    int other_sector;
 } overlap_t;
 
 /* ------------------------------------------------------------------ */
@@ -174,7 +174,7 @@ static bool add_wall(macc *a, float x0, float z0, float x1, float z1, float bot,
     if (top - bot < 0.001f)
         return true;
     float dx = x1 - x0, dz = z1 - z0;
-    float len = sqrtf(dx * dx + dz * dz);
+    float len = SDL_sqrtf(dx * dx + dz * dz);
     if (len < 0.0001f)
         return true;
     float nx = dz / len, nz = -dx / len;
@@ -268,6 +268,18 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         return SDL_OutOfMemory();
     }
 
+    /* Portal accumulator — collect adjacencies during edge overlap detection. */
+    int portal_cap = 32, portal_count = 0;
+    sdl3d_level_portal *portals = SDL_malloc((size_t)portal_cap * sizeof(sdl3d_level_portal));
+    if (!portals)
+    {
+        for (int ai = 0; ai < acc_count; ai++)
+            macc_free(&accs[ai]);
+        SDL_free(accs);
+        SDL_free(edges);
+        return SDL_OutOfMemory();
+    }
+
     for (int s = 0; s < sector_count; s++)
     {
         const sdl3d_sector *sec = &sectors[s];
@@ -316,7 +328,41 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                     overlaps[novl].t1 = t1;
                     overlaps[novl].other_floor = sectors[edges[j].sector].floor_y;
                     overlaps[novl].other_ceil = sectors[edges[j].sector].ceil_y;
+                    overlaps[novl].other_sector = edges[j].sector;
                     novl++;
+
+                    /* Record portal (only when s < neighbor to avoid duplicates). */
+                    if (s < edges[j].sector)
+                    {
+                        if (portal_count >= portal_cap)
+                        {
+                            portal_cap *= 2;
+                            sdl3d_level_portal *tmp =
+                                SDL_realloc(portals, (size_t)portal_cap * sizeof(sdl3d_level_portal));
+                            if (tmp)
+                                portals = tmp;
+                        }
+                        if (portal_count < portal_cap)
+                        {
+                            float px0 = ax + (bx - ax) * t0, pz0 = az + (bz - az) * t0;
+                            float px1 = ax + (bx - ax) * t1, pz1 = az + (bz - az) * t1;
+                            float p_floor = sec->floor_y > overlaps[novl - 1].other_floor
+                                                ? sec->floor_y
+                                                : overlaps[novl - 1].other_floor;
+                            float p_ceil = sec->ceil_y < overlaps[novl - 1].other_ceil
+                                               ? sec->ceil_y
+                                               : overlaps[novl - 1].other_ceil;
+                            sdl3d_level_portal *p = &portals[portal_count++];
+                            p->sector_a = s;
+                            p->sector_b = edges[j].sector;
+                            p->min_x = px0 < px1 ? px0 : px1;
+                            p->max_x = px0 > px1 ? px0 : px1;
+                            p->min_z = pz0 < pz1 ? pz0 : pz1;
+                            p->max_z = pz0 > pz1 ? pz0 : pz1;
+                            p->floor_y = p_floor;
+                            p->ceil_y = p_ceil;
+                        }
+                    }
                 }
             }
 
@@ -384,7 +430,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                 {
                     float lx = lights[li].position[0] - px, ly = lights[li].position[1] - py,
                           lz = lights[li].position[2] - pz;
-                    float dist = sqrtf(lx * lx + ly * ly + lz * lz);
+                    float dist = SDL_sqrtf(lx * lx + ly * ly + lz * lz);
                     if (dist < 0.0001f || dist > lights[li].range)
                         continue;
                     float inv = 1.0f / dist;
@@ -419,13 +465,16 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
     sdl3d_mesh *meshes = SDL_calloc((size_t)num_meshes, sizeof(sdl3d_mesh));
     sdl3d_material *out_mats = SDL_calloc((size_t)material_count, sizeof(sdl3d_material));
-    if (!meshes || !out_mats)
+    int *mesh_sector_ids = SDL_malloc((size_t)num_meshes * sizeof(int));
+    if (!meshes || !out_mats || !mesh_sector_ids)
     {
         for (int ai = 0; ai < acc_count; ai++)
             macc_free(&accs[ai]);
         SDL_free(accs);
         SDL_free(meshes);
         SDL_free(out_mats);
+        SDL_free(mesh_sector_ids);
+        SDL_free(portals);
         return SDL_OutOfMemory();
     }
 
@@ -464,6 +513,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
             total_verts += a->vc;
             total_tris += a->ic / 3;
+            mesh_sector_ids[mi] = s;
             mi++;
         }
     }
@@ -483,14 +533,170 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
     out->model.mesh_count = num_meshes;
     out->model.materials = out_mats;
     out->model.material_count = material_count;
+    out->sector_count = sector_count;
+    out->mesh_sector_ids = mesh_sector_ids;
+    out->portal_count = portal_count;
+    out->portals = portals;
 
-    SDL_Log("SDL3D level: %d verts, %d tris, %d meshes from %d sectors", total_verts, total_tris, num_meshes,
-            sector_count);
+    SDL_Log("SDL3D level: %d verts, %d tris, %d meshes, %d portals from %d sectors", total_verts, total_tris,
+            num_meshes, portal_count, sector_count);
     return true;
 }
 
 void sdl3d_free_level(sdl3d_level *level)
 {
     if (level)
+    {
         sdl3d_free_model(&level->model);
+        SDL_free(level->mesh_sector_ids);
+        SDL_free(level->portals);
+        level->mesh_sector_ids = NULL;
+        level->portals = NULL;
+        level->portal_count = 0;
+        level->sector_count = 0;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Sector lookup                                                       */
+/* ------------------------------------------------------------------ */
+
+static bool point_in_polygon_xz(const sdl3d_sector *sector, float x, float z)
+{
+    bool inside = false;
+    for (int i = 0, j = sector->num_points - 1; i < sector->num_points; j = i++)
+    {
+        float xi = sector->points[i][0], zi = sector->points[i][1];
+        float xj = sector->points[j][0], zj = sector->points[j][1];
+        if (((zi > z) != (zj > z)) && (x < (xj - xi) * (z - zi) / (zj - zi) + xi))
+            inside = !inside;
+    }
+    return inside;
+}
+
+int sdl3d_level_find_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z)
+{
+    if (!level || !sectors)
+        return -1;
+    for (int i = 0; i < level->sector_count; i++)
+    {
+        if (point_in_polygon_xz(&sectors[i], x, z))
+            return i;
+    }
+    return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Portal visibility traversal                                         */
+/* ------------------------------------------------------------------ */
+
+static bool portal_box_in_frustum(const sdl3d_level_portal *p, const float planes[6][4])
+{
+    for (int i = 0; i < 6; ++i)
+    {
+        float a = planes[i][0], b = planes[i][1], c = planes[i][2], d = planes[i][3];
+        float px = a >= 0.0f ? p->max_x : p->min_x;
+        float py = b >= 0.0f ? p->ceil_y : p->floor_y;
+        float pz = c >= 0.0f ? p->max_z : p->min_z;
+        if (a * px + b * py + c * pz + d < 0.0f)
+            return false;
+    }
+    return true;
+}
+
+static bool portal_behind_camera(const sdl3d_level_portal *p, sdl3d_vec3 cam_pos, sdl3d_vec3 cam_dir)
+{
+    /* Test portal center against camera forward half-space. */
+    float cx = (p->min_x + p->max_x) * 0.5f - cam_pos.x;
+    float cy = (p->floor_y + p->ceil_y) * 0.5f - cam_pos.y;
+    float cz = (p->min_z + p->max_z) * 0.5f - cam_pos.z;
+    float dot = cx * cam_dir.x + cy * cam_dir.y + cz * cam_dir.z;
+    if (dot >= 0.0f)
+        return false;
+
+    /* Also test all 8 corners — portal is only behind if ALL corners are. */
+    float xs[2] = {p->min_x, p->max_x};
+    float ys[2] = {p->floor_y, p->ceil_y};
+    float zs[2] = {p->min_z, p->max_z};
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            for (int k = 0; k < 2; k++)
+            {
+                float dx = xs[i] - cam_pos.x;
+                float dy = ys[j] - cam_pos.y;
+                float dz = zs[k] - cam_pos.z;
+                if (dx * cam_dir.x + dy * cam_dir.y + dz * cam_dir.z >= 0.0f)
+                    return false;
+            }
+    return true;
+}
+
+void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector, sdl3d_vec3 camera_pos,
+                                    sdl3d_vec3 camera_dir, const float frustum_planes[6][4],
+                                    sdl3d_visibility_result *result)
+{
+    if (!level || !result || !result->sector_visible)
+        return;
+
+    for (int i = 0; i < level->sector_count; i++)
+        result->sector_visible[i] = false;
+    result->visible_count = 0;
+
+    if (current_sector < 0 || current_sector >= level->sector_count)
+    {
+        /* Outside all sectors — mark everything visible as fallback. */
+        for (int i = 0; i < level->sector_count; i++)
+            result->sector_visible[i] = true;
+        result->visible_count = level->sector_count;
+        return;
+    }
+
+    /* BFS from current sector through portals. */
+    int *queue = SDL_malloc((size_t)level->sector_count * sizeof(int));
+    if (!queue)
+    {
+        /* OOM fallback: show everything. */
+        for (int i = 0; i < level->sector_count; i++)
+            result->sector_visible[i] = true;
+        result->visible_count = level->sector_count;
+        return;
+    }
+
+    int head = 0, tail = 0;
+    result->sector_visible[current_sector] = true;
+    result->visible_count = 1;
+    queue[tail++] = current_sector;
+
+    while (head < tail)
+    {
+        int s = queue[head++];
+        for (int pi = 0; pi < level->portal_count; pi++)
+        {
+            const sdl3d_level_portal *p = &level->portals[pi];
+            int neighbor = -1;
+            if (p->sector_a == s)
+                neighbor = p->sector_b;
+            else if (p->sector_b == s)
+                neighbor = p->sector_a;
+            else
+                continue;
+
+            if (result->sector_visible[neighbor])
+                continue;
+
+            /* Reject portals fully behind camera. */
+            if (portal_behind_camera(p, camera_pos, camera_dir))
+                continue;
+
+            /* Reject portals outside frustum. */
+            if (frustum_planes && !portal_box_in_frustum(p, frustum_planes))
+                continue;
+
+            result->sector_visible[neighbor] = true;
+            result->visible_count++;
+            queue[tail++] = neighbor;
+        }
+    }
+
+    SDL_free(queue);
 }

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -87,6 +87,12 @@ struct sdl3d_render_context
 
     /* OpenGL backend (NULL when using software backend). */
     struct sdl3d_gl_context *gl;
+
+    /* Cached frustum planes extracted from view_projection. Updated once
+     * per sdl3d_begin_mode_3d so per-mesh visibility tests avoid redundant
+     * extraction. Order: left, right, bottom, top, near, far. */
+    float frustum_planes[6][4]; /* {a,b,c,d} per plane, normalized */
+    bool frustum_planes_valid;
 };
 
 static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_context *context)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SDL3D_TEST_SOURCES
     test_collision.cpp
     test_animation.cpp
     test_effects.cpp
+    test_level.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -168,6 +169,8 @@ else()
     sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
     sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
+    sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
+    target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
 
     if(NOT EMSCRIPTEN)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,13 +58,20 @@ function(sdl3d_add_test target_name source_file test_label)
         )
     endif()
 
+    set(_sdl3d_test_timeout 15)
+    if(test_label STREQUAL "render")
+        # GPU/windowed tests are reliable locally but can stall briefly on
+        # hosted macOS runners when creating hidden GL contexts.
+        set(_sdl3d_test_timeout 30)
+    endif()
+
     gtest_discover_tests(
         ${target_name}
         DISCOVERY_TIMEOUT 10
         DISCOVERY_MODE PRE_TEST
         PROPERTIES
             LABELS ${test_label}
-            TIMEOUT 15
+            TIMEOUT ${_sdl3d_test_timeout}
     )
 endfunction()
 

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -76,6 +76,149 @@ TEST(SDL3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
     sdl3d_free_level(&level);
 }
 
+TEST(SDL3DLevelBuilder, MeshSectorIdsMatchSectorCount)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    EXPECT_EQ(level.sector_count, 2);
+    ASSERT_NE(level.mesh_sector_ids, nullptr);
+
+    for (int i = 0; i < level.model.mesh_count; ++i)
+    {
+        EXPECT_GE(level.mesh_sector_ids[i], 0);
+        EXPECT_LT(level.mesh_sector_ids[i], level.sector_count);
+    }
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelBuilder, DetectsPortalsBetweenAdjacentSectors)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    /* Two rooms sharing an edge at x=4, z=[1..3]. */
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(4.0f, 1.0f, 8.0f, 3.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    EXPECT_GT(level.portal_count, 0);
+    ASSERT_NE(level.portals, nullptr);
+
+    /* Verify at least one portal connects sector 0 and 1. */
+    bool found = false;
+    for (int i = 0; i < level.portal_count; i++)
+    {
+        const sdl3d_level_portal &p = level.portals[i];
+        if ((p.sector_a == 0 && p.sector_b == 1) || (p.sector_a == 1 && p.sector_b == 0))
+        {
+            found = true;
+            EXPECT_LE(p.floor_y, p.ceil_y);
+        }
+    }
+    EXPECT_TRUE(found) << "Expected portal between sector 0 and 1";
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelBuilder, NoPortalsBetweenDisjointSectors)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    /* Two rooms with no shared edge. */
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(10.0f, 0.0f, 14.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    EXPECT_EQ(level.portal_count, 0);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelVisibility, FindSectorReturnsCorrectSector)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    EXPECT_EQ(sdl3d_level_find_sector(&level, sectors, 2.0f, 2.0f), 0);
+    EXPECT_EQ(sdl3d_level_find_sector(&level, sectors, 6.0f, 2.0f), 1);
+    EXPECT_EQ(sdl3d_level_find_sector(&level, sectors, 20.0f, 20.0f), -1);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelVisibility, VisibilityFromSectorZeroSeesNeighbor)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    /* Three rooms in a line: [0]--[1]--[2] */
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f),
+                                    MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 3, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    bool visible[3] = {};
+    sdl3d_visibility_result vis;
+    vis.sector_visible = visible;
+    vis.visible_count = 0;
+
+    /* Camera in sector 0, looking toward +X (toward sectors 1 and 2). */
+    sdl3d_vec3 cam_pos = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    sdl3d_vec3 cam_dir = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+
+    /* No frustum planes — just test BFS reachability. */
+    sdl3d_level_compute_visibility(&level, 0, cam_pos, cam_dir, nullptr, &vis);
+
+    EXPECT_TRUE(visible[0]) << "Current sector should be visible";
+    EXPECT_TRUE(visible[1]) << "Adjacent sector should be visible";
+    /* Sector 2 should also be reachable through sector 1. */
+    EXPECT_TRUE(visible[2]) << "Sector 2 reachable through sector 1";
+    EXPECT_EQ(vis.visible_count, 3);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelVisibility, OutsideSectorsFallsBackToAllVisible)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    bool visible[1] = {};
+    sdl3d_visibility_result vis;
+    vis.sector_visible = visible;
+    vis.visible_count = 0;
+
+    sdl3d_vec3 cam_pos = sdl3d_vec3_make(100.0f, 1.5f, 100.0f);
+    sdl3d_vec3 cam_dir = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+
+    sdl3d_level_compute_visibility(&level, -1, cam_pos, cam_dir, nullptr, &vis);
+
+    EXPECT_TRUE(visible[0]) << "Fallback should mark all sectors visible";
+    EXPECT_EQ(vis.visible_count, 1);
+
+    sdl3d_free_level(&level);
+}
+
 TEST(SDL3DDrawModelCulling, SkipsOffscreenChunkBeforeMaterialValidation)
 {
     ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+
+extern "C"
+{
+#include "sdl3d/drawing3d.h"
+#include "sdl3d/level.h"
+#include "sdl3d/math.h"
+}
+
+namespace
+{
+sdl3d_sector MakeSquareSector(float min_x, float min_z, float max_x, float max_z)
+{
+    sdl3d_sector sector{};
+    sector.points[0][0] = min_x;
+    sector.points[0][1] = min_z;
+    sector.points[1][0] = max_x;
+    sector.points[1][1] = min_z;
+    sector.points[2][0] = max_x;
+    sector.points[2][1] = max_z;
+    sector.points[3][0] = min_x;
+    sector.points[3][1] = max_z;
+    sector.num_points = 4;
+    sector.floor_y = 0.0f;
+    sector.ceil_y = 3.0f;
+    sector.floor_material = 0;
+    sector.ceil_material = 1;
+    sector.wall_material = 2;
+    return sector;
+}
+
+sdl3d_level_material MakeLevelMaterial(const char *texture)
+{
+    sdl3d_level_material material{};
+    material.albedo[0] = 1.0f;
+    material.albedo[1] = 1.0f;
+    material.albedo[2] = 1.0f;
+    material.albedo[3] = 1.0f;
+    material.roughness = 1.0f;
+    material.texture = texture;
+    material.tex_scale = 4.0f;
+    return material;
+}
+
+} // namespace
+
+TEST(SDL3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    EXPECT_EQ(level.model.material_count, 3);
+    EXPECT_EQ(level.model.mesh_count, 6);
+
+    for (int i = 0; i < level.model.mesh_count; ++i)
+    {
+        const sdl3d_mesh &mesh = level.model.meshes[i];
+        EXPECT_TRUE(mesh.has_local_bounds);
+        EXPECT_GT(mesh.vertex_count, 0);
+        EXPECT_GT(mesh.index_count, 0);
+        EXPECT_GE(mesh.material_index, 0);
+        EXPECT_LT(mesh.material_index, level.model.material_count);
+        EXPECT_LE(mesh.local_bounds.min.x, mesh.local_bounds.max.x);
+        EXPECT_LE(mesh.local_bounds.min.y, mesh.local_bounds.max.y);
+        EXPECT_LE(mesh.local_bounds.min.z, mesh.local_bounds.max.z);
+    }
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DDrawModelCulling, SkipsOffscreenChunkBeforeMaterialValidation)
+{
+    ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+
+    SDL_Window *window = nullptr;
+    SDL_Renderer *renderer = nullptr;
+    ASSERT_TRUE(SDL_CreateWindowAndRenderer("level culling", 64, 64, 0, &window, &renderer)) << SDL_GetError();
+
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(window, renderer, nullptr, &ctx)) << SDL_GetError();
+
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam)) << SDL_GetError();
+
+    sdl3d_model model{};
+    sdl3d_mesh meshes[2] = {};
+
+    meshes[0].material_index = 99;
+    meshes[0].has_local_bounds = true;
+    meshes[0].local_bounds.min = sdl3d_vec3_make(50.0f, -0.25f, -5.5f);
+    meshes[0].local_bounds.max = sdl3d_vec3_make(52.0f, 0.25f, -4.5f);
+
+    meshes[1].material_index = 99;
+    meshes[1].has_local_bounds = true;
+    meshes[1].local_bounds.min = sdl3d_vec3_make(-52.0f, -0.25f, -5.5f);
+    meshes[1].local_bounds.max = sdl3d_vec3_make(-50.0f, 0.25f, -4.5f);
+
+    model.meshes = meshes;
+    model.mesh_count = 2;
+    model.material_count = 0;
+
+    SDL_ClearError();
+    EXPECT_TRUE(sdl3d_draw_model(ctx, &model, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 1.0f, (sdl3d_color){255, 255, 255, 255}))
+        << SDL_GetError();
+    EXPECT_TRUE(sdl3d_end_mode_3d(ctx)) << SDL_GetError();
+
+    sdl3d_destroy_render_context(ctx);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+}

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -51,7 +51,8 @@ TEST(SDL3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
                                               MakeLevelMaterial("wall.png")};
-    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
+                                    MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
     sdl3d_level level{};
 
     ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
@@ -112,7 +113,8 @@ TEST(SDL3DDrawModelCulling, SkipsOffscreenChunkBeforeMaterialValidation)
     model.material_count = 0;
 
     SDL_ClearError();
-    EXPECT_TRUE(sdl3d_draw_model(ctx, &model, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 1.0f, (sdl3d_color){255, 255, 255, 255}))
+    EXPECT_TRUE(
+        sdl3d_draw_model(ctx, &model, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 1.0f, (sdl3d_color){255, 255, 255, 255}))
         << SDL_GetError();
     EXPECT_TRUE(sdl3d_end_mode_3d(ctx)) << SDL_GetError();
 


### PR DESCRIPTION
## Summary
- package built levels as sector-local material chunks instead of one mesh per material
- add per-mesh local bounds and frustum culling in the model draw path
- add regression tests for level chunking and offscreen mesh culling

## Testing
- cmake --build build --target sdl3d_level_test sdl3d_gl_renderer_test -j4
- ./build/tests/sdl3d_level_test
- ./build/tests/sdl3d_gl_renderer_test
- cmake --build build/debug --target sdl3d_doom_level -j4