### PR TITLE
Light billboard sprites with scene lights

### DIFF
--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -15,8 +15,7 @@
 #define ROCKET_LIGHT_INTENSITY 4.0f
 #define ROCKET_LIGHT_RANGE 4.0f
 
-static sdl3d_color sample_actor_tint(const sdl3d_level_light *lights, int light_count, sdl3d_vec3 position,
-                                     const player_state *player)
+static sdl3d_color sample_actor_tint(const sdl3d_level_light *lights, int light_count, sdl3d_vec3 position)
 {
     float r = 0.7f, g = 0.7f, b = 0.72f;
 
@@ -34,23 +33,6 @@ static sdl3d_color sample_actor_tint(const sdl3d_level_light *lights, int light_
         r += lights[i].color[0] * scale;
         g += lights[i].color[1] * scale;
         b += lights[i].color[2] * scale;
-    }
-
-    if (player->proj_active)
-    {
-        float dx = player->proj_x - position.x;
-        float dy = player->proj_y - position.y;
-        float dz = player->proj_z - position.z;
-        float dist = SDL_sqrtf(dx * dx + dy * dy + dz * dz);
-        if (dist < ROCKET_LIGHT_RANGE && dist > 0.0001f)
-        {
-            float t = 1.0f - (dist / ROCKET_LIGHT_RANGE);
-            float atten = t * t;
-            float scale = ROCKET_LIGHT_INTENSITY * atten * 0.35f;
-            r += ROCKET_LIGHT_R * scale;
-            g += ROCKET_LIGHT_G * scale;
-            b += ROCKET_LIGHT_B * scale;
-        }
     }
 
     if (r > 1.0f)
@@ -159,7 +141,9 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
         for (int i = 0; i < ent->sprites.count; ++i)
         {
             sdl3d_sprite_actor *sa = &ent->sprites.actors[i];
-            sa->tint = sample_actor_tint(g_lights, g_light_count, sa->position, player);
+            sdl3d_vec3 light_sample_position = sa->position;
+            light_sample_position.y += sa->size.y * 0.5f;
+            sa->tint = sample_actor_tint(g_lights, g_light_count, light_sample_position);
             sa->sector_id =
                 rs->portal_culling ? sdl3d_level_find_sector(active, g_sectors, sa->position.x, sa->position.z) : -1;
         }

--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -84,8 +84,10 @@ extern "C"
      * - x=0 left, 0.5 center, 1 right
      * - y=0 bottom, 0.5 center, 1 top
      *
-     * Billboards always use the unlit textured path so sprite art keeps its
-     * authored shading while still participating in depth/culling correctly.
+     * Billboards use the lit textured path when scene lighting is enabled and
+     * active, and otherwise fall back to the unlit textured path. This keeps
+     * authored sprite shading intact in unlit scenes while allowing point
+     * lights, such as projectiles, to affect billboard sprites.
      */
     bool sdl3d_draw_billboard_ex(sdl3d_render_context *context, const sdl3d_texture2d *texture, sdl3d_vec3 position,
                                  sdl3d_vec2 size, sdl3d_vec2 anchor, sdl3d_billboard_mode mode, sdl3d_color tint);

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1394,7 +1394,7 @@ bool sdl3d_draw_billboard_ex(sdl3d_render_context *context, const sdl3d_texture2
         }
         up = world_up;
     }
-    normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(up, right));
+    normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(right, up));
 
     {
         const sdl3d_vec3 bl =
@@ -1434,6 +1434,14 @@ bool sdl3d_draw_billboard_ex(sdl3d_render_context *context, const sdl3d_texture2
     mesh.vertex_count = 4;
     mesh.indices = indices;
     mesh.index_count = 12;
+
+    if (context->shading_mode != SDL3D_SHADING_UNLIT && context->light_count > 0)
+    {
+        sdl3d_lighting_params lp;
+        sdl3d_build_lighting_params(context, &lp);
+        lp.roughness = 1.0f;
+        return sdl3d_draw_mesh_internal(context, &mesh, texture, NULL, sdl3d_color_to_modulate(tint), &lp, NULL);
+    }
 
     return sdl3d_draw_mesh_internal(context, &mesh, texture, NULL, sdl3d_color_to_modulate(tint), NULL, NULL);
 }

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -620,6 +620,59 @@ TEST_F(SDL3DDrawingFixture, ClearResetsDepthBuffer)
     sdl3d_destroy_render_context(ctx);
 }
 
