### PR TITLE
feat: lightmap data plumbing — structs, UV channel, surface tracking

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -335,19 +335,19 @@ int main(int argc, char *argv[])
     };
 
     sdl3d_level_light lights[] = {
-        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 3.0f, 9.5f},     /* Start room — warm tungsten */
-        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 1.8f, 7.0f},    /* South corridor — amber */
-        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 3.8f, 12.0f},   /* Nukage basin — red */
-        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.9f, 8.5f},  /* West alcove — toxic green */
-        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 1.7f, 7.0f},      /* Upper hall — cold white */
-        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 3.0f, 10.5f},   /* Computer core — cyan */
-        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 1.8f, 6.0f},    /* Security bend — sodium */
-        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 3.2f, 14.0f}, /* Courtyard — moonlight */
-        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 2.4f, 10.0f},   /* Storage — magenta */
-        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 4.0f, 8.0f},     /* Exit — green */
-        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 2.8f, 11.0f},  /* Reactor hall — violet */
-        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 1.9f, 7.0f},   /* Secret annex — orange */
-        {{24, 8.5f, 74}, {0.32f, 0.38f, 0.7f}, 3.6f, 32.0f},  /* Exterior yard — night sky fill */
+        {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 2.4f, 9.5f},     /* Start room — warm tungsten */
+        {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 1.4f, 7.0f},    /* South corridor — amber */
+        {{4, 1.0f, 21}, {1.0f, 0.16f, 0.10f}, 3.1f, 12.0f},   /* Nukage basin — red */
+        {{-6, 1.8f, 21}, {0.25f, 0.95f, 0.35f}, 2.4f, 8.5f},  /* West alcove — toxic green */
+        {{14, 2.7f, 4}, {0.7f, 0.8f, 1.0f}, 1.3f, 7.0f},      /* Upper hall — cold white */
+        {{24, 3.2f, 4}, {0.15f, 0.85f, 1.0f}, 2.4f, 10.5f},   /* Computer core — cyan */
+        {{24, 2.6f, 11}, {1.0f, 0.9f, 0.45f}, 1.4f, 6.0f},    /* Security bend — sodium */
+        {{22, 7.0f, 20}, {0.36f, 0.46f, 0.78f}, 2.3f, 14.0f}, /* Courtyard — moonlight */
+        {{33, 3.0f, 18}, {0.9f, 0.35f, 1.0f}, 1.9f, 10.0f},   /* Storage — magenta */
+        {{24, 2.5f, 29}, {0.2f, 1.0f, 0.2f}, 3.2f, 8.0f},     /* Exit — green */
+        {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 2.2f, 11.0f},  /* Reactor hall — violet */
+        {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 1.5f, 7.0f},   /* Secret annex — orange */
+        {{24, 8.5f, 74}, {0.32f, 0.38f, 0.7f}, 2.4f, 32.0f},  /* Exterior yard — night sky fill */
     };
     const int sector_count = (int)SDL_arraysize(sectors);
     const int light_count = (int)SDL_arraysize(lights);

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -169,6 +169,21 @@ static int compare_actor_draws(const void *lhs, const void *rhs)
     return 0;
 }
 
+static void strip_level_lightmap(sdl3d_level *level)
+{
+    SDL_free(level->lightmap_pixels);
+    level->lightmap_pixels = NULL;
+    level->lightmap_width = 0;
+    level->lightmap_height = 0;
+    sdl3d_free_texture(&level->lightmap_texture);
+
+    for (int i = 0; i < level->model.mesh_count; ++i)
+    {
+        SDL_free(level->model.meshes[i].lightmap_uvs);
+        level->model.meshes[i].lightmap_uvs = NULL;
+    }
+}
+
 int main(int argc, char *argv[])
 {
     SDL_Window *win = NULL;
@@ -337,9 +352,9 @@ int main(int argc, char *argv[])
     const int sector_count = (int)SDL_arraysize(sectors);
     const int light_count = (int)SDL_arraysize(lights);
 
-    /* Build two versions: baked lighting and raw materials. */
-    sdl3d_level level_lit, level_unlit;
-    if (!sdl3d_build_level(sectors, sector_count, mats, 6, lights, light_count, &level_lit))
+    /* Build three versions: lightmapped, vertex-baked fallback, and unlit. */
+    sdl3d_level level_lightmapped, level_vertex_baked, level_unlit;
+    if (!sdl3d_build_level(sectors, sector_count, mats, 6, lights, light_count, &level_lightmapped))
     {
         SDL_Log("Level build failed: %s", SDL_GetError());
         sdl3d_free_texture(&enemy_tex);
@@ -355,10 +370,29 @@ int main(int argc, char *argv[])
         SDL_Quit();
         return 1;
     }
+    if (!sdl3d_build_level(sectors, sector_count, mats, 6, lights, light_count, &level_vertex_baked))
+    {
+        SDL_Log("Level build failed: %s", SDL_GetError());
+        sdl3d_free_level(&level_lightmapped);
+        sdl3d_free_texture(&enemy_tex);
+        sdl3d_free_texture(&health_tex);
+        sdl3d_free_texture(&sky_px);
+        sdl3d_free_texture(&sky_nx);
+        sdl3d_free_texture(&sky_py);
+        sdl3d_free_texture(&sky_ny);
+        sdl3d_free_texture(&sky_pz);
+        sdl3d_free_texture(&sky_nz);
+        sdl3d_destroy_render_context(ctx);
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return 1;
+    }
+    strip_level_lightmap(&level_vertex_baked);
     if (!sdl3d_build_level(sectors, sector_count, mats, 6, NULL, 0, &level_unlit))
     {
         SDL_Log("Level build failed: %s", SDL_GetError());
-        sdl3d_free_level(&level_lit);
+        sdl3d_free_level(&level_lightmapped);
+        sdl3d_free_level(&level_vertex_baked);
         sdl3d_free_texture(&enemy_tex);
         sdl3d_free_texture(&health_tex);
         sdl3d_free_texture(&sky_px);
@@ -372,7 +406,8 @@ int main(int argc, char *argv[])
         SDL_Quit();
         return 1;
     }
-    bool use_baked = true;
+    bool use_lit_world = true;
+    bool use_lightmaps = true;
 
     demo_sprite_actor actors[] = {
         {&enemy_tex, sdl3d_vec3_make(5.8f, 0.0f, 6.8f), (sdl3d_vec2){1.7f, 2.6f}, true, 0.10f, 7.0f},
@@ -390,10 +425,10 @@ int main(int argc, char *argv[])
     float elapsed = 0.0f;
     sdl3d_skybox_textured skybox = {&sky_px, &sky_nx, &sky_py, &sky_ny, &sky_pz, &sky_nz, 350.0f};
 
-    SDL_Log("Portals detected: %d", level_lit.portal_count);
-    for (int i = 0; i < level_lit.portal_count; i++)
+    SDL_Log("Portals detected: %d", level_lightmapped.portal_count);
+    for (int i = 0; i < level_lightmapped.portal_count; i++)
     {
-        const sdl3d_level_portal *p = &level_lit.portals[i];
+        const sdl3d_level_portal *p = &level_lightmapped.portals[i];
         SDL_Log("  portal %d: sector %d <-> %d  x[%.1f,%.1f] z[%.1f,%.1f] y[%.2f,%.2f]", i, p->sector_a, p->sector_b,
                 p->min_x, p->max_x, p->min_z, p->max_z, p->floor_y, p->ceil_y);
     }
@@ -430,7 +465,15 @@ int main(int argc, char *argv[])
             if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_ESCAPE)
                 running = false;
             if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_L)
-                use_baked = !use_baked;
+            {
+                use_lit_world = !use_lit_world;
+                SDL_Log("World lighting: %s", use_lit_world ? (use_lightmaps ? "LIGHTMAP" : "VERTEX-BAKED") : "UNLIT");
+            }
+            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_M)
+            {
+                use_lightmaps = !use_lightmaps;
+                SDL_Log("Lightmap mode: %s", use_lightmaps ? "LIGHTMAP" : "VERTEX-BAKED");
+            }
             if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F1)
             {
                 show_debug = !show_debug;
@@ -526,7 +569,8 @@ int main(int argc, char *argv[])
                            proj_dz, &proj_life);
 
         /* Compute portal visibility. */
-        sdl3d_level *active_level = use_baked ? &level_lit : &level_unlit;
+        sdl3d_level *active_level =
+            use_lit_world ? (use_lightmaps ? &level_lightmapped : &level_vertex_baked) : &level_unlit;
         int current_sector = sdl3d_level_find_sector(active_level, sectors, px, pz);
         sdl3d_vec3 cam_dir = sdl3d_vec3_make(fx, SDL_sinf(pitch), fz);
 
