### PR TITLE
Add managed game loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(
         src/drawing3d.c
         src/effects.c
         src/fbx_loader.c
+        src/game.c
         src/gltf_loader.c
         src/gl_renderer.c
         src/image.c

--- a/demos/doom_level/backend.c
+++ b/demos/doom_level/backend.c
@@ -1,22 +1,5 @@
-/* Window/backend creation and hot-switching. */
+/* Doom-level render defaults. */
 #include "backend.h"
-
-bool backend_create(SDL_Window **out_win, sdl3d_render_context **out_ctx, sdl3d_backend backend)
-{
-    sdl3d_window_config wcfg;
-    sdl3d_init_window_config(&wcfg);
-    wcfg.width = (backend == SDL3D_BACKEND_SOFTWARE) ? SOFTWARE_W : WINDOW_W;
-    wcfg.height = (backend == SDL3D_BACKEND_SOFTWARE) ? SOFTWARE_H : WINDOW_H;
-    wcfg.title = "SDL3D \xe2\x80\x94 Doom Level";
-    wcfg.backend = backend;
-    wcfg.allow_backend_fallback = false;
-
-    if (!sdl3d_create_window(&wcfg, out_win, out_ctx))
-        return false;
-
-    SDL_SetWindowRelativeMouseMode(*out_win, true);
-    return true;
-}
 
 void backend_apply_defaults(sdl3d_render_context *ctx)
 {

--- a/demos/doom_level/backend.h
+++ b/demos/doom_level/backend.h
@@ -1,19 +1,11 @@
-/* Window/backend creation and hot-switching. */
+/* Doom-level render defaults and dimensions. */
 #ifndef DOOM_BACKEND_H
 #define DOOM_BACKEND_H
 
 #include "sdl3d/sdl3d.h"
 
-#include <SDL3/SDL_video.h>
-
-#include <stdbool.h>
-
 #define WINDOW_W 1280
 #define WINDOW_H 720
-#define SOFTWARE_W (WINDOW_W / 2)
-#define SOFTWARE_H (WINDOW_H / 2)
-
-bool backend_create(SDL_Window **out_win, sdl3d_render_context **out_ctx, sdl3d_backend backend);
 
 /* Apply default render settings after creating or switching backends. */
 void backend_apply_defaults(sdl3d_render_context *ctx);

--- a/demos/doom_level/entities.c
+++ b/demos/doom_level/entities.c
@@ -13,9 +13,11 @@ static void configure_sprite_texture(sdl3d_texture2d *texture)
     sdl3d_set_texture_wrap(texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP);
 }
 
-bool entities_init(entities *e)
+bool entities_init(entities *e, sdl3d_actor_registry *registry, sdl3d_signal_bus *bus)
 {
     SDL_zerop(e);
+    e->registry = registry;
+    e->bus = bus;
 
     /* Load enemy rotation sprites. */
     const char *rot_paths[SDL3D_SPRITE_ROTATION_COUNT] = {
@@ -135,9 +137,7 @@ bool entities_init(entities *e)
             sdl3d_actor_play_animation(dragon, 0, true);
     }
 
-    /* Actor registry — register all game objects for unified state. */
-    e->bus = sdl3d_signal_bus_create();
-    e->registry = sdl3d_actor_registry_create();
+    /* Register game objects in the managed-loop actor registry. */
     if (e->registry)
     {
         sdl3d_registered_actor *ra;
@@ -172,8 +172,6 @@ bool entities_init(entities *e)
 
 void entities_free(entities *e)
 {
-    sdl3d_actor_registry_destroy(e->registry);
-    sdl3d_signal_bus_destroy(e->bus);
     sdl3d_sprite_scene_free(&e->sprites);
     sdl3d_destroy_scene(e->scene);
     if (e->has_robot)
@@ -186,6 +184,8 @@ void entities_free(entities *e)
     sdl3d_free_texture(&e->crate_tex);
     for (int i = 0; i < 6; ++i)
         sdl3d_free_texture(&e->sky[i]);
+    e->registry = NULL;
+    e->bus = NULL;
 }
 
 void entities_update(entities *e, float dt, sdl3d_vec3 player_position)

--- a/demos/doom_level/entities.h
+++ b/demos/doom_level/entities.h
@@ -32,12 +32,12 @@ typedef struct entities
     bool has_dragon;
     sdl3d_scene *scene;
 
-    /* Actor registry — unified game object table. */
+    /* Actor registry and signal bus are provided by the managed game loop. */
     sdl3d_actor_registry *registry;
     sdl3d_signal_bus *bus;
 } entities;
 
-bool entities_init(entities *e);
+bool entities_init(entities *e, sdl3d_actor_registry *registry, sdl3d_signal_bus *bus);
 void entities_free(entities *e);
 
 /* Advance sprite bobbing, model animations, and registry triggers. */

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -1,18 +1,15 @@
 /*
- * Doom-style level demo — thin game loop shell.
+ * Doom-style level demo using the SDL3D managed game loop.
  *
- * All logic is split into subsystems:
- *   backend.h   — window/backend creation
- *   level_data.h — sector geometry, materials, lights
- *   entities.h  — sprites, 3D models, textures
- *   player.h    — FPS mover, input, projectile
- *   renderer.h  — per-frame drawing, visibility, HUD
+ * Gameplay stays in subsystem modules. The managed loop owns SDL init,
+ * event polling, fixed-timestep ticking, presentation, and engine cleanup.
  */
 #define SDL_MAIN_HANDLED
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 
 #include "sdl3d/font.h"
+#include "sdl3d/game.h"
 #include "sdl3d/sdl3d.h"
 #include "sdl3d/ui.h"
 
@@ -22,123 +19,187 @@
 #include "player.h"
 #include "renderer.h"
 
+typedef struct doom_state
+{
+    level_data level;
+    entities ent;
+    player_state player;
+    render_state render;
+    sdl3d_font debug_font;
+    sdl3d_ui_context *ui;
+    sdl3d_backend current_backend;
+    bool has_font;
+    bool level_ready;
+    bool entities_ready;
+} doom_state;
+
+static void doom_state_cleanup(doom_state *state)
+{
+    if (state->entities_ready)
+    {
+        entities_free(&state->ent);
+        state->entities_ready = false;
+    }
+    if (state->level_ready)
+    {
+        level_data_free(&state->level);
+        state->level_ready = false;
+    }
+    sdl3d_ui_destroy(state->ui);
+    state->ui = NULL;
+    if (state->has_font)
+    {
+        sdl3d_free_font(&state->debug_font);
+        state->has_font = false;
+    }
+}
+
+static void apply_window_defaults(sdl3d_game_context *ctx)
+{
+    backend_apply_defaults(ctx->renderer);
+    SDL_SetWindowRelativeMouseMode(ctx->window, true);
+}
+
+static bool game_init(sdl3d_game_context *ctx, void *userdata)
+{
+    doom_state *state = (doom_state *)userdata;
+
+    state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
+    apply_window_defaults(ctx);
+
+    state->has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &state->debug_font);
+    if (!sdl3d_ui_create(state->has_font ? &state->debug_font : NULL, &state->ui))
+    {
+        doom_state_cleanup(state);
+        return false;
+    }
+
+    if (!level_data_init(&state->level))
+    {
+        doom_state_cleanup(state);
+        return false;
+    }
+    state->level_ready = true;
+
+    if (!entities_init(&state->ent, ctx->registry, ctx->bus))
+    {
+        entities_free(&state->ent);
+        doom_state_cleanup(state);
+        return false;
+    }
+    state->entities_ready = true;
+
+    player_init(&state->player);
+    render_state_init(&state->render);
+    return true;
+}
+
+static bool switch_demo_backend(sdl3d_game_context *ctx, doom_state *state)
+{
+    sdl3d_backend next =
+        (state->current_backend == SDL3D_BACKEND_SDLGPU) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_SDLGPU;
+
+    if (sdl3d_switch_backend(&ctx->window, &ctx->renderer, next))
+    {
+        state->current_backend = next;
+        apply_window_defaults(ctx);
+        return true;
+    }
+
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Backend switch failed: %s", SDL_GetError());
+    if (!sdl3d_switch_backend(&ctx->window, &ctx->renderer, state->current_backend))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not restore previous backend: %s", SDL_GetError());
+        return false;
+    }
+
+    apply_window_defaults(ctx);
+    return true;
+}
+
+static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
+{
+    doom_state *state = (doom_state *)userdata;
+
+    sdl3d_ui_process_event(state->ui, event);
+
+    if (!player_handle_event(&state->player, event))
+    {
+        return false;
+    }
+
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_L)
+    {
+        state->level.use_lit = !state->level.use_lit;
+    }
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_M)
+    {
+        state->level.use_lightmaps = !state->level.use_lightmaps;
+    }
+
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_F1)
+    {
+        state->render.show_debug = !state->render.show_debug;
+    }
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_F2)
+    {
+        state->render.portal_culling = !state->render.portal_culling;
+    }
+
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_TAB)
+    {
+        return switch_demo_backend(ctx, state);
+    }
+
+    return true;
+}
+
+static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    (void)ctx;
+    doom_state *state = (doom_state *)userdata;
+
+    entities_update(&state->ent, dt, state->player.mover.position);
+    player_update(&state->player, &state->level.unlit, g_sectors, dt);
+}
+
+static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    (void)alpha;
+    doom_state *state = (doom_state *)userdata;
+    const float frame_dt = sdl3d_time_get_unscaled_delta_time();
+
+    render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
+                      &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt);
+}
+
+static void game_shutdown(sdl3d_game_context *ctx, void *userdata)
+{
+    (void)ctx;
+    doom_state *state = (doom_state *)userdata;
+
+    doom_state_cleanup(state);
+}
+
 int main(int argc, char *argv[])
 {
     (void)argc;
     (void)argv;
-    SDL_SetMainReady();
-    if (!SDL_Init(SDL_INIT_VIDEO))
-        return 1;
 
-    /* Backend */
-    SDL_Window *win = NULL;
-    sdl3d_render_context *ctx = NULL;
-    sdl3d_backend current_backend = SDL3D_BACKEND_SDLGPU;
-    if (!backend_create(&win, &ctx, current_backend))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Backend init failed: %s", SDL_GetError());
-        SDL_Quit();
-        return 1;
-    }
-    backend_apply_defaults(ctx);
+    doom_state state = {0};
+    sdl3d_game_config config = {0};
+    config.title = "SDL3D - Doom Level";
+    config.width = WINDOW_W;
+    config.height = WINDOW_H;
+    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.tick_rate = 1.0f / 60.0f;
 
