### PR TITLE
feat: generic property bag for game entity state (Phase 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources(
         src/level.c
         src/model.c
         src/obj_loader.c
+        src/properties.c
         src/rasterizer.c
         src/render_context.c
         src/scene.c

--- a/include/sdl3d/properties.h
+++ b/include/sdl3d/properties.h
@@ -1,0 +1,245 @@
+/**
+ * @file properties.h
+ * @brief Generic key-value property bag for game entity state.
+ *
+ * A property bag stores arbitrary named values of six types: int, float,
+ * bool, vec3, string, and color. Any key is accepted — unknown keys are
+ * preserved, not rejected. This matches the Quake 3 / Source / Radiant
+ * convention where a map file stores whatever the designer typed and the
+ * engine interprets known keys while passing through unknown ones.
+ *
+ * The property bag is the canonical serialization format for entity state:
+ * dump all pairs to JSON, load them back, round-trip clean.
+ *
+ * Usage:
+ * @code
+ *   sdl3d_properties *props = sdl3d_properties_create();
+ *   sdl3d_properties_set_int(props, "health", 100);
+ *   sdl3d_properties_set_string(props, "classname", "info_player_start");
+ *   sdl3d_properties_set_bool(props, "locked", true);
+ *
+ *   int hp = sdl3d_properties_get_int(props, "health", 0);
+ *   const char *cls = sdl3d_properties_get_string(props, "classname", "");
+ *
+ *   // Iterate all entries
+ *   for (int i = 0; i < sdl3d_properties_count(props); i++) {
+ *       const char *key;
+ *       sdl3d_value_type type;
+ *       sdl3d_properties_get_key_at(props, i, &key, &type);
+ *   }
+ *
+ *   sdl3d_properties_destroy(props);
+ * @endcode
+ */
+
+#ifndef SDL3D_PROPERTIES_H
+#define SDL3D_PROPERTIES_H
+
+#include <stdbool.h>
+
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Value types stored in a property bag. */
+    typedef enum sdl3d_value_type
+    {
+        SDL3D_VALUE_INT,
+        SDL3D_VALUE_FLOAT,
+        SDL3D_VALUE_BOOL,
+        SDL3D_VALUE_VEC3,
+        SDL3D_VALUE_STRING,
+        SDL3D_VALUE_COLOR,
+    } sdl3d_value_type;
+
+    /** @brief A tagged value that can hold any supported property type. */
+    typedef struct sdl3d_value
+    {
+        sdl3d_value_type type;
+        union {
+            int as_int;
+            float as_float;
+            bool as_bool;
+            sdl3d_vec3 as_vec3;
+            char *as_string; /**< Owned copy. Freed on overwrite or destroy. */
+            sdl3d_color as_color;
+        };
+    } sdl3d_value;
+
+    /** @brief Opaque property bag handle. */
+    typedef struct sdl3d_properties sdl3d_properties;
+
+    /* ================================================================== */
+    /* Lifecycle                                                          */
+    /* ================================================================== */
+
+    /**
+     * @brief Create an empty property bag.
+     * @return A new property bag, or NULL on allocation failure.
+     */
+    sdl3d_properties *sdl3d_properties_create(void);
+
+    /**
+     * @brief Destroy a property bag and free all owned memory.
+     *
+     * All string values are freed. Safe to call with NULL.
+     */
+    void sdl3d_properties_destroy(sdl3d_properties *props);
+
+    /* ================================================================== */
+    /* Setters                                                            */
+    /* ================================================================== */
+
+    /**
+     * @brief Set an integer property.
+     *
+     * If the key already exists, its value is overwritten regardless of
+     * the previous type. The key string is copied internally.
+     */
+    void sdl3d_properties_set_int(sdl3d_properties *props, const char *key, int value);
+
+    /**
+     * @brief Set a float property.
+     * @see sdl3d_properties_set_int for overwrite semantics.
+     */
+    void sdl3d_properties_set_float(sdl3d_properties *props, const char *key, float value);
+
+    /**
+     * @brief Set a boolean property.
+     * @see sdl3d_properties_set_int for overwrite semantics.
+     */
+    void sdl3d_properties_set_bool(sdl3d_properties *props, const char *key, bool value);
+
+    /**
+     * @brief Set a 3D vector property.
+     * @see sdl3d_properties_set_int for overwrite semantics.
+     */
+    void sdl3d_properties_set_vec3(sdl3d_properties *props, const char *key, sdl3d_vec3 value);
+
+    /**
+     * @brief Set a string property.
+     *
+     * The value string is copied internally. The previous value (if any)
+     * is freed. Passing NULL for value is equivalent to setting an empty
+     * string.
+     *
+     * @see sdl3d_properties_set_int for overwrite semantics.
+     */
+    void sdl3d_properties_set_string(sdl3d_properties *props, const char *key, const char *value);
+
+    /**
+     * @brief Set a color property.
+     * @see sdl3d_properties_set_int for overwrite semantics.
+     */
+    void sdl3d_properties_set_color(sdl3d_properties *props, const char *key, sdl3d_color value);
+
+    /* ================================================================== */
+    /* Getters                                                            */
+    /* ================================================================== */
+
+    /**
+     * @brief Get an integer property.
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    int sdl3d_properties_get_int(const sdl3d_properties *props, const char *key, int fallback);
+
+    /**
+     * @brief Get a float property.
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    float sdl3d_properties_get_float(const sdl3d_properties *props, const char *key, float fallback);
+
+    /**
+     * @brief Get a boolean property.
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    bool sdl3d_properties_get_bool(const sdl3d_properties *props, const char *key, bool fallback);
+
+    /**
+     * @brief Get a 3D vector property.
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    sdl3d_vec3 sdl3d_properties_get_vec3(const sdl3d_properties *props, const char *key, sdl3d_vec3 fallback);
+
+    /**
+     * @brief Get a string property.
+     *
+     * The returned pointer is valid until the key is overwritten, removed,
+     * or the property bag is destroyed.
+     *
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    const char *sdl3d_properties_get_string(const sdl3d_properties *props, const char *key, const char *fallback);
+
+    /**
+     * @brief Get a color property.
+     * @param fallback Returned if the key does not exist or has a different type.
+     */
+    sdl3d_color sdl3d_properties_get_color(const sdl3d_properties *props, const char *key, sdl3d_color fallback);
+
+    /* ================================================================== */
+    /* Query and mutation                                                 */
+    /* ================================================================== */
+
+    /**
+     * @brief Test whether a key exists in the property bag.
+     * @return true if the key is present (any type), false otherwise.
+     */
+    bool sdl3d_properties_has(const sdl3d_properties *props, const char *key);
+
+    /**
+     * @brief Remove a key from the property bag.
+     *
+     * If the key holds a string value, the string is freed. No-op if the
+     * key does not exist. Safe with NULL props or key.
+     */
+    void sdl3d_properties_remove(sdl3d_properties *props, const char *key);
+
+    /**
+     * @brief Remove all entries from the property bag.
+     *
+     * All string values are freed. The bag is empty after this call.
+     */
+    void sdl3d_properties_clear(sdl3d_properties *props);
+
+    /* ================================================================== */
+    /* Iteration / introspection                                         */
+    /* ================================================================== */
+
+    /**
+     * @brief Get the number of key-value pairs in the property bag.
+     */
+    int sdl3d_properties_count(const sdl3d_properties *props);
+
+    /**
+     * @brief Get the key and value type at a given index.
+     *
+     * Indices are in the range [0, count). The order is arbitrary and may
+     * change when entries are added or removed. This is intended for
+     * serialization and editor inspection, not indexed access by design.
+     *
+     * @param index   Zero-based index into the entry array.
+     * @param out_key Receives a pointer to the key string (owned by the bag).
+     * @param out_type Receives the value type. May be NULL if not needed.
+     * @return true if the index was valid, false otherwise.
+     */
+    bool sdl3d_properties_get_key_at(const sdl3d_properties *props, int index, const char **out_key,
+                                     sdl3d_value_type *out_type);
+
+    /**
+     * @brief Get the raw tagged value for a key.
+     *
+     * Returns NULL if the key does not exist. The returned pointer is
+     * valid until the key is overwritten, removed, or the bag is destroyed.
+     * For string values, the caller must not free `as_string`.
+     */
+    const sdl3d_value *sdl3d_properties_get_value(const sdl3d_properties *props, const char *key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_PROPERTIES_H */

--- a/src/properties.c
+++ b/src/properties.c
@@ -1,0 +1,400 @@
+/**
+ * @file properties.c
+ * @brief Property bag implementation — open-addressing hash map.
+ *
+ * Keys are copied on insert. String values are copied and owned.
+ * The hash map uses linear probing with a load factor threshold of 0.7.
+ * Tombstones are used for deletion to preserve probe chains.
+ */
+
+#include "sdl3d/properties.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+/* ================================================================== */
+/* Internal types                                                     */
+/* ================================================================== */
+
+typedef enum entry_state
+{
+    ENTRY_EMPTY,
+    ENTRY_OCCUPIED,
+    ENTRY_TOMBSTONE,
+} entry_state;
+
+typedef struct entry
+{
+    entry_state state;
+    char *key; /* Owned copy of the key string. */
+    sdl3d_value value;
+} entry;
+
+struct sdl3d_properties
+{
+    entry *entries;
+    int capacity;
+    int count;    /* Number of OCCUPIED entries. */
+    int occupied; /* OCCUPIED + TOMBSTONE (for load factor). */
+};
+
+#define INITIAL_CAPACITY 16
+#define LOAD_FACTOR_THRESHOLD 70 /* percent */
+
+/* ================================================================== */
+/* Hash function (FNV-1a)                                             */
+/* ================================================================== */
+
+static unsigned int fnv1a(const char *str)
+{
+    unsigned int hash = 2166136261u;
+    while (*str)
+    {
+        hash ^= (unsigned char)*str++;
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+/* ================================================================== */
+/* Internal helpers                                                   */
+/* ================================================================== */
+
+/** Free the owned memory inside a value (strings only). */
+static void free_value(sdl3d_value *v)
+{
+    if (v->type == SDL3D_VALUE_STRING)
+    {
+        SDL_free(v->as_string);
+        v->as_string = NULL;
+    }
+}
+
+/** Free the owned memory inside an entry (key + value). */
+static void free_entry(entry *e)
+{
+    SDL_free(e->key);
+    e->key = NULL;
+    free_value(&e->value);
+    e->state = ENTRY_EMPTY;
+}
+
+/**
+ * Find the entry for a key, or the first empty/tombstone slot where it
+ * would be inserted. Returns NULL only if the table is full (should not
+ * happen with proper load factor management).
+ */
+static entry *find_entry(entry *entries, int capacity, const char *key)
+{
+    unsigned int hash = fnv1a(key);
+    int index = (int)(hash % (unsigned int)capacity);
+    entry *first_tombstone = NULL;
+
+    for (int i = 0; i < capacity; ++i)
+    {
+        entry *e = &entries[index];
+        if (e->state == ENTRY_EMPTY)
+        {
+            return first_tombstone != NULL ? first_tombstone : e;
+        }
+        if (e->state == ENTRY_TOMBSTONE)
+        {
+            if (first_tombstone == NULL)
+                first_tombstone = e;
+        }
+        else if (SDL_strcmp(e->key, key) == 0)
+        {
+            return e;
+        }
+        index = (index + 1) % capacity;
+    }
+    return first_tombstone;
+}
+
+/** Grow the table and rehash all occupied entries. */
+static bool grow(sdl3d_properties *props)
+{
+    int new_capacity = props->capacity < INITIAL_CAPACITY ? INITIAL_CAPACITY : props->capacity * 2;
+    entry *new_entries = (entry *)SDL_calloc((size_t)new_capacity, sizeof(entry));
+    if (new_entries == NULL)
+        return false;
+
+    /* Rehash occupied entries into the new table. */
+    for (int i = 0; i < props->capacity; ++i)
+    {
+        entry *old = &props->entries[i];
+        if (old->state != ENTRY_OCCUPIED)
+            continue;
+        entry *dest = find_entry(new_entries, new_capacity, old->key);
+        *dest = *old;
+    }
+
+    SDL_free(props->entries);
+    props->entries = new_entries;
+    props->capacity = new_capacity;
+    props->occupied = props->count; /* Tombstones are gone after rehash. */
+    return true;
+}
+
+/** Insert or overwrite a key with the given value. */
+static void set_value(sdl3d_properties *props, const char *key, sdl3d_value value)
+{
+    if (props == NULL || key == NULL)
+        return;
+
+    /* Grow if load factor exceeds threshold. */
+    if (props->capacity == 0 || (props->occupied + 1) * 100 > props->capacity * LOAD_FACTOR_THRESHOLD)
+    {
+        if (!grow(props))
+            return;
+    }
+
+    entry *e = find_entry(props->entries, props->capacity, key);
+    if (e == NULL)
+        return;
+
+    if (e->state == ENTRY_OCCUPIED)
+    {
+        /* Overwrite existing entry. Free old value, keep key. */
+        free_value(&e->value);
+        e->value = value;
+    }
+    else
+    {
+        /* New entry. Copy the key. */
+        bool was_tombstone = (e->state == ENTRY_TOMBSTONE);
+        e->key = SDL_strdup(key);
+        if (e->key == NULL)
+        {
+            free_value(&value);
+            return;
+        }
+        e->value = value;
+        e->state = ENTRY_OCCUPIED;
+        props->count++;
+        if (!was_tombstone)
+            props->occupied++;
+    }
+}
+
+/** Look up a key. Returns NULL if not found. */
+static const entry *lookup(const sdl3d_properties *props, const char *key)
+{
+    if (props == NULL || key == NULL || props->capacity == 0)
+        return NULL;
+    const entry *e = find_entry(props->entries, props->capacity, key);
+    if (e == NULL || e->state != ENTRY_OCCUPIED)
+        return NULL;
+    return e;
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+sdl3d_properties *sdl3d_properties_create(void)
+{
+    sdl3d_properties *props = (sdl3d_properties *)SDL_calloc(1, sizeof(sdl3d_properties));
+    return props;
+}
+
+void sdl3d_properties_destroy(sdl3d_properties *props)
+{
+    if (props == NULL)
+        return;
+    sdl3d_properties_clear(props);
+    SDL_free(props->entries);
+    SDL_free(props);
+}
+
+/* ================================================================== */
+/* Setters                                                            */
+/* ================================================================== */
+
+void sdl3d_properties_set_int(sdl3d_properties *props, const char *key, int value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_INT;
+    v.as_int = value;
+    set_value(props, key, v);
+}
+
+void sdl3d_properties_set_float(sdl3d_properties *props, const char *key, float value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_FLOAT;
+    v.as_float = value;
+    set_value(props, key, v);
+}
+
+void sdl3d_properties_set_bool(sdl3d_properties *props, const char *key, bool value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_BOOL;
+    v.as_bool = value;
+    set_value(props, key, v);
+}
+
+void sdl3d_properties_set_vec3(sdl3d_properties *props, const char *key, sdl3d_vec3 value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_VEC3;
+    v.as_vec3 = value;
+    set_value(props, key, v);
+}
+
+void sdl3d_properties_set_string(sdl3d_properties *props, const char *key, const char *value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_STRING;
+    v.as_string = SDL_strdup(value != NULL ? value : "");
+    if (v.as_string == NULL)
+        return;
+    set_value(props, key, v);
+}
+
+void sdl3d_properties_set_color(sdl3d_properties *props, const char *key, sdl3d_color value)
+{
+    sdl3d_value v;
+    SDL_zero(v);
+    v.type = SDL3D_VALUE_COLOR;
+    v.as_color = value;
+    set_value(props, key, v);
+}
+
+/* ================================================================== */
+/* Getters                                                            */
+/* ================================================================== */
+
+int sdl3d_properties_get_int(const sdl3d_properties *props, const char *key, int fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_INT)
+        return fallback;
+    return e->value.as_int;
+}
+
+float sdl3d_properties_get_float(const sdl3d_properties *props, const char *key, float fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_FLOAT)
+        return fallback;
+    return e->value.as_float;
+}
+
+bool sdl3d_properties_get_bool(const sdl3d_properties *props, const char *key, bool fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_BOOL)
+        return fallback;
+    return e->value.as_bool;
+}
+
+sdl3d_vec3 sdl3d_properties_get_vec3(const sdl3d_properties *props, const char *key, sdl3d_vec3 fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_VEC3)
+        return fallback;
+    return e->value.as_vec3;
+}
+
+const char *sdl3d_properties_get_string(const sdl3d_properties *props, const char *key, const char *fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_STRING)
+        return fallback;
+    return e->value.as_string;
+}
+
+sdl3d_color sdl3d_properties_get_color(const sdl3d_properties *props, const char *key, sdl3d_color fallback)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL || e->value.type != SDL3D_VALUE_COLOR)
+        return fallback;
+    return e->value.as_color;
+}
+
+/* ================================================================== */
+/* Query and mutation                                                 */
+/* ================================================================== */
+
+bool sdl3d_properties_has(const sdl3d_properties *props, const char *key)
+{
+    return lookup(props, key) != NULL;
+}
+
+void sdl3d_properties_remove(sdl3d_properties *props, const char *key)
+{
+    if (props == NULL || key == NULL || props->capacity == 0)
+        return;
+    entry *e = find_entry(props->entries, props->capacity, key);
+    if (e == NULL || e->state != ENTRY_OCCUPIED)
+        return;
+    free_value(&e->value);
+    SDL_free(e->key);
+    e->key = NULL;
+    e->state = ENTRY_TOMBSTONE;
+    props->count--;
+    /* occupied stays the same — tombstones count toward load factor. */
+}
+
+void sdl3d_properties_clear(sdl3d_properties *props)
+{
+    if (props == NULL)
+        return;
+    for (int i = 0; i < props->capacity; ++i)
+    {
+        if (props->entries[i].state == ENTRY_OCCUPIED)
+            free_entry(&props->entries[i]);
+        else
+            props->entries[i].state = ENTRY_EMPTY;
+    }
+    props->count = 0;
+    props->occupied = 0;
+}
+
+/* ================================================================== */
+/* Iteration / introspection                                         */
+/* ================================================================== */
+
+int sdl3d_properties_count(const sdl3d_properties *props)
+{
+    if (props == NULL)
+        return 0;
+    return props->count;
+}
+
+bool sdl3d_properties_get_key_at(const sdl3d_properties *props, int index, const char **out_key,
+                                 sdl3d_value_type *out_type)
+{
+    if (props == NULL || index < 0 || index >= props->count || out_key == NULL)
+        return false;
+
+    int seen = 0;
+    for (int i = 0; i < props->capacity; ++i)
+    {
+        if (props->entries[i].state != ENTRY_OCCUPIED)
+            continue;
+        if (seen == index)
+        {
+            *out_key = props->entries[i].key;
+            if (out_type != NULL)
+                *out_type = props->entries[i].value.type;
+            return true;
+        }
+        seen++;
+    }
+    return false;
+}
+
+const sdl3d_value *sdl3d_properties_get_value(const sdl3d_properties *props, const char *key)
+{
+    const entry *e = lookup(props, key);
+    if (e == NULL)
+        return NULL;
+    return &e->value;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SDL3D_TEST_SOURCES
     test_animation.cpp
     test_effects.cpp
     test_level.cpp
+    test_properties.cpp
     test_fps_mover.cpp
     test_sprite_actor.cpp
 )
