### PR TITLE
feat: game framework Phase A+B — sector queries and FPS mover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ target_sources(
         src/lighting.c
         src/math.c
         src/font.c
+        src/fps_mover.c
         src/level.c
         src/model.c
         src/obj_loader.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(
         src/rasterizer.c
         src/render_context.c
         src/scene.c
+        src/sprite_actor.c
         src/sdl3d.c
         src/shading.c
         src/shapes.c

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -60,39 +60,6 @@ static void free_texture_array(sdl3d_texture2d *textures, int count)
  * by the visibility-side sector lookup below. */
 #define PLAYER_MIN_HEADROOM (PLAYER_HEIGHT + PLAYER_CEILING_CLEARANCE)
 
-static void advance_projectile(const sdl3d_level *level, const sdl3d_sector *sectors, float dt, bool *proj_active,
-                               float *proj_x, float *proj_y, float *proj_z, float proj_dx, float proj_dy, float proj_dz,
-                               float *proj_life)
-{
-    if (!*proj_active)
-        return;
-
-    float travel = PROJ_SPEED * dt;
-    int steps = (int)SDL_ceilf(travel / 0.25f);
-    if (steps < 1)
-        steps = 1;
-    float step_dist = travel / (float)steps;
-
-    for (int i = 0; i < steps; i++)
-    {
-        float next_x = *proj_x + proj_dx * step_dist;
-        float next_y = *proj_y + proj_dy * step_dist;
-        float next_z = *proj_z + proj_dz * step_dist;
-        if (!sdl3d_level_point_inside(level, sectors, next_x, next_y, next_z))
-        {
-            *proj_active = false;
-            return;
-        }
-        *proj_x = next_x;
-        *proj_y = next_y;
-        *proj_z = next_z;
-    }
-
-    *proj_life -= dt;
-    if (*proj_life <= 0.0f)
-        *proj_active = false;
-}
-
 static sdl3d_color sample_actor_tint(const sdl3d_level_light *lights, int light_count, sdl3d_vec3 position,
                                      bool proj_active, float proj_x, float proj_y, float proj_z)
 {
@@ -774,9 +741,22 @@ int main(int argc, char *argv[])
 
         sdl3d_camera3d cam = sdl3d_fps_mover_camera(&mover, 75.0f);
 
-        /* Update projectile. */
-        advance_projectile(&level_unlit, sectors, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
-                           proj_dz, &proj_life);
+        /* Update projectile via library trace. */
+        if (proj_active)
+        {
+            float travel = PROJ_SPEED * dt;
+            sdl3d_vec3 proj_dir = sdl3d_vec3_make(proj_dx, proj_dy, proj_dz);
+            sdl3d_level_trace_result tr = sdl3d_level_trace_point(
+                &level_unlit, sectors, sdl3d_vec3_make(proj_x, proj_y, proj_z), proj_dir, travel);
+            proj_x = tr.end_point.x;
+            proj_y = tr.end_point.y;
+            proj_z = tr.end_point.z;
+            if (tr.hit)
+                proj_active = false;
+            proj_life -= dt;
+            if (proj_life <= 0.0f)
+                proj_active = false;
+        }
 
         /* Compute portal visibility. */
         sdl3d_level *active_level =
@@ -787,8 +767,6 @@ int main(int argc, char *argv[])
             current_sector = sdl3d_level_find_walkable_sector(&level_unlit, sectors, px, pz, py - PLAYER_HEIGHT,
                                                               PLAYER_STEP_HEIGHT, PLAYER_MIN_HEADROOM);
         }
-        sdl3d_vec3 cam_dir = sdl3d_vec3_make(fx, SDL_sinf(pitch), fz);
-
         sdl3d_clear_lights(ctx);
         if (proj_active)
         {
@@ -808,18 +786,11 @@ int main(int argc, char *argv[])
         sdl3d_begin_mode_3d(ctx, cam);
         sdl3d_draw_skybox_textured(ctx, &skybox);
 
-        /* Compute visibility using cached frustum planes from begin_mode_3d.
-         * We pass the frustum planes through to the visibility system. */
+        /* Compute visibility using the camera convenience wrapper. */
         if (portal_culling)
         {
-            sdl3d_mat4 vview, vproj;
-            sdl3d_camera3d_compute_matrices(&cam, WINDOW_W, WINDOW_H, 0.01f, 1000.0f, &vview, &vproj);
-            sdl3d_mat4 vp = sdl3d_mat4_multiply(vproj, vview);
-
-            float fp[6][4];
-            sdl3d_extract_frustum_planes(vp, fp);
-
-            sdl3d_level_compute_visibility(active_level, current_sector, cam.position, cam_dir, fp, &vis);
+            sdl3d_level_compute_visibility_from_camera(active_level, sectors, &cam, WINDOW_W, WINDOW_H, 0.01f, 1000.0f,
+                                                       &vis);
         }
         else
         {

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -14,6 +14,7 @@
 #include "sdl3d/model.h"
 #include "sdl3d/scene.h"
 #include "sdl3d/sdl3d.h"
+#include "sdl3d/sprite_actor.h"
 #include "sdl3d/ui.h"
 
 #define WINDOW_W 1280
@@ -38,46 +39,6 @@
 #define ROCKET_LIGHT_B 0.2f
 #define ROCKET_LIGHT_INTENSITY 4.0f
 #define ROCKET_LIGHT_RANGE 4.0f
-#define DEMO_SPRITE_ROTATION_COUNT 8
-
-static const float DEMO_PI = 3.14159265358979323846f;
-
-typedef enum demo_sprite_rotation
-{
-    DEMO_SPRITE_SOUTH = 0,
-    DEMO_SPRITE_SOUTH_EAST = 1,
-    DEMO_SPRITE_EAST = 2,
-    DEMO_SPRITE_NORTH_EAST = 3,
-    DEMO_SPRITE_NORTH = 4,
-    DEMO_SPRITE_NORTH_WEST = 5,
-    DEMO_SPRITE_WEST = 6,
-    DEMO_SPRITE_SOUTH_WEST = 7
-} demo_sprite_rotation;
-
-typedef struct demo_sprite_rotation_set
-{
-    const sdl3d_texture2d *frames[DEMO_SPRITE_ROTATION_COUNT];
-} demo_sprite_rotation_set;
-
-typedef struct demo_sprite_actor
-{
-    const sdl3d_texture2d *texture;
-    const demo_sprite_rotation_set *rotations;
-    sdl3d_vec3 position;
-    sdl3d_vec2 size;
-    bool bob;
-    float bob_amplitude;
-    float bob_speed;
-} demo_sprite_actor;
-
-typedef struct demo_actor_draw
-{
-    const demo_sprite_actor *actor;
-    const sdl3d_texture2d *texture;
-    sdl3d_vec3 position;
-    sdl3d_color tint;
-    float distance_sq;
-} demo_actor_draw;
 
 static void configure_sprite_texture(sdl3d_texture2d *texture)
 {
@@ -90,39 +51,6 @@ static void free_texture_array(sdl3d_texture2d *textures, int count)
     for (int i = 0; i < count; ++i)
     {
         sdl3d_free_texture(&textures[i]);
-    }
-}
-
-static const sdl3d_texture2d *select_actor_texture(const demo_sprite_actor *actor, sdl3d_vec3 actor_pos, float cam_x,
-                                                   float cam_z)
-{
-    if (actor->rotations == NULL)
-    {
-        return actor->texture;
-    }
-
-    {
-        /* Frame names follow the "view from that direction" convention:
-         *   south.png  — what the camera sees when standing south of the actor (actor's front)
-         *   north.png  — camera north of the actor (actor's back)
-         *   east/west  — side profiles
-         *
-         * atan2(dx, dz) measures the camera's bearing from the actor,
-         * CW from +Z (north). Enum order is S, SE, E, NE, N, NW, W, SW
-         * — CCW from south. The (π - angle) shift aligns camera-south
-         * with index 0 so a viewer circling the actor sees the front,
-         * sides, and back in turn. */
-        const float dx = cam_x - actor_pos.x;
-        const float dz = cam_z - actor_pos.z;
-        const float angle = SDL_atan2f(dx, dz);
-        const float octant = (DEMO_PI - angle) / (DEMO_PI * 0.25f);
-        int index = (int)SDL_floorf(octant + 0.5f) % DEMO_SPRITE_ROTATION_COUNT;
-        if (index < 0)
-        {
-            index += DEMO_SPRITE_ROTATION_COUNT;
-        }
-        const sdl3d_texture2d *texture = actor->rotations->frames[index];
-        return texture != NULL ? texture : actor->texture;
     }
 }
 
@@ -223,17 +151,6 @@ static sdl3d_color sample_actor_tint(const sdl3d_level_light *lights, int light_
     return (sdl3d_color){(Uint8)(r * 255.0f), (Uint8)(g * 255.0f), (Uint8)(b * 255.0f), 255};
 }
 
-static int compare_actor_draws(const void *lhs, const void *rhs)
-{
-    const demo_actor_draw *a = (const demo_actor_draw *)lhs;
-    const demo_actor_draw *b = (const demo_actor_draw *)rhs;
-    if (a->distance_sq < b->distance_sq)
-        return 1;
-    if (a->distance_sq > b->distance_sq)
-        return -1;
-    return 0;
-}
-
 static void strip_level_lightmap(sdl3d_level *level)
 {
     SDL_free(level->lightmap_pixels);
@@ -279,7 +196,7 @@ int main(int argc, char *argv[])
 {
     SDL_Window *win = NULL;
     sdl3d_render_context *ctx = NULL;
-    sdl3d_texture2d enemy_rot_tex[DEMO_SPRITE_ROTATION_COUNT] = {0};
+    sdl3d_texture2d enemy_rot_tex[SDL3D_SPRITE_ROTATION_COUNT] = {0};
     sdl3d_texture2d health_tex = {0};
     sdl3d_texture2d crate_tex = {0};
     sdl3d_texture2d sky_px = {0};
@@ -329,7 +246,7 @@ int main(int argc, char *argv[])
     sdl3d_ui_context *ui = NULL;
     sdl3d_ui_create(has_font ? &debug_font : NULL, &ui);
 
-    const char *enemy_rotation_paths[DEMO_SPRITE_ROTATION_COUNT] = {
+    const char *enemy_rotation_paths[SDL3D_SPRITE_ROTATION_COUNT] = {
         SDL3D_MEDIA_DIR "/sprites/skeletal_robot/south.png", SDL3D_MEDIA_DIR "/sprites/skeletal_robot/south-east.png",
         SDL3D_MEDIA_DIR "/sprites/skeletal_robot/east.png",  SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north-east.png",
         SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north.png", SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north-west.png",
@@ -337,7 +254,7 @@ int main(int argc, char *argv[])
     };
     bool enemy_sprites_ok = true;
 
-    for (int i = 0; i < DEMO_SPRITE_ROTATION_COUNT; ++i)
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
     {
         if (!sdl3d_load_texture_from_file(enemy_rotation_paths[i], &enemy_rot_tex[i]))
         {
@@ -350,7 +267,7 @@ int main(int argc, char *argv[])
     if (!enemy_sprites_ok || !sdl3d_load_texture_from_file(SDL3D_MEDIA_DIR "/sprites/health-pack.png", &health_tex))
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Sprite load failed: %s", SDL_GetError());
-        free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+        free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
         sdl3d_free_texture(&health_tex);
         sdl3d_destroy_render_context(ctx);
         SDL_DestroyWindow(win);
@@ -370,7 +287,7 @@ int main(int argc, char *argv[])
         !sdl3d_load_texture_from_file(SDL3D_MEDIA_DIR "/skyboxes/sky_17/nz.png", &sky_nz))
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Skybox load failed: %s", SDL_GetError());
-        free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+        free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
         sdl3d_free_texture(&health_tex);
         sdl3d_free_texture(&sky_px);
         sdl3d_free_texture(&sky_nx);
@@ -489,7 +406,7 @@ int main(int argc, char *argv[])
     if (!sdl3d_build_level(sectors, sector_count, mats, 6, lights, light_count, &level_lightmapped))
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Level build failed: %s", SDL_GetError());
-        free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+        free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
         sdl3d_free_texture(&health_tex);
         sdl3d_free_texture(&sky_px);
         sdl3d_free_texture(&sky_nx);
@@ -506,7 +423,7 @@ int main(int argc, char *argv[])
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Level build failed: %s", SDL_GetError());
         sdl3d_free_level(&level_lightmapped);
-        free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+        free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
         sdl3d_free_texture(&health_tex);
         sdl3d_free_texture(&sky_px);
         sdl3d_free_texture(&sky_nx);
@@ -525,7 +442,7 @@ int main(int argc, char *argv[])
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Level build failed: %s", SDL_GetError());
         sdl3d_free_level(&level_lightmapped);
         sdl3d_free_level(&level_vertex_baked);
-        free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+        free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
         sdl3d_free_texture(&health_tex);
         sdl3d_free_texture(&sky_px);
         sdl3d_free_texture(&sky_nx);
@@ -540,16 +457,20 @@ int main(int argc, char *argv[])
     }
     bool use_lit_world = true;
     bool use_lightmaps = true;
-    demo_sprite_rotation_set enemy_rotations = {{
-        &enemy_rot_tex[DEMO_SPRITE_SOUTH],
-        &enemy_rot_tex[DEMO_SPRITE_SOUTH_EAST],
-        &enemy_rot_tex[DEMO_SPRITE_EAST],
-        &enemy_rot_tex[DEMO_SPRITE_NORTH_EAST],
-        &enemy_rot_tex[DEMO_SPRITE_NORTH],
-        &enemy_rot_tex[DEMO_SPRITE_NORTH_WEST],
-        &enemy_rot_tex[DEMO_SPRITE_WEST],
-        &enemy_rot_tex[DEMO_SPRITE_SOUTH_WEST],
+    sdl3d_sprite_rotation_set enemy_rotations = {{
+        &enemy_rot_tex[0],
+        &enemy_rot_tex[1],
+        &enemy_rot_tex[2],
+        &enemy_rot_tex[3],
+        &enemy_rot_tex[4],
+        &enemy_rot_tex[5],
+        &enemy_rot_tex[6],
+        &enemy_rot_tex[7],
     }};
+
+    /* Sprite scene — replaces the old demo_sprite_actor array. */
+    sdl3d_sprite_scene sprites;
+    sdl3d_sprite_scene_init(&sprites);
 
     /* Enemy sprites are anchored at bottom-center (feet = position.y),
      * but the AI-generated art has a chunk of transparent padding under
@@ -558,25 +479,37 @@ int main(int argc, char *argv[])
      * the boots on the floor and keeps 2×-scale figures under the low
      * 3–4m ceilings in the start/south-corridor sectors without
      * clipping. */
-    demo_sprite_actor actors[] = {
-        {enemy_rotations.frames[DEMO_SPRITE_SOUTH], &enemy_rotations, sdl3d_vec3_make(5.8f, -1.05f, 6.8f),
-         (sdl3d_vec2){3.4f, 5.2f}, true, 0.10f, 7.0f},
-        {&health_tex, NULL, sdl3d_vec3_make(5.0f, 0.25f, 10.8f), (sdl3d_vec2){1.0f, 1.0f}, true, 0.12f, 1.8f},
-        {enemy_rotations.frames[DEMO_SPRITE_SOUTH], &enemy_rotations, sdl3d_vec3_make(4.2f, -1.4f, 21.5f),
-         (sdl3d_vec2){3.2f, 4.8f}, true, 0.08f, 6.0f},
-        {&health_tex, NULL, sdl3d_vec3_make(24.0f, 0.25f, 4.5f), (sdl3d_vec2){1.0f, 1.0f}, true, 0.15f, 1.5f},
-        {enemy_rotations.frames[DEMO_SPRITE_SOUTH], &enemy_rotations, sdl3d_vec3_make(24.0f, -1.05f, 19.0f),
-         (sdl3d_vec2){3.6f, 5.6f}, true, 0.09f, 6.5f},
-        {&health_tex, NULL, sdl3d_vec3_make(24.0f, 0.25f, 28.5f), (sdl3d_vec2){1.0f, 1.0f}, true, 0.12f, 2.1f},
-        {enemy_rotations.frames[DEMO_SPRITE_SOUTH], &enemy_rotations, sdl3d_vec3_make(24.0f, -1.05f, 37.5f),
-         (sdl3d_vec2){3.4f, 5.2f}, true, 0.09f, 5.8f},
-        {&health_tex, NULL, sdl3d_vec3_make(35.5f, 0.25f, 27.0f), (sdl3d_vec2){1.0f, 1.0f}, true, 0.1f, 1.7f},
-        {enemy_rotations.frames[DEMO_SPRITE_SOUTH], &enemy_rotations, sdl3d_vec3_make(24.0f, -1.05f, 72.0f),
-         (sdl3d_vec2){3.6f, 5.6f}, true, 0.11f, 5.5f},
-        {&health_tex, NULL, sdl3d_vec3_make(10.0f, 0.25f, 84.0f), (sdl3d_vec2){1.0f, 1.0f}, true, 0.14f, 1.6f},
-    };
-    demo_actor_draw actor_draws[SDL_arraysize(actors)];
-    float elapsed = 0.0f;
+    {
+        struct
+        {
+            const sdl3d_texture2d *tex;
+            const sdl3d_sprite_rotation_set *rot;
+            float x, y, z, w, h, amp, spd;
+        } sprite_defs[] = {
+            {NULL, &enemy_rotations, 5.8f, -1.05f, 6.8f, 3.4f, 5.2f, 0.10f, 7.0f},
+            {&health_tex, NULL, 5.0f, 0.25f, 10.8f, 1.0f, 1.0f, 0.12f, 1.8f},
+            {NULL, &enemy_rotations, 4.2f, -1.4f, 21.5f, 3.2f, 4.8f, 0.08f, 6.0f},
+            {&health_tex, NULL, 24.0f, 0.25f, 4.5f, 1.0f, 1.0f, 0.15f, 1.5f},
+            {NULL, &enemy_rotations, 24.0f, -1.05f, 19.0f, 3.6f, 5.6f, 0.09f, 6.5f},
+            {&health_tex, NULL, 24.0f, 0.25f, 28.5f, 1.0f, 1.0f, 0.12f, 2.1f},
+            {NULL, &enemy_rotations, 24.0f, -1.05f, 37.5f, 3.4f, 5.2f, 0.09f, 5.8f},
+            {&health_tex, NULL, 35.5f, 0.25f, 27.0f, 1.0f, 1.0f, 0.1f, 1.7f},
+            {NULL, &enemy_rotations, 24.0f, -1.05f, 72.0f, 3.6f, 5.6f, 0.11f, 5.5f},
+            {&health_tex, NULL, 10.0f, 0.25f, 84.0f, 1.0f, 1.0f, 0.14f, 1.6f},
+        };
+        for (int i = 0; i < (int)SDL_arraysize(sprite_defs); ++i)
+        {
+            sdl3d_sprite_actor *a = sdl3d_sprite_scene_add(&sprites);
+            a->position = sdl3d_vec3_make(sprite_defs[i].x, sprite_defs[i].y, sprite_defs[i].z);
+            a->size = (sdl3d_vec2){sprite_defs[i].w, sprite_defs[i].h};
+            a->texture = sprite_defs[i].tex ? sprite_defs[i].tex : enemy_rotations.frames[0];
+            a->rotations = sprite_defs[i].rot;
+            a->bob_amplitude = sprite_defs[i].amp;
+            a->bob_speed = sprite_defs[i].spd;
+            a->bob_phase = (float)i; /* stagger phase like the old demo */
+        }
+    }
+
     sdl3d_skybox_textured skybox = {&sky_px, &sky_nx, &sky_py, &sky_ny, &sky_pz, &sky_nz, 350.0f};
 
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Portals detected: %d", level_lightmapped.portal_count);
@@ -777,7 +710,8 @@ int main(int argc, char *argv[])
         Uint64 now = SDL_GetPerformanceCounter();
         float dt = (float)(now - last) / (float)SDL_GetPerformanceFrequency();
         last = now;
-        elapsed += dt;
+
+        sdl3d_sprite_scene_update(&sprites, dt);
 
         /* Advance all actor animations. */
         if (scene)
@@ -946,46 +880,18 @@ int main(int argc, char *argv[])
             }
         }
 
+        /* Update sprite tints and sector IDs, then draw via the library. */
         {
-            int actor_draw_count = 0;
-            for (int i = 0; i < (int)SDL_arraysize(actors); ++i)
+            for (int i = 0; i < sprites.count; ++i)
             {
-                sdl3d_vec3 actor_pos = actors[i].position;
-                if (actors[i].bob)
-                {
-                    actor_pos.y += SDL_sinf(elapsed * actors[i].bob_speed + (float)i) * actors[i].bob_amplitude;
-                }
-
+                sdl3d_sprite_actor *sa = &sprites.actors[i];
+                sa->tint = sample_actor_tint(lights, light_count, sa->position, proj_active, proj_x, proj_y, proj_z);
                 if (portal_culling)
-                {
-                    int actor_sector = sdl3d_level_find_sector(active_level, sectors, actor_pos.x, actor_pos.z);
-                    if (actor_sector >= 0 && actor_sector < sector_count && !vis.sector_visible[actor_sector])
-                    {
-                        continue;
-                    }
-                }
-
-                actor_draws[actor_draw_count].actor = &actors[i];
-                actor_draws[actor_draw_count].texture = select_actor_texture(&actors[i], actor_pos, px, pz);
-                actor_draws[actor_draw_count].position = actor_pos;
-                actor_draws[actor_draw_count].tint =
-                    sample_actor_tint(lights, light_count, actor_pos, proj_active, proj_x, proj_y, proj_z);
-                {
-                    float dx = actor_pos.x - px;
-                    float dy = actor_pos.y - py;
-                    float dz = actor_pos.z - pz;
-                    actor_draws[actor_draw_count].distance_sq = dx * dx + dy * dy + dz * dz;
-                }
-                actor_draw_count++;
+                    sa->sector_id = sdl3d_level_find_sector(active_level, sectors, sa->position.x, sa->position.z);
+                else
+                    sa->sector_id = -1;
             }
-
-            SDL_qsort(actor_draws, (size_t)actor_draw_count, sizeof(actor_draws[0]), compare_actor_draws);
-
-            for (int i = 0; i < actor_draw_count; ++i)
-            {
-                const demo_actor_draw *draw = &actor_draws[i];
-                sdl3d_draw_billboard(ctx, draw->texture, draw->position, draw->actor->size, draw->tint);
-            }
+            sdl3d_sprite_scene_draw(&sprites, ctx, cam.position, portal_culling ? &vis : NULL);
         }
 
         /* Projectile sphere. */
@@ -1044,7 +950,7 @@ int main(int argc, char *argv[])
     sdl3d_free_level(&level_lightmapped);
     sdl3d_free_level(&level_vertex_baked);
     sdl3d_free_level(&level_unlit);
-    free_texture_array(enemy_rot_tex, DEMO_SPRITE_ROTATION_COUNT);
+    free_texture_array(enemy_rot_tex, SDL3D_SPRITE_ROTATION_COUNT);
     sdl3d_free_texture(&health_tex);
     sdl3d_free_texture(&crate_tex);
     sdl3d_free_texture(&sky_px);
@@ -1056,6 +962,7 @@ int main(int argc, char *argv[])
     if (has_font)
         sdl3d_free_font(&debug_font);
     sdl3d_ui_destroy(ui);
+    sdl3d_sprite_scene_free(&sprites);
     sdl3d_destroy_scene(scene);
     if (has_robot)
         sdl3d_free_model(&robot_model);

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -8,6 +8,7 @@
 
 #include "sdl3d/animation.h"
 #include "sdl3d/font.h"
+#include "sdl3d/fps_mover.h"
 #include "sdl3d/level.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/model.h"
@@ -125,140 +126,13 @@ static const sdl3d_texture2d *select_actor_texture(const demo_sprite_actor *acto
     }
 }
 
-static bool point_in_sector_xz(const sdl3d_sector *sector, float x, float z)
-{
-    bool inside = false;
-    for (int i = 0, j = sector->num_points - 1; i < sector->num_points; j = i++)
-    {
-        float xi = sector->points[i][0];
-        float zi = sector->points[i][1];
-        float xj = sector->points[j][0];
-        float zj = sector->points[j][1];
-        bool crosses = ((zi > z) != (zj > z));
-        if (!crosses)
-            continue;
-        float intersect_x = (xj - xi) * (z - zi) / (zj - zi) + xi;
-        if (x < intersect_x)
-            inside = !inside;
-    }
-    return inside;
-}
+/* Sector queries and player physics are provided by the public API:
+ * sdl3d_level_* helpers (see sdl3d/level.h) plus sdl3d_fps_mover (see
+ * sdl3d/fps_mover.h). PLAYER_MIN_HEADROOM is the headroom argument used
+ * by the visibility-side sector lookup below. */
+#define PLAYER_MIN_HEADROOM (PLAYER_HEIGHT + PLAYER_CEILING_CLEARANCE)
 
-static bool point_in_any_sector(const sdl3d_sector *sectors, int sector_count, float x, float y, float z)
-{
-    for (int i = 0; i < sector_count; i++)
-    {
-        const sdl3d_sector *sector = &sectors[i];
-        if (y < sector->floor_y || y > sector->ceil_y)
-            continue;
-        if (point_in_sector_xz(sector, x, z))
-            return true;
-    }
-    return false;
-}
-
-static int find_sector_at(const sdl3d_sector *sectors, int sector_count, float x, float z, float feet_y)
-{
-    int best = -1;
-    float best_floor = -1000000.0f;
-
-    for (int i = 0; i < sector_count; ++i)
-    {
-        const sdl3d_sector *sector = &sectors[i];
-        if (!point_in_sector_xz(sector, x, z))
-            continue;
-        if (sector->floor_y > feet_y || feet_y >= sector->ceil_y)
-            continue;
-        if (sector->floor_y > best_floor)
-        {
-            best = i;
-            best_floor = sector->floor_y;
-        }
-    }
-
-    return best;
-}
-
-static int find_walkable_sector_at(const sdl3d_sector *sectors, int sector_count, float x, float z, float feet_y,
-                                   float max_step_up)
-{
-    int best = -1;
-    float best_floor = -1000000.0f;
-
-    for (int i = 0; i < sector_count; ++i)
-    {
-        const sdl3d_sector *sector = &sectors[i];
-        if (!point_in_sector_xz(sector, x, z))
-            continue;
-        if (sector->floor_y > feet_y + max_step_up)
-            continue;
-        if (sector->ceil_y - sector->floor_y < PLAYER_HEIGHT + PLAYER_CEILING_CLEARANCE)
-            continue;
-        if (sector->floor_y > best_floor)
-        {
-            best = i;
-            best_floor = sector->floor_y;
-        }
-    }
-
-    return best;
-}
-
-static int find_support_sector_at(const sdl3d_sector *sectors, int sector_count, float x, float z, float feet_y)
-{
-    int best = -1;
-    float best_floor = -1000000.0f;
-
-    for (int i = 0; i < sector_count; ++i)
-    {
-        const sdl3d_sector *sector = &sectors[i];
-        if (!point_in_sector_xz(sector, x, z))
-            continue;
-        if (sector->floor_y > feet_y)
-            continue;
-        if (sector->ceil_y - sector->floor_y < PLAYER_HEIGHT + PLAYER_CEILING_CLEARANCE)
-            continue;
-        if (sector->floor_y > best_floor)
-        {
-            best = i;
-            best_floor = sector->floor_y;
-        }
-    }
-
-    return best;
-}
-
-static bool position_is_walkable(const sdl3d_sector *sectors, int sector_count, float x, float z, float feet_y,
-                                 float max_step_up, int *out_sector)
-{
-    static const float sample_dirs[8][2] = {
-        {1.0f, 0.0f},       {-1.0f, 0.0f},       {0.0f, 1.0f},        {0.0f, -1.0f},
-        {0.7071f, 0.7071f}, {0.7071f, -0.7071f}, {-0.7071f, 0.7071f}, {-0.7071f, -0.7071f},
-    };
-    int center_sector = find_walkable_sector_at(sectors, sector_count, x, z, feet_y, max_step_up);
-    float target_floor;
-
-    if (center_sector < 0)
-        return false;
-
-    target_floor = sectors[center_sector].floor_y;
-    for (int i = 0; i < 8; ++i)
-    {
-        float sx = x + sample_dirs[i][0] * PLAYER_RADIUS;
-        float sz = z + sample_dirs[i][1] * PLAYER_RADIUS;
-        int sample_sector = find_walkable_sector_at(sectors, sector_count, sx, sz, feet_y, max_step_up);
-        if (sample_sector < 0)
-            return false;
-        if (SDL_fabsf(sectors[sample_sector].floor_y - target_floor) > max_step_up)
-            return false;
-    }
-
-    if (out_sector != NULL)
-        *out_sector = center_sector;
-    return true;
-}
-
-static void advance_projectile(const sdl3d_sector *sectors, int sector_count, float dt, bool *proj_active,
+static void advance_projectile(const sdl3d_level *level, const sdl3d_sector *sectors, float dt, bool *proj_active,
                                float *proj_x, float *proj_y, float *proj_z, float proj_dx, float proj_dy, float proj_dz,
                                float *proj_life)
 {
@@ -276,7 +150,7 @@ static void advance_projectile(const sdl3d_sector *sectors, int sector_count, fl
         float next_x = *proj_x + proj_dx * step_dist;
         float next_y = *proj_y + proj_dy * step_dist;
         float next_z = *proj_z + proj_dz * step_dist;
-        if (!point_in_any_sector(sectors, sector_count, next_x, next_y, next_z))
+        if (!sdl3d_level_point_inside(level, sectors, next_x, next_y, next_z))
         {
             *proj_active = false;
             return;
@@ -392,16 +266,11 @@ static bool create_backend(SDL_Window **out_win, sdl3d_render_context **out_ctx,
     return true;
 }
 
-static void reset_demo_state(float *px, float *py, float *pz, float *yaw, float *pitch, float *vy, bool *on_ground,
-                             bool *proj_active, float *proj_life)
+static void reset_demo_state(sdl3d_fps_mover *mover, const sdl3d_fps_mover_config *config, bool *proj_active,
+                             float *proj_life)
 {
-    *px = PLAYER_SPAWN_X;
-    *py = PLAYER_HEIGHT;
-    *pz = PLAYER_SPAWN_Z;
-    *yaw = PLAYER_SPAWN_YAW;
-    *pitch = 0.0f;
-    *vy = 0.0f;
-    *on_ground = true;
+    sdl3d_fps_mover_init(mover, config, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
+                         PLAYER_SPAWN_YAW);
     *proj_active = false;
     *proj_life = 0.0f;
 }
@@ -727,20 +596,31 @@ int main(int argc, char *argv[])
     bool show_debug = false;
     bool portal_culling = true;
 
-    /* Player */
-    float px = PLAYER_SPAWN_X, py = PLAYER_HEIGHT, pz = PLAYER_SPAWN_Z;
-    float yaw = PLAYER_SPAWN_YAW, pitch = 0;
-    float vy = 0;          /* vertical velocity for jump */
-    float view_smooth = 0; /* Quake-style view smoothing for stairs */
-    bool on_ground = true;
+    /* Player physics: the FPS mover encapsulates gravity, jumping, stair
+     * stepping, sliding collision, view smoothing, ground rescue, and the
+     * last-known-good fallback. We keep px/py/pz/yaw/pitch as locals
+     * synced from the mover so the rest of the demo (projectile fire,
+     * sprite rotation pick, debug labels) reads them naturally. */
+    sdl3d_fps_mover_config fps_cfg = {
+        .move_speed = MOVE_SPEED,
+        .jump_velocity = JUMP_VELOCITY,
+        .gravity = GRAVITY,
+        .player_height = PLAYER_HEIGHT,
+        .player_radius = PLAYER_RADIUS,
+        .step_height = PLAYER_STEP_HEIGHT,
+        .ceiling_clearance = PLAYER_CEILING_CLEARANCE,
+    };
+    sdl3d_fps_mover mover;
+    sdl3d_fps_mover_init(&mover, &fps_cfg, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
+                         PLAYER_SPAWN_YAW);
+    float px = mover.position.x, py = mover.position.y, pz = mover.position.z;
+    float yaw = mover.yaw, pitch = mover.pitch;
     bool mouse_init = false;
 
-    /* Last-known-good position. Captured each frame the player is on solid
-     * ground inside a valid sector, used as a safety net if vertical
-     * collision puts the player in the void (Quake's PM_Trace fallback). */
-    float last_good_x = px;
-    float last_good_y = py;
-    float last_good_z = pz;
+    /* Mouse deltas accumulated during event poll, consumed by the mover
+     * each frame and reset to zero. */
+    float frame_mdx = 0.0f;
+    float frame_mdy = 0.0f;
 
     /* Projectile. */
     bool proj_active = false;
@@ -829,16 +709,19 @@ int main(int argc, char *argv[])
                 portal_culling = !portal_culling;
                 SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Portal culling: %s", portal_culling ? "ON" : "OFF");
             }
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_SPACE && on_ground)
+            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_SPACE)
             {
-                vy = JUMP_VELOCITY;
-                on_ground = false;
+                sdl3d_fps_mover_jump(&mover);
             }
             if (ev.type == SDL_EVENT_KEY_DOWN &&
                 (ev.key.scancode == SDL_SCANCODE_BACKSPACE || ev.key.scancode == SDL_SCANCODE_DELETE))
             {
-                reset_demo_state(&px, &py, &pz, &yaw, &pitch, &vy, &on_ground, &proj_active, &proj_life);
-                view_smooth = 0;
+                reset_demo_state(&mover, &fps_cfg, &proj_active, &proj_life);
+                px = mover.position.x;
+                py = mover.position.y;
+                pz = mover.position.z;
+                yaw = mover.yaw;
+                pitch = mover.pitch;
             }
             if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_TAB)
             {
@@ -873,12 +756,8 @@ int main(int argc, char *argv[])
             }
             if (ev.type == SDL_EVENT_MOUSE_MOTION && mouse_init)
             {
-                yaw += ev.motion.xrel * MOUSE_SENS;
-                pitch -= ev.motion.yrel * MOUSE_SENS;
-                if (pitch > 1.4f)
-                    pitch = 1.4f;
-                if (pitch < -1.4f)
-                    pitch = -1.4f;
+                frame_mdx += ev.motion.xrel;
+                frame_mdy += ev.motion.yrel;
             }
             if (ev.type == SDL_EVENT_MOUSE_MOTION)
                 mouse_init = true;
@@ -912,289 +791,67 @@ int main(int argc, char *argv[])
             }
         }
 
-        /* Look direction (for camera target). */
-        float fx = SDL_sinf(yaw) * SDL_cosf(pitch);
-        float fz = -SDL_cosf(yaw) * SDL_cosf(pitch);
-
-        /* Doom-style movement: accumulate wish direction on XZ plane,
-         * normalize so diagonal isn't faster, constant speed regardless of pitch. */
-        float fwd_x = SDL_sinf(yaw);
-        float fwd_z = -SDL_cosf(yaw);
-        float right_x = SDL_cosf(yaw);
-        float right_z = SDL_sinf(yaw);
-        float wish_x = 0, wish_z = 0;
+        /* Compute wish direction in world XZ space from current keys and
+         * the mover's facing. The mover normalizes any vector with
+         * magnitude > 1 internally; we just need a direction. */
+        float fwd_x = SDL_sinf(mover.yaw);
+        float fwd_z = -SDL_cosf(mover.yaw);
+        float right_x = SDL_cosf(mover.yaw);
+        float right_z = SDL_sinf(mover.yaw);
+        sdl3d_vec2 wish = {0.0f, 0.0f};
 
         const Uint8 *keys = (const Uint8 *)SDL_GetKeyboardState(NULL);
         if (keys[SDL_SCANCODE_W])
         {
-            wish_x += fwd_x;
-            wish_z += fwd_z;
+            wish.x += fwd_x;
+            wish.y += fwd_z;
         }
         if (keys[SDL_SCANCODE_S])
         {
-            wish_x -= fwd_x;
-            wish_z -= fwd_z;
+            wish.x -= fwd_x;
+            wish.y -= fwd_z;
         }
         if (keys[SDL_SCANCODE_A])
         {
-            wish_x -= right_x;
-            wish_z -= right_z;
+            wish.x -= right_x;
+            wish.y -= right_z;
         }
         if (keys[SDL_SCANCODE_D])
         {
-            wish_x += right_x;
-            wish_z += right_z;
+            wish.x += right_x;
+            wish.y += right_z;
         }
 
-        /* Quake-style view smoothing: decay the offset each frame. */
-        {
-            float smooth_speed = 12.0f; /* higher = snappier */
-            if (view_smooth > 0.01f)
-                view_smooth -= view_smooth * smooth_speed * dt;
-            else if (view_smooth < -0.01f)
-                view_smooth -= view_smooth * smooth_speed * dt;
-            else
-                view_smooth = 0.0f;
-        }
+        sdl3d_fps_mover_update(&mover, &level_unlit, sectors, wish, frame_mdx, frame_mdy, MOUSE_SENS, dt);
+        frame_mdx = 0.0f;
+        frame_mdy = 0.0f;
 
-        float py_before_collision = py;
+        /* Sync legacy locals for the rest of the frame (projectile fire,
+         * sprite rotation pick, debug overlays). */
+        px = mover.position.x;
+        py = mover.position.y;
+        pz = mover.position.z;
+        yaw = mover.yaw;
+        pitch = mover.pitch;
 
-        /* Normalize wish direction, then apply Doom-style sliding collision
-         * against sector boundaries. */
-        {
-            float feet_y = py - PLAYER_HEIGHT;
-            int current_sector = find_sector_at(sectors, sector_count, px, pz, feet_y);
-            float current_floor = feet_y;
+        /* Look direction reused below for visibility computation. */
+        float fx = SDL_sinf(yaw) * SDL_cosf(pitch);
+        float fz = -SDL_cosf(yaw) * SDL_cosf(pitch);
 
-            if (current_sector < 0)
-            {
-                current_sector = find_walkable_sector_at(sectors, sector_count, px, pz, feet_y, PLAYER_STEP_HEIGHT);
-            }
-            if (current_sector >= 0)
-            {
-                current_floor = sectors[current_sector].floor_y;
-            }
-
-            {
-                float wish_len = SDL_sqrtf(wish_x * wish_x + wish_z * wish_z);
-                if (wish_len > 0.001f)
-                {
-                    float move_x;
-                    float move_z;
-                    int candidate_sector = -1;
-
-                    wish_x /= wish_len;
-                    wish_z /= wish_len;
-                    move_x = wish_x * MOVE_SPEED * dt;
-                    move_z = wish_z * MOVE_SPEED * dt;
-
-                    if (position_is_walkable(sectors, sector_count, px + move_x, pz + move_z, feet_y,
-                                             PLAYER_STEP_HEIGHT, &candidate_sector))
-                    {
-                        px += move_x;
-                        pz += move_z;
-                        current_sector = candidate_sector;
-                    }
-                    else
-                    {
-                        if (position_is_walkable(sectors, sector_count, px + move_x, pz, feet_y, PLAYER_STEP_HEIGHT,
-                                                 &candidate_sector))
-                        {
-                            px += move_x;
-                            current_sector = candidate_sector;
-                        }
-                        else
-                        {
-                            if (position_is_walkable(sectors, sector_count, px, pz + move_z, feet_y, PLAYER_STEP_HEIGHT,
-                                                     &candidate_sector))
-                            {
-                                pz += move_z;
-                                current_sector = candidate_sector;
-                            }
-                        }
-                    }
-                }
-            }
-
-            feet_y = py - PLAYER_HEIGHT;
-            current_sector = find_sector_at(sectors, sector_count, px, pz, feet_y);
-            if (current_sector < 0)
-            {
-                current_sector = find_walkable_sector_at(sectors, sector_count, px, pz, feet_y, PLAYER_STEP_HEIGHT);
-            }
-
-            if (on_ground)
-            {
-                if (current_sector >= 0)
-                {
-                    const float target_floor = sectors[current_sector].floor_y;
-                    if (target_floor < current_floor - PLAYER_STEP_HEIGHT)
-                    {
-                        on_ground = false;
-                    }
-                    else
-                    {
-                        py = target_floor + PLAYER_HEIGHT;
-                    }
-                }
-                else
-                {
-                    on_ground = false;
-                }
-            }
-        }
-
-        /* Jump / gravity. Quake-style substepped vertical integration: a
-         * single large dy can skip past a thin stair sector entirely
-         * (issue #76). Split the motion so each substep moves at most
-         * half a stair step and re-runs the floor-cross test. */
-        if (!on_ground)
-        {
-            vy -= GRAVITY * dt;
-            float dy = vy * dt;
-
-            const float max_substep = PLAYER_STEP_HEIGHT * 0.5f;
-            int substeps = 1;
-            float abs_dy = SDL_fabsf(dy);
-            if (abs_dy > max_substep)
-            {
-                substeps = (int)SDL_ceilf(abs_dy / max_substep);
-            }
-            float sub_dy = dy / (float)substeps;
-
-            for (int s = 0; s < substeps; ++s)
-            {
-                float prev_py = py;
-                float prev_feet_y = py - PLAYER_HEIGHT;
-                py += sub_dy;
-                float feet_y = py - PLAYER_HEIGHT;
-
-                /* Ceiling check: head crossed downward-facing ceiling plane. */
-                int containing_sector = find_sector_at(sectors, sector_count, px, pz, SDL_max(prev_feet_y, feet_y));
-                if (containing_sector >= 0)
-                {
-                    float ceiling_y = sectors[containing_sector].ceil_y - PLAYER_CEILING_CLEARANCE;
-                    if (prev_py <= ceiling_y && py > ceiling_y)
-                    {
-                        py = ceiling_y;
-                        if (vy > 0.0f)
-                            vy = 0.0f;
-                        break;
-                    }
-                }
-
-                /* Floor snap: feet crossed any support floor going down. */
-                if (vy <= 0.0f)
-                {
-                    int support_sector = find_support_sector_at(sectors, sector_count, px, pz,
-                                                                SDL_max(prev_feet_y, feet_y) + PLAYER_STEP_HEIGHT);
-                    if (support_sector >= 0)
-                    {
-                        float floor_y = sectors[support_sector].floor_y;
-                        if (prev_feet_y >= floor_y && feet_y <= floor_y)
-                        {
-                            py = floor_y + PLAYER_HEIGHT;
-                            vy = 0.0f;
-                            on_ground = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            /* Ground-trace rescue: if the player ended up outside any
-             * sector but a support floor exists nearby above their feet
-             * (within step height), snap to it. Catches the case where
-             * a stair edge briefly leaves the player in the void.
-             * Quake 3's PM_GroundTrace pattern. */
-            if (!on_ground && vy <= 0.0f)
-            {
-                float feet_y = py - PLAYER_HEIGHT;
-                int containing_now = find_sector_at(sectors, sector_count, px, pz, feet_y);
-                if (containing_now < 0)
-                {
-                    int rescue = find_support_sector_at(sectors, sector_count, px, pz, feet_y + PLAYER_STEP_HEIGHT);
-                    if (rescue >= 0)
-                    {
-                        float floor_y = sectors[rescue].floor_y;
-                        if (floor_y >= feet_y && (floor_y - feet_y) <= PLAYER_STEP_HEIGHT)
-                        {
-                            py = floor_y + PLAYER_HEIGHT;
-                            vy = 0.0f;
-                            on_ground = true;
-                        }
-                    }
-                }
-            }
-
-            /* Last-known-good fallback: if all of the above failed and
-             * the player is dropping through the world, restore the
-             * cached safe position rather than teleporting to spawn. */
-            if (!on_ground && py < -20.0f)
-            {
-                px = last_good_x;
-                py = last_good_y;
-                pz = last_good_z;
-                vy = 0.0f;
-                on_ground = true;
-                view_smooth = 0;
-            }
-        }
-
-        {
-            float feet_y = py - PLAYER_HEIGHT;
-            int containing_sector = find_sector_at(sectors, sector_count, px, pz, feet_y);
-            if (containing_sector >= 0)
-            {
-                float ceiling_y = sectors[containing_sector].ceil_y - PLAYER_CEILING_CLEARANCE;
-                if (py > ceiling_y)
-                {
-                    py = ceiling_y;
-                    if (vy > 0.0f)
-                        vy = 0.0f;
-                }
-            }
-        }
-
-        /* Accumulate view smooth offset from floor snaps (not jumps). */
-        {
-            float py_delta = py - py_before_collision;
-            if (on_ground && SDL_fabsf(py_delta) > 0.01f)
-                view_smooth -= py_delta;
-        }
-
-        /* Capture last-known-good while standing in a valid sector. */
-        if (on_ground)
-        {
-            int validate = find_sector_at(sectors, sector_count, px, pz, py - PLAYER_HEIGHT);
-            if (validate >= 0)
-            {
-                last_good_x = px;
-                last_good_y = py;
-                last_good_z = pz;
-            }
-        }
-
-        sdl3d_camera3d cam;
-        float eye_y = py + view_smooth;
-        cam.position = sdl3d_vec3_make(px, eye_y, pz);
-        cam.target = sdl3d_vec3_make(px + fx, eye_y + SDL_sinf(pitch), pz + fz);
-        cam.up = sdl3d_vec3_make(0, 1, 0);
-        cam.fovy = 75.0f;
-        cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+        sdl3d_camera3d cam = sdl3d_fps_mover_camera(&mover, 75.0f);
 
         /* Update projectile. */
-        advance_projectile(sectors, sector_count, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
+        advance_projectile(&level_unlit, sectors, dt, &proj_active, &proj_x, &proj_y, &proj_z, proj_dx, proj_dy,
                            proj_dz, &proj_life);
 
         /* Compute portal visibility. */
         sdl3d_level *active_level =
             use_lit_world ? (use_lightmaps ? &level_lightmapped : &level_vertex_baked) : &level_unlit;
-        int current_sector = find_sector_at(sectors, sector_count, px, pz, py - PLAYER_HEIGHT);
+        int current_sector = sdl3d_level_find_sector_at(&level_unlit, sectors, px, pz, py - PLAYER_HEIGHT);
         if (current_sector < 0)
         {
-            current_sector =
-                find_walkable_sector_at(sectors, sector_count, px, pz, py - PLAYER_HEIGHT, PLAYER_STEP_HEIGHT);
+            current_sector = sdl3d_level_find_walkable_sector(&level_unlit, sectors, px, pz, py - PLAYER_HEIGHT,
+                                                              PLAYER_STEP_HEIGHT, PLAYER_MIN_HEADROOM);
         }
         sdl3d_vec3 cam_dir = sdl3d_vec3_make(fx, SDL_sinf(pitch), fz);
 
@@ -1224,34 +881,9 @@ int main(int argc, char *argv[])
             sdl3d_mat4 vview, vproj;
             sdl3d_camera3d_compute_matrices(&cam, WINDOW_W, WINDOW_H, 0.01f, 1000.0f, &vview, &vproj);
             sdl3d_mat4 vp = sdl3d_mat4_multiply(vproj, vview);
-            const float *m = vp.m;
 
-            /* Gribb/Hartmann frustum plane extraction: left, right, bottom, top, near, far. */
             float fp[6][4];
-            float raw[6][4] = {
-                {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
-                {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
-                {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
-                {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
-                {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
-                {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
-            };
-            for (int i = 0; i < 6; i++)
-            {
-                float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
-                if (len > 0.000001f)
-                {
-                    fp[i][0] = raw[i][0] / len;
-                    fp[i][1] = raw[i][1] / len;
-                    fp[i][2] = raw[i][2] / len;
-                    fp[i][3] = raw[i][3] / len;
-                }
-                else
-                {
-                    fp[i][0] = fp[i][1] = fp[i][2] = 0.0f;
-                    fp[i][3] = raw[i][3];
-                }
-            }
+            sdl3d_extract_frustum_planes(vp, fp);
 
             sdl3d_level_compute_visibility(active_level, current_sector, cam.position, cam_dir, fp, &vis);
         }
@@ -1367,9 +999,9 @@ int main(int argc, char *argv[])
 
         /* Crosshair. */
         {
-            float chx = px + fx * 0.4f;
-            float chy = eye_y + SDL_sinf(pitch) * 0.4f;
-            float chz = pz + fz * 0.4f;
+            float chx = cam.position.x + fx * 0.4f;
+            float chy = cam.position.y + SDL_sinf(pitch) * 0.4f;
+            float chz = cam.position.z + fz * 0.4f;
             sdl3d_set_emissive(ctx, 8, 8, 8);
             sdl3d_draw_cube(ctx, sdl3d_vec3_make(chx, chy, chz), sdl3d_vec3_make(0.003f, 0.003f, 0.003f),
                             (sdl3d_color){255, 255, 255, 255});

--- a/include/sdl3d/fps_mover.h
+++ b/include/sdl3d/fps_mover.h
@@ -1,0 +1,101 @@
+/*
+ * First-person movement controller for sector-based levels.
+ *
+ * Encapsulates the physics that ship in the doom_level demo: gravity,
+ * jumping, stair stepping, wall sliding, ceiling collision, substepped
+ * vertical integration (so a single fast frame cannot skip past a thin
+ * stair), ground-trace rescue, and a last-known-good position fallback.
+ *
+ * The caller owns the game loop and the input system. Per frame:
+ *   - poll input, accumulate mouse_dx / mouse_dy and a wish direction
+ *     in world XZ space (already rotated by the player's facing);
+ *   - call sdl3d_fps_mover_update;
+ *   - build a camera with sdl3d_fps_mover_camera and render.
+ *
+ * Use sdl3d_fps_mover_jump from the input handler when the jump key
+ * fires; the mover ignores the call if it is not on the ground.
+ */
+
+#ifndef SDL3D_FPS_MOVER_H
+#define SDL3D_FPS_MOVER_H
+
+#include <stdbool.h>
+
+#include "sdl3d/camera.h"
+#include "sdl3d/level.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct sdl3d_fps_mover_config
+    {
+        float move_speed;        /* horizontal units / second                   */
+        float jump_velocity;     /* upward velocity applied on jump             */
+        float gravity;           /* downward acceleration (positive number)     */
+        float player_height;     /* eye to feet                                 */
+        float player_radius;     /* cylinder radius for sliding collision tests */
+        float step_height;       /* maximum stair step the player can climb    */
+        float ceiling_clearance; /* required gap between head and ceiling       */
+    } sdl3d_fps_mover_config;
+
+    typedef struct sdl3d_fps_mover
+    {
+        /* Public read/write — position and orientation. Treat as the eye
+         * position; feet are at position.y - config.player_height. */
+        sdl3d_vec3 position;
+        float yaw;
+        float pitch;
+
+        /* Public read — physics state. */
+        bool on_ground;
+        float vertical_velocity;
+        float view_smooth; /* Quake-style stair smoothing offset, eye-space */
+        int current_sector;
+
+        /* Internal. */
+        sdl3d_fps_mover_config config;
+        sdl3d_vec3 last_good_position;
+        bool has_last_good;
+    } sdl3d_fps_mover;
+
+    /*
+     * Initialize a mover with the given configuration. Spawn position is
+     * the eye position (feet land at spawn_position.y - player_height).
+     */
+    void sdl3d_fps_mover_init(sdl3d_fps_mover *mover, const sdl3d_fps_mover_config *config, sdl3d_vec3 spawn_position,
+                              float spawn_yaw);
+
+    /*
+     * Advance the mover by dt seconds.
+     *
+     * wish_dir is the desired XZ movement direction in world space — the
+     * caller is responsible for rotating WASD input by the player's yaw
+     * before passing it in. Magnitudes greater than 1 are clamped.
+     *
+     * mouse_dx / mouse_dy are raw event deltas (typically xrel / yrel
+     * from SDL_EVENT_MOUSE_MOTION); they are scaled by mouse_sensitivity
+     * before being applied to yaw / pitch.
+     */
+    void sdl3d_fps_mover_update(sdl3d_fps_mover *mover, const sdl3d_level *level, const sdl3d_sector *sectors,
+                                sdl3d_vec2 wish_dir, float mouse_dx, float mouse_dy, float mouse_sensitivity, float dt);
+
+    /*
+     * Apply jump_velocity if the mover is currently on the ground.
+     * No-op otherwise. Safe with NULL.
+     */
+    void sdl3d_fps_mover_jump(sdl3d_fps_mover *mover);
+
+    /*
+     * Build a camera looking along the mover's facing. The camera position
+     * includes the view-smooth offset so stair transitions appear smooth.
+     */
+    sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -19,6 +19,7 @@
 #ifndef SDL3D_LEVEL_H
 #define SDL3D_LEVEL_H
 
+#include "sdl3d/camera.h"
 #include "sdl3d/model.h"
 #include "sdl3d/texture.h"
 #include "sdl3d/types.h"
@@ -188,6 +189,36 @@ extern "C"
     void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector, sdl3d_vec3 camera_pos,
                                         sdl3d_vec3 camera_dir, const float frustum_planes[6][4],
                                         sdl3d_visibility_result *result);
+
+    /*
+     * Convenience wrapper: compute portal visibility directly from a camera.
+     * Internally derives the view-projection matrix, extracts frustum planes,
+     * finds the camera's current sector, and calls sdl3d_level_compute_visibility.
+     * The caller must provide result->sector_visible as a bool array of at
+     * least level->sector_count elements.
+     */
+    void sdl3d_level_compute_visibility_from_camera(const sdl3d_level *level, const sdl3d_sector *sectors,
+                                                    const sdl3d_camera3d *camera, int backbuffer_width,
+                                                    int backbuffer_height, float near_plane, float far_plane,
+                                                    sdl3d_visibility_result *result);
+
+    /* Result of a point trace through sector volumes. */
+    typedef struct sdl3d_level_trace_result
+    {
+        bool hit;             /* true if the trace left all sectors          */
+        sdl3d_vec3 end_point; /* final position (exit point or end of range) */
+        int end_sector;       /* sector at end_point, or -1 if outside      */
+        float fraction;       /* 0-1, how far along the trace               */
+    } sdl3d_level_trace_result;
+
+    /*
+     * Trace a point through sector volumes from origin along direction for
+     * up to max_distance. Stops when the point exits all sectors. Internally
+     * substepped (0.25 unit steps) so thin sectors are not skipped.
+     * Useful for projectiles, hitscan, and line-of-sight checks.
+     */
+    sdl3d_level_trace_result sdl3d_level_trace_point(const sdl3d_level *level, const sdl3d_sector *sectors,
+                                                     sdl3d_vec3 origin, sdl3d_vec3 direction, float max_distance);
 
     /*
      * Draw a built level, skipping meshes whose sector is not marked visible.

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -123,6 +123,56 @@ extern "C"
     int sdl3d_level_find_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z);
 
     /*
+     * Find the sector containing (x, z) where feet_y is inside the sector's
+     * vertical span (floor_y <= feet_y < ceil_y). Returns the sector with
+     * the highest floor when multiple stacked sectors qualify (the sector
+     * the player is "standing on"). Returns -1 if no sector qualifies.
+     */
+    int sdl3d_level_find_sector_at(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z,
+                                   float feet_y);
+
+    /*
+     * Find the highest sector at (x, z) whose floor is at most step_height
+     * above feet_y and that has at least player_height of headroom. Used
+     * for stair climbing and walkable-position queries. The player_height
+     * argument should include any ceiling clearance the caller wants
+     * enforced. Returns -1 if no walkable sector exists.
+     */
+    int sdl3d_level_find_walkable_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z,
+                                         float feet_y, float step_height, float player_height);
+
+    /*
+     * Find the highest sector at (x, z) whose floor is at or below feet_y
+     * and that has at least player_height of headroom. Used for falling /
+     * floor-snap queries: returns the floor the player will land on.
+     * Returns -1 if no support sector exists.
+     */
+    int sdl3d_level_find_support_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z,
+                                        float feet_y, float player_height);
+
+    /*
+     * Test whether the world-space point (x, y, z) is inside any sector
+     * volume (XZ polygon plus floor_y <= y <= ceil_y). Useful for
+     * projectile lifetime and trigger volume checks.
+     */
+    bool sdl3d_level_point_inside(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float y, float z);
+
+    /*
+     * Extract 6 normalized frustum planes from a row-major view-projection
+     * matrix. The output planes use the convention a*x + b*y + c*z + d >= 0
+     * for the inside half-space. Order: left, right, bottom, top, near, far.
+     */
+    void sdl3d_extract_frustum_planes(sdl3d_mat4 view_projection, float out_planes[6][4]);
+
+    /*
+     * Sample the accumulated point-light contribution at a world-space
+     * position. Each light uses quadratic distance falloff scaled by its
+     * intensity. The result is clamped to sdl3d_color range and contains
+     * no ambient term — callers add their own ambient floor.
+     */
+    sdl3d_color sdl3d_level_sample_light(const sdl3d_level_light *lights, int light_count, sdl3d_vec3 position);
+
+    /*
      * Compute which sectors are visible from the camera's current sector
      * by traversing the portal graph. Portals behind the camera or outside
      * the frustum are rejected. The caller must provide sector_visible as

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -187,7 +187,7 @@ extern "C"
      * Returns the number of visible sectors via result->visible_count.
      */
     void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector, sdl3d_vec3 camera_pos,
-                                        sdl3d_vec3 camera_dir, const float frustum_planes[6][4],
+                                        sdl3d_vec3 camera_dir, float frustum_planes[6][4],
                                         sdl3d_visibility_result *result);
 
     /*

--- a/include/sdl3d/sprite_actor.h
+++ b/include/sdl3d/sprite_actor.h
@@ -1,0 +1,113 @@
+/*
+ * Doom-style billboard sprite actors with 8-direction rotation sets,
+ * portal-based visibility culling, and depth-sorted drawing.
+ *
+ * Usage:
+ *   sdl3d_sprite_scene sprites;
+ *   sdl3d_sprite_scene_init(&sprites);
+ *   sdl3d_sprite_actor *e = sdl3d_sprite_scene_add(&sprites);
+ *   e->position = sdl3d_vec3_make(5, 0, 10);
+ *   e->size     = (sdl3d_vec2){3.4f, 5.2f};
+ *   e->texture  = &enemy_tex;
+ *   e->rotations = &enemy_rot;
+ *   e->tint     = (sdl3d_color){255,255,255,255};
+ *
+ *   // each frame:
+ *   sdl3d_sprite_scene_update(&sprites, dt);
+ *   sdl3d_sprite_scene_draw(&sprites, ctx, cam_pos, &vis);
+ *
+ *   sdl3d_sprite_scene_free(&sprites);
+ *
+ * Tinting is the caller's responsibility — set each actor's tint
+ * before drawing. Use sdl3d_level_sample_light from level.h as a
+ * building block for point-light contribution.
+ */
+
+#ifndef SDL3D_SPRITE_ACTOR_H
+#define SDL3D_SPRITE_ACTOR_H
+
+#include <stdbool.h>
+
+#include "sdl3d/level.h"
+#include "sdl3d/render_context.h"
+#include "sdl3d/texture.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SDL3D_SPRITE_ROTATION_COUNT 8
+
+    /*
+     * 8-direction rotation set. Frame order follows the Doom convention:
+     *   [0] S, [1] SE, [2] E, [3] NE, [4] N, [5] NW, [6] W, [7] SW
+     * NULL entries fall back to the actor's single texture.
+     */
+    typedef struct sdl3d_sprite_rotation_set
+    {
+        const sdl3d_texture2d *frames[SDL3D_SPRITE_ROTATION_COUNT];
+    } sdl3d_sprite_rotation_set;
+
+    typedef struct sdl3d_sprite_actor
+    {
+        sdl3d_vec3 position;
+        sdl3d_vec2 size;
+        const sdl3d_texture2d *texture;             /* single-frame fallback     */
+        const sdl3d_sprite_rotation_set *rotations; /* NULL = no rotation      */
+        sdl3d_color tint;
+        bool visible;
+        int sector_id; /* for portal culling, -1 = unassigned */
+
+        /* Bobbing animation. Set bob_amplitude > 0 to enable. */
+        float bob_amplitude;
+        float bob_speed;
+        float bob_phase; /* internal accumulator, advanced by _update */
+    } sdl3d_sprite_actor;
+
+    typedef struct sdl3d_sprite_scene
+    {
+        sdl3d_sprite_actor *actors;
+        int count;
+        int capacity;
+    } sdl3d_sprite_scene;
+
+    void sdl3d_sprite_scene_init(sdl3d_sprite_scene *scene);
+    void sdl3d_sprite_scene_free(sdl3d_sprite_scene *scene);
+
+    /*
+     * Add a sprite actor to the scene. Returns a pointer to the new actor
+     * (valid until the next add or remove). The actor is zero-initialized
+     * with visible = true and sector_id = -1.
+     */
+    sdl3d_sprite_actor *sdl3d_sprite_scene_add(sdl3d_sprite_scene *scene);
+
+    /* Remove the actor at the given index. Swaps with the last element. */
+    void sdl3d_sprite_scene_remove(sdl3d_sprite_scene *scene, int index);
+
+    /* Advance bobbing phase for all actors. */
+    void sdl3d_sprite_scene_update(sdl3d_sprite_scene *scene, float dt);
+
+    /*
+     * Select the correct rotation frame for a sprite given the camera's
+     * XZ position. Returns the actor's single texture if rotations is NULL
+     * or the selected frame is NULL.
+     */
+    const sdl3d_texture2d *sdl3d_sprite_select_texture(const sdl3d_sprite_actor *actor, float cam_x, float cam_z);
+
+    /*
+     * Draw all visible sprites: portal cull via vis (optional), select
+     * rotation frame, depth sort back-to-front, draw billboards.
+     *
+     * The caller is responsible for setting each actor's tint before
+     * calling this function. Pass vis = NULL to skip portal culling.
+     */
+    void sdl3d_sprite_scene_draw(sdl3d_sprite_scene *scene, sdl3d_render_context *context, sdl3d_vec3 camera_position,
+                                 const sdl3d_visibility_result *vis);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fps_mover.c
+++ b/src/fps_mover.c
@@ -1,0 +1,357 @@
+#include "sdl3d/fps_mover.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/math.h"
+
+/* Hard limits / tuning constants kept private. The pitch limit prevents
+ * gimbal lock at the poles. The view-smooth decay rate matches the
+ * doom_level demo's tuning (higher = snappier). */
+#define SDL3D_FPS_PITCH_LIMIT 1.4f
+#define SDL3D_FPS_VIEW_SMOOTH_SPEED 12.0f
+
+/* Stop polling smoothing once the residual is below this threshold; keeps
+ * the eye from oscillating around 0 when dt is small. */
+#define SDL3D_FPS_VIEW_SMOOTH_EPSILON 0.01f
+
+static float fps_min_headroom(const sdl3d_fps_mover *mover)
+{
+    return mover->config.player_height + mover->config.ceiling_clearance;
+}
+
+static bool position_is_walkable(const sdl3d_fps_mover *mover, const sdl3d_level *level, const sdl3d_sector *sectors,
+                                 float x, float z, float feet_y, int *out_sector)
+{
+    static const float sample_dirs[8][2] = {
+        {1.0f, 0.0f},       {-1.0f, 0.0f},       {0.0f, 1.0f},        {0.0f, -1.0f},
+        {0.7071f, 0.7071f}, {0.7071f, -0.7071f}, {-0.7071f, 0.7071f}, {-0.7071f, -0.7071f},
+    };
+
+    const float headroom = fps_min_headroom(mover);
+    const float step = mover->config.step_height;
+    const float radius = mover->config.player_radius;
+
+    int center = sdl3d_level_find_walkable_sector(level, sectors, x, z, feet_y, step, headroom);
+    if (center < 0)
+    {
+        return false;
+    }
+
+    float target_floor = sectors[center].floor_y;
+    for (int i = 0; i < 8; ++i)
+    {
+        float sx = x + sample_dirs[i][0] * radius;
+        float sz = z + sample_dirs[i][1] * radius;
+        int sample = sdl3d_level_find_walkable_sector(level, sectors, sx, sz, feet_y, step, headroom);
+        if (sample < 0)
+        {
+            return false;
+        }
+        if (SDL_fabsf(sectors[sample].floor_y - target_floor) > step)
+        {
+            return false;
+        }
+    }
+
+    if (out_sector)
+    {
+        *out_sector = center;
+    }
+    return true;
+}
+
+void sdl3d_fps_mover_init(sdl3d_fps_mover *mover, const sdl3d_fps_mover_config *config, sdl3d_vec3 spawn_position,
+                          float spawn_yaw)
+{
+    if (mover == NULL || config == NULL)
+    {
+        return;
+    }
+    SDL_zerop(mover);
+    mover->config = *config;
+    mover->position = spawn_position;
+    mover->yaw = spawn_yaw;
+    mover->pitch = 0.0f;
+    mover->on_ground = true;
+    mover->vertical_velocity = 0.0f;
+    mover->view_smooth = 0.0f;
+    mover->current_sector = -1;
+    mover->last_good_position = spawn_position;
+    mover->has_last_good = true;
+}
+
+void sdl3d_fps_mover_jump(sdl3d_fps_mover *mover)
+{
+    if (mover == NULL || !mover->on_ground)
+    {
+        return;
+    }
+    mover->vertical_velocity = mover->config.jump_velocity;
+    mover->on_ground = false;
+}
+
+sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy)
+{
+    sdl3d_camera3d cam;
+    SDL_zero(cam);
+
+    if (mover == NULL)
+    {
+        cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+        cam.fovy = fovy;
+        cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+        return cam;
+    }
+
+    float fx = SDL_sinf(mover->yaw) * SDL_cosf(mover->pitch);
+    float fz = -SDL_cosf(mover->yaw) * SDL_cosf(mover->pitch);
+    float fy = SDL_sinf(mover->pitch);
+
+    float eye_y = mover->position.y + mover->view_smooth;
+    cam.position = sdl3d_vec3_make(mover->position.x, eye_y, mover->position.z);
+    cam.target = sdl3d_vec3_make(mover->position.x + fx, eye_y + fy, mover->position.z + fz);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = fovy;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return cam;
+}
+
+void sdl3d_fps_mover_update(sdl3d_fps_mover *mover, const sdl3d_level *level, const sdl3d_sector *sectors,
+                            sdl3d_vec2 wish_dir, float mouse_dx, float mouse_dy, float mouse_sensitivity, float dt)
+{
+    if (mover == NULL || level == NULL || sectors == NULL || dt <= 0.0f)
+    {
+        return;
+    }
+
+    const float player_height = mover->config.player_height;
+    const float step_height = mover->config.step_height;
+    const float headroom = fps_min_headroom(mover);
+    const float ceiling_clearance = mover->config.ceiling_clearance;
+
+    /* ---- Mouse look ---- */
+    mover->yaw += mouse_dx * mouse_sensitivity;
+    mover->pitch -= mouse_dy * mouse_sensitivity;
+    if (mover->pitch > SDL3D_FPS_PITCH_LIMIT)
+        mover->pitch = SDL3D_FPS_PITCH_LIMIT;
+    if (mover->pitch < -SDL3D_FPS_PITCH_LIMIT)
+        mover->pitch = -SDL3D_FPS_PITCH_LIMIT;
+
+    /* ---- View smoothing decay ---- */
+    if (SDL_fabsf(mover->view_smooth) > SDL3D_FPS_VIEW_SMOOTH_EPSILON)
+    {
+        mover->view_smooth -= mover->view_smooth * SDL3D_FPS_VIEW_SMOOTH_SPEED * dt;
+    }
+    else
+    {
+        mover->view_smooth = 0.0f;
+    }
+
+    float py_before_collision = mover->position.y;
+
+    /* ---- Horizontal movement with sliding collision ---- */
+    {
+        float feet_y = mover->position.y - player_height;
+        int current_sector = sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z, feet_y);
+        float current_floor = feet_y;
+        if (current_sector < 0)
+        {
+            current_sector = sdl3d_level_find_walkable_sector(level, sectors, mover->position.x, mover->position.z,
+                                                              feet_y, step_height, headroom);
+        }
+        if (current_sector >= 0)
+        {
+            current_floor = sectors[current_sector].floor_y;
+        }
+
+        float wish_len = SDL_sqrtf(wish_dir.x * wish_dir.x + wish_dir.y * wish_dir.y);
+        if (wish_len > 1.0f)
+        {
+            wish_dir.x /= wish_len;
+            wish_dir.y /= wish_len;
+        }
+
+        if (wish_len > 0.001f)
+        {
+            float move_x = wish_dir.x * mover->config.move_speed * dt;
+            float move_z = wish_dir.y * mover->config.move_speed * dt;
+            int candidate = -1;
+
+            if (position_is_walkable(mover, level, sectors, mover->position.x + move_x, mover->position.z + move_z,
+                                     feet_y, &candidate))
+            {
+                mover->position.x += move_x;
+                mover->position.z += move_z;
+                current_sector = candidate;
+            }
+            else if (position_is_walkable(mover, level, sectors, mover->position.x + move_x, mover->position.z, feet_y,
+                                          &candidate))
+            {
+                mover->position.x += move_x;
+                current_sector = candidate;
+            }
+            else if (position_is_walkable(mover, level, sectors, mover->position.x, mover->position.z + move_z, feet_y,
+                                          &candidate))
+            {
+                mover->position.z += move_z;
+                current_sector = candidate;
+            }
+        }
+
+        /* Step-up onto a higher floor when on solid ground. */
+        feet_y = mover->position.y - player_height;
+        current_sector = sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z, feet_y);
+        if (current_sector < 0)
+        {
+            current_sector = sdl3d_level_find_walkable_sector(level, sectors, mover->position.x, mover->position.z,
+                                                              feet_y, step_height, headroom);
+        }
+        if (mover->on_ground)
+        {
+            if (current_sector >= 0)
+            {
+                float target_floor = sectors[current_sector].floor_y;
+                if (target_floor < current_floor - step_height)
+                {
+                    mover->on_ground = false;
+                }
+                else
+                {
+                    mover->position.y = target_floor + player_height;
+                }
+            }
+            else
+            {
+                mover->on_ground = false;
+            }
+        }
+    }
+
+    /* ---- Vertical: substepped gravity, ceiling, floor snap, rescue ---- */
+    if (!mover->on_ground)
+    {
+        mover->vertical_velocity -= mover->config.gravity * dt;
+        float dy = mover->vertical_velocity * dt;
+
+        const float max_substep = step_height * 0.5f;
+        int substeps = 1;
+        float abs_dy = SDL_fabsf(dy);
+        if (abs_dy > max_substep && max_substep > 0.0f)
+        {
+            substeps = (int)SDL_ceilf(abs_dy / max_substep);
+        }
+        float sub_dy = dy / (float)substeps;
+
+        for (int s = 0; s < substeps; ++s)
+        {
+            float prev_py = mover->position.y;
+            float prev_feet_y = prev_py - player_height;
+            mover->position.y += sub_dy;
+            float feet_y = mover->position.y - player_height;
+
+            /* Ceiling: head crossed downward into ceiling plane. */
+            int containing = sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z,
+                                                        SDL_max(prev_feet_y, feet_y));
+            if (containing >= 0)
+            {
+                float ceiling_y = sectors[containing].ceil_y - ceiling_clearance;
+                if (prev_py <= ceiling_y && mover->position.y > ceiling_y)
+                {
+                    mover->position.y = ceiling_y;
+                    if (mover->vertical_velocity > 0.0f)
+                        mover->vertical_velocity = 0.0f;
+                    break;
+                }
+            }
+
+            /* Floor: feet crossed any support floor going down. */
+            if (mover->vertical_velocity <= 0.0f)
+            {
+                int support = sdl3d_level_find_support_sector(level, sectors, mover->position.x, mover->position.z,
+                                                              SDL_max(prev_feet_y, feet_y) + step_height, headroom);
+                if (support >= 0)
+                {
+                    float floor_y = sectors[support].floor_y;
+                    if (prev_feet_y >= floor_y && feet_y <= floor_y)
+                    {
+                        mover->position.y = floor_y + player_height;
+                        mover->vertical_velocity = 0.0f;
+                        mover->on_ground = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        /* Ground-trace rescue: outside any sector but a support is within
+         * step height — Quake's PM_GroundTrace pattern. */
+        if (!mover->on_ground && mover->vertical_velocity <= 0.0f)
+        {
+            float feet_y = mover->position.y - player_height;
+            int containing_now =
+                sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z, feet_y);
+            if (containing_now < 0)
+            {
+                int rescue = sdl3d_level_find_support_sector(level, sectors, mover->position.x, mover->position.z,
+                                                             feet_y + step_height, headroom);
+                if (rescue >= 0)
+                {
+                    float floor_y = sectors[rescue].floor_y;
+                    if (floor_y >= feet_y && (floor_y - feet_y) <= step_height)
+                    {
+                        mover->position.y = floor_y + player_height;
+                        mover->vertical_velocity = 0.0f;
+                        mover->on_ground = true;
+                    }
+                }
+            }
+        }
+
+        /* Last-known-good fallback: dropped through the world. */
+        if (!mover->on_ground && mover->position.y < -20.0f && mover->has_last_good)
+        {
+            mover->position = mover->last_good_position;
+            mover->vertical_velocity = 0.0f;
+            mover->on_ground = true;
+            mover->view_smooth = 0.0f;
+        }
+    }
+
+    /* ---- Final ceiling clamp (handles ceilings encountered while
+     * walking / step-up). ---- */
+    {
+        float feet_y = mover->position.y - player_height;
+        int containing = sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z, feet_y);
+        if (containing >= 0)
+        {
+            float ceiling_y = sectors[containing].ceil_y - ceiling_clearance;
+            if (mover->position.y > ceiling_y)
+            {
+                mover->position.y = ceiling_y;
+                if (mover->vertical_velocity > 0.0f)
+                    mover->vertical_velocity = 0.0f;
+            }
+        }
+    }
+
+    /* ---- View smoothing: accumulate from floor-snap delta (not jumps). ---- */
+    {
+        float py_delta = mover->position.y - py_before_collision;
+        if (mover->on_ground && SDL_fabsf(py_delta) > SDL3D_FPS_VIEW_SMOOTH_EPSILON)
+        {
+            mover->view_smooth -= py_delta;
+        }
+    }
+
+    /* ---- Update current_sector and last-known-good. ---- */
+    {
+        float feet_y = mover->position.y - player_height;
+        mover->current_sector =
+            sdl3d_level_find_sector_at(level, sectors, mover->position.x, mover->position.z, feet_y);
+        if (mover->on_ground && mover->current_sector >= 0)
+        {
+            mover->last_good_position = mover->position;
+            mover->has_last_good = true;
+        }
+    }
+}

--- a/src/level.c
+++ b/src/level.c
@@ -1374,3 +1374,86 @@ void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector
 
     SDL_free(queue);
 }
+
+void sdl3d_level_compute_visibility_from_camera(const sdl3d_level *level, const sdl3d_sector *sectors,
+                                                const sdl3d_camera3d *camera, int backbuffer_width,
+                                                int backbuffer_height, float near_plane, float far_plane,
+                                                sdl3d_visibility_result *result)
+{
+    if (!level || !sectors || !camera || !result || !result->sector_visible)
+        return;
+
+    /* Mark everything visible as fallback. */
+    for (int i = 0; i < level->sector_count; ++i)
+        result->sector_visible[i] = true;
+    result->visible_count = level->sector_count;
+
+    sdl3d_mat4 view, proj;
+    if (!sdl3d_camera3d_compute_matrices(camera, backbuffer_width, backbuffer_height, near_plane, far_plane, &view,
+                                         &proj))
+        return;
+
+    sdl3d_mat4 vp = sdl3d_mat4_multiply(proj, view);
+    float fp[6][4];
+    sdl3d_extract_frustum_planes(vp, fp);
+
+    sdl3d_vec3 dir = sdl3d_vec3_make(camera->target.x - camera->position.x, camera->target.y - camera->position.y,
+                                     camera->target.z - camera->position.z);
+
+    int current =
+        sdl3d_level_find_sector_at(level, sectors, camera->position.x, camera->position.z, camera->position.y);
+
+    sdl3d_level_compute_visibility(level, current, camera->position, dir, fp, result);
+}
+
+sdl3d_level_trace_result sdl3d_level_trace_point(const sdl3d_level *level, const sdl3d_sector *sectors,
+                                                 sdl3d_vec3 origin, sdl3d_vec3 direction, float max_distance)
+{
+    sdl3d_level_trace_result r;
+    r.hit = false;
+    r.end_point = origin;
+    r.end_sector = -1;
+    r.fraction = 0.0f;
+
+    if (!level || !sectors || max_distance <= 0.0f)
+        return r;
+
+    float len = SDL_sqrtf(direction.x * direction.x + direction.y * direction.y + direction.z * direction.z);
+    if (len < 1e-6f)
+        return r;
+    float inv_len = 1.0f / len;
+    float dx = direction.x * inv_len;
+    float dy = direction.y * inv_len;
+    float dz = direction.z * inv_len;
+
+    const float step_size = 0.25f;
+    int steps = (int)SDL_ceilf(max_distance / step_size);
+    if (steps < 1)
+        steps = 1;
+    float step_dist = max_distance / (float)steps;
+
+    float px = origin.x, py = origin.y, pz = origin.z;
+    for (int i = 0; i < steps; ++i)
+    {
+        float nx = px + dx * step_dist;
+        float ny = py + dy * step_dist;
+        float nz = pz + dz * step_dist;
+        if (!sdl3d_level_point_inside(level, sectors, nx, ny, nz))
+        {
+            r.hit = true;
+            r.end_point = sdl3d_vec3_make(px, py, pz);
+            r.fraction = (float)(i) / (float)steps;
+            r.end_sector = sdl3d_level_find_sector_at(level, sectors, px, pz, py);
+            return r;
+        }
+        px = nx;
+        py = ny;
+        pz = nz;
+    }
+
+    r.hit = false;
+    r.end_point = sdl3d_vec3_make(px, py, pz);
+    r.fraction = 1.0f;
+    r.end_sector = sdl3d_level_find_sector_at(level, sectors, px, pz, py);
+    return r;
+}

--- a/src/level.c
+++ b/src/level.c
@@ -1264,7 +1264,7 @@ sdl3d_color sdl3d_level_sample_light(const sdl3d_level_light *lights, int light_
 /* Portal visibility traversal                                         */
 /* ------------------------------------------------------------------ */
 
-static bool portal_box_in_frustum(const sdl3d_level_portal *p, const float planes[6][4])
+static bool portal_box_in_frustum(const sdl3d_level_portal *p, float planes[6][4])
 {
     for (int i = 0; i < 6; ++i)
     {
@@ -1306,8 +1306,7 @@ static bool portal_behind_camera(const sdl3d_level_portal *p, sdl3d_vec3 cam_pos
 }
 
 void sdl3d_level_compute_visibility(const sdl3d_level *level, int current_sector, sdl3d_vec3 camera_pos,
-                                    sdl3d_vec3 camera_dir, const float frustum_planes[6][4],
-                                    sdl3d_visibility_result *result)
+                                    sdl3d_vec3 camera_dir, float frustum_planes[6][4], sdl3d_visibility_result *result)
 {
     if (!level || !result || !result->sector_visible)
         return;

--- a/src/level.c
+++ b/src/level.c
@@ -1096,6 +1096,170 @@ int sdl3d_level_find_sector(const sdl3d_level *level, const sdl3d_sector *sector
     return -1;
 }
 
+int sdl3d_level_find_sector_at(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z, float feet_y)
+{
+    int best = -1;
+    float best_floor = -1e30f;
+
+    if (!level || !sectors)
+        return -1;
+
+    for (int i = 0; i < level->sector_count; ++i)
+    {
+        const sdl3d_sector *sector = &sectors[i];
+        if (!point_in_polygon_xz(sector, x, z))
+            continue;
+        if (sector->floor_y > feet_y || feet_y >= sector->ceil_y)
+            continue;
+        if (sector->floor_y > best_floor)
+        {
+            best = i;
+            best_floor = sector->floor_y;
+        }
+    }
+    return best;
+}
+
+int sdl3d_level_find_walkable_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z,
+                                     float feet_y, float step_height, float player_height)
+{
+    int best = -1;
+    float best_floor = -1e30f;
+
+    if (!level || !sectors)
+        return -1;
+
+    for (int i = 0; i < level->sector_count; ++i)
+    {
+        const sdl3d_sector *sector = &sectors[i];
+        if (!point_in_polygon_xz(sector, x, z))
+            continue;
+        if (sector->floor_y > feet_y + step_height)
+            continue;
+        if (sector->ceil_y - sector->floor_y < player_height)
+            continue;
+        if (sector->floor_y > best_floor)
+        {
+            best = i;
+            best_floor = sector->floor_y;
+        }
+    }
+    return best;
+}
+
+int sdl3d_level_find_support_sector(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float z,
+                                    float feet_y, float player_height)
+{
+    int best = -1;
+    float best_floor = -1e30f;
+
+    if (!level || !sectors)
+        return -1;
+
+    for (int i = 0; i < level->sector_count; ++i)
+    {
+        const sdl3d_sector *sector = &sectors[i];
+        if (!point_in_polygon_xz(sector, x, z))
+            continue;
+        if (sector->floor_y > feet_y)
+            continue;
+        if (sector->ceil_y - sector->floor_y < player_height)
+            continue;
+        if (sector->floor_y > best_floor)
+        {
+            best = i;
+            best_floor = sector->floor_y;
+        }
+    }
+    return best;
+}
+
+bool sdl3d_level_point_inside(const sdl3d_level *level, const sdl3d_sector *sectors, float x, float y, float z)
+{
+    if (!level || !sectors)
+        return false;
+    for (int i = 0; i < level->sector_count; ++i)
+    {
+        const sdl3d_sector *sector = &sectors[i];
+        if (y < sector->floor_y || y > sector->ceil_y)
+            continue;
+        if (point_in_polygon_xz(sector, x, z))
+            return true;
+    }
+    return false;
+}
+
+void sdl3d_extract_frustum_planes(sdl3d_mat4 view_projection, float out_planes[6][4])
+{
+    const float *m = view_projection.m;
+    float raw[6][4] = {
+        {m[3] + m[0], m[7] + m[4], m[11] + m[8], m[15] + m[12]},
+        {m[3] - m[0], m[7] - m[4], m[11] - m[8], m[15] - m[12]},
+        {m[3] + m[1], m[7] + m[5], m[11] + m[9], m[15] + m[13]},
+        {m[3] - m[1], m[7] - m[5], m[11] - m[9], m[15] - m[13]},
+        {m[3] + m[2], m[7] + m[6], m[11] + m[10], m[15] + m[14]},
+        {m[3] - m[2], m[7] - m[6], m[11] - m[10], m[15] - m[14]},
+    };
+    for (int i = 0; i < 6; ++i)
+    {
+        float len = SDL_sqrtf(raw[i][0] * raw[i][0] + raw[i][1] * raw[i][1] + raw[i][2] * raw[i][2]);
+        if (len > 1e-6f)
+        {
+            out_planes[i][0] = raw[i][0] / len;
+            out_planes[i][1] = raw[i][1] / len;
+            out_planes[i][2] = raw[i][2] / len;
+            out_planes[i][3] = raw[i][3] / len;
+        }
+        else
+        {
+            out_planes[i][0] = 0.0f;
+            out_planes[i][1] = 0.0f;
+            out_planes[i][2] = 0.0f;
+            out_planes[i][3] = raw[i][3];
+        }
+    }
+}
+
+sdl3d_color sdl3d_level_sample_light(const sdl3d_level_light *lights, int light_count, sdl3d_vec3 position)
+{
+    float r = 0.0f, g = 0.0f, b = 0.0f;
+
+    if (lights == NULL || light_count <= 0)
+    {
+        return (sdl3d_color){0, 0, 0, 255};
+    }
+
+    for (int i = 0; i < light_count; ++i)
+    {
+        float dx = lights[i].position[0] - position.x;
+        float dy = lights[i].position[1] - position.y;
+        float dz = lights[i].position[2] - position.z;
+        float dist = SDL_sqrtf(dx * dx + dy * dy + dz * dz);
+        if (lights[i].range <= 0.0f || dist >= lights[i].range || dist <= 1e-4f)
+            continue;
+        float t = 1.0f - dist / lights[i].range;
+        float scale = lights[i].intensity * t * t;
+        r += lights[i].color[0] * scale;
+        g += lights[i].color[1] * scale;
+        b += lights[i].color[2] * scale;
+    }
+
+    if (r > 1.0f)
+        r = 1.0f;
+    if (g > 1.0f)
+        g = 1.0f;
+    if (b > 1.0f)
+        b = 1.0f;
+    if (r < 0.0f)
+        r = 0.0f;
+    if (g < 0.0f)
+        g = 0.0f;
+    if (b < 0.0f)
+        b = 0.0f;
+
+    return (sdl3d_color){(Uint8)(r * 255.0f), (Uint8)(g * 255.0f), (Uint8)(b * 255.0f), 255};
+}
+
 /* ------------------------------------------------------------------ */
 /* Portal visibility traversal                                         */
 /* ------------------------------------------------------------------ */

--- a/src/sprite_actor.c
+++ b/src/sprite_actor.c
@@ -1,0 +1,160 @@
+#include "sdl3d/sprite_actor.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/drawing3d.h"
+#include "sdl3d/math.h"
+
+static const float SPRITE_PI = 3.14159265358979323846f;
+
+/* Internal draw entry for depth sorting. */
+typedef struct sprite_draw_entry
+{
+    const sdl3d_sprite_actor *actor;
+    const sdl3d_texture2d *texture;
+    sdl3d_vec3 position;
+    float distance_sq;
+} sprite_draw_entry;
+
+static int compare_sprite_draws(const void *lhs, const void *rhs)
+{
+    const sprite_draw_entry *a = (const sprite_draw_entry *)lhs;
+    const sprite_draw_entry *b = (const sprite_draw_entry *)rhs;
+    if (a->distance_sq < b->distance_sq)
+        return 1;
+    if (a->distance_sq > b->distance_sq)
+        return -1;
+    return 0;
+}
+
+void sdl3d_sprite_scene_init(sdl3d_sprite_scene *scene)
+{
+    if (scene == NULL)
+        return;
+    scene->actors = NULL;
+    scene->count = 0;
+    scene->capacity = 0;
+}
+
+void sdl3d_sprite_scene_free(sdl3d_sprite_scene *scene)
+{
+    if (scene == NULL)
+        return;
+    SDL_free(scene->actors);
+    scene->actors = NULL;
+    scene->count = 0;
+    scene->capacity = 0;
+}
+
+sdl3d_sprite_actor *sdl3d_sprite_scene_add(sdl3d_sprite_scene *scene)
+{
+    sdl3d_sprite_actor *actor;
+    if (scene == NULL)
+        return NULL;
+
+    if (scene->count >= scene->capacity)
+    {
+        int new_cap = scene->capacity < 8 ? 8 : scene->capacity * 2;
+        sdl3d_sprite_actor *new_buf =
+            (sdl3d_sprite_actor *)SDL_realloc(scene->actors, (size_t)new_cap * sizeof(sdl3d_sprite_actor));
+        if (new_buf == NULL)
+            return NULL;
+        scene->actors = new_buf;
+        scene->capacity = new_cap;
+    }
+
+    actor = &scene->actors[scene->count];
+    SDL_zerop(actor);
+    actor->visible = true;
+    actor->sector_id = -1;
+    actor->tint = (sdl3d_color){255, 255, 255, 255};
+    scene->count++;
+    return actor;
+}
+
+void sdl3d_sprite_scene_remove(sdl3d_sprite_scene *scene, int index)
+{
+    if (scene == NULL || index < 0 || index >= scene->count)
+        return;
+    scene->count--;
+    if (index < scene->count)
+        scene->actors[index] = scene->actors[scene->count];
+}
+
+void sdl3d_sprite_scene_update(sdl3d_sprite_scene *scene, float dt)
+{
+    if (scene == NULL || dt <= 0.0f)
+        return;
+    for (int i = 0; i < scene->count; ++i)
+        scene->actors[i].bob_phase += dt;
+}
+
+const sdl3d_texture2d *sdl3d_sprite_select_texture(const sdl3d_sprite_actor *actor, float cam_x, float cam_z)
+{
+    if (actor == NULL)
+        return NULL;
+    if (actor->rotations == NULL)
+        return actor->texture;
+
+    float dx = cam_x - actor->position.x;
+    float dz = cam_z - actor->position.z;
+    float angle = SDL_atan2f(dx, dz);
+    float octant = (SPRITE_PI - angle) / (SPRITE_PI * 0.25f);
+    int index = (int)SDL_floorf(octant + 0.5f) % SDL3D_SPRITE_ROTATION_COUNT;
+    if (index < 0)
+        index += SDL3D_SPRITE_ROTATION_COUNT;
+
+    const sdl3d_texture2d *tex = actor->rotations->frames[index];
+    return tex != NULL ? tex : actor->texture;
+}
+
+void sdl3d_sprite_scene_draw(sdl3d_sprite_scene *scene, sdl3d_render_context *context, sdl3d_vec3 camera_position,
+                             const sdl3d_visibility_result *vis)
+{
+    sprite_draw_entry *draws;
+    int draw_count = 0;
+
+    if (scene == NULL || context == NULL || scene->count == 0)
+        return;
+
+    draws = (sprite_draw_entry *)SDL_malloc((size_t)scene->count * sizeof(sprite_draw_entry));
+    if (draws == NULL)
+        return;
+
+    for (int i = 0; i < scene->count; ++i)
+    {
+        const sdl3d_sprite_actor *actor = &scene->actors[i];
+        if (!actor->visible)
+            continue;
+
+        sdl3d_vec3 pos = actor->position;
+        if (actor->bob_amplitude > 0.0f)
+            pos.y += SDL_sinf(actor->bob_phase * actor->bob_speed) * actor->bob_amplitude;
+
+        /* Portal cull. */
+        if (vis != NULL && vis->sector_visible != NULL && actor->sector_id >= 0)
+        {
+            if (!vis->sector_visible[actor->sector_id])
+                continue;
+        }
+
+        float dx = pos.x - camera_position.x;
+        float dy = pos.y - camera_position.y;
+        float dz = pos.z - camera_position.z;
+
+        draws[draw_count].actor = actor;
+        draws[draw_count].texture = sdl3d_sprite_select_texture(actor, camera_position.x, camera_position.z);
+        draws[draw_count].position = pos;
+        draws[draw_count].distance_sq = dx * dx + dy * dy + dz * dz;
+        draw_count++;
+    }
+
+    SDL_qsort(draws, (size_t)draw_count, sizeof(draws[0]), compare_sprite_draws);
+
+    for (int i = 0; i < draw_count; ++i)
+    {
+        sdl3d_draw_billboard(context, draws[i].texture, draws[i].position, draws[i].actor->size, draws[i].actor->tint);
+    }
+
+    SDL_free(draws);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SDL3D_TEST_SOURCES
     test_animation.cpp
     test_effects.cpp
     test_level.cpp
+    test_fps_mover.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -179,6 +180,7 @@ else()
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SDL3D_TEST_SOURCES
     test_effects.cpp
     test_level.cpp
     test_fps_mover.cpp
+    test_sprite_actor.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -181,6 +182,7 @@ else()
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
+    sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
 

--- a/tests/test_fps_mover.cpp
+++ b/tests/test_fps_mover.cpp
@@ -1,0 +1,260 @@
+/*
+ * Unit tests for sdl3d_fps_mover. The mover is exercised against a
+ * minimal level (a single flat sector or two stacked sectors) so the
+ * physics paths can be observed without a real renderer.
+ */
+
+#include <gtest/gtest.h>
+
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+
+extern "C"
+{
+#include "sdl3d/fps_mover.h"
+#include "sdl3d/level.h"
+#include "sdl3d/math.h"
+}
+
+namespace
+{
+sdl3d_sector MakeSquareSector(float min_x, float min_z, float max_x, float max_z, float floor_y, float ceil_y)
+{
+    sdl3d_sector s{};
+    s.points[0][0] = min_x;
+    s.points[0][1] = min_z;
+    s.points[1][0] = max_x;
+    s.points[1][1] = min_z;
+    s.points[2][0] = max_x;
+    s.points[2][1] = max_z;
+    s.points[3][0] = min_x;
+    s.points[3][1] = max_z;
+    s.num_points = 4;
+    s.floor_y = floor_y;
+    s.ceil_y = ceil_y;
+    s.floor_material = 0;
+    s.ceil_material = 1;
+    s.wall_material = 2;
+    return s;
+}
+
+sdl3d_level_material MakeMaterial()
+{
+    sdl3d_level_material m{};
+    m.albedo[0] = m.albedo[1] = m.albedo[2] = m.albedo[3] = 1.0f;
+    m.roughness = 1.0f;
+    m.tex_scale = 4.0f;
+    return m;
+}
+
+sdl3d_fps_mover_config DefaultConfig()
+{
+    sdl3d_fps_mover_config c{};
+    c.move_speed = 12.0f;
+    c.jump_velocity = 6.0f;
+    c.gravity = 14.0f;
+    c.player_height = 1.6f;
+    c.player_radius = 0.35f;
+    c.step_height = 1.1f;
+    c.ceiling_clearance = 0.1f;
+    return c;
+}
+
+class FpsMoverFixture : public ::testing::Test
+{
+  protected:
+    sdl3d_level level{};
+    std::vector<sdl3d_sector> sectors;
+
+    void BuildFlat()
+    {
+        sectors = {MakeSquareSector(-10, -10, 10, 10, 0.0f, 5.0f)};
+        const sdl3d_level_material mats[] = {MakeMaterial(), MakeMaterial(), MakeMaterial()};
+        ASSERT_TRUE(sdl3d_build_level(sectors.data(), (int)sectors.size(), mats, 3, nullptr, 0, &level))
+            << SDL_GetError();
+    }
+
+    void BuildStair()
+    {
+        /* Two sectors side by side, the second one a step up. */
+        sectors = {MakeSquareSector(-10, -10, 0, 10, 0.0f, 5.0f), MakeSquareSector(0, -10, 10, 10, 1.0f, 6.0f)};
+        const sdl3d_level_material mats[] = {MakeMaterial(), MakeMaterial(), MakeMaterial()};
+        ASSERT_TRUE(sdl3d_build_level(sectors.data(), (int)sectors.size(), mats, 3, nullptr, 0, &level))
+            << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        sdl3d_free_level(&level);
+    }
+};
+
+} // namespace
+
+TEST_F(FpsMoverFixture, InitSetsSpawnAndDefaults)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(1, 1.6f, 2), 0.5f);
+
+    EXPECT_FLOAT_EQ(m.position.x, 1.0f);
+    EXPECT_FLOAT_EQ(m.position.y, 1.6f);
+    EXPECT_FLOAT_EQ(m.position.z, 2.0f);
+    EXPECT_FLOAT_EQ(m.yaw, 0.5f);
+    EXPECT_FLOAT_EQ(m.pitch, 0.0f);
+    EXPECT_TRUE(m.on_ground);
+    EXPECT_FLOAT_EQ(m.vertical_velocity, 0.0f);
+    EXPECT_FLOAT_EQ(m.view_smooth, 0.0f);
+}
+
+TEST_F(FpsMoverFixture, JumpRequiresOnGround)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    sdl3d_fps_mover_jump(&m);
+    EXPECT_FLOAT_EQ(m.vertical_velocity, cfg.jump_velocity);
+    EXPECT_FALSE(m.on_ground);
+
+    /* Second jump in mid-air is a no-op. */
+    sdl3d_fps_mover_jump(&m);
+    EXPECT_FLOAT_EQ(m.vertical_velocity, cfg.jump_velocity);
+}
+
+TEST_F(FpsMoverFixture, JumpRisesAndFallsBackToFloor)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    sdl3d_fps_mover_jump(&m);
+
+    /* Simulate ~2 seconds of physics; player should be back on the ground. */
+    sdl3d_vec2 zero{0, 0};
+    for (int i = 0; i < 200; ++i)
+    {
+        sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+
+    EXPECT_TRUE(m.on_ground);
+    EXPECT_NEAR(m.position.y, 1.6f, 0.01f);
+    EXPECT_FLOAT_EQ(m.vertical_velocity, 0.0f);
+}
+
+TEST_F(FpsMoverFixture, MouseDeltaUpdatesYawAndClampsPitch)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    sdl3d_vec2 zero{0, 0};
+    /* Yaw moves with mouse_dx. */
+    sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 100.0f, 0.0f, 0.002f, 1.0f / 60.0f);
+    EXPECT_NEAR(m.yaw, 0.2f, 1e-4f);
+
+    /* Pitch saturates at the internal limit. */
+    sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 0.0f, -100000.0f, 0.002f, 1.0f / 60.0f);
+    EXPECT_GT(m.pitch, 1.39f);
+    EXPECT_LT(m.pitch, 1.41f);
+}
+
+TEST_F(FpsMoverFixture, WishDirectionAdvancesPosition)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    sdl3d_vec2 forward{1.0f, 0.0f};
+    /* 1 second @ 12 u/s wish in +X direction. */
+    for (int i = 0; i < 60; ++i)
+    {
+        sdl3d_fps_mover_update(&m, &level, sectors.data(), forward, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+    EXPECT_GT(m.position.x, 5.0f);
+    EXPECT_LT(m.position.x, 13.0f);
+    EXPECT_NEAR(m.position.z, 0.0f, 0.01f);
+}
+
+TEST_F(FpsMoverFixture, StepUpOntoHigherSectorWhenWalking)
+{
+    BuildStair();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    /* Spawn standing on the lower sector, near the boundary. */
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(-1.0f, 1.6f, 0), 0);
+
+    /* Walk in +X over the step. */
+    sdl3d_vec2 fwd{1.0f, 0.0f};
+    for (int i = 0; i < 60; ++i)
+    {
+        sdl3d_fps_mover_update(&m, &level, sectors.data(), fwd, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+
+    EXPECT_GT(m.position.x, 1.0f);
+    /* Player should now be standing on floor=1.0 → eye at 2.6. */
+    EXPECT_NEAR(m.position.y, 2.6f, 0.05f);
+    EXPECT_TRUE(m.on_ground);
+}
+
+TEST_F(FpsMoverFixture, FallingBelowWorldRestoresLastGood)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    /* Run one frame to capture last-known-good. */
+    sdl3d_vec2 zero{0, 0};
+    sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 0, 0, 0.002f, 1.0f / 60.0f);
+    sdl3d_vec3 expected_good = m.position;
+
+    /* Forcibly drop the player below the world and run physics. */
+    m.position.y = -100.0f;
+    m.on_ground = false;
+    m.vertical_velocity = -10.0f;
+
+    sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 0, 0, 0.002f, 1.0f / 60.0f);
+
+    EXPECT_TRUE(m.on_ground);
+    EXPECT_NEAR(m.position.x, expected_good.x, 0.01f);
+    EXPECT_NEAR(m.position.y, expected_good.y, 0.01f);
+    EXPECT_NEAR(m.position.z, expected_good.z, 0.01f);
+}
+
+TEST_F(FpsMoverFixture, NullArgsAreSafeNoOps)
+{
+    BuildFlat();
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0, 1.6f, 0), 0);
+
+    sdl3d_vec2 zero{0, 0};
+    /* These should not crash. */
+    sdl3d_fps_mover_update(nullptr, &level, sectors.data(), zero, 0, 0, 0, 1.0f / 60.0f);
+    sdl3d_fps_mover_update(&m, nullptr, sectors.data(), zero, 0, 0, 0, 1.0f / 60.0f);
+    sdl3d_fps_mover_update(&m, &level, nullptr, zero, 0, 0, 0, 1.0f / 60.0f);
+    sdl3d_fps_mover_jump(nullptr);
+    sdl3d_fps_mover_init(nullptr, &cfg, sdl3d_vec3_make(0, 0, 0), 0);
+    sdl3d_fps_mover_init(&m, nullptr, sdl3d_vec3_make(0, 0, 0), 0);
+}
+
+TEST(FpsMoverCamera, CameraIncludesViewSmoothOffset)
+{
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(1, 2, 3), 0);
+    m.view_smooth = 0.25f;
+
+    sdl3d_camera3d cam = sdl3d_fps_mover_camera(&m, 75.0f);
+    EXPECT_FLOAT_EQ(cam.position.x, 1.0f);
+    EXPECT_FLOAT_EQ(cam.position.y, 2.25f);
+    EXPECT_FLOAT_EQ(cam.position.z, 3.0f);
+    EXPECT_FLOAT_EQ(cam.fovy, 75.0f);
+    EXPECT_EQ(cam.projection, SDL3D_CAMERA_PERSPECTIVE);
+}

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -292,6 +292,163 @@ TEST(SDL3DLevelVisibility, FindSectorReturnsCorrectSector)
     sdl3d_free_level(&level);
 }
 
