### PR TITLE
Use input actions for Doom demo controls

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -34,6 +34,11 @@ typedef struct doom_state
     sdl3d_backend current_backend;
     int action_pause;
     int action_menu;
+    int action_toggle_lighting;
+    int action_toggle_lightmaps;
+    int action_toggle_debug_stats;
+    int action_toggle_portal_culling;
+    int action_switch_backend;
     float pause_flash_timer;
     bool has_font;
     bool level_ready;
@@ -116,14 +121,31 @@ static void toggle_pause(sdl3d_game_context *ctx, doom_state *state)
     state->pause_flash_timer = 0.0f;
 }
 
+static int bind_doom_key_action(sdl3d_input_manager *input, const char *name, SDL_Scancode key)
+{
+    int action = sdl3d_input_register_action(input, name);
+    sdl3d_input_bind_key(input, action, key);
+    return action;
+}
+
+static void bind_doom_actions(sdl3d_input_manager *input, doom_state *state)
+{
+    sdl3d_input_bind_fps_defaults(input);
+    state->action_pause = sdl3d_input_find_action(input, "pause");
+    state->action_menu = sdl3d_input_find_action(input, "menu");
+    state->action_toggle_lighting = bind_doom_key_action(input, "toggle_lighting", SDL_SCANCODE_L);
+    state->action_toggle_lightmaps = bind_doom_key_action(input, "toggle_lightmaps", SDL_SCANCODE_M);
+    state->action_toggle_debug_stats = bind_doom_key_action(input, "toggle_debug_stats", SDL_SCANCODE_F1);
+    state->action_toggle_portal_culling = bind_doom_key_action(input, "toggle_portal_culling", SDL_SCANCODE_F2);
+    state->action_switch_backend = bind_doom_key_action(input, "switch_backend", SDL_SCANCODE_TAB);
+}
+
 static bool game_init(sdl3d_game_context *ctx, void *userdata)
 {
     doom_state *state = (doom_state *)userdata;
 
     state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
-    sdl3d_input_bind_fps_defaults(ctx->input);
-    state->action_pause = sdl3d_input_find_action(ctx->input, "pause");
-    state->action_menu = sdl3d_input_find_action(ctx->input, "menu");
+    bind_doom_actions(ctx->input, state);
     apply_window_defaults(ctx);
 
     if (sdl3d_signal_connect(ctx->bus, SIG_FADE_OUT_DONE, on_fade_out_done, ctx) == 0)
@@ -191,39 +213,35 @@ static bool switch_demo_backend(sdl3d_game_context *ctx, doom_state *state)
 
 static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
 {
+    (void)ctx;
     doom_state *state = (doom_state *)userdata;
 
     sdl3d_ui_process_event(state->ui, event);
+    return true;
+}
 
-    if (ctx->paused)
-    {
-        return true;
-    }
-
-    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_L)
+static void apply_doom_debug_actions(sdl3d_game_context *ctx, doom_state *state)
+{
+    if (sdl3d_input_is_pressed(ctx->input, state->action_toggle_lighting))
     {
         state->level.use_lit = !state->level.use_lit;
     }
-    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_M)
+    if (sdl3d_input_is_pressed(ctx->input, state->action_toggle_lightmaps))
     {
         state->level.use_lightmaps = !state->level.use_lightmaps;
     }
-
-    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_F1)
+    if (sdl3d_input_is_pressed(ctx->input, state->action_toggle_debug_stats))
     {
         state->render.show_debug = !state->render.show_debug;
     }
-    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_F2)
+    if (sdl3d_input_is_pressed(ctx->input, state->action_toggle_portal_culling))
     {
         state->render.portal_culling = !state->render.portal_culling;
     }
-
-    if (event->type == SDL_EVENT_KEY_DOWN && event->key.scancode == SDL_SCANCODE_TAB)
+    if (sdl3d_input_is_pressed(ctx->input, state->action_switch_backend) && !switch_demo_backend(ctx, state))
     {
-        return switch_demo_backend(ctx, state);
+        ctx->quit_requested = true;
     }
-
-    return true;
 }
 
 static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
@@ -235,6 +253,8 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
         toggle_pause(ctx, state);
         return;
     }
+
+    apply_doom_debug_actions(ctx, state);
 
     if (state->demo_player != NULL && sdl3d_demo_playback_finished(state->demo_player))
     {

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -278,6 +278,30 @@ TEST(Input, MultipleBindingsSameAction)
     EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
 }
 
+TEST(Input, MultipleKeyboardActionsShareOneSnapshot)
+{
+    InputPtr input;
+    int toggle_lighting = sdl3d_input_register_action(input.input, "toggle_lighting");
+    int toggle_debug = sdl3d_input_register_action(input.input, "toggle_debug");
+    sdl3d_input_bind_key(input.input, toggle_lighting, SDL_SCANCODE_L);
+    sdl3d_input_bind_key(input.input, toggle_debug, SDL_SCANCODE_F1);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_L);
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_F1);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, toggle_lighting));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, toggle_debug));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, toggle_lighting));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, toggle_debug));
+
+    sdl3d_input_update(input.input, 2);
+    EXPECT_FALSE(sdl3d_input_is_pressed(input.input, toggle_lighting));
+    EXPECT_FALSE(sdl3d_input_is_pressed(input.input, toggle_debug));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, toggle_lighting));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, toggle_debug));
+}
+
 TEST(Input, AxisPairComposesFourActions)
 {
     InputPtr input;
@@ -457,6 +481,29 @@ TEST(InputDemo, RecordAndPlayback)
 
     sdl3d_demo_playback_stop(playback_input.input);
     sdl3d_demo_playback_free(player);
+}
+
+TEST(InputDemo, RecordsKeyboardActions)
+{
+    InputPtr input;
+    int toggle_lighting = sdl3d_input_register_action(input.input, "toggle_lighting");
+    sdl3d_input_bind_key(input.input, toggle_lighting, SDL_SCANCODE_L);
+
+    sdl3d_demo_recorder *recorder = sdl3d_demo_record_start(input.input);
+    ASSERT_NE(recorder, nullptr);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_L);
+    ASSERT_NE(sdl3d_input_update(input.input, 7), nullptr);
+    sdl3d_demo_record_stop(recorder);
+
+    ASSERT_EQ(1U, sdl3d_demo_record_count(recorder));
+    const sdl3d_input_snapshot *recorded = sdl3d_demo_record_snapshot(recorder, 0);
+    ASSERT_NE(recorded, nullptr);
+    EXPECT_EQ(7, recorded->tick);
+    EXPECT_TRUE(recorded->actions[toggle_lighting].pressed);
+    EXPECT_TRUE(recorded->actions[toggle_lighting].held);
+
+    sdl3d_demo_record_free(recorder);
 }
 
 TEST(InputDemo, PlaybackStopResumesLiveInput)


### PR DESCRIPTION
## Summary
- replace the Doom demo's remaining raw key-event debug controls with registered input actions
- handle debug toggles and backend switching from the managed input snapshot
- add input tests for multiple keyboard actions in one snapshot and keyboard action demo recording

Closes #93

## Tests
- cmake --build build/default --target sdl3d_input_test doom_level -j 8
- ctest --test-dir build/default -R "^(Input|InputDemo)\." --output-on-failure
- ctest --test-dir build/default -R "^ManagedGameLoop\." --output-on-failure
- ctest --test-dir build/default --output-on-failure