### PR TITLE
Add runtime sector geometry updates

### DIFF
--- a/demos/doom_level/level_data.c
+++ b/demos/doom_level/level_data.c
@@ -27,8 +27,10 @@ static const sdl3d_level_material g_mats[] = {
  *   [2] Nukage Basin -- [3] East Passage -- [4] Courtyard -- [10] Storage -- [12] Secret Annex
  *      |                                       |
  *   [6] West Alcove                           [5] Exit Room -- [11] Reactor Hall -- [13] Exterior Yard
+ *                                                                                 |
+ *                                                 [31] Lift Bay -- [32] Lift -- [33] Upper Deck
  */
-const sdl3d_sector g_sectors[] = {
+static const sdl3d_sector g_base_sectors[] = {
     {{{0, 0}, {10, 0}, {10, 8}, {0, 8}}, 4, 0.0f, 4.0f, 0, 1, 2},
     {{{3, 8}, {7, 8}, {7, 16}, {3, 16}}, 4, 0.0f, 3.5f, 5, 1, 4},
     {{{-2, 16}, {10, 16}, {10, 26}, {-2, 26}}, 4, -0.5f, 4.5f, 3, 1, 2},
@@ -62,8 +64,13 @@ const sdl3d_sector g_sectors[] = {
     {{{-6, 64}, {-2, 64}, {-2, 72}, {-6, 72}}, 4, 2.5f, 12.0f, 5, -1, 2},
     {{{-6, 72}, {-2, 72}, {-2, 80}, {-6, 80}}, 4, 1.25f, 12.0f, 5, -1, 2, {0.0f, 0.95448f, 0.298275f}, {0, 0, 0}},
     {{{-6, 80}, {-2, 80}, {-2, 104}, {-6, 104}}, 4, 0.0f, 12.0f, 5, -1, 2},
+    /* Runtime sector modification showcase: an outdoor lift bay. */
+    {{{54, 57}, {60, 57}, {60, 69}, {54, 69}}, 4, 2.5f, 12.0f, 5, -1, 2},
+    {{{60, 57}, {68, 57}, {68, 69}, {60, 69}}, 4, 0.0f, 12.0f, 0, -1, 4},
+    {{{68, 57}, {78, 57}, {78, 69}, {68, 69}}, 4, 2.5f, 12.0f, 5, -1, 2},
 };
-const int g_sector_count = (int)SDL_arraysize(g_sectors);
+sdl3d_sector g_sectors[SDL_arraysize(g_base_sectors)];
+const int g_sector_count = (int)SDL_arraysize(g_base_sectors);
 
 const sdl3d_level_light g_lights[] = {
     {{5, 3.5f, 4}, {1.0f, 0.82f, 0.58f}, 2.4f, 9.5f},    {{5, 3.0f, 12}, {1.0f, 0.68f, 0.28f}, 1.4f, 7.0f},
@@ -74,6 +81,7 @@ const sdl3d_level_light g_lights[] = {
     {{24, 3.8f, 38}, {0.45f, 0.35f, 1.0f}, 2.2f, 11.0f}, {{36, 2.2f, 27}, {1.0f, 0.55f, 0.22f}, 1.5f, 7.0f},
     {{24, 8.5f, 74}, {0.32f, 0.38f, 0.7f}, 2.4f, 32.0f}, {{37, 2.5f, 22}, {1.0f, 0.8f, 0.5f}, 1.5f, 8.0f},
     {{37, 5.0f, 15}, {0.8f, 0.6f, 1.0f}, 1.8f, 10.0f},   {{34, 8.5f, 7}, {1.0f, 0.95f, 0.8f}, 3.0f, 16.0f},
+    {{66, 6.0f, 63}, {0.25f, 0.7f, 1.0f}, 2.1f, 14.0f},
 };
 const int g_light_count = (int)SDL_arraysize(g_lights);
 
@@ -91,11 +99,21 @@ static void strip_lightmap(sdl3d_level *level)
     }
 }
 
+static void apply_sector_geometry(sdl3d_sector *sector, const sdl3d_sector_geometry *geometry)
+{
+    sector->floor_y = geometry->floor_y;
+    sector->ceil_y = geometry->ceil_y;
+    SDL_memcpy(sector->floor_normal, geometry->floor_normal, sizeof(sector->floor_normal));
+    SDL_memcpy(sector->ceil_normal, geometry->ceil_normal, sizeof(sector->ceil_normal));
+}
+
 bool level_data_init(level_data *ld)
 {
     int mc = (int)SDL_arraysize(g_mats);
     ld->use_lit = true;
     ld->use_lightmaps = true;
+
+    SDL_memcpy(g_sectors, g_base_sectors, sizeof(g_base_sectors));
 
     if (!sdl3d_build_level(g_sectors, g_sector_count, g_mats, mc, g_lights, g_light_count, &ld->lightmapped))
     {
@@ -124,6 +142,67 @@ void level_data_free(level_data *ld)
     sdl3d_free_level(&ld->lightmapped);
     sdl3d_free_level(&ld->vertex_baked);
     sdl3d_free_level(&ld->unlit);
+}
+
+bool level_data_set_sector_geometry(level_data *ld, int sector_index, const sdl3d_sector_geometry *geometry)
+{
+    const int mc = (int)SDL_arraysize(g_mats);
+    sdl3d_sector *candidate_sectors = NULL;
+    sdl3d_level lightmapped;
+    sdl3d_level vertex_baked;
+    sdl3d_level unlit;
+
+    if (ld == NULL || geometry == NULL)
+    {
+        return SDL_InvalidParamError("level_data");
+    }
+    if (sector_index < 0 || sector_index >= g_sector_count)
+    {
+        return SDL_SetError("sector_index is out of range.");
+    }
+    if (geometry->ceil_y <= geometry->floor_y + 0.000001f)
+    {
+        return SDL_SetError("sector ceiling must be above sector floor.");
+    }
+
+    candidate_sectors = SDL_malloc(sizeof(g_sectors));
+    if (candidate_sectors == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+    SDL_memcpy(candidate_sectors, g_sectors, sizeof(g_sectors));
+    apply_sector_geometry(&candidate_sectors[sector_index], geometry);
+
+    SDL_zero(lightmapped);
+    SDL_zero(vertex_baked);
+    SDL_zero(unlit);
+    if (!sdl3d_build_level(candidate_sectors, g_sector_count, g_mats, mc, g_lights, g_light_count, &lightmapped))
+    {
+        SDL_free(candidate_sectors);
+        return false;
+    }
+    if (!sdl3d_build_level(candidate_sectors, g_sector_count, g_mats, mc, g_lights, g_light_count, &vertex_baked))
+    {
+        sdl3d_free_level(&lightmapped);
+        SDL_free(candidate_sectors);
+        return false;
+    }
+    if (!sdl3d_build_level(candidate_sectors, g_sector_count, g_mats, mc, NULL, 0, &unlit))
+    {
+        sdl3d_free_level(&lightmapped);
+        sdl3d_free_level(&vertex_baked);
+        SDL_free(candidate_sectors);
+        return false;
+    }
+
+    strip_lightmap(&vertex_baked);
+    SDL_memcpy(g_sectors, candidate_sectors, sizeof(g_sectors));
+    SDL_free(candidate_sectors);
+    level_data_free(ld);
+    ld->lightmapped = lightmapped;
+    ld->vertex_baked = vertex_baked;
+    ld->unlit = unlit;
+    return true;
 }
 
 sdl3d_level *level_data_active(level_data *ld)

--- a/demos/doom_level/level_data.h
+++ b/demos/doom_level/level_data.h
@@ -15,14 +15,17 @@ typedef struct level_data
     bool use_lightmaps;
 } level_data;
 
+#define DOOM_DYNAMIC_LIFT_SECTOR 32
+
 /* Sector and light arrays are exposed so the player/renderer can query them. */
-extern const sdl3d_sector g_sectors[];
+extern sdl3d_sector g_sectors[];
 extern const int g_sector_count;
 extern const sdl3d_level_light g_lights[];
 extern const int g_light_count;
 
 bool level_data_init(level_data *ld);
 void level_data_free(level_data *ld);
+bool level_data_set_sector_geometry(level_data *ld, int sector_index, const sdl3d_sector_geometry *geometry);
 
 /* Return the active level variant based on current toggle state. */
 sdl3d_level *level_data_active(level_data *ld);

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -20,6 +20,11 @@
 #include "renderer.h"
 
 #define SIG_FADE_OUT_DONE 2001
+#define LIFT_FLOOR_MIN_Y 0.0f
+#define LIFT_FLOOR_MAX_Y 2.5f
+#define LIFT_CEIL_Y 12.0f
+#define LIFT_CYCLE_SECONDS 6.0f
+#define LIFT_REBUILD_MIN_DELTA 0.02f
 
 typedef struct doom_state
 {
@@ -33,6 +38,8 @@ typedef struct doom_state
     sdl3d_demo_player *demo_player;
     sdl3d_backend current_backend;
     doom_render_profile render_profile;
+    float lift_timer;
+    float lift_last_floor_y;
     int action_pause;
     int action_menu;
     int action_toggle_lighting;
@@ -50,6 +57,7 @@ typedef struct doom_state
 
 static void doom_state_cleanup(doom_state *state)
 {
+    render_state_free(&state->render);
     if (state->entities_ready)
     {
         entities_free(&state->ent);
@@ -178,6 +186,8 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
         return false;
     }
     state->level_ready = true;
+    state->lift_timer = 0.0f;
+    state->lift_last_floor_y = g_sectors[DOOM_DYNAMIC_LIFT_SECTOR].floor_y;
 
     if (!entities_init(&state->ent, &state->level.unlit, ctx->registry, ctx->bus))
     {
@@ -278,6 +288,44 @@ static void apply_doom_profile_actions(sdl3d_game_context *ctx, doom_state *stat
     }
 }
 
+static void update_dynamic_lift(doom_state *state, float dt)
+{
+    if (state == NULL || !state->level_ready)
+    {
+        return;
+    }
+
+    state->lift_timer += dt;
+    while (state->lift_timer >= LIFT_CYCLE_SECONDS)
+    {
+        state->lift_timer -= LIFT_CYCLE_SECONDS;
+    }
+
+    const float phase = state->lift_timer / LIFT_CYCLE_SECONDS;
+    const float wave = (SDL_sinf(phase * SDL_PI_F * 2.0f - SDL_PI_F * 0.5f) + 1.0f) * 0.5f;
+    const float floor_y = LIFT_FLOOR_MIN_Y + (LIFT_FLOOR_MAX_Y - LIFT_FLOOR_MIN_Y) * wave;
+    if (SDL_fabsf(floor_y - state->lift_last_floor_y) < LIFT_REBUILD_MIN_DELTA)
+    {
+        return;
+    }
+
+    sdl3d_sector_geometry geometry;
+    SDL_zero(geometry);
+    geometry.floor_y = floor_y;
+    geometry.ceil_y = LIFT_CEIL_Y;
+    geometry.floor_normal[1] = 1.0f;
+    geometry.ceil_normal[1] = -1.0f;
+
+    if (level_data_set_sector_geometry(&state->level, DOOM_DYNAMIC_LIFT_SECTOR, &geometry))
+    {
+        state->lift_last_floor_y = floor_y;
+    }
+    else
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Dynamic lift update failed: %s", SDL_GetError());
+    }
+}
+
 static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     doom_state *state = (doom_state *)userdata;
@@ -298,6 +346,7 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     }
 
     sdl3d_transition_update(&state->transition, ctx->bus, dt);
+    update_dynamic_lift(state, dt);
     entities_update(&state->ent, &state->level.unlit, dt, state->player.mover.position);
     if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
     {

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -48,7 +48,39 @@ void render_state_init(render_state *rs)
 {
     SDL_zerop(rs);
     rs->portal_culling = true;
+}
+
+void render_state_free(render_state *rs)
+{
+    if (rs == NULL)
+    {
+        return;
+    }
+
+    SDL_free(rs->sector_visible);
+    SDL_zerop(rs);
+}
+
+static bool render_state_ensure_sector_capacity(render_state *rs, int sector_count)
+{
+    if (rs == NULL || sector_count <= 0)
+    {
+        return false;
+    }
+
+    if (rs->sector_visible_capacity < sector_count)
+    {
+        bool *sector_visible = SDL_realloc(rs->sector_visible, (size_t)sector_count * sizeof(*sector_visible));
+        if (sector_visible == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+        rs->sector_visible = sector_visible;
+        rs->sector_visible_capacity = sector_count;
+    }
+
     rs->vis.sector_visible = rs->sector_visible;
+    return true;
 }
 
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
@@ -58,6 +90,7 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     const sdl3d_fps_mover *mover = &player->mover;
     sdl3d_level *active = level_data_active(ld);
     sdl3d_camera3d cam = sdl3d_fps_mover_camera(mover, 75.0f);
+    const int sector_count = active->sector_count;
 
     float px = mover->position.x, py = mover->position.y;
     float pz = mover->position.z;
@@ -94,6 +127,12 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     sdl3d_draw_skybox_textured(ctx, &skybox);
 
     /* Visibility */
+    if (rs->portal_culling && !render_state_ensure_sector_capacity(rs, sector_count))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Portal visibility allocation failed: %s", SDL_GetError());
+        rs->portal_culling = false;
+    }
+
     if (rs->portal_culling)
     {
         sdl3d_level_compute_visibility_from_camera(active, g_sectors, &cam, backbuffer_w, backbuffer_h, 0.01f, 1000.0f,
@@ -101,9 +140,9 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     }
     else
     {
-        for (int i = 0; i < g_sector_count; i++)
+        for (int i = 0; i < sector_count && rs->sector_visible != NULL; i++)
             rs->sector_visible[i] = true;
-        rs->vis.visible_count = g_sector_count;
+        rs->vis.visible_count = sector_count;
     }
 
     /* Level geometry */
@@ -181,7 +220,7 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
         sdl3d_ui_begin_frame(ui, sdl3d_get_render_context_width(ctx), sdl3d_get_render_context_height(ctx));
         sdl3d_ui_label(ui, 10.0f, 60.0f, "SDL3D UI - Phase 1");
         sdl3d_ui_labelf(ui, 10.0f, 100.0f, "sector=%d  visible=%d/%d", current_sector, rs->vis.visible_count,
-                        g_sector_count);
+                        sector_count);
         sdl3d_ui_labelf(ui, 10.0f, 140.0f, "pos %.1f, %.1f, %.1f", px, py, pz);
         sdl3d_ui_labelf(ui, 10.0f, 180.0f, "profile=%s", render_profile_name ? render_profile_name : "Modern");
         sdl3d_ui_end_frame(ui);
@@ -196,7 +235,7 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
             for (int i = 0; i < active->model.mesh_count; i++)
             {
                 int sid = active->mesh_sector_ids[i];
-                if (sid >= 0 && sid < g_sector_count && rs->sector_visible[sid])
+                if (sid >= 0 && sid < sector_count && rs->sector_visible != NULL && rs->sector_visible[sid])
                     visible_meshes++;
             }
         }
@@ -206,7 +245,7 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
         }
         SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
                      "[VIS] sector=%d  visible=%d/%d sectors  meshes=%d/%d  portals=%d  culling=%s", current_sector,
-                     rs->vis.visible_count, g_sector_count, visible_meshes, active->model.mesh_count,
+                     rs->vis.visible_count, sector_count, visible_meshes, active->model.mesh_count,
                      active->portal_count, rs->portal_culling ? "ON" : "OFF");
     }
 }

