### PR TITLE
fix: restore correct world backface culling

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
     sdl3d_set_bloom_enabled(ctx, true);
     sdl3d_set_ssao_enabled(ctx, false);
     sdl3d_set_point_shadows_enabled(ctx, false);
-    sdl3d_set_backface_culling_enabled(ctx, false);
+    sdl3d_set_backface_culling_enabled(ctx, true);
     sdl3d_set_shading_mode(ctx, SDL3D_SHADING_PHONG);
 
     /* ---- Material palette ---- */

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -186,18 +186,18 @@ int main(int argc, char *argv[])
     };
 
     sdl3d_level_light lights[] = {
-        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 4.4f, 11.0f},    /* Start room — warm tungsten */
-        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 2.6f, 8.0f},    /* South corridor — amber */
-        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 4.0f, 14.0f},   /* Nukage basin — red */
-        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.8f, 9.0f},  /* West alcove — toxic green */
-        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 2.4f, 8.0f},      /* Upper hall — cold white */
-        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.8f, 12.0f},   /* Computer core — cyan */
-        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 2.4f, 7.0f},    /* Security bend — sodium */
-        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 5.0f, 18.0f}, /* Courtyard — moonlight */
-        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 3.0f, 12.0f},   /* Storage — magenta */
-        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 3.8f, 8.0f},     /* Exit — green */
-        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 3.4f, 13.0f},  /* Reactor hall — violet */
-        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 2.5f, 8.0f},   /* Secret annex — orange */
+        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 3.0f, 9.5f},     /* Start room — warm tungsten */
+        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 1.8f, 7.0f},    /* South corridor — amber */
+        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 3.8f, 12.0f},   /* Nukage basin — red */
+        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.9f, 8.5f},  /* West alcove — toxic green */
+        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 1.7f, 7.0f},      /* Upper hall — cold white */
+        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.0f, 10.5f},   /* Computer core — cyan */
+        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 1.8f, 6.0f},    /* Security bend — sodium */
+        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 3.2f, 14.0f}, /* Courtyard — moonlight */
+        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 2.4f, 10.0f},   /* Storage — magenta */
+        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 4.0f, 8.0f},     /* Exit — green */
+        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 2.8f, 11.0f},  /* Reactor hall — violet */
+        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 1.9f, 7.0f},   /* Secret annex — orange */
     };
     const int sector_count = (int)SDL_arraysize(sectors);
     const int light_count = (int)SDL_arraysize(lights);

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -76,15 +76,15 @@ extern "C"
         int sector_b;
         float min_x, max_x; /* XZ span of the opening */
         float min_z, max_z;
-        float floor_y;      /* opening bottom */
-        float ceil_y;       /* opening top */
+        float floor_y; /* opening bottom */
+        float ceil_y;  /* opening top */
     } sdl3d_level_portal;
 
     /* Visibility query result. */
     typedef struct sdl3d_visibility_result
     {
-        bool *sector_visible;  /* caller-provided array[sector_count] */
-        int visible_count;     /* number of visible sectors */
+        bool *sector_visible; /* caller-provided array[sector_count] */
+        int visible_count;    /* number of visible sectors */
     } sdl3d_visibility_result;
 
     typedef struct sdl3d_level_light

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -1704,6 +1704,23 @@ static void replay_draw_list_geometry(sdl3d_gl_context *ctx)
     }
 }
 
+static void apply_geometry_cull_state(sdl3d_gl_context *ctx)
+{
+    sdl3d_gl_funcs *gl = &ctx->gl;
+    gl->Enable(GL_DEPTH_TEST);
+    gl->CullFace(GL_BACK);
+    gl->FrontFace(GL_CCW);
+
+    if (ctx->current_ctx && ctx->current_ctx->backface_culling_enabled)
+    {
+        gl->Enable(GL_CULL_FACE);
+    }
+    else
+    {
+        gl->Disable(GL_CULL_FACE);
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* FBO helpers                                                         */
 /* ------------------------------------------------------------------ */
@@ -2752,7 +2769,10 @@ static bool gl_present(sdl3d_render_context *context)
         gl->CullFace(GL_BACK);
     }
 
-    /* Geometry pass: replay all entries into main FBO. */
+    /* Geometry pass: replay all entries into main FBO using the caller's
+     * configured backface-culling state. Post-process passes disable culling,
+     * so this must be restored explicitly every frame. */
+    apply_geometry_cull_state(ctx);
     replay_draw_list_geometry(ctx);
 
     /* ---- Post-process pipeline ---- */
@@ -3029,6 +3049,7 @@ void sdl3d_gl_read_pixel(sdl3d_gl_context *ctx, int x, int y, unsigned char *rgb
             gl->Disable(GL_CULL_FACE);
             gl->CullFace(GL_BACK);
         }
+        apply_geometry_cull_state(ctx);
         replay_draw_list_geometry(ctx);
     }
     rgba[0] = rgba[1] = rgba[2] = rgba[3] = 0;