+/* ================================================================== */
+/* Sector queries (find_sector_at, walkable, support, point_inside)   */
+/* ================================================================== */
+
+namespace
+{
+sdl3d_sector MakeStackedSector(float min_x, float min_z, float max_x, float max_z, float floor_y, float ceil_y)
+{
+    sdl3d_sector s = MakeSquareSector(min_x, min_z, max_x, max_z);
+    s.floor_y = floor_y;
+    s.ceil_y = ceil_y;
+    return s;
+}
+} // namespace
+
+TEST(SDL3DSectorQueries, FindSectorAtPicksHighestFloorContaining)
+{
+    /* Two sectors at the same XZ but stacked: lower (floor=0,ceil=1) and
+     * upper (floor=2,ceil=4). feet_y=0.5 sits in the lower; feet_y=2.5 in
+     * the upper; feet_y between them returns -1. */
+    const sdl3d_level_material mats[] = {MakeLevelMaterial("a.png"), MakeLevelMaterial("b.png"),
+                                         MakeLevelMaterial("c.png")};
+    const sdl3d_sector sectors[] = {MakeStackedSector(0, 0, 4, 4, 0, 1), MakeStackedSector(0, 0, 4, 4, 2, 4)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, mats, 3, nullptr, 0, &level));
+
+    EXPECT_EQ(sdl3d_level_find_sector_at(&level, sectors, 2, 2, 0.5f), 0);
+    EXPECT_EQ(sdl3d_level_find_sector_at(&level, sectors, 2, 2, 2.5f), 1);
+    EXPECT_EQ(sdl3d_level_find_sector_at(&level, sectors, 2, 2, 1.5f), -1);
+    EXPECT_EQ(sdl3d_level_find_sector_at(&level, sectors, 20, 20, 0.5f), -1);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DSectorQueries, FindWalkableAcceptsStepUpButRejectsTooHigh)
+{
+    /* Stair: low (floor=0) adjacent to mid (floor=1.0). With step=1.1
+     * the mid is reachable from the low. With step=0.5 it is not. */
+    const sdl3d_level_material mats[] = {MakeLevelMaterial("a.png"), MakeLevelMaterial("b.png"),
+                                         MakeLevelMaterial("c.png")};
+    const sdl3d_sector sectors[] = {MakeStackedSector(0, 0, 4, 4, 0, 4), MakeStackedSector(4, 0, 8, 4, 1, 5)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, mats, 3, nullptr, 0, &level));
+
+    /* From the low sector (feet at floor 0), the mid sector is one step up. */
+    EXPECT_EQ(sdl3d_level_find_walkable_sector(&level, sectors, 6, 2, 0.0f, 1.1f, 1.6f), 1);
+    EXPECT_EQ(sdl3d_level_find_walkable_sector(&level, sectors, 6, 2, 0.0f, 0.5f, 1.6f), -1);
+
+    /* Headroom rejection: a 1.0-tall sector should be rejected for a 1.6 player. */
+    const sdl3d_sector tight[] = {MakeStackedSector(0, 0, 4, 4, 0, 1.0f)};
+    sdl3d_level tight_level{};
+    ASSERT_TRUE(sdl3d_build_level(tight, 1, mats, 3, nullptr, 0, &tight_level));
+    EXPECT_EQ(sdl3d_level_find_walkable_sector(&tight_level, tight, 2, 2, 0.0f, 1.0f, 1.6f), -1);
+    sdl3d_free_level(&tight_level);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DSectorQueries, FindSupportPicksHighestFloorAtOrBelow)
+{
+    /* Stacked: floors at 0 and 2. From feet_y=3 the support is the
+     * upper floor (2); from feet_y=1.5 the support is the lower (0);
+     * from feet_y=-1 there is no support. */
+    const sdl3d_level_material mats[] = {MakeLevelMaterial("a.png"), MakeLevelMaterial("b.png"),
+                                         MakeLevelMaterial("c.png")};
+    const sdl3d_sector sectors[] = {MakeStackedSector(0, 0, 4, 4, 0, 1.7f), MakeStackedSector(0, 0, 4, 4, 2, 4)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, mats, 3, nullptr, 0, &level));
+
+    EXPECT_EQ(sdl3d_level_find_support_sector(&level, sectors, 2, 2, 3.0f, 1.6f), 1);
+    EXPECT_EQ(sdl3d_level_find_support_sector(&level, sectors, 2, 2, 1.5f, 1.6f), 0);
+    EXPECT_EQ(sdl3d_level_find_support_sector(&level, sectors, 2, 2, -1.0f, 1.6f), -1);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DSectorQueries, PointInsideRespectsXZAndY)
+{
+    const sdl3d_level_material mats[] = {MakeLevelMaterial("a.png"), MakeLevelMaterial("b.png"),
+                                         MakeLevelMaterial("c.png")};
+    const sdl3d_sector sectors[] = {MakeStackedSector(0, 0, 4, 4, 0, 3)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, mats, 3, nullptr, 0, &level));
+
+    EXPECT_TRUE(sdl3d_level_point_inside(&level, sectors, 2, 1.5f, 2));
+    EXPECT_FALSE(sdl3d_level_point_inside(&level, sectors, 2, 5.0f, 2));  /* above ceil */
+    EXPECT_FALSE(sdl3d_level_point_inside(&level, sectors, 2, -1.0f, 2)); /* below floor */
+    EXPECT_FALSE(sdl3d_level_point_inside(&level, sectors, 20, 1.5f, 2)); /* outside xz */
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DSectorQueries, NullArgsReturnSafeDefaults)
+{
+    EXPECT_EQ(sdl3d_level_find_sector_at(nullptr, nullptr, 0, 0, 0), -1);
+    EXPECT_EQ(sdl3d_level_find_walkable_sector(nullptr, nullptr, 0, 0, 0, 1, 1), -1);
+    EXPECT_EQ(sdl3d_level_find_support_sector(nullptr, nullptr, 0, 0, 0, 1), -1);
+    EXPECT_FALSE(sdl3d_level_point_inside(nullptr, nullptr, 0, 0, 0));
+}
+
+/* ================================================================== */
+/* Frustum extraction                                                 */
+/* ================================================================== */
+
+TEST(SDL3DExtractFrustumPlanes, IdentityVPYieldsUnitCubeBoundary)
+{
+    /* For VP = identity, the frustum is the clip-space cube [-1,1]^3. */
+    sdl3d_mat4 vp = sdl3d_mat4_identity();
+    float planes[6][4];
+    sdl3d_extract_frustum_planes(vp, planes);
+
+    /* Plane d should be 1 for each face of the unit cube. */
+    for (int i = 0; i < 6; ++i)
+    {
+        EXPECT_NEAR(planes[i][3], 1.0f, 1e-4f) << "plane " << i;
+    }
+}
+
+/* ================================================================== */
+/* Light sampling                                                     */
+/* ================================================================== */
+
+TEST(SDL3DLevelSampleLight, AccumulatesAndAttenuates)
+{
+    sdl3d_level_light l{};
+    l.position[0] = 0;
+    l.position[1] = 0;
+    l.position[2] = 0;
+    l.color[0] = 1.0f;
+    l.color[1] = 0.0f;
+    l.color[2] = 0.0f;
+    l.intensity = 1.0f;
+    l.range = 4.0f;
+
+    /* At the center, fully lit (clamped to 255). */
+    sdl3d_color at_center = sdl3d_level_sample_light(&l, 1, sdl3d_vec3_make(0.001f, 0, 0));
+    EXPECT_GT(at_center.r, 200);
+    EXPECT_EQ(at_center.g, 0);
+
+    /* Outside range, no light. */
+    sdl3d_color far_away = sdl3d_level_sample_light(&l, 1, sdl3d_vec3_make(10, 0, 0));
+    EXPECT_EQ(far_away.r, 0);
+
+    /* Halfway, attenuated. */
+    sdl3d_color mid = sdl3d_level_sample_light(&l, 1, sdl3d_vec3_make(2, 0, 0));
+    EXPECT_GT(mid.r, 0);
+    EXPECT_LT(mid.r, at_center.r);
+}
+
+TEST(SDL3DLevelSampleLight, NullOrEmptyReturnsBlack)
+{
+    sdl3d_color c = sdl3d_level_sample_light(nullptr, 0, sdl3d_vec3_make(0, 0, 0));
+    EXPECT_EQ(c.r, 0);
+    EXPECT_EQ(c.g, 0);
+    EXPECT_EQ(c.b, 0);
+}
+
 TEST(SDL3DLevelVisibility, VisibilityFromSectorZeroSeesNeighbor)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -553,3 +553,118 @@ TEST(SDL3DDrawModelCulling, SkipsOffscreenChunkBeforeMaterialValidation)
     SDL_DestroyWindow(window);
     SDL_Quit();
 }
