### PR TITLE
feat(ui): inspector row, list view, tree view (Phase 3 complete)

### DIFF
--- a/demos/ui_editor/main.c
+++ b/demos/ui_editor/main.c
@@ -69,6 +69,17 @@ typedef struct editor_state
     /* Inspector */
     int inspector_tab;
     char log_msg[128]; /* status feedback from actions */
+
+    /* Scene hierarchy (tree view) */
+    bool tree_root_expanded;
+    bool tree_geometry_expanded;
+    bool tree_lights_expanded;
+    bool tree_triggers_expanded;
+    int tree_selected;
+
+    /* Texture list (list view) */
+    int texture_selected;
+    float texture_scroll;
 } editor_state;
 
 static void editor_reset(editor_state *st)
@@ -91,6 +102,13 @@ static void editor_reset(editor_state *st)
     st->light_intensity = 1.0f;
     st->inspector_tab = 0;
     st->log_msg[0] = '\0';
+    st->tree_root_expanded = true;
+    st->tree_geometry_expanded = true;
+    st->tree_lights_expanded = false;
+    st->tree_triggers_expanded = false;
+    st->tree_selected = 1;
+    st->texture_selected = 0;
+    st->texture_scroll = 0.0f;
 }
 
 static void parse_origin(editor_state *st)