--- a/src/level.c
+++ b/src/level.c
@@ -177,7 +177,9 @@ static bool add_wall(macc *a, float x0, float z0, float x1, float z1, float bot,
     float len = SDL_sqrtf(dx * dx + dz * dz);
     if (len < 0.0001f)
         return true;
-    float nx = dz / len, nz = -dx / len;
+    /* Sector polygons are CCW in XZ, so edge interior lies on the left side.
+     * Keep wall winding interior-facing and align the stored normal with it. */
+    float nx = -dz / len, nz = dx / len;
     float s = tex_scale > 0 ? tex_scale : 4.0f;
     float u0 = 0.0f, u1 = len / s;
     float v0 = bot / s, v1 = top / s;
@@ -207,12 +209,12 @@ static bool add_floor_ceil(macc *a, const sdl3d_sector *s, float y, float ny, co
     {
         if (ny > 0)
         {
-            if (!macc_tri(a, base, base + i, base + i + 1))
+            if (!macc_tri(a, base, base + i + 1, base + i))
                 return false;
         }
         else
         {
-            if (!macc_tri(a, base, base + i + 1, base + i))
+            if (!macc_tri(a, base, base + i, base + i + 1))
                 return false;
         }
     }
@@ -349,9 +351,8 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                             float p_floor = sec->floor_y > overlaps[novl - 1].other_floor
                                                 ? sec->floor_y
                                                 : overlaps[novl - 1].other_floor;
-                            float p_ceil = sec->ceil_y < overlaps[novl - 1].other_ceil
-                                               ? sec->ceil_y
-                                               : overlaps[novl - 1].other_ceil;
+                            float p_ceil = sec->ceil_y < overlaps[novl - 1].other_ceil ? sec->ceil_y
+                                                                                       : overlaps[novl - 1].other_ceil;
                             sdl3d_level_portal *p = &portals[portal_count++];
                             p->sector_a = s;
                             p->sector_b = edges[j].sector;

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -12,6 +12,7 @@ extern "C"
 {
 #include "gl_renderer.h"
 #include "render_context_internal.h"
+#include "sdl3d/level.h"
 #include "sdl3d/sdl3d.h"
 }
 
@@ -200,6 +201,78 @@ TEST_F(GLRendererTest, BackfaceCullingShowsFrontFaces)
 
     /* With correct culling, we should see the front face (red), not black. */
     EXPECT_GT(px[0], 50);
+}
+
+TEST_F(GLRendererTest, BackfaceCullingHidesCubeInteriorAcrossFrames)
+{
+    sdl3d_set_ambient_light(ctx, 1.0f, 1.0f, 1.0f);
+    sdl3d_set_backface_culling_enabled(ctx, true);
+
+    sdl3d_camera3d cam;
+    cam.position = sdl3d_vec3_make(0, 0, 0);
+    cam.target = sdl3d_vec3_make(0, 0, -1);
+    cam.up = sdl3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    for (int frame = 0; frame < 2; ++frame)
+    {
+        sdl3d_clear_render_context(ctx, (sdl3d_color){0, 0, 0, 255});
+        sdl3d_begin_mode_3d(ctx, cam);
+        sdl3d_draw_cube(ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(4, 4, 4), (sdl3d_color){255, 0, 0, 255});
+        sdl3d_end_mode_3d(ctx);
+
+        unsigned char px[4];
+        readPixel(160, 120, px);
+        EXPECT_LT(px[0] + px[1] + px[2], 20) << "Interior cube faces should remain culled on frame " << frame;
+    }
+}
+
+TEST_F(GLRendererTest, LevelInteriorVisibleWithBackfaceCulling)
+{
+    const sdl3d_level_material materials[] = {{{1, 1, 1, 1}, 0.0f, 1.0f, nullptr, 4.0f},
+                                              {{1, 1, 1, 1}, 0.0f, 1.0f, nullptr, 4.0f},
+                                              {{1, 1, 1, 1}, 0.0f, 1.0f, nullptr, 4.0f}};
+    sdl3d_sector sector{};
+    sector.points[0][0] = 0.0f;
+    sector.points[0][1] = 0.0f;
+    sector.points[1][0] = 4.0f;
+    sector.points[1][1] = 0.0f;
+    sector.points[2][0] = 4.0f;
+    sector.points[2][1] = 4.0f;
+    sector.points[3][0] = 0.0f;
+    sector.points[3][1] = 4.0f;
+    sector.num_points = 4;
+    sector.floor_y = 0.0f;
+    sector.ceil_y = 3.0f;
+    sector.floor_material = 0;
+    sector.ceil_material = 1;
+    sector.wall_material = 2;
+
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(&sector, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    sdl3d_set_backface_culling_enabled(ctx, true);
+    sdl3d_set_ambient_light(ctx, 1.0f, 1.0f, 1.0f);
+
+    sdl3d_camera3d cam;
+    cam.position = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    cam.target = sdl3d_vec3_make(2.0f, 1.5f, 0.0f);
+    cam.up = sdl3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_clear_render_context(ctx, (sdl3d_color){0, 0, 0, 255});
+    sdl3d_begin_mode_3d(ctx, cam);
+    ASSERT_TRUE(sdl3d_draw_level(ctx, &level, nullptr, (sdl3d_color){255, 255, 255, 255})) << SDL_GetError();
+    sdl3d_end_mode_3d(ctx);
+
+    unsigned char px[4];
+    readPixel(160, 120, px);
+
+    sdl3d_free_level(&level);
+
+    EXPECT_GT(px[0] + px[1] + px[2], 30);
 }
 
 TEST_F(GLRendererTest, ToggleRecreateProducesCorrectOutput)

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -12,6 +12,13 @@ extern "C"
 
 namespace
 {
+struct TestVec3
+{
+    float x;
+    float y;
+    float z;
+};
+
 sdl3d_sector MakeSquareSector(float min_x, float min_z, float max_x, float max_z)
 {
     sdl3d_sector sector{};
@@ -43,6 +50,42 @@ sdl3d_level_material MakeLevelMaterial(const char *texture)
     material.texture = texture;
     material.tex_scale = 4.0f;
     return material;
+}
+
+TestVec3 LoadPosition(const sdl3d_mesh &mesh, int vertex_index)
+{
+    return {mesh.positions[vertex_index * 3], mesh.positions[vertex_index * 3 + 1],
+            mesh.positions[vertex_index * 3 + 2]};
+}
+
+TestVec3 LoadNormal(const sdl3d_mesh &mesh, int vertex_index)
+{
+    return {mesh.normals[vertex_index * 3], mesh.normals[vertex_index * 3 + 1], mesh.normals[vertex_index * 3 + 2]};
+}
+
+TestVec3 Subtract(TestVec3 a, TestVec3 b)
+{
+    return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+TestVec3 Cross(TestVec3 a, TestVec3 b)
+{
+    return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+
+float Dot(TestVec3 a, TestVec3 b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+TestVec3 Normalize(TestVec3 v)
+{
+    const float len = SDL_sqrtf(Dot(v, v));
+    if (len <= 0.000001f)
+    {
+        return {0.0f, 0.0f, 0.0f};
+    }
+    return {v.x / len, v.y / len, v.z / len};
 }
 
 } // namespace
@@ -98,13 +141,57 @@ TEST(SDL3DLevelBuilder, MeshSectorIdsMatchSectorCount)
     sdl3d_free_level(&level);
 }
 
+TEST(SDL3DLevelBuilder, InteriorFacingTrianglesMatchStoredNormals)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f)};
+    const TestVec3 room_center = {2.0f, 1.5f, 2.0f};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    for (int mesh_index = 0; mesh_index < level.model.mesh_count; ++mesh_index)
+    {
+        const sdl3d_mesh &mesh = level.model.meshes[mesh_index];
+        ASSERT_NE(mesh.positions, nullptr);
+        ASSERT_NE(mesh.normals, nullptr);
+        ASSERT_NE(mesh.indices, nullptr);
+
+        for (int i = 0; i < mesh.index_count; i += 3)
+        {
+            const int i0 = static_cast<int>(mesh.indices[i]);
+            const int i1 = static_cast<int>(mesh.indices[i + 1]);
+            const int i2 = static_cast<int>(mesh.indices[i + 2]);
+
+            const TestVec3 p0 = LoadPosition(mesh, i0);
+            const TestVec3 p1 = LoadPosition(mesh, i1);
+            const TestVec3 p2 = LoadPosition(mesh, i2);
+            const TestVec3 tri_center = {(p0.x + p1.x + p2.x) / 3.0f, (p0.y + p1.y + p2.y) / 3.0f,
+                                         (p0.z + p1.z + p2.z) / 3.0f};
+            const TestVec3 face_normal = Normalize(Cross(Subtract(p1, p0), Subtract(p2, p0)));
+            const TestVec3 to_interior = Normalize(Subtract(room_center, tri_center));
+
+            const TestVec3 n0 = LoadNormal(mesh, i0);
+            const TestVec3 n1 = LoadNormal(mesh, i1);
+            const TestVec3 n2 = LoadNormal(mesh, i2);
+            const TestVec3 avg_normal =
+                Normalize({(n0.x + n1.x + n2.x) / 3.0f, (n0.y + n1.y + n2.y) / 3.0f, (n0.z + n1.z + n2.z) / 3.0f});
+
+            EXPECT_GT(Dot(face_normal, to_interior), 0.70f) << "Triangle should face the playable interior";
+            EXPECT_GT(Dot(face_normal, avg_normal), 0.95f) << "Stored normals should match front-face winding";
+        }
+    }
+
+    sdl3d_free_level(&level);
+}
+
 TEST(SDL3DLevelBuilder, DetectsPortalsBetweenAdjacentSectors)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
                                               MakeLevelMaterial("wall.png")};
     /* Two rooms sharing an edge at x=4, z=[1..3]. */