-    /* Font + UI */
-    sdl3d_font debug_font;
-    bool has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &debug_font);
-    sdl3d_ui_context *ui = NULL;
-    sdl3d_ui_create(has_font ? &debug_font : NULL, &ui);
+    sdl3d_game_callbacks callbacks = {0};
+    callbacks.init = game_init;
+    callbacks.event = game_event;
+    callbacks.tick = game_tick;
+    callbacks.render = game_render;
+    callbacks.shutdown = game_shutdown;
 
-    /* Subsystems */
-    level_data ld;
-    if (!level_data_init(&ld))
-    {
-        sdl3d_destroy_render_context(ctx);
-        SDL_DestroyWindow(win);
-        SDL_Quit();
-        return 1;
-    }
-
-    entities ent;
-    if (!entities_init(&ent))
-    {
-        level_data_free(&ld);
-        sdl3d_destroy_render_context(ctx);
-        SDL_DestroyWindow(win);
-        SDL_Quit();
-        return 1;
-    }
-
-    player_state player;
-    player_init(&player);
-
-    render_state rs;
-    render_state_init(&rs);
-
-    /* Game loop */
-    bool running = true;
-    Uint64 last = SDL_GetPerformanceCounter();
-
-    while (running)
-    {
-        SDL_Event ev;
-        while (SDL_PollEvent(&ev))
-        {
-            sdl3d_ui_process_event(ui, &ev);
-
-            if (!player_handle_event(&player, &ev))
-                running = false;
-
-            /* Level lighting toggles */
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_L)
-                ld.use_lit = !ld.use_lit;
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_M)
-                ld.use_lightmaps = !ld.use_lightmaps;
-
-            /* Render toggles */
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F1)
-                rs.show_debug = !rs.show_debug;
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F2)
-                rs.portal_culling = !rs.portal_culling;
-
-            /* Backend hot-switch */
-            if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_TAB)
-            {
-                sdl3d_backend next =
-                    (current_backend == SDL3D_BACKEND_SDLGPU) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_SDLGPU;
-                sdl3d_destroy_render_context(ctx);
-                SDL_DestroyWindow(win);
-                ctx = NULL;
-                win = NULL;
-                if (!backend_create(&win, &ctx, next))
-                {
-                    backend_create(&win, &ctx, current_backend);
-                }
-                else
-                {
-                    current_backend = next;
-                }
-                backend_apply_defaults(ctx);
-            }
-        }
-
-        Uint64 now = SDL_GetPerformanceCounter();
-        float dt = (float)(now - last) / (float)SDL_GetPerformanceFrequency();
-        last = now;
-
-        entities_update(&ent, dt, player.mover.position);
-        player_update(&player, &ld.unlit, g_sectors, dt);
-
-        render_draw_frame(&rs, ctx, has_font ? &debug_font : NULL, ui, &ld, &ent, &player, WINDOW_W, WINDOW_H, dt);
-    }
-
-    /* Cleanup */
-    entities_free(&ent);
-    level_data_free(&ld);
-    if (has_font)
-        sdl3d_free_font(&debug_font);
-    sdl3d_ui_destroy(ui);
-    sdl3d_destroy_render_context(ctx);
-    SDL_DestroyWindow(win);
-    SDL_Quit();
-    return 0;
+    return sdl3d_run_game(&config, &callbacks, &state);
 }

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -203,8 +203,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
         sdl3d_ui_render(ui, ctx);
     }
 
