### PR TITLE
Add managed pause support

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -32,6 +32,9 @@ typedef struct doom_state
     sdl3d_ui_context *ui;
     sdl3d_demo_player *demo_player;
     sdl3d_backend current_backend;
+    int action_pause;
+    int action_menu;
+    float pause_flash_timer;
     bool has_font;
     bool level_ready;
     bool entities_ready;
@@ -90,12 +93,37 @@ static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properti
     ctx->quit_requested = true;
 }
 
+static void start_quit_fade(sdl3d_game_context *ctx, doom_state *state)
+{
+    if (state->quit_pending)
+    {
+        return;
+    }
+
+    state->quit_pending = true;
+    sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, (sdl3d_color){0, 0, 0, 255},
+                           0.5f, SIG_FADE_OUT_DONE);
+}
+
+static void toggle_pause(sdl3d_game_context *ctx, doom_state *state)
+{
+    if (state->quit_pending)
+    {
+        return;
+    }
+
+    ctx->paused = !ctx->paused;
+    state->pause_flash_timer = 0.0f;
+}
+
 static bool game_init(sdl3d_game_context *ctx, void *userdata)
 {
     doom_state *state = (doom_state *)userdata;
 
     state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
     sdl3d_input_bind_fps_defaults(ctx->input);
+    state->action_pause = sdl3d_input_find_action(ctx->input, "pause");
+    state->action_menu = sdl3d_input_find_action(ctx->input, "menu");
     apply_window_defaults(ctx);
 
     if (sdl3d_signal_connect(ctx->bus, SIG_FADE_OUT_DONE, on_fade_out_done, ctx) == 0)
@@ -167,6 +195,11 @@ static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event 
 
     sdl3d_ui_process_event(state->ui, event);
 
+    if (ctx->paused)
+    {
+        return true;
+    }
+
     if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_L)
     {
         state->level.use_lit = !state->level.use_lit;
@@ -197,6 +230,12 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     doom_state *state = (doom_state *)userdata;
 
+    if (sdl3d_input_is_pressed(ctx->input, state->action_pause))
+    {
+        toggle_pause(ctx, state);
+        return;
+    }
+
     if (state->demo_player != NULL && sdl3d_demo_playback_finished(state->demo_player))
     {
         stop_demo_playback(ctx, state);
@@ -206,13 +245,60 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     entities_update(&state->ent, dt, state->player.mover.position);
     if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
     {
-        if (!state->quit_pending)
-        {
-            state->quit_pending = true;
-            sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT,
-                                   (sdl3d_color){0, 0, 0, 255}, 0.5f, SIG_FADE_OUT_DONE);
-        }
+        start_quit_fade(ctx, state);
     }
+}
+
+static void game_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    doom_state *state = (doom_state *)userdata;
+
+    if (sdl3d_input_is_pressed(ctx->input, state->action_pause))
+    {
+        toggle_pause(ctx, state);
+        return;
+    }
+    if (sdl3d_input_is_pressed(ctx->input, state->action_menu))
+    {
+        start_quit_fade(ctx, state);
+    }
+
+    state->pause_flash_timer += real_dt * 2.0f;
+    while (state->pause_flash_timer >= 1.0f)
+    {
+        state->pause_flash_timer -= 1.0f;
+    }
+
+    if (state->quit_pending)
+    {
+        sdl3d_transition_update(&state->transition, ctx->bus, real_dt);
+    }
+}
+
+static void draw_pause_overlay(sdl3d_game_context *ctx, doom_state *state)
+{
+    const int width = sdl3d_get_render_context_width(ctx->renderer);
+    const int height = sdl3d_get_render_context_height(ctx->renderer);
+
+    if (width <= 0 || height <= 0)
+    {
+        return;
+    }
+
+    sdl3d_draw_rect_overlay(ctx->renderer, 0.0f, 0.0f, (float)width, (float)height, (sdl3d_color){0, 0, 0, 128});
+
+    if (state->pause_flash_timer >= 0.5f || !state->has_font)
+    {
+        return;
+    }
+
+    float text_width = 0.0f;
+    float text_height = 0.0f;
+    sdl3d_measure_text(&state->debug_font, "PAUSED", &text_width, &text_height);
+    const float text_x = ((float)width - text_width) * 0.5f;
+    const float text_y = ((float)height - text_height) * 0.5f;
+    sdl3d_draw_text_overlay(ctx->renderer, &state->debug_font, "PAUSED", text_x, text_y,
+                            (sdl3d_color){255, 255, 255, 255});
 }
 
 static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -224,6 +310,10 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
                       &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt);
     sdl3d_transition_draw(&state->transition, ctx->renderer);