@@ -181,6 +182,7 @@ else()
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
     sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -1,0 +1,502 @@
+/**
+ * @file test_properties.cpp
+ * @brief Unit tests for sdl3d_properties — generic key-value property bag.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+TEST(Properties, CreateAndDestroy)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, DestroyNullIsSafe)
+{
+    sdl3d_properties_destroy(nullptr);
+}
+
+/* ================================================================== */
+/* Int                                                                */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetInt)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "health", 100);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "health", 0), 100);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetIntFallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_EQ(sdl3d_properties_get_int(p, "missing", 42), 42);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetIntFallbackOnTypeMismatch)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_float(p, "speed", 3.5f);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "speed", -1), -1);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, OverwriteIntChangesValue)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "ammo", 50);
+    sdl3d_properties_set_int(p, "ammo", 25);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "ammo", 0), 25);
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Float                                                              */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetFloat)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_float(p, "speed", 12.5f);
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(p, "speed", 0.0f), 12.5f);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetFloatFallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(p, "x", 1.0f), 1.0f);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Bool                                                               */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetBool)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_bool(p, "locked", true);
+    EXPECT_TRUE(sdl3d_properties_get_bool(p, "locked", false));
+    sdl3d_properties_set_bool(p, "locked", false);
+    EXPECT_FALSE(sdl3d_properties_get_bool(p, "locked", true));
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetBoolFallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_TRUE(sdl3d_properties_get_bool(p, "missing", true));
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Vec3                                                               */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetVec3)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_vec3 origin = sdl3d_vec3_make(1.0f, 2.0f, 3.0f);
+    sdl3d_properties_set_vec3(p, "origin", origin);
+    sdl3d_vec3 result = sdl3d_properties_get_vec3(p, "origin", sdl3d_vec3_make(0, 0, 0));
+    EXPECT_FLOAT_EQ(result.x, 1.0f);
+    EXPECT_FLOAT_EQ(result.y, 2.0f);
+    EXPECT_FLOAT_EQ(result.z, 3.0f);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetVec3FallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_vec3 fb = sdl3d_vec3_make(9, 9, 9);
+    sdl3d_vec3 result = sdl3d_properties_get_vec3(p, "nope", fb);
+    EXPECT_FLOAT_EQ(result.x, 9.0f);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* String                                                             */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetString)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_string(p, "classname", "info_player_start");
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "classname", ""), "info_player_start");
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, StringIsCopied)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    char buf[32];
+    SDL_strlcpy(buf, "hello", sizeof(buf));
+    sdl3d_properties_set_string(p, "msg", buf);
+    /* Mutate the original buffer. */
+    buf[0] = 'X';
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "msg", ""), "hello");
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, OverwriteStringFreesOld)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_string(p, "name", "first");
+    sdl3d_properties_set_string(p, "name", "second");
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "name", ""), "second");
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, SetStringNullBecomesEmpty)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_string(p, "msg", NULL);
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "msg", "fallback"), "");
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetStringFallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "missing", "default"), "default");
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetStringFallbackOnTypeMismatch)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "health", 100);
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "health", "nope"), "nope");
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Color                                                              */
+/* ================================================================== */
+
+TEST(Properties, SetAndGetColor)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_color red = {255, 0, 0, 255};
+    sdl3d_properties_set_color(p, "tint", red);
+    sdl3d_color result = sdl3d_properties_get_color(p, "tint", (sdl3d_color){0, 0, 0, 0});
+    EXPECT_EQ(result.r, 255);
+    EXPECT_EQ(result.g, 0);
+    EXPECT_EQ(result.b, 0);
+    EXPECT_EQ(result.a, 255);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetColorFallbackOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_color fb = {1, 2, 3, 4};
+    sdl3d_color result = sdl3d_properties_get_color(p, "nope", fb);
+    EXPECT_EQ(result.r, 1);
+    EXPECT_EQ(result.a, 4);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Type overwrite (changing type of existing key)                     */
+/* ================================================================== */
+
+TEST(Properties, OverwriteChangesType)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "x", 10);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "x", 0), 10);
+
+    sdl3d_properties_set_string(p, "x", "hello");
+    EXPECT_EQ(sdl3d_properties_get_int(p, "x", -1), -1);
+    EXPECT_STREQ(sdl3d_properties_get_string(p, "x", ""), "hello");
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, OverwriteStringWithIntFreesString)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_string(p, "val", "some long string value");
+    sdl3d_properties_set_int(p, "val", 42);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "val", 0), 42);
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Has / Remove / Clear                                               */
+/* ================================================================== */
+
+TEST(Properties, HasReturnsTrueForExistingKey)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "a", 1);
+    EXPECT_TRUE(sdl3d_properties_has(p, "a"));
+    EXPECT_FALSE(sdl3d_properties_has(p, "b"));
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, RemoveDeletesKey)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "a", 1);
+    sdl3d_properties_set_int(p, "b", 2);
+    EXPECT_EQ(sdl3d_properties_count(p), 2);
+
+    sdl3d_properties_remove(p, "a");
+    EXPECT_FALSE(sdl3d_properties_has(p, "a"));
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(p, "b", 0), 2);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, RemoveStringFreesMemory)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_string(p, "msg", "hello world");
+    sdl3d_properties_remove(p, "msg");
+    EXPECT_FALSE(sdl3d_properties_has(p, "msg"));
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, RemoveNonexistentIsNoOp)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_remove(p, "nope");
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, ClearRemovesAll)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "a", 1);
+    sdl3d_properties_set_string(p, "b", "hello");
+    sdl3d_properties_set_float(p, "c", 3.0f);
+    EXPECT_EQ(sdl3d_properties_count(p), 3);
+
+    sdl3d_properties_clear(p);
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+    EXPECT_FALSE(sdl3d_properties_has(p, "a"));
+    EXPECT_FALSE(sdl3d_properties_has(p, "b"));
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Iteration                                                          */
+/* ================================================================== */
+
+TEST(Properties, CountReflectsEntries)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+    sdl3d_properties_set_int(p, "a", 1);
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_set_float(p, "b", 2.0f);
+    EXPECT_EQ(sdl3d_properties_count(p), 2);
+    sdl3d_properties_remove(p, "a");
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetKeyAtEnumeratesAll)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "health", 100);
+    sdl3d_properties_set_string(p, "name", "player");
+    sdl3d_properties_set_bool(p, "alive", true);
+
+    bool found_health = false, found_name = false, found_alive = false;
+    for (int i = 0; i < sdl3d_properties_count(p); i++)
+    {
+        const char *key = NULL;
+        sdl3d_value_type type;
+        ASSERT_TRUE(sdl3d_properties_get_key_at(p, i, &key, &type));
+        ASSERT_NE(key, nullptr);
+        if (SDL_strcmp(key, "health") == 0)
+        {
+            EXPECT_EQ(type, SDL3D_VALUE_INT);
+            found_health = true;
+        }
+        else if (SDL_strcmp(key, "name") == 0)
+        {
+            EXPECT_EQ(type, SDL3D_VALUE_STRING);
+            found_name = true;
+        }
+        else if (SDL_strcmp(key, "alive") == 0)
+        {
+            EXPECT_EQ(type, SDL3D_VALUE_BOOL);
+            found_alive = true;
+        }
+    }
+    EXPECT_TRUE(found_health);
+    EXPECT_TRUE(found_name);
+    EXPECT_TRUE(found_alive);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetKeyAtOutOfRangeReturnsFalse)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "a", 1);
+    const char *key = NULL;
+    EXPECT_FALSE(sdl3d_properties_get_key_at(p, -1, &key, NULL));
+    EXPECT_FALSE(sdl3d_properties_get_key_at(p, 1, &key, NULL));
+    EXPECT_FALSE(sdl3d_properties_get_key_at(p, 100, &key, NULL));
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetKeyAtTypeParamIsOptional)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "x", 1);
+    const char *key = NULL;
+    EXPECT_TRUE(sdl3d_properties_get_key_at(p, 0, &key, NULL));
+    EXPECT_STREQ(key, "x");
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Get value (raw tagged union)                                       */
+/* ================================================================== */
+
+TEST(Properties, GetValueReturnsTaggedUnion)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "hp", 75);
+    const sdl3d_value *v = sdl3d_properties_get_value(p, "hp");
+    ASSERT_NE(v, nullptr);
+    EXPECT_EQ(v->type, SDL3D_VALUE_INT);
+    EXPECT_EQ(v->as_int, 75);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, GetValueReturnsNullOnMissing)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    EXPECT_EQ(sdl3d_properties_get_value(p, "nope"), nullptr);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Stress: many keys trigger growth                                   */
+/* ================================================================== */
+
+TEST(Properties, GrowthHandlesManyKeys)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    char key[32];
+    for (int i = 0; i < 200; i++)
+    {
+        SDL_snprintf(key, sizeof(key), "key_%d", i);
+        sdl3d_properties_set_int(p, key, i);
+    }
+    EXPECT_EQ(sdl3d_properties_count(p), 200);
+
+    for (int i = 0; i < 200; i++)
+    {
+        SDL_snprintf(key, sizeof(key), "key_%d", i);
+        EXPECT_EQ(sdl3d_properties_get_int(p, key, -1), i) << "key=" << key;
+    }
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* Tombstone correctness: remove then re-insert                       */
+/* ================================================================== */
+
+TEST(Properties, RemoveThenReinsertSameKey)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, "x", 1);
+    sdl3d_properties_remove(p, "x");
+    EXPECT_FALSE(sdl3d_properties_has(p, "x"));
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+
+    sdl3d_properties_set_int(p, "x", 2);
+    EXPECT_TRUE(sdl3d_properties_has(p, "x"));
+    EXPECT_EQ(sdl3d_properties_get_int(p, "x", 0), 2);
+    EXPECT_EQ(sdl3d_properties_count(p), 1);
+    sdl3d_properties_destroy(p);
+}
+
+TEST(Properties, RemoveDoesNotBreakProbeChain)
+{
+    /* Insert keys that hash to the same bucket, remove the first,
+     * verify the second is still findable. */
+    sdl3d_properties *p = sdl3d_properties_create();
+    /* Insert enough keys that collisions are likely. */
+    for (int i = 0; i < 50; i++)
+    {
+        char key[16];
+        SDL_snprintf(key, sizeof(key), "k%d", i);
+        sdl3d_properties_set_int(p, key, i);
+    }
+    /* Remove every other key. */
+    for (int i = 0; i < 50; i += 2)
+    {
+        char key[16];
+        SDL_snprintf(key, sizeof(key), "k%d", i);
+        sdl3d_properties_remove(p, key);
+    }
+    /* Remaining keys must still be findable. */
+    for (int i = 1; i < 50; i += 2)
+    {
+        char key[16];
+        SDL_snprintf(key, sizeof(key), "k%d", i);
+        EXPECT_EQ(sdl3d_properties_get_int(p, key, -1), i) << "key=" << key;
+    }
+    EXPECT_EQ(sdl3d_properties_count(p), 25);
+    sdl3d_properties_destroy(p);
+}
+
+/* ================================================================== */
+/* NULL safety                                                        */
+/* ================================================================== */
+
+TEST(Properties, NullPropsAreSafe)
+{
+    EXPECT_EQ(sdl3d_properties_count(nullptr), 0);
+    EXPECT_FALSE(sdl3d_properties_has(nullptr, "x"));
+    EXPECT_EQ(sdl3d_properties_get_int(nullptr, "x", 42), 42);
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(nullptr, "x", 1.0f), 1.0f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(nullptr, "x", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(nullptr, "x", "fb"), "fb");
+    EXPECT_EQ(sdl3d_properties_get_value(nullptr, "x"), nullptr);
+
+    sdl3d_properties_set_int(nullptr, "x", 1);
+    sdl3d_properties_remove(nullptr, "x");
+    sdl3d_properties_clear(nullptr);
+
+    const char *key = NULL;
+    EXPECT_FALSE(sdl3d_properties_get_key_at(nullptr, 0, &key, NULL));
+}
+
+TEST(Properties, NullKeyAreSafe)
+{
+    sdl3d_properties *p = sdl3d_properties_create();
+    sdl3d_properties_set_int(p, NULL, 1);
+    EXPECT_EQ(sdl3d_properties_count(p), 0);
+    EXPECT_FALSE(sdl3d_properties_has(p, NULL));
+    EXPECT_EQ(sdl3d_properties_get_int(p, NULL, 42), 42);
+    sdl3d_properties_remove(p, NULL);
+    sdl3d_properties_destroy(p);
+}


