### PR TITLE
Add action input abstraction and demo playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ target_sources(
         src/gltf_loader.c
         src/gl_renderer.c
         src/image.c
+        src/input.c
         src/lighting.c
         src/math.c
         src/font.c

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -27,6 +27,7 @@ typedef struct doom_state
     render_state render;
     sdl3d_font debug_font;
     sdl3d_ui_context *ui;
+    sdl3d_demo_player *demo_player;
     sdl3d_backend current_backend;
     bool has_font;
     bool level_ready;
@@ -47,11 +48,28 @@ static void doom_state_cleanup(doom_state *state)
     }
     sdl3d_ui_destroy(state->ui);
     state->ui = NULL;
+    sdl3d_demo_playback_free(state->demo_player);
+    state->demo_player = NULL;
     if (state->has_font)
     {
         sdl3d_free_font(&state->debug_font);
         state->has_font = false;
     }
+}
+
+static void stop_demo_playback(sdl3d_game_context *ctx, doom_state *state)
+{
+    if (state->demo_player == NULL)
+    {
+        return;
+    }
+
+    if (ctx != NULL && ctx->input != NULL)
+    {
+        sdl3d_demo_playback_stop(ctx->input);
+    }
+    sdl3d_demo_playback_free(state->demo_player);
+    state->demo_player = NULL;
 }
 
 static void apply_window_defaults(sdl3d_game_context *ctx)
@@ -65,6 +83,7 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     doom_state *state = (doom_state *)userdata;
 
     state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
+    sdl3d_input_bind_fps_defaults(ctx->input);
     apply_window_defaults(ctx);
 
     state->has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &state->debug_font);
@@ -89,8 +108,14 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     }
     state->entities_ready = true;
 
-    player_init(&state->player);
+    player_init(&state->player, ctx->input);
     render_state_init(&state->render);
+
+    state->demo_player = sdl3d_demo_playback_load("attract.dem");
+    if (state->demo_player != NULL)
+    {
+        sdl3d_demo_playback_start(ctx->input, state->demo_player);
+    }
     return true;
 }
 
@@ -123,11 +148,6 @@ static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event 
 
     sdl3d_ui_process_event(state->ui, event);
 
-    if (!player_handle_event(&state->player, event))
-    {
-        return false;
-    }
-
     if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_L)
     {
         state->level.use_lit = !state->level.use_lit;
@@ -156,11 +176,18 @@ static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event 
 
 static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
-    (void)ctx;
     doom_state *state = (doom_state *)userdata;
 
+    if (state->demo_player != NULL && sdl3d_demo_playback_finished(state->demo_player))
+    {
+        stop_demo_playback(ctx, state);
+    }
+
     entities_update(&state->ent, dt, state->player.mover.position);
-    player_update(&state->player, &state->level.unlit, g_sectors, dt);
+    if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
+    {
+        ctx->quit_requested = true;
+    }
 }
 
 static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -175,9 +202,9 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 
 static void game_shutdown(sdl3d_game_context *ctx, void *userdata)
 {
-    (void)ctx;
     doom_state *state = (doom_state *)userdata;
 
+    stop_demo_playback(ctx, state);
     doom_state_cleanup(state);
 }
 

--- a/demos/doom_level/player.c
+++ b/demos/doom_level/player.c
@@ -1,7 +1,6 @@
 /* Player controller: FPS mover, input, projectile. */
 #include "player.h"
 
-#include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_stdinc.h>
 
@@ -13,7 +12,27 @@
 #define PROJ_SPEED 20.0f
 #define PROJ_LIFETIME 3.0f
 
-void player_init(player_state *p)
+static void player_fire_projectile(player_state *p)
+{
+    p->proj_active = true;
+    p->proj_x = p->mover.position.x;
+    p->proj_y = p->mover.position.y;
+    p->proj_z = p->mover.position.z;
+    p->proj_dx = SDL_sinf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
+    p->proj_dy = SDL_sinf(p->mover.pitch);
+    p->proj_dz = -SDL_cosf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
+    p->proj_life = PROJ_LIFETIME;
+}
+
+static void player_reset(player_state *p)
+{
+    sdl3d_fps_mover_init(&p->mover, &p->config, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
+                         PLAYER_SPAWN_YAW);
+    p->proj_active = false;
+    p->proj_life = 0.0f;
+}
+
+void player_init(player_state *p, sdl3d_input_manager *input)
 {
     SDL_zerop(p);
     p->config.move_speed = MOVE_SPEED;
@@ -23,86 +42,59 @@ void player_init(player_state *p)
     p->config.player_radius = PLAYER_RADIUS;
     p->config.step_height = PLAYER_STEP_HEIGHT;
     p->config.ceiling_clearance = PLAYER_CEILING_CLEARANCE;
-    sdl3d_fps_mover_init(&p->mover, &p->config, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
-                         PLAYER_SPAWN_YAW);
+
+    p->action_move_forward = sdl3d_input_find_action(input, "move_forward");
+    p->action_move_back = sdl3d_input_find_action(input, "move_back");
+    p->action_move_left = sdl3d_input_find_action(input, "move_left");
+    p->action_move_right = sdl3d_input_find_action(input, "move_right");
+    p->action_jump = sdl3d_input_find_action(input, "jump");
+    p->action_fire = sdl3d_input_find_action(input, "fire");
+    p->action_menu = sdl3d_input_find_action(input, "menu");
+    p->action_reset = sdl3d_input_register_action(input, "reset_player");
+    sdl3d_input_bind_key(input, p->action_reset, SDL_SCANCODE_BACKSPACE);
+    sdl3d_input_bind_key(input, p->action_reset, SDL_SCANCODE_DELETE);
+
+    player_reset(p);
 }
 
-bool player_handle_event(player_state *p, const SDL_Event *ev)
+bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3d_level *level,
+                   const sdl3d_sector *sectors, float dt)
 {
-    if (ev->type == SDL_EVENT_QUIT)
+    if (sdl3d_input_is_pressed(input, p->action_menu))
+    {
         return false;
-    if (ev->type == SDL_EVENT_KEY_DOWN && ev->key.scancode == SDL_SCANCODE_ESCAPE)
-        return false;
+    }
 
-    if (ev->type == SDL_EVENT_KEY_DOWN && ev->key.scancode == SDL_SCANCODE_SPACE)
+    if (sdl3d_input_is_pressed(input, p->action_reset))
+    {
+        player_reset(p);
+    }
+
+    if (sdl3d_input_is_pressed(input, p->action_jump))
+    {
         sdl3d_fps_mover_jump(&p->mover);
-
-    if (ev->type == SDL_EVENT_KEY_DOWN &&
-        (ev->key.scancode == SDL_SCANCODE_BACKSPACE || ev->key.scancode == SDL_SCANCODE_DELETE))
-    {
-        sdl3d_fps_mover_init(&p->mover, &p->config, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
-                             PLAYER_SPAWN_YAW);
-        p->proj_active = false;
-        p->proj_life = 0.0f;
     }
 
-    if (ev->type == SDL_EVENT_MOUSE_MOTION && p->mouse_init)
+    if (sdl3d_input_is_pressed(input, p->action_fire))
     {
-        p->frame_mdx += ev->motion.xrel;
-        p->frame_mdy += ev->motion.yrel;
-    }
-    if (ev->type == SDL_EVENT_MOUSE_MOTION)
-        p->mouse_init = true;
-
-    if (ev->type == SDL_EVENT_MOUSE_BUTTON_DOWN && ev->button.button == SDL_BUTTON_LEFT)
-    {
-        p->proj_active = true;
-        p->proj_x = p->mover.position.x;
-        p->proj_y = p->mover.position.y;
-        p->proj_z = p->mover.position.z;
-        p->proj_dx = SDL_sinf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
-        p->proj_dy = SDL_sinf(p->mover.pitch);
-        p->proj_dz = -SDL_cosf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
-        p->proj_life = PROJ_LIFETIME;
+        player_fire_projectile(p);
     }
 
-    return true;
-}
-
-void player_update(player_state *p, const sdl3d_level *level, const sdl3d_sector *sectors, float dt)
-{
-    /* WASD wish direction in world XZ space. */
+    /* Action movement in world XZ space. */
     float fwd_x = SDL_sinf(p->mover.yaw);
     float fwd_z = -SDL_cosf(p->mover.yaw);
     float right_x = SDL_cosf(p->mover.yaw);
     float right_z = SDL_sinf(p->mover.yaw);
-    sdl3d_vec2 wish = {0.0f, 0.0f};
+    float forward =
+        sdl3d_input_get_value(input, p->action_move_forward) - sdl3d_input_get_value(input, p->action_move_back);
+    float side = sdl3d_input_get_value(input, p->action_move_right) - sdl3d_input_get_value(input, p->action_move_left);
+    sdl3d_vec2 wish = {
+        fwd_x * forward + right_x * side,
+        fwd_z * forward + right_z * side,
+    };
 
-    const Uint8 *keys = (const Uint8 *)SDL_GetKeyboardState(NULL);
-    if (keys[SDL_SCANCODE_W])
-    {
-        wish.x += fwd_x;
-        wish.y += fwd_z;
-    }
-    if (keys[SDL_SCANCODE_S])
-    {
-        wish.x -= fwd_x;
-        wish.y -= fwd_z;
-    }
-    if (keys[SDL_SCANCODE_A])
-    {
-        wish.x -= right_x;
-        wish.y -= right_z;
-    }
-    if (keys[SDL_SCANCODE_D])
-    {
-        wish.x += right_x;
-        wish.y += right_z;
-    }
-
-    sdl3d_fps_mover_update(&p->mover, level, sectors, wish, p->frame_mdx, p->frame_mdy, MOUSE_SENS, dt);
-    p->frame_mdx = 0.0f;
-    p->frame_mdy = 0.0f;
+    sdl3d_fps_mover_update(&p->mover, level, sectors, wish, sdl3d_input_get_mouse_dx(input),
+                           sdl3d_input_get_mouse_dy(input), MOUSE_SENS, dt);
 
     /* Projectile trace. */
     if (p->proj_active)
@@ -120,4 +112,6 @@ void player_update(player_state *p, const sdl3d_level *level, const sdl3d_sector
         if (p->proj_life <= 0.0f)
             p->proj_active = false;
     }
+
+    return true;
 }

--- a/demos/doom_level/player.h
+++ b/demos/doom_level/player.h
@@ -3,10 +3,9 @@
 #define DOOM_PLAYER_H
 
 #include "sdl3d/fps_mover.h"
+#include "sdl3d/input.h"
 #include "sdl3d/level.h"
 #include "sdl3d/types.h"
-
-#include <SDL3/SDL_events.h>
 
 #include <stdbool.h>
 
@@ -25,10 +24,14 @@ typedef struct player_state
     sdl3d_fps_mover mover;
     sdl3d_fps_mover_config config;
 
-    /* Accumulated mouse delta, consumed each frame. */
-    float frame_mdx;
-    float frame_mdy;
-    bool mouse_init;
+    int action_move_forward;
+    int action_move_back;
+    int action_move_left;
+    int action_move_right;
+    int action_jump;
+    int action_fire;
+    int action_menu;
+    int action_reset;
 
     /* Projectile */
     bool proj_active;
@@ -37,12 +40,10 @@ typedef struct player_state
     float proj_life;
 } player_state;
 
-void player_init(player_state *p);
+void player_init(player_state *p, sdl3d_input_manager *input);
 
-/* Process a single SDL event. Returns false if the event signals quit. */
-bool player_handle_event(player_state *p, const SDL_Event *ev);
-
-/* Advance physics: WASD, mouse look, gravity, projectile trace. */
-void player_update(player_state *p, const sdl3d_level *level, const sdl3d_sector *sectors, float dt);
+/* Advance physics from action input. Returns false when the menu action requests quit. */
+bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3d_level *level,
+                   const sdl3d_sector *sectors, float dt);
 
 #endif

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -17,6 +17,7 @@
 #include <SDL3/SDL_video.h>
 
 #include "sdl3d/actor_registry.h"
+#include "sdl3d/input.h"
 #include "sdl3d/render_context.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/timer_pool.h"
@@ -31,7 +32,8 @@ extern "C"
      *
      * The game may read these fields and may set quit_requested to request
      * shutdown. The loop creates the window, render context, registry, signal
