### PR TITLE
feat: software/GL backend toggle + fix grid, wireframe, checkboxes, text blending

### DIFF
--- a/demos/ui_editor/main.c
+++ b/demos/ui_editor/main.c
@@ -80,6 +80,9 @@ typedef struct editor_state
     /* Texture list (list view) */
     int texture_selected;
     float texture_scroll;
+
+    /* Backend display */
+    const char *backend_name;
 } editor_state;
 
 static void editor_reset(editor_state *st)
@@ -109,6 +112,7 @@ static void editor_reset(editor_state *st)
     st->tree_selected = 1;
     st->texture_selected = 0;
     st->texture_scroll = 0.0f;
+    st->backend_name = "GL";
 }
 
 static void parse_origin(editor_state *st)
@@ -416,9 +420,10 @@ static void draw_status_bar(sdl3d_ui_context *ui, float y0, float w, float dt, c
     sdl3d_ui_labelf(ui, 180, ty, "FPS: %d", fps);
     sdl3d_ui_labelf(ui, 280, ty, "Grid: %.0f", (double)st->grid_size);
     sdl3d_ui_labelf(ui, 380, ty, "Snap: %s", st->snap_enabled ? "On" : "Off");
+    sdl3d_ui_labelf(ui, 500, ty, "[%s]", st->backend_name);
     /* Show last action feedback */
     if (st->log_msg[0])
-        sdl3d_ui_label_colored(ui, 500, ty, (sdl3d_color){140, 255, 140, 255}, st->log_msg);
+        sdl3d_ui_label_colored(ui, 580, ty, (sdl3d_color){140, 255, 140, 255}, st->log_msg);
 }
 
 /* ------------------------------------------------------------------ */
@@ -503,34 +508,54 @@ int main(int argc, char *argv[])
     if (!SDL_Init(SDL_INIT_VIDEO))
         return 1;
 
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    /* Backend creation helper — recreates window + renderer + context. */
+    SDL_Window *win = NULL;
+    SDL_Renderer *ren = NULL;
+    sdl3d_render_context *ctx = NULL;
+    sdl3d_backend current_backend = SDL3D_BACKEND_SDLGPU;
 
-    SDL_Window *win = SDL_CreateWindow("SDL3D \xe2\x80\x94 UI Editor Demo", WINDOW_W, WINDOW_H,
-                                       SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    /* clang-format off */
+    #define CREATE_BACKEND(backend_type) do { \
+        if (ctx) sdl3d_destroy_render_context(ctx); \
+        if (ren) SDL_DestroyRenderer(ren); \
+        if (win) { SDL_StopTextInput(win); SDL_DestroyWindow(win); } \
+        ctx = NULL; ren = NULL; win = NULL; \
+        SDL_WindowFlags flags = SDL_WINDOW_RESIZABLE; \
+        if ((backend_type) == SDL3D_BACKEND_SDLGPU) { \
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE); \
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3); \
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3); \
+            SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24); \
+            SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1); \
+            flags |= SDL_WINDOW_OPENGL; \
+        } \
+        win = SDL_CreateWindow("SDL3D \xe2\x80\x94 UI Editor Demo", WINDOW_W, WINDOW_H, flags); \
+        if (!win) break; \
+        SDL_StartTextInput(win); \
+        if ((backend_type) != SDL3D_BACKEND_SDLGPU) { \
+            ren = SDL_CreateRenderer(win, NULL); \
+            if (!ren) { SDL_DestroyWindow(win); win = NULL; break; } \
+        } \
+        sdl3d_render_context_config cfg_; \
+        sdl3d_init_render_context_config(&cfg_); \
+        cfg_.backend = (backend_type); \
+        cfg_.allow_backend_fallback = false; \
+        cfg_.logical_width = WINDOW_W; \
+        cfg_.logical_height = WINDOW_H; \
+        if (!sdl3d_create_render_context(win, ren, &cfg_, &ctx)) { \
+            if (ren) SDL_DestroyRenderer(ren); ren = NULL; \
+            SDL_DestroyWindow(win); win = NULL; break; \
+        } \
+        sdl3d_set_bloom_enabled(ctx, false); \
+        sdl3d_set_ssao_enabled(ctx, false); \
+        current_backend = (backend_type); \
+        SDL_Log("Backend: %s", sdl3d_get_backend_name(current_backend)); \
+    } while (0)
+    /* clang-format on */
+
+    CREATE_BACKEND(SDL3D_BACKEND_SDLGPU);
     if (!win)
         return 1;