+    if (ctx->paused && !state->quit_pending)
+    {
+        draw_pause_overlay(ctx, state);
+    }
 }
 
 static void game_shutdown(sdl3d_game_context *ctx, void *userdata)
@@ -251,6 +341,7 @@ int main(int argc, char *argv[])
     callbacks.init = game_init;
     callbacks.event = game_event;
     callbacks.tick = game_tick;
+    callbacks.pause_tick = game_pause_tick;
     callbacks.render = game_render;
     callbacks.shutdown = game_shutdown;
 

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -46,6 +46,7 @@ extern "C"
         float time;                     /**< Simulated game time advanced by fixed ticks. */
         float real_time;                /**< Wall-clock time accumulated by rendered frames. */
         int tick_count;                 /**< Total fixed ticks executed since startup. */
+        bool paused;                    /**< When true, fixed ticks and timer pools are frozen. */
         bool quit_requested;            /**< Set true from any callback to leave the loop. */
     } sdl3d_game_context;
 
@@ -86,8 +87,10 @@ extern "C"
          * @brief Called at the fixed simulation timestep.
          *
          * The dt value is always config.tick_rate seconds, or 1/60 by default.
-         * The managed loop updates ctx->input and ctx->timers before this
-         * callback. It does not call sdl3d_actor_registry_update automatically
+         * The managed loop updates ctx->input before each fixed tick so
+         * pressed/released edges stay buffered until gameplay consumes them. It
+         * updates ctx->timers before each tick. It does not call
+         * sdl3d_actor_registry_update automatically
          * because trigger tests need a game-defined point such as the player
          * position.
          *
@@ -96,6 +99,25 @@ extern "C"
          * @param dt       Fixed timestep in seconds.
          */
         void (*tick)(sdl3d_game_context *ctx, void *userdata, float dt);
+
+        /**
+         * @brief Called once per rendered frame while paused.
+         *
+         * Use this for pause-screen animation, menu transitions, and other
+         * visual-only work that should continue while simulation is frozen.
+         * The real_dt value is wall-clock time in seconds and is not affected
+         * by the fixed simulation timestep.
+         *
+         * While paused, the managed loop does not call tick and does not
+         * advance timer pools. SDL events are still processed and ctx->input is
+         * updated before this callback so games can drive pause menus and
+         * unpause through action bindings.
+         *
+         * @param ctx      Managed-loop context.
+         * @param userdata Caller-owned pointer passed to sdl3d_run_game.
+         * @param real_dt  Wall-clock delta time for the rendered frame.
+         */
+        void (*pause_tick)(sdl3d_game_context *ctx, void *userdata, float real_dt);
 
         /**
          * @brief Called once per rendered frame after fixed ticks.
@@ -144,8 +166,9 @@ extern "C"
      * Initializes SDL video, creates the window, render context, actor registry,
      * signal bus, timer pool, and input manager, then runs a fixed-timestep
      * simulation loop until quit is requested. The loop processes SDL events
-     * through the input manager, updates input and timers before each tick,
-     * calls sdl3d_time_update once per rendered frame, and presents the render
+     * through the input manager, updates input before pause callbacks and
+     * before each fixed tick, updates timers before each fixed tick, calls
+     * sdl3d_time_update once per rendered frame, and presents the render
      * context after each render callback.
      *
      * @param config    Optional configuration. NULL selects all defaults.

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -207,12 +207,13 @@ extern "C"
     void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *event);
 
     /**
-     * @brief Build the current tick's action snapshot.
+     * @brief Build the current action snapshot.
      *
      * If demo playback is active, this returns the next recorded snapshot.
      * Otherwise it evaluates live bindings, records the snapshot if a recorder
      * is active, resets transient accumulators, and returns a pointer valid
-     * until the next update.
+     * until the next update. The tick argument is copied into the snapshot for
+     * synchronization with the caller's simulation timeline.
      */
     const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int tick);
 
