### PR TITLE
feat: trigger system for condition detection and signal emission (Phase 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(
         src/render_context.c
         src/scene.c
         src/signal_bus.c
+        src/trigger.c
         src/sprite_actor.c
         src/sdl3d.c
         src/shading.c

--- a/include/sdl3d/trigger.h
+++ b/include/sdl3d/trigger.h
@@ -1,0 +1,206 @@
+/**
+ * @file trigger.h
+ * @brief Condition detectors that emit signals when criteria are met.
+ *
+ * A trigger is a condition that, when met, emits a signal via the signal
+ * bus. Triggers only detect — they never act. This separation is what
+ * makes the system composable: the response to a trigger is defined
+ * elsewhere by connecting handlers to the emitted signal.
+ *
+ * Three trigger types are supported:
+ *
+ * - **Spatial:** a point enters or exits a bounding box (motion sensor).
+ * - **Property:** a numeric property crosses a threshold (health <= 0).
+ * - **Signal:** fires in response to another signal (chaining).
+ *
+ * Edge detection is built in. Most game triggers are edge-triggered
+ * ("fire once when the player enters the zone"), not level-triggered
+ * ("fire every frame while inside"). All four modes are supported.
+ *
+ * Triggers are plain structs, not heap-allocated opaque types. This
+ * makes them embeddable in entity structs and trivially serializable
+ * for the future level editor.
+ *
+ * Usage:
+ * @code
+ *   // Spatial trigger: emit SIG_ALARM when a point enters the zone.
+ *   sdl3d_trigger sensor = {0};
+ *   sensor.type = SDL3D_TRIGGER_SPATIAL;
+ *   sensor.edge = SDL3D_TRIGGER_EDGE_ENTER;
+ *   sensor.emit_signal_id = SIG_ALARM;
+ *   sensor.enabled = true;
+ *   sensor.spatial.zone = (sdl3d_bounding_box){{8,0,13}, {12,3,17}};
+ *
+ *   // Each frame:
+ *   sdl3d_trigger_test_spatial(&sensor, player_position);
+ *   sdl3d_trigger_evaluate(&sensor, bus);
+ * @endcode
+ */
+
+#ifndef SDL3D_TRIGGER_H
+#define SDL3D_TRIGGER_H
+
+#include <stdbool.h>
+
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Trigger condition type. */
+    typedef enum sdl3d_trigger_type
+    {
+        SDL3D_TRIGGER_SPATIAL,  /**< Point enters/exits a bounding box. */
+        SDL3D_TRIGGER_PROPERTY, /**< A numeric property crosses a threshold. */
+        SDL3D_TRIGGER_SIGNAL,   /**< Fires in response to another signal. */
+    } sdl3d_trigger_type;
+
+    /**
+     * @brief Edge detection mode for trigger firing.
+     *
+     * Controls when the trigger's signal is emitted relative to the
+     * condition transitioning between true and false.
+     */
+    typedef enum sdl3d_trigger_edge
+    {
+        SDL3D_TRIGGER_EDGE_ENTER, /**< Fire once when condition becomes true. */
+        SDL3D_TRIGGER_EDGE_EXIT,  /**< Fire once when condition becomes false. */
+        SDL3D_TRIGGER_EDGE_BOTH,  /**< Fire on both enter and exit transitions. */
+        SDL3D_TRIGGER_LEVEL,      /**< Fire every evaluation while condition is true. */
+    } sdl3d_trigger_edge;
+
+    /** @brief Comparison operators for property triggers. */
+    typedef enum sdl3d_compare_op
+    {
+        SDL3D_CMP_EQ, /**< Equal. */
+        SDL3D_CMP_NE, /**< Not equal. */
+        SDL3D_CMP_LT, /**< Less than. */
+        SDL3D_CMP_LE, /**< Less than or equal. */
+        SDL3D_CMP_GT, /**< Greater than. */
+        SDL3D_CMP_GE, /**< Greater than or equal. */
+    } sdl3d_compare_op;
+
+    /**
+     * @brief A trigger — a condition that emits a signal when met.
+     *
+     * Triggers are plain value types. Zero-initialize and set the fields
+     * you need. The `enabled` field must be set to true for the trigger
+     * to fire. The `was_active` and `active` fields are managed
+     * internally by the test and evaluate functions.
+     */
+    typedef struct sdl3d_trigger
+    {
+        sdl3d_trigger_type type;
+        sdl3d_trigger_edge edge;
+        int emit_signal_id; /**< Signal emitted when the trigger fires. */
+        bool enabled;
+
+        /* Edge-detection state (internal, managed by test/evaluate). */
+        bool was_active; /**< Condition state from the previous evaluation. */
+        bool active;     /**< Condition state from the current evaluation. */
+
+        union {
+            /** @brief Spatial trigger: point-in-AABB test. */
+            struct
+            {
+                sdl3d_bounding_box zone;
+            } spatial;
+
+            /**
+             * @brief Property trigger: numeric comparison.
+             *
+             * Reads a float property from `source` and compares it against
+             * `threshold` using `op`. For int properties, the value is
+             * read as float via get_float (returns fallback on type
+             * mismatch, so use float properties for thresholds). For bool
+             * properties, use get_float with a threshold of 0.5 and
+             * SDL3D_CMP_GE to test truthiness.
+             */
+            struct
+            {
+                const sdl3d_properties *source;
+                const char *key; /**< Property key to read. Not copied. */
+                sdl3d_compare_op op;
+                float threshold;
+            } property;
+
+            /** @brief Signal trigger: fires when a specific signal is received. */
+            struct
+            {
+                int listen_signal_id;
+            } signal;
+        };
+    } sdl3d_trigger;
+
+    /* ================================================================== */
+    /* Condition testing                                                  */
+    /* ================================================================== */
+
+    /**
+     * @brief Test a spatial trigger against a world-space point.
+     *
+     * Sets `trigger->active` to true if the point is inside the zone,
+     * false otherwise. Does nothing if trigger is NULL, disabled, or
+     * not of type SDL3D_TRIGGER_SPATIAL.
+     */
+    void sdl3d_trigger_test_spatial(sdl3d_trigger *trigger, sdl3d_vec3 point);
+
+    /**
+     * @brief Test a property trigger against its source property bag.
+     *
+     * Reads the float value at `trigger->property.key` from
+     * `trigger->property.source` and compares it against the threshold.
+     * Sets `trigger->active` accordingly. Does nothing if trigger is
+     * NULL, disabled, or not of type SDL3D_TRIGGER_PROPERTY.
+     */
+    void sdl3d_trigger_test_property(sdl3d_trigger *trigger);
+
+    /**
+     * @brief Mark a signal trigger as active.
+     *
+     * Called when the listened signal is received. Sets `trigger->active`
+     * to true. The trigger will fire on the next evaluate call. Does
+     * nothing if trigger is NULL, disabled, or not of type
+     * SDL3D_TRIGGER_SIGNAL.
+     */
+    void sdl3d_trigger_activate_signal(sdl3d_trigger *trigger);
+
+    /* ================================================================== */
+    /* Evaluation                                                        */
+    /* ================================================================== */
+
+    /**
+     * @brief Evaluate a trigger and emit its signal if the edge condition is met.
+     *
+     * Compares `active` against `was_active` to detect transitions:
+     * - EDGE_ENTER: emits when active transitions from false to true.
+     * - EDGE_EXIT: emits when active transitions from true to false.
+     * - EDGE_BOTH: emits on either transition.
+     * - LEVEL: emits every call while active is true.
+     *
+     * After evaluation, `was_active` is updated to `active`, and for
+     * signal triggers, `active` is reset to false (signal triggers are
+     * pulse-based: they activate for one evaluation cycle per received
+     * signal).
+     *
+     * Does nothing if trigger is NULL, disabled, or bus is NULL.
+     */
+    void sdl3d_trigger_evaluate(sdl3d_trigger *trigger, sdl3d_signal_bus *bus);
+
+    /**
+     * @brief Reset a trigger's edge-detection state.
+     *
+     * Sets both `was_active` and `active` to false. Useful when
+     * re-enabling a trigger or resetting a level.
+     */
+    void sdl3d_trigger_reset(sdl3d_trigger *trigger);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_TRIGGER_H */

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -1,0 +1,139 @@
+/**
+ * @file trigger.c
+ * @brief Trigger implementation — condition detection and edge-based emission.
+ */
+
+#include "sdl3d/trigger.h"
+
+/* ================================================================== */
+/* Spatial: point-in-AABB                                             */
+/* ================================================================== */
+
+void sdl3d_trigger_test_spatial(sdl3d_trigger *trigger, sdl3d_vec3 point)
+{
+    if (trigger == NULL || !trigger->enabled || trigger->type != SDL3D_TRIGGER_SPATIAL)
+        return;
+
+    const sdl3d_bounding_box *z = &trigger->spatial.zone;
+    trigger->active = (point.x >= z->min.x && point.x <= z->max.x && point.y >= z->min.y && point.y <= z->max.y &&
+                       point.z >= z->min.z && point.z <= z->max.z);
+}
+
+/* ================================================================== */
+/* Property: numeric comparison                                       */
+/* ================================================================== */
+
+static bool compare_float(float value, sdl3d_compare_op op, float threshold)
+{
+    switch (op)
+    {
+    case SDL3D_CMP_EQ:
+        return value == threshold;
+    case SDL3D_CMP_NE:
+        return value != threshold;
+    case SDL3D_CMP_LT:
+        return value < threshold;
+    case SDL3D_CMP_LE:
+        return value <= threshold;
+    case SDL3D_CMP_GT:
+        return value > threshold;
+    case SDL3D_CMP_GE:
+        return value >= threshold;
+    }
+    return false;
+}
+
+void sdl3d_trigger_test_property(sdl3d_trigger *trigger)
+{
+    if (trigger == NULL || !trigger->enabled || trigger->type != SDL3D_TRIGGER_PROPERTY)
+        return;
+
+    if (trigger->property.source == NULL || trigger->property.key == NULL)
+    {
+        trigger->active = false;
+        return;
+    }
+
+    /*
+     * Read the property as float. If the key does not exist or is not a
+     * float, get_float returns a NaN-like fallback that will fail most
+     * comparisons, which is the correct behavior (missing property =
+     * condition not met). We use a fallback that makes all comparisons
+     * return false for the "missing" case.
+     */
+    float value =
+        sdl3d_properties_get_float(trigger->property.source, trigger->property.key, trigger->property.threshold);
+
+    /*
+     * If the key doesn't exist at all, the fallback equals the threshold.
+     * For EQ that would incorrectly return true. Check existence explicitly.
+     */
+    if (!sdl3d_properties_has(trigger->property.source, trigger->property.key))
+    {
+        trigger->active = false;
+        return;
+    }
+
+    trigger->active = compare_float(value, trigger->property.op, trigger->property.threshold);
+}
+
+/* ================================================================== */
+/* Signal: pulse activation                                           */
+/* ================================================================== */
+
+void sdl3d_trigger_activate_signal(sdl3d_trigger *trigger)
+{
+    if (trigger == NULL || !trigger->enabled || trigger->type != SDL3D_TRIGGER_SIGNAL)
+        return;
+    trigger->active = true;
+}
+
+/* ================================================================== */
+/* Evaluation: edge detection and emission                            */
+/* ================================================================== */
+
+void sdl3d_trigger_evaluate(sdl3d_trigger *trigger, sdl3d_signal_bus *bus)
+{
+    if (trigger == NULL || !trigger->enabled || bus == NULL)
+        return;
+
+    bool should_fire = false;
+
+    switch (trigger->edge)
+    {
+    case SDL3D_TRIGGER_EDGE_ENTER:
+        should_fire = trigger->active && !trigger->was_active;
+        break;
+    case SDL3D_TRIGGER_EDGE_EXIT:
+        should_fire = !trigger->active && trigger->was_active;
+        break;
+    case SDL3D_TRIGGER_EDGE_BOTH:
+        should_fire = trigger->active != trigger->was_active;
+        break;
+    case SDL3D_TRIGGER_LEVEL:
+        should_fire = trigger->active;
+        break;
+    }
+
+    if (should_fire)
+        sdl3d_signal_emit(bus, trigger->emit_signal_id, NULL);
+
+    trigger->was_active = trigger->active;
+
+    /* Signal triggers are pulse-based: reset active after evaluation so
+     * they require a fresh activation each cycle. */
+    if (trigger->type == SDL3D_TRIGGER_SIGNAL)
+        trigger->active = false;
+}
+
+/* ================================================================== */
+/* Reset                                                              */
+/* ================================================================== */
+
+void sdl3d_trigger_reset(sdl3d_trigger *trigger)
+{
+    if (trigger == NULL)
+        return;
+    trigger->was_active = false;
+    trigger->active = false;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SDL3D_TEST_SOURCES
     test_level.cpp
     test_properties.cpp
     test_signal_bus.cpp
+    test_trigger.cpp
     test_fps_mover.cpp
     test_sprite_actor.cpp
 )
@@ -185,6 +186,7 @@ else()
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)
     sdl3d_add_test(sdl3d_signal_bus_test test_signal_bus.cpp unit)
+    sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
     sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)

