### PR TITLE
feat: timer pool for deferred and repeating signal emission (Phase 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ target_sources(
         src/sw_backend.c
         src/texture.c
         src/time.c
+        src/timer_pool.c
         src/ui.c
         $<TARGET_OBJECTS:sdl3d_cgltf>
         $<TARGET_OBJECTS:sdl3d_ufbx>

--- a/include/sdl3d/timer_pool.h
+++ b/include/sdl3d/timer_pool.h
@@ -1,0 +1,128 @@
+/**
+ * @file timer_pool.h
+ * @brief Deferred and repeating signal emission via countdown timers.
+ *
+ * A timer counts down by caller-provided dt each frame. When it
+ * expires, it emits a signal via the signal bus. One-shot timers
+ * become inactive after firing. Repeating timers reset and fire
+ * again at the specified interval.
+ *
+ * Timers emit signals, not callbacks. This keeps them in the same
+ * composable signal/action framework as the rest of the gameplay
+ * mechanics system.
+ *
+ * Usage:
+ * @code
+ *   sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+ *
+ *   // 30-second countdown → emit SIG_UNLOCK when it expires.
+ *   int id = sdl3d_timer_start(pool, 30.0f, SIG_UNLOCK, false, 0);
+ *
+ *   // Each frame:
+ *   sdl3d_timer_pool_update(pool, bus, dt);
+ *
+ *   // Cancel if needed:
+ *   sdl3d_timer_cancel(pool, id);
+ *
+ *   sdl3d_timer_pool_destroy(pool);
+ * @endcode
+ */
+
+#ifndef SDL3D_TIMER_POOL_H
+#define SDL3D_TIMER_POOL_H
+
+#include <stdbool.h>
+
+#include "sdl3d/signal_bus.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque timer pool handle. */
+    typedef struct sdl3d_timer_pool sdl3d_timer_pool;
+
+    /* ================================================================== */
+    /* Lifecycle                                                          */
+    /* ================================================================== */
+
+    /**
+     * @brief Create an empty timer pool.
+     * @return A new timer pool, or NULL on allocation failure.
+     */
+    sdl3d_timer_pool *sdl3d_timer_pool_create(void);
+
+    /**
+     * @brief Destroy a timer pool and free all timers.
+     *
+     * Active timers are silently cancelled. Safe to call with NULL.
+     */
+    void sdl3d_timer_pool_destroy(sdl3d_timer_pool *pool);
+
+    /* ================================================================== */
+    /* Timer management                                                   */
+    /* ================================================================== */
+
+    /**
+     * @brief Start a new timer.
+     *
+     * The timer counts down from @p delay seconds. When it reaches zero,
+     * it emits @p signal_id via the bus passed to sdl3d_timer_pool_update.
+     *
+     * @param pool      The timer pool.
+     * @param delay     Initial countdown in seconds. Must be > 0.
+     * @param signal_id Signal to emit on expiry.
+     * @param repeating If true, the timer resets to @p interval after
+     *                  firing and fires again. If false, the timer
+     *                  becomes inactive after one firing.
+     * @param interval  Reset interval for repeating timers (seconds).
+     *                  Ignored for one-shot timers. Must be > 0 for
+     *                  repeating timers.
+     * @return A timer ID (>= 1) for cancellation, or 0 on failure.
+     */
+    int sdl3d_timer_start(sdl3d_timer_pool *pool, float delay, int signal_id, bool repeating, float interval);
+
+    /**
+     * @brief Cancel an active timer.
+     *
+     * The timer will not fire. No-op if the ID is invalid or the timer
+     * has already fired/been cancelled.
+     */
+    void sdl3d_timer_cancel(sdl3d_timer_pool *pool, int timer_id);
+
+    /* ================================================================== */
+    /* Per-frame update                                                   */
+    /* ================================================================== */
+
+    /**
+     * @brief Tick all active timers by dt seconds.
+     *
+     * Expired timers emit their signal via @p bus. One-shot timers
+     * become inactive. Repeating timers reset their countdown to
+     * their interval.
+     *
+     * Uses caller-provided dt, not sdl3d_time_get_delta_time(). This
+     * lets the caller decide whether timers respect time scale (game
+     * time) or run at real time.
+     *
+     * @param pool The timer pool.
+     * @param bus  Signal bus for emission. Must not be NULL.
+     * @param dt   Elapsed time in seconds. Must be >= 0.
+     */
+    void sdl3d_timer_pool_update(sdl3d_timer_pool *pool, sdl3d_signal_bus *bus, float dt);
+
+    /* ================================================================== */
+    /* Query                                                              */
+    /* ================================================================== */
+
+    /**
+     * @brief Get the number of active timers in the pool.
+     */
+    int sdl3d_timer_pool_active_count(const sdl3d_timer_pool *pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_TIMER_POOL_H */

--- a/src/action.c
+++ b/src/action.c
@@ -8,6 +8,8 @@
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include "sdl3d/timer_pool.h"
+
 /* ================================================================== */
 /* Property setters by value type                                     */
 /* ================================================================== */
@@ -61,8 +63,9 @@ void sdl3d_action_execute(const sdl3d_action *action, sdl3d_signal_bus *bus, sdl
         break;
 
     case SDL3D_ACTION_START_TIMER:
-        /* Phase 5 integration point. No-op until timer_pool exists. */
-        (void)timer_pool;
+        if (timer_pool != NULL)
+            sdl3d_timer_start(timer_pool, action->start_timer.delay, action->start_timer.signal_id,
+                              action->start_timer.repeating, action->start_timer.interval);
         break;
 
     case SDL3D_ACTION_LOG:

--- a/src/timer_pool.c
+++ b/src/timer_pool.c
@@ -1,0 +1,172 @@
+/**
+ * @file timer_pool.c
+ * @brief Timer pool implementation — flat dynamic array of countdown timers.
+ */
+
+#include "sdl3d/timer_pool.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+/* ================================================================== */
+/* Internal types                                                     */
+/* ================================================================== */
+
+typedef struct timer_entry
+{
+    int id;
+    int signal_id;
+    float remaining;
+    float interval;
+    bool repeating;
+    bool active;
+} timer_entry;
+
+struct sdl3d_timer_pool
+{
+    timer_entry *timers;
+    int count;
+    int capacity;
+    int next_id;
+};
+
+/* ================================================================== */
+/* Internal helpers                                                   */
+/* ================================================================== */
+
+static bool ensure_capacity(sdl3d_timer_pool *pool)
+{
+    if (pool->count < pool->capacity)
+        return true;
+    int new_cap = pool->capacity < 8 ? 8 : pool->capacity * 2;
+    timer_entry *buf = (timer_entry *)SDL_realloc(pool->timers, (size_t)new_cap * sizeof(timer_entry));
+    if (buf == NULL)
+        return false;
+    pool->timers = buf;
+    pool->capacity = new_cap;
+    return true;
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+sdl3d_timer_pool *sdl3d_timer_pool_create(void)
+{
+    sdl3d_timer_pool *pool = (sdl3d_timer_pool *)SDL_calloc(1, sizeof(sdl3d_timer_pool));
+    if (pool != NULL)
+        pool->next_id = 1;
+    return pool;
+}
+
+void sdl3d_timer_pool_destroy(sdl3d_timer_pool *pool)
+{
+    if (pool == NULL)
+        return;
+    SDL_free(pool->timers);
+    SDL_free(pool);
+}
+
+/* ================================================================== */
+/* Timer management                                                   */
+/* ================================================================== */
+
+int sdl3d_timer_start(sdl3d_timer_pool *pool, float delay, int signal_id, bool repeating, float interval)
+{
+    if (pool == NULL || delay <= 0.0f)
+        return 0;
+    if (repeating && interval <= 0.0f)
+        return 0;
+
+    if (!ensure_capacity(pool))
+        return 0;
+
+    int id = pool->next_id++;
+    timer_entry *t = &pool->timers[pool->count++];
+    t->id = id;
+    t->signal_id = signal_id;
+    t->remaining = delay;
+    t->interval = interval;
+    t->repeating = repeating;
+    t->active = true;
+    return id;
+}
+
+void sdl3d_timer_cancel(sdl3d_timer_pool *pool, int timer_id)
+{
+    if (pool == NULL || timer_id <= 0)
+        return;
+    for (int i = 0; i < pool->count; ++i)
+    {
+        if (pool->timers[i].active && pool->timers[i].id == timer_id)
+        {
+            pool->timers[i].active = false;
+            return;
+        }
+    }
+}
+
+/* ================================================================== */
+/* Per-frame update                                                   */
+/* ================================================================== */
+
+void sdl3d_timer_pool_update(sdl3d_timer_pool *pool, sdl3d_signal_bus *bus, float dt)
+{
+    if (pool == NULL || bus == NULL || dt < 0.0f)
+        return;
+
+    for (int i = 0; i < pool->count; ++i)
+    {
+        timer_entry *t = &pool->timers[i];
+        if (!t->active)
+            continue;
+
+        t->remaining -= dt;
+        if (t->remaining <= 0.0f)
+        {
+            sdl3d_signal_emit(bus, t->signal_id, NULL);
+            if (t->repeating)
+            {
+                t->remaining += t->interval;
+                /* Guard against spiral-of-death: if remaining is still
+                 * negative after one reset, clamp to the interval. This
+                 * means at most one firing per update call. */
+                if (t->remaining <= 0.0f)
+                    t->remaining = t->interval;
+            }
+            else
+            {
+                t->active = false;
+            }
+        }
+    }
+
+    /* Compact inactive timers. */
+    int write = 0;
+    for (int read = 0; read < pool->count; ++read)
+    {
+        if (pool->timers[read].active)
+        {
+            if (write != read)
+                pool->timers[write] = pool->timers[read];
+            write++;
+        }
+    }
+    pool->count = write;
+}
+
+/* ================================================================== */
+/* Query                                                              */
+/* ================================================================== */
+
+int sdl3d_timer_pool_active_count(const sdl3d_timer_pool *pool)
+{
+    if (pool == NULL)
+        return 0;
+    int count = 0;
+    for (int i = 0; i < pool->count; ++i)
+    {
+        if (pool->timers[i].active)
+            count++;
+    }
+    return count;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SDL3D_TEST_SOURCES
     test_properties.cpp
     test_signal_bus.cpp
     test_trigger.cpp
+    test_timer_pool.cpp
     test_fps_mover.cpp
     test_sprite_actor.cpp
 )
@@ -189,6 +190,7 @@ else()
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)
     sdl3d_add_test(sdl3d_signal_bus_test test_signal_bus.cpp unit)
     sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
+    sdl3d_add_test(sdl3d_timer_pool_test test_timer_pool.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
     sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)

--- a/tests/test_timer_pool.cpp
+++ b/tests/test_timer_pool.cpp
@@ -1,0 +1,306 @@
+/**
+ * @file test_timer_pool.cpp
+ * @brief Unit tests for sdl3d_timer_pool — deferred and repeating signal emission.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/action.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/timer_pool.h"
+}
+
+/* ================================================================== */
+/* Helpers                                                            */
+/* ================================================================== */
+
+static int g_fire_count;
+static int g_last_signal;
+
+static void reset_globals()
+{
+    g_fire_count = 0;
+    g_last_signal = -1;
+}
+
+static void fire_counter(void *ud, int signal_id, const sdl3d_properties *payload)
+{
+    (void)ud;
+    (void)payload;
+    g_fire_count++;
+    g_last_signal = signal_id;
+}
+
+/* ================================================================== */
+/* Lifecycle                                                          */
+/* ================================================================== */
+
+TEST(TimerPool, CreateAndDestroy)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    ASSERT_NE(pool, nullptr);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 0);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, DestroyNullIsSafe)
+{
+    sdl3d_timer_pool_destroy(nullptr);
+}
+
+/* ================================================================== */
+/* One-shot timer                                                     */
+/* ================================================================== */
+
+TEST(TimerPool, OneShotFiresAfterDelay)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    int id = sdl3d_timer_start(pool, 1.0f, 1, false, 0);
+    EXPECT_GT(id, 0);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 1);
+
+    /* Not yet expired. */
+    sdl3d_timer_pool_update(pool, bus, 0.5f);
+    EXPECT_EQ(g_fire_count, 0);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 1);
+
+    /* Expires. */
+    sdl3d_timer_pool_update(pool, bus, 0.6f);
+    EXPECT_EQ(g_fire_count, 1);
+    EXPECT_EQ(g_last_signal, 1);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 0);
+
+    /* Does not fire again. */
+    sdl3d_timer_pool_update(pool, bus, 1.0f);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, OneShotFiresExactlyAtZero)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    sdl3d_timer_start(pool, 1.0f, 1, false, 0);
+    sdl3d_timer_pool_update(pool, bus, 1.0f);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+/* ================================================================== */
+/* Repeating timer                                                    */
+/* ================================================================== */
+
+TEST(TimerPool, RepeatingFiresMultipleTimes)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 2, fire_counter, NULL);
+
+    sdl3d_timer_start(pool, 0.5f, 2, true, 0.5f);
+
+    /* First firing at 0.5s. */
+    sdl3d_timer_pool_update(pool, bus, 0.5f);
+    EXPECT_EQ(g_fire_count, 1);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 1);
+
+    /* Second firing at 1.0s. */
+    sdl3d_timer_pool_update(pool, bus, 0.5f);
+    EXPECT_EQ(g_fire_count, 2);
+
+    /* Third firing at 1.5s. */
+    sdl3d_timer_pool_update(pool, bus, 0.5f);
+    EXPECT_EQ(g_fire_count, 3);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, RepeatingAtMostOncePerUpdate)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    /* Interval 0.1s, but we pass dt=10s. Should fire once, not 100 times. */
+    sdl3d_timer_start(pool, 0.1f, 1, true, 0.1f);
+    sdl3d_timer_pool_update(pool, bus, 10.0f);
+    EXPECT_EQ(g_fire_count, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+/* ================================================================== */
+/* Cancel                                                             */
+/* ================================================================== */
+
+TEST(TimerPool, CancelPreventsFireing)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, fire_counter, NULL);
+
+    int id = sdl3d_timer_start(pool, 1.0f, 1, false, 0);
+    sdl3d_timer_cancel(pool, id);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 0);
+
+    sdl3d_timer_pool_update(pool, bus, 2.0f);
+    EXPECT_EQ(g_fire_count, 0);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, CancelInvalidIdIsNoOp)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_timer_cancel(pool, 999);
+    sdl3d_timer_cancel(pool, 0);
+    sdl3d_timer_cancel(pool, -1);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, CancelNullPoolIsNoOp)
+{
+    sdl3d_timer_cancel(nullptr, 1);
+}
+
+/* ================================================================== */
+/* Multiple timers                                                    */
+/* ================================================================== */
+
+TEST(TimerPool, MultipleTimersFireIndependently)
+{
+    int count_a = 0, count_b = 0;
+    auto handler_a = [](void *ud, int sig, const sdl3d_properties *p) {
+        (void)sig;
+        (void)p;
+        (*(int *)ud)++;
+    };
+
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 1, handler_a, &count_a);
+    sdl3d_signal_connect(bus, 2, handler_a, &count_b);
+
+    sdl3d_timer_start(pool, 0.5f, 1, false, 0);
+    sdl3d_timer_start(pool, 1.5f, 2, false, 0);
+
+    sdl3d_timer_pool_update(pool, bus, 0.6f);
+    EXPECT_EQ(count_a, 1);
+    EXPECT_EQ(count_b, 0);
+
+    sdl3d_timer_pool_update(pool, bus, 1.0f);
+    EXPECT_EQ(count_a, 1);
+    EXPECT_EQ(count_b, 1);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+/* ================================================================== */
+/* Validation                                                         */
+/* ================================================================== */
+
+TEST(TimerPool, StartWithZeroDelayReturnsZero)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    EXPECT_EQ(sdl3d_timer_start(pool, 0.0f, 1, false, 0), 0);
+    EXPECT_EQ(sdl3d_timer_start(pool, -1.0f, 1, false, 0), 0);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, RepeatingWithZeroIntervalReturnsZero)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    EXPECT_EQ(sdl3d_timer_start(pool, 1.0f, 1, true, 0.0f), 0);
+    EXPECT_EQ(sdl3d_timer_start(pool, 1.0f, 1, true, -1.0f), 0);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+TEST(TimerPool, StartNullPoolReturnsZero)
+{
+    EXPECT_EQ(sdl3d_timer_start(nullptr, 1.0f, 1, false, 0), 0);
+}
+
+/* ================================================================== */
+/* NULL safety                                                        */
+/* ================================================================== */
+
+TEST(TimerPool, UpdateNullArgsAreSafe)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_timer_pool_update(nullptr, bus, 1.0f);
+    sdl3d_timer_pool_update(pool, nullptr, 1.0f);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(nullptr), 0);
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+/* ================================================================== */
+/* Timer IDs are monotonic                                            */
+/* ================================================================== */
+
+TEST(TimerPool, IdsAreMonotonic)
+{
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    int a = sdl3d_timer_start(pool, 1.0f, 1, false, 0);
+    int b = sdl3d_timer_start(pool, 1.0f, 2, false, 0);
+    int c = sdl3d_timer_start(pool, 1.0f, 3, false, 0);
+    EXPECT_GT(a, 0);
+    EXPECT_GT(b, a);
+    EXPECT_GT(c, b);
+    sdl3d_timer_pool_destroy(pool);
+}
+
+/* ================================================================== */
+/* Integration: action START_TIMER → timer → signal                   */
+/* ================================================================== */
+
+TEST(TimerPool, ActionStartTimerIntegration)
+{
+    reset_globals();
+    sdl3d_timer_pool *pool = sdl3d_timer_pool_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_signal_connect(bus, 99, fire_counter, NULL);
+
+    /* Execute a START_TIMER action. */
+    sdl3d_action a{};
+    a.type = SDL3D_ACTION_START_TIMER;
+    a.start_timer.delay = 2.0f;
+    a.start_timer.signal_id = 99;
+    a.start_timer.repeating = false;
+    a.start_timer.interval = 0;
+
+    sdl3d_action_execute(&a, bus, pool);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(pool), 1);
+
+    /* Not yet. */
+    sdl3d_timer_pool_update(pool, bus, 1.0f);
+    EXPECT_EQ(g_fire_count, 0);
+
+    /* Fires. */
+    sdl3d_timer_pool_update(pool, bus, 1.5f);
+    EXPECT_EQ(g_fire_count, 1);
+    EXPECT_EQ(g_last_signal, 99);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_timer_pool_destroy(pool);
+}