-    SDL_StartTextInput(win);
-
-    sdl3d_render_context_config cfg;
-    sdl3d_init_render_context_config(&cfg);
-    cfg.backend = SDL3D_BACKEND_SDLGPU;
-    cfg.logical_width = WINDOW_W;
-    cfg.logical_height = WINDOW_H;
-
-    sdl3d_render_context *ctx = NULL;
-    if (!sdl3d_create_render_context(win, NULL, &cfg, &ctx))
-    {
-        SDL_Log("Render context failed: %s", SDL_GetError());
-        SDL_DestroyWindow(win);
-        return 1;
-    }
-
-    sdl3d_set_bloom_enabled(ctx, false);
-    sdl3d_set_ssao_enabled(ctx, false);
 
     sdl3d_font ui_font;
     if (!sdl3d_load_builtin_font(SDL3D_MEDIA_DIR, SDL3D_BUILTIN_FONT_INTER, 16.0f, &ui_font))
@@ -544,6 +569,7 @@ int main(int argc, char *argv[])
 
     editor_state st;
     editor_reset(&st);
+    st.backend_name = sdl3d_get_backend_name(current_backend);
 
     float elapsed = 0.0f;
     Uint64 last = SDL_GetPerformanceCounter();
@@ -566,8 +592,25 @@ int main(int argc, char *argv[])
                 continue;
             }
             bool ui_consumed = sdl3d_ui_process_event(ui, &ev);
-            if (!ui_consumed && ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_ESCAPE)
-                running = false;
+            if (!ui_consumed && ev.type == SDL_EVENT_KEY_DOWN)
+            {
+                if (ev.key.scancode == SDL_SCANCODE_ESCAPE)
+                    running = false;
+                if (ev.key.scancode == SDL_SCANCODE_GRAVE)
+                {
+                    sdl3d_backend next =
+                        (current_backend == SDL3D_BACKEND_SDLGPU) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_SDLGPU;
+                    CREATE_BACKEND(next);
+                    if (!win)
+                    {
+                        SDL_Log("Backend switch failed, reverting");
+                        CREATE_BACKEND(current_backend);
+                    }
+                    st.backend_name = sdl3d_get_backend_name(current_backend);
+                    SDL_snprintf(st.log_msg, sizeof(st.log_msg), "Switched to %s",
+                                 sdl3d_get_backend_name(current_backend));
+                }
+            }
         }
 
         Uint64 now = SDL_GetPerformanceCounter();
@@ -600,6 +643,8 @@ int main(int argc, char *argv[])
     sdl3d_ui_destroy(ui);
     sdl3d_free_font(&ui_font);
     sdl3d_destroy_render_context(ctx);
+    if (ren)
+        SDL_DestroyRenderer(ren);
     SDL_StopTextInput(win);
     SDL_DestroyWindow(win);
     SDL_Quit();

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1283,6 +1283,15 @@ bool sdl3d_draw_line_3d(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_v
         return false;
     }
 