--- a/tests/test_trigger.cpp
+++ b/tests/test_trigger.cpp
@@ -1,0 +1,493 @@
+/**
+ * @file test_trigger.cpp
+ * @brief Unit tests for sdl3d_trigger — condition detection and emission.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/trigger.h"
+}
+
+/* ================================================================== */
+/* Test helpers                                                       */
+/* ================================================================== */
+
+static int g_fire_count;
+static int g_last_signal;
+
+static void reset_globals()
+{
+    g_fire_count = 0;
+    g_last_signal = -1;
+}
+
+static void fire_counter(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)ud;
+    (void)payload;
+    g_fire_count++;
+    g_last_signal = signal_id;
+}
+
+static sdl3d_trigger make_spatial_trigger(sdl3d_bounding_box zone, sdl3d_trigger_edge edge, int signal_id)
+{
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_SPATIAL;
+    t.edge = edge;
+    t.emit_signal_id = signal_id;
+    t.enabled = true;
+    t.spatial.zone = zone;
+    return t;
+}
+
+static sdl3d_bounding_box make_box(float x0, float y0, float z0, float x1, float y1, float z1)
+{
+    return (sdl3d_bounding_box){{x0, y0, z0}, {x1, y1, z1}};
+}
+
+/* ================================================================== */
+/* Spatial trigger — edge enter                                       */
+/* ================================================================== */
+
+TEST(TriggerSpatial, EnterFiresOnTransitionIntoZone)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+
+    /* Outside → evaluate: no fire. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 0);
+
+    /* Enter zone → fire. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Stay inside → no additional fire (edge, not level). */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(6, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(TriggerSpatial, EnterDoesNotFireOnExit)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+
+    /* Enter. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Exit. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1); /* No fire on exit. */
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Spatial trigger — edge exit                                        */
+/* ================================================================== */
+
+TEST(TriggerSpatial, ExitFiresOnTransitionOutOfZone)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 2, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_EXIT, 2);
+
+    /* Start inside. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 0);
+
+    /* Leave zone → fire. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+    EXPECT_EQ(g_last_signal, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Spatial trigger — edge both                                        */
+/* ================================================================== */
+
+TEST(TriggerSpatial, BothFiresOnEnterAndExit)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 3, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_BOTH, 3);
+
+    /* Enter. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Exit. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Spatial trigger — level (fires every frame while inside)           */
+/* ================================================================== */
+
+TEST(TriggerSpatial, LevelFiresEveryFrameWhileInside)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 4, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_LEVEL, 4);
+
+    /* Inside: fires each frame. */
+    for (int i = 0; i < 3; i++)
+    {
+        sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+        sdl3d_trigger_evaluate(&t, bus);
+    }
+    EXPECT_EQ(g_fire_count, 3);
+
+    /* Outside: stops firing. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 3);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Spatial trigger — boundary (point on edge is inside)               */
+/* ================================================================== */
+
+TEST(TriggerSpatial, PointOnBoundaryIsInside)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(0, 0, 0));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Property trigger                                                   */
+/* ================================================================== */
+
+TEST(TriggerProperty, FiresWhenThresholdCrossed)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 10, fire_counter, NULL);
+
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_properties_set_float(props, "health", 100.0f);
+
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_PROPERTY;
+    t.edge = SDL3D_TRIGGER_EDGE_ENTER;
+    t.emit_signal_id = 10;
+    t.enabled = true;
+    t.property.source = props;
+    t.property.key = "health";
+    t.property.op = SDL3D_CMP_LE;
+    t.property.threshold = 0.0f;
+
+    /* health=100, condition false. */
+    sdl3d_trigger_test_property(&t);
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 0);
+
+    /* health=0, condition becomes true → fire. */
+    sdl3d_properties_set_float(props, "health", 0.0f);
+    sdl3d_trigger_test_property(&t);
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Still 0, no re-fire (edge enter). */
+    sdl3d_trigger_test_property(&t);
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_properties_destroy(props);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(TriggerProperty, AllComparisonOps)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_properties_set_float(props, "x", 5.0f);
+
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_PROPERTY;
+    t.edge = SDL3D_TRIGGER_LEVEL;
+    t.enabled = true;
+    t.property.source = props;
+    t.property.key = "x";
+
+    /* EQ: 5 == 5 → true */
+    t.property.op = SDL3D_CMP_EQ;
+    t.property.threshold = 5.0f;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_TRUE(t.active);
+
+    /* NE: 5 != 5 → false */
+    t.property.op = SDL3D_CMP_NE;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_FALSE(t.active);
+
+    /* LT: 5 < 10 → true */
+    t.property.op = SDL3D_CMP_LT;
+    t.property.threshold = 10.0f;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_TRUE(t.active);
+
+    /* LE: 5 <= 5 → true */
+    t.property.op = SDL3D_CMP_LE;
+    t.property.threshold = 5.0f;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_TRUE(t.active);
+
+    /* GT: 5 > 3 → true */
+    t.property.op = SDL3D_CMP_GT;
+    t.property.threshold = 3.0f;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_TRUE(t.active);
+
+    /* GE: 5 >= 6 → false */
+    t.property.op = SDL3D_CMP_GE;
+    t.property.threshold = 6.0f;
+    sdl3d_trigger_test_property(&t);
+    EXPECT_FALSE(t.active);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(TriggerProperty, MissingKeyIsInactive)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_PROPERTY;
+    t.edge = SDL3D_TRIGGER_LEVEL;
+    t.enabled = true;
+    t.property.source = props;
+    t.property.key = "nonexistent";
+    t.property.op = SDL3D_CMP_EQ;
+    t.property.threshold = 0.0f;
+
+    sdl3d_trigger_test_property(&t);
+    EXPECT_FALSE(t.active);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(TriggerProperty, NullSourceIsInactive)
+{
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_PROPERTY;
+    t.edge = SDL3D_TRIGGER_LEVEL;
+    t.enabled = true;
+    t.property.source = NULL;
+    t.property.key = "x";
+    t.property.op = SDL3D_CMP_EQ;
+    t.property.threshold = 0.0f;
+
+    sdl3d_trigger_test_property(&t);
+    EXPECT_FALSE(t.active);
+}
+
+/* ================================================================== */
+/* Signal trigger                                                     */
+/* ================================================================== */
+
+TEST(TriggerSignal, ActivateAndEvaluate)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 20, fire_counter, NULL);
+
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_SIGNAL;
+    t.edge = SDL3D_TRIGGER_EDGE_ENTER;
+    t.emit_signal_id = 20;
+    t.enabled = true;
+    t.signal.listen_signal_id = 10;
+
+    /* Not activated → no fire. */
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 0);
+
+    /* Activate (simulating signal reception) → fire on evaluate. */
+    sdl3d_trigger_activate_signal(&t);
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Auto-reset: next evaluate without activation → no fire. */
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(TriggerSignal, PulseResetsAfterEvaluate)
+{
+    sdl3d_trigger t{};
+    t.type = SDL3D_TRIGGER_SIGNAL;
+    t.edge = SDL3D_TRIGGER_LEVEL;
+    t.emit_signal_id = 1;
+    t.enabled = true;
+
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    reset_globals();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    /* Activate and evaluate: fires. */
+    sdl3d_trigger_activate_signal(&t);
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Without re-activation: does not fire (pulse reset). */
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Disabled trigger                                                   */
+/* ================================================================== */
+
+TEST(TriggerDisabled, DisabledTriggerDoesNotFire)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+    t.enabled = false;
+
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 0);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Reset                                                              */
+/* ================================================================== */
+
+TEST(TriggerReset, ResetClearsState)
+{
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+    t.active = true;
+    t.was_active = true;
+
+    sdl3d_trigger_reset(&t);
+    EXPECT_FALSE(t.active);
+    EXPECT_FALSE(t.was_active);
+}
+
+TEST(TriggerReset, ResetAllowsRefire)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+
+    /* Enter → fire. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Reset, then enter again → fires again. */
+    sdl3d_trigger_reset(&t);
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* Re-entry after exit                                                */
+/* ================================================================== */
+
+TEST(TriggerSpatial, ReentryAfterExitFiresAgain)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+
+    /* Enter. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Exit. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(-1, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 1);
+
+    /* Re-enter → fires again. */
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, bus);
+    EXPECT_EQ(g_fire_count, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* NULL safety                                                        */
+/* ================================================================== */
+
+TEST(TriggerNull, NullTriggerIsSafe)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_trigger_test_spatial(NULL, sdl3d_vec3_make(0, 0, 0));
+    sdl3d_trigger_test_property(NULL);
+    sdl3d_trigger_activate_signal(NULL);
+    sdl3d_trigger_evaluate(NULL, bus);
+    sdl3d_trigger_reset(NULL);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(TriggerNull, NullBusDoesNotCrash)
+{
+    sdl3d_trigger t = make_spatial_trigger(make_box(0, 0, 0, 10, 10, 10), SDL3D_TRIGGER_EDGE_ENTER, 1);
+    sdl3d_trigger_test_spatial(&t, sdl3d_vec3_make(5, 5, 5));
+    sdl3d_trigger_evaluate(&t, NULL); /* Should not crash. */
+}


### PR DESCRIPTION
Refs #82 (Phase 3 of gameplay mechanics primitives).

## Summary

New `sdl3d_trigger` — plain-struct condition detectors that emit signals when criteria are met. Triggers only detect, never act. Responses are defined elsewhere by connecting handlers to the emitted signal.

### Trigger types

| Type | Condition | Use case |
|------|-----------|----------|
| Spatial | Point inside bounding box | Motion sensors, zone detection |
| Property | Float value crosses threshold | Health <= 0, ammo == 0 |
| Signal | Another signal was received | Cascading mechanics |

### Edge-detection modes

| Mode | Fires when |
|------|-----------|
| ENTER | Condition transitions false → true |
| EXIT | Condition transitions true → false |
| BOTH | Either transition |
| LEVEL | Every frame while condition is true |

### Design decisions

- **Plain structs:** embeddable in entity structs, trivially serializable for the future editor. No heap allocation.
- **Detect only:** triggers never act. They emit a signal. The response is defined by signal handlers. This is the composability mechanism.
- **Pulse-based signal triggers:** active resets after each evaluation, requiring fresh activation per cycle. Prevents infinite loops from signal chains.
- **Explicit existence check:** property triggers return inactive for missing keys, avoiding false positives when the fallback equals the threshold.

### API

- `test_spatial(trigger, point)` — set condition from point-in-AABB
- `test_property(trigger)` — set condition from property comparison
- `activate_signal(trigger)` — mark signal trigger as active
- `evaluate(trigger, bus)` — edge-detect and emit signal
- `reset(trigger)` — clear edge state

### Test plan

25 unit tests covering:
- Spatial: enter, exit, both, level, boundary, re-entry after exit
- Property: threshold crossing, all 6 comparison ops, missing key, null source
- Signal: activate + evaluate, pulse reset
- Disabled trigger, reset (clears state, allows re-fire)
- NULL safety (null trigger, null bus)

645/645 tests green; format clean.