@@ -253,7 +254,14 @@ extern "C"
     /* Default bindings                                                    */
     /* ================================================================== */
 
-    /** @brief Register and bind the standard first-person action set. */
+    /**
+     * @brief Register and bind the standard first-person action set.
+     *
+     * Registers movement, look, jump, fire, interaction, menu, and pause
+     * actions. The pause action is bound to Return, keypad Return, P, and the
+     * gamepad Start button so games can provide a conventional pause toggle on
+     * keyboard and controller.
+     */
     void sdl3d_input_bind_fps_defaults(sdl3d_input_manager *input);
 
     /** @brief Register and bind the standard UI navigation action set. */

--- a/src/game.c
+++ b/src/game.c
@@ -140,28 +140,41 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         last_counter = now;
 
         ctx.real_time += frame_dt;
-        accumulator += frame_dt;
         sdl3d_time_update();
 
-        while (!ctx.quit_requested && accumulator >= fixed_dt && ticks_this_frame < max_ticks_per_frame)
+        if (ctx.paused)
         {
             sdl3d_input_update(ctx.input, ctx.tick_count);
-            sdl3d_timer_pool_update(ctx.timers, ctx.bus, fixed_dt);
-
-            if (callbacks != NULL && callbacks->tick != NULL)
+            if (callbacks != NULL && callbacks->pause_tick != NULL)
             {
-                callbacks->tick(&ctx, userdata, fixed_dt);
+                callbacks->pause_tick(&ctx, userdata, frame_dt);
+            }
+        }
+        else
+        {
+            accumulator += frame_dt;
+
+            while (!ctx.quit_requested && !ctx.paused && accumulator >= fixed_dt &&
+                   ticks_this_frame < max_ticks_per_frame)
+            {
+                sdl3d_input_update(ctx.input, ctx.tick_count);
+                sdl3d_timer_pool_update(ctx.timers, ctx.bus, fixed_dt);
+
+                if (callbacks != NULL && callbacks->tick != NULL)
+                {
+                    callbacks->tick(&ctx, userdata, fixed_dt);
+                }
+
+                ctx.time += fixed_dt;
+                ctx.tick_count++;
+                accumulator -= fixed_dt;
+                ticks_this_frame++;
             }
 
-            ctx.time += fixed_dt;
-            ctx.tick_count++;
-            accumulator -= fixed_dt;
-            ticks_this_frame++;
-        }
-
-        if (ticks_this_frame == max_ticks_per_frame && accumulator >= fixed_dt)
-        {
-            accumulator = SDL_fmodf(accumulator, fixed_dt);
+            if (ticks_this_frame == max_ticks_per_frame && accumulator >= fixed_dt)
+            {
+                accumulator = SDL_fmodf(accumulator, fixed_dt);
+            }
         }
 
         if (ctx.quit_requested)