@@ -685,7 +729,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    sdl3d_free_level(&level_lit);
+    sdl3d_free_level(&level_lightmapped);
+    sdl3d_free_level(&level_vertex_baked);
     sdl3d_free_level(&level_unlit);
     sdl3d_free_texture(&enemy_tex);
     sdl3d_free_texture(&health_tex);

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -67,6 +67,11 @@ extern "C"
         /* Portal adjacency graph. */
         int portal_count;
         struct sdl3d_level_portal *portals;
+
+        /* Lightmap atlas (NULL when no lightmap baked). */
+        unsigned char *lightmap_pixels; /* RGB, lightmap_width × lightmap_height */
+        int lightmap_width;
+        int lightmap_height;
     } sdl3d_level;
 
     /* A portal connecting two adjacent sectors through a shared edge opening. */

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -20,6 +20,7 @@
 #define SDL3D_LEVEL_H
 
 #include "sdl3d/model.h"
+#include "sdl3d/texture.h"
 #include "sdl3d/types.h"
 
 #include <stdbool.h>
@@ -72,6 +73,7 @@ extern "C"
         unsigned char *lightmap_pixels; /* RGB, lightmap_width × lightmap_height */
         int lightmap_width;
         int lightmap_height;
+        sdl3d_texture2d lightmap_texture; /* RGBA upload texture, zero-initialized when absent */
     } sdl3d_level;
 
     /* A portal connecting two adjacent sectors through a shared edge opening. */
@@ -104,8 +106,9 @@ extern "C"
      * Build a watertight mesh from sector definitions.
      * Shared edges between sectors become doorways (no wall generated).
      * If lights are provided, vertex lighting is baked into vertex colors
-     * (render in UNLIT mode — no real-time lighting needed).
-     * Pass NULL/0 for lights to use raw material colors.
+     * for fallback compatibility and a lightmap atlas is generated for
+     * per-pixel baked world lighting. Pass NULL/0 for lights to use raw
+     * material colors and skip lightmap generation.
      * Returns false with SDL_GetError on failure.
      */
     bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3d_level_material *materials,

--- a/include/sdl3d/model.h
+++ b/include/sdl3d/model.h
@@ -60,6 +60,7 @@ extern "C"
         float *positions;
         float *normals;
         float *uvs;
+        float *lightmap_uvs; /* second UV channel for lightmap atlas, or NULL */
         float *colors;
         bool colors_are_baked_light;
         int vertex_count;

--- a/src/backend.h
+++ b/src/backend.h
@@ -47,11 +47,13 @@ typedef struct sdl3d_draw_params_lit
     const float *positions;
     const float *normals;
     const float *uvs;
+    const float *lightmap_uvs;
     const float *colors;
     const unsigned int *indices;
     int vertex_count;
     int index_count;
     const sdl3d_texture2d *texture;
+    const sdl3d_texture2d *lightmap;
     const float *mvp;
     const float *model_matrix;
     float normal_matrix[9];

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -640,8 +640,9 @@ static sdl3d_vec4 sdl3d_shade_point_retro(const sdl3d_lighting_params *lp, sdl3d
 }
 
 static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_mesh *mesh,
-                                     const sdl3d_texture2d *texture, sdl3d_vec4 base_modulate,
-                                     const sdl3d_lighting_params *lighting, const sdl3d_mat4 *joint_matrices)
+                                     const sdl3d_texture2d *texture, const sdl3d_texture2d *lightmap_texture,
+                                     sdl3d_vec4 base_modulate, const sdl3d_lighting_params *lighting,
+                                     const sdl3d_mat4 *joint_matrices)
 {
     const bool indexed = mesh->indices != NULL;
     const int triangle_count = indexed ? (mesh->index_count / 3) : (mesh->vertex_count / 3);
@@ -736,11 +737,13 @@ static bool sdl3d_draw_mesh_internal(sdl3d_render_context *context, const sdl3d_
         lp.positions = (skinned_positions != NULL) ? skinned_positions : mesh->positions;
         lp.normals = (skinned_normals != NULL) ? skinned_normals : mesh->normals;
         lp.uvs = mesh->uvs;
+        lp.lightmap_uvs = mesh->lightmap_uvs;
         lp.colors = mesh->colors;
         lp.indices = mesh->indices;
         lp.vertex_count = mesh->vertex_count;
         lp.index_count = mesh->index_count;
         lp.texture = texture;
+        lp.lightmap = lightmap_texture;
         lp.mvp = context->model_view_projection.m;
         lp.model_matrix = context->model.m;
         lp.normal_matrix[0] = context->model.m[0];
@@ -1360,7 +1363,7 @@ bool sdl3d_draw_billboard_ex(sdl3d_render_context *context, const sdl3d_texture2
     mesh.indices = indices;
     mesh.index_count = 12;
 
-    return sdl3d_draw_mesh_internal(context, &mesh, texture, sdl3d_color_to_modulate(tint), NULL, NULL);
+    return sdl3d_draw_mesh_internal(context, &mesh, texture, NULL, sdl3d_color_to_modulate(tint), NULL, NULL);
 }
 
 bool sdl3d_draw_billboard(sdl3d_render_context *context, const sdl3d_texture2d *texture, sdl3d_vec3 position,
@@ -1379,9 +1382,9 @@ bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, cons
         sdl3d_lighting_params lp;
         sdl3d_build_lighting_params(context, &lp);
         lp.roughness = 1.0f;
-        return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint), &lp, NULL);
+        return sdl3d_draw_mesh_internal(context, mesh, texture, NULL, sdl3d_color_to_modulate(tint), &lp, NULL);
     }
-    return sdl3d_draw_mesh_internal(context, mesh, texture, sdl3d_color_to_modulate(tint), NULL, NULL);
+    return sdl3d_draw_mesh_internal(context, mesh, texture, NULL, sdl3d_color_to_modulate(tint), NULL, NULL);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1420,7 +1423,8 @@ static sdl3d_mat4 sdl3d_mat4_from_trs_node(const float *t, const float *r, const
  * joint_matrices may be NULL for non-skinned draws.
  */
 static bool sdl3d_draw_model_mesh(sdl3d_render_context *context, const sdl3d_model *model, int mesh_index,
-                                  sdl3d_vec4 tint_modulate, const sdl3d_mat4 *joint_matrices)
+                                  const sdl3d_texture2d *lightmap_texture, sdl3d_vec4 tint_modulate,
+                                  const sdl3d_mat4 *joint_matrices)
 {
     const sdl3d_mesh *mesh = &model->meshes[mesh_index];
     const sdl3d_texture2d *texture = NULL;
@@ -1525,7 +1529,7 @@ static bool sdl3d_draw_model_mesh(sdl3d_render_context *context, const sdl3d_mod
             lp_ptr = &lp_storage;
         }
 
-        ok = sdl3d_draw_mesh_internal(context, mesh, texture, mesh_modulate, lp_ptr, joint_matrices);
+        ok = sdl3d_draw_mesh_internal(context, mesh, texture, lightmap_texture, mesh_modulate, lp_ptr, joint_matrices);
     }
     return ok;
 }