+    if (context->gl != NULL)
+    {
+        const float positions[6] = {start.x, start.y, start.z, end.x, end.y, end.z};
+        const float c = 1.0f / 255.0f;
+        const float colors[8] = {color.r * c, color.g * c, color.b * c, color.a * c,
+                                 color.r * c, color.g * c, color.b * c, color.a * c};
+        return sdl3d_gl_append_line(context->gl, positions, colors, context->model_view_projection.m);
+    }
+
     sdl3d_framebuffer framebuffer = sdl3d_framebuffer_from_context(context);
     sdl3d_rasterize_line(&framebuffer, context->model_view_projection, start, end, color);
     return true;

--- a/src/font.c
+++ b/src/font.c
@@ -570,9 +570,14 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
     if (!font->atlas_texture.pixels)
         return SDL_SetError("sdl3d_draw_text_overlay: font atlas not initialized");
 
-    /* Software backend: fall through to the normal path. */
+    /* Software backend: enable alpha blending for text overlay. */
     if (!context->gl)
-        return sdl3d_draw_text(context, font, text, x, y, color);
+    {
+        context->color_buffer_blend = true;
+        bool ok = sdl3d_draw_text(context, font, text, x, y, color);
+        context->color_buffer_blend = false;
+        return ok;
+    }
 
     int ctx_w = sdl3d_get_render_context_width(context);
     int ctx_h = sdl3d_get_render_context_height(context);

--- a/src/gl_funcs.h
+++ b/src/gl_funcs.h
@@ -22,6 +22,7 @@ typedef unsigned int GLbitfield;
 /* GL constants. */
 #define GL_FALSE 0
 #define GL_TRUE 1
+#define GL_LINES 0x0001
 #define GL_TRIANGLES 0x0004
 #define GL_UNSIGNED_INT 0x1405
 #define GL_FLOAT 0x1406

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -118,6 +118,7 @@ typedef struct sdl3d_draw_entry
     bool lit;
     bool baked_light_mode;
     bool has_lightmap;
+    GLenum primitive_mode;
     float mvp[16];
 } sdl3d_draw_entry;
 
@@ -1240,6 +1241,8 @@ static sdl3d_overlay_entry *append_overlay_entry(sdl3d_gl_context *ctx)
     return e;
 }
 
+static float *copy_floats(const float *src, size_t count);
+
 bool sdl3d_gl_append_overlay(sdl3d_gl_context *ctx, const float *positions, const float *uvs, int vertex_count,
                              const float *mvp, const float *tint, const sdl3d_texture2d *texture, bool scissor_enabled,
                              const SDL_Rect *scissor_rect)