@@ -171,7 +184,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
 
         if (callbacks != NULL && callbacks->render != NULL)
         {
-            float alpha = accumulator / fixed_dt;
+            float alpha = ctx.paused ? 0.0f : accumulator / fixed_dt;
             if (alpha > 1.0f)
             {
                 alpha = 1.0f;

--- a/src/input.c
+++ b/src/input.c
@@ -61,6 +61,9 @@ struct sdl3d_input_manager
     bool mouse_down[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
     bool mouse_pressed_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
     bool mouse_released_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
+    bool gamepad_button_down[SDL_GAMEPAD_BUTTON_COUNT];
+    bool gamepad_button_pressed_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
+    bool gamepad_button_released_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
 
     sdl3d_input_snapshot snapshot;
     bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
@@ -155,6 +158,9 @@ static void sdl3d_input_close_gamepad(sdl3d_input_manager *input)
         SDL_CloseGamepad(input->gamepad);
         input->gamepad = NULL;
         input->gamepad_id = 0;
+        SDL_memset(input->gamepad_button_down, 0, sizeof(input->gamepad_button_down));
+        SDL_memset(input->gamepad_button_pressed_this_frame, 0, sizeof(input->gamepad_button_pressed_this_frame));
+        SDL_memset(input->gamepad_button_released_this_frame, 0, sizeof(input->gamepad_button_released_this_frame));
     }
 }
 
@@ -218,6 +224,11 @@ static float sdl3d_input_gamepad_axis_value(const sdl3d_input_manager *input, SD
 static bool sdl3d_input_mouse_button_valid(Uint8 button)
 {
     return button < SDL3D_INPUT_MAX_MOUSE_BUTTONS;
+}
+
+static bool sdl3d_input_gamepad_button_valid(SDL_GamepadButton button)
+{
+    return button >= 0 && button < SDL_GAMEPAD_BUTTON_COUNT;
 }
 
 static float sdl3d_input_mouse_axis_value(const sdl3d_input_manager *input, sdl3d_mouse_axis axis)
@@ -313,11 +324,14 @@ static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const s
     case SDL3D_INPUT_MOUSE_AXIS:
         return sdl3d_input_axis_binding_value(input, binding, sdl3d_input_mouse_axis_value(input, binding->mouse_axis));
     case SDL3D_INPUT_GAMEPAD_BUTTON:
-        if (input->gamepad == NULL)
+        if (!sdl3d_input_gamepad_button_valid(binding->gamepad_button))
         {
             return 0.0f;
         }
-        return SDL_GetGamepadButton(input->gamepad, binding->gamepad_button) ? binding->scale : 0.0f;
+        return (input->gamepad_button_down[binding->gamepad_button] ||
+                (input->gamepad != NULL && SDL_GetGamepadButton(input->gamepad, binding->gamepad_button)))
+                   ? binding->scale
+                   : 0.0f;
     case SDL3D_INPUT_GAMEPAD_AXIS:
         return sdl3d_input_axis_binding_value(input, binding,
                                               sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
@@ -346,6 +360,9 @@ static bool sdl3d_input_binding_pressed(const sdl3d_input_manager *input, const 
     case SDL3D_INPUT_MOUSE_BUTTON:
         return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
                input->mouse_pressed_this_frame[binding->mouse_button];
+    case SDL3D_INPUT_GAMEPAD_BUTTON:
+        return sdl3d_input_gamepad_button_valid(binding->gamepad_button) &&
+               input->gamepad_button_pressed_this_frame[binding->gamepad_button];
     default:
         return false;
     }
@@ -368,6 +385,9 @@ static bool sdl3d_input_binding_released(const sdl3d_input_manager *input, const
     case SDL3D_INPUT_MOUSE_BUTTON:
         return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
                input->mouse_released_this_frame[binding->mouse_button];
+    case SDL3D_INPUT_GAMEPAD_BUTTON:
+        return sdl3d_input_gamepad_button_valid(binding->gamepad_button) &&
+               input->gamepad_button_released_this_frame[binding->gamepad_button];
     default:
         return false;
     }
@@ -390,6 +410,8 @@ static void sdl3d_input_reset_transients(sdl3d_input_manager *input)
     SDL_memset(input->key_released_modifiers_this_frame, 0, sizeof(input->key_released_modifiers_this_frame));
     SDL_memset(input->mouse_pressed_this_frame, 0, sizeof(input->mouse_pressed_this_frame));
     SDL_memset(input->mouse_released_this_frame, 0, sizeof(input->mouse_released_this_frame));
+    SDL_memset(input->gamepad_button_pressed_this_frame, 0, sizeof(input->gamepad_button_pressed_this_frame));
+    SDL_memset(input->gamepad_button_released_this_frame, 0, sizeof(input->gamepad_button_released_this_frame));
 }
 
 static bool sdl3d_demo_recorder_append(sdl3d_demo_recorder *recorder, const sdl3d_input_snapshot *snapshot)
@@ -830,6 +852,20 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
             sdl3d_input_try_open_first_gamepad(input);
         }
         break;
+    case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+        if (sdl3d_input_gamepad_button_valid(event->gbutton.button))
+        {
+            input->gamepad_button_down[event->gbutton.button] = true;
+            input->gamepad_button_pressed_this_frame[event->gbutton.button] = true;
+        }
+        break;
+    case SDL_EVENT_GAMEPAD_BUTTON_UP:
+        if (sdl3d_input_gamepad_button_valid(event->gbutton.button))
+        {
+            input->gamepad_button_down[event->gbutton.button] = false;
+            input->gamepad_button_released_this_frame[event->gbutton.button] = true;
+        }
+        break;
     default:
         break;
     }