@@ -1568,7 +1572,7 @@ static bool sdl3d_draw_model_node(sdl3d_render_context *context, const sdl3d_mod
     /* Draw this node's mesh if it has one. */
     if (node->mesh_index >= 0 && node->mesh_index < model->mesh_count)
     {
-        ok = sdl3d_draw_model_mesh(context, model, node->mesh_index, tint_modulate, joint_matrices);
+        ok = sdl3d_draw_model_mesh(context, model, node->mesh_index, NULL, tint_modulate, joint_matrices);
     }
 
     /* Recurse into children. */
@@ -1637,7 +1641,7 @@ bool sdl3d_draw_model_ex(sdl3d_render_context *context, const sdl3d_model *model
     {
         for (int mesh_index = 0; ok && mesh_index < model->mesh_count; ++mesh_index)
         {
-            ok = sdl3d_draw_model_mesh(context, model, mesh_index, tint_modulate, NULL);
+            ok = sdl3d_draw_model_mesh(context, model, mesh_index, NULL, tint_modulate, NULL);
         }
     }
 
@@ -1700,7 +1704,7 @@ bool sdl3d_draw_model_skinned(sdl3d_render_context *context, const sdl3d_model *
     {
         for (int mesh_index = 0; ok && mesh_index < model->mesh_count; ++mesh_index)
         {
-            ok = sdl3d_draw_model_mesh(context, model, mesh_index, tint_modulate, joint_matrices);
+            ok = sdl3d_draw_model_mesh(context, model, mesh_index, NULL, tint_modulate, joint_matrices);
         }
     }
 
@@ -1785,7 +1789,9 @@ bool sdl3d_draw_level(sdl3d_render_context *context, const sdl3d_level *level, c
             if (sid >= 0 && sid < level->sector_count && !vis->sector_visible[sid])
                 continue;
         }
-        ok = sdl3d_draw_model_mesh(context, model, i, tint_modulate, NULL);
+        ok = sdl3d_draw_model_mesh(context, model, i,
+                                   level->lightmap_texture.pixels != NULL ? &level->lightmap_texture : NULL,
+                                   tint_modulate, NULL);
     }
 
     return ok;

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -74,6 +74,7 @@ typedef struct sdl3d_draw_entry
     float *positions;
     float *normals;
     float *uvs;
+    float *lightmap_uvs;
     float *colors;
     unsigned int *indices;
     int vertex_count;
@@ -85,8 +86,10 @@ typedef struct sdl3d_draw_entry
     float roughness;
     float emissive[3];
     const sdl3d_texture2d *texture;
+    const sdl3d_texture2d *lightmap_texture;
     bool lit;
     bool baked_light_mode;
+    bool has_lightmap;
     float mvp[16];
 } sdl3d_draw_entry;
 
@@ -120,6 +123,8 @@ struct sdl3d_gl_context
     GLint pbr_roughness_loc;
     GLint pbr_emissive_loc;
     GLint pbr_baked_light_mode_loc;
+    GLint pbr_lightmap_loc;
+    GLint pbr_has_lightmap_loc;
 
     /* Unlit uniform locations */
     GLint unlit_mvp_loc;
@@ -138,6 +143,7 @@ struct sdl3d_gl_context
     GLuint lit_position_vbo;
     GLuint lit_normal_vbo;
     GLuint lit_uv_vbo;
+    GLuint lit_lightmap_uv_vbo;
     GLuint lit_color_vbo;
     GLuint lit_ebo;
 
@@ -271,6 +277,7 @@ static const char k_pbr_vert[] = "layout(location = 0) in vec3 aPosition;\n"
                                  "layout(location = 1) in vec3 aNormal;\n"
                                  "layout(location = 2) in vec2 aTexCoord;\n"
                                  "layout(location = 3) in vec4 aColor;\n"
+                                 "layout(location = 4) in vec2 aLightmapUV;\n"
                                  "\n"
                                  "#define MAX_LIGHTS 8\n"
                                  "struct Light {\n"
@@ -304,6 +311,7 @@ static const char k_pbr_vert[] = "layout(location = 0) in vec3 aPosition;\n"
                                  "out vec3 vWorldPos;\n"
                                  "out vec3 vWorldNormal;\n"
                                  "out vec2 vTexCoord;\n"
+                                 "out vec2 vLightmapUV;\n"
                                  "out vec4 vColor;\n"
                                  "\n"
                                  "void main() {\n"
@@ -311,6 +319,7 @@ static const char k_pbr_vert[] = "layout(location = 0) in vec3 aPosition;\n"
                                  "    vWorldPos = worldPos.xyz;\n"
                                  "    vWorldNormal = normalize(uNormalMatrix * aNormal);\n"
                                  "    vTexCoord = aTexCoord;\n"
+                                 "    vLightmapUV = aLightmapUV;\n"
                                  "    vColor = aColor;\n"
                                  "    gl_Position = uViewProjection * worldPos;\n"
                                  "}\n";
@@ -348,10 +357,13 @@ static const char k_pbr_frag_decl[] =
     "in vec3 vWorldPos;\n"
     "in vec3 vWorldNormal;\n"
     "in vec2 vTexCoord;\n"
+    "in vec2 vLightmapUV;\n"
     "in vec4 vColor;\n"
     "\n"
     "uniform sampler2D uTexture;\n"
     "uniform int uHasTexture;\n"
+    "uniform sampler2D uLightmap;\n"
+    "uniform int uHasLightmap;\n"
     "uniform vec4 uTint;\n"
     "uniform float uMetallic;\n"
     "uniform float uRoughness;\n"
@@ -404,7 +416,6 @@ static const char k_pbr_frag_main[] =
     "    vec2 uv = vTexCoord;\n"
     "    vec4 texel = (uHasTexture != 0) ? texture(uTexture, uv) : vec4(1.0);\n"
     "    vec3 albedo = texel.rgb * ((uBakedLightMode != 0) ? uTint.rgb : (vColor.rgb * uTint.rgb));\n"
-    "    vec3 bakedBaseColor = texel.rgb * vColor.rgb * uTint.rgb;\n"
     "    float alpha = texel.a * vColor.a * uTint.a;\n"
     "    if (alpha <= 0.0) discard;\n"
     "\n"
@@ -463,6 +474,8 @@ static const char k_pbr_frag_post[] =
     "\n"
     "    vec3 color;\n"
     "    if (uBakedLightMode != 0) {\n"
+    "        vec3 bakedLight = (uHasLightmap != 0) ? texture(uLightmap, vLightmapUV).rgb : vColor.rgb;\n"
+    "        vec3 bakedBaseColor = texel.rgb * bakedLight * uTint.rgb;\n"
     "        color = bakedBaseColor + Lo + uEmissive;\n"
     "    } else {\n"
     "        /* Shadow (CSM cascade selection with PCF 3x3). */\n"
@@ -1123,6 +1136,7 @@ static void free_draw_list(sdl3d_gl_context *ctx)
         SDL_free(e->positions);
         SDL_free(e->normals);
         SDL_free(e->uvs);
+        SDL_free(e->lightmap_uvs);
         SDL_free(e->colors);
         SDL_free(e->indices);
     }
@@ -1561,6 +1575,12 @@ static void replay_draw_list_geometry(sdl3d_gl_context *ctx)
             gl->BindTexture(GL_TEXTURE_2D, tex);
             gl->Uniform1i(ctx->pbr_texture_loc, 0);
             gl->Uniform1i(ctx->pbr_has_texture_loc, e->texture ? 1 : 0);
+            gl->ActiveTexture(GL_TEXTURE0 + 7);
+            gl->BindTexture(GL_TEXTURE_2D,
+                            e->has_lightmap ? resolve_texture(ctx, e->lightmap_texture) : ctx->black_texture);
+            gl->Uniform1i(ctx->pbr_lightmap_loc, 7);
+            gl->Uniform1i(ctx->pbr_has_lightmap_loc, e->has_lightmap ? 1 : 0);
+            gl->ActiveTexture(GL_TEXTURE0);
 
             /* Shadow uniforms — always bind the texture array to prevent
              * undefined sampler behavior on some drivers. */
@@ -1651,6 +1671,9 @@ static void replay_draw_list_geometry(sdl3d_gl_context *ctx)
             gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_uv_vbo);
             gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->vertex_count * 2 * sizeof(float)), e->uvs,
                            GL_DYNAMIC_DRAW);
+            gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_lightmap_uv_vbo);
+            gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->vertex_count * 2 * sizeof(float)),
+                           e->has_lightmap ? e->lightmap_uvs : e->uvs, GL_DYNAMIC_DRAW);
             gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_color_vbo);
             gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->vertex_count * 4 * sizeof(float)), e->colors,
                            GL_DYNAMIC_DRAW);
@@ -2132,6 +2155,8 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
     ctx->pbr_normal_matrix_loc = gl->GetUniformLocation(ctx->pbr_program, "uNormalMatrix");
     ctx->pbr_texture_loc = gl->GetUniformLocation(ctx->pbr_program, "uTexture");
     ctx->pbr_has_texture_loc = gl->GetUniformLocation(ctx->pbr_program, "uHasTexture");
+    ctx->pbr_lightmap_loc = gl->GetUniformLocation(ctx->pbr_program, "uLightmap");
+    ctx->pbr_has_lightmap_loc = gl->GetUniformLocation(ctx->pbr_program, "uHasLightmap");
     ctx->pbr_tint_loc = gl->GetUniformLocation(ctx->pbr_program, "uTint");
     ctx->pbr_metallic_loc = gl->GetUniformLocation(ctx->pbr_program, "uMetallic");
     ctx->pbr_roughness_loc = gl->GetUniformLocation(ctx->pbr_program, "uRoughness");
@@ -2219,6 +2244,11 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
     gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_uv_vbo);
     gl->EnableVertexAttribArray(2);
     gl->VertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 0, NULL);
+
+    gl->GenBuffers(1, &ctx->lit_lightmap_uv_vbo);
+    gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_lightmap_uv_vbo);
+    gl->EnableVertexAttribArray(4);
+    gl->VertexAttribPointer(4, 2, GL_FLOAT, GL_FALSE, 0, NULL);
 
     gl->GenBuffers(1, &ctx->lit_color_vbo);
     gl->BindBuffer(GL_ARRAY_BUFFER, ctx->lit_color_vbo);
@@ -2473,8 +2503,9 @@ void sdl3d_gl_destroy(sdl3d_gl_context *ctx)
     if (ctx->scene_ubo)
         gl->DeleteBuffers(1, &ctx->scene_ubo);
 