-    sdl3d_present_render_context(ctx);
-
     if (rs->show_debug)
     {
         int visible_meshes = 0;

--- a/demos/doom_level/renderer.h
+++ b/demos/doom_level/renderer.h
@@ -22,7 +22,7 @@ typedef struct render_state
 
 void render_state_init(render_state *rs);
 
-/* Draw one complete frame. */
+/* Draw one complete frame. Presentation is owned by the managed game loop. */
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
                        level_data *ld, entities *ent, const player_state *player, int backbuffer_w, int backbuffer_h,
                        float dt);

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -1,0 +1,157 @@
+/**
+ * @file game.h
+ * @brief Managed SDL3D game loop with fixed-timestep simulation.
+ *
+ * The managed game loop owns SDL initialization, window and render-context
+ * creation, SDL event polling, fixed-rate simulation ticks, frame presentation,
+ * and engine subsystem cleanup. Games provide callbacks and caller-owned
+ * userdata; SDL3D owns the outer loop.
+ */
+
+#ifndef SDL3D_GAME_H
+#define SDL3D_GAME_H
+
+#include <stdbool.h>
+
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_video.h>
+
+#include "sdl3d/actor_registry.h"
+#include "sdl3d/render_context.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/timer_pool.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief Engine-owned state passed to every managed-loop callback.
+     *
+     * The game may read these fields and may set quit_requested to request
+     * shutdown. The loop creates the window, render context, registry, signal
+     * bus, and timer pool before init, then destroys them after shutdown.
+     */
+    typedef struct sdl3d_game_context
+    {
+        SDL_Window *window;             /**< SDL window owned by the managed loop. */
+        sdl3d_render_context *renderer; /**< SDL3D render context owned by the managed loop. */
+        sdl3d_actor_registry *registry; /**< Actor registry owned by the managed loop. */
+        sdl3d_signal_bus *bus;          /**< Signal bus owned by the managed loop. */
+        sdl3d_timer_pool *timers;       /**< Timer pool owned by the managed loop. */
+        float time;                     /**< Simulated game time advanced by fixed ticks. */
+        float real_time;                /**< Wall-clock time accumulated by rendered frames. */
+        int tick_count;                 /**< Total fixed ticks executed since startup. */
+        bool quit_requested;            /**< Set true from any callback to leave the loop. */
+    } sdl3d_game_context;
+
+    /**
+     * @brief Callback table for sdl3d_run_game.
+     *
+     * Every callback receives the engine-owned context plus the userdata passed
+     * to sdl3d_run_game. Any callback may be NULL and is treated as a no-op.
+     */
+    typedef struct sdl3d_game_callbacks
+    {
+        /**
+         * @brief Called once after engine subsystems are created.
+         *
+         * Load assets, create actors, initialize UI, and build level state here.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         * @return true to enter the game loop, false to abort startup.
+         */
+        bool (*init)(sdl3d_game_context *ctx, void *userdata);
+
+        /**
+         * @brief Called for each non-quit SDL event.
+         *
+         * SDL_EVENT_QUIT is handled by the managed loop and always requests
+         * shutdown. Return false from this callback to request shutdown for
+         * game-specific events such as Escape.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         * @param event    SDL event for game-specific handling.
+         * @return true to continue, false to request shutdown.
+         */
+        bool (*event)(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event);
+
+        /**
+         * @brief Called at the fixed simulation timestep.
+         *
+         * The dt value is always config.tick_rate seconds, or 1/60 by default.
+         * The managed loop updates ctx->timers before this callback. It does not
+         * call sdl3d_actor_registry_update automatically because trigger tests
+         * need a game-defined point such as the player position.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         * @param dt       Fixed timestep in seconds.
+         */
+        void (*tick)(sdl3d_game_context *ctx, void *userdata, float dt);
+
+        /**
+         * @brief Called once per rendered frame after fixed ticks.
+         *
+         * The alpha value is the interpolation fraction in [0, 1] between the
+         * last completed tick and the next tick. The game owns clearing and all
+         * drawing. The managed loop presents ctx->renderer after this callback
+         * returns, so render callbacks should not call sdl3d_present_render_context.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         * @param alpha    Render interpolation factor in the range [0, 1].
+         */
+        void (*render)(sdl3d_game_context *ctx, void *userdata, float alpha);
+
+        /**
+         * @brief Called once after the loop exits and before engine cleanup.
+         *
+         * Free caller-owned assets, UI, levels, and gameplay state here. Engine
+         * subsystems in ctx are still valid for the duration of this callback.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         */
+        void (*shutdown)(sdl3d_game_context *ctx, void *userdata);
+    } sdl3d_game_callbacks;
+
+    /**
+     * @brief Configuration for sdl3d_run_game.
+     *
+     * Zero-initialization selects sensible defaults.
+     */
+    typedef struct sdl3d_game_config
+    {
+        const char *title;       /**< Window title, or "SDL3D" when NULL. */
+        int width;               /**< Window width in pixels, or 1280 when <= 0. */
+        int height;              /**< Window height in pixels, or 720 when <= 0. */
+        sdl3d_backend backend;   /**< Requested backend, or SDL3D_BACKEND_AUTO when zero. */
+        float tick_rate;         /**< Fixed timestep in seconds, or 1/60 when <= 0. */
+        int max_ticks_per_frame; /**< Catch-up tick cap per rendered frame, or 8 when <= 0. */
+    } sdl3d_game_config;
+
+    /**
+     * @brief Run a managed SDL3D game loop.
+     *
+     * Initializes SDL video, creates the window, render context, actor registry,
+     * signal bus, and timer pool, then runs a fixed-timestep simulation loop
+     * until quit is requested. The loop updates the timer pool before each tick,
+     * calls sdl3d_time_update once per rendered frame, and presents the render
+     * context after each render callback.
+     *
+     * @param config    Optional configuration. NULL selects all defaults.
+     * @param callbacks Optional callback table. NULL treats all callbacks as no-ops.
+     * @param userdata  Caller-owned pointer passed to every callback.
+     * @return 0 on normal shutdown, 1 on startup or runtime failure.
+     */
+    int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *callbacks, void *userdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_GAME_H */

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -86,6 +86,18 @@ extern "C"
     bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_window,
                              sdl3d_render_context **out_context);
 