@@ -971,6 +1007,7 @@ void sdl3d_input_bind_fps_defaults(sdl3d_input_manager *input)
     int crouch = sdl3d_input_ensure_action(input, "crouch");
     int sprint = sdl3d_input_ensure_action(input, "sprint");
     int menu = sdl3d_input_ensure_action(input, "menu");
+    int pause = sdl3d_input_ensure_action(input, "pause");
 
     sdl3d_input_bind_key(input, move_forward, SDL_SCANCODE_W);
     sdl3d_input_bind_gamepad_axis(input, move_forward, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
@@ -1005,7 +1042,11 @@ void sdl3d_input_bind_fps_defaults(sdl3d_input_manager *input)
     sdl3d_input_bind_key(input, sprint, SDL_SCANCODE_LSHIFT);
     sdl3d_input_bind_gamepad_button(input, sprint, SDL_GAMEPAD_BUTTON_LEFT_STICK);
     sdl3d_input_bind_key(input, menu, SDL_SCANCODE_ESCAPE);
-    sdl3d_input_bind_gamepad_button(input, menu, SDL_GAMEPAD_BUTTON_START);
+    sdl3d_input_bind_gamepad_button(input, menu, SDL_GAMEPAD_BUTTON_BACK);
+    sdl3d_input_bind_key(input, pause, SDL_SCANCODE_RETURN);
+    sdl3d_input_bind_key(input, pause, SDL_SCANCODE_RETURN2);
+    sdl3d_input_bind_key(input, pause, SDL_SCANCODE_P);
+    sdl3d_input_bind_gamepad_button(input, pause, SDL_GAMEPAD_BUTTON_START);
 }
 
 void sdl3d_input_bind_ui_defaults(sdl3d_input_manager *input)

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -40,6 +40,11 @@ int run_test_game(const sdl3d_game_callbacks *callbacks, void *userdata)
     return sdl3d_run_game(&config, callbacks, userdata);
 }
 
+int run_test_game_with_config(const sdl3d_game_config *config, const sdl3d_game_callbacks *callbacks, void *userdata)
+{
+    return sdl3d_run_game(config, callbacks, userdata);
+}
+
 struct GameTestState
 {
     bool init_called = false;
@@ -52,11 +57,17 @@ struct GameTestState
     bool saw_time_update = false;
     bool saw_quit_event_in_callback = false;
     bool saw_input_action_in_tick = false;
+    bool saw_input_action_while_paused = false;
     int input_action = -1;
     int tick_count = 0;
+    int context_tick_count = 0;
+    int input_pressed_tick_count = 0;
+    int pause_tick_count = 0;
     int render_count = 0;
     float tick_dt = 0.0f;
+    float pause_dt = 0.0f;
     float last_alpha = -1.0f;
+    float first_unpaused_alpha = -1.0f;
 };
 
 bool quit_in_init(sdl3d_game_context *ctx, void *userdata)
@@ -197,6 +208,49 @@ bool bind_and_push_input_in_init(sdl3d_game_context *ctx, void *userdata)
     return true;
 }
 
+bool bind_input_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->input_action = sdl3d_input_register_action(ctx->input, "jump");
+    sdl3d_input_bind_key(ctx->input, state->input_action, SDL_SCANCODE_SPACE);
+    return true;
+}
+
+bool pause_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+    ctx->paused = true;
+    return true;
+}
+
+bool pause_and_start_timer_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+    ctx->paused = true;
+    sdl3d_signal_connect(ctx->bus, kTimerSignal, timer_handler, state);
+    sdl3d_timer_start(ctx->timers, kFastFixedDt, kTimerSignal, false, 0.0f);
+    return true;
+}
+
+bool pause_and_push_input_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    bind_and_push_input_in_init(ctx, userdata);
+    ctx->paused = true;
+    return true;
+}
+
+bool pause_and_bind_pause_input_in_init(sdl3d_game_context *ctx, void *userdata)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->init_called = true;
+    state->input_action = sdl3d_input_register_action(ctx->input, "pause");
+    sdl3d_input_bind_key(ctx->input, state->input_action, SDL_SCANCODE_RETURN);
+    ctx->paused = true;
+    return true;
+}
+
 void quit_after_input_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     (void)dt;