-    GLuint lit_bufs[] = {ctx->lit_position_vbo, ctx->lit_normal_vbo, ctx->lit_uv_vbo, ctx->lit_color_vbo, ctx->lit_ebo};
-    gl->DeleteBuffers(5, lit_bufs);
+    GLuint lit_bufs[] = {ctx->lit_position_vbo,    ctx->lit_normal_vbo, ctx->lit_uv_vbo,
+                         ctx->lit_lightmap_uv_vbo, ctx->lit_color_vbo,  ctx->lit_ebo};
+    gl->DeleteBuffers(6, lit_bufs);
     if (ctx->lit_vao)
         gl->DeleteVertexArrays(1, &ctx->lit_vao);
 
@@ -2629,9 +2660,11 @@ static bool gl_draw_mesh_lit(sdl3d_render_context *context, const sdl3d_draw_par
     e->positions = copy_floats(params->positions, (size_t)params->vertex_count * 3);
     e->normals = copy_floats(params->normals, (size_t)params->vertex_count * 3);
     e->uvs = copy_floats(params->uvs, (size_t)params->vertex_count * 2);
+    e->lightmap_uvs = copy_floats(params->lightmap_uvs, (size_t)params->vertex_count * 2);
     e->colors = copy_floats(colors, (size_t)params->vertex_count * 4);
     e->indices = copy_indices(params->indices, (size_t)e->index_count);
     e->texture = params->texture;
+    e->lightmap_texture = params->lightmap;
     SDL_memcpy(e->model_matrix, params->model_matrix, 16 * sizeof(float));
     SDL_memcpy(e->normal_matrix, params->normal_matrix, 9 * sizeof(float));
     SDL_memcpy(e->tint, params->tint, 4 * sizeof(float));
@@ -2639,6 +2672,7 @@ static bool gl_draw_mesh_lit(sdl3d_render_context *context, const sdl3d_draw_par
     e->roughness = params->roughness;
     SDL_memcpy(e->emissive, params->emissive, 3 * sizeof(float));
     e->baked_light_mode = params->baked_light_mode;
+    e->has_lightmap = params->lightmap_uvs != NULL && params->lightmap != NULL;
 
     /* check_z_fighting(ctx, e); — disabled: triggers on authored model geometry */
     (void)check_z_fighting;

--- a/src/level.c
+++ b/src/level.c
@@ -165,6 +165,92 @@ static void macc_free(macc *a)
 }
 
 /* ------------------------------------------------------------------ */
+/* Surface tracking for lightmap UV generation                         */
+/* ------------------------------------------------------------------ */
+
+typedef struct
+{
+    int acc_index;    /* which macc (sector × material) */
+    int first_vert;   /* first vertex index in that macc */
+    int vert_count;   /* number of vertices in this surface */
+    float nx, ny, nz; /* surface normal */
+    /* World-space bounds of the surface (for atlas sizing). */
+    float world_min[3], world_max[3];
+} lm_surface;
+
+typedef struct
+{
+    lm_surface *surfaces;
+    int count, cap;
+} lm_surface_list;
+
+static void lm_surface_list_init(lm_surface_list *l)
+{
+    l->surfaces = NULL;
+    l->count = 0;
+    l->cap = 0;
+}
+
+static lm_surface *lm_surface_list_add(lm_surface_list *l)
+{
+    if (l->count == l->cap)
+    {
+        int c = l->cap ? l->cap * 2 : 64;
+        lm_surface *s = SDL_realloc(l->surfaces, (size_t)c * sizeof(lm_surface));
+        if (!s)
+            return NULL;
+        l->surfaces = s;
+        l->cap = c;
+    }
+    lm_surface *s = &l->surfaces[l->count++];
+    SDL_memset(s, 0, sizeof(*s));
+    return s;
+}
+
+static void lm_surface_list_free(lm_surface_list *l)
+{
+    SDL_free(l->surfaces);
+    l->surfaces = NULL;
+    l->count = l->cap = 0;
+}
+
+/* Record a surface from vertices [first_vert, macc.vc) in accumulator acc_index. */
+static void lm_record_surface(lm_surface_list *sl, int acc_index, const macc *a, int first_vert, float snx, float sny,
+                              float snz)
+{
+    int nv = a->vc - first_vert;
+    if (nv < 3)
+        return;
+    lm_surface *s = lm_surface_list_add(sl);
+    if (!s)
+        return;
+    s->acc_index = acc_index;
+    s->first_vert = first_vert;
+    s->vert_count = nv;
+    s->nx = snx;
+    s->ny = sny;
+    s->nz = snz;
+    /* Compute world bounds. */
+    s->world_min[0] = s->world_min[1] = s->world_min[2] = 1e30f;
+    s->world_max[0] = s->world_max[1] = s->world_max[2] = -1e30f;
+    for (int i = first_vert; i < a->vc; i++)
+    {
+        for (int c = 0; c < 3; c++)
+        {
+            float v = a->pos[i * 3 + c];
+            if (v < s->world_min[c])
+                s->world_min[c] = v;
+            if (v > s->world_max[c])
+                s->world_max[c] = v;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Suppress unused warnings until full lightmap baking is wired up. */
+SDL_COMPILE_TIME_ASSERT(lm_surface_size, sizeof(lm_surface) > 0);
+static const void *lm_unused_[] = {(void *)lm_record_surface, (void *)lm_surface_list_free, (void *)lm_unused_};
+
 /* Geometry helpers                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -282,6 +368,9 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         return SDL_OutOfMemory();
     }
 
+    lm_surface_list surf_list;
+    lm_surface_list_init(&surf_list);
+
     for (int s = 0; s < sector_count; s++)
     {
         const sdl3d_sector *sec = &sectors[s];
@@ -292,13 +381,19 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
         if (fi >= 0)
         {
-            macc *floor_acc = &accs[s * material_count + fi];
+            int ai = s * material_count + fi;
+            macc *floor_acc = &accs[ai];
+            int vb = floor_acc->vc;
             add_floor_ceil(floor_acc, sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale);
+            lm_record_surface(&surf_list, ai, floor_acc, vb, 0, 1, 0);
         }
         if (ci >= 0)
         {
-            macc *ceil_acc = &accs[s * material_count + ci];
+            int ai = s * material_count + ci;
+            macc *ceil_acc = &accs[ai];
+            int vb = ceil_acc->vc;
             add_floor_ceil(ceil_acc, sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale);
+            lm_record_surface(&surf_list, ai, ceil_acc, vb, 0, -1, 0);
         }
 
         for (int e = 0; e < total_edges; e++)
@@ -557,10 +652,14 @@ void sdl3d_free_level(sdl3d_level *level)
         sdl3d_free_model(&level->model);
         SDL_free(level->mesh_sector_ids);
         SDL_free(level->portals);
+        SDL_free(level->lightmap_pixels);
         level->mesh_sector_ids = NULL;
         level->portals = NULL;
+        level->lightmap_pixels = NULL;
         level->portal_count = 0;
         level->sector_count = 0;
+        level->lightmap_width = 0;
+        level->lightmap_height = 0;
     }
 }
 

--- a/src/level.c
+++ b/src/level.c
@@ -12,6 +12,11 @@
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
+#define LM_TEXELS_PER_UNIT 4
+#define LM_MIN_SURFACE_TEXELS 2
+#define LM_MIN_ATLAS_SIZE 256
+#define LM_MAX_ATLAS_SIZE 2048
+
 /* ------------------------------------------------------------------ */
 /* Edge overlap detection                                              */
 /* ------------------------------------------------------------------ */
@@ -56,12 +61,44 @@ typedef struct
     float *nrm;
     float *col;
     float *uvs;
+    float *lm_uvs;
     unsigned int *idx;
     int vc, vc_cap;
     int ic, ic_cap;
     bool has_bounds;
     sdl3d_bounding_box bounds;
 } macc;
+
+typedef enum
+{
+    LM_SURFACE_WALL = 0,
+    LM_SURFACE_FLOOR = 1,
+    LM_SURFACE_CEILING = 2
+} lm_surface_type;
+
+typedef struct
+{
+    int acc_index;
+    int first_vertex;
+    int vertex_count;
+    lm_surface_type type;
+    float nx, ny, nz;
+    float min_x, max_x;
+    float min_y, max_y;
+    float min_z, max_z;
+    float x0, z0, x1, z1;
+    float bot, top;
+    float surface_y;
+    int atlas_x, atlas_y;
+    int atlas_w, atlas_h;
+} lm_surface;
+
+typedef struct
+{
+    lm_surface *items;
+    int count;
+    int capacity;
+} lm_surface_list;
 
 static bool macc_grow_v(macc *a, int n)
 {
@@ -161,7 +198,378 @@ static void macc_free(macc *a)
     SDL_free(a->nrm);
     SDL_free(a->col);
     SDL_free(a->uvs);
+    SDL_free(a->lm_uvs);
     SDL_free(a->idx);
+}
+
+static bool lm_surface_list_append(lm_surface_list *list, const lm_surface *surface)
+{
+    if (list->count == list->capacity)
+    {
+        int new_capacity = list->capacity > 0 ? list->capacity * 2 : 64;
+        lm_surface *items = SDL_realloc(list->items, (size_t)new_capacity * sizeof(*items));
+        if (items == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+        list->items = items;
+        list->capacity = new_capacity;
+    }
+    list->items[list->count++] = *surface;
+    return true;
+}
+
+static int lm_surface_texels(float units)
+{
+    int texels = (int)SDL_ceilf(units * (float)LM_TEXELS_PER_UNIT);
+    return texels < LM_MIN_SURFACE_TEXELS ? LM_MIN_SURFACE_TEXELS : texels;
+}
+
+static void lm_sector_bounds_xz(const sdl3d_sector *sector, float *min_x, float *max_x, float *min_z, float *max_z)
+{
+    float sx0 = sector->points[0][0], sx1 = sector->points[0][0];
+    float sz0 = sector->points[0][1], sz1 = sector->points[0][1];
+
+    for (int i = 1; i < sector->num_points; ++i)
+    {
+        float x = sector->points[i][0];
+        float z = sector->points[i][1];
+        if (x < sx0)
+            sx0 = x;
+        if (x > sx1)
+            sx1 = x;
+        if (z < sz0)
+            sz0 = z;
+        if (z > sz1)
+            sz1 = z;
+    }
+
+    *min_x = sx0;
+    *max_x = sx1;
+    *min_z = sz0;
+    *max_z = sz1;
+}
+
+static bool lm_record_wall_surface(lm_surface_list *list, int acc_index, const macc *acc, int first_vertex, float x0,
+                                   float z0, float x1, float z1, float bot, float top)
+{
+    float dx = x1 - x0;
+    float dz = z1 - z0;
+    float len = SDL_sqrtf(dx * dx + dz * dz);
+    lm_surface surface;
+
+    if (acc->vc <= first_vertex || len < 0.0001f || top - bot < 0.001f)
+    {
+        return true;
+    }
+
+    SDL_zero(surface);
+    surface.acc_index = acc_index;
+    surface.first_vertex = first_vertex;
+    surface.vertex_count = acc->vc - first_vertex;
+    surface.type = LM_SURFACE_WALL;
+    surface.nx = -dz / len;
+    surface.ny = 0.0f;
+    surface.nz = dx / len;
+    surface.min_x = x0 < x1 ? x0 : x1;
+    surface.max_x = x0 > x1 ? x0 : x1;
+    surface.min_y = bot;
+    surface.max_y = top;
+    surface.min_z = z0 < z1 ? z0 : z1;
+    surface.max_z = z0 > z1 ? z0 : z1;
+    surface.x0 = x0;
+    surface.z0 = z0;
+    surface.x1 = x1;
+    surface.z1 = z1;
+    surface.bot = bot;
+    surface.top = top;
+    surface.atlas_w = lm_surface_texels(len);
+    surface.atlas_h = lm_surface_texels(top - bot);
+    return lm_surface_list_append(list, &surface);
+}
+
+static bool lm_record_floor_ceil_surface(lm_surface_list *list, int acc_index, const macc *acc, int first_vertex,
+                                         const sdl3d_sector *sector, float y, float ny)
+{
+    lm_surface surface;
+
+    if (acc->vc <= first_vertex)
+    {
+        return true;
+    }
+
+    SDL_zero(surface);
+    surface.acc_index = acc_index;
+    surface.first_vertex = first_vertex;
+    surface.vertex_count = acc->vc - first_vertex;
+    surface.type = ny > 0.0f ? LM_SURFACE_FLOOR : LM_SURFACE_CEILING;
+    surface.nx = 0.0f;
+    surface.ny = ny;
+    surface.nz = 0.0f;
+    lm_sector_bounds_xz(sector, &surface.min_x, &surface.max_x, &surface.min_z, &surface.max_z);
+    surface.min_y = y;
+    surface.max_y = y;
+    surface.surface_y = y;
+    surface.atlas_w = lm_surface_texels(surface.max_x - surface.min_x);
+    surface.atlas_h = lm_surface_texels(surface.max_z - surface.min_z);
+    return lm_surface_list_append(list, &surface);
+}
+
+static bool lm_pack_surfaces(lm_surface_list *list, int *atlas_w, int *atlas_h)
+{
+    for (int size = LM_MIN_ATLAS_SIZE; size <= LM_MAX_ATLAS_SIZE; size *= 2)
+    {
+        int cursor_x = 0;
+        int cursor_y = 0;
+        int row_h = 0;
+        bool fits = true;
+
+        for (int i = 0; i < list->count; ++i)
+        {
+            lm_surface *surface = &list->items[i];
+            if (surface->atlas_w > size || surface->atlas_h > size)
+            {
+                fits = false;
+                break;
+            }
+            if (cursor_x + surface->atlas_w > size)
+            {
+                cursor_x = 0;
+                cursor_y += row_h;
+                row_h = 0;
+            }
+            if (cursor_y + surface->atlas_h > size)
+            {
+                fits = false;
+                break;
+            }
+            surface->atlas_x = cursor_x;
+            surface->atlas_y = cursor_y;
+            cursor_x += surface->atlas_w;
+            if (surface->atlas_h > row_h)
+            {
+                row_h = surface->atlas_h;
+            }
+        }
+
+        if (fits)
+        {
+            *atlas_w = size;
+            *atlas_h = size;
+            return true;
+        }
+    }
+
+    return SDL_SetError("Lightmap atlas exceeds %dx%d.", LM_MAX_ATLAS_SIZE, LM_MAX_ATLAS_SIZE);
+}
+
+static bool lm_allocate_uvs(macc *accs, int acc_count)
+{
+    for (int i = 0; i < acc_count; ++i)
+    {
+        macc *acc = &accs[i];
+        if (acc->vc <= 0)
+        {
+            continue;
+        }
+        acc->lm_uvs = SDL_calloc((size_t)acc->vc * 2U, sizeof(float));
+        if (acc->lm_uvs == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+    }
+    return true;
+}
+
+static void lm_assign_surface_uvs(macc *acc, const lm_surface *surface, int atlas_w, int atlas_h)
+{
+    const float u0 = ((float)surface->atlas_x + 0.5f) / (float)atlas_w;
+    const float v0 = ((float)surface->atlas_y + 0.5f) / (float)atlas_h;
+    const float u1 = ((float)(surface->atlas_x + surface->atlas_w) - 0.5f) / (float)atlas_w;
+    const float v1 = ((float)(surface->atlas_y + surface->atlas_h) - 0.5f) / (float)atlas_h;
+
+    if (surface->type == LM_SURFACE_WALL && surface->vertex_count >= 4)
+    {
+        int base = surface->first_vertex;
+        acc->lm_uvs[base * 2 + 0] = u0;
+        acc->lm_uvs[base * 2 + 1] = v0;
+        acc->lm_uvs[(base + 1) * 2 + 0] = u1;
+        acc->lm_uvs[(base + 1) * 2 + 1] = v0;
+        acc->lm_uvs[(base + 2) * 2 + 0] = u1;
+        acc->lm_uvs[(base + 2) * 2 + 1] = v1;
+        acc->lm_uvs[(base + 3) * 2 + 0] = u0;
+        acc->lm_uvs[(base + 3) * 2 + 1] = v1;
+        return;
+    }
+
+    for (int i = 0; i < surface->vertex_count; ++i)
+    {
+        int vi = surface->first_vertex + i;
+        float x = acc->pos[vi * 3 + 0];
+        float z = acc->pos[vi * 3 + 2];
+        float sx = surface->max_x > surface->min_x ? (x - surface->min_x) / (surface->max_x - surface->min_x) : 0.0f;
+        float sz = surface->max_z > surface->min_z ? (z - surface->min_z) / (surface->max_z - surface->min_z) : 0.0f;
+        acc->lm_uvs[vi * 2 + 0] = u0 + sx * (u1 - u0);
+        acc->lm_uvs[vi * 2 + 1] = v0 + sz * (v1 - v0);
+    }
+}
+
+static Uint8 lm_channel_clamp(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0;
+    }
+    if (value >= 255.0f)
+    {
+        return 255;
+    }
+    return (Uint8)(value + 0.5f);
+}
+
+static bool lm_build_texture(sdl3d_level *out)
+{
+    sdl3d_image image;
+    size_t pixel_count = (size_t)out->lightmap_width * (size_t)out->lightmap_height;
+
+    if (out->lightmap_pixels == NULL || out->lightmap_width <= 0 || out->lightmap_height <= 0)
+    {
+        return true;
+    }
+
+    SDL_zero(image);
+    image.width = out->lightmap_width;
+    image.height = out->lightmap_height;
+    image.pixels = SDL_malloc(pixel_count * 4U);
+    if (image.pixels == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    for (size_t i = 0; i < pixel_count; ++i)
+    {
+        image.pixels[i * 4 + 0] = out->lightmap_pixels[i * 3 + 0];
+        image.pixels[i * 4 + 1] = out->lightmap_pixels[i * 3 + 1];
+        image.pixels[i * 4 + 2] = out->lightmap_pixels[i * 3 + 2];
+        image.pixels[i * 4 + 3] = 255;
+    }
+
+    if (!sdl3d_create_texture_from_image(&image, &out->lightmap_texture))
+    {
+        SDL_free(image.pixels);
+        return false;
+    }
+    SDL_free(image.pixels);
+    if (!sdl3d_set_texture_filter(&out->lightmap_texture, SDL3D_TEXTURE_FILTER_BILINEAR) ||
+        !sdl3d_set_texture_wrap(&out->lightmap_texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP))
+    {
+        sdl3d_free_texture(&out->lightmap_texture);
+        return false;
+    }
+    return true;
+}
+
+static bool lm_bake_lightmap(const lm_surface_list *list, const sdl3d_level_light *lights, int light_count,
+                             sdl3d_level *out)
+{
+    const int atlas_w = out->lightmap_width;
+    const int atlas_h = out->lightmap_height;
+    unsigned char *pixels;
+
+    if (atlas_w <= 0 || atlas_h <= 0)
+    {
+        return true;
+    }
+
+    pixels = SDL_malloc((size_t)atlas_w * (size_t)atlas_h * 3U);
+    if (pixels == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    for (int i = 0; i < atlas_w * atlas_h; ++i)
+    {
+        pixels[i * 3 + 0] = 51;
+        pixels[i * 3 + 1] = 51;
+        pixels[i * 3 + 2] = 51;
+    }
+
+    for (int si = 0; si < list->count; ++si)
+    {
+        const lm_surface *surface = &list->items[si];
+        for (int y = 0; y < surface->atlas_h; ++y)
+        {
+            for (int x = 0; x < surface->atlas_w; ++x)
+            {
+                float s = surface->atlas_w > 1 ? (float)x / (float)(surface->atlas_w - 1) : 0.0f;
+                float t = surface->atlas_h > 1 ? (float)y / (float)(surface->atlas_h - 1) : 0.0f;
+                float wx, wy, wz;
+                float lr = 51.0f;
+                float lg = 51.0f;
+                float lb = 51.0f;
+                int atlas_index;
+
+                if (surface->type == LM_SURFACE_WALL)
+                {
+                    wx = surface->x0 + (surface->x1 - surface->x0) * s;
+                    wy = surface->bot + (surface->top - surface->bot) * t;
+                    wz = surface->z0 + (surface->z1 - surface->z0) * s;
+                }
+                else
+                {
+                    wx = surface->min_x + (surface->max_x - surface->min_x) * s;
+                    wy = surface->surface_y;
+                    wz = surface->min_z + (surface->max_z - surface->min_z) * t;
+                }
+
+                for (int li = 0; li < light_count; ++li)
+                {
+                    float lx = lights[li].position[0] - wx;
+                    float ly = lights[li].position[1] - wy;
+                    float lz = lights[li].position[2] - wz;
+                    float dist = SDL_sqrtf(lx * lx + ly * ly + lz * lz);
+                    float inv;
+                    float ndotl;
+                    float r;
+                    float atten;
+                    float scale;
+
+                    if (dist < 0.0001f || dist > lights[li].range)
+                    {
+                        continue;
+                    }
+                    inv = 1.0f / dist;
+                    lx *= inv;
+                    ly *= inv;
+                    lz *= inv;
+                    ndotl = surface->nx * lx + surface->ny * ly + surface->nz * lz;
+                    if (ndotl <= 0.0f)
+                    {
+                        continue;
+                    }
+                    r = dist / lights[li].range;
+                    atten = 1.0f - r * r;
+                    if (atten < 0.0f)
+                    {
+                        atten = 0.0f;
+                    }
+                    atten *= atten;
+                    scale = lights[li].intensity * atten * ndotl * 255.0f;
+                    lr += lights[li].color[0] * scale;
+                    lg += lights[li].color[1] * scale;
+                    lb += lights[li].color[2] * scale;
+                }
+
+                atlas_index = ((surface->atlas_y + y) * atlas_w + (surface->atlas_x + x)) * 3;
+                pixels[atlas_index + 0] = lm_channel_clamp(lr);
+                pixels[atlas_index + 1] = lm_channel_clamp(lg);
+                pixels[atlas_index + 2] = lm_channel_clamp(lb);
+            }
+        }
+    }
+
+    out->lightmap_pixels = pixels;
+    return true;
 }
 
 /* Geometry helpers                                                     */
@@ -227,12 +635,15 @@ static bool add_floor_ceil(macc *a, const sdl3d_sector *s, float y, float ny, co
 bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3d_level_material *materials,
                        int material_count, const sdl3d_level_light *lights, int light_count, sdl3d_level *out)
 {
+    lm_surface_list surf_list;
+
     if (!sectors || sector_count <= 0 || !out)
         return SDL_InvalidParamError("sectors");
     if (!materials || material_count <= 0)
         return SDL_InvalidParamError("materials");
 
     SDL_zerop(out);
+    SDL_zero(surf_list);
 
     /* Build edge list. */
     int total_edges = 0;
@@ -287,17 +698,30 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         int fi = (sec->floor_material >= 0 && sec->floor_material < material_count) ? sec->floor_material : -1;
         int ci = (sec->ceil_material >= 0 && sec->ceil_material < material_count) ? sec->ceil_material : -1;
         int wi = sec->wall_material < material_count ? sec->wall_material : 0;
-        macc *wall_acc = &accs[s * material_count + wi];
+        int wall_acc_index = s * material_count + wi;
+        macc *wall_acc = &accs[wall_acc_index];
 
         if (fi >= 0)
         {
-            macc *floor_acc = &accs[s * material_count + fi];
-            add_floor_ceil(floor_acc, sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale);
+            int floor_acc_index = s * material_count + fi;
+            macc *floor_acc = &accs[floor_acc_index];
+            int vb = floor_acc->vc;
+            if (!add_floor_ceil(floor_acc, sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale) ||
+                !lm_record_floor_ceil_surface(&surf_list, floor_acc_index, floor_acc, vb, sec, sec->floor_y, 1.0f))
+            {
+                goto fail;
+            }
         }
         if (ci >= 0)
         {
-            macc *ceil_acc = &accs[s * material_count + ci];
-            add_floor_ceil(ceil_acc, sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale);
+            int ceil_acc_index = s * material_count + ci;
+            macc *ceil_acc = &accs[ceil_acc_index];
+            int vb = ceil_acc->vc;
+            if (!add_floor_ceil(ceil_acc, sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale) ||
+                !lm_record_floor_ceil_surface(&surf_list, ceil_acc_index, ceil_acc, vb, sec, sec->ceil_y, -1.0f))
+            {
+                goto fail;
+            }
         }
 
         for (int e = 0; e < total_edges; e++)
@@ -374,8 +798,14 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
             if (novl == 0)
             {
-                add_wall(wall_acc, ax, az, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
-                         materials[wi].tex_scale);
+                int vb = wall_acc->vc;
+                if (!add_wall(wall_acc, ax, az, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                              materials[wi].tex_scale) ||
+                    !lm_record_wall_surface(&surf_list, wall_acc_index, wall_acc, vb, ax, az, bx, bz, sec->floor_y,
+                                            sec->ceil_y))
+                {
+                    goto fail;
+                }
             }
             else
             {
@@ -395,30 +825,59 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                     {
                         float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
                         float wx1 = ax + (bx - ax) * overlaps[oi].t0, wz1 = az + (bz - az) * overlaps[oi].t0;
-                        add_wall(wall_acc, wx0, wz0, wx1, wz1, sec->floor_y, sec->ceil_y, materials[wi].albedo,
-                                 materials[wi].tex_scale);
+                        int vb = wall_acc->vc;
+                        if (!add_wall(wall_acc, wx0, wz0, wx1, wz1, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                                      materials[wi].tex_scale) ||
+                            !lm_record_wall_surface(&surf_list, wall_acc_index, wall_acc, vb, wx0, wz0, wx1, wz1,
+                                                    sec->floor_y, sec->ceil_y))
+                        {
+                            goto fail;
+                        }
                     }
                     float ox0 = ax + (bx - ax) * overlaps[oi].t0, oz0 = az + (bz - az) * overlaps[oi].t0;
                     float ox1 = ax + (bx - ax) * overlaps[oi].t1, oz1 = az + (bz - az) * overlaps[oi].t1;
                     if (sec->floor_y < overlaps[oi].other_floor - 0.001f)
-                        add_wall(wall_acc, ox0, oz0, ox1, oz1, sec->floor_y, overlaps[oi].other_floor,
-                                 materials[wi].albedo, materials[wi].tex_scale);
+                    {
+                        int vb = wall_acc->vc;
+                        if (!add_wall(wall_acc, ox0, oz0, ox1, oz1, sec->floor_y, overlaps[oi].other_floor,
+                                      materials[wi].albedo, materials[wi].tex_scale) ||
+                            !lm_record_wall_surface(&surf_list, wall_acc_index, wall_acc, vb, ox0, oz0, ox1, oz1,
+                                                    sec->floor_y, overlaps[oi].other_floor))
+                        {
+                            goto fail;
+                        }
+                    }
                     if (sec->ceil_y > overlaps[oi].other_ceil + 0.001f)
-                        add_wall(wall_acc, ox0, oz0, ox1, oz1, overlaps[oi].other_ceil, sec->ceil_y,
-                                 materials[wi].albedo, materials[wi].tex_scale);
+                    {
+                        int vb = wall_acc->vc;
+                        if (!add_wall(wall_acc, ox0, oz0, ox1, oz1, overlaps[oi].other_ceil, sec->ceil_y,
+                                      materials[wi].albedo, materials[wi].tex_scale) ||
+                            !lm_record_wall_surface(&surf_list, wall_acc_index, wall_acc, vb, ox0, oz0, ox1, oz1,
+                                                    overlaps[oi].other_ceil, sec->ceil_y))
+                        {
+                            goto fail;
+                        }
+                    }
                     cursor = overlaps[oi].t1;
                 }
                 if (cursor < 1.0f - 0.001f)
                 {
                     float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
-                    add_wall(wall_acc, wx0, wz0, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
-                             materials[wi].tex_scale);
+                    int vb = wall_acc->vc;
+                    if (!add_wall(wall_acc, wx0, wz0, bx, bz, sec->floor_y, sec->ceil_y, materials[wi].albedo,
+                                  materials[wi].tex_scale) ||
+                        !lm_record_wall_surface(&surf_list, wall_acc_index, wall_acc, vb, wx0, wz0, bx, bz,
+                                                sec->floor_y, sec->ceil_y))
+                    {
+                        goto fail;
+                    }
                 }
             }
         }
     }
 
     SDL_free(edges);
+    edges = NULL;
 
     /* ---- Bake vertex lighting per material ---- */
     if (lights && light_count > 0)
@@ -461,6 +920,31 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
                 a->col[v * 4 + 2] = lb > 1.0f ? 1.0f : lb;
             }
         }
+
+        if (surf_list.count > 0)
+        {
+            int atlas_w = 0;
+            int atlas_h = 0;
+
+            if (!lm_allocate_uvs(accs, acc_count) || !lm_pack_surfaces(&surf_list, &atlas_w, &atlas_h))
+            {
+                goto fail;
+            }
+
+            out->lightmap_width = atlas_w;
+            out->lightmap_height = atlas_h;
+
+            for (int si = 0; si < surf_list.count; ++si)
+            {
+                const lm_surface *surface = &surf_list.items[si];
+                lm_assign_surface_uvs(&accs[surface->acc_index], surface, atlas_w, atlas_h);
+            }
+
+            if (!lm_bake_lightmap(&surf_list, lights, light_count, out) || !lm_build_texture(out))
+            {
+                goto fail;
+            }
+        }
     }
 
     /* ---- Package: one mesh per sector/material chunk ---- */
@@ -474,14 +958,11 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
     int *mesh_sector_ids = SDL_malloc((size_t)num_meshes * sizeof(int));
     if (!meshes || !out_mats || !mesh_sector_ids)
     {
-        for (int ai = 0; ai < acc_count; ai++)
-            macc_free(&accs[ai]);
-        SDL_free(accs);
         SDL_free(meshes);
         SDL_free(out_mats);
         SDL_free(mesh_sector_ids);
-        SDL_free(portals);
-        return SDL_OutOfMemory();
+        SDL_OutOfMemory();
+        goto fail;
     }
 
     for (int m = 0; m < material_count; m++)
@@ -512,6 +993,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
             meshes[mi].colors = a->col;
             meshes[mi].colors_are_baked_light = (lights != NULL && light_count > 0);
             meshes[mi].uvs = a->uvs;
+            meshes[mi].lightmap_uvs = a->lm_uvs;
             meshes[mi].indices = a->idx;
             meshes[mi].material_index = m;
             meshes[mi].has_local_bounds = a->has_bounds;
@@ -524,6 +1006,7 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         }
     }
     SDL_free(accs);