-     * bus, and timer pool before init, then destroys them after shutdown.
+     * bus, timer pool, and input manager before init, then destroys them after
+     * shutdown.
      */
     typedef struct sdl3d_game_context
     {
@@ -40,6 +42,7 @@ extern "C"
         sdl3d_actor_registry *registry; /**< Actor registry owned by the managed loop. */
         sdl3d_signal_bus *bus;          /**< Signal bus owned by the managed loop. */
         sdl3d_timer_pool *timers;       /**< Timer pool owned by the managed loop. */
+        sdl3d_input_manager *input;     /**< Action input manager owned by the managed loop. */
         float time;                     /**< Simulated game time advanced by fixed ticks. */
         float real_time;                /**< Wall-clock time accumulated by rendered frames. */
         int tick_count;                 /**< Total fixed ticks executed since startup. */
@@ -83,9 +86,10 @@ extern "C"
          * @brief Called at the fixed simulation timestep.
          *
          * The dt value is always config.tick_rate seconds, or 1/60 by default.
-         * The managed loop updates ctx->timers before this callback. It does not
-         * call sdl3d_actor_registry_update automatically because trigger tests
-         * need a game-defined point such as the player position.
+         * The managed loop updates ctx->input and ctx->timers before this
+         * callback. It does not call sdl3d_actor_registry_update automatically
+         * because trigger tests need a game-defined point such as the player
+         * position.
          *
          * @param ctx      Managed-loop context.
          * @param userdata Caller-owned pointer passed to sdl3d_run_game.
@@ -138,8 +142,9 @@ extern "C"
      * @brief Run a managed SDL3D game loop.
      *
      * Initializes SDL video, creates the window, render context, actor registry,
-     * signal bus, and timer pool, then runs a fixed-timestep simulation loop
-     * until quit is requested. The loop updates the timer pool before each tick,
+     * signal bus, timer pool, and input manager, then runs a fixed-timestep
+     * simulation loop until quit is requested. The loop processes SDL events
+     * through the input manager, updates input and timers before each tick,
      * calls sdl3d_time_update once per rendered frame, and presents the render
      * context after each render callback.
      *

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -285,7 +285,14 @@ extern "C"
     /** @brief Stop recording. The recorder remains valid for saving/freeing. */
     void sdl3d_demo_record_stop(sdl3d_demo_recorder *recorder);
 
-    /** @brief Save a recorded demo to disk. */
+    /**
+     * @brief Save a recorded demo to disk.
+     *
+     * Demo files use an explicit little-endian binary format with fixed-size
+     * integer fields, IEEE-754 float32 values, and per-action flag bytes. The
+     * file format does not depend on host struct padding, bool size, or native
+     * endianness.
+     */
     bool sdl3d_demo_save(const sdl3d_demo_recorder *recorder, const char *path, float tick_rate);
 
     /** @brief Return the number of snapshots in a recorder. */
@@ -297,7 +304,7 @@ extern "C"
     /** @brief Free a recorder and its snapshot buffer. */
     void sdl3d_demo_record_free(sdl3d_demo_recorder *recorder);
 
-    /** @brief Load a demo file for playback. */
+    /** @brief Load a portable SDL3D demo file for playback. */
     sdl3d_demo_player *sdl3d_demo_playback_load(const char *path);
 
     /** @brief Start feeding recorded snapshots into an input manager. */

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -1,0 +1,325 @@
+/**
+ * @file input.h
+ * @brief Action-based input abstraction and demo input recording.
+ *
+ * SDL3D input maps physical devices to named actions. Gameplay code reads
+ * action snapshots instead of raw SDL keyboard, mouse, or gamepad state. The
+ * same snapshot format can be recorded and played back for deterministic
+ * Quake-style demos.
+ */
+
+#ifndef SDL3D_INPUT_H
+#define SDL3D_INPUT_H
+
+#include <stdbool.h>
+
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_gamepad.h>
+#include <SDL3/SDL_keyboard.h>
+#include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_scancode.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SDL3D_INPUT_MAX_ACTIONS 64
+#define SDL3D_INPUT_MAX_BINDINGS 128
+#define SDL3D_INPUT_ACTION_NAME_MAX 32
+
+    /**
+     * @brief Physical input source kind for an action binding.
+     */
+    typedef enum sdl3d_input_source
+    {
+        SDL3D_INPUT_KEYBOARD = 0,
+        SDL3D_INPUT_MOUSE_BUTTON,
+        SDL3D_INPUT_MOUSE_AXIS,
+        SDL3D_INPUT_GAMEPAD_BUTTON,
+        SDL3D_INPUT_GAMEPAD_AXIS,
+    } sdl3d_input_source;
+
+    /**
+     * @brief Mouse axes exposed as action bindings.
+     */
+    typedef enum sdl3d_mouse_axis
+    {
+        SDL3D_MOUSE_AXIS_X = 0,   /**< Horizontal mouse motion delta. */
+        SDL3D_MOUSE_AXIS_Y,       /**< Vertical mouse motion delta. */
+        SDL3D_MOUSE_AXIS_WHEEL,   /**< Vertical scroll-wheel delta. */
+        SDL3D_MOUSE_AXIS_WHEEL_X, /**< Horizontal scroll-wheel delta. */
+    } sdl3d_mouse_axis;
+
+    /**
+     * @brief Optional keyboard modifier mask for keyboard bindings.
+     */
+    typedef enum sdl3d_input_modifier
+    {
+        SDL3D_INPUT_MOD_NONE = 0,
+        SDL3D_INPUT_MOD_SHIFT = 1 << 0,
+        SDL3D_INPUT_MOD_CTRL = 1 << 1,
+        SDL3D_INPUT_MOD_ALT = 1 << 2,
+        SDL3D_INPUT_MOD_GUI = 1 << 3,
+    } sdl3d_input_modifier;
+
+    /**
+     * @brief A physical input mapped to a registered action.
+     */
+    typedef struct sdl3d_input_binding
+    {
+        int action_id;             /**< Registered action ID. */
+        sdl3d_input_source source; /**< Source device/control kind. */
+        int required_modifiers;    /**< sdl3d_input_modifier mask for keyboard bindings. */
+        int excluded_modifiers;    /**< sdl3d_input_modifier mask that must be absent for keyboard bindings. */
+        union {
+            SDL_Scancode scancode;            /**< Keyboard scancode. */
+            Uint8 mouse_button;               /**< SDL mouse button number. */
+            sdl3d_mouse_axis mouse_axis;      /**< Mouse axis. */
+            SDL_GamepadButton gamepad_button; /**< SDL gamepad button. */
+            SDL_GamepadAxis gamepad_axis;     /**< SDL gamepad axis. */
+        };
+        float scale; /**< Input multiplier; use -1 to invert axes. */
+    } sdl3d_input_binding;
+
+    /**
+     * @brief Per-action state for one input tick.
+     */
+    typedef struct sdl3d_action_state
+    {
+        bool pressed;  /**< True on the tick the action first becomes active. */
+        bool released; /**< True on the tick the action becomes inactive. */
+        bool held;     /**< True while the action is active. */
+        float value;   /**< Analog value in [-1, 1], or 0/1 for digital input. */
+    } sdl3d_action_state;
+
+    /**
+     * @brief Fixed-size input state captured for one simulation tick.
+     */
+    typedef struct sdl3d_input_snapshot
+    {
+        sdl3d_action_state actions[SDL3D_INPUT_MAX_ACTIONS];
+        float mouse_dx; /**< Raw horizontal mouse motion accumulated this tick. */
+        float mouse_dy; /**< Raw vertical mouse motion accumulated this tick. */
+        int tick;       /**< Simulation tick number for demo synchronization. */
+    } sdl3d_input_snapshot;
+
+    /** @brief Opaque action input manager. */
+    typedef struct sdl3d_input_manager sdl3d_input_manager;
+
+    /** @brief Opaque input demo recorder. */
+    typedef struct sdl3d_demo_recorder sdl3d_demo_recorder;
+
+    /** @brief Opaque input demo playback object. */
+    typedef struct sdl3d_demo_player sdl3d_demo_player;
+
+    /* ================================================================== */
+    /* Lifecycle                                                          */
+    /* ================================================================== */
+
+    /**
+     * @brief Create an input manager.
+     * @return A new manager, or NULL on allocation failure.
+     */
+    sdl3d_input_manager *sdl3d_input_create(void);
+
+    /**
+     * @brief Destroy an input manager.
+     *
+     * Active demo playback is detached but not freed; callers own demo players.
+     * Safe to call with NULL.
+     */
+    void sdl3d_input_destroy(sdl3d_input_manager *input);
+
+    /* ================================================================== */
+    /* Action registration                                                 */
+    /* ================================================================== */
+
+    /**
+     * @brief Register a named action.
+     *
+     * Re-registering an existing action returns its existing ID.
+     *
+     * @return A 0-based action ID, or -1 if invalid, too long, or full.
+     */
+    int sdl3d_input_register_action(sdl3d_input_manager *input, const char *name);
+
+    /**
+     * @brief Find a registered action by name.
+     * @return The action ID, or -1 if not found.
+     */
+    int sdl3d_input_find_action(const sdl3d_input_manager *input, const char *name);
+
+    /* ================================================================== */
+    /* Bindings                                                           */
+    /* ================================================================== */
+
+    /** @brief Bind a key to an action. */
+    void sdl3d_input_bind_key(sdl3d_input_manager *input, int action_id, SDL_Scancode key);
+
+    /** @brief Bind a key plus required modifiers to an action. */
+    void sdl3d_input_bind_key_mod(sdl3d_input_manager *input, int action_id, SDL_Scancode key, int required_modifiers);
+
+    /** @brief Bind a key with required and excluded modifier masks. */
+    void sdl3d_input_bind_key_mod_mask(sdl3d_input_manager *input, int action_id, SDL_Scancode key,
+                                       int required_modifiers, int excluded_modifiers);
+
+    /** @brief Bind a mouse button to an action. */
+    void sdl3d_input_bind_mouse_button(sdl3d_input_manager *input, int action_id, Uint8 button);
+
+    /**
+     * @brief Bind a mouse motion or wheel axis to an action.
+     *
+     * If the same physical axis is bound to another action with an opposite
+     * scale, each binding reports only its positive half. This supports
+     * directional actions such as look_left/look_right on one axis.
+     */
+    void sdl3d_input_bind_mouse_axis(sdl3d_input_manager *input, int action_id, sdl3d_mouse_axis axis, float scale);
+
+    /** @brief Bind a gamepad button to an action. */
+    void sdl3d_input_bind_gamepad_button(sdl3d_input_manager *input, int action_id, SDL_GamepadButton button);
+
+    /**
+     * @brief Bind a gamepad axis to an action.
+     *
+     * If the same physical axis is bound to another action with an opposite
+     * scale, each binding reports only its positive half. This supports
+     * directional actions such as move_forward/move_back on one stick axis.
+     */
+    void sdl3d_input_bind_gamepad_axis(sdl3d_input_manager *input, int action_id, SDL_GamepadAxis axis, float scale);
+
+    /** @brief Remove all bindings for an action. */
+    void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id);
+
+    /* ================================================================== */
+    /* Per-frame processing                                                */
+    /* ================================================================== */
+
+    /**
+     * @brief Process one SDL event.
+     *
+     * Call this before gameplay event handling so the input manager can track
+     * key/button edges, mouse deltas, wheel deltas, and gamepad hotplug.
+     */
+    void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *event);
+
+    /**
+     * @brief Build the current tick's action snapshot.
+     *
+     * If demo playback is active, this returns the next recorded snapshot.
+     * Otherwise it evaluates live bindings, records the snapshot if a recorder
+     * is active, resets transient accumulators, and returns a pointer valid
+     * until the next update.
+     */
+    const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int tick);
+
+    /* ================================================================== */
+    /* Queries                                                            */
+    /* ================================================================== */
+
+    /** @brief Return true if the action was pressed on the current tick. */
+    bool sdl3d_input_is_pressed(const sdl3d_input_manager *input, int action_id);
+
+    /** @brief Return true if the action was released on the current tick. */
+    bool sdl3d_input_is_released(const sdl3d_input_manager *input, int action_id);
+
+    /** @brief Return true if the action is held on the current tick. */
+    bool sdl3d_input_is_held(const sdl3d_input_manager *input, int action_id);
+
+    /** @brief Return the action's current analog value. */
+    float sdl3d_input_get_value(const sdl3d_input_manager *input, int action_id);
+
+    /** @brief Return raw horizontal mouse motion for the current tick. */
+    float sdl3d_input_get_mouse_dx(const sdl3d_input_manager *input);
+
+    /** @brief Return raw vertical mouse motion for the current tick. */
+    float sdl3d_input_get_mouse_dy(const sdl3d_input_manager *input);
+
+    /**
+     * @brief Build a 2D axis pair from four action IDs.
+     *
+     * The result is (positive_x - negative_x, positive_y - negative_y).
+     */
+    sdl3d_vec2 sdl3d_input_get_axis_pair(const sdl3d_input_manager *input, int negative_x_action, int positive_x_action,
+                                         int negative_y_action, int positive_y_action);
+
+    /** @brief Return the current snapshot, or NULL for a NULL manager. */
+    const sdl3d_input_snapshot *sdl3d_input_get_snapshot(const sdl3d_input_manager *input);
+
+    /* ================================================================== */
+    /* Default bindings                                                    */
+    /* ================================================================== */
+
+    /** @brief Register and bind the standard first-person action set. */
+    void sdl3d_input_bind_fps_defaults(sdl3d_input_manager *input);
+
+    /** @brief Register and bind the standard UI navigation action set. */
+    void sdl3d_input_bind_ui_defaults(sdl3d_input_manager *input);
+
+    /* ================================================================== */
+    /* Deadzone                                                           */
+    /* ================================================================== */
+
+    /**
+     * @brief Set gamepad axis deadzone.
+     *
+     * Values are clamped to [0, 1]. Default is 0.15.
+     */
+    void sdl3d_input_set_deadzone(sdl3d_input_manager *input, float deadzone);
+
+    /* ================================================================== */
+    /* Demo recording and playback                                         */
+    /* ================================================================== */
+
+    /**
+     * @brief Start recording input snapshots from an input manager.
+     *
+     * One recorder may be active per manager. The recorder grows internally as
+     * snapshots are appended during sdl3d_input_update.
+     */
+    sdl3d_demo_recorder *sdl3d_demo_record_start(sdl3d_input_manager *input);
+
+    /** @brief Stop recording. The recorder remains valid for saving/freeing. */
+    void sdl3d_demo_record_stop(sdl3d_demo_recorder *recorder);
+
+    /** @brief Save a recorded demo to disk. */
+    bool sdl3d_demo_save(const sdl3d_demo_recorder *recorder, const char *path, float tick_rate);
+
+    /** @brief Return the number of snapshots in a recorder. */
+    Uint32 sdl3d_demo_record_count(const sdl3d_demo_recorder *recorder);
+
+    /** @brief Return a recorded snapshot by index, or NULL if out of range. */
+    const sdl3d_input_snapshot *sdl3d_demo_record_snapshot(const sdl3d_demo_recorder *recorder, Uint32 index);
+
+    /** @brief Free a recorder and its snapshot buffer. */
+    void sdl3d_demo_record_free(sdl3d_demo_recorder *recorder);
+
+    /** @brief Load a demo file for playback. */
+    sdl3d_demo_player *sdl3d_demo_playback_load(const char *path);
+
+    /** @brief Start feeding recorded snapshots into an input manager. */
+    void sdl3d_demo_playback_start(sdl3d_input_manager *input, sdl3d_demo_player *player);
+
+    /** @brief Stop demo playback and resume live input. */
+    void sdl3d_demo_playback_stop(sdl3d_input_manager *input);
+
+    /** @brief Return true when playback has consumed every snapshot. */
+    bool sdl3d_demo_playback_finished(const sdl3d_demo_player *player);
+
+    /** @brief Return the demo tick rate stored in the file header. */
+    float sdl3d_demo_playback_tick_rate(const sdl3d_demo_player *player);
+
+    /** @brief Return the total snapshots loaded for playback. */
+    Uint32 sdl3d_demo_playback_count(const sdl3d_demo_player *player);
+
+    /** @brief Free a demo playback object. */
+    void sdl3d_demo_playback_free(sdl3d_demo_player *player);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_INPUT_H */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -13,6 +13,7 @@
 #include "sdl3d/effects.h"
 #include "sdl3d/game.h"
 #include "sdl3d/image.h"