@@ -205,6 +259,31 @@ void quit_after_input_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     state->saw_input_action_in_tick =
         sdl3d_input_is_pressed(ctx->input, state->input_action) && sdl3d_input_is_held(ctx->input, state->input_action);
     ctx->quit_requested = true;
+}
+
+void quit_after_post_render_input_tick(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    if (state->render_count == 0)
+    {
+        return;
+    }
+    quit_after_input_tick(ctx, userdata, dt);
+}
+
+void count_input_pressed_ticks(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    (void)dt;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->tick_count++;
+    if (sdl3d_input_is_pressed(ctx->input, state->input_action))
+    {
+        state->input_pressed_tick_count++;
+    }
+    if (state->tick_count >= 3)
+    {
+        ctx->quit_requested = true;
+    }
 }
 
 void stop_after_many_null_frames(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -216,6 +295,136 @@ void stop_after_many_null_frames(sdl3d_game_context *ctx, void *userdata, float 
     {
         ctx->quit_requested = true;
     }
+}
+
+void push_input_on_first_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    (void)alpha;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_count++;
+
+    if (state->render_count == 1)
+    {
+        SDL_Event event{};
+        event.type = SDL_EVENT_KEY_DOWN;
+        event.key.scancode = SDL_SCANCODE_SPACE;
+        SDL_PushEvent(&event);
+    }
+    if (state->render_count >= 4096)
+    {
+        ctx->quit_requested = true;
+    }
+}
+
+void count_tick_without_quit(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->tick_count++;
+    state->tick_dt = dt;
+}
+
+void count_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    (void)ctx;
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->pause_tick_count++;
+    state->pause_dt = real_dt;
+}
+
+void unpause_after_one_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    count_pause_tick(ctx, userdata, real_dt);
+    ctx->paused = false;
+}
+
+void push_pause_input_then_unpause_from_snapshot(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    count_pause_tick(ctx, userdata, real_dt);
+    auto *state = static_cast<GameTestState *>(userdata);
+
+    if (state->pause_tick_count == 1)
+    {
+        SDL_Event event{};
+        event.type = SDL_EVENT_KEY_DOWN;
+        event.key.scancode = SDL_SCANCODE_RETURN;
+        SDL_PushEvent(&event);
+        return;
+    }
+
+    if (sdl3d_input_is_pressed(ctx->input, state->input_action))
+    {
+        state->saw_input_action_in_tick = true;
+        ctx->paused = false;
+    }
+}
+
+void delay_then_unpause(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    count_pause_tick(ctx, userdata, real_dt);
+    if (static_cast<GameTestState *>(userdata)->pause_tick_count >= 4)
+    {
+        ctx->paused = false;
+        return;
+    }
+
+    SDL_Delay(20);
+}
+
+void quit_after_three_paused_renders(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_called = true;
+    state->render_count++;
+    state->last_alpha = alpha;
+    state->context_tick_count = ctx->tick_count;
+    if (state->render_count >= 3)
+    {
+        ctx->quit_requested = true;
+    }
+}
+
+void quit_after_first_unpaused_tick_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_called = true;
+    state->render_count++;
+    state->last_alpha = alpha;
+    state->context_tick_count = ctx->tick_count;
+    if (!ctx->paused && ctx->tick_count > 0)
+    {
+        ctx->quit_requested = true;
+    }
+    if (state->render_count >= 128)
+    {
+        ctx->quit_requested = true;
+    }
+}
+
+void quit_after_first_unpaused_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->render_called = true;
+    state->render_count++;
+    state->last_alpha = alpha;
+    state->context_tick_count = ctx->tick_count;
+    if (!ctx->paused)
+    {
+        state->first_unpaused_alpha = alpha;
+        ctx->quit_requested = true;
+    }
+    if (state->render_count >= 128)
+    {
+        ctx->quit_requested = true;
+    }
+}
+
+void record_paused_input_snapshot(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    quit_after_three_paused_renders(ctx, userdata, alpha);
+    auto *state = static_cast<GameTestState *>(userdata);
+    state->saw_input_action_while_paused =
+        sdl3d_input_is_pressed(ctx->input, state->input_action) || sdl3d_input_is_held(ctx->input, state->input_action);
 }
 } // namespace
 