+    SDL_free(surf_list.items);
 
     /* source_path for texture resolver — use first texture's directory. */
     for (int m = 0; m < material_count; m++)
@@ -547,6 +1030,22 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
     SDL_Log("SDL3D level: %d verts, %d tris, %d meshes, %d portals from %d sectors", total_verts, total_tris,
             num_meshes, portal_count, sector_count);
     return true;
+
+fail:
+    SDL_free(edges);
+    for (int ai = 0; ai < acc_count; ++ai)
+    {
+        macc_free(&accs[ai]);
+    }
+    SDL_free(accs);
+    SDL_free(surf_list.items);
+    SDL_free(portals);
+    SDL_free(out->lightmap_pixels);
+    out->lightmap_pixels = NULL;
+    out->lightmap_width = 0;
+    out->lightmap_height = 0;
+    sdl3d_free_texture(&out->lightmap_texture);
+    return false;
 }
 
 void sdl3d_free_level(sdl3d_level *level)
@@ -557,6 +1056,7 @@ void sdl3d_free_level(sdl3d_level *level)
         SDL_free(level->mesh_sector_ids);
         SDL_free(level->portals);
         SDL_free(level->lightmap_pixels);
+        sdl3d_free_texture(&level->lightmap_texture);
         level->mesh_sector_ids = NULL;
         level->portals = NULL;
         level->lightmap_pixels = NULL;