+    /**
+     * @brief Destroy a window and render context created by sdl3d_create_window.
+     *
+     * This releases the SDL3D render context, the SDL_Renderer owned by the
+     * software backend path, and the SDL_Window. Safe to call with NULL
+     * arguments.
+     *
+     * @param window  SDL window returned by sdl3d_create_window.
+     * @param context Render context returned by sdl3d_create_window.
+     */
+    void sdl3d_destroy_window(SDL_Window *window, sdl3d_render_context *context);
+
     /*
      * Switch to a different backend at runtime. Destroys the current
      * window and context, creates new ones with the same dimensions

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -11,6 +11,7 @@
 #include "sdl3d/collision.h"
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/effects.h"
+#include "sdl3d/game.h"
 #include "sdl3d/image.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/math.h"

--- a/src/app.c
+++ b/src/app.c
@@ -54,16 +54,9 @@ bool sdl3d_init(int width, int height, const char *title)
 
 void sdl3d_close(void)
 {
-    if (s_ctx)
-    {
-        sdl3d_destroy_render_context(s_ctx);
-        s_ctx = NULL;
-    }
-    if (s_window)
-    {
-        SDL_DestroyWindow(s_window);
-        s_window = NULL;
-    }
+    sdl3d_destroy_window(s_window, s_ctx);
+    s_ctx = NULL;
+    s_window = NULL;
     SDL_Quit();
 }
 

--- a/src/game.c
+++ b/src/game.c
@@ -6,7 +6,6 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_stdinc.h>
 
-#include "render_context_internal.h"
 #include "sdl3d/time.h"
 
 #define SDL3D_GAME_DEFAULT_WIDTH 1280
@@ -23,23 +22,6 @@ static int sdl3d_game_max_ticks_per_frame(const sdl3d_game_config *config)
 {
     return (config != NULL && config->max_ticks_per_frame > 0) ? config->max_ticks_per_frame
                                                                : SDL3D_GAME_DEFAULT_MAX_TICKS;
-}
-
-static void sdl3d_game_destroy_window_and_renderer(SDL_Window *window, sdl3d_render_context *renderer)
-{
-    SDL_Renderer *sdl_renderer = renderer != NULL ? renderer->renderer : NULL;
-
-    sdl3d_destroy_render_context(renderer);
-
-    if (sdl_renderer != NULL)
-    {
-        SDL_DestroyRenderer(sdl_renderer);
-    }
-
-    if (window != NULL)
-    {
-        SDL_DestroyWindow(window);
-    }
 }
 
 static bool sdl3d_game_create_context(const sdl3d_game_config *config, sdl3d_game_context *ctx)
@@ -75,7 +57,7 @@ static void sdl3d_game_cleanup_context(sdl3d_game_context *ctx)
     sdl3d_timer_pool_destroy(ctx->timers);
     sdl3d_signal_bus_destroy(ctx->bus);
     sdl3d_actor_registry_destroy(ctx->registry);
-    sdl3d_game_destroy_window_and_renderer(ctx->window, ctx->renderer);
+    sdl3d_destroy_window(ctx->window, ctx->renderer);
     SDL_zero(*ctx);
 }
 
@@ -184,7 +166,12 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
 
         if (callbacks != NULL && callbacks->render != NULL)
         {
-            callbacks->render(&ctx, userdata, accumulator / fixed_dt);
+            float alpha = accumulator / fixed_dt;
+            if (alpha > 1.0f)
+            {
+                alpha = 1.0f;
+            }
+            callbacks->render(&ctx, userdata, alpha);
         }
 
         if (!sdl3d_present_render_context(ctx.renderer))

--- a/src/game.c
+++ b/src/game.c
@@ -1,0 +1,206 @@
+#define SDL_MAIN_HANDLED
+#include "sdl3d/game.h"
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "render_context_internal.h"
+#include "sdl3d/time.h"
+
+#define SDL3D_GAME_DEFAULT_WIDTH 1280
+#define SDL3D_GAME_DEFAULT_HEIGHT 720
+#define SDL3D_GAME_DEFAULT_FIXED_DT (1.0f / 60.0f)
+#define SDL3D_GAME_DEFAULT_MAX_TICKS 8
+
+static float sdl3d_game_fixed_dt(const sdl3d_game_config *config)
+{
+    return (config != NULL && config->tick_rate > 0.0f) ? config->tick_rate : SDL3D_GAME_DEFAULT_FIXED_DT;
+}
+
+static int sdl3d_game_max_ticks_per_frame(const sdl3d_game_config *config)
+{
+    return (config != NULL && config->max_ticks_per_frame > 0) ? config->max_ticks_per_frame
+                                                               : SDL3D_GAME_DEFAULT_MAX_TICKS;
+}
+
+static void sdl3d_game_destroy_window_and_renderer(SDL_Window *window, sdl3d_render_context *renderer)
+{
+    SDL_Renderer *sdl_renderer = renderer != NULL ? renderer->renderer : NULL;
+
+    sdl3d_destroy_render_context(renderer);
+
+    if (sdl_renderer != NULL)
+    {
+        SDL_DestroyRenderer(sdl_renderer);
+    }
+
+    if (window != NULL)
+    {
+        SDL_DestroyWindow(window);
+    }
+}
+
+static bool sdl3d_game_create_context(const sdl3d_game_config *config, sdl3d_game_context *ctx)
+{
+    sdl3d_window_config window_config;
+
+    sdl3d_init_window_config(&window_config);
+    window_config.width = (config != NULL && config->width > 0) ? config->width : SDL3D_GAME_DEFAULT_WIDTH;
+    window_config.height = (config != NULL && config->height > 0) ? config->height : SDL3D_GAME_DEFAULT_HEIGHT;
+    window_config.title = (config != NULL && config->title != NULL) ? config->title : "SDL3D";
+    window_config.backend = (config != NULL) ? config->backend : SDL3D_BACKEND_AUTO;
+
+    if (!sdl3d_create_window(&window_config, &ctx->window, &ctx->renderer))
+    {
+        return false;
+    }
+
+    ctx->registry = sdl3d_actor_registry_create();
+    ctx->bus = sdl3d_signal_bus_create();
+    ctx->timers = sdl3d_timer_pool_create();
+
+    if (ctx->registry == NULL || ctx->bus == NULL || ctx->timers == NULL)
+    {
+        SDL_OutOfMemory();
+        return false;
+    }
+
+    return true;
+}
+
+static void sdl3d_game_cleanup_context(sdl3d_game_context *ctx)
+{
+    sdl3d_timer_pool_destroy(ctx->timers);
+    sdl3d_signal_bus_destroy(ctx->bus);
+    sdl3d_actor_registry_destroy(ctx->registry);
+    sdl3d_game_destroy_window_and_renderer(ctx->window, ctx->renderer);
+    SDL_zero(*ctx);
+}
+
+static float sdl3d_game_frame_delta(Uint64 now, Uint64 last)
+{
+    const Uint64 frequency = SDL_GetPerformanceFrequency();
+    if (frequency == 0 || now < last)
+    {
+        return 0.0f;
+    }
+
+    return (float)(now - last) / (float)frequency;
+}
+
+int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *callbacks, void *userdata)
+{
+    sdl3d_game_context ctx;
+    const float fixed_dt = sdl3d_game_fixed_dt(config);
+    const int max_ticks_per_frame = sdl3d_game_max_ticks_per_frame(config);
+    float accumulator = 0.0f;
+    Uint64 last_counter = 0;
+    int result = 0;
+
+    SDL_zero(ctx);
+    SDL_SetMainReady();
+
+    if (!SDL_Init(SDL_INIT_VIDEO))
+    {
+        return 1;
+    }
+
+    if (!sdl3d_game_create_context(config, &ctx))
+    {
+        sdl3d_game_cleanup_context(&ctx);
+        SDL_Quit();
+        return 1;
+    }
+
+    sdl3d_time_reset();
+
+    if (callbacks != NULL && callbacks->init != NULL && !callbacks->init(&ctx, userdata))
+    {
+        sdl3d_game_cleanup_context(&ctx);
+        SDL_Quit();
+        return 1;
+    }
+
+    last_counter = SDL_GetPerformanceCounter();
+
+    while (!ctx.quit_requested)
+    {
+        SDL_Event event;
+        while (SDL_PollEvent(&event))
+        {
+            if (event.type == SDL_EVENT_QUIT)
+            {
+                ctx.quit_requested = true;
+                break;
+            }
+
+            if (callbacks != NULL && callbacks->event != NULL && !callbacks->event(&ctx, userdata, &event))
+            {
+                ctx.quit_requested = true;
+                break;
+            }
+        }
+
+        if (ctx.quit_requested)
+        {
+            break;
+        }
+
+        const Uint64 now = SDL_GetPerformanceCounter();
+        const float frame_dt = sdl3d_game_frame_delta(now, last_counter);
+        int ticks_this_frame = 0;
+        last_counter = now;
+
+        ctx.real_time += frame_dt;
+        accumulator += frame_dt;
+        sdl3d_time_update();
+
+        while (!ctx.quit_requested && accumulator >= fixed_dt && ticks_this_frame < max_ticks_per_frame)
+        {
+            sdl3d_timer_pool_update(ctx.timers, ctx.bus, fixed_dt);
+
+            if (callbacks != NULL && callbacks->tick != NULL)
+            {
+                callbacks->tick(&ctx, userdata, fixed_dt);
+            }
+
+            ctx.time += fixed_dt;
+            ctx.tick_count++;
+            accumulator -= fixed_dt;
+            ticks_this_frame++;
+        }
+
+        if (ticks_this_frame == max_ticks_per_frame && accumulator >= fixed_dt)
+        {
+            accumulator = SDL_fmodf(accumulator, fixed_dt);
+        }
+
+        if (ctx.quit_requested)
+        {
+            break;
+        }
+
+        if (callbacks != NULL && callbacks->render != NULL)
+        {
+            callbacks->render(&ctx, userdata, accumulator / fixed_dt);
+        }
+
+        if (!sdl3d_present_render_context(ctx.renderer))
+        {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D present failed: %s", SDL_GetError());
+            result = 1;
+            ctx.quit_requested = true;
+        }
+    }
+
+    if (callbacks != NULL && callbacks->shutdown != NULL)
+    {
+        callbacks->shutdown(&ctx, userdata);
+    }
+
+    sdl3d_game_cleanup_context(&ctx);
+    SDL_Quit();
+    return result;
+}

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -652,6 +652,23 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
     return true;
 }
 
+void sdl3d_destroy_window(SDL_Window *window, sdl3d_render_context *context)
+{
+    SDL_Renderer *renderer = context != NULL ? context->renderer : NULL;
+
+    sdl3d_destroy_render_context(context);
+
+    if (renderer != NULL)
+    {
+        SDL_DestroyRenderer(renderer);
+    }
+
+    if (window != NULL)
+    {
+        SDL_DestroyWindow(window);
+    }
+}
+
 bool sdl3d_switch_backend(SDL_Window **window, sdl3d_render_context **context, sdl3d_backend new_backend)
 {
     int w, h;
@@ -676,21 +693,9 @@ bool sdl3d_switch_backend(SDL_Window **window, sdl3d_render_context **context, s
     }
 
     /* Tear down old context and window. */