### PR DESCRIPTION
Closes Phase 1 of #82.

## Summary

New `sdl3d_properties` — a generic key-value property bag with 6 value types, arbitrary keys, and an iteration API. This is the state/memory layer for the gameplay mechanics system.

### Value types

| Type | C type | Q3 usage |
|------|--------|----------|
| int | `int` | health, ammo, damage, spawnflags |
| float | `float` | speed, wait, lip, scale |
| bool | `bool` | toggle states |
| vec3 | `sdl3d_vec3` | origin, angles, target positions |
| string | `const char *` | classname, targetname, target, model, message |
| color | `sdl3d_color` | light color, fog color, tint |

### API surface

- `create` / `destroy`
- 6 typed setters, 6 typed getters (type-mismatch returns fallback)
- `has` / `remove` / `clear`
- `count` / `get_key_at` / `get_value` (iteration + introspection)

### Design decisions

- **Arbitrary keys:** any key is accepted, unknown keys are preserved. Matches Q3/Source/Radiant conventions.
- **String keys:** readable, serializable, O(1) amortized via FNV-1a hash map.
- **Owned copies:** keys and string values are copied on insert, freed on overwrite/remove/destroy.
- **Tombstone deletion:** preserves probe chains for correct lookup after removal.
- **70% load factor:** automatic growth keeps operations fast.

### Implementation

Open-addressing hash map (~400 LOC). FNV-1a hash, linear probing, tombstone deletion, automatic growth at 70% load.

### Test plan

38 unit tests covering:
- All 6 types: set, get, fallback on missing, fallback on type mismatch
- Overwrite: same type, cross-type, string→int frees old string
- has / remove / clear
- Iteration: enumerate all, out-of-range, optional type param
- get_value raw tagged union access
- Growth: 200 keys with correct retrieval
- Tombstone correctness: remove + reinsert, probe chain preservation
- NULL safety: null props, null key

606/606 tests green; format clean.