### PR TITLE
Add screen transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ target_sources(
         src/texture.c
         src/time.c
         src/timer_pool.c
+        src/transition.c
+        src/transition_gl.c
         src/ui.c
         $<TARGET_OBJECTS:sdl3d_cgltf>
         $<TARGET_OBJECTS:sdl3d_ufbx>

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -19,12 +19,15 @@
 #include "player.h"
 #include "renderer.h"
 
+#define SIG_FADE_OUT_DONE 2001
+
 typedef struct doom_state
 {
     level_data level;
     entities ent;
     player_state player;
     render_state render;
+    sdl3d_transition transition;
     sdl3d_font debug_font;
     sdl3d_ui_context *ui;
     sdl3d_demo_player *demo_player;
@@ -32,6 +35,7 @@ typedef struct doom_state
     bool has_font;
     bool level_ready;
     bool entities_ready;
+    bool quit_pending;
 } doom_state;
 
 static void doom_state_cleanup(doom_state *state)
@@ -78,6 +82,14 @@ static void apply_window_defaults(sdl3d_game_context *ctx)
     SDL_SetWindowRelativeMouseMode(ctx->window, true);
 }
 
+static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    (void)payload;
+    sdl3d_game_context *ctx = (sdl3d_game_context *)userdata;
+    ctx->quit_requested = true;
+}
+
 static bool game_init(sdl3d_game_context *ctx, void *userdata)
 {
     doom_state *state = (doom_state *)userdata;
@@ -85,6 +97,11 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
     sdl3d_input_bind_fps_defaults(ctx->input);
     apply_window_defaults(ctx);
+
+    if (sdl3d_signal_connect(ctx->bus, SIG_FADE_OUT_DONE, on_fade_out_done, ctx) == 0)
+    {
+        return false;
+    }
 
     state->has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &state->debug_font);
     if (!sdl3d_ui_create(state->has_font ? &state->debug_font : NULL, &state->ui))
@@ -110,6 +127,8 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
 
     player_init(&state->player, ctx->input);
     render_state_init(&state->render);
+    sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, (sdl3d_color){0, 0, 0, 255},
+                           1.0f, -1);
 
     state->demo_player = sdl3d_demo_playback_load("attract.dem");
     if (state->demo_player != NULL)
@@ -183,10 +202,16 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
         stop_demo_playback(ctx, state);
     }
 
+    sdl3d_transition_update(&state->transition, ctx->bus, dt);
     entities_update(&state->ent, dt, state->player.mover.position);
     if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
     {
-        ctx->quit_requested = true;
+        if (!state->quit_pending)
+        {
+            state->quit_pending = true;
+            sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT,
+                                   (sdl3d_color){0, 0, 0, 255}, 0.5f, SIG_FADE_OUT_DONE);
+        }
     }
 }
 
@@ -198,6 +223,7 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 
     render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
                       &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt);
+    sdl3d_transition_draw(&state->transition, ctx->renderer);
 }
 
 static void game_shutdown(sdl3d_game_context *ctx, void *userdata)

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -22,6 +22,7 @@
 #include "sdl3d/shapes.h"
 #include "sdl3d/texture.h"
 #include "sdl3d/time.h"
+#include "sdl3d/transition.h"
 #include "sdl3d/types.h"
 
 #ifdef __cplusplus