--- a/demos/doom_level/renderer.h
+++ b/demos/doom_level/renderer.h
@@ -16,11 +16,13 @@ typedef struct render_state
 {
     bool portal_culling;
     bool show_debug;
-    bool sector_visible[32]; /* must be >= g_sector_count */
+    bool *sector_visible;
+    int sector_visible_capacity;
     sdl3d_visibility_result vis;
 } render_state;
 
 void render_state_init(render_state *rs);
+void render_state_free(render_state *rs);
 
 /* Draw one complete frame. Presentation is owned by the managed game loop. */
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -57,6 +57,22 @@ extern "C"
         float ceil_normal[3];  /* Ceiling plane normal. Zero defaults to (0, -1, 0). */
     } sdl3d_sector;
 
+    /**
+     * @brief Runtime-editable vertical sector geometry.
+     *
+     * This describes the part of a sector that can move during gameplay:
+     * the floor and ceiling plane heights at the sector centroid, plus the
+     * floor and ceiling normals. The sector polygon, materials, and winding
+     * remain owned by the existing sdl3d_sector definition.
+     */
+    typedef struct sdl3d_sector_geometry
+    {
+        float floor_y;         /**< Floor height at the sector centroid. */
+        float ceil_y;          /**< Ceiling height at the sector centroid. */
+        float floor_normal[3]; /**< Floor plane normal, or zero for flat up. */
+        float ceil_normal[3];  /**< Ceiling plane normal, or zero for flat down. */
+    } sdl3d_sector_geometry;
+
     typedef struct sdl3d_level
     {
         sdl3d_model model;
@@ -116,6 +132,36 @@ extern "C"
      */
     bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3d_level_material *materials,
                            int material_count, const sdl3d_level_light *lights, int light_count, sdl3d_level *out);
