### PR TITLE
feat: actor visibility culling (Phases 1-3)

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -1210,9 +1210,23 @@ int main(int argc, char *argv[])
 
         sdl3d_draw_level(ctx, active_level, portal_culling ? &vis : NULL, (sdl3d_color){255, 255, 255, 255});
 
-        /* Draw 3D scene actors (robot models). */
+        /* Draw 3D scene actors (robot models). Refresh each actor's sector
+         * from its current world XZ so sdl3d_draw_scene_with_visibility can
+         * skip actors in unreachable rooms before any frustum work runs. */
         if (scene)
-            sdl3d_draw_scene(ctx, scene);
+        {
+            int actor_count = sdl3d_scene_get_actor_count(scene);
+            for (int i = 0; i < actor_count; ++i)
+            {
+                sdl3d_actor *a = sdl3d_scene_get_actor_at(scene, i);
+                if (!a)
+                    continue;
+                sdl3d_vec3 ap = sdl3d_actor_get_position(a);
+                int sid = sdl3d_level_find_sector(active_level, sectors, ap.x, ap.z);
+                sdl3d_actor_set_sector(a, sid);
+            }
+            sdl3d_draw_scene_with_visibility(ctx, scene, portal_culling ? &vis : NULL);
+        }
 
         /* Crate props — simple textured cubes placed around the level. */
         {

--- a/include/sdl3d/collision.h
+++ b/include/sdl3d/collision.h
@@ -43,6 +43,13 @@ extern "C"
     bool sdl3d_check_sphere_sphere(sdl3d_sphere a, sdl3d_sphere b);
     bool sdl3d_check_aabb_sphere(sdl3d_bounding_box box, sdl3d_sphere sphere);
 
+    /*
+     * Test a sphere against 6 normalized frustum planes (a,b,c,d) where
+     * the inside half-space satisfies a*x + b*y + c*z + d >= 0. Returns
+     * true when the sphere is at least partially inside the frustum.
+     */
+    bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, const float planes[6][4]);
+
     /* ============================================================== */
     /* Ray tests                                                      */
     /* ============================================================== */

--- a/include/sdl3d/collision.h
+++ b/include/sdl3d/collision.h
@@ -47,8 +47,12 @@ extern "C"
      * Test a sphere against 6 normalized frustum planes (a,b,c,d) where
      * the inside half-space satisfies a*x + b*y + c*z + d >= 0. Returns
      * true when the sphere is at least partially inside the frustum.
+     *
+     * The plane array is read-only despite the lack of `const`; pre-C23
+     * pedantic mode rejects the deep-const conversion that would
+     * otherwise require callers to cast their non-const local arrays.
      */
-    bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, const float planes[6][4]);
+    bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, float planes[6][4]);
 
     /* ============================================================== */
     /* Ray tests                                                      */

--- a/include/sdl3d/scene.h
+++ b/include/sdl3d/scene.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+#include "sdl3d/level.h"
 #include "sdl3d/model.h"
 #include "sdl3d/render_context.h"
 #include "sdl3d/types.h"
@@ -61,6 +62,18 @@ extern "C"
 
     void sdl3d_actor_set_tint(sdl3d_actor *actor, sdl3d_color tint);
 
+    /*
+     * Optional sector ownership for portal-based visibility culling.
+     * Defaults to -1 (no sector). When set and a sdl3d_visibility_result
+     * is supplied to sdl3d_draw_scene_with_visibility, actors whose
+     * sector is not visible are skipped before any frustum work.
+     *
+     * Callers typically derive the id with sdl3d_level_find_sector
+     * after positioning the actor.
+     */
+    void sdl3d_actor_set_sector(sdl3d_actor *actor, int sector_id);
+    int sdl3d_actor_get_sector(const sdl3d_actor *actor);
+
     const sdl3d_model *sdl3d_actor_get_model(const sdl3d_actor *actor);
 
     /* ============================================================== */
@@ -74,6 +87,16 @@ extern "C"
      * iterates actors and calls sdl3d_draw_model_ex for each.
      */
     bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene);