-    if (*context != NULL)
-    {
-        /* Save renderer pointer before destroying context (context doesn't
-         * own the renderer, but sdl3d_create_window created it). */
-        SDL_Renderer *old_ren = (*context)->renderer;
-        sdl3d_destroy_render_context(*context);
-        *context = NULL;
-        if (old_ren != NULL)
-            SDL_DestroyRenderer(old_ren);
-    }
-    if (*window != NULL)
-    {
-        SDL_DestroyWindow(*window);
-        *window = NULL;
-    }
+    sdl3d_destroy_window(*window, *context);
+    *window = NULL;
+    *context = NULL;
 
     /* Create fresh window + context with the new backend. */
     sdl3d_init_window_config(&wcfg);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SDL3D_TEST_SOURCES
     test_actor_registry.cpp
     test_animation.cpp
     test_effects.cpp
+    test_game.cpp
     test_level.cpp
     test_properties.cpp
     test_signal_bus.cpp
@@ -187,6 +188,7 @@ else()
     sdl3d_add_test(sdl3d_actor_registry_test test_actor_registry.cpp unit)
     sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
+    sdl3d_add_test(sdl3d_game_test test_game.cpp render)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -1,0 +1,338 @@
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/game.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/time.h"
+#include "sdl3d/timer_pool.h"
+}
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr int kTestWidth = 96;
+constexpr int kTestHeight = 64;
+constexpr float kFastFixedDt = 0.000001f;
+constexpr int kTimerSignal = 17;
+
+sdl3d_game_config test_config()
+{
+    sdl3d_game_config config{};
+    config.title = "SDL3D Managed Game Loop Test";
+    config.width = kTestWidth;
+    config.height = kTestHeight;
+    config.backend = SDL3D_BACKEND_SOFTWARE;
+    config.tick_rate = kFastFixedDt;
+    config.max_ticks_per_frame = 1;
+    return config;
+}
+
+int run_test_game(const sdl3d_game_callbacks *callbacks, void *userdata)
+{
+    sdl3d_game_config config = test_config();
+    return sdl3d_run_game(&config, callbacks, userdata);
+}
+
+struct GameTestState
+{
+    bool init_called = false;
+    bool event_called = false;
+    bool render_called = false;
+    bool shutdown_called = false;
+    bool timer_fired = false;
+    bool saw_valid_context = false;
+    bool saw_default_config = false;
+    bool saw_time_update = false;
+    bool saw_quit_event_in_callback = false;
+    int tick_count = 0;
+    int render_count = 0;
+    float tick_dt = 0.0f;
+    float last_alpha = -1.0f;
+};
+
+bool quit_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+    ctx->quit_requested = true;
+    return true;
+}
+
+bool fail_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+    ctx->quit_requested = true;
+    return false;
+}
+
+void record_shutdown(sdl3d_game_context *ctx, void *userdata)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->shutdown_called = true;
+}
+
+bool validate_context_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->saw_valid_context = ctx->window != nullptr && ctx->renderer != nullptr && ctx->registry != nullptr &&
+                               ctx->bus != nullptr && ctx->timers != nullptr;
+    ctx->quit_requested = true;
+    return true;
+}
+
+bool validate_default_config_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    int width = 0;
+    int height = 0;
+    SDL_GetWindowSize(ctx->window, &width, &height);
+    state->saw_default_config = width == 1280 && height == 720 &&
+                                sdl3d_get_render_context_width(ctx->renderer) == 1280 &&
+                                sdl3d_get_render_context_height(ctx->renderer) == 720;
+    ctx->quit_requested = true;
+    return true;
+}
+
+bool push_user_event_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_USER;
+    SDL_PushEvent(&event);
+    return true;
+}
+
+bool push_quit_event_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&event);
+    return true;
+}
+
+bool event_returns_false(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->saw_quit_event_in_callback = event->type == SDL_EVENT_QUIT;
+    if (event->type == SDL_EVENT_USER)
+    {
+        state->event_called = true;
+        return false;
+    }
+    return true;
+}
+
+void quit_in_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_called = true;
+    state->render_count++;
+    state->last_alpha = alpha;
+    state->saw_time_update = sdl3d_time_get_real_time() >= 0.0f;
+    ctx->quit_requested = true;
+}
+
+void quit_after_tick(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->tick_count++;
+    state->tick_dt = dt;
+    ctx->quit_requested = true;
+}
+
+void timer_handler(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    (void)payload;
+    auto *state = static_cast<GameTestState *>(userdata);
+    if (signal_id == kTimerSignal)
+    {
+        state->timer_fired = true;
+    }
+}
+
+bool start_timer_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    sdl3d_signal_connect(ctx->bus, kTimerSignal, timer_handler, state);
+    sdl3d_timer_start(ctx->timers, kFastFixedDt, kTimerSignal, false, 0.0f);
+    return true;
+}
+
+void quit_when_timer_fires(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    (void)dt;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->tick_count++;
+    if (state->timer_fired || state->tick_count > 16)
+    {
+        ctx->quit_requested = true;
+    }
+}
+
+void stop_after_many_null_frames(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_count++;
+    state->last_alpha = alpha;
+    if (state->render_count >= 2)
+    {
+        ctx->quit_requested = true;
+    }
+}
+} // namespace
+
+TEST(ManagedGameLoop, InitCallbackIsCalled)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = quit_in_init;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.init_called);
+}
+
+TEST(ManagedGameLoop, InitFailureReturnsOneAndSkipsShutdown)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = fail_in_init;
+    callbacks.shutdown = record_shutdown;
+
+    EXPECT_EQ(1, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.init_called);
+    EXPECT_FALSE(state.shutdown_called);
+}
+
+TEST(ManagedGameLoop, ShutdownCallbackIsCalledAfterQuit)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = quit_in_init;
+    callbacks.shutdown = record_shutdown;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.shutdown_called);
+}
+
+TEST(ManagedGameLoop, ContextHasValidSubsystems)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = validate_context_in_init;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.saw_valid_context);
+}
+
+TEST(ManagedGameLoop, EventCallbackReceivesUserEvents)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = push_user_event_in_init;
+    callbacks.event = event_returns_false;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.event_called);
+    EXPECT_FALSE(state.saw_quit_event_in_callback);
+}
+
+TEST(ManagedGameLoop, SDLQuitEventIsHandledInternally)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = push_quit_event_in_init;
+    callbacks.event = event_returns_false;
+    callbacks.shutdown = record_shutdown;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_FALSE(state.saw_quit_event_in_callback);
+    EXPECT_TRUE(state.shutdown_called);
+}
+
+TEST(ManagedGameLoop, TickCallbackReceivesFixedDt)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.tick = quit_after_tick;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.tick_count, 1);
+    EXPECT_NEAR(kFastFixedDt, state.tick_dt, kFastFixedDt * 0.01f);
+}
+
+TEST(ManagedGameLoop, RenderCallbackIsCalledWithNormalizedAlpha)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.render = quit_in_render;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.render_called);
+    EXPECT_GE(state.last_alpha, 0.0f);
+    EXPECT_LE(state.last_alpha, 1.0f);
+    EXPECT_TRUE(state.saw_time_update);
+}
+
+TEST(ManagedGameLoop, TimerPoolIsTickedAutomatically)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = start_timer_in_init;
+    callbacks.tick = quit_when_timer_fires;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.timer_fired);
+}
+
+TEST(ManagedGameLoop, QuitRequestedFromTickExitsAndRunsShutdown)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.tick = quit_after_tick;
+    callbacks.shutdown = record_shutdown;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.tick_count, 1);
+    EXPECT_TRUE(state.shutdown_called);
+}
+
+TEST(ManagedGameLoop, NullCallbacksCanExitFromQueuedQuitEvent)
+{
+    SDL_SetMainReady();
+    ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    SDL_Event event{};
+    event.type = SDL_EVENT_QUIT;
+    ASSERT_TRUE(SDL_PushEvent(&event)) << SDL_GetError();
+
+    sdl3d_game_config config = test_config();
+    EXPECT_EQ(0, sdl3d_run_game(&config, nullptr, nullptr));
+}
+
+TEST(ManagedGameLoop, DefaultConfigValues)
+{
+    GameTestState state;
+    sdl3d_game_config config{};
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = validate_default_config_in_init;
+
+    EXPECT_EQ(0, sdl3d_run_game(&config, &callbacks, &state));
+    EXPECT_TRUE(state.saw_default_config);
+}

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -1,3 +1,5 @@
+#define SDL_MAIN_HANDLED
+
 #include <gtest/gtest.h>
 
 extern "C"