+
+    /**
+     * @brief Change one sector's runtime geometry and rebuild level data.
+     *
+     * The update is transactional for a single level: the function copies
+     * `sectors`, applies `geometry` to `sector_index`, rebuilds a temporary
+     * level, and swaps it into `level` only after the rebuild succeeds. On
+     * success, `sectors[sector_index]` is updated to match the committed
+     * geometry. On failure, the live level and caller-owned sector array are
+     * left unchanged and SDL_GetError() describes the problem.
+     *
+     * Rebuilding the level refreshes generated floor, ceiling, wall, portal,
+     * visibility, vertex lighting, and lightmap data so adjacent step walls
+     * remain consistent when a floor or ceiling moves.
+     *
+     * @param level Built level to replace on success.
+     * @param sectors Mutable sector definitions used by gameplay queries.
+     * @param sector_count Number of entries in `sectors`; must match
+     *        `level->sector_count`.
+     * @param sector_index Sector to edit.
+     * @param geometry New vertical geometry for the sector.
+     * @param materials Material palette used to rebuild the level.
+     * @param material_count Number of entries in `materials`.
+     * @param lights Optional baked lights, or NULL with `light_count` 0.
+     * @param light_count Number of entries in `lights`.
+     * @return true when the new geometry was committed, false on error.
+     */
+    bool sdl3d_level_set_sector_geometry(sdl3d_level *level, sdl3d_sector *sectors, int sector_count, int sector_index,
+                                         const sdl3d_sector_geometry *geometry, const sdl3d_level_material *materials,
+                                         int material_count, const sdl3d_level_light *lights, int light_count);
 
     void sdl3d_free_level(sdl3d_level *level);
 