+#include "sdl3d/input.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/math.h"
 #include "sdl3d/model.h"

--- a/src/game.c
+++ b/src/game.c
@@ -42,8 +42,9 @@ static bool sdl3d_game_create_context(const sdl3d_game_config *config, sdl3d_gam
     ctx->registry = sdl3d_actor_registry_create();
     ctx->bus = sdl3d_signal_bus_create();
     ctx->timers = sdl3d_timer_pool_create();
+    ctx->input = sdl3d_input_create();
 
-    if (ctx->registry == NULL || ctx->bus == NULL || ctx->timers == NULL)
+    if (ctx->registry == NULL || ctx->bus == NULL || ctx->timers == NULL || ctx->input == NULL)
     {
         SDL_OutOfMemory();
         return false;
@@ -57,6 +58,7 @@ static void sdl3d_game_cleanup_context(sdl3d_game_context *ctx)
     sdl3d_timer_pool_destroy(ctx->timers);
     sdl3d_signal_bus_destroy(ctx->bus);
     sdl3d_actor_registry_destroy(ctx->registry);
+    sdl3d_input_destroy(ctx->input);
     sdl3d_destroy_window(ctx->window, ctx->renderer);
     SDL_zero(*ctx);
 }
@@ -84,7 +86,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
     SDL_zero(ctx);
     SDL_SetMainReady();
 
-    if (!SDL_Init(SDL_INIT_VIDEO))
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD))
     {
         return 1;
     }