+
+/* ================================================================== */
+/* Visibility from camera convenience                                 */
+/* ================================================================== */
+
+TEST(SDL3DLevelVisibility, ComputeVisibilityFromCameraBasic)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    /* Two adjacent sectors sharing an edge at x=4. */
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    bool visible[2] = {};
+    sdl3d_visibility_result vis;
+    vis.sector_visible = visible;
+    vis.visible_count = 0;
+
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    cam.target = sdl3d_vec3_make(6.0f, 1.5f, 2.0f); /* looking toward sector 1 */
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 75.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_level_compute_visibility_from_camera(&level, sectors, &cam, 1280, 720, 0.01f, 1000.0f, &vis);
+
+    EXPECT_TRUE(visible[0]);
+    EXPECT_TRUE(visible[1]);
+    EXPECT_EQ(vis.visible_count, 2);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelVisibility, ComputeVisibilityFromCameraNullSafe)
+{
+    sdl3d_visibility_result vis{};
+    sdl3d_camera3d cam{};
+    /* Should not crash. */
+    sdl3d_level_compute_visibility_from_camera(nullptr, nullptr, &cam, 1280, 720, 0.01f, 1000.0f, &vis);
+    sdl3d_level_compute_visibility_from_camera(nullptr, nullptr, nullptr, 1280, 720, 0.01f, 1000.0f, &vis);
+}
+
+/* ================================================================== */
+/* Point trace                                                        */
+/* ================================================================== */
+
+TEST(SDL3DLevelTrace, TraceInsideSectorReachesEnd)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 20.0f, 20.0f)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    sdl3d_vec3 origin = sdl3d_vec3_make(10.0f, 1.5f, 10.0f);
+    sdl3d_vec3 dir = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    sdl3d_level_trace_result r = sdl3d_level_trace_point(&level, sectors, origin, dir, 2.0f);
+
+    EXPECT_FALSE(r.hit);
+    EXPECT_NEAR(r.end_point.x, 12.0f, 0.3f);
+    EXPECT_FLOAT_EQ(r.fraction, 1.0f);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelTrace, TraceExitsSectorHits)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    sdl3d_vec3 origin = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    sdl3d_vec3 dir = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    sdl3d_level_trace_result r = sdl3d_level_trace_point(&level, sectors, origin, dir, 20.0f);
+
+    EXPECT_TRUE(r.hit);
+    /* Should stop near x=4 (the sector boundary). */
+    EXPECT_GT(r.end_point.x, 3.5f);
+    EXPECT_LT(r.end_point.x, 4.5f);
+    EXPECT_GT(r.fraction, 0.0f);
+    EXPECT_LT(r.fraction, 1.0f);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelTrace, TraceNullSafe)
+{
+    sdl3d_vec3 o = sdl3d_vec3_make(0, 0, 0);
+    sdl3d_vec3 d = sdl3d_vec3_make(1, 0, 0);
+    sdl3d_level_trace_result r = sdl3d_level_trace_point(nullptr, nullptr, o, d, 10.0f);
+    EXPECT_FALSE(r.hit);
+    EXPECT_FLOAT_EQ(r.fraction, 0.0f);
+}
+
+TEST(SDL3DLevelTrace, TraceZeroDistanceReturnsOrigin)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    const sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f)};
+    sdl3d_level level{};
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    sdl3d_vec3 origin = sdl3d_vec3_make(2.0f, 1.5f, 2.0f);
+    sdl3d_vec3 dir = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+    sdl3d_level_trace_result r = sdl3d_level_trace_point(&level, sectors, origin, dir, 0.0f);
+
+    EXPECT_FALSE(r.hit);
+    EXPECT_FLOAT_EQ(r.fraction, 0.0f);
+
+    sdl3d_free_level(&level);
+}