--- a/src/level.c
+++ b/src/level.c
@@ -770,6 +770,14 @@ static bool add_wall_and_lightmap(macc *wall_acc, lm_surface_list *surf_list, in
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
+static void sector_apply_runtime_geometry(sdl3d_sector *sector, const sdl3d_sector_geometry *geometry)
+{
+    sector->floor_y = geometry->floor_y;
+    sector->ceil_y = geometry->ceil_y;
+    SDL_memcpy(sector->floor_normal, geometry->floor_normal, sizeof(sector->floor_normal));
+    SDL_memcpy(sector->ceil_normal, geometry->ceil_normal, sizeof(sector->ceil_normal));
+}
+
 bool sdl3d_build_level(const sdl3d_sector *sectors, int sector_count, const sdl3d_level_material *materials,
                        int material_count, const sdl3d_level_light *lights, int light_count, sdl3d_level *out)
 {
@@ -1191,6 +1199,65 @@ fail:
     out->lightmap_height = 0;
     sdl3d_free_texture(&out->lightmap_texture);
     return false;
+}
+
+bool sdl3d_level_set_sector_geometry(sdl3d_level *level, sdl3d_sector *sectors, int sector_count, int sector_index,
+                                     const sdl3d_sector_geometry *geometry, const sdl3d_level_material *materials,
+                                     int material_count, const sdl3d_level_light *lights, int light_count)
+{
+    sdl3d_sector *candidate_sectors;
+    sdl3d_level rebuilt;
+
+    if (level == NULL)
+    {
+        return SDL_InvalidParamError("level");
+    }
+    if (sectors == NULL || sector_count <= 0)
+    {
+        return SDL_InvalidParamError("sectors");
+    }
+    if (geometry == NULL)
+    {
+        return SDL_InvalidParamError("geometry");
+    }
+    if (materials == NULL || material_count <= 0)
+    {
+        return SDL_InvalidParamError("materials");
+    }
+    if (level->sector_count != sector_count)
+    {
+        return SDL_SetError("sector_count must match the built level.");
+    }
+    if (sector_index < 0 || sector_index >= sector_count)
+    {
+        return SDL_SetError("sector_index is out of range.");
+    }
+    if (geometry->ceil_y <= geometry->floor_y + SDL3D_LEVEL_PLANE_EPSILON)
+    {
+        return SDL_SetError("sector ceiling must be above sector floor.");
+    }
+
+    candidate_sectors = SDL_malloc((size_t)sector_count * sizeof(*candidate_sectors));
+    if (candidate_sectors == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    SDL_memcpy(candidate_sectors, sectors, (size_t)sector_count * sizeof(*candidate_sectors));
+    sector_apply_runtime_geometry(&candidate_sectors[sector_index], geometry);
+
+    SDL_zero(rebuilt);
+    if (!sdl3d_build_level(candidate_sectors, sector_count, materials, material_count, lights, light_count, &rebuilt))
+    {
+        SDL_free(candidate_sectors);
+        return false;
+    }
+
+    sector_apply_runtime_geometry(&sectors[sector_index], geometry);
+    SDL_free(candidate_sectors);
+    sdl3d_free_level(level);
+    *level = rebuilt;
+    return true;
 }
 
 void sdl3d_free_level(sdl3d_level *level)

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -63,6 +63,18 @@ TestVec3 LoadNormal(const sdl3d_mesh &mesh, int vertex_index)
     return {mesh.normals[vertex_index * 3], mesh.normals[vertex_index * 3 + 1], mesh.normals[vertex_index * 3 + 2]};
 }
 
+const sdl3d_mesh *FindSectorMaterialMesh(const sdl3d_level &level, int sector_id, int material_index)
+{
+    for (int i = 0; i < level.model.mesh_count; ++i)
+    {
+        if (level.mesh_sector_ids[i] == sector_id && level.model.meshes[i].material_index == material_index)
+        {
+            return &level.model.meshes[i];
+        }
+    }
+    return nullptr;
+}
+
 TestVec3 Subtract(TestVec3 a, TestVec3 b)
 {
     return {a.x - b.x, a.y - b.y, a.z - b.z};
@@ -272,6 +284,119 @@ TEST(SDL3DLevelBuilder, BakesLightmapAtlasAndMeshUVs)
             EXPECT_LE(mesh.lightmap_uvs[v * 2 + 1], 1.0f);
         }
     }
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelRuntimeGeometry, SetSectorGeometryUpdatesSectorAndMeshes)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f), MakeSquareSector(4.0f, 0.0f, 8.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 2, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+    const sdl3d_mesh *old_floor_mesh = FindSectorMaterialMesh(level, 1, sectors[1].floor_material);
+    ASSERT_NE(old_floor_mesh, nullptr);
+    EXPECT_NEAR(old_floor_mesh->local_bounds.min.y, 0.0f, 1e-4f);
+
+    sdl3d_sector_geometry geometry{};
+    geometry.floor_y = 1.25f;
+    geometry.ceil_y = 5.0f;
+    geometry.floor_normal[1] = 1.0f;
+    geometry.ceil_normal[1] = -1.0f;
+
+    ASSERT_TRUE(sdl3d_level_set_sector_geometry(&level, sectors, 2, 1, &geometry, materials, 3, nullptr, 0))
+        << SDL_GetError();
+
+    EXPECT_FLOAT_EQ(sectors[1].floor_y, 1.25f);
+    EXPECT_FLOAT_EQ(sectors[1].ceil_y, 5.0f);
+    EXPECT_EQ(level.sector_count, 2);
+    EXPECT_GT(level.portal_count, 0);
+
+    const sdl3d_mesh *new_floor_mesh = FindSectorMaterialMesh(level, 1, sectors[1].floor_material);
+    ASSERT_NE(new_floor_mesh, nullptr);
+    EXPECT_NEAR(new_floor_mesh->local_bounds.min.y, 1.25f, 1e-4f);
+    EXPECT_NEAR(new_floor_mesh->local_bounds.max.y, 1.25f, 1e-4f);
+
+    bool portal_updated = false;
+    for (int i = 0; i < level.portal_count; ++i)
+    {
+        const sdl3d_level_portal &portal = level.portals[i];
+        if ((portal.sector_a == 0 && portal.sector_b == 1) || (portal.sector_a == 1 && portal.sector_b == 0))
+        {
+            portal_updated = true;
+            EXPECT_NEAR(portal.floor_y, 1.25f, 1e-4f);
+            EXPECT_NEAR(portal.ceil_y, 3.0f, 1e-4f);
+        }
+    }
+    EXPECT_TRUE(portal_updated);
+
+    EXPECT_EQ(sdl3d_level_find_walkable_sector(&level, sectors, 6.0f, 2.0f, 1.0f, 0.5f, 1.6f), 1);
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelRuntimeGeometry, SetSectorGeometrySupportsSlopedFloors)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 10.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+
+    sdl3d_sector_geometry geometry{};
+    geometry.floor_y = 1.0f;
+    geometry.ceil_y = 6.0f;
+    geometry.floor_normal[0] = -0.19611613f;
+    geometry.floor_normal[1] = 0.98058069f;
+    geometry.ceil_normal[1] = -1.0f;
+
+    ASSERT_TRUE(sdl3d_level_set_sector_geometry(&level, sectors, 1, 0, &geometry, materials, 3, nullptr, 0))
+        << SDL_GetError();
+
+    EXPECT_NEAR(sdl3d_sector_floor_at(&sectors[0], 0.0f, 2.0f), 0.0f, 1e-4f);
+    EXPECT_NEAR(sdl3d_sector_floor_at(&sectors[0], 10.0f, 2.0f), 2.0f, 1e-4f);
+
+    const sdl3d_mesh *floor_mesh = FindSectorMaterialMesh(level, 0, sectors[0].floor_material);
+    ASSERT_NE(floor_mesh, nullptr);
+    for (int i = 0; i < floor_mesh->vertex_count; ++i)
+    {
+        float x = floor_mesh->positions[i * 3 + 0];
+        float y = floor_mesh->positions[i * 3 + 1];
+        float z = floor_mesh->positions[i * 3 + 2];
+        EXPECT_NEAR(y, sdl3d_sector_floor_at(&sectors[0], x, z), 1e-4f);
+    }
+
+    sdl3d_free_level(&level);
+}
+
+TEST(SDL3DLevelRuntimeGeometry, SetSectorGeometryLeavesStateUnchangedOnInvalidUpdate)
+{
+    const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                              MakeLevelMaterial("wall.png")};
+    sdl3d_sector sectors[] = {MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f)};
+    sdl3d_level level{};
+
+    ASSERT_TRUE(sdl3d_build_level(sectors, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+    const sdl3d_mesh *floor_mesh = FindSectorMaterialMesh(level, 0, sectors[0].floor_material);
+    ASSERT_NE(floor_mesh, nullptr);
+    const float old_floor_bound = floor_mesh->local_bounds.min.y;
+
+    sdl3d_sector_geometry invalid_geometry{};
+    invalid_geometry.floor_y = 3.0f;
+    invalid_geometry.ceil_y = 3.0f;
+    invalid_geometry.floor_normal[1] = 1.0f;
+    invalid_geometry.ceil_normal[1] = -1.0f;
+
+    EXPECT_FALSE(sdl3d_level_set_sector_geometry(&level, sectors, 1, 0, &invalid_geometry, materials, 3, nullptr, 0));
+    EXPECT_FLOAT_EQ(sectors[0].floor_y, 0.0f);
+    EXPECT_FLOAT_EQ(sectors[0].ceil_y, 3.0f);
+
+    floor_mesh = FindSectorMaterialMesh(level, 0, sectors[0].floor_material);
+    ASSERT_NE(floor_mesh, nullptr);
+    EXPECT_NEAR(floor_mesh->local_bounds.min.y, old_floor_bound, 1e-4f);
 
     sdl3d_free_level(&level);
 }


### PR DESCRIPTION
## Summary
- add a public runtime sector geometry API for changing sector floor/ceiling planes transactionally
- rebuild generated level meshes, portals, lighting data, and gameplay sector definitions after committed geometry changes
- add an outdoor lift bay to the doom_level demo that animates a moving sector floor
- replace doom_level's fixed 32-sector visibility buffer with dynamic allocation for the expanded map

## Tests
- cmake --build build/default --target sdl3d_level_test doom_level -j 8
- ./build/default/tests/sdl3d_level_test
- ./build/default/tests/doom_backend_test
- ./build/default/tests/sdl3d_fps_mover_test