@@ -112,6 +114,8 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         SDL_Event event;
         while (SDL_PollEvent(&event))
         {
+            sdl3d_input_process_event(ctx.input, &event);
+
             if (event.type == SDL_EVENT_QUIT)
             {
                 ctx.quit_requested = true;
@@ -141,6 +145,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
 
         while (!ctx.quit_requested && accumulator >= fixed_dt && ticks_this_frame < max_ticks_per_frame)
         {
+            sdl3d_input_update(ctx.input, ctx.tick_count);
             sdl3d_timer_pool_update(ctx.timers, ctx.bus, fixed_dt);
 
             if (callbacks != NULL && callbacks->tick != NULL)

--- a/src/input.c
+++ b/src/input.c
@@ -1,0 +1,1099 @@
+#include "sdl3d/input.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_stdinc.h>
+
+#define SDL3D_INPUT_DEFAULT_DEADZONE 0.15f
+#define SDL3D_INPUT_MAX_MOUSE_BUTTONS 16
+#define SDL3D_INPUT_DEMO_MAGIC "SDL3DEMO"
+#define SDL3D_INPUT_DEMO_MAGIC_SIZE 8
+#define SDL3D_INPUT_DEMO_VERSION 1U
+
+typedef struct sdl3d_input_action_entry
+{
+    char name[SDL3D_INPUT_ACTION_NAME_MAX];
+    bool registered;
+} sdl3d_input_action_entry;
+
+typedef struct sdl3d_input_demo_header
+{
+    char magic[SDL3D_INPUT_DEMO_MAGIC_SIZE];
+    Uint32 version;
+    float tick_rate;
+    Uint32 tick_count;
+} sdl3d_input_demo_header;
+
+struct sdl3d_demo_recorder
+{
+    sdl3d_input_manager *input;
+    sdl3d_input_snapshot *snapshots;
+    Uint32 count;
+    Uint32 capacity;
+    bool recording;
+};
+
+struct sdl3d_demo_player
+{
+    sdl3d_input_snapshot *snapshots;
+    Uint32 count;
+    Uint32 cursor;
+    float tick_rate;
+};
+
+struct sdl3d_input_manager
+{
+    sdl3d_input_action_entry actions[SDL3D_INPUT_MAX_ACTIONS];
+    int action_count;
+
+    sdl3d_input_binding bindings[SDL3D_INPUT_MAX_BINDINGS];
+    int binding_count;
+
+    float mouse_dx_accum;
+    float mouse_dy_accum;
+    float mouse_wheel_x_accum;
+    float mouse_wheel_y_accum;
+
+    bool key_down[SDL_SCANCODE_COUNT];
+    int key_down_modifiers[SDL_SCANCODE_COUNT];
+    bool key_pressed_this_frame[SDL_SCANCODE_COUNT];
+    bool key_released_this_frame[SDL_SCANCODE_COUNT];
+    int key_pressed_modifiers_this_frame[SDL_SCANCODE_COUNT];
+    int key_released_modifiers_this_frame[SDL_SCANCODE_COUNT];
+    bool mouse_down[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
+    bool mouse_pressed_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
+    bool mouse_released_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
+
+    sdl3d_input_snapshot snapshot;
+    bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
+
+    SDL_Gamepad *gamepad;
+    SDL_JoystickID gamepad_id;
+    float deadzone;
+
+    sdl3d_demo_recorder *recorder;
+    sdl3d_demo_player *demo_player;
+};
+
+static bool sdl3d_input_action_id_valid(int action_id)
+{
+    return action_id >= 0 && action_id < SDL3D_INPUT_MAX_ACTIONS;
+}
+
+static int sdl3d_input_modifier_mask_from_sdl(SDL_Keymod mod)
+{
+    int mask = SDL3D_INPUT_MOD_NONE;
+
+    if ((mod & SDL_KMOD_SHIFT) != 0)
+    {
+        mask |= SDL3D_INPUT_MOD_SHIFT;
+    }
+    if ((mod & SDL_KMOD_CTRL) != 0)
+    {
+        mask |= SDL3D_INPUT_MOD_CTRL;
+    }
+    if ((mod & SDL_KMOD_ALT) != 0)
+    {
+        mask |= SDL3D_INPUT_MOD_ALT;
+    }
+    if ((mod & SDL_KMOD_GUI) != 0)
+    {
+        mask |= SDL3D_INPUT_MOD_GUI;
+    }
+
+    return mask;
+}
+
+static bool sdl3d_input_modifiers_match(int current_modifiers, int required_modifiers, int excluded_modifiers)
+{
+    return ((current_modifiers & required_modifiers) == required_modifiers) &&
+           ((current_modifiers & excluded_modifiers) == 0);
+}
+
+static float sdl3d_input_absf(float value)
+{
+    return value < 0.0f ? -value : value;
+}
+
+static float sdl3d_input_clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value)
+    {
+        return min_value;
+    }
+    if (value > max_value)
+    {
+        return max_value;
+    }
+    return value;
+}
+
+static float sdl3d_input_signed_max_magnitude(float current, float candidate)
+{
+    return sdl3d_input_absf(candidate) > sdl3d_input_absf(current) ? candidate : current;
+}
+
+static bool sdl3d_input_binding_valid(const sdl3d_input_manager *input, int action_id)
+{
+    return input != NULL && sdl3d_input_action_id_valid(action_id) && action_id < input->action_count &&
+           input->actions[action_id].registered;
+}
+
+static void sdl3d_input_add_binding(sdl3d_input_manager *input, const sdl3d_input_binding *binding)
+{
+    if (input == NULL || binding == NULL || !sdl3d_input_binding_valid(input, binding->action_id) ||
+        input->binding_count >= SDL3D_INPUT_MAX_BINDINGS)
+    {
+        return;
+    }
+
+    input->bindings[input->binding_count++] = *binding;
+}
+
+static void sdl3d_input_close_gamepad(sdl3d_input_manager *input)
+{
+    if (input != NULL && input->gamepad != NULL)
+    {
+        SDL_CloseGamepad(input->gamepad);
+        input->gamepad = NULL;
+        input->gamepad_id = 0;
+    }
+}
+
+static void sdl3d_input_open_gamepad(sdl3d_input_manager *input, SDL_JoystickID joystick_id)
+{
+    if (input == NULL || input->gamepad != NULL)
+    {
+        return;
+    }
+
+    SDL_Gamepad *gamepad = SDL_OpenGamepad(joystick_id);
+    if (gamepad != NULL)
+    {
+        input->gamepad = gamepad;
+        input->gamepad_id = joystick_id;
+    }
+}
+
+static void sdl3d_input_try_open_first_gamepad(sdl3d_input_manager *input)
+{
+    int count = 0;
+    SDL_JoystickID *gamepads;
+
+    if (input == NULL || input->gamepad != NULL)
+    {
+        return;
+    }
+
+    gamepads = SDL_GetGamepads(&count);
+    if (gamepads == NULL)
+    {
+        return;
+    }
+
+    for (int i = 0; i < count && input->gamepad == NULL; ++i)
+    {
+        sdl3d_input_open_gamepad(input, gamepads[i]);
+    }
+
+    SDL_free(gamepads);
+}
+
+static float sdl3d_input_gamepad_axis_value(const sdl3d_input_manager *input, SDL_GamepadAxis axis)
+{
+    if (input == NULL || input->gamepad == NULL)
+    {
+        return 0.0f;
+    }
+
+    float value = (float)SDL_GetGamepadAxis(input->gamepad, axis) / 32767.0f;
+    value = sdl3d_input_clampf(value, -1.0f, 1.0f);
+
+    if (sdl3d_input_absf(value) < input->deadzone)
+    {
+        return 0.0f;
+    }
+
+    return value;
+}
+
+static bool sdl3d_input_mouse_button_valid(Uint8 button)
+{
+    return button < SDL3D_INPUT_MAX_MOUSE_BUTTONS;
+}
+
+static float sdl3d_input_mouse_axis_value(const sdl3d_input_manager *input, sdl3d_mouse_axis axis)
+{
+    if (input == NULL)
+    {
+        return 0.0f;
+    }
+
+    switch (axis)
+    {
+    case SDL3D_MOUSE_AXIS_X:
+        return input->mouse_dx_accum;
+    case SDL3D_MOUSE_AXIS_Y:
+        return input->mouse_dy_accum;
+    case SDL3D_MOUSE_AXIS_WHEEL:
+        return input->mouse_wheel_y_accum;
+    case SDL3D_MOUSE_AXIS_WHEEL_X:
+        return input->mouse_wheel_x_accum;
+    default:
+        return 0.0f;
+    }
+}
+
+static bool sdl3d_input_has_opposite_axis_binding(const sdl3d_input_manager *input, const sdl3d_input_binding *binding)
+{
+    if (input == NULL || binding == NULL ||
+        (binding->source != SDL3D_INPUT_MOUSE_AXIS && binding->source != SDL3D_INPUT_GAMEPAD_AXIS))
+    {
+        return false;
+    }
+
+    for (int i = 0; i < input->binding_count; ++i)
+    {
+        const sdl3d_input_binding *other = &input->bindings[i];
+        if (other == binding || other->action_id == binding->action_id || other->source != binding->source)
+        {
+            continue;
+        }
+
+        if (binding->source == SDL3D_INPUT_MOUSE_AXIS && other->mouse_axis == binding->mouse_axis &&
+            other->scale * binding->scale < 0.0f)
+        {
+            return true;
+        }
+        if (binding->source == SDL3D_INPUT_GAMEPAD_AXIS && other->gamepad_axis == binding->gamepad_axis &&
+            other->scale * binding->scale < 0.0f)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static float sdl3d_input_axis_binding_value(const sdl3d_input_manager *input, const sdl3d_input_binding *binding,
+                                            float raw_value)
+{
+    float value = raw_value * binding->scale;
+    if (sdl3d_input_has_opposite_axis_binding(input, binding) && value < 0.0f)
+    {
+        return 0.0f;
+    }
+    return value;
+}
+
+static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const sdl3d_input_binding *binding)
+{
+    if (input == NULL || binding == NULL)
+    {
+        return 0.0f;
+    }
+
+    switch (binding->source)
+    {
+    case SDL3D_INPUT_KEYBOARD:
+        if (binding->scancode < 0 || binding->scancode >= SDL_SCANCODE_COUNT)
+        {
+            return 0.0f;
+        }
+        if (!sdl3d_input_modifiers_match(input->key_down_modifiers[binding->scancode], binding->required_modifiers,
+                                         binding->excluded_modifiers))
+        {
+            return 0.0f;
+        }
+        return input->key_down[binding->scancode] ? binding->scale : 0.0f;
+    case SDL3D_INPUT_MOUSE_BUTTON:
+        if (!sdl3d_input_mouse_button_valid(binding->mouse_button))
+        {
+            return 0.0f;
+        }
+        return input->mouse_down[binding->mouse_button] ? binding->scale : 0.0f;
+    case SDL3D_INPUT_MOUSE_AXIS:
+        return sdl3d_input_axis_binding_value(input, binding, sdl3d_input_mouse_axis_value(input, binding->mouse_axis));
+    case SDL3D_INPUT_GAMEPAD_BUTTON:
+        if (input->gamepad == NULL)
+        {
+            return 0.0f;
+        }
+        return SDL_GetGamepadButton(input->gamepad, binding->gamepad_button) ? binding->scale : 0.0f;
+    case SDL3D_INPUT_GAMEPAD_AXIS:
+        return sdl3d_input_axis_binding_value(input, binding,
+                                              sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
+    default:
+        return 0.0f;
+    }
+}
+
+static bool sdl3d_input_binding_pressed(const sdl3d_input_manager *input, const sdl3d_input_binding *binding)
+{
+    if (input == NULL || binding == NULL)
+    {
+        return false;
+    }
+
+    switch (binding->source)
+    {
+    case SDL3D_INPUT_KEYBOARD:
+        if (binding->scancode < 0 || binding->scancode >= SDL_SCANCODE_COUNT)
+        {
+            return false;
+        }
+        return sdl3d_input_modifiers_match(input->key_pressed_modifiers_this_frame[binding->scancode],
+                                           binding->required_modifiers, binding->excluded_modifiers) &&
+               input->key_pressed_this_frame[binding->scancode];
+    case SDL3D_INPUT_MOUSE_BUTTON:
+        return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
+               input->mouse_pressed_this_frame[binding->mouse_button];
+    default:
+        return false;
+    }
+}
+
+static bool sdl3d_input_binding_released(const sdl3d_input_manager *input, const sdl3d_input_binding *binding)
+{
+    if (input == NULL || binding == NULL)
+    {
+        return false;
+    }
+
+    switch (binding->source)
+    {
+    case SDL3D_INPUT_KEYBOARD:
+        return binding->scancode >= 0 && binding->scancode < SDL_SCANCODE_COUNT &&
+               sdl3d_input_modifiers_match(input->key_released_modifiers_this_frame[binding->scancode],
+                                           binding->required_modifiers, binding->excluded_modifiers) &&
+               input->key_released_this_frame[binding->scancode];
+    case SDL3D_INPUT_MOUSE_BUTTON:
+        return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
+               input->mouse_released_this_frame[binding->mouse_button];
+    default:
+        return false;
+    }
+}
+
+static void sdl3d_input_reset_transients(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    input->mouse_dx_accum = 0.0f;
+    input->mouse_dy_accum = 0.0f;
+    input->mouse_wheel_x_accum = 0.0f;
+    input->mouse_wheel_y_accum = 0.0f;
+    SDL_memset(input->key_pressed_this_frame, 0, sizeof(input->key_pressed_this_frame));
+    SDL_memset(input->key_released_this_frame, 0, sizeof(input->key_released_this_frame));
+    SDL_memset(input->key_pressed_modifiers_this_frame, 0, sizeof(input->key_pressed_modifiers_this_frame));
+    SDL_memset(input->key_released_modifiers_this_frame, 0, sizeof(input->key_released_modifiers_this_frame));
+    SDL_memset(input->mouse_pressed_this_frame, 0, sizeof(input->mouse_pressed_this_frame));
+    SDL_memset(input->mouse_released_this_frame, 0, sizeof(input->mouse_released_this_frame));
+}
+
+static bool sdl3d_demo_recorder_append(sdl3d_demo_recorder *recorder, const sdl3d_input_snapshot *snapshot)
+{
+    sdl3d_input_snapshot *grown;
+    Uint32 next_capacity;
+    size_t bytes;
+
+    if (recorder == NULL || snapshot == NULL || !recorder->recording)
+    {
+        return true;
+    }
+
+    if (recorder->count >= recorder->capacity)
+    {
+        next_capacity = recorder->capacity == 0 ? 64U : recorder->capacity * 2U;
+        bytes = (size_t)next_capacity * sizeof(*recorder->snapshots);
+        grown = (sdl3d_input_snapshot *)SDL_realloc(recorder->snapshots, bytes);
+        if (grown == NULL)
+        {
+            return false;
+        }
+        recorder->snapshots = grown;
+        recorder->capacity = next_capacity;
+    }
+
+    recorder->snapshots[recorder->count++] = *snapshot;
+    return true;
+}
+
+static bool sdl3d_input_write_all(SDL_IOStream *stream, const void *data, size_t size)
+{
+    return stream != NULL && data != NULL && SDL_WriteIO(stream, data, size) == size;
+}
+
+static bool sdl3d_input_read_all(SDL_IOStream *stream, void *data, size_t size)
+{
+    return stream != NULL && data != NULL && SDL_ReadIO(stream, data, size) == size;
+}
+
+sdl3d_input_manager *sdl3d_input_create(void)
+{
+    sdl3d_input_manager *input = (sdl3d_input_manager *)SDL_calloc(1, sizeof(*input));
+    if (input == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    input->deadzone = SDL3D_INPUT_DEFAULT_DEADZONE;
+    return input;
+}
+
+void sdl3d_input_destroy(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    if (input->recorder != NULL)
+    {
+        input->recorder->input = NULL;
+        input->recorder->recording = false;
+    }
+    sdl3d_input_close_gamepad(input);
+    SDL_free(input);
+}
+
+int sdl3d_input_register_action(sdl3d_input_manager *input, const char *name)
+{
+    size_t length;
+    int existing;
+
+    if (input == NULL || name == NULL || name[0] == '\0')
+    {
+        return -1;
+    }
+
+    existing = sdl3d_input_find_action(input, name);
+    if (existing >= 0)
+    {
+        return existing;
+    }
+
+    length = SDL_strlen(name);
+    if (length >= SDL3D_INPUT_ACTION_NAME_MAX || input->action_count >= SDL3D_INPUT_MAX_ACTIONS)
+    {
+        return -1;
+    }
+
+    int action_id = input->action_count++;
+    SDL_strlcpy(input->actions[action_id].name, name, sizeof(input->actions[action_id].name));
+    input->actions[action_id].registered = true;
+    return action_id;
+}
+
+int sdl3d_input_find_action(const sdl3d_input_manager *input, const char *name)
+{
+    if (input == NULL || name == NULL)
+    {
+        return -1;
+    }
+
+    for (int i = 0; i < input->action_count; ++i)
+    {
+        if (input->actions[i].registered && SDL_strcmp(input->actions[i].name, name) == 0)
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+void sdl3d_input_bind_key(sdl3d_input_manager *input, int action_id, SDL_Scancode key)
+{
+    sdl3d_input_bind_key_mod_mask(input, action_id, key, SDL3D_INPUT_MOD_NONE, SDL3D_INPUT_MOD_NONE);
+}
+
+void sdl3d_input_bind_key_mod(sdl3d_input_manager *input, int action_id, SDL_Scancode key, int required_modifiers)
+{
+    sdl3d_input_bind_key_mod_mask(input, action_id, key, required_modifiers, SDL3D_INPUT_MOD_NONE);
+}
+
+void sdl3d_input_bind_key_mod_mask(sdl3d_input_manager *input, int action_id, SDL_Scancode key, int required_modifiers,
+                                   int excluded_modifiers)
+{
+    sdl3d_input_binding binding;
+    SDL_zero(binding);
+    binding.action_id = action_id;
+    binding.source = SDL3D_INPUT_KEYBOARD;
+    binding.required_modifiers = required_modifiers;
+    binding.excluded_modifiers = excluded_modifiers;
+    binding.scancode = key;
+    binding.scale = 1.0f;
+    sdl3d_input_add_binding(input, &binding);
+}
+
+void sdl3d_input_bind_mouse_button(sdl3d_input_manager *input, int action_id, Uint8 button)
+{
+    sdl3d_input_binding binding;
+    SDL_zero(binding);
+    binding.action_id = action_id;
+    binding.source = SDL3D_INPUT_MOUSE_BUTTON;
+    binding.mouse_button = button;
+    binding.scale = 1.0f;
+    sdl3d_input_add_binding(input, &binding);
+}
+
+void sdl3d_input_bind_mouse_axis(sdl3d_input_manager *input, int action_id, sdl3d_mouse_axis axis, float scale)
+{
+    sdl3d_input_binding binding;
+    SDL_zero(binding);
+    binding.action_id = action_id;
+    binding.source = SDL3D_INPUT_MOUSE_AXIS;
+    binding.mouse_axis = axis;
+    binding.scale = scale;
+    sdl3d_input_add_binding(input, &binding);
+}
+
+void sdl3d_input_bind_gamepad_button(sdl3d_input_manager *input, int action_id, SDL_GamepadButton button)
+{
+    sdl3d_input_binding binding;
+    SDL_zero(binding);
+    binding.action_id = action_id;
+    binding.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+    binding.gamepad_button = button;
+    binding.scale = 1.0f;
+    sdl3d_input_add_binding(input, &binding);
+}
+
+void sdl3d_input_bind_gamepad_axis(sdl3d_input_manager *input, int action_id, SDL_GamepadAxis axis, float scale)
+{
+    sdl3d_input_binding binding;
+    SDL_zero(binding);
+    binding.action_id = action_id;
+    binding.source = SDL3D_INPUT_GAMEPAD_AXIS;
+    binding.gamepad_axis = axis;
+    binding.scale = scale;
+    sdl3d_input_add_binding(input, &binding);
+}
+
+void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    for (int i = 0; i < input->binding_count;)
+    {
+        if (input->bindings[i].action_id == action_id)
+        {
+            input->bindings[i] = input->bindings[input->binding_count - 1];
+            input->binding_count--;
+        }
+        else
+        {
+            i++;
+        }
+    }
+}
+
+void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *event)
+{
+    if (input == NULL || event == NULL)
+    {
+        return;
+    }
+
+    switch (event->type)
+    {
+    case SDL_EVENT_KEY_DOWN:
+        if (event->key.scancode >= 0 && event->key.scancode < SDL_SCANCODE_COUNT && !event->key.repeat)
+        {
+            int modifiers = sdl3d_input_modifier_mask_from_sdl(event->key.mod) |
+                            sdl3d_input_modifier_mask_from_sdl(SDL_GetModState());
+            input->key_down[event->key.scancode] = true;
+            input->key_down_modifiers[event->key.scancode] = modifiers;
+            input->key_pressed_this_frame[event->key.scancode] = true;
+            input->key_pressed_modifiers_this_frame[event->key.scancode] |= modifiers;
+        }
+        break;
+    case SDL_EVENT_KEY_UP:
+        if (event->key.scancode >= 0 && event->key.scancode < SDL_SCANCODE_COUNT)
+        {
+            int modifiers = input->key_down_modifiers[event->key.scancode] |
+                            sdl3d_input_modifier_mask_from_sdl(event->key.mod) |
+                            sdl3d_input_modifier_mask_from_sdl(SDL_GetModState());
+            input->key_down[event->key.scancode] = false;
+            input->key_down_modifiers[event->key.scancode] = SDL3D_INPUT_MOD_NONE;
+            input->key_released_this_frame[event->key.scancode] = true;
+            input->key_released_modifiers_this_frame[event->key.scancode] |= modifiers;
+        }
+        break;
+    case SDL_EVENT_MOUSE_MOTION:
+        input->mouse_dx_accum += event->motion.xrel;
+        input->mouse_dy_accum += event->motion.yrel;
+        break;
+    case SDL_EVENT_MOUSE_WHEEL:
+        input->mouse_wheel_x_accum += event->wheel.x;
+        input->mouse_wheel_y_accum += event->wheel.y;
+        break;
+    case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        if (sdl3d_input_mouse_button_valid(event->button.button))
+        {
+            input->mouse_down[event->button.button] = true;
+            input->mouse_pressed_this_frame[event->button.button] = true;
+        }
+        break;
+    case SDL_EVENT_MOUSE_BUTTON_UP:
+        if (sdl3d_input_mouse_button_valid(event->button.button))
+        {
+            input->mouse_down[event->button.button] = false;
+            input->mouse_released_this_frame[event->button.button] = true;
+        }
+        break;
+    case SDL_EVENT_GAMEPAD_ADDED:
+        sdl3d_input_open_gamepad(input, event->gdevice.which);
+        break;
+    case SDL_EVENT_GAMEPAD_REMOVED:
+        if (input->gamepad != NULL && input->gamepad_id == event->gdevice.which)
+        {
+            sdl3d_input_close_gamepad(input);
+            sdl3d_input_try_open_first_gamepad(input);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int tick)
+{
+    if (input == NULL)
+    {
+        return NULL;
+    }
+
+    if (input->demo_player != NULL)
+    {
+        sdl3d_demo_player *player = input->demo_player;
+        if (player->cursor < player->count)
+        {
+            input->snapshot = player->snapshots[player->cursor++];
+            SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
+            for (int i = 0; i < SDL3D_INPUT_MAX_ACTIONS; ++i)
+            {
+                input->prev_held[i] = input->snapshot.actions[i].held;
+            }
+            sdl3d_input_reset_transients(input);
+            return &input->snapshot;
+        }
+    }
+
+    sdl3d_input_snapshot next;
+    SDL_zero(next);
+    next.tick = tick;
+    next.mouse_dx = input->mouse_dx_accum;
+    next.mouse_dy = input->mouse_dy_accum;
+
+    for (int action_id = 0; action_id < input->action_count; ++action_id)
+    {
+        bool explicit_pressed = false;
+        bool explicit_released = false;
+        bool was_held = input->prev_held[action_id];
+        float value = 0.0f;
+
+        for (int i = 0; i < input->binding_count; ++i)
+        {
+            const sdl3d_input_binding *binding = &input->bindings[i];
+            if (binding->action_id != action_id)
+            {
+                continue;
+            }
+
+            value = sdl3d_input_signed_max_magnitude(value, sdl3d_input_binding_value(input, binding));
+            explicit_pressed = explicit_pressed || sdl3d_input_binding_pressed(input, binding);
+            explicit_released = explicit_released || sdl3d_input_binding_released(input, binding);
+        }
+
+        value = sdl3d_input_clampf(value, -1.0f, 1.0f);
+        next.actions[action_id].value = value;
+        next.actions[action_id].held = sdl3d_input_absf(value) > 0.0001f;
+        next.actions[action_id].pressed = (next.actions[action_id].held && !was_held) || explicit_pressed;
+        next.actions[action_id].released =
+            (!next.actions[action_id].held && was_held) || (explicit_released && (was_held || explicit_pressed));
+        input->prev_held[action_id] = next.actions[action_id].held;
+    }
+
+    input->snapshot = next;
+    (void)sdl3d_demo_recorder_append(input->recorder, &input->snapshot);
+    sdl3d_input_reset_transients(input);
+    return &input->snapshot;
+}
+
+bool sdl3d_input_is_pressed(const sdl3d_input_manager *input, int action_id)
+{
+    return input != NULL && sdl3d_input_action_id_valid(action_id) && input->snapshot.actions[action_id].pressed;
+}
+
+bool sdl3d_input_is_released(const sdl3d_input_manager *input, int action_id)
+{
+    return input != NULL && sdl3d_input_action_id_valid(action_id) && input->snapshot.actions[action_id].released;
+}
+
+bool sdl3d_input_is_held(const sdl3d_input_manager *input, int action_id)
+{
+    return input != NULL && sdl3d_input_action_id_valid(action_id) && input->snapshot.actions[action_id].held;
+}
+
+float sdl3d_input_get_value(const sdl3d_input_manager *input, int action_id)
+{
+    return input != NULL && sdl3d_input_action_id_valid(action_id) ? input->snapshot.actions[action_id].value : 0.0f;
+}
+
+float sdl3d_input_get_mouse_dx(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->snapshot.mouse_dx : 0.0f;
+}
+
+float sdl3d_input_get_mouse_dy(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->snapshot.mouse_dy : 0.0f;
+}
+
+sdl3d_vec2 sdl3d_input_get_axis_pair(const sdl3d_input_manager *input, int negative_x_action, int positive_x_action,
+                                     int negative_y_action, int positive_y_action)
+{
+    sdl3d_vec2 axis = {0.0f, 0.0f};
+    axis.x = sdl3d_input_get_value(input, positive_x_action) - sdl3d_input_get_value(input, negative_x_action);
+    axis.y = sdl3d_input_get_value(input, positive_y_action) - sdl3d_input_get_value(input, negative_y_action);
+    return axis;
+}
+
+const sdl3d_input_snapshot *sdl3d_input_get_snapshot(const sdl3d_input_manager *input)
+{
+    return input != NULL ? &input->snapshot : NULL;
+}
+
+static int sdl3d_input_ensure_action(sdl3d_input_manager *input, const char *name)
+{
+    return sdl3d_input_register_action(input, name);
+}
+
+void sdl3d_input_bind_fps_defaults(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    int move_forward = sdl3d_input_ensure_action(input, "move_forward");
+    int move_back = sdl3d_input_ensure_action(input, "move_back");
+    int move_left = sdl3d_input_ensure_action(input, "move_left");
+    int move_right = sdl3d_input_ensure_action(input, "move_right");
+    int look_up = sdl3d_input_ensure_action(input, "look_up");
+    int look_down = sdl3d_input_ensure_action(input, "look_down");
+    int look_left = sdl3d_input_ensure_action(input, "look_left");
+    int look_right = sdl3d_input_ensure_action(input, "look_right");
+    int jump = sdl3d_input_ensure_action(input, "jump");
+    int fire = sdl3d_input_ensure_action(input, "fire");
+    int alt_fire = sdl3d_input_ensure_action(input, "alt_fire");
+    int reload = sdl3d_input_ensure_action(input, "reload");
+    int interact = sdl3d_input_ensure_action(input, "interact");
+    int crouch = sdl3d_input_ensure_action(input, "crouch");
+    int sprint = sdl3d_input_ensure_action(input, "sprint");
+    int menu = sdl3d_input_ensure_action(input, "menu");
+
+    sdl3d_input_bind_key(input, move_forward, SDL_SCANCODE_W);
+    sdl3d_input_bind_gamepad_axis(input, move_forward, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+    sdl3d_input_bind_key(input, move_back, SDL_SCANCODE_S);
+    sdl3d_input_bind_gamepad_axis(input, move_back, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+    sdl3d_input_bind_key(input, move_left, SDL_SCANCODE_A);
+    sdl3d_input_bind_gamepad_axis(input, move_left, SDL_GAMEPAD_AXIS_LEFTX, -1.0f);
+    sdl3d_input_bind_key(input, move_right, SDL_SCANCODE_D);
+    sdl3d_input_bind_gamepad_axis(input, move_right, SDL_GAMEPAD_AXIS_LEFTX, 1.0f);
+
+    sdl3d_input_bind_mouse_axis(input, look_up, SDL3D_MOUSE_AXIS_Y, -1.0f);
+    sdl3d_input_bind_gamepad_axis(input, look_up, SDL_GAMEPAD_AXIS_RIGHTY, -1.0f);
+    sdl3d_input_bind_mouse_axis(input, look_down, SDL3D_MOUSE_AXIS_Y, 1.0f);
+    sdl3d_input_bind_gamepad_axis(input, look_down, SDL_GAMEPAD_AXIS_RIGHTY, 1.0f);
+    sdl3d_input_bind_mouse_axis(input, look_left, SDL3D_MOUSE_AXIS_X, -1.0f);
+    sdl3d_input_bind_gamepad_axis(input, look_left, SDL_GAMEPAD_AXIS_RIGHTX, -1.0f);
+    sdl3d_input_bind_mouse_axis(input, look_right, SDL3D_MOUSE_AXIS_X, 1.0f);
+    sdl3d_input_bind_gamepad_axis(input, look_right, SDL_GAMEPAD_AXIS_RIGHTX, 1.0f);
+
+    sdl3d_input_bind_key(input, jump, SDL_SCANCODE_SPACE);
+    sdl3d_input_bind_gamepad_button(input, jump, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_bind_mouse_button(input, fire, SDL_BUTTON_LEFT);
+    sdl3d_input_bind_gamepad_axis(input, fire, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, 1.0f);
+    sdl3d_input_bind_mouse_button(input, alt_fire, SDL_BUTTON_RIGHT);
+    sdl3d_input_bind_gamepad_axis(input, alt_fire, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, 1.0f);
+    sdl3d_input_bind_key(input, reload, SDL_SCANCODE_R);
+    sdl3d_input_bind_gamepad_button(input, reload, SDL_GAMEPAD_BUTTON_WEST);
+    sdl3d_input_bind_key(input, interact, SDL_SCANCODE_E);
+    sdl3d_input_bind_gamepad_button(input, interact, SDL_GAMEPAD_BUTTON_NORTH);
+    sdl3d_input_bind_key(input, crouch, SDL_SCANCODE_LCTRL);
+    sdl3d_input_bind_gamepad_button(input, crouch, SDL_GAMEPAD_BUTTON_EAST);
+    sdl3d_input_bind_key(input, sprint, SDL_SCANCODE_LSHIFT);
+    sdl3d_input_bind_gamepad_button(input, sprint, SDL_GAMEPAD_BUTTON_LEFT_STICK);
+    sdl3d_input_bind_key(input, menu, SDL_SCANCODE_ESCAPE);
+    sdl3d_input_bind_gamepad_button(input, menu, SDL_GAMEPAD_BUTTON_START);
+}
+
+void sdl3d_input_bind_ui_defaults(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    int accept = sdl3d_input_ensure_action(input, "ui_accept");
+    int back = sdl3d_input_ensure_action(input, "ui_back");
+    int up = sdl3d_input_ensure_action(input, "ui_up");
+    int down = sdl3d_input_ensure_action(input, "ui_down");
+    int left = sdl3d_input_ensure_action(input, "ui_left");
+    int right = sdl3d_input_ensure_action(input, "ui_right");
+    int tab_next = sdl3d_input_ensure_action(input, "ui_tab_next");
+    int tab_prev = sdl3d_input_ensure_action(input, "ui_tab_prev");
+
+    sdl3d_input_bind_key(input, accept, SDL_SCANCODE_RETURN);
+    sdl3d_input_bind_gamepad_button(input, accept, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_bind_key(input, back, SDL_SCANCODE_ESCAPE);
+    sdl3d_input_bind_gamepad_button(input, back, SDL_GAMEPAD_BUTTON_EAST);
+
+    sdl3d_input_bind_key(input, up, SDL_SCANCODE_UP);
+    sdl3d_input_bind_gamepad_button(input, up, SDL_GAMEPAD_BUTTON_DPAD_UP);
+    sdl3d_input_bind_gamepad_axis(input, up, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+    sdl3d_input_bind_key(input, down, SDL_SCANCODE_DOWN);
+    sdl3d_input_bind_gamepad_button(input, down, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+    sdl3d_input_bind_gamepad_axis(input, down, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+    sdl3d_input_bind_key(input, left, SDL_SCANCODE_LEFT);
+    sdl3d_input_bind_gamepad_button(input, left, SDL_GAMEPAD_BUTTON_DPAD_LEFT);
+    sdl3d_input_bind_gamepad_axis(input, left, SDL_GAMEPAD_AXIS_LEFTX, -1.0f);
+    sdl3d_input_bind_key(input, right, SDL_SCANCODE_RIGHT);
+    sdl3d_input_bind_gamepad_button(input, right, SDL_GAMEPAD_BUTTON_DPAD_RIGHT);
+    sdl3d_input_bind_gamepad_axis(input, right, SDL_GAMEPAD_AXIS_LEFTX, 1.0f);
+
+    sdl3d_input_bind_key_mod_mask(input, tab_next, SDL_SCANCODE_TAB, SDL3D_INPUT_MOD_NONE, SDL3D_INPUT_MOD_SHIFT);
+    sdl3d_input_bind_gamepad_button(input, tab_next, SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER);
+    sdl3d_input_bind_key_mod(input, tab_prev, SDL_SCANCODE_TAB, SDL3D_INPUT_MOD_SHIFT);
+    sdl3d_input_bind_gamepad_button(input, tab_prev, SDL_GAMEPAD_BUTTON_LEFT_SHOULDER);
+}
+
+void sdl3d_input_set_deadzone(sdl3d_input_manager *input, float deadzone)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+    input->deadzone = sdl3d_input_clampf(deadzone, 0.0f, 1.0f);
+}
+
+sdl3d_demo_recorder *sdl3d_demo_record_start(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return NULL;
+    }
+
+    sdl3d_demo_recorder *recorder = (sdl3d_demo_recorder *)SDL_calloc(1, sizeof(*recorder));
+    if (recorder == NULL)
+    {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    if (input->recorder != NULL)
+    {
+        input->recorder->input = NULL;
+        input->recorder->recording = false;
+    }
+
+    recorder->input = input;
+    recorder->recording = true;
+    input->recorder = recorder;
+    return recorder;
+}
+
+void sdl3d_demo_record_stop(sdl3d_demo_recorder *recorder)
+{
+    if (recorder == NULL)
+    {
+        return;
+    }
+
+    recorder->recording = false;
+    if (recorder->input != NULL && recorder->input->recorder == recorder)
+    {
+        recorder->input->recorder = NULL;
+    }
+    recorder->input = NULL;
+}
+
+bool sdl3d_demo_save(const sdl3d_demo_recorder *recorder, const char *path, float tick_rate)
+{
+    SDL_IOStream *stream;
+    sdl3d_input_demo_header header;
+    bool ok;
+
+    if (recorder == NULL || path == NULL)
+    {
+        return SDL_InvalidParamError(recorder == NULL ? "recorder" : "path");
+    }
+
+    stream = SDL_IOFromFile(path, "wb");
+    if (stream == NULL)
+    {
+        return false;
+    }
+
+    SDL_zero(header);
+    SDL_memcpy(header.magic, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE);
+    header.version = SDL3D_INPUT_DEMO_VERSION;
+    header.tick_rate = tick_rate;
+    header.tick_count = recorder->count;
+
+    ok = sdl3d_input_write_all(stream, &header, sizeof(header));
+    if (ok && recorder->count > 0)
+    {
+        ok = sdl3d_input_write_all(stream, recorder->snapshots, (size_t)recorder->count * sizeof(*recorder->snapshots));
+    }
+
+    return SDL_CloseIO(stream) && ok;
+}
+
+Uint32 sdl3d_demo_record_count(const sdl3d_demo_recorder *recorder)
+{
+    return recorder != NULL ? recorder->count : 0U;
+}
+
+const sdl3d_input_snapshot *sdl3d_demo_record_snapshot(const sdl3d_demo_recorder *recorder, Uint32 index)
+{
+    return recorder != NULL && index < recorder->count ? &recorder->snapshots[index] : NULL;
+}
+
+void sdl3d_demo_record_free(sdl3d_demo_recorder *recorder)
+{
+    if (recorder == NULL)
+    {
+        return;
+    }
+
+    sdl3d_demo_record_stop(recorder);
+    SDL_free(recorder->snapshots);
+    SDL_free(recorder);
+}
+
+sdl3d_demo_player *sdl3d_demo_playback_load(const char *path)
+{
+    SDL_IOStream *stream;
+    sdl3d_input_demo_header header;
+    sdl3d_demo_player *player;
+    size_t snapshot_bytes;
+
+    if (path == NULL)
+    {
+        SDL_InvalidParamError("path");
+        return NULL;
+    }
+
+    stream = SDL_IOFromFile(path, "rb");
+    if (stream == NULL)
+    {
+        return NULL;
+    }
+
+    if (!sdl3d_input_read_all(stream, &header, sizeof(header)) ||
+        SDL_memcmp(header.magic, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE) != 0 ||
+        header.version != SDL3D_INPUT_DEMO_VERSION)
+    {
+        SDL_CloseIO(stream);
+        SDL_SetError("Invalid SDL3D demo file.");
+        return NULL;
+    }
+
+    player = (sdl3d_demo_player *)SDL_calloc(1, sizeof(*player));
+    if (player == NULL)
+    {
+        SDL_CloseIO(stream);
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    player->tick_rate = header.tick_rate;
+    player->count = header.tick_count;
+
+    if (header.tick_count > 0)
+    {
+        snapshot_bytes = (size_t)header.tick_count * sizeof(*player->snapshots);
+        player->snapshots = (sdl3d_input_snapshot *)SDL_malloc(snapshot_bytes);
+        if (player->snapshots == NULL)
+        {
+            sdl3d_demo_playback_free(player);
+            SDL_CloseIO(stream);
+            SDL_OutOfMemory();
+            return NULL;
+        }
+        if (!sdl3d_input_read_all(stream, player->snapshots, snapshot_bytes))
+        {
+            sdl3d_demo_playback_free(player);
+            SDL_CloseIO(stream);
+            SDL_SetError("Truncated SDL3D demo file.");
+            return NULL;
+        }
+    }
+
+    if (!SDL_CloseIO(stream))
+    {
+        sdl3d_demo_playback_free(player);
+        return NULL;
+    }
+
+    return player;
+}
+
+void sdl3d_demo_playback_start(sdl3d_input_manager *input, sdl3d_demo_player *player)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    input->demo_player = player;
+    if (player != NULL)
+    {
+        player->cursor = 0;
+    }
+}
+
+void sdl3d_demo_playback_stop(sdl3d_input_manager *input)
+{
+    if (input != NULL)
+    {
+        input->demo_player = NULL;
+    }
+}
+
+bool sdl3d_demo_playback_finished(const sdl3d_demo_player *player)
+{
+    return player == NULL || player->cursor >= player->count;
+}
+
+float sdl3d_demo_playback_tick_rate(const sdl3d_demo_player *player)
+{
+    return player != NULL ? player->tick_rate : 0.0f;
+}
+
+Uint32 sdl3d_demo_playback_count(const sdl3d_demo_player *player)
+{
+    return player != NULL ? player->count : 0U;
+}
+
+void sdl3d_demo_playback_free(sdl3d_demo_player *player)
+{
+    if (player == NULL)
+    {
+        return;
+    }
+
+    SDL_free(player->snapshots);
+    SDL_free(player);
+}

--- a/src/input.c
+++ b/src/input.c
@@ -4,25 +4,23 @@
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include <stdint.h>
+
 #define SDL3D_INPUT_DEFAULT_DEADZONE 0.15f
 #define SDL3D_INPUT_MAX_MOUSE_BUTTONS 16
 #define SDL3D_INPUT_DEMO_MAGIC "SDL3DEMO"
 #define SDL3D_INPUT_DEMO_MAGIC_SIZE 8
-#define SDL3D_INPUT_DEMO_VERSION 1U
+#define SDL3D_INPUT_DEMO_VERSION 2U
+#define SDL3D_INPUT_DEMO_ACTION_COUNT SDL3D_INPUT_MAX_ACTIONS
+#define SDL3D_INPUT_DEMO_FLAG_PRESSED 0x01U
+#define SDL3D_INPUT_DEMO_FLAG_RELEASED 0x02U
+#define SDL3D_INPUT_DEMO_FLAG_HELD 0x04U
 
 typedef struct sdl3d_input_action_entry
 {
     char name[SDL3D_INPUT_ACTION_NAME_MAX];
     bool registered;
 } sdl3d_input_action_entry;
-
-typedef struct sdl3d_input_demo_header
-{
-    char magic[SDL3D_INPUT_DEMO_MAGIC_SIZE];
-    Uint32 version;
-    float tick_rate;
-    Uint32 tick_count;
-} sdl3d_input_demo_header;
 
 struct sdl3d_demo_recorder
 {
@@ -430,6 +428,178 @@ static bool sdl3d_input_write_all(SDL_IOStream *stream, const void *data, size_t
 static bool sdl3d_input_read_all(SDL_IOStream *stream, void *data, size_t size)
 {
     return stream != NULL && data != NULL && SDL_ReadIO(stream, data, size) == size;
+}
+
+static bool sdl3d_input_write_u8(SDL_IOStream *stream, Uint8 value)
+{
+    return sdl3d_input_write_all(stream, &value, sizeof(value));
+}
+
+static bool sdl3d_input_read_u8(SDL_IOStream *stream, Uint8 *out_value)
+{
+    return sdl3d_input_read_all(stream, out_value, sizeof(*out_value));
+}
+
+static bool sdl3d_input_write_u32_le(SDL_IOStream *stream, Uint32 value)
+{
+    Uint8 bytes[4];
+    bytes[0] = (Uint8)(value & 0xffU);
+    bytes[1] = (Uint8)((value >> 8U) & 0xffU);
+    bytes[2] = (Uint8)((value >> 16U) & 0xffU);
+    bytes[3] = (Uint8)((value >> 24U) & 0xffU);
+    return sdl3d_input_write_all(stream, bytes, sizeof(bytes));
+}
+
+static bool sdl3d_input_read_u32_le(SDL_IOStream *stream, Uint32 *out_value)
+{
+    Uint8 bytes[4];
+    if (out_value == NULL || !sdl3d_input_read_all(stream, bytes, sizeof(bytes)))
+    {
+        return false;
+    }
+
+    *out_value = (Uint32)bytes[0] | ((Uint32)bytes[1] << 8U) | ((Uint32)bytes[2] << 16U) | ((Uint32)bytes[3] << 24U);
+    return true;
+}
+
+static bool sdl3d_input_write_i32_le(SDL_IOStream *stream, int value)
+{
+    return sdl3d_input_write_u32_le(stream, (Uint32)(Sint32)value);
+}
+
+static bool sdl3d_input_read_i32_le(SDL_IOStream *stream, int *out_value)
+{
+    Uint32 bits;
+    if (out_value == NULL || !sdl3d_input_read_u32_le(stream, &bits))
+    {
+        return false;
+    }
+
+    *out_value = (int)(Sint32)bits;
+    return true;
+}
+
+static bool sdl3d_input_write_f32_le(SDL_IOStream *stream, float value)
+{
+    Uint32 bits;
+    SDL_memcpy(&bits, &value, sizeof(bits));
+    return sdl3d_input_write_u32_le(stream, bits);
+}
+
+static bool sdl3d_input_read_f32_le(SDL_IOStream *stream, float *out_value)
+{
+    Uint32 bits;
+    if (out_value == NULL || !sdl3d_input_read_u32_le(stream, &bits))
+    {
+        return false;
+    }
+
+    SDL_memcpy(out_value, &bits, sizeof(bits));
+    return true;
+}
+
+static Uint8 sdl3d_input_demo_flags_from_action(const sdl3d_action_state *action)
+{
+    Uint8 flags = 0U;
+    if (action->pressed)
+    {
+        flags |= SDL3D_INPUT_DEMO_FLAG_PRESSED;
+    }
+    if (action->released)
+    {
+        flags |= SDL3D_INPUT_DEMO_FLAG_RELEASED;
+    }
+    if (action->held)
+    {
+        flags |= SDL3D_INPUT_DEMO_FLAG_HELD;
+    }
+    return flags;
+}
+
+static void sdl3d_input_demo_flags_to_action(Uint8 flags, sdl3d_action_state *action)
+{
+    action->pressed = (flags & SDL3D_INPUT_DEMO_FLAG_PRESSED) != 0;
+    action->released = (flags & SDL3D_INPUT_DEMO_FLAG_RELEASED) != 0;
+    action->held = (flags & SDL3D_INPUT_DEMO_FLAG_HELD) != 0;
+}
+
+static bool sdl3d_demo_write_header(SDL_IOStream *stream, float tick_rate, Uint32 tick_count)
+{
+    return sdl3d_input_write_all(stream, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE) &&
+           sdl3d_input_write_u32_le(stream, SDL3D_INPUT_DEMO_VERSION) && sdl3d_input_write_f32_le(stream, tick_rate) &&
+           sdl3d_input_write_u32_le(stream, tick_count) &&
+           sdl3d_input_write_u32_le(stream, SDL3D_INPUT_DEMO_ACTION_COUNT);
+}
+
+static bool sdl3d_demo_read_header(SDL_IOStream *stream, float *out_tick_rate, Uint32 *out_tick_count,
+                                   Uint32 *out_action_count)
+{
+    char magic[SDL3D_INPUT_DEMO_MAGIC_SIZE];
+    Uint32 version;
+
+    if (!sdl3d_input_read_all(stream, magic, sizeof(magic)) ||
+        SDL_memcmp(magic, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE) != 0 ||
+        !sdl3d_input_read_u32_le(stream, &version) || version != SDL3D_INPUT_DEMO_VERSION ||
+        !sdl3d_input_read_f32_le(stream, out_tick_rate) || !sdl3d_input_read_u32_le(stream, out_tick_count) ||
+        !sdl3d_input_read_u32_le(stream, out_action_count) || *out_action_count != SDL3D_INPUT_DEMO_ACTION_COUNT)
+    {
+        SDL_SetError("Invalid SDL3D demo file.");
+        return false;
+    }
+
+    return true;
+}
+
+static bool sdl3d_demo_write_snapshot(SDL_IOStream *stream, const sdl3d_input_snapshot *snapshot)
+{
+    if (stream == NULL || snapshot == NULL)
+    {
+        return false;
+    }
+
+    if (!sdl3d_input_write_i32_le(stream, snapshot->tick) || !sdl3d_input_write_f32_le(stream, snapshot->mouse_dx) ||
+        !sdl3d_input_write_f32_le(stream, snapshot->mouse_dy))
+    {
+        return false;
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_DEMO_ACTION_COUNT; ++i)
+    {
+        if (!sdl3d_input_write_u8(stream, sdl3d_input_demo_flags_from_action(&snapshot->actions[i])) ||
+            !sdl3d_input_write_f32_le(stream, snapshot->actions[i].value))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool sdl3d_demo_read_snapshot(SDL_IOStream *stream, sdl3d_input_snapshot *snapshot)
+{
+    if (stream == NULL || snapshot == NULL)
+    {
+        return false;
+    }
+
+    SDL_zero(*snapshot);
+    if (!sdl3d_input_read_i32_le(stream, &snapshot->tick) || !sdl3d_input_read_f32_le(stream, &snapshot->mouse_dx) ||
+        !sdl3d_input_read_f32_le(stream, &snapshot->mouse_dy))
+    {
+        return false;
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_DEMO_ACTION_COUNT; ++i)
+    {
+        Uint8 flags;
+        if (!sdl3d_input_read_u8(stream, &flags) || !sdl3d_input_read_f32_le(stream, &snapshot->actions[i].value))
+        {
+            return false;
+        }
+        sdl3d_input_demo_flags_to_action(flags, &snapshot->actions[i]);
+    }
+
+    return true;
 }
 
 sdl3d_input_manager *sdl3d_input_create(void)
@@ -931,7 +1101,6 @@ void sdl3d_demo_record_stop(sdl3d_demo_recorder *recorder)
 bool sdl3d_demo_save(const sdl3d_demo_recorder *recorder, const char *path, float tick_rate)
 {
     SDL_IOStream *stream;
-    sdl3d_input_demo_header header;
     bool ok;
 
     if (recorder == NULL || path == NULL)
@@ -945,16 +1114,10 @@ bool sdl3d_demo_save(const sdl3d_demo_recorder *recorder, const char *path, floa
         return false;
     }
 
-    SDL_zero(header);
-    SDL_memcpy(header.magic, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE);
-    header.version = SDL3D_INPUT_DEMO_VERSION;
-    header.tick_rate = tick_rate;
-    header.tick_count = recorder->count;
-
-    ok = sdl3d_input_write_all(stream, &header, sizeof(header));
-    if (ok && recorder->count > 0)
+    ok = sdl3d_demo_write_header(stream, tick_rate, recorder->count);
+    for (Uint32 i = 0; ok && i < recorder->count; ++i)
     {
-        ok = sdl3d_input_write_all(stream, recorder->snapshots, (size_t)recorder->count * sizeof(*recorder->snapshots));
+        ok = sdl3d_demo_write_snapshot(stream, &recorder->snapshots[i]);
     }
 
     return SDL_CloseIO(stream) && ok;
@@ -985,9 +1148,11 @@ void sdl3d_demo_record_free(sdl3d_demo_recorder *recorder)
 sdl3d_demo_player *sdl3d_demo_playback_load(const char *path)
 {
     SDL_IOStream *stream;
-    sdl3d_input_demo_header header;
     sdl3d_demo_player *player;
+    Uint32 tick_count;
+    Uint32 action_count;
     size_t snapshot_bytes;
+    float tick_rate;
 
     if (path == NULL)
     {
@@ -1001,12 +1166,9 @@ sdl3d_demo_player *sdl3d_demo_playback_load(const char *path)
         return NULL;
     }
 
-    if (!sdl3d_input_read_all(stream, &header, sizeof(header)) ||
-        SDL_memcmp(header.magic, SDL3D_INPUT_DEMO_MAGIC, SDL3D_INPUT_DEMO_MAGIC_SIZE) != 0 ||
-        header.version != SDL3D_INPUT_DEMO_VERSION)
+    if (!sdl3d_demo_read_header(stream, &tick_rate, &tick_count, &action_count))
     {
         SDL_CloseIO(stream);
-        SDL_SetError("Invalid SDL3D demo file.");
         return NULL;
     }
 
@@ -1018,12 +1180,20 @@ sdl3d_demo_player *sdl3d_demo_playback_load(const char *path)
         return NULL;
     }
 
-    player->tick_rate = header.tick_rate;
-    player->count = header.tick_count;
+    player->tick_rate = tick_rate;
+    player->count = tick_count;
 
-    if (header.tick_count > 0)
+    if (tick_count > 0)
     {
-        snapshot_bytes = (size_t)header.tick_count * sizeof(*player->snapshots);
+        if (tick_count > (Uint32)(SIZE_MAX / sizeof(*player->snapshots)))
+        {
+            sdl3d_demo_playback_free(player);
+            SDL_CloseIO(stream);
+            SDL_SetError("SDL3D demo file is too large.");
+            return NULL;
+        }
+
+        snapshot_bytes = (size_t)tick_count * sizeof(*player->snapshots);
         player->snapshots = (sdl3d_input_snapshot *)SDL_malloc(snapshot_bytes);
         if (player->snapshots == NULL)
         {
@@ -1032,12 +1202,16 @@ sdl3d_demo_player *sdl3d_demo_playback_load(const char *path)
             SDL_OutOfMemory();
             return NULL;
         }
-        if (!sdl3d_input_read_all(stream, player->snapshots, snapshot_bytes))
+
+        for (Uint32 i = 0; i < tick_count; ++i)
         {
-            sdl3d_demo_playback_free(player);
-            SDL_CloseIO(stream);
-            SDL_SetError("Truncated SDL3D demo file.");
-            return NULL;
+            if (!sdl3d_demo_read_snapshot(stream, &player->snapshots[i]))
+            {
+                sdl3d_demo_playback_free(player);
+                SDL_CloseIO(stream);
+                SDL_SetError("Truncated SDL3D demo file.");
+                return NULL;
+            }
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SDL3D_TEST_SOURCES
     test_animation.cpp
     test_effects.cpp
     test_game.cpp
+    test_input.cpp
     test_level.cpp
     test_properties.cpp
     test_signal_bus.cpp
@@ -189,6 +190,7 @@ else()
     sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_game_test test_game.cpp render)
+    sdl3d_add_test(sdl3d_input_test test_input.cpp unit)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -51,6 +51,8 @@ struct GameTestState
     bool saw_default_config = false;
     bool saw_time_update = false;
     bool saw_quit_event_in_callback = false;
+    bool saw_input_action_in_tick = false;
+    int input_action = -1;
     int tick_count = 0;
     int render_count = 0;
     float tick_dt = 0.0f;
@@ -84,7 +86,7 @@ bool validate_context_in_init(sdl3d_game_context *ctx, void *userdata)
 {
     auto *state = static_cast<GameTestState *>(userdata);
     state->saw_valid_context = ctx->window != nullptr && ctx->renderer != nullptr && ctx->registry != nullptr &&
-                               ctx->bus != nullptr && ctx->timers != nullptr;
+                               ctx->bus != nullptr && ctx->timers != nullptr && ctx->input != nullptr;
     ctx->quit_requested = true;
     return true;
 }
@@ -180,6 +182,29 @@ void quit_when_timer_fires(sdl3d_game_context *ctx, void *userdata, float dt)
     {
         ctx->quit_requested = true;
     }
+}
+
+bool bind_and_push_input_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->input_action = sdl3d_input_register_action(ctx->input, "jump");
+    sdl3d_input_bind_key(ctx->input, state->input_action, SDL_SCANCODE_SPACE);
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_SPACE;
+    SDL_PushEvent(&event);
+    return true;
+}
+
+void quit_after_input_tick(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    (void)dt;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->tick_count++;
+    state->saw_input_action_in_tick =
+        sdl3d_input_is_pressed(ctx->input, state->input_action) && sdl3d_input_is_held(ctx->input, state->input_action);
+    ctx->quit_requested = true;
 }
 
 void stop_after_many_null_frames(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -297,6 +322,19 @@ TEST(ManagedGameLoop, TimerPoolIsTickedAutomatically)
 
     EXPECT_EQ(0, run_test_game(&callbacks, &state));
     EXPECT_TRUE(state.timer_fired);
+}
+
+TEST(ManagedGameLoop, InputManagerProcessesEventsBeforeTick)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = bind_and_push_input_in_init;
+    callbacks.tick = quit_after_input_tick;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.tick_count, 1);
+    EXPECT_TRUE(state.saw_input_action_in_tick);
 }
 
 TEST(ManagedGameLoop, QuitRequestedFromTickExitsAndRunsShutdown)

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -13,7 +13,10 @@ extern "C"
 #include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include <fstream>
+#include <iterator>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -39,6 +42,18 @@ std::string demo_path()
     SDL_free(pref_path);
     path += "sdl3d_input_test.dem";
     return path;
+}
+
+std::vector<unsigned char> read_binary_file(const std::string &path)
+{
+    std::ifstream file(path, std::ios::binary);
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+
+Uint32 read_u32_le(const std::vector<unsigned char> &bytes, size_t offset)
+{
+    return static_cast<Uint32>(bytes[offset]) | (static_cast<Uint32>(bytes[offset + 1]) << 8U) |
+           (static_cast<Uint32>(bytes[offset + 2]) << 16U) | (static_cast<Uint32>(bytes[offset + 3]) << 24U);
 }
 
 void push_key(sdl3d_input_manager *input, SDL_EventType type, SDL_Scancode scancode)
@@ -379,6 +394,23 @@ TEST(InputDemo, RecordAndPlayback)
 
     std::string path = demo_path();
     ASSERT_TRUE(sdl3d_demo_save(recorder, path.c_str(), 1.0f / 60.0f)) << SDL_GetError();
+
+    std::vector<unsigned char> bytes = read_binary_file(path);
+    constexpr size_t kDemoHeaderSize = 24U;
+    constexpr size_t kDemoSnapshotSize = 12U + SDL3D_INPUT_MAX_ACTIONS * 5U;
+    ASSERT_EQ(kDemoHeaderSize + 2U * kDemoSnapshotSize, bytes.size());
+    EXPECT_EQ('S', bytes[0]);
+    EXPECT_EQ('D', bytes[1]);
+    EXPECT_EQ('L', bytes[2]);
+    EXPECT_EQ('3', bytes[3]);
+    EXPECT_EQ('D', bytes[4]);
+    EXPECT_EQ('E', bytes[5]);
+    EXPECT_EQ('M', bytes[6]);
+    EXPECT_EQ('O', bytes[7]);
+    EXPECT_EQ(2U, read_u32_le(bytes, 8));
+    EXPECT_EQ(2U, read_u32_le(bytes, 16));
+    EXPECT_EQ(SDL3D_INPUT_MAX_ACTIONS, read_u32_le(bytes, 20));
+
     sdl3d_demo_record_free(recorder);
 
     sdl3d_demo_player *player = sdl3d_demo_playback_load(path.c_str());

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -1,0 +1,418 @@
+#define SDL_MAIN_HANDLED
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/input.h"
+}
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_keyboard.h>
+#include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_scancode.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include <string>
+
+namespace
+{
+struct InputPtr
+{
+    sdl3d_input_manager *input = sdl3d_input_create();
+
+    ~InputPtr()
+    {
+        sdl3d_input_destroy(input);
+    }
+};
+
+std::string demo_path()
+{
+    char *pref_path = SDL_GetPrefPath("SDL3D", "tests");
+    if (pref_path == nullptr)
+    {
+        return "sdl3d_input_test.dem";
+    }
+
+    std::string path = pref_path;
+    SDL_free(pref_path);
+    path += "sdl3d_input_test.dem";
+    return path;
+}
+
+void push_key(sdl3d_input_manager *input, SDL_EventType type, SDL_Scancode scancode)
+{
+    SDL_Event event{};
+    event.type = type;
+    event.key.scancode = scancode;
+    sdl3d_input_process_event(input, &event);
+}
+
+void push_key_mod(sdl3d_input_manager *input, SDL_EventType type, SDL_Scancode scancode, SDL_Keymod modifiers)
+{
+    SDL_Event event{};
+    event.type = type;
+    event.key.scancode = scancode;
+    event.key.mod = modifiers;
+    sdl3d_input_process_event(input, &event);
+}
+
+void push_mouse_button(sdl3d_input_manager *input, SDL_EventType type, Uint8 button)
+{
+    SDL_Event event{};
+    event.type = type;
+    event.button.button = button;
+    sdl3d_input_process_event(input, &event);
+}
+
+void push_mouse_motion(sdl3d_input_manager *input, float dx, float dy)
+{
+    SDL_Event event{};
+    event.type = SDL_EVENT_MOUSE_MOTION;
+    event.motion.xrel = dx;
+    event.motion.yrel = dy;
+    sdl3d_input_process_event(input, &event);
+}
+} // namespace
+
+TEST(Input, RegisterActionFindsByName)
+{
+    InputPtr input;
+    ASSERT_NE(input.input, nullptr);
+
+    int action = sdl3d_input_register_action(input.input, "jump");
+    EXPECT_GE(action, 0);
+    EXPECT_EQ(action, sdl3d_input_find_action(input.input, "jump"));
+    EXPECT_EQ(-1, sdl3d_input_find_action(input.input, "missing"));
+}
+
+TEST(Input, RegisterDuplicateReturnsSameId)
+{
+    InputPtr input;
+
+    int first = sdl3d_input_register_action(input.input, "fire");
+    int second = sdl3d_input_register_action(input.input, "fire");
+
+    EXPECT_GE(first, 0);
+    EXPECT_EQ(first, second);
+}
+
+TEST(Input, RejectsInvalidActionNames)
+{
+    InputPtr input;
+    char long_name[SDL3D_INPUT_ACTION_NAME_MAX + 2]{};
+    SDL_memset(long_name, 'x', sizeof(long_name) - 1);
+
+    EXPECT_EQ(-1, sdl3d_input_register_action(input.input, nullptr));
+    EXPECT_EQ(-1, sdl3d_input_register_action(input.input, ""));
+    EXPECT_EQ(-1, sdl3d_input_register_action(input.input, long_name));
+}
+
+TEST(Input, BindKeyAndQueryHeld)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "move_forward");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_W);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_W);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+    EXPECT_FLOAT_EQ(1.0f, sdl3d_input_get_value(input.input, action));
+}
+
+TEST(Input, PressedEdgeDetection)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "jump");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_SPACE);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_SPACE);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, action));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+
+    sdl3d_input_update(input.input, 2);
+    EXPECT_FALSE(sdl3d_input_is_pressed(input.input, action));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+}
+
+TEST(Input, ReleasedEdgeDetection)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "jump");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_SPACE);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_SPACE);
+    sdl3d_input_update(input.input, 1);
+    push_key(input.input, SDL_EVENT_KEY_UP, SDL_SCANCODE_SPACE);
+    sdl3d_input_update(input.input, 2);
+
+    EXPECT_TRUE(sdl3d_input_is_released(input.input, action));
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, action));
+
+    sdl3d_input_update(input.input, 3);
+    EXPECT_FALSE(sdl3d_input_is_released(input.input, action));
+}
+
+TEST(Input, MouseDeltaAccumulation)
+{
+    InputPtr input;
+
+    push_mouse_motion(input.input, 3.0f, -2.0f);
+    push_mouse_motion(input.input, 4.5f, 1.0f);
+    sdl3d_input_update(input.input, 10);
+
+    EXPECT_FLOAT_EQ(7.5f, sdl3d_input_get_mouse_dx(input.input));
+    EXPECT_FLOAT_EQ(-1.0f, sdl3d_input_get_mouse_dy(input.input));
+
+    sdl3d_input_update(input.input, 11);
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_mouse_dx(input.input));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_mouse_dy(input.input));
+}
+
+TEST(Input, MouseAxisBindingUsesScale)
+{
+    InputPtr input;
+    int look_left = sdl3d_input_register_action(input.input, "look_left");
+    sdl3d_input_bind_mouse_axis(input.input, look_left, SDL3D_MOUSE_AXIS_X, -1.0f);
+
+    push_mouse_motion(input.input, 0.25f, 0.0f);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, look_left));
+    EXPECT_FLOAT_EQ(-0.25f, sdl3d_input_get_value(input.input, look_left));
+}
+
+TEST(Input, OppositeMouseAxisBindingsUsePositiveDirection)
+{
+    InputPtr input;
+    int look_left = sdl3d_input_register_action(input.input, "look_left");
+    int look_right = sdl3d_input_register_action(input.input, "look_right");
+    sdl3d_input_bind_mouse_axis(input.input, look_left, SDL3D_MOUSE_AXIS_X, -1.0f);
+    sdl3d_input_bind_mouse_axis(input.input, look_right, SDL3D_MOUSE_AXIS_X, 1.0f);
+
+    push_mouse_motion(input.input, 0.25f, 0.0f);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, look_left));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, look_right));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_value(input.input, look_left));
+    EXPECT_FLOAT_EQ(0.25f, sdl3d_input_get_value(input.input, look_right));
+
+    push_mouse_motion(input.input, -0.5f, 0.0f);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, look_left));
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, look_right));
+    EXPECT_FLOAT_EQ(0.5f, sdl3d_input_get_value(input.input, look_left));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_value(input.input, look_right));
+}
+
+TEST(Input, MouseButtonPressAndRelease)
+{
+    InputPtr input;
+    int fire = sdl3d_input_register_action(input.input, "fire");
+    sdl3d_input_bind_mouse_button(input.input, fire, SDL_BUTTON_LEFT);
+
+    push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_DOWN, SDL_BUTTON_LEFT);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, fire));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, fire));
+
+    push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_UP, SDL_BUTTON_LEFT);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_TRUE(sdl3d_input_is_released(input.input, fire));
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, fire));
+}
+
+TEST(Input, MultipleBindingsSameAction)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "move_forward");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_W);
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_UP);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_UP);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+}
+
+TEST(Input, AxisPairComposesFourActions)
+{
+    InputPtr input;
+    int left = sdl3d_input_register_action(input.input, "left");
+    int right = sdl3d_input_register_action(input.input, "right");
+    int down = sdl3d_input_register_action(input.input, "down");
+    int up = sdl3d_input_register_action(input.input, "up");
+    sdl3d_input_bind_key(input.input, right, SDL_SCANCODE_D);
+    sdl3d_input_bind_key(input.input, up, SDL_SCANCODE_W);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_D);
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_W);
+    sdl3d_input_update(input.input, 1);
+
+    sdl3d_vec2 axis = sdl3d_input_get_axis_pair(input.input, left, right, down, up);
+    EXPECT_FLOAT_EQ(1.0f, axis.x);
+    EXPECT_FLOAT_EQ(1.0f, axis.y);
+}
+
+TEST(Input, UnbindActionRemovesBindings)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "jump");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_SPACE);
+    sdl3d_input_unbind_action(input.input, action);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_SPACE);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, action));
+}
+
+TEST(Input, FpsDefaultsRegisterAllActions)
+{
+    InputPtr input;
+    sdl3d_input_bind_fps_defaults(input.input);
+
+    const char *names[] = {"move_forward", "move_back",  "move_left", "move_right", "look_up",  "look_down",
+                           "look_left",    "look_right", "jump",      "fire",       "alt_fire", "reload",
+                           "interact",     "crouch",     "sprint",    "menu"};
+    for (const char *name : names)
+    {
+        EXPECT_GE(sdl3d_input_find_action(input.input, name), 0) << name;
+    }
+}
+
+TEST(Input, UiDefaultsRegisterAllActions)
+{
+    InputPtr input;
+    sdl3d_input_bind_ui_defaults(input.input);
+
+    const char *names[] = {"ui_accept", "ui_back",  "ui_up",       "ui_down",
+                           "ui_left",   "ui_right", "ui_tab_next", "ui_tab_prev"};
+    for (const char *name : names)
+    {
+        EXPECT_GE(sdl3d_input_find_action(input.input, name), 0) << name;
+    }
+}
+
+TEST(Input, ShiftTabTriggersPreviousTabOnly)
+{
+    InputPtr input;
+    sdl3d_input_bind_ui_defaults(input.input);
+    int tab_next = sdl3d_input_find_action(input.input, "ui_tab_next");
+    int tab_prev = sdl3d_input_find_action(input.input, "ui_tab_prev");
+
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    push_key_mod(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_TAB, SDL_KMOD_SHIFT);
+    sdl3d_input_update(input.input, 1);
+    SDL_SetModState(SDL_KMOD_NONE);
+
+    EXPECT_FALSE(sdl3d_input_is_pressed(input.input, tab_next));
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, tab_next));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, tab_prev));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, tab_prev));
+}
+
+TEST(Input, SnapshotPointerIsStableUntilNextUpdate)
+{
+    InputPtr input;
+    const sdl3d_input_snapshot *first = sdl3d_input_update(input.input, 1);
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(1, first->tick);
+
+    const sdl3d_input_snapshot *second = sdl3d_input_get_snapshot(input.input);
+    EXPECT_EQ(first, second);
+
+    const sdl3d_input_snapshot *third = sdl3d_input_update(input.input, 2);
+    EXPECT_EQ(first, third);
+    EXPECT_EQ(2, third->tick);
+}
+
+TEST(Input, NullSafety)
+{
+    sdl3d_input_destroy(nullptr);
+    EXPECT_EQ(-1, sdl3d_input_register_action(nullptr, "x"));
+    EXPECT_EQ(-1, sdl3d_input_find_action(nullptr, "x"));
+    sdl3d_input_bind_key(nullptr, 0, SDL_SCANCODE_A);
+    sdl3d_input_bind_key_mod_mask(nullptr, 0, SDL_SCANCODE_A, SDL3D_INPUT_MOD_SHIFT, SDL3D_INPUT_MOD_CTRL);
+    sdl3d_input_bind_mouse_button(nullptr, 0, SDL_BUTTON_LEFT);
+    sdl3d_input_bind_mouse_axis(nullptr, 0, SDL3D_MOUSE_AXIS_X, 1.0f);
+    sdl3d_input_bind_gamepad_button(nullptr, 0, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_bind_gamepad_axis(nullptr, 0, SDL_GAMEPAD_AXIS_LEFTX, 1.0f);
+    sdl3d_input_unbind_action(nullptr, 0);
+    sdl3d_input_process_event(nullptr, nullptr);
+    EXPECT_EQ(nullptr, sdl3d_input_update(nullptr, 0));
+    EXPECT_FALSE(sdl3d_input_is_pressed(nullptr, 0));
+    EXPECT_FALSE(sdl3d_input_is_released(nullptr, 0));
+    EXPECT_FALSE(sdl3d_input_is_held(nullptr, 0));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_value(nullptr, 0));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_mouse_dx(nullptr));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_input_get_mouse_dy(nullptr));
+    EXPECT_EQ(nullptr, sdl3d_input_get_snapshot(nullptr));
+    sdl3d_input_bind_fps_defaults(nullptr);
+    sdl3d_input_bind_ui_defaults(nullptr);
+    sdl3d_input_set_deadzone(nullptr, 0.2f);
+}
+
+TEST(InputDemo, RecordAndPlayback)
+{
+    InputPtr input;
+    int fire = sdl3d_input_register_action(input.input, "fire");
+    sdl3d_input_bind_mouse_button(input.input, fire, SDL_BUTTON_LEFT);
+
+    sdl3d_demo_recorder *recorder = sdl3d_demo_record_start(input.input);
+    ASSERT_NE(recorder, nullptr);
+
+    push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_DOWN, SDL_BUTTON_LEFT);
+    const sdl3d_input_snapshot *first = sdl3d_input_update(input.input, 100);
+    ASSERT_NE(first, nullptr);
+    push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_UP, SDL_BUTTON_LEFT);
+    const sdl3d_input_snapshot *second = sdl3d_input_update(input.input, 101);
+    ASSERT_NE(second, nullptr);
+    sdl3d_demo_record_stop(recorder);
+
+    ASSERT_EQ(2U, sdl3d_demo_record_count(recorder));
+    ASSERT_TRUE(sdl3d_demo_record_snapshot(recorder, 0)->actions[fire].pressed);
+    ASSERT_TRUE(sdl3d_demo_record_snapshot(recorder, 1)->actions[fire].released);
+
+    std::string path = demo_path();
+    ASSERT_TRUE(sdl3d_demo_save(recorder, path.c_str(), 1.0f / 60.0f)) << SDL_GetError();
+    sdl3d_demo_record_free(recorder);
+
+    sdl3d_demo_player *player = sdl3d_demo_playback_load(path.c_str());
+    ASSERT_NE(player, nullptr) << SDL_GetError();
+    EXPECT_EQ(2U, sdl3d_demo_playback_count(player));
+    EXPECT_FLOAT_EQ(1.0f / 60.0f, sdl3d_demo_playback_tick_rate(player));
+
+    InputPtr playback_input;
+    sdl3d_demo_playback_start(playback_input.input, player);
+    const sdl3d_input_snapshot *played_first = sdl3d_input_update(playback_input.input, 0);
+    ASSERT_NE(played_first, nullptr);
+    EXPECT_TRUE(played_first->actions[fire].pressed);
+    EXPECT_FALSE(sdl3d_demo_playback_finished(player));
+
+    const sdl3d_input_snapshot *played_second = sdl3d_input_update(playback_input.input, 1);
+    ASSERT_NE(played_second, nullptr);
+    EXPECT_TRUE(played_second->actions[fire].released);
+    EXPECT_TRUE(sdl3d_demo_playback_finished(player));
+
+    sdl3d_demo_playback_stop(playback_input.input);
+    sdl3d_demo_playback_free(player);
+}
+
+TEST(InputDemo, PlaybackStopResumesLiveInput)
+{
+    InputPtr input;
+    int jump = sdl3d_input_register_action(input.input, "jump");
+    sdl3d_input_bind_key(input.input, jump, SDL_SCANCODE_SPACE);
+
+    sdl3d_demo_player *empty = nullptr;
+    sdl3d_demo_playback_start(input.input, empty);
+    sdl3d_demo_playback_stop(input.input);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_SPACE);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, jump));
+}


### PR DESCRIPTION
## Summary
- add SDL3D action-based input manager with keyboard, mouse, gamepad, default FPS/UI bindings, and per-tick snapshots
- add binary demo recording/playback support for Quake-style input replay
- wire managed game loop to own/update input and refactor doom_level player controls to consume actions
- add optional doom_level attract.dem playback and managed-loop/input regression tests

## Verification
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Note: local CTest result was 731 passed, 1 skipped for SDLGPU availability.