--- a/tests/test_sprite_actor.cpp
+++ b/tests/test_sprite_actor.cpp
@@ -1,0 +1,200 @@
+/*
+ * Unit tests for sdl3d_sprite_actor / sdl3d_sprite_scene.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/math.h"
+#include "sdl3d/sprite_actor.h"
+}
+
+/* ================================================================== */
+/* Scene lifecycle                                                    */
+/* ================================================================== */
+
+TEST(SpriteScene, InitAndFree)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+    EXPECT_EQ(scene.count, 0);
+    EXPECT_EQ(scene.capacity, 0);
+    sdl3d_sprite_scene_free(&scene);
+}
+
+TEST(SpriteScene, FreeNullIsSafe)
+{
+    sdl3d_sprite_scene_free(nullptr);
+}
+
+TEST(SpriteScene, AddReturnsValidActor)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+
+    sdl3d_sprite_actor *a = sdl3d_sprite_scene_add(&scene);
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(scene.count, 1);
+    EXPECT_TRUE(a->visible);
+    EXPECT_EQ(a->sector_id, -1);
+    EXPECT_EQ(a->tint.r, 255);
+    EXPECT_EQ(a->tint.a, 255);
+
+    sdl3d_sprite_scene_free(&scene);
+}
+
+TEST(SpriteScene, AddNullReturnsNull)
+{
+    EXPECT_EQ(sdl3d_sprite_scene_add(nullptr), nullptr);
+}
+
+TEST(SpriteScene, RemoveSwapsWithLast)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+
+    sdl3d_sprite_actor *a = sdl3d_sprite_scene_add(&scene);
+    sdl3d_sprite_actor *b = sdl3d_sprite_scene_add(&scene);
+    sdl3d_sprite_actor *c = sdl3d_sprite_scene_add(&scene);
+    a->bob_speed = 1.0f;
+    b->bob_speed = 2.0f;
+    c->bob_speed = 3.0f;
+
+    /* Remove index 0 — c should swap into slot 0. */
+    sdl3d_sprite_scene_remove(&scene, 0);
+    EXPECT_EQ(scene.count, 2);
+    EXPECT_FLOAT_EQ(scene.actors[0].bob_speed, 3.0f);
+    EXPECT_FLOAT_EQ(scene.actors[1].bob_speed, 2.0f);
+
+    sdl3d_sprite_scene_free(&scene);
+}
+
+TEST(SpriteScene, RemoveOutOfBoundsIsSafe)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+    sdl3d_sprite_scene_remove(&scene, 0);
+    sdl3d_sprite_scene_remove(&scene, -1);
+    sdl3d_sprite_scene_remove(nullptr, 0);
+    sdl3d_sprite_scene_free(&scene);
+}
+
+/* ================================================================== */
+/* Update                                                             */
+/* ================================================================== */
+
+TEST(SpriteScene, UpdateAdvancesBobPhase)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+
+    sdl3d_sprite_actor *a = sdl3d_sprite_scene_add(&scene);
+    a->bob_amplitude = 0.1f;
+    a->bob_speed = 2.0f;
+    EXPECT_FLOAT_EQ(a->bob_phase, 0.0f);
+
+    sdl3d_sprite_scene_update(&scene, 0.5f);
+    EXPECT_FLOAT_EQ(scene.actors[0].bob_phase, 0.5f);
+
+    sdl3d_sprite_scene_update(&scene, 0.25f);
+    EXPECT_FLOAT_EQ(scene.actors[0].bob_phase, 0.75f);
+
+    sdl3d_sprite_scene_free(&scene);
+}
+
+TEST(SpriteScene, UpdateNullIsSafe)
+{
+    sdl3d_sprite_scene_update(nullptr, 1.0f);
+}
+
+/* ================================================================== */
+/* Texture selection                                                  */
+/* ================================================================== */
+
+TEST(SpriteActor, SelectTextureNoRotationsReturnsSingle)
+{
+    sdl3d_texture2d tex{};
+    tex.width = 32;
+    sdl3d_sprite_actor actor{};
+    actor.texture = &tex;
+    actor.rotations = nullptr;
+
+    const sdl3d_texture2d *result = sdl3d_sprite_select_texture(&actor, 10.0f, 10.0f);
+    EXPECT_EQ(result, &tex);
+}
+
+TEST(SpriteActor, SelectTextureNullActorReturnsNull)
+{
+    EXPECT_EQ(sdl3d_sprite_select_texture(nullptr, 0, 0), nullptr);
+}
+
+TEST(SpriteActor, SelectTextureSouthWhenCameraSouth)
+{
+    sdl3d_texture2d frames[SDL3D_SPRITE_ROTATION_COUNT]{};
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
+        frames[i].width = i + 1; /* use width as a tag */
+
+    sdl3d_sprite_rotation_set rot{};
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
+        rot.frames[i] = &frames[i];
+
+    sdl3d_sprite_actor actor{};
+    actor.position = sdl3d_vec3_make(0, 0, 0);
+    actor.rotations = &rot;
+
+    /* Camera directly south of actor (negative Z). */
+    const sdl3d_texture2d *result = sdl3d_sprite_select_texture(&actor, 0.0f, -10.0f);
+    /* Should select frame[0] = south. */
+    EXPECT_EQ(result->width, 1);
+}
+
+TEST(SpriteActor, SelectTextureNorthWhenCameraNorth)
+{
+    sdl3d_texture2d frames[SDL3D_SPRITE_ROTATION_COUNT]{};
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
+        frames[i].width = i + 1;
+
+    sdl3d_sprite_rotation_set rot{};
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
+        rot.frames[i] = &frames[i];
+
+    sdl3d_sprite_actor actor{};
+    actor.position = sdl3d_vec3_make(0, 0, 0);
+    actor.rotations = &rot;
+
+    /* Camera directly north of actor (positive Z). */
+    const sdl3d_texture2d *result = sdl3d_sprite_select_texture(&actor, 0.0f, 10.0f);
+    /* Should select frame[4] = north. */
+    EXPECT_EQ(result->width, 5);
+}
+
+TEST(SpriteActor, SelectTextureFallsBackWhenFrameNull)
+{
+    sdl3d_texture2d fallback{};
+    fallback.width = 99;
+
+    sdl3d_sprite_rotation_set rot{};
+    /* All frames NULL. */
+
+    sdl3d_sprite_actor actor{};
+    actor.position = sdl3d_vec3_make(0, 0, 0);
+    actor.texture = &fallback;
+    actor.rotations = &rot;
+
+    const sdl3d_texture2d *result = sdl3d_sprite_select_texture(&actor, 0.0f, -10.0f);
+    EXPECT_EQ(result, &fallback);
+}
+
+/* ================================================================== */
+/* Draw (NULL safety)                                                 */
+/* ================================================================== */
+
+TEST(SpriteScene, DrawNullArgsAreSafe)
+{
+    sdl3d_sprite_scene scene;
+    sdl3d_sprite_scene_init(&scene);
+    sdl3d_sprite_scene_draw(nullptr, nullptr, sdl3d_vec3_make(0, 0, 0), nullptr);
+    sdl3d_sprite_scene_draw(&scene, nullptr, sdl3d_vec3_make(0, 0, 0), nullptr);
+    sdl3d_sprite_scene_free(&scene);
+}


