### PR TITLE
feat: data-driven action system for gameplay effects (Phase 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(SDL3D::sdl3d ALIAS sdl3d)
 target_sources(
     sdl3d
     PRIVATE
+        src/action.c
         src/app.c
         src/animation.c
         src/camera.c

--- a/include/sdl3d/action.h
+++ b/include/sdl3d/action.h
@@ -1,0 +1,174 @@
+/**
+ * @file action.h
+ * @brief Data-driven responses to signals — the effect side of gameplay mechanics.
+ *
+ * An action is a response to a signal. Actions are data, not code: a
+ * designer selects an action type, fills in parameters, and wires it to
+ * a signal. This is what makes actions serializable and editable in the
+ * future level editor.
+ *
+ * Supported action types:
+ *
+ * - **Set property:** write a value to a property bag.
+ * - **Emit signal:** emit another signal (cascading / chaining).
+ * - **Start timer:** start a deferred or repeating timer (Phase 5).
+ * - **Log:** debug-print a message.
+ *
+ * Actions are plain structs. They do not own the resources they
+ * reference (property bags, strings). The caller is responsible for
+ * ensuring referenced resources outlive the action.
+ *
+ * Usage:
+ * @code
+ *   // Lock a door when an alarm fires.
+ *   sdl3d_action lock_door = {0};
+ *   lock_door.type = SDL3D_ACTION_SET_PROPERTY;
+ *   lock_door.set_property.target = door_props;
+ *   lock_door.set_property.key = "locked";
+ *   lock_door.set_property.value.type = SDL3D_VALUE_BOOL;
+ *   lock_door.set_property.value.as_bool = true;
+ *
+ *   sdl3d_action_execute(&lock_door, bus, NULL);
+ * @endcode
+ */
+
+#ifndef SDL3D_ACTION_H
+#define SDL3D_ACTION_H
+
+#include <stdbool.h>
+
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /* Forward declaration — timer_pool is Phase 5. Actions that start
+     * timers are no-ops when the pool pointer is NULL, so Phase 4 can
+     * ship independently. */
+    typedef struct sdl3d_timer_pool sdl3d_timer_pool;
+
+    /** @brief Action types. */
+    typedef enum sdl3d_action_type
+    {
+        SDL3D_ACTION_SET_PROPERTY, /**< Write a value to a property bag. */
+        SDL3D_ACTION_EMIT_SIGNAL,  /**< Emit another signal via the bus. */
+        SDL3D_ACTION_START_TIMER,  /**< Start a timer (requires Phase 5). */
+        SDL3D_ACTION_LOG,          /**< Log a debug message via SDL_Log. */
+    } sdl3d_action_type;
+
+    /**
+     * @brief A data-driven action — a response to a signal.
+     *
+     * Actions are plain value types. Zero-initialize and set the fields
+     * you need. The action does not own any of the pointers it holds;
+     * the caller must ensure they remain valid for the action's lifetime.
+     */
+    typedef struct sdl3d_action
+    {
+        sdl3d_action_type type;
+
+        union {
+            /**
+             * @brief Set a property on a target property bag.
+             *
+             * The key string is NOT copied — it must remain valid for the
+             * lifetime of the action. For string values, the property bag
+             * copies the string on set, so the value's as_string pointer
+             * only needs to be valid at execution time.
+             */
+            struct
+            {
+                sdl3d_properties *target;
+                const char *key;
+                sdl3d_value value;
+            } set_property;
+
+            /** @brief Emit another signal, enabling cascading mechanics. */
+            struct
+            {
+                int signal_id;
+            } emit_signal;
+
+            /**
+             * @brief Start a timer that emits a signal after a delay.
+             *
+             * No-op if the timer_pool argument to sdl3d_action_execute
+             * is NULL (Phase 5 not yet integrated).
+             */
+            struct
+            {
+                float delay;
+                int signal_id;
+                bool repeating;
+                float interval;
+            } start_timer;
+
+            /**
+             * @brief Log a debug message via SDL_LogInfo.
+             *
+             * The message string is NOT copied — it must remain valid
+             * for the lifetime of the action.
+             */
+            struct
+            {
+                const char *message;
+            } log;
+        };
+    } sdl3d_action;
+
+    /**
+     * @brief Execute an action.
+     *
+     * Performs the effect described by the action struct:
+     * - SET_PROPERTY: writes the value to the target property bag.
+     * - EMIT_SIGNAL: emits the signal via the bus.
+     * - START_TIMER: starts a timer via the pool (no-op if pool is NULL).
+     * - LOG: logs the message via SDL_LogInfo.
+     *
+     * @param action     The action to execute. Must not be NULL.
+     * @param bus        Signal bus for EMIT_SIGNAL actions. May be NULL
+     *                   if the action does not emit signals.
+     * @param timer_pool Timer pool for START_TIMER actions. May be NULL
+     *                   (the action becomes a no-op).
+     */
+    void sdl3d_action_execute(const sdl3d_action *action, sdl3d_signal_bus *bus, sdl3d_timer_pool *timer_pool);
+
+    /* ================================================================== */
+    /* Convenience constructors                                          */
+    /* ================================================================== */
+
+    /**
+     * @brief Create a set-property action for a boolean value.
+     *
+     * Convenience for the common case of toggling a flag.
+     */
+    sdl3d_action sdl3d_action_make_set_bool(sdl3d_properties *target, const char *key, bool value);
+
+    /**
+     * @brief Create a set-property action for a float value.
+     */
+    sdl3d_action sdl3d_action_make_set_float(sdl3d_properties *target, const char *key, float value);
+
+    /**
+     * @brief Create a set-property action for an int value.
+     */
+    sdl3d_action sdl3d_action_make_set_int(sdl3d_properties *target, const char *key, int value);
+
+    /**
+     * @brief Create an emit-signal action.
+     */
+    sdl3d_action sdl3d_action_make_emit_signal(int signal_id);
+
+    /**
+     * @brief Create a log action.
+     */
+    sdl3d_action sdl3d_action_make_log(const char *message);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_ACTION_H */

--- a/src/action.c
+++ b/src/action.c
@@ -1,0 +1,131 @@
+/**
+ * @file action.c
+ * @brief Action execution — data-driven effects for gameplay mechanics.
+ */
+
+#include "sdl3d/action.h"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+/* ================================================================== */
+/* Property setters by value type                                     */
+/* ================================================================== */
+
+static void set_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
+{
+    if (target == NULL || key == NULL || value == NULL)
+        return;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        sdl3d_properties_set_int(target, key, value->as_int);
+        break;
+    case SDL3D_VALUE_FLOAT:
+        sdl3d_properties_set_float(target, key, value->as_float);
+        break;
+    case SDL3D_VALUE_BOOL:
+        sdl3d_properties_set_bool(target, key, value->as_bool);
+        break;
+    case SDL3D_VALUE_VEC3:
+        sdl3d_properties_set_vec3(target, key, value->as_vec3);
+        break;
+    case SDL3D_VALUE_STRING:
+        sdl3d_properties_set_string(target, key, value->as_string);
+        break;
+    case SDL3D_VALUE_COLOR:
+        sdl3d_properties_set_color(target, key, value->as_color);
+        break;
+    }
+}
+
+/* ================================================================== */
+/* Execute                                                            */
+/* ================================================================== */
+
+void sdl3d_action_execute(const sdl3d_action *action, sdl3d_signal_bus *bus, sdl3d_timer_pool *timer_pool)
+{
+    if (action == NULL)
+        return;
+
+    switch (action->type)
+    {
+    case SDL3D_ACTION_SET_PROPERTY:
+        set_property_value(action->set_property.target, action->set_property.key, &action->set_property.value);
+        break;
+
+    case SDL3D_ACTION_EMIT_SIGNAL:
+        if (bus != NULL)
+            sdl3d_signal_emit(bus, action->emit_signal.signal_id, NULL);
+        break;
+
+    case SDL3D_ACTION_START_TIMER:
+        /* Phase 5 integration point. No-op until timer_pool exists. */
+        (void)timer_pool;
+        break;
+
+    case SDL3D_ACTION_LOG:
+        if (action->log.message != NULL)
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[action] %s", action->log.message);
+        break;
+    }
+}
+
+/* ================================================================== */
+/* Convenience constructors                                          */
+/* ================================================================== */
+
+sdl3d_action sdl3d_action_make_set_bool(sdl3d_properties *target, const char *key, bool value)
+{
+    sdl3d_action a;
+    SDL_zero(a);
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = target;
+    a.set_property.key = key;
+    a.set_property.value.type = SDL3D_VALUE_BOOL;
+    a.set_property.value.as_bool = value;
+    return a;
+}
+
+sdl3d_action sdl3d_action_make_set_float(sdl3d_properties *target, const char *key, float value)
+{
+    sdl3d_action a;
+    SDL_zero(a);
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = target;
+    a.set_property.key = key;
+    a.set_property.value.type = SDL3D_VALUE_FLOAT;
+    a.set_property.value.as_float = value;
+    return a;
+}
+
+sdl3d_action sdl3d_action_make_set_int(sdl3d_properties *target, const char *key, int value)
+{
+    sdl3d_action a;
+    SDL_zero(a);
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = target;
+    a.set_property.key = key;
+    a.set_property.value.type = SDL3D_VALUE_INT;
+    a.set_property.value.as_int = value;
+    return a;
+}
+
+sdl3d_action sdl3d_action_make_emit_signal(int signal_id)
+{
+    sdl3d_action a;
+    SDL_zero(a);
+    a.type = SDL3D_ACTION_EMIT_SIGNAL;
+    a.emit_signal.signal_id = signal_id;
+    return a;
+}
+
+sdl3d_action sdl3d_action_make_log(const char *message)
+{
+    sdl3d_action a;
+    SDL_zero(a);
+    a.type = SDL3D_ACTION_LOG;
+    a.log.message = message;
+    return a;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SDL3D_TEST_SOURCES
     test_lighting.cpp
     test_scene.cpp
     test_collision.cpp
+    test_action.cpp
     test_animation.cpp
     test_effects.cpp
     test_level.cpp
@@ -180,6 +181,7 @@ else()
     target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
     sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
+    sdl3d_add_test(sdl3d_action_test test_action.cpp unit)
     sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)

--- a/tests/test_action.cpp
+++ b/tests/test_action.cpp
@@ -1,0 +1,324 @@
+/**
+ * @file test_action.cpp
+ * @brief Unit tests for sdl3d_action — data-driven gameplay effects.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/action.h"
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+}
+
+/* ================================================================== */
+/* Helpers                                                            */
+/* ================================================================== */
+
+static int g_signal_count;
+static int g_last_signal;
+
+static void reset_globals()
+{
+    g_signal_count = 0;
+    g_last_signal = -1;
+}
+
+static void signal_counter(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)ud;
+    (void)payload;
+    g_signal_count++;
+    g_last_signal = signal_id;
+}
+
+/* ================================================================== */
+/* SET_PROPERTY — all value types                                     */
+/* ================================================================== */
+
+TEST(Action, SetPropertyBool)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_action a = sdl3d_action_make_set_bool(props, "locked", true);
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "locked", false));
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyFloat)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_action a = sdl3d_action_make_set_float(props, "speed", 12.5f);
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(props, "speed", 0.0f), 12.5f);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyInt)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_action a = sdl3d_action_make_set_int(props, "ammo", 50);
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    EXPECT_EQ(sdl3d_properties_get_int(props, "ammo", 0), 50);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyVec3)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action a{};
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = props;
+    a.set_property.key = "origin";
+    a.set_property.value.type = SDL3D_VALUE_VEC3;
+    a.set_property.value.as_vec3 = sdl3d_vec3_make(1.0f, 2.0f, 3.0f);
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    sdl3d_vec3 v = sdl3d_properties_get_vec3(props, "origin", sdl3d_vec3_make(0, 0, 0));
+    EXPECT_FLOAT_EQ(v.x, 1.0f);
+    EXPECT_FLOAT_EQ(v.y, 2.0f);
+    EXPECT_FLOAT_EQ(v.z, 3.0f);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyString)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action a{};
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = props;
+    a.set_property.key = "classname";
+    a.set_property.value.type = SDL3D_VALUE_STRING;
+    a.set_property.value.as_string = (char *)"func_door";
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    EXPECT_STREQ(sdl3d_properties_get_string(props, "classname", ""), "func_door");
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyColor)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action a{};
+    a.type = SDL3D_ACTION_SET_PROPERTY;
+    a.set_property.target = props;
+    a.set_property.key = "tint";
+    a.set_property.value.type = SDL3D_VALUE_COLOR;
+    a.set_property.value.as_color = (sdl3d_color){255, 0, 0, 255};
+
+    sdl3d_action_execute(&a, NULL, NULL);
+    sdl3d_color c = sdl3d_properties_get_color(props, "tint", (sdl3d_color){0, 0, 0, 0});
+    EXPECT_EQ(c.r, 255);
+    EXPECT_EQ(c.g, 0);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyOverwritesExisting)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_properties_set_int(props, "health", 100);
+
+    sdl3d_action a = sdl3d_action_make_set_int(props, "health", 0);
+    sdl3d_action_execute(&a, NULL, NULL);
+    EXPECT_EQ(sdl3d_properties_get_int(props, "health", -1), 0);
+
+    sdl3d_properties_destroy(props);
+}
+
+TEST(Action, SetPropertyNullTargetIsNoOp)
+{
+    sdl3d_action a = sdl3d_action_make_set_bool(NULL, "x", true);
+    sdl3d_action_execute(&a, NULL, NULL); /* Should not crash. */
+}
+
+/* ================================================================== */
+/* EMIT_SIGNAL                                                        */
+/* ================================================================== */
+
+TEST(Action, EmitSignal)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 42, signal_counter, NULL);
+
+    sdl3d_action a = sdl3d_action_make_emit_signal(42);
+    sdl3d_action_execute(&a, bus, NULL);
+
+    EXPECT_EQ(g_signal_count, 1);
+    EXPECT_EQ(g_last_signal, 42);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(Action, EmitSignalNullBusIsNoOp)
+{
+    sdl3d_action a = sdl3d_action_make_emit_signal(1);
+    sdl3d_action_execute(&a, NULL, NULL); /* Should not crash. */
+}
+
+TEST(Action, EmitSignalCascade)
+{
+    reset_globals();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+
+    /* Signal 1 handler emits signal 2 via an action. */
+    struct cascade_ctx
+    {
+        sdl3d_signal_bus *bus;
+        int count;
+    };
+    static struct cascade_ctx ctx;
+    ctx.bus = bus;
+    ctx.count = 0;
+
+    auto cascade_handler = [](void *ud, int sig, const sdl3d_properties *p) {
+        (void)sig;
+        (void)p;
+        struct cascade_ctx *c = (struct cascade_ctx *)ud;
+        sdl3d_action a2 = sdl3d_action_make_emit_signal(2);
+        sdl3d_action_execute(&a2, c->bus, NULL);
+    };
+
+    sdl3d_signal_connect(bus, 1, cascade_handler, &ctx);
+    sdl3d_signal_connect(bus, 2, signal_counter, NULL);
+
+    sdl3d_action a = sdl3d_action_make_emit_signal(1);
+    sdl3d_action_execute(&a, bus, NULL);
+
+    EXPECT_EQ(g_signal_count, 1);
+    EXPECT_EQ(g_last_signal, 2);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+/* ================================================================== */
+/* START_TIMER (no-op without Phase 5)                                */
+/* ================================================================== */
+
+TEST(Action, StartTimerWithNullPoolIsNoOp)
+{
+    sdl3d_action a{};
+    a.type = SDL3D_ACTION_START_TIMER;
+    a.start_timer.delay = 5.0f;
+    a.start_timer.signal_id = 99;
+    a.start_timer.repeating = false;
+
+    sdl3d_action_execute(&a, NULL, NULL); /* Should not crash. */
+}
+
+/* ================================================================== */
+/* LOG                                                                */
+/* ================================================================== */
+
+TEST(Action, LogDoesNotCrash)
+{
+    sdl3d_action a = sdl3d_action_make_log("test message");
+    sdl3d_action_execute(&a, NULL, NULL);
+}
+
+TEST(Action, LogNullMessageDoesNotCrash)
+{
+    sdl3d_action a = sdl3d_action_make_log(NULL);
+    sdl3d_action_execute(&a, NULL, NULL);
+}
+
+/* ================================================================== */
+/* NULL action                                                        */
+/* ================================================================== */
+
+TEST(Action, NullActionIsSafe)
+{
+    sdl3d_action_execute(NULL, NULL, NULL);
+}
+
+/* ================================================================== */
+/* Convenience constructors produce correct types                     */
+/* ================================================================== */
+
+TEST(Action, MakeSetBoolHasCorrectType)
+{
+    sdl3d_action a = sdl3d_action_make_set_bool(NULL, "x", true);
+    EXPECT_EQ(a.type, SDL3D_ACTION_SET_PROPERTY);
+    EXPECT_EQ(a.set_property.value.type, SDL3D_VALUE_BOOL);
+    EXPECT_TRUE(a.set_property.value.as_bool);
+}
+
+TEST(Action, MakeSetFloatHasCorrectType)
+{
+    sdl3d_action a = sdl3d_action_make_set_float(NULL, "x", 3.14f);
+    EXPECT_EQ(a.type, SDL3D_ACTION_SET_PROPERTY);
+    EXPECT_EQ(a.set_property.value.type, SDL3D_VALUE_FLOAT);
+    EXPECT_FLOAT_EQ(a.set_property.value.as_float, 3.14f);
+}
+
+TEST(Action, MakeSetIntHasCorrectType)
+{
+    sdl3d_action a = sdl3d_action_make_set_int(NULL, "x", 42);
+    EXPECT_EQ(a.type, SDL3D_ACTION_SET_PROPERTY);
+    EXPECT_EQ(a.set_property.value.type, SDL3D_VALUE_INT);
+    EXPECT_EQ(a.set_property.value.as_int, 42);
+}
+
+TEST(Action, MakeEmitSignalHasCorrectType)
+{
+    sdl3d_action a = sdl3d_action_make_emit_signal(7);
+    EXPECT_EQ(a.type, SDL3D_ACTION_EMIT_SIGNAL);
+    EXPECT_EQ(a.emit_signal.signal_id, 7);
+}
+
+TEST(Action, MakeLogHasCorrectType)
+{
+    sdl3d_action a = sdl3d_action_make_log("hello");
+    EXPECT_EQ(a.type, SDL3D_ACTION_LOG);
+    EXPECT_STREQ(a.log.message, "hello");
+}
+
+/* ================================================================== */
+/* Integration: trigger → signal → action → property change           */
+/* ================================================================== */
+
+TEST(ActionIntegration, TriggerToSignalToPropertyChange)
+{
+    sdl3d_properties *door_props = sdl3d_properties_create();
+    sdl3d_properties_set_bool(door_props, "locked", false);
+
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+
+    /* When signal 1 fires, lock the door. */
+    struct action_ctx
+    {
+        sdl3d_action action;
+    };
+    static struct action_ctx actx;
+    actx.action = sdl3d_action_make_set_bool(door_props, "locked", true);
+
+    auto action_handler = [](void *ud, int sig, const sdl3d_properties *p) {
+        (void)sig;
+        (void)p;
+        struct action_ctx *c = (struct action_ctx *)ud;
+        sdl3d_action_execute(&c->action, NULL, NULL);
+    };
+
+    sdl3d_signal_connect(bus, 1, action_handler, &actx);
+
+    /* Emit signal 1 → handler executes action → door.locked = true. */
+    sdl3d_signal_emit(bus, 1, NULL);
+    EXPECT_TRUE(sdl3d_properties_get_bool(door_props, "locked", false));
+
+    sdl3d_properties_destroy(door_props);
+    sdl3d_signal_bus_destroy(bus);
+}


### PR DESCRIPTION
Refs #82 (Phase 4 of gameplay mechanics primitives).

## Summary

New `sdl3d_action` — plain-struct data-driven effects that respond to signals. Actions are data, not code: a designer selects a type, fills in parameters, and wires it to a signal. This is what makes actions serializable and editable in the future level editor.

### Action types

| Type | Effect | Use case |
|------|--------|----------|
| SET_PROPERTY | Write any value type to a property bag | Lock doors, change light color, set health |
| EMIT_SIGNAL | Emit another signal via the bus | Cascading mechanics |
| START_TIMER | Start a deferred/repeating timer | Countdown → unlock (no-op until Phase 5) |
| LOG | Debug message via SDL_LogInfo | Development/debugging |

### Design decisions

- **Plain structs:** not heap-allocated. Embeddable, serializable, editable.
- **Data, not callbacks:** the action struct describes the effect. `sdl3d_action_execute` interprets it. This is the key property for the future editor.
- **Cascading via EMIT_SIGNAL:** one signal triggers an action that emits another signal, which triggers more actions. This is the composition mechanism.
- **START_TIMER is a no-op** when `timer_pool` is NULL, so Phase 4 ships independently of Phase 5.
- **Convenience constructors:** `make_set_bool`, `make_set_float`, `make_set_int`, `make_emit_signal`, `make_log` for the common cases.

### Test plan

21 unit tests covering:
- All 6 value types via SET_PROPERTY
- Overwrite existing property, NULL target safety
- EMIT_SIGNAL: basic, NULL bus, cascading (signal 1 → action → signal 2)
- START_TIMER: no-op with NULL pool
- LOG: normal message, NULL message
- NULL action safety
- All convenience constructors produce correct types
- Integration: trigger → signal → action → property change (end-to-end)

666/666 tests green; format clean.