+
+    /*
+     * Same as sdl3d_draw_scene, but additionally rejects actors whose
+     * assigned sector (see sdl3d_actor_set_sector) is not present in the
+     * supplied visibility result. Pass vis = NULL for behavior identical
+     * to sdl3d_draw_scene. Actors with sector_id < 0 are unaffected by
+     * the visibility test and fall through to the frustum check.
+     */
+    bool sdl3d_draw_scene_with_visibility(sdl3d_render_context *context, const sdl3d_scene *scene,
+                                          const sdl3d_visibility_result *vis);
 
 #ifdef __cplusplus
 }

--- a/src/collision.c
+++ b/src/collision.c
@@ -34,6 +34,24 @@ bool sdl3d_check_sphere_sphere(sdl3d_sphere a, sdl3d_sphere b)
     return dist_sq <= r_sum * r_sum;
 }
 
+bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, const float planes[6][4])
+{
+    if (planes == NULL)
+    {
+        return true;
+    }
+    for (int i = 0; i < 6; ++i)
+    {
+        float distance = planes[i][0] * sphere.center.x + planes[i][1] * sphere.center.y +
+                         planes[i][2] * sphere.center.z + planes[i][3];
+        if (distance < -sphere.radius)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool sdl3d_check_aabb_sphere(sdl3d_bounding_box box, sdl3d_sphere sphere)
 {
     /* Find the closest point on the AABB to the sphere center. */

--- a/src/collision.c
+++ b/src/collision.c
@@ -34,7 +34,7 @@ bool sdl3d_check_sphere_sphere(sdl3d_sphere a, sdl3d_sphere b)
     return dist_sq <= r_sum * r_sum;
 }
 
-bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, const float planes[6][4])
+bool sdl3d_sphere_intersects_frustum(sdl3d_sphere sphere, float planes[6][4])
 {
     if (planes == NULL)
     {

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -121,6 +121,43 @@ static bool sdl3d_ensure_model_stack_capacity(sdl3d_render_context *context, int
     return true;
 }
 
+/* Derive the 6 frustum planes (a*x + b*y + c*z + d >= 0 for inside) from
+ * a row-major MVP. Caller writes them into context->frustum_planes and
+ * sets context->frustum_planes_valid. Used by both the camera frustum
+ * (begin_mode_3d) and the shadow-light frustum (begin_shadow_pass) so
+ * actor and mesh culling work in shadow passes too. */
+void sdl3d_internal_extract_frustum_planes(sdl3d_render_context *context, sdl3d_mat4 view_projection)
+{
+    const float *m = view_projection.m;
+    float raw[6][4] = {
+        {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
+        {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
+        {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
+        {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
+        {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
+        {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
+    };
+    for (int i = 0; i < 6; ++i)
+    {
+        float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
+        if (len > 0.000001f)
+        {
+            context->frustum_planes[i][0] = raw[i][0] / len;
+            context->frustum_planes[i][1] = raw[i][1] / len;
+            context->frustum_planes[i][2] = raw[i][2] / len;
+            context->frustum_planes[i][3] = raw[i][3] / len;
+        }
+        else
+        {
+            context->frustum_planes[i][0] = 0.0f;
+            context->frustum_planes[i][1] = 0.0f;
+            context->frustum_planes[i][2] = 0.0f;
+            context->frustum_planes[i][3] = raw[i][3];
+        }
+    }
+    context->frustum_planes_valid = true;
+}
+
 static void sdl3d_update_current_model_matrices(sdl3d_render_context *context)
 {
     if (context->model_stack_depth <= 0)
@@ -164,36 +201,7 @@ bool sdl3d_begin_mode_3d(sdl3d_render_context *context, sdl3d_camera3d camera)
     sdl3d_update_current_model_matrices(context);
 
     /* Cache frustum planes once per frame so per-mesh culling is cheap. */
-    {
-        const float *m = context->view_projection.m;
-        float raw[6][4] = {
-            {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
-            {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
-            {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
-            {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
-            {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
-            {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
-        };
-        for (int i = 0; i < 6; ++i)
-        {
-            float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
-            if (len > 0.000001f)
-            {
-                context->frustum_planes[i][0] = raw[i][0] / len;
-                context->frustum_planes[i][1] = raw[i][1] / len;
-                context->frustum_planes[i][2] = raw[i][2] / len;
-                context->frustum_planes[i][3] = raw[i][3] / len;
-            }
-            else
-            {
-                context->frustum_planes[i][0] = 0.0f;
-                context->frustum_planes[i][1] = 0.0f;
-                context->frustum_planes[i][2] = 0.0f;
-                context->frustum_planes[i][3] = raw[i][3];
-            }
-        }
-        context->frustum_planes_valid = true;
-    }
+    sdl3d_internal_extract_frustum_planes(context, context->view_projection);
 
     context->in_mode_3d = true;
     return true;

--- a/src/lighting.c
+++ b/src/lighting.c
@@ -525,6 +525,11 @@ bool sdl3d_begin_shadow_pass(sdl3d_render_context *context)
     context->model_view_projection = context->shadow_vp[0];
     context->in_mode_3d = true;
 
+    /* Reuse Phase 1's per-actor frustum culling for the shadow pass by
+     * pointing the cached planes at the light's view-projection. Skips
+     * actors and meshes that cannot cast shadows into the depth buffer. */
+    sdl3d_internal_extract_frustum_planes(context, context->shadow_vp[0]);
+
     if (context->gl)
     {
         sdl3d_gl_begin_shadow_pass(context->gl, context->shadow_vp[0].m,

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -96,6 +96,11 @@ struct sdl3d_render_context
     bool frustum_planes_valid;
 };
 
+/* Recompute the cached frustum planes from the supplied view-projection.
+ * Defined in drawing3d.c; shared so the shadow pass can repurpose the
+ * actor/mesh culling against the light frustum. */
+void sdl3d_internal_extract_frustum_planes(sdl3d_render_context *context, sdl3d_mat4 view_projection);
+
 static inline sdl3d_framebuffer sdl3d_framebuffer_from_context(sdl3d_render_context *context)
 {
     sdl3d_framebuffer framebuffer;

--- a/src/scene.c
+++ b/src/scene.c
@@ -4,7 +4,11 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/animation.h"
+#include "sdl3d/collision.h"
 #include "sdl3d/drawing3d.h"
+#include "sdl3d/math.h"
+
+#include "render_context_internal.h"
 
 struct sdl3d_actor
 {
@@ -23,7 +27,125 @@ struct sdl3d_actor
     float anim_time;
     bool anim_playing;
     bool anim_looping;
+
+    /* Cached local-space bounding sphere derived from the model's mesh
+     * AABBs at attach time. World bounds are produced per-frame by
+     * applying the actor's position and scale. */
+    sdl3d_vec3 local_bounds_center;
+    float local_bounds_radius;
+    bool local_bounds_valid;
 };
+
+static void sdl3d_actor_compute_local_bounds(sdl3d_actor *actor)
+{
+    const sdl3d_model *model;
+    sdl3d_bounding_box combined;
+    bool have_box = false;
+    sdl3d_vec3 center;
+    float max_r_sq = 0.0f;
+
+    actor->local_bounds_valid = false;
+    actor->local_bounds_center = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    actor->local_bounds_radius = 0.0f;
+
+    model = actor->model;
+    if (model == NULL || model->meshes == NULL || model->mesh_count <= 0)
+    {
+        return;
+    }
+
+    SDL_zero(combined);
+    for (int i = 0; i < model->mesh_count; ++i)
+    {
+        const sdl3d_mesh *mesh = &model->meshes[i];
+        if (!mesh->has_local_bounds)
+        {
+            continue;
+        }
+        if (!have_box)
+        {
+            combined = mesh->local_bounds;
+            have_box = true;
+        }
+        else
+        {
+            if (mesh->local_bounds.min.x < combined.min.x)
+                combined.min.x = mesh->local_bounds.min.x;
+            if (mesh->local_bounds.min.y < combined.min.y)
+                combined.min.y = mesh->local_bounds.min.y;
+            if (mesh->local_bounds.min.z < combined.min.z)
+                combined.min.z = mesh->local_bounds.min.z;
+            if (mesh->local_bounds.max.x > combined.max.x)
+                combined.max.x = mesh->local_bounds.max.x;
+            if (mesh->local_bounds.max.y > combined.max.y)
+                combined.max.y = mesh->local_bounds.max.y;
+            if (mesh->local_bounds.max.z > combined.max.z)
+                combined.max.z = mesh->local_bounds.max.z;
+        }
+    }
+
+    if (!have_box)
+    {
+        return;
+    }
+
+    center = sdl3d_vec3_make((combined.min.x + combined.max.x) * 0.5f, (combined.min.y + combined.max.y) * 0.5f,
+                             (combined.min.z + combined.max.z) * 0.5f);
+
+    /* Radius = max distance from center to any AABB corner. */
+    for (int i = 0; i < 8; ++i)
+    {
+        float cx = (i & 1) ? combined.max.x : combined.min.x;
+        float cy = (i & 2) ? combined.max.y : combined.min.y;
+        float cz = (i & 4) ? combined.max.z : combined.min.z;
+        float dx = cx - center.x;
+        float dy = cy - center.y;
+        float dz = cz - center.z;
+        float r_sq = dx * dx + dy * dy + dz * dz;
+        if (r_sq > max_r_sq)
+        {
+            max_r_sq = r_sq;
+        }
+    }
+
+    actor->local_bounds_center = center;
+    actor->local_bounds_radius = SDL_sqrtf(max_r_sq);
+    actor->local_bounds_valid = true;
+}
+
+static bool sdl3d_actor_world_bounds(const sdl3d_actor *actor, sdl3d_sphere *out)
+{
+    float sx, sy, sz, max_scale;
+
+    if (!actor->local_bounds_valid)
+    {
+        return false;
+    }
+
+    sx = actor->scale.x < 0.0f ? -actor->scale.x : actor->scale.x;
+    sy = actor->scale.y < 0.0f ? -actor->scale.y : actor->scale.y;
+    sz = actor->scale.z < 0.0f ? -actor->scale.z : actor->scale.z;
+    max_scale = sx;
+    if (sy > max_scale)
+        max_scale = sy;
+    if (sz > max_scale)
+        max_scale = sz;
+
+    /* The local center can be anywhere relative to the actor's pivot;
+     * rotation about the pivot would sweep it around a sphere of radius
+     * |local_center| * max_scale. Place the world sphere at the actor's
+     * position and inflate the radius by that swept distance to stay
+     * correct under arbitrary rotation. */
+    {
+        float lcx = actor->local_bounds_center.x;
+        float lcy = actor->local_bounds_center.y;
+        float lcz = actor->local_bounds_center.z;
+        float center_dist = SDL_sqrtf(lcx * lcx + lcy * lcy + lcz * lcz);
+        out->center = actor->position;
+        out->radius = (center_dist + actor->local_bounds_radius) * max_scale;
+    }
+    return true;
+}
 
 struct sdl3d_scene
 {
@@ -94,6 +216,8 @@ sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model)
     actor->anim_time = 0.0f;
     actor->anim_playing = false;
     actor->anim_looping = false;
+
+    sdl3d_actor_compute_local_bounds(actor);
 
     /* Prepend to linked list. */
     actor->next = scene->first;
@@ -252,6 +376,18 @@ bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
         if (!actor->visible || actor->model == NULL)
         {
             continue;
+        }
+
+        /* Per-actor frustum cull: reject the whole actor before any
+         * matrix push or per-mesh iteration. */
+        if (context->frustum_planes_valid && actor->local_bounds_valid)
+        {
+            sdl3d_sphere world_bounds;
+            if (sdl3d_actor_world_bounds(actor, &world_bounds) &&
+                !sdl3d_sphere_intersects_frustum(world_bounds, context->frustum_planes))
+            {
+                continue;
+            }
         }
 
         /* Animated actors: evaluate skeleton and draw skinned. */

--- a/src/scene.c
+++ b/src/scene.c
@@ -34,6 +34,9 @@ struct sdl3d_actor
     sdl3d_vec3 local_bounds_center;
     float local_bounds_radius;
     bool local_bounds_valid;
+
+    /* Optional sector for portal-based visibility culling; -1 = none. */
+    int sector_id;
 };
 
 static void sdl3d_actor_compute_local_bounds(sdl3d_actor *actor)
@@ -216,6 +219,7 @@ sdl3d_actor *sdl3d_scene_add_actor(sdl3d_scene *scene, const sdl3d_model *model)
     actor->anim_time = 0.0f;
     actor->anim_playing = false;
     actor->anim_looping = false;
+    actor->sector_id = -1;
 
     sdl3d_actor_compute_local_bounds(actor);
 
@@ -341,6 +345,23 @@ bool sdl3d_actor_is_visible(const sdl3d_actor *actor)
     return actor->visible;
 }
 
+void sdl3d_actor_set_sector(sdl3d_actor *actor, int sector_id)
+{
+    if (actor != NULL)
+    {
+        actor->sector_id = sector_id;
+    }
+}
+
+int sdl3d_actor_get_sector(const sdl3d_actor *actor)
+{
+    if (actor == NULL)
+    {
+        return -1;
+    }
+    return actor->sector_id;
+}
+
 void sdl3d_actor_set_tint(sdl3d_actor *actor, sdl3d_color tint)
 {
     if (actor != NULL)
@@ -358,7 +379,8 @@ const sdl3d_model *sdl3d_actor_get_model(const sdl3d_actor *actor)
     return actor->model;
 }
 
-bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
+static bool sdl3d_draw_scene_impl(sdl3d_render_context *context, const sdl3d_scene *scene,
+                                  const sdl3d_visibility_result *vis)
 {
     const sdl3d_actor *actor;
 
@@ -376,6 +398,17 @@ bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
         if (!actor->visible || actor->model == NULL)
         {
             continue;
+        }
+
+        /* Portal cull: actors with a known sector are skipped when that
+         * sector is not in the visibility set. Actors with sector_id < 0
+         * (the default) bypass this check and rely on frustum culling. */
+        if (vis != NULL && vis->sector_visible != NULL && actor->sector_id >= 0)
+        {
+            if (!vis->sector_visible[actor->sector_id])
+            {
+                continue;
+            }
         }
 
         /* Per-actor frustum cull: reject the whole actor before any
@@ -418,6 +451,17 @@ bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
     }
 
     return true;
+}
+
+bool sdl3d_draw_scene(sdl3d_render_context *context, const sdl3d_scene *scene)
+{
+    return sdl3d_draw_scene_impl(context, scene, NULL);
+}
+
+bool sdl3d_draw_scene_with_visibility(sdl3d_render_context *context, const sdl3d_scene *scene,
+                                      const sdl3d_visibility_result *vis)
+{
+    return sdl3d_draw_scene_impl(context, scene, vis);
 }
 
 /* ------------------------------------------------------------------ */

--- a/tests/test_collision.cpp
+++ b/tests/test_collision.cpp
@@ -122,6 +122,75 @@ INSTANTIATE_TEST_SUITE_P(
                       AABBSphereCase{"corner miss", bb(0, 0, 0, 1, 1, 1), sp(2, 2, 2, 1.7f), false}));
 
 /* ================================================================== */
+/* Sphere-Frustum                                                     */
+/* ================================================================== */
+
+namespace
+{
+/* Build a unit-cube frustum: 6 planes bounding the box [-1,1]^3, each
+ * plane oriented so the inside half-space is a*x + b*y + c*z + d >= 0. */
+void make_unit_frustum(float planes[6][4])
+{
+    /* +x <= 1  ->  -x + 1 >= 0 */
+    planes[0][0] = -1;
+    planes[0][1] = 0;
+    planes[0][2] = 0;
+    planes[0][3] = 1;
+    /* -x <= 1  ->   x + 1 >= 0 */
+    planes[1][0] = 1;
+    planes[1][1] = 0;
+    planes[1][2] = 0;
+    planes[1][3] = 1;
+    planes[2][0] = 0;
+    planes[2][1] = -1;
+    planes[2][2] = 0;
+    planes[2][3] = 1;
+    planes[3][0] = 0;
+    planes[3][1] = 1;
+    planes[3][2] = 0;
+    planes[3][3] = 1;
+    planes[4][0] = 0;
+    planes[4][1] = 0;
+    planes[4][2] = -1;
+    planes[4][3] = 1;
+    planes[5][0] = 0;
+    planes[5][1] = 0;
+    planes[5][2] = 1;
+    planes[5][3] = 1;
+}
+} // namespace
+
+TEST(SphereFrustum, CenterInsideIsVisible)
+{
+    float planes[6][4];
+    make_unit_frustum(planes);
+    EXPECT_TRUE(sdl3d_sphere_intersects_frustum(sp(0, 0, 0, 0.1f), planes));
+}
+
+TEST(SphereFrustum, FarOutsideIsCulled)
+{
+    float planes[6][4];
+    make_unit_frustum(planes);
+    EXPECT_FALSE(sdl3d_sphere_intersects_frustum(sp(10, 0, 0, 1), planes));
+    EXPECT_FALSE(sdl3d_sphere_intersects_frustum(sp(0, -10, 0, 1), planes));
+}
+
+TEST(SphereFrustum, StraddlingPlaneIsVisible)
+{
+    float planes[6][4];
+    make_unit_frustum(planes);
+    /* Center is just outside +x plane but radius reaches inside. */
+    EXPECT_TRUE(sdl3d_sphere_intersects_frustum(sp(1.5f, 0, 0, 0.6f), planes));
+}
+
+TEST(SphereFrustum, JustOutsidePlaneIsCulled)
+{
+    float planes[6][4];
+    make_unit_frustum(planes);
+    EXPECT_FALSE(sdl3d_sphere_intersects_frustum(sp(2.0f, 0, 0, 0.9f), planes));
+}
+
+/* ================================================================== */
 /* Ray-AABB                                                           */
 /* ================================================================== */
 

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -15,6 +15,7 @@
 extern "C"
 {
 #include "lighting_internal.h"
+#include "render_context_internal.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/sdl3d.h"
 }
@@ -585,6 +586,28 @@ TEST(SDL3DShadowAPI, NullContextRejected)
     EXPECT_FALSE(sdl3d_enable_shadow(nullptr, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
     EXPECT_FALSE(sdl3d_disable_shadow(nullptr, 0));
     EXPECT_FALSE(sdl3d_render_shadow_map(nullptr, nullptr, 0, nullptr));
+}
+
+TEST_F(SDL3DLightingFixture, BeginShadowPassPopulatesFrustumPlanes)
+{
+    sdl3d_light dl{};
+    dl.type = SDL3D_LIGHT_DIRECTIONAL;
+    dl.direction = {0.0f, -1.0f, 0.0f};
+    dl.color[0] = dl.color[1] = dl.color[2] = 1.0f;
+    dl.intensity = 1.0f;
+    ASSERT_TRUE(sdl3d_add_light(ctx, &dl));
+    ASSERT_TRUE(sdl3d_enable_shadow(ctx, 0, sdl3d_vec3_make(0, 0, 0), 10.0f));
+
+    /* No frustum planes are valid before any 3D mode begins. */
+    EXPECT_FALSE(ctx->frustum_planes_valid);
+
+    /* Shadow pass should set up the light frustum so per-actor culling
+     * (Phase 1) works against the light's view-projection. */
+    ASSERT_TRUE(sdl3d_begin_shadow_pass(ctx));
+    EXPECT_TRUE(ctx->frustum_planes_valid);
+    ASSERT_TRUE(sdl3d_end_shadow_pass(ctx));
+
+    sdl3d_disable_shadow(ctx, 0);
 }
 
 TEST_F(SDL3DLightingFixture, RenderShadowMapWithNoMeshes)

--- a/tests/test_scene.cpp
+++ b/tests/test_scene.cpp
@@ -144,6 +144,20 @@ TEST(SDL3DScene, DrawSceneNullSceneFails)
     EXPECT_FALSE(sdl3d_draw_scene(nullptr, nullptr));
 }
 
+TEST(SDL3DScene, DrawSceneWithVisibilityRejectsNullArgs)
+{
+    sdl3d_visibility_result vis{};
+    bool sectors[1] = {true};
+    vis.sector_visible = sectors;
+    vis.visible_count = 1;
+
+    EXPECT_FALSE(sdl3d_draw_scene_with_visibility(nullptr, nullptr, &vis));
+
+    sdl3d_scene *scene = sdl3d_create_scene();
+    EXPECT_FALSE(sdl3d_draw_scene_with_visibility(nullptr, scene, &vis));
+    sdl3d_destroy_scene(scene);
+}
+
 /* ================================================================== */
 /* Actor properties — defaults                                        */
 /* ================================================================== */
@@ -166,6 +180,26 @@ TEST(SDL3DActor, DefaultProperties)
 
     EXPECT_TRUE(sdl3d_actor_is_visible(actor));
     EXPECT_EQ(sdl3d_actor_get_model(actor), &model);
+    EXPECT_EQ(sdl3d_actor_get_sector(actor), -1);
+
+    sdl3d_destroy_scene(scene);
+}
+
+TEST(SDL3DActor, SectorSetAndGet)
+{
+    sdl3d_model model{};
+    sdl3d_scene *scene = sdl3d_create_scene();
+    sdl3d_actor *actor = sdl3d_scene_add_actor(scene, &model);
+
+    sdl3d_actor_set_sector(actor, 7);
+    EXPECT_EQ(sdl3d_actor_get_sector(actor), 7);
+
+    sdl3d_actor_set_sector(actor, -1);
+    EXPECT_EQ(sdl3d_actor_get_sector(actor), -1);
+
+    /* NULL-safe accessors. */
+    sdl3d_actor_set_sector(nullptr, 3);
+    EXPECT_EQ(sdl3d_actor_get_sector(nullptr), -1);
 
     sdl3d_destroy_scene(scene);
 }


### PR DESCRIPTION
## Summary

Implements Phases 1-3 of the actor visibility culling plan. Phase 4 (spatial partitioning) is deferred indefinitely — at current actor counts the linear list walk is not the bottleneck, and a grid/BVH would add ~500-800 LOC of state to maintain on actor add/remove/move for no measurable win.

### Phase 1 — per-actor frustum culling

Each actor caches a local-space bounding sphere (union of mesh AABBs) at attach time. `sdl3d_draw_scene` derives a world sphere per frame and tests it against the cached camera frustum planes via the new `sdl3d_sphere_intersects_frustum` primitive. Off-screen actors skip the matrix push, TRS computation, and per-mesh iteration entirely.

### Phase 2 — actor portal integration

Actors now carry an optional `sector_id` (default `-1` = unassigned), set via `sdl3d_actor_set_sector` / read via `sdl3d_actor_get_sector`. The new `sdl3d_draw_scene_with_visibility(context, scene, vis)` rejects actors whose sector is not in the supplied `sdl3d_visibility_result` before any frustum work. The legacy `sdl3d_draw_scene` is behaviorally unchanged.

The `doom_level` demo is wired up: each frame it refreshes every actor's sector via `sdl3d_level_find_sector` and passes the active visibility result.

### Phase 3 — shadow pass culling

Extracted the view-projection → frustum-plane derivation into a shared internal helper, and call it from both `begin_mode_3d` (camera) and `begin_shadow_pass` (shadow light). Phase 1's per-actor sphere test and the existing per-mesh AABB test now automatically reject geometry that cannot influence the shadow depth buffer — *before* any vertex copy or `append_draw_entry` runs. This is the alternative path called out in the plan, and is cleaner than stashing bounds on every `sdl3d_draw_entry`.

## Performance characteristics

| Phase | Cost reduced | Scales with |
|---|---|---|
| 1 | Off-screen actors: matrix push + per-mesh AABB test + draw-list copy | total actors − visible actors |
| 2 | Actors in occluded rooms: same as Phase 1, with O(1) sector lookup beforehand | hidden sectors × actors-per-sector |
| 3 | Shadow-caster geometry outside the active light frustum | actors × shadow-casting lights |

## Files touched

- `include/sdl3d/collision.h`, `src/collision.c` — new `sdl3d_sphere_intersects_frustum` primitive
- `include/sdl3d/scene.h`, `src/scene.c` — actor bounding sphere, sector_id, `sdl3d_draw_scene_with_visibility`
- `src/drawing3d.c`, `src/render_context_internal.h` — shared frustum-plane extraction helper
- `src/lighting.c` — extract light frustum in `begin_shadow_pass`
- `tests/test_collision.cpp`, `tests/test_scene.cpp`, `tests/test_lighting.cpp` — unit coverage
- `demos/doom_level/main.c` — wire `sdl3d_draw_scene_with_visibility` into the demo

## Test plan

- [x] `sdl3d_sphere_intersects_frustum`: inside, far outside, straddling a plane, just-outside-plane
- [x] Actor sector accessors: default value, set/get, NULL safety
- [x] `sdl3d_draw_scene_with_visibility`: NULL-arg validation
- [x] `sdl3d_begin_shadow_pass`: frustum planes become valid for actor/mesh culling
- [x] Full test suite green (531/531)
- [x] `make format` clean
- [x] Strict `-std=c17 -Wpedantic -Werror` build clean (Linux/Windows CI)
- [x] doom_level demo builds and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)