+TEST_F(SDL3DDrawingFixture, BillboardRespondsToPointLight)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx));
+
+    sdl3d_texture2d texture = MakeSolidTexture({80, 80, 80, 255});
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(0.0f, 1.0f, 4.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(sdl3d_draw_billboard(ctx, &texture, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), (sdl3d_vec2){2.0f, 2.0f},
+                                     (sdl3d_color){255, 255, 255, 255}));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color unlit{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 48, &unlit));
+
+    sdl3d_light light{};
+    light.type = SDL3D_LIGHT_POINT;
+    light.position = sdl3d_vec3_make(0.0f, 1.0f, 3.0f);
+    light.color[0] = 1.0f;
+    light.color[1] = 0.25f;
+    light.color[2] = 0.1f;
+    light.intensity = 12.0f;
+    light.range = 8.0f;
+    ASSERT_TRUE(sdl3d_set_shading_mode(ctx, SDL3D_SHADING_PHONG));
+    ASSERT_TRUE(sdl3d_set_ambient_light(ctx, 0.0f, 0.0f, 0.0f));
+    ASSERT_TRUE(sdl3d_clear_lights(ctx));
+    ASSERT_TRUE(sdl3d_add_light(ctx, &light));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(sdl3d_draw_billboard(ctx, &texture, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), (sdl3d_vec2){2.0f, 2.0f},
+                                     (sdl3d_color){255, 255, 255, 255}));
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+
+    sdl3d_color lit{};
+    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 48, &lit));
+
+    EXPECT_GT(lit.r, unlit.r);
+    EXPECT_GT(lit.r, lit.g);
+
+    sdl3d_free_texture(&texture);
+    sdl3d_destroy_render_context(ctx);
+}
+
 TEST_F(SDL3DDrawingFixture, ScissorRestrictsDrawingToClippedRegion)
 {
     WindowRenderer wr(64, 64);

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -117,6 +117,52 @@ int CountColor(sdl3d_render_context *ctx, sdl3d_color c)
     return n;
 }
 
+struct ColorRegionStats
+{
+    int max_r = 0;
+    int max_g = 0;
+    int max_b = 0;
+    int sum_r = 0;
+    int sum_g = 0;
+    int sum_b = 0;
+    int non_black_pixels = 0;
+};
+
+ColorRegionStats SampleColorRegion(sdl3d_render_context *ctx, SDL_Point center, int radius)
+{
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    const int x0 = SDL_max(0, center.x - radius);
+    const int x1 = SDL_min(w - 1, center.x + radius);
+    const int y0 = SDL_max(0, center.y - radius);
+    const int y1 = SDL_min(h - 1, center.y + radius);
+
+    ColorRegionStats stats{};
+    for (int y = y0; y <= y1; ++y)
+    {
+        for (int x = x0; x <= x1; ++x)
+        {
+            sdl3d_color px{};
+            if (!sdl3d_get_framebuffer_pixel(ctx, x, y, &px))
+            {
+                continue;
+            }
+
+            stats.max_r = SDL_max(stats.max_r, (int)px.r);
+            stats.max_g = SDL_max(stats.max_g, (int)px.g);
+            stats.max_b = SDL_max(stats.max_b, (int)px.b);
+            stats.sum_r += (int)px.r;
+            stats.sum_g += (int)px.g;
+            stats.sum_b += (int)px.b;
+            if (px.r != 0 || px.g != 0 || px.b != 0)
+            {
+                ++stats.non_black_pixels;
+            }
+        }
+    }
+    return stats;
+}
+
 SDL_Point ProjectPointToFramebuffer(const sdl3d_render_context *ctx, sdl3d_camera3d camera, sdl3d_vec3 point)
 {
     sdl3d_mat4 view{};
@@ -641,8 +687,11 @@ TEST_F(SDL3DDrawingFixture, BillboardRespondsToPointLight)
                                      (sdl3d_color){255, 255, 255, 255}));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    sdl3d_color unlit{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 48, &unlit));
+    const SDL_Point billboard_center = ProjectPointToFramebuffer(ctx, cam, sdl3d_vec3_make(0.0f, 1.0f, 0.0f));
+    const int sample_radius =
+        SDL_max(4, SDL_min(sdl3d_get_render_context_width(ctx), sdl3d_get_render_context_height(ctx)) / 32);
+    const ColorRegionStats unlit = SampleColorRegion(ctx, billboard_center, sample_radius);
+    ASSERT_GT(unlit.non_black_pixels, 0);
 
     sdl3d_light light{};
     light.type = SDL3D_LIGHT_POINT;
@@ -663,11 +712,11 @@ TEST_F(SDL3DDrawingFixture, BillboardRespondsToPointLight)
                                      (sdl3d_color){255, 255, 255, 255}));
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
 
-    sdl3d_color lit{};
-    ASSERT_TRUE(sdl3d_get_framebuffer_pixel(ctx, 48, 48, &lit));
+    const ColorRegionStats lit = SampleColorRegion(ctx, billboard_center, sample_radius);
+    ASSERT_GT(lit.non_black_pixels, 0);
 
-    EXPECT_GT(lit.r, unlit.r);
-    EXPECT_GT(lit.r, lit.g);
+    EXPECT_GT(lit.max_r, unlit.max_r);
+    EXPECT_GT(lit.sum_r, lit.sum_g);
 
     sdl3d_free_texture(&texture);
     sdl3d_destroy_render_context(ctx);


### PR DESCRIPTION
## Summary
- let billboard sprites use the lit mesh path when scene lighting is enabled and active
- orient billboard normals toward the camera so point lights in front of sprites affect them correctly
- remove projectile-specific manual sprite tinting in the Doom demo and let the projectile's dynamic point light drive billboard lighting
- sample static Doom sprite tint from the sprite body instead of the ground contact point

## Verification
- cmake --build build/default --target sdl3d_drawing3d_test doom_level -j 8
- ./build/default/tests/sdl3d_drawing3d_test
- cmake --build build/default --target sdl3d_sprite_actor_test sdl3d_lighting_test doom_backend_test -j 8
- ./build/default/tests/sdl3d_sprite_actor_test
- ./build/default/tests/sdl3d_lighting_test
- ./build/default/tests/doom_backend_test
- cmake --build build/default --target sdl3d_gl_renderer_test -j 8
- ./build/default/tests/sdl3d_gl_renderer_test --gtest_filter='GLRendererTest.Billboard*'