--- a/include/sdl3d/transition.h
+++ b/include/sdl3d/transition.h
@@ -1,0 +1,123 @@
+/**
+ * @file transition.h
+ * @brief Screen transition state and rendering API.
+ *
+ * Transitions are time-based full-screen effects used for scene changes,
+ * level loads, menu handoffs, and polished quits. The transition state
+ * machine is renderer-independent; sdl3d_transition_draw dispatches to the
+ * active backend.
+ */
+
+#ifndef SDL3D_TRANSITION_H
+#define SDL3D_TRANSITION_H
+
+#include <stdbool.h>
+
+#include "sdl3d/render_context.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SDL3D_TRANSITION_MELT_COLUMNS 320
+
+    /**
+     * @brief Visual effect used for a screen transition.
+     */
+    typedef enum sdl3d_transition_type
+    {
+        SDL3D_TRANSITION_FADE = 0,     /**< Linear blend to or from a solid color. */
+        SDL3D_TRANSITION_CIRCLE = 1,   /**< Centered circular reveal or cover. */
+        SDL3D_TRANSITION_MELT = 2,     /**< Doom-style staggered column melt. */
+        SDL3D_TRANSITION_PIXELATE = 3, /**< Pixel block dissolve approximation. */
+    } sdl3d_transition_type;
+
+    /**
+     * @brief Whether a transition reveals the scene or covers it.
+     */
+    typedef enum sdl3d_transition_direction
+    {
+        SDL3D_TRANSITION_IN = 0,  /**< Effect recedes and reveals the scene. */
+        SDL3D_TRANSITION_OUT = 1, /**< Effect grows and covers the scene. */
+    } sdl3d_transition_direction;
+
+    /**
+     * @brief Complete state for one active or completed transition.
+     *
+     * The struct is caller-owned and may be stack, static, or heap allocated.
+     * Use sdl3d_transition_start to initialize and begin an effect, then call
+     * sdl3d_transition_update once per simulation tick and
+     * sdl3d_transition_draw once per rendered frame.
+     */
+    typedef struct sdl3d_transition
+    {
+        sdl3d_transition_type type;                        /**< Transition visual effect. */
+        sdl3d_transition_direction direction;              /**< Reveal or cover direction. */
+        sdl3d_color color;                                 /**< Solid transition color. */
+        float duration;                                    /**< Transition length in seconds. */
+        float elapsed;                                     /**< Elapsed transition time in seconds. */
+        bool active;                                       /**< True while the transition is still running. */
+        bool finished;                                     /**< True after a transition reaches duration. */
+        int done_signal_id;                                /**< Signal emitted on completion, or -1 for none. */
+        float melt_offsets[SDL3D_TRANSITION_MELT_COLUMNS]; /**< Deterministic per-column melt offsets. */
+    } sdl3d_transition;
+
+    /**
+     * @brief Start or restart a transition.
+     *
+     * @param transition     Transition state to initialize.
+     * @param type           Visual effect.
+     * @param direction      Whether the effect reveals or covers the scene.
+     * @param color          Transition color.
+     * @param duration       Length in seconds. Values <= 0 use a tiny positive duration.
+     * @param done_signal_id Signal emitted on completion, or -1 to emit nothing.
+     */
+    void sdl3d_transition_start(sdl3d_transition *transition, sdl3d_transition_type type,
+                                sdl3d_transition_direction direction, sdl3d_color color, float duration,
+                                int done_signal_id);
+
+    /**
+     * @brief Advance a transition and emit its completion signal if needed.
+     *
+     * Completion is emitted at most once. Negative dt values are ignored.
+     *
+     * @param transition Transition to update.
+     * @param bus        Optional signal bus used for completion notification.
+     * @param dt         Fixed or variable timestep in seconds.
+     */
+    void sdl3d_transition_update(sdl3d_transition *transition, sdl3d_signal_bus *bus, float dt);
+
+    /**
+     * @brief Draw or queue a transition on the active render backend.
+     *
+     * The software backend draws immediately into the color buffer. The GL
+     * backend queues the transition so it can be applied during present after
+     * post-processing and before the final window blit.
+     *
+     * @param transition Transition to draw. Inactive transitions are no-ops.
+     * @param context    Render context receiving the transition.
+     */
+    void sdl3d_transition_draw(const sdl3d_transition *transition, sdl3d_render_context *context);
+
+    /**
+     * @brief Reset transition state to an inactive default.
+     *
+     * The reset state does not emit a signal; done_signal_id is set to -1.
+     */
+    void sdl3d_transition_reset(sdl3d_transition *transition);
+
+    /**
+     * @brief Return normalized progress in the range [0, 1].
+     *
+     * Returns 0 for NULL transitions or non-positive durations.
+     */
+    float sdl3d_transition_progress(const sdl3d_transition *transition);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_TRANSITION_H */

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -164,6 +164,19 @@ struct sdl3d_gl_context
     /* Copy uniform locations */
     GLint copy_texture_loc;
 
+    /* Transition pass */
+    GLuint transition_program;
+    GLint transition_scene_loc;
+    GLint transition_type_loc;
+    GLint transition_direction_loc;
+    GLint transition_progress_loc;
+    GLint transition_color_loc;
+    GLint transition_resolution_loc;
+    GLint transition_melt_offsets_loc;
+    GLuint transition_melt_offsets_tex;
+    bool transition_pending;
+    sdl3d_transition pending_transition;
+
     /* Scene UBO */
     GLuint scene_ubo;
 
@@ -651,6 +664,51 @@ static const char k_copy_frag[] = "in vec2 vTexCoord;\n"
                                   "void main() {\n"
                                   "    fragColor = texture(uScene, vTexCoord);\n"
                                   "}\n";