@@ -1319,6 +1322,31 @@ bool sdl3d_gl_append_overlay(sdl3d_gl_context *ctx, const float *positions, cons
     e->scissor_rect = scissor_rect ? *scissor_rect : (SDL_Rect){0, 0, 0, 0};
     e->atlas_index = atlas_idx;
     return true;
+}
+
+bool sdl3d_gl_append_line(sdl3d_gl_context *ctx, const float *positions, const float *colors, const float *mvp)
+{
+    static const float k_zero_uvs[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    static const float k_white_tint[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+
+    if (!ctx || !positions || !colors || !mvp)
+    {
+        return false;
+    }
+
+    sdl3d_draw_entry *e = append_draw_entry(ctx);
+    if (!e)
+        return false;
+
+    e->lit = false;
+    e->primitive_mode = GL_LINES;
+    e->vertex_count = 2;
+    e->positions = copy_floats(positions, 6);
+    e->uvs = copy_floats(k_zero_uvs, 4);
+    e->colors = copy_floats(colors, 8);
+    SDL_memcpy(e->mvp, mvp, 16 * sizeof(float));
+    SDL_memcpy(e->tint, k_white_tint, sizeof(k_white_tint));
+    return e->positions != NULL && e->uvs != NULL && e->colors != NULL;
 }
 
 /* Check for potential z-fighting: warn if two lit draw entries have
@@ -1845,11 +1873,11 @@ static void replay_draw_list_geometry(sdl3d_gl_context *ctx)
                 gl->BindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx->lit_ebo);
                 gl->BufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->index_count * sizeof(unsigned int)),
                                e->indices, GL_DYNAMIC_DRAW);
-                gl->DrawElements(GL_TRIANGLES, e->index_count, GL_UNSIGNED_INT, NULL);
+                gl->DrawElements(e->primitive_mode, e->index_count, GL_UNSIGNED_INT, NULL);
             }
             else
             {
-                gl->DrawArrays(GL_TRIANGLES, 0, e->vertex_count);
+                gl->DrawArrays(e->primitive_mode, 0, e->vertex_count);
             }
         }
         else
@@ -1879,11 +1907,11 @@ static void replay_draw_list_geometry(sdl3d_gl_context *ctx)
                 gl->BindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx->unlit_ebo);
                 gl->BufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->index_count * sizeof(unsigned int)),
                                e->indices, GL_DYNAMIC_DRAW);
-                gl->DrawElements(GL_TRIANGLES, e->index_count, GL_UNSIGNED_INT, NULL);
+                gl->DrawElements(e->primitive_mode, e->index_count, GL_UNSIGNED_INT, NULL);
             }
             else
             {
-                gl->DrawArrays(GL_TRIANGLES, 0, e->vertex_count);
+                gl->DrawArrays(e->primitive_mode, 0, e->vertex_count);
             }
         }
     }
@@ -2806,6 +2834,7 @@ static bool gl_draw_mesh_unlit(sdl3d_render_context *context, const sdl3d_draw_p
     e->colors = copy_floats(colors, (size_t)params->vertex_count * 4);
     e->indices = copy_indices(params->indices, (size_t)e->index_count);
     e->texture = params->texture;
+    e->primitive_mode = GL_TRIANGLES;
     SDL_memcpy(e->mvp, params->mvp, 16 * sizeof(float));
     SDL_memcpy(e->tint, params->tint, 4 * sizeof(float));
 
@@ -2833,6 +2862,7 @@ static bool gl_draw_mesh_lit(sdl3d_render_context *context, const sdl3d_draw_par
     e->indices = copy_indices(params->indices, (size_t)e->index_count);
     e->texture = params->texture;
     e->lightmap_texture = params->lightmap;
+    e->primitive_mode = GL_TRIANGLES;
     SDL_memcpy(e->model_matrix, params->model_matrix, 16 * sizeof(float));
     SDL_memcpy(e->normal_matrix, params->normal_matrix, 9 * sizeof(float));
     SDL_memcpy(e->tint, params->tint, 4 * sizeof(float));

--- a/src/gl_renderer.h
+++ b/src/gl_renderer.h
@@ -36,4 +36,6 @@ bool sdl3d_gl_append_overlay(sdl3d_gl_context *ctx, const float *positions, cons
                              const float *mvp, const float *tint, const sdl3d_texture2d *texture, bool scissor_enabled,
                              const SDL_Rect *scissor_rect);
 
+bool sdl3d_gl_append_line(sdl3d_gl_context *ctx, const float *positions, const float *colors, const float *mvp);
+
 #endif

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -188,12 +188,45 @@ static void sdl3d_write_pixel(sdl3d_framebuffer *framebuffer, int x, int y, floa
         return;
     }
 
-    framebuffer->depth_pixels[index] = depth;
     Uint8 *pixel = &framebuffer->color_pixels[index * 4];
-    pixel[0] = color.r;
-    pixel[1] = color.g;
-    pixel[2] = color.b;
-    pixel[3] = color.a;
+
+    if (color.a == 0)
+    {
+        return;
+    }
+
+    framebuffer->depth_pixels[index] = depth;
+
+    if (color.a == 255 || !framebuffer->blend_enabled)
+    {
+        pixel[0] = color.r;
+        pixel[1] = color.g;
+        pixel[2] = color.b;
+        pixel[3] = color.a;
+        return;
+    }
+
+    const float src_a = (float)color.a / 255.0f;
+    const float dst_a = (float)pixel[3] / 255.0f;
+    const float out_a = src_a + dst_a * (1.0f - src_a);
+
+    float out_r = (float)color.r * src_a;
+    float out_g = (float)color.g * src_a;
+    float out_b = (float)color.b * src_a;
+    if (out_a > 0.0f)
+    {
+        out_r += (float)pixel[0] * dst_a * (1.0f - src_a);
+        out_g += (float)pixel[1] * dst_a * (1.0f - src_a);
+        out_b += (float)pixel[2] * dst_a * (1.0f - src_a);
+        out_r /= out_a;
+        out_g /= out_a;
+        out_b /= out_a;
+    }
+
+    pixel[0] = (Uint8)(out_r + 0.5f);
+    pixel[1] = (Uint8)(out_g + 0.5f);
+    pixel[2] = (Uint8)(out_b + 0.5f);
+    pixel[3] = (Uint8)(out_a * 255.0f + 0.5f);
 }
 
 /* --- Clip-space plane tests ---------------------------------------------- */

--- a/src/rasterizer.h
+++ b/src/rasterizer.h
@@ -43,6 +43,7 @@ typedef struct sdl3d_framebuffer
     sdl3d_parallel_rasterizer *parallel_rasterizer;
     bool scissor_enabled;
     SDL_Rect scissor_rect;
+    bool blend_enabled; /* when true, alpha-composite instead of overwrite */
 } sdl3d_framebuffer;
 
 bool sdl3d_parallel_rasterizer_create(int worker_count, sdl3d_parallel_rasterizer **out_rasterizer);

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -45,6 +45,7 @@ struct sdl3d_render_context
     bool wireframe_enabled;
     bool scissor_enabled;
     SDL_Rect scissor_rect;
+    bool color_buffer_blend; /* software overlay: enable alpha compositing */
     sdl3d_mat4 model;
     sdl3d_mat4 view;
     sdl3d_mat4 projection;
@@ -105,6 +106,7 @@ static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_cont
     framebuffer.parallel_rasterizer = context->parallel_rasterizer;
     framebuffer.scissor_enabled = context->scissor_enabled;
     framebuffer.scissor_rect = context->scissor_rect;
+    framebuffer.blend_enabled = context->color_buffer_blend;
     return framebuffer;
 }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -1094,6 +1094,37 @@ bool sdl3d_ui_layout_button(sdl3d_ui_context *ui, const char *label)
 #define SDL3D_UI_CHECKBOX_SIZE 16.0f
 #define SDL3D_UI_CHECKBOX_GAP 6.0f
 