--- a/src/level.c
+++ b/src/level.c
@@ -164,93 +164,6 @@ static void macc_free(macc *a)
     SDL_free(a->idx);
 }
 
-/* ------------------------------------------------------------------ */
-/* Surface tracking for lightmap UV generation                         */
-/* ------------------------------------------------------------------ */
-
-typedef struct
-{
-    int acc_index;    /* which macc (sector × material) */
-    int first_vert;   /* first vertex index in that macc */
-    int vert_count;   /* number of vertices in this surface */
-    float nx, ny, nz; /* surface normal */
-    /* World-space bounds of the surface (for atlas sizing). */
-    float world_min[3], world_max[3];
-} lm_surface;
-
-typedef struct
-{
-    lm_surface *surfaces;
-    int count, cap;
-} lm_surface_list;
-
-static void lm_surface_list_init(lm_surface_list *l)
-{
-    l->surfaces = NULL;
-    l->count = 0;
-    l->cap = 0;
-}
-
-static lm_surface *lm_surface_list_add(lm_surface_list *l)
-{
-    if (l->count == l->cap)
-    {
-        int c = l->cap ? l->cap * 2 : 64;
-        lm_surface *s = SDL_realloc(l->surfaces, (size_t)c * sizeof(lm_surface));
-        if (!s)
-            return NULL;
-        l->surfaces = s;
-        l->cap = c;
-    }
-    lm_surface *s = &l->surfaces[l->count++];
-    SDL_memset(s, 0, sizeof(*s));
-    return s;
-}
-
-static void lm_surface_list_free(lm_surface_list *l)
-{
-    SDL_free(l->surfaces);
-    l->surfaces = NULL;
-    l->count = l->cap = 0;
-}
-
-/* Record a surface from vertices [first_vert, macc.vc) in accumulator acc_index. */
-static void lm_record_surface(lm_surface_list *sl, int acc_index, const macc *a, int first_vert, float snx, float sny,
-                              float snz)
-{
-    int nv = a->vc - first_vert;
-    if (nv < 3)
-        return;
-    lm_surface *s = lm_surface_list_add(sl);
-    if (!s)
-        return;
-    s->acc_index = acc_index;
-    s->first_vert = first_vert;
-    s->vert_count = nv;
-    s->nx = snx;
-    s->ny = sny;
-    s->nz = snz;
-    /* Compute world bounds. */
-    s->world_min[0] = s->world_min[1] = s->world_min[2] = 1e30f;
-    s->world_max[0] = s->world_max[1] = s->world_max[2] = -1e30f;
-    for (int i = first_vert; i < a->vc; i++)
-    {
-        for (int c = 0; c < 3; c++)
-        {
-            float v = a->pos[i * 3 + c];
-            if (v < s->world_min[c])
-                s->world_min[c] = v;
-            if (v > s->world_max[c])
-                s->world_max[c] = v;
-        }
-    }
-}
-
-/* ------------------------------------------------------------------ */
-/* Suppress unused warnings until full lightmap baking is wired up. */
-SDL_COMPILE_TIME_ASSERT(lm_surface_size, sizeof(lm_surface) > 0);
-static const void *lm_unused_[] = {(void *)lm_record_surface, (void *)lm_surface_list_free, (void *)lm_unused_};
-
 /* Geometry helpers                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -368,9 +281,6 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
         return SDL_OutOfMemory();
     }
 
-    lm_surface_list surf_list;
-    lm_surface_list_init(&surf_list);
-
     for (int s = 0; s < sector_count; s++)
     {
         const sdl3d_sector *sec = &sectors[s];
@@ -381,19 +291,13 @@ bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3
 
         if (fi >= 0)
         {
-            int ai = s * material_count + fi;
-            macc *floor_acc = &accs[ai];
-            int vb = floor_acc->vc;
+            macc *floor_acc = &accs[s * material_count + fi];
             add_floor_ceil(floor_acc, sec, sec->floor_y, 1.0f, materials[fi].albedo, materials[fi].tex_scale);
-            lm_record_surface(&surf_list, ai, floor_acc, vb, 0, 1, 0);
         }
         if (ci >= 0)
         {
-            int ai = s * material_count + ci;
-            macc *ceil_acc = &accs[ai];
-            int vb = ceil_acc->vc;
+            macc *ceil_acc = &accs[s * material_count + ci];
             add_floor_ceil(ceil_acc, sec, sec->ceil_y, -1.0f, materials[ci].albedo, materials[ci].tex_scale);
-            lm_record_surface(&surf_list, ai, ceil_acc, vb, 0, -1, 0);
         }
 
         for (int e = 0; e < total_edges; e++)

--- a/src/model.c
+++ b/src/model.c
@@ -21,6 +21,7 @@ void sdl3d_free_model(sdl3d_model *model)
         SDL_free(mesh->positions);
         SDL_free(mesh->normals);
         SDL_free(mesh->uvs);
+        SDL_free(mesh->lightmap_uvs);
         SDL_free(mesh->colors);
         SDL_free(mesh->indices);
         SDL_free(mesh->joint_indices);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -293,6 +293,69 @@ TEST_F(GLRendererTest, LevelInteriorVisibleWithBackfaceCulling)
     EXPECT_GT(px[0] + px[1] + px[2], 30);
 }
 
+TEST_F(GLRendererTest, LightmappedLevelRendersWithoutVertexColorFallback)
+{
+    const sdl3d_level_material materials[] = {
+        {{1.0f, 1.0f, 1.0f, 1.0f}, 0.0f, 1.0f, nullptr, 4.0f},
+        {{1.0f, 1.0f, 1.0f, 1.0f}, 0.0f, 1.0f, nullptr, 4.0f},
+        {{1.0f, 1.0f, 1.0f, 1.0f}, 0.0f, 1.0f, nullptr, 4.0f},
+    };
+    const sdl3d_level_light light = {{2.0f, 2.2f, 2.0f}, {1.0f, 0.9f, 0.8f}, 3.0f, 8.0f};
+    sdl3d_sector sector{};
+    sector.points[0][0] = 0.0f;
+    sector.points[0][1] = 0.0f;
+    sector.points[1][0] = 4.0f;
+    sector.points[1][1] = 0.0f;
+    sector.points[2][0] = 4.0f;
+    sector.points[2][1] = 4.0f;
+    sector.points[3][0] = 0.0f;
+    sector.points[3][1] = 4.0f;
+    sector.num_points = 4;
+    sector.floor_y = 0.0f;
+    sector.ceil_y = 3.0f;
+    sector.floor_material = 0;
+    sector.ceil_material = 1;
+    sector.wall_material = 2;
+
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(&sector, 1, materials, 3, &light, 1, &level)) << SDL_GetError();
+
+    for (int mi = 0; mi < level.model.mesh_count; ++mi)
+    {
+        sdl3d_mesh &mesh = level.model.meshes[mi];
+        ASSERT_NE(mesh.colors, nullptr);
+        for (int v = 0; v < mesh.vertex_count; ++v)
+        {
+            mesh.colors[v * 4 + 0] = 0.0f;
+            mesh.colors[v * 4 + 1] = 0.0f;
+            mesh.colors[v * 4 + 2] = 0.0f;
+            mesh.colors[v * 4 + 3] = 1.0f;
+        }
+    }
+
+    ASSERT_TRUE(sdl3d_set_shading_mode(ctx, SDL3D_SHADING_PHONG));
+    sdl3d_set_ambient_light(ctx, 0.0f, 0.0f, 0.0f);
+    sdl3d_set_backface_culling_enabled(ctx, true);
+
+    sdl3d_camera3d cam;
+    cam.position = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    cam.target = sdl3d_vec3_make(2.0f, 1.5f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_clear_render_context(ctx, (sdl3d_color){0, 0, 0, 255});
+    sdl3d_begin_mode_3d(ctx, cam);
+    ASSERT_TRUE(sdl3d_draw_level(ctx, &level, nullptr, (sdl3d_color){255, 255, 255, 255})) << SDL_GetError();
+    sdl3d_end_mode_3d(ctx);
+
+    unsigned char px[4];
+    readPixel(160, 120, px);
+    sdl3d_free_level(&level);
+
+    EXPECT_GT(px[0] + px[1] + px[2], 30);
+}
+
 TEST_F(GLRendererTest, BillboardVisibleWithTexture)
 {
     const Uint8 pixels[] = {

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -246,6 +246,36 @@ TEST(SDL3DLevelBuilder, AllowsOpenCeilingBySkippingCeilingGeometry)
     sdl3d_free_level(&level);
 }
 
+TEST(SDL3DLevelBuilder, BakesLightmapAtlasAndMeshUVs)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial(nullptr), MakeLevelMaterial(nullptr),
+                                              MakeLevelMaterial(nullptr)};
+    const sdl3d_sector sector = MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f);
+    const sdl3d_level_light light = {{2.0f, 2.0f, 2.0f}, {1.0f, 0.8f, 0.6f}, 3.0f, 8.0f};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(&sector, 1, materials, 3, &light, 1, &level)) << SDL_GetError();
+    EXPECT_NE(level.lightmap_pixels, nullptr);
+    EXPECT_GT(level.lightmap_width, 0);
+    EXPECT_GT(level.lightmap_height, 0);
+    EXPECT_NE(level.lightmap_texture.pixels, nullptr);
+
+    for (int i = 0; i < level.model.mesh_count; ++i)
+    {
+        const sdl3d_mesh &mesh = level.model.meshes[i];
+        ASSERT_NE(mesh.lightmap_uvs, nullptr);
+        for (int v = 0; v < mesh.vertex_count; ++v)
+        {
+            EXPECT_GE(mesh.lightmap_uvs[v * 2 + 0], 0.0f);
+            EXPECT_LE(mesh.lightmap_uvs[v * 2 + 0], 1.0f);
+            EXPECT_GE(mesh.lightmap_uvs[v * 2 + 1], 0.0f);
+            EXPECT_LE(mesh.lightmap_uvs[v * 2 + 1], 1.0f);
+        }
+    }
+
+    sdl3d_free_level(&level);
+}
+
 TEST(SDL3DLevelVisibility, FindSectorReturnsCorrectSector)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),


### PR DESCRIPTION
## Summary

Data foundation for lightmap support. No rendering changes — the demo looks identical.

## Changes

- `sdl3d_mesh.lightmap_uvs`: second UV channel (float*, 2 per vertex, NULL when unused)
- `sdl3d_level.lightmap_pixels/width/height`: RGB atlas storage
- `lm_surface` tracking in level builder: records per-surface vertex ranges and world bounds for future atlas packing
- Surface recording wired into floor/ceiling generation
- Proper cleanup in `sdl3d_free_model` and `sdl3d_free_level`

## What this enables (next PR)

- Atlas packing: assign each surface a rectangular region in a lightmap texture
- Lightmap UV generation: second UV channel mapping vertices to atlas regions
- Light baking into texels instead of vertices (smoother gradients on large surfaces)
- Lightmap sampling in the PBR shader (texture unit 7, vertex attribute location 4)

## Testing

- 453 tests pass, no regressions
- Demo visually identical to `stable-doom-projectile` tag
- No new rendering code paths exercised yet

## Files changed

- `include/sdl3d/model.h` — added `lightmap_uvs` to mesh struct
- `include/sdl3d/level.h` — added lightmap atlas fields to level struct
- `src/level.c` — surface tracking infrastructure + recording in geometry loop
- `src/model.c` — free `lightmap_uvs` in cleanup