+
+static const char k_transition_frag[] =
+    "in vec2 vTexCoord;\n"
+    "uniform sampler2D uScene;\n"
+    "uniform int uType;\n"
+    "uniform int uDirection;\n"
+    "uniform float uProgress;\n"
+    "uniform vec4 uColor;\n"
+    "uniform vec2 uResolution;\n"
+    "uniform sampler2D uMeltOffsets;\n"
+    "out vec4 fragColor;\n"
+    "\n"
+    "void main() {\n"
+    "    vec4 scene = texture(uScene, vTexCoord);\n"
+    "    float cover = (uDirection == 0) ? (1.0 - uProgress) : uProgress;\n"
+    "    cover = clamp(cover, 0.0, 1.0);\n"
+    "\n"
+    "    if (uType == 0) {\n"
+    "        fragColor = mix(scene, uColor, cover * uColor.a);\n"
+    "    } else if (uType == 1) {\n"
+    "        float aspect = uResolution.x / max(uResolution.y, 1.0);\n"
+    "        vec2 centered = vTexCoord - vec2(0.5);\n"
+    "        centered.x *= aspect;\n"
+    "        float maxRadius = length(vec2(0.5 * aspect, 0.5));\n"
+    "        float radius = maxRadius * (1.0 - cover);\n"
+    "        vec4 covered = mix(scene, uColor, uColor.a);\n"
+    "        fragColor = (length(centered) <= radius) ? scene : covered;\n"
+    "    } else if (uType == 2) {\n"
+    "        float offset = texture(uMeltOffsets, vec2(vTexCoord.x, 0.5)).r;\n"
+    "        float columnProgress = clamp((cover - offset * 0.3) / 0.7, 0.0, 1.0);\n"
+    "        float yShift = columnProgress * 1.5;\n"
+    "        vec2 sampleUV = vec2(vTexCoord.x, vTexCoord.y - yShift);\n"
+    "        vec4 covered = mix(scene, uColor, uColor.a);\n"
+    "        fragColor = (sampleUV.y < 0.0) ? covered : texture(uScene, sampleUV);\n"
+    "    } else if (uType == 3) {\n"
+    "        float blockSize = mix(1.0, 64.0, cover);\n"
+    "        vec2 safeResolution = max(uResolution, vec2(1.0));\n"
+    "        vec2 pixelUV = floor(vTexCoord * safeResolution / blockSize) * blockSize / safeResolution;\n"
+    "        vec4 pixelated = texture(uScene, pixelUV);\n"
+    "        float colorBlend = smoothstep(0.7, 1.0, cover) * uColor.a;\n"
+    "        fragColor = mix(pixelated, uColor, colorBlend);\n"
+    "    } else {\n"
+    "        fragColor = scene;\n"
+    "    }\n"
+    "}\n";
 
 static const char k_shadow_vert[] = "layout(location = 0) in vec3 aPosition;\n"
                                     "uniform mat4 uLightVP;\n"
@@ -2327,8 +2385,9 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
     }
     ctx->unlit_program = build_program(gl, version_prefix, k_unlit_vert, k_unlit_frag);
     ctx->copy_program = build_program(gl, version_prefix, k_fullscreen_vert, k_copy_frag);
+    ctx->transition_program = build_program(gl, version_prefix, k_fullscreen_vert, k_transition_frag);
 
-    if (!ctx->pbr_program || !ctx->unlit_program || !ctx->copy_program)
+    if (!ctx->pbr_program || !ctx->unlit_program || !ctx->copy_program || !ctx->transition_program)
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D GL: shader compilation failed");
         sdl3d_gl_destroy(ctx);
@@ -2397,6 +2456,24 @@ sdl3d_gl_context *sdl3d_gl_create(SDL_Window *window, int width, int height)
 
     /* Copy uniform locations. */
     ctx->copy_texture_loc = gl->GetUniformLocation(ctx->copy_program, "uScene");