+static const char *ui_visible_label_text(const char *label, char *buffer, size_t buffer_size)
+{
+    if (!label)
+    {
+        return "";
+    }
+
+    const char *sep = SDL_strstr(label, "##");
+    if (!sep)
+    {
+        return label;
+    }
+    if (sep == label)
+    {
+        return "";
+    }
+    if (!buffer || buffer_size == 0)
+    {
+        return "";
+    }
+
+    size_t len = (size_t)(sep - label);
+    if (len >= buffer_size)
+    {
+        len = buffer_size - 1;
+    }
+    SDL_memcpy(buffer, label, len);
+    buffer[len] = '\0';
+    return buffer;
+}
+
 bool sdl3d_ui_checkbox(sdl3d_ui_context *ui, float x, float y, const char *label, bool *value)
 {
     if (!ui || !ui->frame_open || !label || !value)
@@ -1102,10 +1133,12 @@ bool sdl3d_ui_checkbox(sdl3d_ui_context *ui, float x, float y, const char *label
     sdl3d_ui_id id = sdl3d_ui_make_id(ui, label);
     const sdl3d_ui_theme *t = &ui->theme;
     float box_size = SDL3D_UI_CHECKBOX_SIZE;
+    char display_buf[256];
+    const char *display = ui_visible_label_text(label, display_buf, sizeof(display_buf));
 
     /* Hit test the full row (box + label). */
     float tw = 0, th = 0;
-    sdl3d_ui_measure_text(ui, label, &tw, &th);
+    sdl3d_ui_measure_text(ui, display, &tw, &th);
     float row_w = box_size + SDL3D_UI_CHECKBOX_GAP + tw;
     float row_h = (th > box_size) ? th : box_size;
 
@@ -1144,7 +1177,8 @@ bool sdl3d_ui_checkbox(sdl3d_ui_context *ui, float x, float y, const char *label
     /* Draw label. */
     float label_x = x + box_size + SDL3D_UI_CHECKBOX_GAP;
     float label_y = y + (row_h - th) * 0.5f;
-    sdl3d_ui_draw_text(ui, label_x, label_y, label, t->text);
+    if (display[0] != '\0')
+        sdl3d_ui_draw_text(ui, label_x, label_y, display, t->text);
 
     return changed;
 }
@@ -1184,6 +1218,8 @@ bool sdl3d_ui_slider(sdl3d_ui_context *ui, float x, float y, float w, const char
     sdl3d_ui_id id = sdl3d_ui_make_id(ui, label);
     const sdl3d_ui_theme *t = &ui->theme;
     bool changed = false;
+    char display_buf[256];
+    const char *display = ui_visible_label_text(label, display_buf, sizeof(display_buf));
 
     /* Track with centered "Label: value" text overlay. */
     float track_y = y;
@@ -1247,7 +1283,10 @@ bool sdl3d_ui_slider(sdl3d_ui_context *ui, float x, float y, float w, const char
 
     /* Draw label + value text. */
     char buf[128];
-    SDL_snprintf(buf, sizeof(buf), "%s: %.2f", label, (double)*value);
+    if (display[0] != '\0')
+        SDL_snprintf(buf, sizeof(buf), "%s: %.2f", display, (double)*value);
+    else
+        SDL_snprintf(buf, sizeof(buf), "%.2f", (double)*value);
     float tw = 0, th = 0;
     sdl3d_ui_measure_text(ui, buf, &tw, &th);
     sdl3d_ui_draw_text(ui, x + (track_w - tw) * 0.5f, track_y + (track_h - th) * 0.5f, buf, t->text);
@@ -1691,7 +1730,9 @@ bool sdl3d_ui_row_checkbox(sdl3d_ui_context *ui, const char *label, bool *value)
 
     /* Draw checkbox box on right (no label text on the checkbox itself). */
     float box_x = x + row_w * 0.35f;
-    return sdl3d_ui_checkbox(ui, box_x, y, "", value);
+    char id_buf[128];
+    SDL_snprintf(id_buf, sizeof(id_buf), "##rc_%s", label);
+    return sdl3d_ui_checkbox(ui, box_x, y, id_buf, value);
 }
 
 void sdl3d_ui_row_label(sdl3d_ui_context *ui, const char *label, const char *value)

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -193,6 +193,39 @@ TEST_F(GLRendererTest, CubeVisibleOnFirstFrame)
     EXPECT_GT(px[1], 50);
 }
 
+TEST_F(GLRendererTest, Line3DVisibleOnGLBackend)
+{
+    sdl3d_camera3d cam;
+    cam.position = sdl3d_vec3_make(0, 0, 5);
+    cam.target = sdl3d_vec3_make(0, 0, 0);
+    cam.up = sdl3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_clear_render_context(ctx, (sdl3d_color){0, 0, 0, 255});
+    sdl3d_begin_mode_3d(ctx, cam);
+    sdl3d_draw_line_3d(ctx, sdl3d_vec3_make(-1.5f, 0.0f, 0.0f), sdl3d_vec3_make(1.5f, 0.0f, 0.0f),
+                       (sdl3d_color){255, 32, 32, 255});
+    sdl3d_end_mode_3d(ctx);
+
+    bool found_red = false;
+    for (int y = 0; y < 240 && !found_red; ++y)
+    {
+        for (int x = 0; x < 320; ++x)
+        {
+            unsigned char px[4];
+            readPixel(x, y, px);
+            if (px[0] > 100 && px[1] < 80 && px[2] < 80)
+            {
+                found_red = true;
+                break;
+            }
+        }
+    }
+
+    EXPECT_TRUE(found_red);
+}
+
 TEST_F(GLRendererTest, BackfaceCullingShowsFrontFaces)
 {
     /* A cube viewed from the front should show the front face, not the back. */

--- a/tests/test_ui.cpp
+++ b/tests/test_ui.cpp
@@ -963,6 +963,36 @@ TEST(SDL3DUI, InspectorRowCheckbox)
     sdl3d_ui_destroy(ui);
 }
 
+TEST(SDL3DUI, InspectorRowCheckboxesUseIndependentHiddenIds)
+{
+    sdl3d_ui_context *ui = nullptr;
+    ASSERT_TRUE(sdl3d_ui_create(nullptr, &ui));
+    bool grid = false;
+    bool axes = false;
+
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 120.0f, 18.0f);
+    sim_mouse_down(ui, 120.0f, 18.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    sdl3d_ui_row_checkbox(ui, "Show Grid:", &grid);
+    sdl3d_ui_row_checkbox(ui, "Show Axes:", &axes);
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_begin_frame(ui, 800, 600);
+    sim_mouse_move(ui, 120.0f, 18.0f);
+    sim_mouse_up(ui, 120.0f, 18.0f);
+    sdl3d_ui_begin_vbox(ui, 10, 10, 300, 400);
+    EXPECT_TRUE(sdl3d_ui_row_checkbox(ui, "Show Grid:", &grid));
+    EXPECT_FALSE(sdl3d_ui_row_checkbox(ui, "Show Axes:", &axes));
+    EXPECT_TRUE(grid);
+    EXPECT_FALSE(axes);
+    sdl3d_ui_end_vbox(ui);
+    sdl3d_ui_end_frame(ui);
+
+    sdl3d_ui_destroy(ui);
+}
+
 TEST(SDL3DUI, ListViewSelection)
 {
     sdl3d_ui_context *ui = nullptr;


### PR DESCRIPTION
## Summary

Adds tilde-key backend switching to the UI editor demo and fixes four rendering bugs discovered during software backend testing.

## Backend toggle
- Press ` (tilde) to switch between GL and software renderers
- Window, renderer, and render context are recreated on each switch
- Current backend shown in status bar

## Bug fixes

### GL line rendering (grid + wireframe invisible on GL)
- Added `primitive_mode` field to GL draw entries (default `GL_TRIANGLES`)
- New `sdl3d_gl_append_line()` for `GL_LINES` primitives
- `sdl3d_draw_line_3d` now routes to the GL draw list when a GL context exists
- GL replay uses per-entry primitive mode instead of hardcoded triangles

### Checkbox ID collision (Show Grid didn't toggle)
- `sdl3d_ui_row_checkbox` was passing `""` to `sdl3d_ui_checkbox`, giving all row checkboxes the same widget ID
- Now passes `"##rc_<label>"` for unique IDs
- Added `ui_visible_label_text` helper to strip `##` suffixes from display text in checkbox and slider

### Software text blending (thin/faint text)
- Software rasterizer now supports alpha compositing (src-over) gated by `framebuffer.blend_enabled`
- Defaults to false (preserves overwrite behavior for 3D geometry)
- `sdl3d_draw_text_overlay` enables blend on the software path

## Tests
- `Line3DVisibleOnGLBackend`: verifies red line pixels in GL readback
- `InspectorRowCheckboxesUseIndependentHiddenIds`: verifies independent toggle
- 507/507 tests pass