-    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
-                                    MakeSquareSector(4.0f, 1.0f, 8.0f, 3.0f)};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(4.0f, 1.0f, 8.0f, 3.0f)};
     sdl3d_level level{};
 
     ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
@@ -148,8 +235,7 @@ TEST(SDL3DLevelVisibility, FindSectorReturnsCorrectSector)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
                                               MakeLevelMaterial("wall.png")};
-    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
-                                    MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f)};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f)};
     sdl3d_level level{};
 
     ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
@@ -166,8 +252,7 @@ TEST(SDL3DLevelVisibility, VisibilityFromSectorZeroSeesNeighbor)
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
                                               MakeLevelMaterial("wall.png")};
     /* Three rooms in a line: [0]--[1]--[2] */
-    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f),
-                                    MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f),
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f),
                                     MakeSquareSector(8.0f, 0.0f, 12.0f, 4.0f)};
     sdl3d_level level{};
 


### PR DESCRIPTION
## Summary
This PR restores correct world backface culling for sector-built indoor levels without backing out the current Doom-style lighting/look.

The underlying issue was twofold:
- level geometry was not consistently wound as interior-facing front faces
- the GL backend was not explicitly restoring the caller's cull state before the geometry pass, so culling could be lost after passes that disabled it

## What Changed
- fix world mesh generation in `src/level.c`
  - walls now use interior-facing winding with matching normals
  - floors/ceilings now emit triangles with front faces toward the playable interior
- fix GL geometry-pass state in `src/gl_renderer.c`
  - reapply depth + front-face + backface-culling state before replaying geometry
  - ensures render-context culling is honored every frame instead of depending on previous GL state
- enable world backface culling in `demos/doom_level/main.c`
- add coverage in `tests/test_level.cpp`
  - validates built room triangles face inward and normals match front-face winding
- add coverage in `tests/test_gl_renderer.cpp`
  - verifies cube interior stays culled across frames
  - verifies a built indoor level remains visible from inside with culling enabled
- retune the Doom demo's baked lights to restore the darker, moodier atmosphere after the correctness fix

## Why This Is The Right Fix
This keeps the renderer honest:
- no demo-specific hacks
- no disabling culling to hide incorrect geometry
- no special-case backend workaround

The world builder now emits correct interior geometry, and the renderer applies culling deterministically.

## Validation
- `./scripts/check_clang_format.sh`
- `./build/tests/sdl3d_level_test`
- `./build/tests/sdl3d_gl_renderer_test`
- `cmake --build build/debug --target sdl3d_doom_level -j4`
- smoke-launched `./build/debug/demos/doom_level/sdl3d_doom_level`