@@ -213,16 +231,18 @@ static void draw_tool_panel(sdl3d_ui_context *ui, float y0, float h, editor_stat
 /* ------------------------------------------------------------------ */
 
 static float inspector_scroll = 0.0f;
-static const char *inspector_tabs[] = {"Entity", "Display", "Actions"};
+static const char *inspector_tabs[] = {"Entity", "Display", "Scene", "Textures"};
+static const char *texture_names[] = {"brick_wall", "concrete",    "metal_floor",   "wood_planks", "tile_mosaic",
+                                      "grass",      "stone_rough", "plaster_white", "rust_panel",  "glass_tint"};
 
 static void draw_inspector_panel(sdl3d_ui_context *ui, float x0, float y0, float h, editor_state *st)
 {
     float pad = 8.0f;
     float inner_w = INSPECTOR_W - pad * 2;
-    float content_h = 500.0f;
+    float content_h = 600.0f;
 
     sdl3d_ui_begin_panel(ui, x0, y0, INSPECTOR_W, h);
-    sdl3d_ui_tab_strip(ui, x0 + pad, y0 + pad, inner_w, 26.0f, inspector_tabs, 3, &st->inspector_tab);
+    sdl3d_ui_tab_strip(ui, x0 + pad, y0 + pad, inner_w, 26.0f, inspector_tabs, 4, &st->inspector_tab);
     float tab_h = 26.0f + pad;
 
     sdl3d_ui_begin_scroll(ui, x0 + pad, y0 + pad + tab_h, inner_w, h - pad * 2 - tab_h, &inspector_scroll, content_h);
@@ -230,7 +250,7 @@ static void draw_inspector_panel(sdl3d_ui_context *ui, float x0, float y0, float
 
     if (st->inspector_tab == 0)
     {
-        /* Entity tab */
+        /* Entity tab — uses inspector row layout */
         sdl3d_ui_layout_label(ui, "Entity Type");
         int prev_type = st->entity_type;
         sdl3d_ui_layout_dropdown(ui, entity_types, 5, &st->entity_type);
@@ -241,50 +261,33 @@ static void draw_inspector_panel(sdl3d_ui_context *ui, float x0, float y0, float
         }
         sdl3d_ui_separator(ui);
 
-        sdl3d_ui_layout_label(ui, "Classname");
-        sdl3d_ui_layout_text_field(ui, st->classname, sizeof(st->classname));
-
-        sdl3d_ui_layout_label(ui, "Origin (x y z)");
-        if (sdl3d_ui_layout_text_field(ui, st->origin, sizeof(st->origin)))
+        sdl3d_ui_layout_label(ui, "Properties");
+        sdl3d_ui_row_text_field(ui, "Classname:", st->classname, sizeof(st->classname));
+        if (sdl3d_ui_row_text_field(ui, "Origin:", st->origin, sizeof(st->origin)))
         {
             parse_origin(st);
             SDL_snprintf(st->log_msg, sizeof(st->log_msg), "Origin: %.1f %.1f %.1f", (double)st->cube_pos[0],
                          (double)st->cube_pos[1], (double)st->cube_pos[2]);
         }
-        sdl3d_ui_separator(ui);
-
-        sdl3d_ui_layout_checkbox(ui, "Visible", &st->entity_visible);
+        sdl3d_ui_row_checkbox(ui, "Visible:", &st->entity_visible);
         sdl3d_ui_separator(ui);
 
         sdl3d_ui_layout_label(ui, "Info");
-        sdl3d_ui_layout_labelf(ui, "  Tool: %s", st->active_tool);
-        sdl3d_ui_layout_labelf(ui, "  Clicks: %d", st->click_count);
-        sdl3d_ui_layout_labelf(ui, "  Pos: %.1f %.1f %.1f", (double)st->cube_pos[0], (double)st->cube_pos[1],
-                               (double)st->cube_pos[2]);
-    }
-    else if (st->inspector_tab == 1)
-    {
-        /* Display tab */
-        sdl3d_ui_layout_label(ui, "Rendering");
-        sdl3d_ui_layout_checkbox(ui, "Wireframe", &st->wireframe);
-        sdl3d_ui_layout_checkbox(ui, "Show Grid", &st->show_grid);
-        sdl3d_ui_layout_checkbox(ui, "Show Axes", &st->show_axes);
-        sdl3d_ui_layout_checkbox(ui, "Snap to Grid", &st->snap_enabled);
+        sdl3d_ui_row_label(ui, "Tool:", st->active_tool);
+        {
+            char buf[32];
+            SDL_snprintf(buf, sizeof(buf), "%d", st->click_count);
+            sdl3d_ui_row_label(ui, "Clicks:", buf);
+        }
+        {
+            char buf[64];
+            SDL_snprintf(buf, sizeof(buf), "%.1f %.1f %.1f", (double)st->cube_pos[0], (double)st->cube_pos[1],
+                         (double)st->cube_pos[2]);
+            sdl3d_ui_row_label(ui, "Position:", buf);
+        }
         sdl3d_ui_separator(ui);
 
-        sdl3d_ui_layout_label(ui, "Camera");
-        sdl3d_ui_layout_slider(ui, "Orbit Speed", &st->orbit_speed, 0.1f, 2.0f);
-        sdl3d_ui_separator(ui);
-
-        sdl3d_ui_layout_label(ui, "Scene");
-        sdl3d_ui_layout_slider(ui, "Grid Size", &st->grid_size, 2.0f, 64.0f);
-        sdl3d_ui_layout_slider(ui, "Cube Scale", &st->cube_scale, 0.5f, 5.0f);
-        sdl3d_ui_layout_slider(ui, "Light", &st->light_intensity, 0.0f, 2.0f);
-    }
-    else
-    {
-        /* Actions tab */
-        sdl3d_ui_layout_label(ui, "Entity Actions");
+        sdl3d_ui_layout_label(ui, "Actions");
         if (sdl3d_ui_layout_button(ui, "Apply##insp1"))
         {
             parse_origin(st);
@@ -303,21 +306,90 @@ static void draw_inspector_panel(sdl3d_ui_context *ui, float x0, float y0, float
             st->entity_visible = false;
             SDL_strlcpy(st->log_msg, "Entity deleted (hidden)", sizeof(st->log_msg));
         }
+    }
+    else if (st->inspector_tab == 1)
+    {
+        /* Display tab — uses inspector rows for sliders and checkboxes */
+        sdl3d_ui_layout_label(ui, "Rendering");
+        sdl3d_ui_row_checkbox(ui, "Wireframe:", &st->wireframe);
+        sdl3d_ui_row_checkbox(ui, "Show Grid:", &st->show_grid);
+        sdl3d_ui_row_checkbox(ui, "Show Axes:", &st->show_axes);
+        sdl3d_ui_row_checkbox(ui, "Snap:", &st->snap_enabled);
         sdl3d_ui_separator(ui);
 
-        sdl3d_ui_layout_label(ui, "View Actions");
-        if (sdl3d_ui_layout_button(ui, "Center##view1"))
+        sdl3d_ui_layout_label(ui, "Camera");
+        sdl3d_ui_row_slider(ui, "Orbit:", &st->orbit_speed, 0.1f, 2.0f);
+        sdl3d_ui_separator(ui);
+
+        sdl3d_ui_layout_label(ui, "Scene");
+        sdl3d_ui_row_slider(ui, "Grid:", &st->grid_size, 2.0f, 64.0f);
+        sdl3d_ui_row_slider(ui, "Scale:", &st->cube_scale, 0.5f, 5.0f);
+        sdl3d_ui_row_slider(ui, "Light:", &st->light_intensity, 0.0f, 2.0f);
+    }
+    else if (st->inspector_tab == 2)
+    {
+        /* Scene tab — tree view hierarchy */
+        sdl3d_ui_layout_label(ui, "Scene Hierarchy");
+        sdl3d_ui_separator(ui);
+
+        sdl3d_ui_tree_node(ui, "World", 1, &st->tree_root_expanded, &st->tree_selected);
+        if (st->tree_root_expanded)
         {
-            SDL_strlcpy(st->origin, "0 0 0", sizeof(st->origin));
-            parse_origin(st);
-            SDL_strlcpy(st->log_msg, "View centered", sizeof(st->log_msg));
+            sdl3d_ui_tree_push(ui);
+
+            sdl3d_ui_tree_node(ui, "Geometry", 10, &st->tree_geometry_expanded, &st->tree_selected);
+            if (st->tree_geometry_expanded)
+            {
+                sdl3d_ui_tree_push(ui);
+                bool leaf = false;
+                sdl3d_ui_tree_node(ui, "Floor", 101, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_node(ui, "Walls", 102, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_node(ui, "Ceiling", 103, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_node(ui, "Cube", 104, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_pop(ui);
+            }
+
+            sdl3d_ui_tree_node(ui, "Lights", 20, &st->tree_lights_expanded, &st->tree_selected);
+            if (st->tree_lights_expanded)
+            {
+                sdl3d_ui_tree_push(ui);
+                bool leaf = false;
+                sdl3d_ui_tree_node(ui, "Sun", 201, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_node(ui, "Point Light 1", 202, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_pop(ui);
+            }
+
+            sdl3d_ui_tree_node(ui, "Triggers", 30, &st->tree_triggers_expanded, &st->tree_selected);
+            if (st->tree_triggers_expanded)
+            {
+                sdl3d_ui_tree_push(ui);
+                bool leaf = false;
+                sdl3d_ui_tree_node(ui, "trigger_once_1", 301, &leaf, &st->tree_selected);
+                sdl3d_ui_tree_pop(ui);
+            }
+
+            sdl3d_ui_tree_pop(ui);
         }
-        if (sdl3d_ui_layout_button(ui, "Top Down##view2"))
+
+        sdl3d_ui_separator(ui);
         {
-            SDL_strlcpy(st->origin, "0 5 0", sizeof(st->origin));
-            parse_origin(st);
-            SDL_strlcpy(st->log_msg, "Top-down view", sizeof(st->log_msg));
+            char buf[64];
+            SDL_snprintf(buf, sizeof(buf), "Selected: %d", st->tree_selected);
+            sdl3d_ui_layout_label(ui, buf);
         }
+    }
+    else
+    {
+        /* Textures tab — list view */
+        sdl3d_ui_layout_label(ui, "Texture Browser");
+        sdl3d_ui_separator(ui);
+
+        if (sdl3d_ui_layout_list_view(ui, 200.0f, texture_names, 10, &st->texture_selected, &st->texture_scroll))
+        {
+            SDL_snprintf(st->log_msg, sizeof(st->log_msg), "Texture: %s", texture_names[st->texture_selected]);
+        }
+        sdl3d_ui_separator(ui);
+        sdl3d_ui_row_label(ui, "Selected:", texture_names[st->texture_selected]);
     }
 
     sdl3d_ui_end_vbox(ui);

--- a/include/sdl3d/ui.h
+++ b/include/sdl3d/ui.h
@@ -338,6 +338,75 @@ extern "C"
                             int tab_count, int *selected);
     bool sdl3d_ui_layout_tab_strip(sdl3d_ui_context *ui, const char *const *tabs, int tab_count, int *selected);
 
+    /* ------------------------------------------------------------------ */
+    /* Inspector row                                                       */
+    /* ------------------------------------------------------------------ */
+
+    /*
+     * A "label: widget" row for property inspectors. Splits the current
+     * layout width into a label portion (left) and a widget portion
+     * (right). `label_fraction` is typically 0.35–0.4.
+     *
+     * begin_row pushes an hbox sized to the current layout width.
+     * The caller draws the label, then the value widget, then calls
+     * end_row. Convenience helpers below handle common patterns.
+     */
+    void sdl3d_ui_begin_row(sdl3d_ui_context *ui, const char *label, float label_fraction);
+    void sdl3d_ui_end_row(sdl3d_ui_context *ui);
+
+    /* Inspector row with a text field value. */
+    bool sdl3d_ui_row_text_field(sdl3d_ui_context *ui, const char *label, char *buf, int buf_size);
+
+    /* Inspector row with a slider value. */
+    bool sdl3d_ui_row_slider(sdl3d_ui_context *ui, const char *label, float *value, float min, float max);
+
+    /* Inspector row with a checkbox value. */
+    bool sdl3d_ui_row_checkbox(sdl3d_ui_context *ui, const char *label, bool *value);
+
+    /* Inspector row with a read-only label value. */
+    void sdl3d_ui_row_label(sdl3d_ui_context *ui, const char *label, const char *value);
+
+    /* ------------------------------------------------------------------ */
+    /* List view                                                           */
+    /* ------------------------------------------------------------------ */
+
+    /*
+     * Scrollable list of selectable text items. Returns true on the
+     * frame the selection changes. `selected` is a caller-owned index
+     * (-1 for no selection). The list is drawn at the given position
+     * with the given size; items that overflow are clipped and can be
+     * scrolled with the mouse wheel.
+     *
+     * `scroll_offset` is caller-owned persistent state (initialize to 0).
+     */
+    bool sdl3d_ui_list_view(sdl3d_ui_context *ui, float x, float y, float w, float h, const char *const *items,
+                            int item_count, int *selected, float *scroll_offset);
+    bool sdl3d_ui_layout_list_view(sdl3d_ui_context *ui, float h, const char *const *items, int item_count,
+                                   int *selected, float *scroll_offset);
+
+    /* ------------------------------------------------------------------ */
+    /* Tree view                                                           */
+    /* ------------------------------------------------------------------ */
+
+    /*
+     * Collapsible tree node. Returns true if the node is expanded
+     * (children should be drawn). `expanded` is caller-owned state.
+     * `selected_id` is a caller-owned pointer to the currently selected
+     * node ID; when the user clicks this node's label, `*selected_id`
+     * is set to `node_id` and the function returns true for the
+     * selection change.
+     *
+     * Typical usage (recursive):
+     *   if (sdl3d_ui_tree_node(ui, "Root", 1, &expanded_root, &sel)) { ... }
+     *     sdl3d_ui_tree_push(ui);
+     *     if (sdl3d_ui_tree_node(ui, "Child", 2, &expanded_child, &sel)) { ... }
+     *     sdl3d_ui_tree_pop(ui);
+     *   (tree_node draws its own row; push/pop indent children)
+     */
+    bool sdl3d_ui_tree_node(sdl3d_ui_context *ui, const char *label, int node_id, bool *expanded, int *selected_id);
+    void sdl3d_ui_tree_push(sdl3d_ui_context *ui);
+    void sdl3d_ui_tree_pop(sdl3d_ui_context *ui);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -140,6 +140,9 @@ struct sdl3d_ui_context
      * auto-position child widgets. */
     sdl3d_ui_layout_entry layout_stack[SDL3D_UI_MAX_LAYOUT_DEPTH];
     int layout_depth;
+
+    /* Tree view indent level (incremented by tree_push, decremented by tree_pop). */
+    int tree_indent;
 };
 
 /* ------------------------------------------------------------------ */
@@ -457,6 +460,7 @@ void sdl3d_ui_begin_frame(sdl3d_ui_context *ui, int screen_w, int screen_h)
     ui->clip_depth = 0;
     ui->scroll_depth = 0;
     ui->layout_depth = 0;
+    ui->tree_indent = 0;
     ui->frame_open = true;
     ui->hovered_id = 0;
     ui->popup_owner_id = 0;
@@ -1595,6 +1599,261 @@ bool sdl3d_ui_layout_tab_strip(sdl3d_ui_context *ui, const char *const *tabs, in
     if (!ui_layout_alloc(ui, w, h, &x, &y))
         return false;
     return sdl3d_ui_tab_strip(ui, x, y, w, h, tabs, tab_count, selected);
+}
+
+/* ------------------------------------------------------------------ */
+/* Inspector row                                                       */
+/* ------------------------------------------------------------------ */
+
+#define SDL3D_UI_ROW_HEIGHT 24.0f
+
+void sdl3d_ui_begin_row(sdl3d_ui_context *ui, const char *label, float label_fraction)
+{
+    if (!ui || !ui->frame_open || !label || ui->layout_depth <= 0)
+        return;
+
+    int d = ui->layout_depth - 1;
+    float row_w = ui->layout_stack[d].w;
+    float row_h = SDL3D_UI_ROW_HEIGHT;
+    float x, y;
+    if (!ui_layout_alloc(ui, row_w, row_h, &x, &y))
+        return;
+
+    /* Draw label on the left portion. */
+    float label_w = row_w * label_fraction;
+    float tw = 0, th = 0;
+    sdl3d_ui_measure_text(ui, label, &tw, &th);
+    sdl3d_ui_draw_text(ui, x, y + (row_h - th) * 0.5f, label, ui->theme.text_muted);
+
+    /* Push an hbox for the value widget on the right portion. */
+    sdl3d_ui_begin_hbox(ui, x + label_w, y, row_w - label_w, row_h);
+}
+
+void sdl3d_ui_end_row(sdl3d_ui_context *ui)
+{
+    if (!ui)
+        return;
+    sdl3d_ui_end_hbox(ui);
+}
+
+bool sdl3d_ui_row_text_field(sdl3d_ui_context *ui, const char *label, char *buf, int buf_size)
+{
+    sdl3d_ui_begin_row(ui, label, 0.35f);
+    bool r = sdl3d_ui_layout_text_field(ui, buf, buf_size);
+    sdl3d_ui_end_row(ui);
+    return r;
+}
+
+bool sdl3d_ui_row_slider(sdl3d_ui_context *ui, const char *label, float *value, float min, float max)
+{
+    sdl3d_ui_begin_row(ui, label, 0.35f);
+    /* Use a label-less slider ID so the row label serves as the label. */
+    if (!ui || !ui->frame_open || !value || ui->layout_depth <= 0 || max <= min)
+    {
+        sdl3d_ui_end_row(ui);
+        return false;
+    }
+    int d = ui->layout_depth - 1;
+    float w = ui->layout_stack[d].w;
+    float h = ui->layout_stack[d].h;
+    float x, y;
+    if (!ui_layout_alloc(ui, w, h, &x, &y))
+    {
+        sdl3d_ui_end_row(ui);
+        return false;
+    }
+    /* Inline slider without the centered label (the row label covers it). */
+    char id_buf[64];
+    SDL_snprintf(id_buf, sizeof(id_buf), "##rs_%s", label);
+    bool r = sdl3d_ui_slider(ui, x, y, w, id_buf, value, min, max);
+    sdl3d_ui_end_row(ui);
+    return r;
+}
+
+bool sdl3d_ui_row_checkbox(sdl3d_ui_context *ui, const char *label, bool *value)
+{
+    /* Checkbox already draws its own label, so use begin_row with a
+     * small fraction just for alignment, then draw a label-less checkbox. */
+    if (!ui || !ui->frame_open || !label || !value || ui->layout_depth <= 0)
+        return false;
+
+    int d = ui->layout_depth - 1;
+    float row_w = ui->layout_stack[d].w;
+    float row_h = SDL3D_UI_ROW_HEIGHT;
+    float x, y;
+    if (!ui_layout_alloc(ui, row_w, row_h, &x, &y))
+        return false;
+
+    /* Draw label on left. */
+    float tw = 0, th = 0;
+    sdl3d_ui_measure_text(ui, label, &tw, &th);
+    sdl3d_ui_draw_text(ui, x, y + (row_h - th) * 0.5f, label, ui->theme.text_muted);
+
+    /* Draw checkbox box on right (no label text on the checkbox itself). */
+    float box_x = x + row_w * 0.35f;
+    return sdl3d_ui_checkbox(ui, box_x, y, "", value);
+}
+
+void sdl3d_ui_row_label(sdl3d_ui_context *ui, const char *label, const char *value)
+{
+    if (!ui || !ui->frame_open || !label || !value || ui->layout_depth <= 0)
+        return;
+
+    int d = ui->layout_depth - 1;
+    float row_w = ui->layout_stack[d].w;
+    float row_h = SDL3D_UI_ROW_HEIGHT;
+    float x, y;
+    if (!ui_layout_alloc(ui, row_w, row_h, &x, &y))
+        return;
+
+    float tw = 0, th = 0;
+    sdl3d_ui_measure_text(ui, label, &tw, &th);
+    sdl3d_ui_draw_text(ui, x, y + (row_h - th) * 0.5f, label, ui->theme.text_muted);
+    sdl3d_ui_draw_text(ui, x + row_w * 0.35f, y + (row_h - th) * 0.5f, value, ui->theme.text);
+}
+
+/* ------------------------------------------------------------------ */
+/* List view                                                           */
+/* ------------------------------------------------------------------ */
+
+#define SDL3D_UI_LIST_ITEM_H 22.0f
+
+bool sdl3d_ui_list_view(sdl3d_ui_context *ui, float x, float y, float w, float h, const char *const *items,
+                        int item_count, int *selected, float *scroll_offset)
+{
+    if (!ui || !ui->frame_open || !items || item_count <= 0 || !selected || !scroll_offset)
+        return false;
+
+    const sdl3d_ui_theme *t = &ui->theme;
+    float content_h = SDL3D_UI_LIST_ITEM_H * (float)item_count;
+    bool changed = false;
+
+    /* Background. */
+    sdl3d_ui_draw_rect(ui, x, y, w, h, t->widget_bg);
+    sdl3d_ui_draw_rect_outline(ui, x, y, w, h, t->border_width, t->widget_border);
+
+    /* Scroll. */
+    sdl3d_ui_begin_scroll(ui, x, y, w, h, scroll_offset, content_h);
+
+    for (int i = 0; i < item_count; i++)
+    {
+        float iy = y - *scroll_offset + SDL3D_UI_LIST_ITEM_H * (float)i;
+
+        /* Skip items outside visible range. */
+        if (iy + SDL3D_UI_LIST_ITEM_H < y || iy > y + h)
+            continue;
+
+        bool is_selected = (i == *selected);
+        bool hovering = sdl3d_ui_is_hovering(ui, x, iy, w, SDL3D_UI_LIST_ITEM_H);
+
+        if (is_selected)
+            sdl3d_ui_draw_rect(ui, x + 1, iy, w - 2, SDL3D_UI_LIST_ITEM_H, t->widget_active);
+        else if (hovering)
+            sdl3d_ui_draw_rect(ui, x + 1, iy, w - 2, SDL3D_UI_LIST_ITEM_H, t->widget_hover);
+
+        if (hovering && ui->input.mouse_pressed[0] && !is_selected)
+        {
+            *selected = i;
+            changed = true;
+        }
+
+        float tw = 0, th = 0;
+        sdl3d_ui_measure_text(ui, items[i], &tw, &th);
+        sdl3d_ui_draw_text(ui, x + t->padding, iy + (SDL3D_UI_LIST_ITEM_H - th) * 0.5f, items[i], t->text);
+    }
+
+    sdl3d_ui_end_scroll(ui);
+    return changed;
+}
+
+bool sdl3d_ui_layout_list_view(sdl3d_ui_context *ui, float h, const char *const *items, int item_count, int *selected,
+                               float *scroll_offset)
+{
+    if (!ui || !ui->frame_open || ui->layout_depth <= 0)
+        return false;
+    int d = ui->layout_depth - 1;
+    float w = ui->layout_stack[d].w;
+    float x, y;
+    if (!ui_layout_alloc(ui, w, h, &x, &y))
+        return false;
+    return sdl3d_ui_list_view(ui, x, y, w, h, items, item_count, selected, scroll_offset);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tree view                                                           */
+/* ------------------------------------------------------------------ */
+
+#define SDL3D_UI_TREE_INDENT 16.0f
+#define SDL3D_UI_TREE_ROW_H 22.0f
+#define SDL3D_UI_TREE_ARROW_W 14.0f
+
+bool sdl3d_ui_tree_node(sdl3d_ui_context *ui, const char *label, int node_id, bool *expanded, int *selected_id)
+{
+    if (!ui || !ui->frame_open || !label || !expanded || !selected_id || ui->layout_depth <= 0)
+        return false;
+
+    int d = ui->layout_depth - 1;
+    float row_w = ui->layout_stack[d].w;
+    float indent = SDL3D_UI_TREE_INDENT * (float)ui->tree_indent;
+    float x, y;
+    if (!ui_layout_alloc(ui, row_w, SDL3D_UI_TREE_ROW_H, &x, &y))
+        return false;
+
+    const sdl3d_ui_theme *t = &ui->theme;
+    float ix = x + indent;
+    float avail_w = row_w - indent;
+    bool is_selected = (*selected_id == node_id);
+    bool hovering = sdl3d_ui_is_hovering(ui, ix, y, avail_w, SDL3D_UI_TREE_ROW_H);
+    bool selection_changed = false;
+
+    /* Highlight. */
+    if (is_selected)
+        sdl3d_ui_draw_rect(ui, ix, y, avail_w, SDL3D_UI_TREE_ROW_H, t->widget_active);
+    else if (hovering)
+        sdl3d_ui_draw_rect(ui, ix, y, avail_w, SDL3D_UI_TREE_ROW_H, t->widget_hover);
+
+    /* Arrow toggle. */
+    float arrow_x = ix;
+    bool arrow_hover = sdl3d_ui_is_hovering(ui, arrow_x, y, SDL3D_UI_TREE_ARROW_W, SDL3D_UI_TREE_ROW_H);
+    const char *arrow = *expanded ? "v" : ">";
+    float aw = 0, ah = 0;
+    sdl3d_ui_measure_text(ui, arrow, &aw, &ah);
+    sdl3d_ui_draw_text(ui, arrow_x + (SDL3D_UI_TREE_ARROW_W - aw) * 0.5f, y + (SDL3D_UI_TREE_ROW_H - ah) * 0.5f, arrow,
+                       arrow_hover ? t->text : t->text_muted);
+
+    /* Label. */
+    float lx = ix + SDL3D_UI_TREE_ARROW_W;
+    float tw = 0, th = 0;
+    sdl3d_ui_measure_text(ui, label, &tw, &th);
+    sdl3d_ui_draw_text(ui, lx, y + (SDL3D_UI_TREE_ROW_H - th) * 0.5f, label, t->text);
+
+    /* Click handling. */
+    if (hovering && ui->input.mouse_pressed[0])
+    {
+        if (arrow_hover)
+        {
+            *expanded = !(*expanded);
+        }
+        else if (!is_selected)
+        {
+            *selected_id = node_id;
+            selection_changed = true;
+        }
+    }
+
+    return selection_changed;
+}
+
+void sdl3d_ui_tree_push(sdl3d_ui_context *ui)
+{
+    if (ui)
+        ui->tree_indent++;
+}
+
+void sdl3d_ui_tree_pop(sdl3d_ui_context *ui)
+{
+    if (ui && ui->tree_indent > 0)
+        ui->tree_indent--;
 }
 
 /* ------------------------------------------------------------------ */

--- a/tests/test_ui.cpp
+++ b/tests/test_ui.cpp
@@ -920,4 +920,148 @@ TEST(SDL3DUI, MeasureTextReturnsNonZero)
     sdl3d_ui_destroy(ui);
 }
 
+TEST(SDL3DUI, InspectorRowLabel)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    sdl3d_ui_row_label(ui, "Name:", "worldspawn");
+    sdl3d_ui_row_label(ui, "Origin:", "0 0 0");
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, InspectorRowCheckbox)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    bool val = false;
+
+    // Frame 1: press on the checkbox area (right side of row at x=10+300*0.35=115)
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 120.0f, 18.0f);
+    sim_mouse_down(ui, 120.0f, 18.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    sdl3d_ui_row_checkbox(ui, "Visible:", &val);
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    // Frame 2: release → toggle
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 120.0f, 18.0f);
+    sim_mouse_up(ui, 120.0f, 18.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    EXPECT_TRUE(sdl3d_ui_row_checkbox(ui, "Visible:", &val));
+    EXPECT_TRUE(val);
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, ListViewSelection)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    const char *items[] = {"Alpha", "Beta", "Gamma", "Delta"};
+    int selected = 0;
+    float scroll = 0.0f;
+
+    // Click on second item (y = 10 + 22*1 + 11 = ~43)
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 50.0f, 43.0f);
+    sim_mouse_down(ui, 50.0f, 43.0f);
+    EXPECT_TRUE(sdl3d_ui_list_view(ui, 10, 10, 200, 100, items, 4, &selected, &scroll));
+    EXPECT_EQ(selected, 1);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, ListViewReClickReturnsFalse)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    const char *items[] = {"A", "B"};
+    int selected = 0;
+    float scroll = 0.0f;
+
+    // Click on already-selected item 0
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 50.0f, 20.0f);
+    sim_mouse_down(ui, 50.0f, 20.0f);
+    EXPECT_FALSE(sdl3d_ui_list_view(ui, 10, 10, 200, 100, items, 2, &selected, &scroll));
+    EXPECT_EQ(selected, 0);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, TreeNodeExpandCollapse)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    bool expanded = false;
+    int sel = -1;
+
+    // Click on the arrow area (left side) to expand
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 17.0f, 21.0f); // arrow at x=10, y=10, w=14
+    sim_mouse_down(ui, 17.0f, 21.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    sdl3d_ui_tree_node(ui, "Root", 1, &expanded, &sel);
+    sdl3d_ui_end_vbox(ui);
+    EXPECT_TRUE(expanded);
+    EXPECT_EQ(sel, -1); // arrow click doesn't select
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, TreeNodeSelect)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    bool expanded = true;
+    int sel = -1;
+
+    // Click on the label area (right of arrow) to select
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 50.0f, 21.0f); // label area
+    sim_mouse_down(ui, 50.0f, 21.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    EXPECT_TRUE(sdl3d_ui_tree_node(ui, "Root", 1, &expanded, &sel));
+    EXPECT_EQ(sel, 1);
+    EXPECT_TRUE(expanded); // selection doesn't toggle expand
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
+TEST(SDL3DUI, TreePushPopIndent)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    bool exp1 = true, exp2 = false;
+    int sel = -1;
+
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    sdl3d_ui_tree_node(ui, "Parent", 1, &exp1, &sel);
+    sdl3d_ui_tree_push(ui);
+    sdl3d_ui_tree_node(ui, "Child", 2, &exp2, &sel);
+    sdl3d_ui_tree_pop(ui);
+    sdl3d_ui_tree_node(ui, "Sibling", 3, &exp1, &sel);
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    // No crash, no leak — validates push/pop balance.
+    sdl3d_ui_destroy(ui);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

Completes Phase 3 of issue #62 with the three remaining editor-oriented widgets.

## New widgets

### Inspector row layout
- `begin_row` / `end_row`: splits layout width into label:widget columns
- `row_text_field`, `row_slider`, `row_checkbox`, `row_label`: convenience helpers
- Compact property editing like TrenchBroom/Unity/Godot inspectors

### List view
- `sdl3d_ui_list_view` / `layout_list_view`: scrollable selectable item list
- Hover highlight, click to select, mouse wheel to scroll
- Returns true on selection change

### Tree view
- `sdl3d_ui_tree_node`: collapsible node with expand arrow + label
- Click arrow to toggle, click label to select
- `tree_push` / `tree_pop` for indentation (16px per level)
- Caller-owned expanded state and selected ID

## Demo updated (4 tabs)
- **Entity**: inspector rows for classname, origin, visible + dropdown + action buttons
- **Display**: row_slider and row_checkbox for all scene properties
- **Scene**: tree view with World > Geometry/Lights/Triggers hierarchy
- **Textures**: list view with 10 texture names, selection feedback

## Tests
7 new tests covering all three widgets. 505/505 total pass.

## Phase 3 checklist (all complete)
- [x] Text field / numeric field
- [x] Dropdown / combo box
- [x] Tab strip
- [x] Inspector-style row layout
- [x] List view
- [x] Tree view / hierarchy panel