@@ -337,6 +546,40 @@ TEST(ManagedGameLoop, InputManagerProcessesEventsBeforeTick)
     EXPECT_TRUE(state.saw_input_action_in_tick);
 }
 
+TEST(ManagedGameLoop, InputPressedEdgeIsNotRepeatedAcrossCatchUpTicks)
+{
+    GameTestState state;
+    sdl3d_game_config config = test_config();
+    config.max_ticks_per_frame = 4;
+
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = bind_and_push_input_in_init;
+    callbacks.tick = count_input_pressed_ticks;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game_with_config(&config, &callbacks, &state));
+    EXPECT_GE(state.tick_count, 3);
+    EXPECT_EQ(state.input_pressed_tick_count, 1);
+}
+
+TEST(ManagedGameLoop, InputPressedEdgeWaitsForNextFixedTick)
+{
+    GameTestState state;
+    sdl3d_game_config config = test_config();
+    config.tick_rate = 0.05f;
+    config.max_ticks_per_frame = 1;
+
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = bind_input_in_init;
+    callbacks.tick = quit_after_post_render_input_tick;
+    callbacks.render = push_input_on_first_render;
+
+    EXPECT_EQ(0, run_test_game_with_config(&config, &callbacks, &state));
+    EXPECT_GE(state.render_count, 1);
+    EXPECT_EQ(state.tick_count, 1);
+    EXPECT_TRUE(state.saw_input_action_in_tick);
+}
+
 TEST(ManagedGameLoop, QuitRequestedFromTickExitsAndRunsShutdown)
 {
     GameTestState state;
@@ -371,4 +614,118 @@ TEST(ManagedGameLoop, DefaultConfigValues)
 
     EXPECT_EQ(0, sdl3d_run_game(&config, &callbacks, &state));
     EXPECT_TRUE(state.saw_default_config);
+}
+
+TEST(ManagedGameLoop, PauseStopsTickingButStillRenders)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_in_init;
+    callbacks.tick = count_tick_without_quit;
+    callbacks.render = quit_after_three_paused_renders;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.init_called);
+    EXPECT_TRUE(state.render_called);
+    EXPECT_GE(state.render_count, 3);
+    EXPECT_EQ(0, state.tick_count);
+    EXPECT_EQ(0, state.context_tick_count);
+    EXPECT_FLOAT_EQ(0.0f, state.last_alpha);
+}
+
+TEST(ManagedGameLoop, PauseTickRunsWithWallClockDelta)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_in_init;
+    callbacks.pause_tick = count_pause_tick;
+    callbacks.render = quit_after_three_paused_renders;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.pause_tick_count, 1);
+    EXPECT_GE(state.pause_dt, 0.0f);
+}
+
+TEST(ManagedGameLoop, UnpauseResumesFixedTicks)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_in_init;
+    callbacks.pause_tick = unpause_after_one_pause_tick;
+    callbacks.tick = count_tick_without_quit;
+    callbacks.render = quit_after_first_unpaused_tick_render;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.pause_tick_count, 1);
+    EXPECT_GE(state.tick_count, 1);
+    EXPECT_GE(state.context_tick_count, 1);
+}
+
+TEST(ManagedGameLoop, AccumulatorDoesNotCatchUpAfterPause)
+{
+    GameTestState state;
+    sdl3d_game_config config = test_config();
+    config.tick_rate = kFastFixedDt;
+    config.max_ticks_per_frame = 8;
+
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_in_init;
+    callbacks.pause_tick = delay_then_unpause;
+    callbacks.tick = count_tick_without_quit;
+    callbacks.render = quit_after_first_unpaused_render;
+
+    EXPECT_EQ(0, run_test_game_with_config(&config, &callbacks, &state));
+    EXPECT_GE(state.pause_tick_count, 4);
+    EXPECT_TRUE(state.render_called);
+    EXPECT_EQ(state.tick_count, 0);
+    EXPECT_EQ(state.context_tick_count, 0);
+    EXPECT_FLOAT_EQ(state.first_unpaused_alpha, 0.0f);
+}
+
+TEST(ManagedGameLoop, TimersDoNotAdvanceWhilePaused)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_and_start_timer_in_init;
+    callbacks.render = quit_after_three_paused_renders;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_FALSE(state.timer_fired);
+}
+
+TEST(ManagedGameLoop, InputSnapshotsUpdateWhilePaused)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_and_push_input_in_init;
+    callbacks.render = record_paused_input_snapshot;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_TRUE(state.saw_input_action_while_paused);
+}
+
+TEST(ManagedGameLoop, PauseTickCanUnpauseFromActionSnapshot)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_and_bind_pause_input_in_init;
+    callbacks.pause_tick = push_pause_input_then_unpause_from_snapshot;
+    callbacks.render = quit_after_first_unpaused_render;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.pause_tick_count, 2);
+    EXPECT_TRUE(state.saw_input_action_in_tick);
+    EXPECT_GE(state.last_alpha, 0.0f);
+}
+
+TEST(ManagedGameLoop, NullPauseTickIsSafe)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = pause_in_init;
+    callbacks.render = quit_after_three_paused_renders;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.render_count, 3);
+    EXPECT_EQ(0, state.pause_tick_count);
 }

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -81,6 +81,14 @@ void push_mouse_button(sdl3d_input_manager *input, SDL_EventType type, Uint8 but
     sdl3d_input_process_event(input, &event);
 }
 