### PR DESCRIPTION
## Summary

Implements Phases A and B of the game framework strategy. These are the foundational primitives that make it natural to build Doom/Quake-style first-person games with SDL3D.

### Phase A — Sector queries (extends `level.h`)

Six new public APIs extracted from the doom_level demo:

- `sdl3d_level_find_sector_at` — sector containing point with height check, picks highest floor for stacked sectors
- `sdl3d_level_find_walkable_sector` — highest sector reachable by stepping up, with headroom enforcement
- `sdl3d_level_find_support_sector` — highest floor at or below feet for falling/floor-snap
- `sdl3d_level_point_inside` — point-in-volume test (XZ polygon + Y bounds)
- `sdl3d_extract_frustum_planes` — Gribb/Hartmann extraction, replaces inline blocks in demos
- `sdl3d_level_sample_light` — accumulated point-light contribution with quadratic falloff, no ambient floor

### Phase B — FPS mover (new `fps_mover.h`)

~330 LOC encapsulating the full Quake-style movement pipeline:

- Mouse look with pitch clamp
- Wish-direction normalization and sliding collision with axis fallback
- Step-up onto higher sectors
- Substepped vertical integration (the issue #76 stair fix, generalized)
- Ceiling clamp, floor snap, ground-trace rescue (PM_GroundTrace)
- Last-known-good position fallback
- Quake-style view smoothing for stair transitions

API: `init`, `update`, `jump`, `camera`. Caller owns the game loop and input mapping.

### Demo refactor

doom_level demo shrank by ~280 lines of inline physics. Local helpers replaced by Phase A library calls. Physics block replaced by one `sdl3d_fps_mover_update` call.

## Test plan

- 8 new level query tests (sector queries, frustum extraction, light sampling, NULL safety)
- 9 new fps_mover tests (init, jump gating, gravity round-trip, mouse look, movement, stair step-up, last-known-good rescue, NULL safety, camera view-smooth)
- Full suite: 548/548 green
- `make format` clean
- doom_level demo builds and runs with identical behavior

🤖 Generated with [Kiro CLI](https://kiro.dev)