### PR DESCRIPTION
Refs #82 (Phase 5 of gameplay mechanics primitives).

## Summary

New `sdl3d_timer_pool` — countdown timers that emit signals via the signal bus. This gives the Time dimension to the gameplay mechanics system.

Also wires the Phase 4 `SDL3D_ACTION_START_TIMER` action type: `sdl3d_action_execute` now calls `sdl3d_timer_start` when a timer pool is provided, completing the action→timer→signal chain.

### API

- `create` / `destroy`
- `start(pool, delay, signal_id, repeating, interval)` → timer ID
- `cancel(pool, timer_id)`
- `update(pool, bus, dt)` — tick all timers, emit expired signals
- `active_count(pool)`

### Design decisions

- **Timers emit signals, not callbacks.** Same composable framework as triggers and actions.
- **Caller-provided dt.** The caller decides whether timers respect time scale (game time) or run at real time.
- **Spiral-of-death guard:** repeating timers fire at most once per update call. If dt exceeds the interval, remaining is clamped to the interval rather than firing multiple times.
- **Monotonic timer IDs** for targeted cancellation.
- **Compact on update:** inactive timers are removed from the array each frame.

### Test plan

16 unit tests covering:
- One-shot: fires after delay, fires exactly at zero, does not re-fire
- Repeating: fires multiple times, at most once per update (spiral guard)
- Cancel: prevents firing, invalid ID, NULL pool
- Multiple timers fire independently
- Validation: zero/negative delay, zero interval for repeating
- NULL safety (null pool, null bus)
- Monotonic IDs
- Integration: action START_TIMER → timer countdown → signal emission

682/682 tests green; format clean.