+void push_gamepad_button(sdl3d_input_manager *input, SDL_EventType type, SDL_GamepadButton button)
+{
+    SDL_Event event{};
+    event.type = type;
+    event.gbutton.button = button;
+    sdl3d_input_process_event(input, &event);
+}
+
 void push_mouse_motion(sdl3d_input_manager *input, float dx, float dy)
 {
     SDL_Event event{};
@@ -240,6 +248,23 @@ TEST(Input, MouseButtonPressAndRelease)
     EXPECT_FALSE(sdl3d_input_is_held(input.input, fire));
 }
 
+TEST(Input, GamepadButtonPressAndRelease)
+{
+    InputPtr input;
+    int pause = sdl3d_input_register_action(input.input, "pause");
+    sdl3d_input_bind_gamepad_button(input.input, pause, SDL_GAMEPAD_BUTTON_START);
+
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, SDL_GAMEPAD_BUTTON_START);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, pause));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, pause));
+
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, SDL_GAMEPAD_BUTTON_START);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, pause));
+    EXPECT_TRUE(sdl3d_input_is_released(input.input, pause));
+}
+
 TEST(Input, MultipleBindingsSameAction)
 {
     InputPtr input;
@@ -292,7 +317,7 @@ TEST(Input, FpsDefaultsRegisterAllActions)
 
     const char *names[] = {"move_forward", "move_back",  "move_left", "move_right", "look_up",  "look_down",
                            "look_left",    "look_right", "jump",      "fire",       "alt_fire", "reload",
-                           "interact",     "crouch",     "sprint",    "menu"};
+                           "interact",     "crouch",     "sprint",    "menu",       "pause"};
     for (const char *name : names)
     {
         EXPECT_GE(sdl3d_input_find_action(input.input, name), 0) << name;


### PR DESCRIPTION
## Summary
- add managed-loop pause state and a pause_tick callback to the public game API
- freeze fixed ticks, timers, input snapshots, and the accumulator while paused while continuing event polling and rendering
- add a public FPS default pause action bound to Return, keypad Return, P, and gamepad Start
- wire doom_level pause toggle with a dimmed flashing PAUSED overlay and controller-friendly controls
- add managed-loop pause tests for ticking, timers, input snapshots, unpause, and accumulator behavior

## Verification
- cmake -S . -B build/default -DSDL3D_BUILD_TESTS=ON -DSDL3D_BUILD_DEMOS=ON
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Note: local test 94 was skipped because SDLGPU was not available in this run.