### PR TITLE
feat: decoupled signal bus for gameplay event dispatch (Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(
         src/rasterizer.c
         src/render_context.c
         src/scene.c
+        src/signal_bus.c
         src/sprite_actor.c
         src/sdl3d.c
         src/shading.c

--- a/include/sdl3d/signal_bus.h
+++ b/include/sdl3d/signal_bus.h
@@ -1,0 +1,145 @@
+/**
+ * @file signal_bus.h
+ * @brief Decoupled event dispatch for gameplay mechanics.
+ *
+ * The signal bus is the wiring layer between triggers and actions. Any
+ * system can emit a signal, any system can listen. Signals are integer
+ * IDs defined by the caller (typically an enum). Payloads are optional
+ * property bags (sdl3d_properties) for a uniform, inspectable format.
+ *
+ * Handlers fire synchronously during sdl3d_signal_emit, in the order
+ * they were connected. There is no deferred queue — if deferred
+ * dispatch is needed, layer it on top via the timer system (Phase 5).
+ *
+ * Usage:
+ * @code
+ *   enum { SIG_ALARM = 1, SIG_DOOR_UNLOCK = 2 };
+ *
+ *   void on_alarm(void *ud, int sig, const sdl3d_properties *payload) {
+ *       printf("Alarm triggered!\n");
+ *   }
+ *
+ *   sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+ *   int conn = sdl3d_signal_connect(bus, SIG_ALARM, on_alarm, NULL);
+ *   sdl3d_signal_emit(bus, SIG_ALARM, NULL);  // fires on_alarm
+ *   sdl3d_signal_disconnect(bus, conn);
+ *   sdl3d_signal_bus_destroy(bus);
+ * @endcode
+ */
+
+#ifndef SDL3D_SIGNAL_BUS_H
+#define SDL3D_SIGNAL_BUS_H
+
+#include <stdbool.h>
+
+#include "sdl3d/properties.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque signal bus handle. */
+    typedef struct sdl3d_signal_bus sdl3d_signal_bus;
+
+    /**
+     * @brief Signal handler callback.
+     *
+     * @param userdata  Caller-provided context pointer from sdl3d_signal_connect.
+     * @param signal_id The signal that was emitted.
+     * @param payload   Optional property bag attached to the emission, or NULL.
+     *                  The payload is valid only for the duration of the call.
+     */
+    typedef void (*sdl3d_signal_handler)(void *userdata, int signal_id, const sdl3d_properties *payload);
+
+    /* ================================================================== */
+    /* Lifecycle                                                          */
+    /* ================================================================== */
+
+    /**
+     * @brief Create an empty signal bus.
+     * @return A new signal bus, or NULL on allocation failure.
+     */
+    sdl3d_signal_bus *sdl3d_signal_bus_create(void);
+
+    /**
+     * @brief Destroy a signal bus and free all connections.
+     *
+     * Any pending emissions in progress (e.g., a handler that destroys
+     * the bus) result in undefined behavior. Safe to call with NULL.
+     */
+    void sdl3d_signal_bus_destroy(sdl3d_signal_bus *bus);
+
+    /* ================================================================== */
+    /* Connection management                                              */
+    /* ================================================================== */
+
+    /**
+     * @brief Connect a handler to a signal.
+     *
+     * The handler will be called each time the signal is emitted, in the
+     * order connections were made. Multiple handlers can be connected to
+     * the same signal. The same handler can be connected multiple times
+     * (each connection fires independently).
+     *
+     * @param bus       The signal bus.
+     * @param signal_id Caller-defined signal identifier (any integer).
+     * @param handler   Callback to invoke on emission. Must not be NULL.
+     * @param userdata  Opaque pointer passed to the handler. May be NULL.
+     * @return A connection ID (>= 1) for use with sdl3d_signal_disconnect,
+     *         or 0 on failure.
+     */
+    int sdl3d_signal_connect(sdl3d_signal_bus *bus, int signal_id, sdl3d_signal_handler handler, void *userdata);
+
+    /**
+     * @brief Disconnect a handler by connection ID.
+     *
+     * The connection ID is the value returned by sdl3d_signal_connect.
+     * After disconnection, the handler will not be called on future
+     * emissions. Safe to call during an emission (the disconnected
+     * handler is skipped for the remainder of the current emission).
+     * No-op if the ID is invalid or already disconnected.
+     */
+    void sdl3d_signal_disconnect(sdl3d_signal_bus *bus, int connection_id);
+
+    /**
+     * @brief Disconnect all handlers for a specific signal.
+     *
+     * All connections listening to signal_id are removed.
+     */
+    void sdl3d_signal_disconnect_all(sdl3d_signal_bus *bus, int signal_id);
+
+    /* ================================================================== */
+    /* Emission                                                           */
+    /* ================================================================== */
+
+    /**
+     * @brief Emit a signal, invoking all connected handlers synchronously.
+     *
+     * Handlers are called in connection order. The payload (if non-NULL)
+     * is passed by const pointer and is valid only for the duration of
+     * each handler call. Handlers may emit other signals (reentrant),
+     * connect new handlers, or disconnect themselves.
+     *
+     * @param bus       The signal bus.
+     * @param signal_id The signal to emit.
+     * @param payload   Optional property bag, or NULL.
+     */
+    void sdl3d_signal_emit(sdl3d_signal_bus *bus, int signal_id, const sdl3d_properties *payload);
+
+    /* ================================================================== */
+    /* Query                                                              */
+    /* ================================================================== */
+
+    /**
+     * @brief Get the number of active connections on the bus.
+     *
+     * Disconnected (dead) connections are not counted.
+     */
+    int sdl3d_signal_bus_connection_count(const sdl3d_signal_bus *bus);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_SIGNAL_BUS_H */

--- a/src/signal_bus.c
+++ b/src/signal_bus.c
@@ -1,0 +1,205 @@
+/**
+ * @file signal_bus.c
+ * @brief Signal bus implementation — flat dynamic array of connections.
+ *
+ * Connections are stored in a single flat array. Each connection has a
+ * unique monotonic ID, a signal_id it listens to, a handler, userdata,
+ * and an alive flag. Disconnection marks the connection as dead rather
+ * than removing it, so iteration during emission is safe. Dead entries
+ * are compacted lazily when not inside an emission.
+ */
+
+#include "sdl3d/signal_bus.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+/* ================================================================== */
+/* Internal types                                                     */
+/* ================================================================== */
+
+typedef struct connection
+{
+    int id;
+    int signal_id;
+    sdl3d_signal_handler handler;
+    void *userdata;
+    bool alive;
+} connection;
+
+struct sdl3d_signal_bus
+{
+    connection *connections;
+    int count;
+    int capacity;
+    int next_id;    /* Monotonically increasing connection ID. */
+    int emit_depth; /* Reentrancy depth. >0 means we are inside emit. */
+    int dead_count; /* Number of dead connections awaiting compaction. */
+};
+
+/* ================================================================== */
+/* Internal helpers                                                   */
+/* ================================================================== */
+
+/**
+ * Remove dead connections by compacting the array. Only safe when
+ * emit_depth == 0 (not inside any emission).
+ */
+static void compact(sdl3d_signal_bus *bus)
+{
+    if (bus->dead_count == 0)
+        return;
+
+    int write = 0;
+    for (int read = 0; read < bus->count; ++read)
+    {
+        if (bus->connections[read].alive)
+        {
+            if (write != read)
+                bus->connections[write] = bus->connections[read];
+            write++;
+        }
+    }
+    bus->count = write;
+    bus->dead_count = 0;
+}
+
+static bool ensure_capacity(sdl3d_signal_bus *bus)
+{
+    if (bus->count < bus->capacity)
+        return true;
+
+    int new_cap = bus->capacity < 8 ? 8 : bus->capacity * 2;
+    connection *new_buf = (connection *)SDL_realloc(bus->connections, (size_t)new_cap * sizeof(connection));
+    if (new_buf == NULL)
+        return false;
+    bus->connections = new_buf;
+    bus->capacity = new_cap;
+    return true;
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+sdl3d_signal_bus *sdl3d_signal_bus_create(void)
+{
+    sdl3d_signal_bus *bus = (sdl3d_signal_bus *)SDL_calloc(1, sizeof(sdl3d_signal_bus));
+    if (bus != NULL)
+        bus->next_id = 1;
+    return bus;
+}
+
+void sdl3d_signal_bus_destroy(sdl3d_signal_bus *bus)
+{
+    if (bus == NULL)
+        return;
+    SDL_free(bus->connections);
+    SDL_free(bus);
+}
+
+/* ================================================================== */
+/* Connection management                                              */
+/* ================================================================== */
+
+int sdl3d_signal_connect(sdl3d_signal_bus *bus, int signal_id, sdl3d_signal_handler handler, void *userdata)
+{
+    if (bus == NULL || handler == NULL)
+        return 0;
+
+    /* Compact dead entries before growing, but only outside emission. */
+    if (bus->emit_depth == 0 && bus->dead_count > 0)
+        compact(bus);
+
+    if (!ensure_capacity(bus))
+        return 0;
+
+    int id = bus->next_id++;
+    connection *c = &bus->connections[bus->count++];
+    c->id = id;
+    c->signal_id = signal_id;
+    c->handler = handler;
+    c->userdata = userdata;
+    c->alive = true;
+    return id;
+}
+
+void sdl3d_signal_disconnect(sdl3d_signal_bus *bus, int connection_id)
+{
+    if (bus == NULL || connection_id <= 0)
+        return;
+
+    for (int i = 0; i < bus->count; ++i)
+    {
+        connection *c = &bus->connections[i];
+        if (c->alive && c->id == connection_id)
+        {
+            c->alive = false;
+            bus->dead_count++;
+            break;
+        }
+    }
+
+    if (bus->emit_depth == 0 && bus->dead_count > 0)
+        compact(bus);
+}
+
+void sdl3d_signal_disconnect_all(sdl3d_signal_bus *bus, int signal_id)
+{
+    if (bus == NULL)
+        return;
+
+    for (int i = 0; i < bus->count; ++i)
+    {
+        connection *c = &bus->connections[i];
+        if (c->alive && c->signal_id == signal_id)
+        {
+            c->alive = false;
+            bus->dead_count++;
+        }
+    }
+
+    if (bus->emit_depth == 0 && bus->dead_count > 0)
+        compact(bus);
+}
+
+/* ================================================================== */
+/* Emission                                                           */
+/* ================================================================== */
+
+void sdl3d_signal_emit(sdl3d_signal_bus *bus, int signal_id, const sdl3d_properties *payload)
+{
+    if (bus == NULL)
+        return;
+
+    bus->emit_depth++;
+
+    /*
+     * Snapshot the count before iterating. Handlers may connect new
+     * handlers (appended beyond current count), which will not fire
+     * during this emission — preventing infinite loops from a handler
+     * that connects itself.
+     */
+    int snapshot = bus->count;
+    for (int i = 0; i < snapshot; ++i)
+    {
+        const connection *c = &bus->connections[i];
+        if (c->alive && c->signal_id == signal_id)
+            c->handler(c->userdata, signal_id, payload);
+    }
+
+    bus->emit_depth--;
+
+    if (bus->emit_depth == 0 && bus->dead_count > 0)
+        compact(bus);
+}
+
+/* ================================================================== */
+/* Query                                                              */
+/* ================================================================== */
+
+int sdl3d_signal_bus_connection_count(const sdl3d_signal_bus *bus)
+{
+    if (bus == NULL)
+        return 0;
+    return bus->count - bus->dead_count;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SDL3D_TEST_SOURCES
     test_effects.cpp
     test_level.cpp
     test_properties.cpp
+    test_signal_bus.cpp
     test_fps_mover.cpp
     test_sprite_actor.cpp
 )
@@ -183,6 +184,7 @@ else()
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)
+    sdl3d_add_test(sdl3d_signal_bus_test test_signal_bus.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
     sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)

--- a/tests/test_signal_bus.cpp
+++ b/tests/test_signal_bus.cpp
@@ -1,0 +1,401 @@
+/**
+ * @file test_signal_bus.cpp
+ * @brief Unit tests for sdl3d_signal_bus — decoupled event dispatch.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+}
+
+/* ================================================================== */
+/* Test helpers                                                       */
+/* ================================================================== */
+
+static int g_call_count;
+static int g_last_signal;
+static const sdl3d_properties *g_last_payload;
+
+static void reset_globals()
+{
+    g_call_count = 0;
+    g_last_signal = -1;
+    g_last_payload = NULL;
+}
+
+static void counting_handler(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)ud;
+    g_call_count++;
+    g_last_signal = signal_id;
+    g_last_payload = payload;
+}
+
+static void increment_handler(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    (void)payload;
+    int *counter = (int *)ud;
+    (*counter)++;
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+TEST(SignalBus, CreateAndDestroy)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(bus, nullptr);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 0);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, DestroyNullIsSafe)
+{
+    sdl3d_signal_bus_destroy(nullptr);
+}
+
+/* ================================================================== */
+/* Connect and emit                                                   */
+/* ================================================================== */
+
+TEST(SignalBus, ConnectReturnsPositiveId)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int id = sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+    EXPECT_GT(id, 0);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 1);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, ConnectNullBusReturnsZero)
+{
+    EXPECT_EQ(sdl3d_signal_connect(nullptr, 1, counting_handler, NULL), 0);
+}
+
+TEST(SignalBus, ConnectNullHandlerReturnsZero)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    EXPECT_EQ(sdl3d_signal_connect(bus, 1, NULL, NULL), 0);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 0);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, EmitFiresHandler)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 42, counting_handler, NULL);
+
+    sdl3d_signal_emit(bus, 42, NULL);
+    EXPECT_EQ(g_call_count, 1);
+    EXPECT_EQ(g_last_signal, 42);
+    EXPECT_EQ(g_last_payload, nullptr);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, EmitOnlyMatchingSignal)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+
+    sdl3d_signal_emit(bus, 2, NULL);
+    EXPECT_EQ(g_call_count, 0);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(g_call_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, MultipleHandlersSameSignal)
+{
+    int a = 0, b = 0;
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, increment_handler, &a);
+    sdl3d_signal_connect(bus, 1, increment_handler, &b);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, SameHandlerConnectedTwiceFiresTwice)
+{
+    int counter = 0;
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, increment_handler, &counter);
+    sdl3d_signal_connect(bus, 1, increment_handler, &counter);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(counter, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, EmitPassesPayload)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "damage", 50);
+    sdl3d_signal_emit(bus, 1, payload);
+
+    EXPECT_EQ(g_call_count, 1);
+    ASSERT_NE(g_last_payload, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(g_last_payload, "damage", 0), 50);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, EmitPassesUserdata)
+{
+    int counter = 0;
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, increment_handler, &counter);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(counter, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Disconnect                                                         */
+/* ================================================================== */
+
+TEST(SignalBus, DisconnectStopsHandler)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int conn = sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(g_call_count, 1);
+
+    sdl3d_signal_disconnect(bus, conn);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 0);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(g_call_count, 1); /* No additional call. */
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, DisconnectInvalidIdIsNoOp)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+    sdl3d_signal_disconnect(bus, 9999);
+    sdl3d_signal_disconnect(bus, 0);
+    sdl3d_signal_disconnect(bus, -1);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 1);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SignalBus, DisconnectAllBySignal)
+{
+    int a = 0, b = 0, c = 0;
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, increment_handler, &a);
+    sdl3d_signal_connect(bus, 1, increment_handler, &b);
+    sdl3d_signal_connect(bus, 2, increment_handler, &c);
+
+    sdl3d_signal_disconnect_all(bus, 1);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 1);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(a, 0);
+    EXPECT_EQ(b, 0);
+
+    sdl3d_signal_emit(bus, 2, NULL);
+    EXPECT_EQ(c, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Disconnect during emission (reentrant safety)                      */
+/* ================================================================== */
+
+struct disconnect_ctx
+{
+    sdl3d_signal_bus *bus;
+    int conn_id;
+    int call_count;
+};
+
+static void self_disconnect_handler(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    (void)payload;
+    struct disconnect_ctx *ctx = (struct disconnect_ctx *)ud;
+    ctx->call_count++;
+    sdl3d_signal_disconnect(ctx->bus, ctx->conn_id);
+}
+
+TEST(SignalBus, DisconnectSelfDuringEmission)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    struct disconnect_ctx ctx = {bus, 0, 0};
+    ctx.conn_id = sdl3d_signal_connect(bus, 1, self_disconnect_handler, &ctx);
+
+    int other_count = 0;
+    sdl3d_signal_connect(bus, 1, increment_handler, &other_count);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(ctx.call_count, 1);
+    EXPECT_EQ(other_count, 1);
+
+    /* Second emit: self-disconnected handler should not fire. */
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(ctx.call_count, 1);
+    EXPECT_EQ(other_count, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Reentrant emission (handler emits another signal)                  */
+/* ================================================================== */
+
+struct reentrant_ctx
+{
+    sdl3d_signal_bus *bus;
+    int secondary_signal;
+    int primary_count;
+};
+
+static void reentrant_handler(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    (void)payload;
+    struct reentrant_ctx *ctx = (struct reentrant_ctx *)ud;
+    ctx->primary_count++;
+    sdl3d_signal_emit(ctx->bus, ctx->secondary_signal, NULL);
+}
+
+TEST(SignalBus, ReentrantEmission)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int secondary_count = 0;
+
+    struct reentrant_ctx ctx = {bus, 2, 0};
+    sdl3d_signal_connect(bus, 1, reentrant_handler, &ctx);
+    sdl3d_signal_connect(bus, 2, increment_handler, &secondary_count);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(ctx.primary_count, 1);
+    EXPECT_EQ(secondary_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Connect during emission                                            */
+/* ================================================================== */
+
+struct connect_ctx
+{
+    sdl3d_signal_bus *bus;
+    int *counter;
+};
+
+static void connect_during_emit_handler(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    (void)payload;
+    struct connect_ctx *ctx = (struct connect_ctx *)ud;
+    /* Connect a new handler during emission. It should NOT fire in
+     * this emission pass (snapshot semantics). */
+    sdl3d_signal_connect(ctx->bus, signal_id, increment_handler, ctx->counter);
+}
+
+TEST(SignalBus, ConnectDuringEmissionDoesNotFireInCurrentPass)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int counter = 0;
+    struct connect_ctx ctx = {bus, &counter};
+    sdl3d_signal_connect(bus, 1, connect_during_emit_handler, &ctx);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    /* The newly connected handler should NOT have fired. */
+    EXPECT_EQ(counter, 0);
+
+    /* But it fires on the next emission. */
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_EQ(counter, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Stress: many connections                                           */
+/* ================================================================== */
+
+TEST(SignalBus, ManyConnections)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int counters[100] = {0};
+
+    for (int i = 0; i < 100; i++)
+        sdl3d_signal_connect(bus, 1, increment_handler, &counters[i]);
+
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 100);
+
+    sdl3d_signal_emit(bus, 1, NULL);
+    for (int i = 0; i < 100; i++)
+        EXPECT_EQ(counters[i], 1) << "counter[" << i << "]";
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* NULL safety                                                        */
+/* ================================================================== */
+
+TEST(SignalBus, NullBusOperationsAreSafe)
+{
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(nullptr), 0);
+    sdl3d_signal_emit(nullptr, 1, NULL);
+    sdl3d_signal_disconnect(nullptr, 1);
+    sdl3d_signal_disconnect_all(nullptr, 1);
+}
+
+/* ================================================================== */
+/* Emit with no handlers is a no-op                                   */
+/* ================================================================== */
+
+TEST(SignalBus, EmitWithNoHandlersIsNoOp)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_emit(bus, 999, NULL); /* Should not crash. */
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Connection IDs are unique and monotonic                            */
+/* ================================================================== */
+
+TEST(SignalBus, ConnectionIdsAreMonotonic)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    int id1 = sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+    int id2 = sdl3d_signal_connect(bus, 1, counting_handler, NULL);
+    int id3 = sdl3d_signal_connect(bus, 2, counting_handler, NULL);
+    EXPECT_GT(id1, 0);
+    EXPECT_GT(id2, id1);
+    EXPECT_GT(id3, id2);
+    sdl3d_signal_bus_destroy(bus);
+}


### PR DESCRIPTION
Refs #82 (Phase 2 of gameplay mechanics primitives).

## Summary

New `sdl3d_signal_bus` — synchronous event dispatch with integer signal IDs and optional `sdl3d_properties` payloads. This is the wiring layer between triggers and actions: any system can emit a signal, any system can listen, with no direct coupling between them.

### API

- `create` / `destroy`
- `connect(bus, signal_id, handler, userdata)` → returns connection ID
- `disconnect(bus, connection_id)` — safe to call during emission
- `disconnect_all(bus, signal_id)` — remove all handlers for a signal
- `emit(bus, signal_id, payload)` — synchronous, reentrant-safe
- `connection_count(bus)`

### Design decisions

- **Integer signal IDs:** caller-defined (enum or constants). No string hashing on the hot path.
- **Properties payload:** uniform, inspectable, serializable format from Phase 1. NULL for signals with no data.
- **Synchronous dispatch:** handlers fire during `emit()`, in connection order. Simple mental model.
- **Reentrant-safe:** handlers may emit other signals, connect new handlers, or disconnect themselves.
- **Snapshot semantics:** new connections added during emission do not fire in the current pass, preventing infinite loops.
- **Monotonic connection IDs:** each `connect()` returns a unique ID for targeted disconnect.

### Implementation

Flat dynamic array of connections (~205 LOC). Dead entries marked with `alive=false`, compacted lazily when not inside an emission. Reentrancy tracked via `emit_depth` counter.

### Test plan

21 unit tests covering:
- Lifecycle (create/destroy, NULL safety)
- Connect/emit basics, signal matching, multiple handlers
- Duplicate handler fires twice, payload + userdata passing
- Disconnect by ID, invalid ID, all by signal
- Self-disconnect during emission
- Reentrant emission (handler emits another signal)
- Connect during emission (snapshot semantics — does not fire in current pass)
- Stress: 100 connections
- Monotonic connection IDs

627/627 tests green; format clean.