+
+    /* Transition uniform locations and lookup texture. */
+    ctx->transition_scene_loc = gl->GetUniformLocation(ctx->transition_program, "uScene");
+    ctx->transition_type_loc = gl->GetUniformLocation(ctx->transition_program, "uType");
+    ctx->transition_direction_loc = gl->GetUniformLocation(ctx->transition_program, "uDirection");
+    ctx->transition_progress_loc = gl->GetUniformLocation(ctx->transition_program, "uProgress");
+    ctx->transition_color_loc = gl->GetUniformLocation(ctx->transition_program, "uColor");
+    ctx->transition_resolution_loc = gl->GetUniformLocation(ctx->transition_program, "uResolution");
+    ctx->transition_melt_offsets_loc = gl->GetUniformLocation(ctx->transition_program, "uMeltOffsets");
+    {
+        gl->GenTextures(1, &ctx->transition_melt_offsets_tex);
+        gl->BindTexture(GL_TEXTURE_2D, ctx->transition_melt_offsets_tex);
+        gl->TexImage2D(GL_TEXTURE_2D, 0, GL_R32F, SDL3D_TRANSITION_MELT_COLUMNS, 1, 0, GL_RED, GL_FLOAT, NULL);
+        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
 
     /* Scene UBO — create, allocate, bind to point 0. */
     gl->GenBuffers(1, &ctx->scene_ubo);
@@ -2691,6 +2768,10 @@ void sdl3d_gl_destroy(sdl3d_gl_context *ctx)
         gl->DeleteProgram(ctx->unlit_program);
     if (ctx->copy_program)
         gl->DeleteProgram(ctx->copy_program);
+    if (ctx->transition_program)
+        gl->DeleteProgram(ctx->transition_program);
+    if (ctx->transition_melt_offsets_tex)
+        gl->DeleteTextures(1, &ctx->transition_melt_offsets_tex);
 
     if (ctx->scene_ubo)
         gl->DeleteBuffers(1, &ctx->scene_ubo);
@@ -2982,6 +3063,75 @@ static void replay_overlay_list(sdl3d_gl_context *ctx, int vp_x, int vp_y, int v
     gl->Enable(GL_DEPTH_TEST);
 }
 
+bool sdl3d_gl_queue_transition(sdl3d_gl_context *ctx, const sdl3d_transition *transition)
+{
+    if (ctx == NULL)
+    {
+        return SDL_InvalidParamError("ctx");
+    }
+    if (transition == NULL)
+    {
+        return SDL_InvalidParamError("transition");
+    }
+    if (!transition->active)
+    {
+        return true;
+    }
+
+    ctx->pending_transition = *transition;
+    ctx->transition_pending = true;
+    return true;
+}
+
+static void apply_transition_pass(sdl3d_gl_context *ctx)
+{
+    if (ctx == NULL || !ctx->transition_pending || ctx->transition_program == 0)
+    {
+        return;
+    }
+
+    sdl3d_gl_funcs *gl = &ctx->gl;
+    const sdl3d_transition *transition = &ctx->pending_transition;
+
+    if (transition->type == SDL3D_TRANSITION_MELT && ctx->transition_melt_offsets_tex != 0)
+    {
+        gl->ActiveTexture(GL_TEXTURE0 + 1);
+        gl->BindTexture(GL_TEXTURE_2D, ctx->transition_melt_offsets_tex);
+        gl->TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, SDL3D_TRANSITION_MELT_COLUMNS, 1, GL_RED, GL_FLOAT,
+                          transition->melt_offsets);
+    }
+
+    gl->BindFramebuffer(GL_FRAMEBUFFER, ctx->pp_fbo_a);
+    gl->Viewport(0, 0, ctx->logical_w, ctx->logical_h);
+    gl->Clear(GL_COLOR_BUFFER_BIT);
+    gl->UseProgram(ctx->transition_program);
+    gl->ActiveTexture(GL_TEXTURE0);
+    gl->BindTexture(GL_TEXTURE_2D, ctx->fbo_color);
+    gl->Uniform1i(ctx->transition_scene_loc, 0);
+    gl->ActiveTexture(GL_TEXTURE0 + 1);
+    gl->BindTexture(GL_TEXTURE_2D, ctx->transition_melt_offsets_tex);
+    gl->Uniform1i(ctx->transition_melt_offsets_loc, 1);
+    gl->Uniform1i(ctx->transition_type_loc, (int)transition->type);
+    gl->Uniform1i(ctx->transition_direction_loc, (int)transition->direction);
+    gl->Uniform1f(ctx->transition_progress_loc, sdl3d_transition_progress(transition));
+    gl->Uniform4f(ctx->transition_color_loc, (float)transition->color.r / 255.0f, (float)transition->color.g / 255.0f,
+                  (float)transition->color.b / 255.0f, (float)transition->color.a / 255.0f);
+    gl->Uniform2f(ctx->transition_resolution_loc, (float)ctx->logical_w, (float)ctx->logical_h);
+    gl->BindVertexArray(ctx->fullscreen_vao);
+    gl->DrawArrays(GL_TRIANGLES, 0, 3);
+
+    gl->BindFramebuffer(GL_FRAMEBUFFER, ctx->fbo);
+    gl->Viewport(0, 0, ctx->logical_w, ctx->logical_h);
+    gl->UseProgram(ctx->copy_program);
+    gl->ActiveTexture(GL_TEXTURE0);
+    gl->BindTexture(GL_TEXTURE_2D, ctx->pp_tex_a);
+    gl->Uniform1i(ctx->copy_texture_loc, 0);
+    gl->DrawArrays(GL_TRIANGLES, 0, 3);
+    gl->ActiveTexture(GL_TEXTURE0);
+
+    ctx->transition_pending = false;
+}
+
 static bool gl_present(sdl3d_render_context *context)
 {
     sdl3d_gl_context *ctx = context->gl;
@@ -3197,6 +3347,8 @@ static bool gl_present(sdl3d_render_context *context)
         gl->DrawArrays(GL_TRIANGLES, 0, 3);
         gl->ActiveTexture(GL_TEXTURE0);
     } /* bloom_enabled */
+
+    apply_transition_pass(ctx);
 
     gl->Disable(GL_CULL_FACE);
     gl->Enable(GL_DEPTH_TEST);

--- a/src/gl_renderer.h
+++ b/src/gl_renderer.h
@@ -8,6 +8,7 @@
 #include <SDL3/SDL.h>
 
 #include "backend.h"
+#include "sdl3d/transition.h"
 
 typedef struct sdl3d_gl_context sdl3d_gl_context;
 
@@ -37,5 +38,9 @@ bool sdl3d_gl_append_overlay(sdl3d_gl_context *ctx, const float *positions, cons
                              const SDL_Rect *scissor_rect);
 
 bool sdl3d_gl_append_line(sdl3d_gl_context *ctx, const float *positions, const float *colors, const float *mvp);
+
+/* Queue a transition to be applied during the next GL present after
+ * post-processing and before the final window blit. */
+bool sdl3d_gl_queue_transition(sdl3d_gl_context *ctx, const sdl3d_transition *transition);
 
 #endif

--- a/src/transition.c
+++ b/src/transition.c
@@ -1,0 +1,319 @@
+#include "sdl3d/transition.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "render_context_internal.h"
+#include "transition_gl.h"
+
+#define SDL3D_TRANSITION_MIN_DURATION 0.001f
+#define SDL3D_TRANSITION_EPSILON 0.00001f
+
+static float sdl3d_transition_clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value)
+    {
+        return min_value;
+    }
+    if (value > max_value)
+    {
+        return max_value;
+    }
+    return value;
+}
+
+static Uint32 sdl3d_transition_hash_u32(Uint32 value)
+{
+    value ^= value >> 16U;
+    value *= 0x7feb352dU;
+    value ^= value >> 15U;
+    value *= 0x846ca68bU;
+    value ^= value >> 16U;
+    return value;
+}
+
+static void sdl3d_transition_seed_melt_offsets(sdl3d_transition *transition)
+{
+    for (int i = 0; i < SDL3D_TRANSITION_MELT_COLUMNS; ++i)
+    {
+        const Uint32 hash = sdl3d_transition_hash_u32((Uint32)i + 0x9e3779b9U);
+        transition->melt_offsets[i] = (float)hash / 4294967295.0f;
+    }
+}
+
+static float sdl3d_transition_cover_amount(const sdl3d_transition *transition)
+{
+    const float progress = sdl3d_transition_progress(transition);
+    return transition->direction == SDL3D_TRANSITION_IN ? 1.0f - progress : progress;
+}
+
+static sdl3d_color sdl3d_transition_color_with_alpha(sdl3d_color color, float alpha_scale)
+{
+    const float alpha = sdl3d_transition_clampf(alpha_scale, 0.0f, 1.0f) * (float)color.a;
+    color.a = (Uint8)(alpha + 0.5f);
+    return color;
+}
+
+static Uint8 sdl3d_transition_blend_channel(Uint8 dst, Uint8 src, float alpha)
+{
+    const float blended = (float)src * alpha + (float)dst * (1.0f - alpha);
+    return (Uint8)sdl3d_transition_clampf(blended + 0.5f, 0.0f, 255.0f);
+}
+
+static void sdl3d_transition_blend_pixel(sdl3d_render_context *context, int x, int y, sdl3d_color color)
+{
+    if (x < 0 || y < 0 || x >= context->width || y >= context->height || color.a == 0)
+    {
+        return;
+    }
+
+    Uint8 *pixel = &context->color_buffer[((y * context->width) + x) * 4];
+    if (color.a == 255)
+    {
+        pixel[0] = color.r;
+        pixel[1] = color.g;
+        pixel[2] = color.b;
+        pixel[3] = color.a;
+        return;
+    }
+
+    const float alpha = (float)color.a / 255.0f;
+    pixel[0] = sdl3d_transition_blend_channel(pixel[0], color.r, alpha);
+    pixel[1] = sdl3d_transition_blend_channel(pixel[1], color.g, alpha);
+    pixel[2] = sdl3d_transition_blend_channel(pixel[2], color.b, alpha);
+    pixel[3] = 255;
+}
+
+static void sdl3d_transition_fill_rect_sw(sdl3d_render_context *context, int x, int y, int w, int h, sdl3d_color color)
+{
+    if (context == NULL || context->color_buffer == NULL || w <= 0 || h <= 0 || color.a == 0)
+    {
+        return;
+    }
+
+    int min_x = x;
+    int min_y = y;
+    int max_x = x + w;
+    int max_y = y + h;
+
+    if (min_x < 0)
+    {
+        min_x = 0;
+    }
+    if (min_y < 0)
+    {
+        min_y = 0;
+    }
+    if (max_x > context->width)
+    {
+        max_x = context->width;
+    }
+    if (max_y > context->height)
+    {
+        max_y = context->height;
+    }
+
+    for (int py = min_y; py < max_y; ++py)
+    {
+        for (int px = min_x; px < max_x; ++px)
+        {
+            sdl3d_transition_blend_pixel(context, px, py, color);
+        }
+    }
+}
+
+static void sdl3d_transition_draw_fade_sw(const sdl3d_transition *transition, sdl3d_render_context *context,
+                                          float cover)
+{
+    const sdl3d_color color = sdl3d_transition_color_with_alpha(transition->color, cover);
+    sdl3d_transition_fill_rect_sw(context, 0, 0, context->width, context->height, color);
+}
+
+static void sdl3d_transition_draw_circle_sw(const sdl3d_transition *transition, sdl3d_render_context *context,
+                                            float cover)
+{
+    const float cx = (float)context->width * 0.5f;
+    const float cy = (float)context->height * 0.5f;
+    const float max_radius = SDL_sqrtf(cx * cx + cy * cy);
+    const float radius = max_radius * (1.0f - cover);
+    const int band_h = SDL_max(1, context->height / 200);
+
+    if (radius <= SDL3D_TRANSITION_EPSILON)
+    {
+        sdl3d_transition_fill_rect_sw(context, 0, 0, context->width, context->height, transition->color);
+        return;
+    }
+
+    if (radius >= max_radius - SDL3D_TRANSITION_EPSILON)
+    {
+        return;
+    }
+
+    for (int y = 0; y < context->height; y += band_h)
+    {
+        const int h = SDL_min(band_h, context->height - y);
+        const float sample_y = (float)y + (float)h * 0.5f;
+        const float dy = sample_y - cy;
+        const float abs_dy = dy < 0.0f ? -dy : dy;
+        if (abs_dy >= radius)
+        {
+            sdl3d_transition_fill_rect_sw(context, 0, y, context->width, h, transition->color);
+            continue;
+        }
+
+        const float half_width = SDL_sqrtf(radius * radius - abs_dy * abs_dy);
+        const int left_w = (int)(cx - half_width);
+        const int right_x = (int)(cx + half_width + 0.5f);
+        sdl3d_transition_fill_rect_sw(context, 0, y, left_w, h, transition->color);
+        sdl3d_transition_fill_rect_sw(context, right_x, y, context->width - right_x, h, transition->color);
+    }
+}
+
+static void sdl3d_transition_draw_melt_sw(const sdl3d_transition *transition, sdl3d_render_context *context,
+                                          float cover)
+{
+    const int band_w = SDL_max(1, context->width / SDL3D_TRANSITION_MELT_COLUMNS);
+    for (int x = 0; x < context->width; x += band_w)
+    {
+        const int column = SDL_min(SDL3D_TRANSITION_MELT_COLUMNS - 1,
+                                   (x * SDL3D_TRANSITION_MELT_COLUMNS) / SDL_max(1, context->width));
+        const float offset = transition->melt_offsets[column];
+        const float column_progress = sdl3d_transition_clampf((cover - offset * 0.3f) / 0.7f, 0.0f, 1.0f);
+        const int cover_h = (int)((float)context->height * column_progress + 0.5f);
+        sdl3d_transition_fill_rect_sw(context, x, 0, band_w, cover_h, transition->color);
+    }
+}
+
+static float sdl3d_transition_smoothstep(float edge0, float edge1, float value)
+{
+    const float t = sdl3d_transition_clampf((value - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+    return t * t * (3.0f - 2.0f * t);
+}
+
+static void sdl3d_transition_draw_pixelate_sw(const sdl3d_transition *transition, sdl3d_render_context *context,
+                                              float cover)
+{
+    const float block_size_f = 1.0f + (63.0f * cover);
+    const int block_size = SDL_max(1, (int)(block_size_f + 0.5f));
+    const sdl3d_color color =
+        sdl3d_transition_color_with_alpha(transition->color, sdl3d_transition_smoothstep(0.15f, 1.0f, cover));
+
+    for (int y = 0; y < context->height; y += block_size)
+    {
+        for (int x = 0; x < context->width; x += block_size)
+        {
+            sdl3d_transition_fill_rect_sw(context, x, y, block_size, block_size, color);
+        }
+    }
+}
+
+static void sdl3d_transition_draw_sw(const sdl3d_transition *transition, sdl3d_render_context *context)
+{
+    const float cover = sdl3d_transition_clampf(sdl3d_transition_cover_amount(transition), 0.0f, 1.0f);
+    if (cover <= 0.0f)
+    {
+        return;
+    }
+
+    switch (transition->type)
+    {
+    case SDL3D_TRANSITION_FADE:
+        sdl3d_transition_draw_fade_sw(transition, context, cover);
+        break;
+    case SDL3D_TRANSITION_CIRCLE:
+        sdl3d_transition_draw_circle_sw(transition, context, cover);
+        break;
+    case SDL3D_TRANSITION_MELT:
+        sdl3d_transition_draw_melt_sw(transition, context, cover);
+        break;
+    case SDL3D_TRANSITION_PIXELATE:
+        sdl3d_transition_draw_pixelate_sw(transition, context, cover);
+        break;
+    default:
+        sdl3d_transition_draw_fade_sw(transition, context, cover);
+        break;
+    }
+}
+
+void sdl3d_transition_start(sdl3d_transition *transition, sdl3d_transition_type type,
+                            sdl3d_transition_direction direction, sdl3d_color color, float duration, int done_signal_id)
+{
+    if (transition == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*transition);
+    transition->type = type;
+    transition->direction = direction;
+    transition->color = color;
+    transition->duration = duration > 0.0f ? duration : SDL3D_TRANSITION_MIN_DURATION;
+    transition->active = true;
+    transition->finished = false;
+    transition->done_signal_id = done_signal_id;
+
+    if (type == SDL3D_TRANSITION_MELT)
+    {
+        sdl3d_transition_seed_melt_offsets(transition);
+    }
+}
+
+void sdl3d_transition_update(sdl3d_transition *transition, sdl3d_signal_bus *bus, float dt)
+{
+    if (transition == NULL || !transition->active)
+    {
+        return;
+    }
+
+    if (dt > 0.0f)
+    {
+        transition->elapsed += dt;
+    }
+
+    if (transition->elapsed >= transition->duration)
+    {
+        transition->elapsed = transition->duration;
+        transition->active = false;
+        transition->finished = true;
+        if (transition->done_signal_id >= 0 && bus != NULL)
+        {
+            sdl3d_signal_emit(bus, transition->done_signal_id, NULL);
+        }
+    }
+}
+
+void sdl3d_transition_draw(const sdl3d_transition *transition, sdl3d_render_context *context)
+{
+    if (transition == NULL || context == NULL || !transition->active)
+    {
+        return;
+    }
+
+    if (context->gl != NULL)
+    {
+        (void)sdl3d_transition_draw_gl(transition, context);
+        return;
+    }
+
+    sdl3d_transition_draw_sw(transition, context);
+}
+
+void sdl3d_transition_reset(sdl3d_transition *transition)
+{
+    if (transition == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*transition);
+    transition->done_signal_id = -1;
+}
+
+float sdl3d_transition_progress(const sdl3d_transition *transition)
+{
+    if (transition == NULL || transition->duration <= 0.0f)
+    {
+        return 0.0f;
+    }
+
+    return sdl3d_transition_clampf(transition->elapsed / transition->duration, 0.0f, 1.0f);
+}

--- a/src/transition_gl.c
+++ b/src/transition_gl.c
@@ -1,0 +1,24 @@
+#include "transition_gl.h"
+
+#include <SDL3/SDL_error.h>
+
+#include "gl_renderer.h"
+#include "render_context_internal.h"
+
+bool sdl3d_transition_draw_gl(const sdl3d_transition *transition, sdl3d_render_context *context)
+{
+    if (transition == NULL)
+    {
+        return SDL_InvalidParamError("transition");
+    }
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (context->gl == NULL)
+    {
+        return SDL_SetError("GL transition draw requires the GL backend.");
+    }
+
+    return sdl3d_gl_queue_transition(context->gl, transition);
+}

--- a/src/transition_gl.h
+++ b/src/transition_gl.h
@@ -1,0 +1,14 @@
+/*
+ * Internal GL transition dispatch. Public callers use sdl3d_transition_draw.
+ */
+
+#ifndef SDL3D_TRANSITION_GL_H
+#define SDL3D_TRANSITION_GL_H
+
+#include <stdbool.h>
+
+#include "sdl3d/transition.h"
+
+bool sdl3d_transition_draw_gl(const sdl3d_transition *transition, sdl3d_render_context *context);
+
+#endif /* SDL3D_TRANSITION_GL_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SDL3D_TEST_SOURCES
     test_effects.cpp
     test_game.cpp
     test_input.cpp
+    test_transition.cpp
     test_level.cpp
     test_properties.cpp
     test_signal_bus.cpp
@@ -191,6 +192,7 @@ else()
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_game_test test_game.cpp render)
     sdl3d_add_test(sdl3d_input_test test_input.cpp unit)
+    sdl3d_add_test(sdl3d_transition_test test_transition.cpp render)
     sdl3d_add_test(sdl3d_level_test test_level.cpp unit)
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)

--- a/tests/test_transition.cpp
+++ b/tests/test_transition.cpp
@@ -1,0 +1,320 @@
+#define SDL_MAIN_HANDLED
+
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+extern "C"
+{
+#include "sdl3d/sdl3d.h"
+}
+
+#include <memory>
+
+namespace
+{
+constexpr int kDoneSignal = 4242;
+
+struct SignalState
+{
+    int count = 0;
+    int last_signal = 0;
+};
+
+void count_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    (void)payload;
+    auto *state = static_cast<SignalState *>(userdata);
+    state->count++;
+    state->last_signal = signal_id;
+}
+
+class WindowRenderer
+{
+  public:
+    WindowRenderer(int width = 64, int height = 64)
+        : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *window = nullptr;
+        SDL_Renderer *renderer = nullptr;
+        if (!SDL_CreateWindowAndRenderer("SDL3D Transition Test", width, height, SDL_WINDOW_HIDDEN, &window, &renderer))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+        window_.reset(window);
+        renderer_.reset(renderer);
+    }
+
+    bool ok() const
+    {
+        return window_ != nullptr && renderer_ != nullptr;
+    }
+
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+class TransitionRenderTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        SDL_Quit();
+    }
+};
+
+sdl3d_color black()
+{
+    return sdl3d_color{0, 0, 0, 255};
+}
+
+sdl3d_color white()
+{
+    return sdl3d_color{255, 255, 255, 255};
+}
+} // namespace
+
+TEST(Transition, StartSetsActive)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, black(), 1.0f, -1);
+
+    EXPECT_EQ(SDL3D_TRANSITION_FADE, transition.type);
+    EXPECT_EQ(SDL3D_TRANSITION_IN, transition.direction);
+    EXPECT_FLOAT_EQ(1.0f, transition.duration);
+    EXPECT_FLOAT_EQ(0.0f, transition.elapsed);
+    EXPECT_TRUE(transition.active);
+    EXPECT_FALSE(transition.finished);
+    EXPECT_EQ(-1, transition.done_signal_id);
+}
+
+TEST(Transition, UpdateAdvancesElapsed)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+
+    sdl3d_transition_update(&transition, nullptr, 0.25f);
+
+    EXPECT_FLOAT_EQ(0.25f, transition.elapsed);
+    EXPECT_TRUE(transition.active);
+}
+
+TEST(Transition, FinishSetsFlags)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+
+    sdl3d_transition_update(&transition, nullptr, 2.0f);
+
+    EXPECT_FLOAT_EQ(1.0f, transition.elapsed);
+    EXPECT_FALSE(transition.active);
+    EXPECT_TRUE(transition.finished);
+}
+
+TEST(Transition, FinishEmitsSignalOnce)
+{
+    sdl3d_transition transition{};
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(nullptr, bus);
+
+    SignalState state;
+    ASSERT_NE(0, sdl3d_signal_connect(bus, kDoneSignal, count_signal, &state));
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, kDoneSignal);
+
+    sdl3d_transition_update(&transition, bus, 1.0f);
+    sdl3d_transition_update(&transition, bus, 1.0f);
+
+    EXPECT_EQ(1, state.count);
+    EXPECT_EQ(kDoneSignal, state.last_signal);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(Transition, NoSignalWhenMinusOne)
+{
+    sdl3d_transition transition{};
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(nullptr, bus);
+
+    SignalState state;
+    ASSERT_NE(0, sdl3d_signal_connect(bus, kDoneSignal, count_signal, &state));
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+
+    sdl3d_transition_update(&transition, bus, 2.0f);
+
+    EXPECT_EQ(0, state.count);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(Transition, ProgressClamped)
+{
+    sdl3d_transition transition{};
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_transition_progress(nullptr));
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_transition_progress(&transition));
+
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+    transition.elapsed = 2.0f;
+    EXPECT_FLOAT_EQ(1.0f, sdl3d_transition_progress(&transition));
+}
+
+TEST(Transition, ResetClearsState)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_MELT, SDL3D_TRANSITION_OUT, black(), 1.0f, kDoneSignal);
+
+    sdl3d_transition_reset(&transition);
+
+    EXPECT_FALSE(transition.active);
+    EXPECT_FALSE(transition.finished);
+    EXPECT_FLOAT_EQ(0.0f, transition.elapsed);
+    EXPECT_FLOAT_EQ(0.0f, transition.duration);
+    EXPECT_EQ(-1, transition.done_signal_id);
+}
+
+TEST(Transition, InactiveUpdateIsNoOp)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_update(&transition, nullptr, 1.0f);
+
+    EXPECT_FLOAT_EQ(0.0f, transition.elapsed);
+    EXPECT_FALSE(transition.finished);
+}
+
+TEST(Transition, MeltOffsetsSeeded)
+{
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_MELT, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+
+    bool saw_nonzero = false;
+    bool saw_distinct = false;
+    for (int i = 0; i < SDL3D_TRANSITION_MELT_COLUMNS; ++i)
+    {
+        EXPECT_GE(transition.melt_offsets[i], 0.0f);
+        EXPECT_LE(transition.melt_offsets[i], 1.0f);
+        saw_nonzero = saw_nonzero || transition.melt_offsets[i] > 0.0f;
+        if (i > 0 && transition.melt_offsets[i] != transition.melt_offsets[0])
+        {
+            saw_distinct = true;
+        }
+    }
+
+    EXPECT_TRUE(saw_nonzero);
+    EXPECT_TRUE(saw_distinct);
+}
+
+TEST(Transition, NullSafety)
+{
+    sdl3d_transition_start(nullptr, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, black(), 1.0f, -1);
+    sdl3d_transition_update(nullptr, nullptr, 1.0f);
+    sdl3d_transition_draw(nullptr, nullptr);
+    sdl3d_transition_reset(nullptr);
+    EXPECT_FLOAT_EQ(0.0f, sdl3d_transition_progress(nullptr));
+}
+
+TEST_F(TransitionRenderTest, FadeDrawBlendsSoftwareBuffer)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, white()));
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+    sdl3d_transition_update(&transition, nullptr, 0.5f);
+    sdl3d_transition_draw(&transition, ctx);
+
+    sdl3d_color pixel{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &pixel));
+    EXPECT_NEAR(128, pixel.r, 1);
+    EXPECT_NEAR(128, pixel.g, 1);
+    EXPECT_NEAR(128, pixel.b, 1);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(TransitionRenderTest, CircleDrawDoesNotCrash)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, white()));
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_CIRCLE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+    sdl3d_transition_update(&transition, nullptr, 0.5f);
+    sdl3d_transition_draw(&transition, ctx);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(TransitionRenderTest, MeltDrawDoesNotCrash)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, white()));
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_MELT, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+    sdl3d_transition_update(&transition, nullptr, 0.5f);
+    sdl3d_transition_draw(&transition, ctx);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(TransitionRenderTest, PixelateDrawDoesNotCrash)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, white()));
+    sdl3d_transition transition{};
+    sdl3d_transition_start(&transition, SDL3D_TRANSITION_PIXELATE, SDL3D_TRANSITION_OUT, black(), 1.0f, -1);
+    sdl3d_transition_update(&transition, nullptr, 0.5f);
+    sdl3d_transition_draw(&transition, ctx);
+
+    sdl3d_destroy_render_context(ctx);
+}
+
+TEST_F(TransitionRenderTest, InactiveDrawIsNoOp)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, white()));
+    sdl3d_transition transition{};
+    sdl3d_transition_draw(&transition, ctx);
+
+    sdl3d_color pixel{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 32, 32, &pixel));
+    EXPECT_EQ(255, pixel.r);
+    EXPECT_EQ(255, pixel.g);
+    EXPECT_EQ(255, pixel.b);
+
+    sdl3d_destroy_render_context(ctx);
+}


### PR DESCRIPTION
## Summary
- add the public sdl3d_transition API with documented state, update, draw, reset, and progress functions
- add software transition rendering plus queued GL fullscreen transition pass after post-processing
- wire doom_level to fade in on startup and fade out before quit
- add transition state/render tests and include them in the test build

## Verification
- cmake -S . -B build/default -DSDL3D_BUILD_TESTS=ON -DSDL3D_BUILD_DEMOS=ON
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Note: test 94 was skipped because SDLGPU was not available in this local run.