@@ -90,12 +92,8 @@ bool validate_context_in_init(sdl3d_game_context *ctx, void *userdata)
 bool validate_default_config_in_init(sdl3d_game_context *ctx, void *userdata)
 {
     auto *state = static_cast<GameTestState *>(userdata);
-    int width = 0;
-    int height = 0;
-    SDL_GetWindowSize(ctx->window, &width, &height);
-    state->saw_default_config = width == 1280 && height == 720 &&
-                                sdl3d_get_render_context_width(ctx->renderer) == 1280 &&
-                                sdl3d_get_render_context_height(ctx->renderer) == 720;
+    state->saw_default_config =
+        sdl3d_get_render_context_width(ctx->renderer) == 1280 && sdl3d_get_render_context_height(ctx->renderer) == 720;
     ctx->quit_requested = true;
     return true;
 }

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -187,7 +187,7 @@ void stop_after_many_null_frames(sdl3d_game_context *ctx, void *userdata, float 
     auto *state = static_cast<GameTestState *>(userdata);
     state->render_count++;
     state->last_alpha = alpha;
-    if (state->render_count >= 2)
+    if (state->render_count >= 256)
     {
         ctx->quit_requested = true;
     }


### PR DESCRIPTION
## Summary
- add a public SDL3D managed game loop with engine-owned SDL/window/subsystem lifecycle, fixed timestep ticks, timer updates, frame presentation, and Doxygen API docs
- add managed-loop tests covering callback behavior, quit handling, fixed dt, timer ticking, default config, and subsystem context
- refactor doom_level to use the managed loop, remove double-present, and use the loop-owned actor registry/signal bus

## Verification
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure