### PR TITLE
Add signal-driven teleporters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ target_sources(
         src/shapes.c
         src/sw_backend.c
         src/texture.c
+        src/teleporter.c
         src/time.c
         src/timer_pool.c
         src/transition.c

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -27,6 +27,8 @@
 #define LIFT_REBUILD_MIN_DELTA 0.02f
 #define AMBIENT_FADE_SECONDS 1.0f
 #define AMBIENT_FEEDBACK_SECONDS 5.0f
+#define TELEPORT_FEEDBACK_SECONDS 2.0f
+#define DRAGON_TELEPORTER_ID 1
 
 typedef struct doom_state
 {
@@ -40,9 +42,11 @@ typedef struct doom_state
     sdl3d_demo_player *demo_player;
     sdl3d_audio_engine *audio;
     sdl3d_sector_watcher sector_watcher;
+    sdl3d_teleporter dragon_teleporter;
     sdl3d_backend current_backend;
     doom_render_profile render_profile;
     float ambient_feedback_timer;
+    float teleport_feedback_timer;
     float lift_timer;
     float lift_last_floor_y;
     int action_pause;
@@ -141,6 +145,43 @@ static void on_entered_sector(void *userdata, int signal_id, const sdl3d_propert
     }
 }
 
+static void on_teleport(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    (void)signal_id;
+    doom_state *state = (doom_state *)userdata;
+    sdl3d_teleport_destination destination;
+
+    if (state == NULL || !sdl3d_teleport_destination_from_payload(payload, &destination))
+    {
+        return;
+    }
+
+    sdl3d_fps_mover_teleport(&state->player.mover, destination.position, destination.use_yaw, destination.yaw,
+                             destination.use_pitch, destination.pitch);
+    state->player.proj_active = false;
+    state->teleport_feedback_timer = TELEPORT_FEEDBACK_SECONDS;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Teleporter %d moved player to %.1f %.1f %.1f",
+                sdl3d_properties_get_int(payload, "teleporter_id", -1), destination.position.x, destination.position.y,
+                destination.position.z);
+}
+
+static void init_dragon_teleporter(doom_state *state)
+{
+    sdl3d_bounding_box source = {
+        sdl3d_vec3_make(22.5f, 0.0f, 86.5f),
+        sdl3d_vec3_make(25.5f, 2.4f, 89.5f),
+    };
+    sdl3d_teleport_destination destination;
+    SDL_zero(destination);
+    destination.position = sdl3d_vec3_make(72.0f, 2.5f + PLAYER_HEIGHT, 63.0f);
+    destination.yaw = -SDL_PI_F * 0.5f;
+    destination.pitch = 0.0f;
+    destination.use_yaw = true;
+    destination.use_pitch = true;
+
+    sdl3d_teleporter_init(&state->dragon_teleporter, DRAGON_TELEPORTER_ID, source, destination);
+}
+
 static void start_quit_fade(sdl3d_game_context *ctx, doom_state *state)
 {
     if (state->quit_pending)
@@ -211,6 +252,10 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     {
         return false;
     }
+    if (sdl3d_signal_connect(ctx->bus, SDL3D_SIGNAL_TELEPORT, on_teleport, state) == 0)
+    {
+        return false;
+    }
 
     state->has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &state->debug_font);
     if (!sdl3d_ui_create(state->has_font ? &state->debug_font : NULL, &state->ui))
@@ -237,6 +282,7 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     state->entities_ready = true;
 
     player_init(&state->player, ctx->input);
+    init_dragon_teleporter(state);
     render_state_init(&state->render);
     sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, (sdl3d_color){0, 0, 0, 255},
                            1.0f, -1);
@@ -400,6 +446,20 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
             state->ambient_feedback_timer = 0.0f;
         }
     }
+    if (state->teleport_feedback_timer > 0.0f)
+    {
+        state->teleport_feedback_timer -= dt;
+        if (state->teleport_feedback_timer < 0.0f)
+        {
+            state->teleport_feedback_timer = 0.0f;
+        }
+    }
+
+    sdl3d_teleporter_update(&state->dragon_teleporter,
+                            sdl3d_vec3_make(state->player.mover.position.x,
+                                            state->player.mover.position.y - PLAYER_HEIGHT,
+                                            state->player.mover.position.z),
+                            dt, ctx->bus);
 
     sdl3d_sector_watcher_update(&state->sector_watcher, &state->level.unlit, g_sectors,
                                 sdl3d_vec3_make(state->player.mover.position.x,
@@ -470,7 +530,8 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 
     render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
                       &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt,
-                      backend_profile_name(state->render_profile), state->ambient_feedback_timer > 0.0f);
+                      backend_profile_name(state->render_profile), state->ambient_feedback_timer > 0.0f,
+                      state->teleport_feedback_timer > 0.0f);
     sdl3d_transition_draw(&state->transition, ctx->renderer);
     if (ctx->paused && !state->quit_pending)
     {

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -85,7 +85,8 @@ static bool render_state_ensure_sector_capacity(render_state *rs, int sector_cou
 
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
                        level_data *ld, entities *ent, const player_state *player, int backbuffer_w, int backbuffer_h,
-                       float dt, const char *render_profile_name, bool ambient_feedback_active)
+                       float dt, const char *render_profile_name, bool ambient_feedback_active,
+                       bool teleport_feedback_active)
 {
     const sdl3d_fps_mover *mover = &player->mover;
     sdl3d_level *active = level_data_active(ld);
@@ -178,6 +179,12 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     /* Ambient-zone feedback beacon. */
     sdl3d_draw_cube(ctx, sdl3d_vec3_make(73.0f, 3.0f, 63.0f), sdl3d_vec3_make(0.7f, 0.7f, 0.7f),
                     ambient_feedback_active ? (sdl3d_color){220, 40, 30, 255} : (sdl3d_color){40, 210, 70, 255});
+
+    /* Dragon-room teleporter source pad and destination beacon. */
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(24.0f, 0.05f, 88.0f), sdl3d_vec3_make(3.0f, 0.1f, 3.0f),
+                    teleport_feedback_active ? (sdl3d_color){255, 210, 60, 255} : (sdl3d_color){40, 190, 230, 255});
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(72.0f, 2.85f, 63.0f), sdl3d_vec3_make(0.8f, 0.7f, 0.8f),
+                    teleport_feedback_active ? (sdl3d_color){255, 210, 60, 255} : (sdl3d_color){80, 120, 255, 255});
 
     /* Sprites */
     {

--- a/demos/doom_level/renderer.h
+++ b/demos/doom_level/renderer.h
@@ -27,6 +27,7 @@ void render_state_free(render_state *rs);
 /* Draw one complete frame. Presentation is owned by the managed game loop. */
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
                        level_data *ld, entities *ent, const player_state *player, int backbuffer_w, int backbuffer_h,
-                       float dt, const char *render_profile_name, bool ambient_feedback_active);
+                       float dt, const char *render_profile_name, bool ambient_feedback_active,
+                       bool teleport_feedback_active);
 
 #endif

--- a/include/sdl3d/fps_mover.h
+++ b/include/sdl3d/fps_mover.h
@@ -88,6 +88,17 @@ extern "C"
      */
     void sdl3d_fps_mover_jump(sdl3d_fps_mover *mover);
 
+    /**
+     * @brief Instantly move a first-person mover to a new eye position.
+     *
+     * Teleporting resets vertical velocity, stair smoothing, sector cache, and
+     * last-known-good state so later collision recovery cannot snap the player
+     * back to the pre-teleport location. Pass false for set_yaw or set_pitch to
+     * preserve the current facing on that axis.
+     */
+    void sdl3d_fps_mover_teleport(sdl3d_fps_mover *mover, sdl3d_vec3 eye_position, bool set_yaw, float yaw,
+                                  bool set_pitch, float pitch);
+
     /*
      * Build a camera looking along the mover's facing. The camera position
      * includes the view-smooth offset so stair transitions appear smooth.

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -21,6 +21,7 @@
 #include "sdl3d/render_context.h"
 #include "sdl3d/scene.h"
 #include "sdl3d/shapes.h"
+#include "sdl3d/teleporter.h"
 #include "sdl3d/texture.h"
 #include "sdl3d/time.h"
 #include "sdl3d/transition.h"

--- a/include/sdl3d/teleporter.h
+++ b/include/sdl3d/teleporter.h
@@ -1,0 +1,114 @@
+/**
+ * @file teleporter.h
+ * @brief Signal-driven teleport trigger volumes.
+ *
+ * Teleporters combine a source volume with a destination transform. They do
+ * not directly move a player or actor; instead they emit a teleport signal
+ * with a property payload. Game code receives the signal and applies the
+ * destination to the appropriate object. This keeps teleport detection,
+ * signaling, and game-specific movement ownership separate.
+ */
+
+#ifndef SDL3D_TELEPORTER_H
+#define SDL3D_TELEPORTER_H
+
+#include <stdbool.h>
+
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Default signal emitted when a teleporter is entered. */
+#define SDL3D_SIGNAL_TELEPORT 0x54454C45
+
+    /**
+     * @brief Destination transform carried by a teleport signal.
+     *
+     * Position is always meaningful. Yaw and pitch are optional so a teleporter
+     * can either force facing, preserve current facing, or only override one
+     * axis.
+     */
+    typedef struct sdl3d_teleport_destination
+    {
+        sdl3d_vec3 position; /**< Caller-defined destination position. */
+        float yaw;           /**< Destination yaw in radians when use_yaw is true. */
+        float pitch;         /**< Destination pitch in radians when use_pitch is true. */
+        bool use_yaw;        /**< Whether yaw should replace the current yaw. */
+        bool use_pitch;      /**< Whether pitch should replace the current pitch. */
+    } sdl3d_teleport_destination;
+
+    /**
+     * @brief Teleporter trigger volume.
+     *
+     * Initialize with sdl3d_teleporter_init(), then call
+     * sdl3d_teleporter_update() once per simulation tick using the point that
+     * represents the object being teleported. The teleporter emits only on the
+     * enter edge of source_bounds, not every frame while the point remains
+     * inside.
+     */
+    typedef struct sdl3d_teleporter
+    {
+        sdl3d_bounding_box source_bounds;       /**< World-space source volume. */
+        sdl3d_teleport_destination destination; /**< Payload destination. */
+        int teleporter_id;                      /**< Stable game/editor id included in the payload. */
+        int signal_id;                          /**< Signal to emit, or SDL3D_SIGNAL_TELEPORT by default. */
+        float cooldown_seconds;                 /**< Minimum seconds before this teleporter can fire again. */
+        float cooldown_remaining;               /**< Runtime cooldown state. */
+        bool enabled;                           /**< Disabled teleporters never emit. */
+        bool was_inside;                        /**< Runtime enter-edge state. */
+    } sdl3d_teleporter;
+
+    /**
+     * @brief Initialize a teleporter with source bounds and a destination.
+     *
+     * The teleporter starts enabled, emits SDL3D_SIGNAL_TELEPORT, and uses a
+     * short default cooldown suitable for paired or nearby teleport volumes.
+     */
+    void sdl3d_teleporter_init(sdl3d_teleporter *teleporter, int teleporter_id, sdl3d_bounding_box source_bounds,
+                               sdl3d_teleport_destination destination);
+
+    /**
+     * @brief Update a teleporter and emit when the sample point enters it.
+     *
+     * The emitted payload contains:
+     * - teleporter_id: int
+     * - destination: vec3
+     * - destination_yaw: float
+     * - destination_pitch: float
+     * - use_yaw: bool
+     * - use_pitch: bool
+     *
+     * @param teleporter Teleporter state.
+     * @param sample_position World-space point to test.
+     * @param dt Simulation delta used to reduce cooldown. Negative values are
+     *        treated as zero.
+     * @param bus Signal bus that receives the teleport signal.
+     * @return true if a signal was emitted, false otherwise.
+     */
+    bool sdl3d_teleporter_update(sdl3d_teleporter *teleporter, sdl3d_vec3 sample_position, float dt,
+                                 sdl3d_signal_bus *bus);
+
+    /**
+     * @brief Reset enter-edge and cooldown state without changing configuration.
+     */
+    void sdl3d_teleporter_reset(sdl3d_teleporter *teleporter);
+
+    /**
+     * @brief Decode a teleport signal payload into a destination transform.
+     *
+     * @return true when the payload contains a destination vector, false when
+     *         payload or out_destination is NULL or the required key is absent.
+     */
+    bool sdl3d_teleport_destination_from_payload(const sdl3d_properties *payload,
+                                                 sdl3d_teleport_destination *out_destination);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_TELEPORTER_H */

--- a/src/fps_mover.c
+++ b/src/fps_mover.c
@@ -353,6 +353,31 @@ void sdl3d_fps_mover_jump(sdl3d_fps_mover *mover)
     mover->on_ground = false;
 }
 
+void sdl3d_fps_mover_teleport(sdl3d_fps_mover *mover, sdl3d_vec3 eye_position, bool set_yaw, float yaw, bool set_pitch,
+                              float pitch)
+{
+    if (mover == NULL)
+    {
+        return;
+    }
+
+    mover->position = eye_position;
+    if (set_yaw)
+    {
+        mover->yaw = yaw;
+    }
+    if (set_pitch)
+    {
+        mover->pitch = pitch;
+    }
+    mover->vertical_velocity = 0.0f;
+    mover->view_smooth = 0.0f;
+    mover->on_ground = false;
+    mover->current_sector = -1;
+    mover->last_good_position = eye_position;
+    mover->has_last_good = true;
+}
+
 sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy)
 {
     sdl3d_camera3d cam;

--- a/src/teleporter.c
+++ b/src/teleporter.c
@@ -1,0 +1,122 @@
+#include "sdl3d/teleporter.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/math.h"
+
+#define SDL3D_TELEPORT_DEFAULT_COOLDOWN 0.25f
+
+static bool point_inside_bounds(sdl3d_bounding_box bounds, sdl3d_vec3 point)
+{
+    return point.x >= bounds.min.x && point.x <= bounds.max.x && point.y >= bounds.min.y && point.y <= bounds.max.y &&
+           point.z >= bounds.min.z && point.z <= bounds.max.z;
+}
+
+static int teleporter_signal_id(const sdl3d_teleporter *teleporter)
+{
+    return teleporter->signal_id != 0 ? teleporter->signal_id : SDL3D_SIGNAL_TELEPORT;
+}
+
+static bool emit_teleport_signal(const sdl3d_teleporter *teleporter, sdl3d_signal_bus *bus)
+{
+    sdl3d_properties *payload;
+
+    if (bus == NULL)
+    {
+        return false;
+    }
+
+    payload = sdl3d_properties_create();
+    if (payload == NULL)
+    {
+        return false;
+    }
+
+    sdl3d_properties_set_int(payload, "teleporter_id", teleporter->teleporter_id);
+    sdl3d_properties_set_vec3(payload, "destination", teleporter->destination.position);
+    sdl3d_properties_set_float(payload, "destination_yaw", teleporter->destination.yaw);
+    sdl3d_properties_set_float(payload, "destination_pitch", teleporter->destination.pitch);
+    sdl3d_properties_set_bool(payload, "use_yaw", teleporter->destination.use_yaw);
+    sdl3d_properties_set_bool(payload, "use_pitch", teleporter->destination.use_pitch);
+
+    sdl3d_signal_emit(bus, teleporter_signal_id(teleporter), payload);
+    sdl3d_properties_destroy(payload);
+    return true;
+}
+
+void sdl3d_teleporter_init(sdl3d_teleporter *teleporter, int teleporter_id, sdl3d_bounding_box source_bounds,
+                           sdl3d_teleport_destination destination)
+{
+    if (teleporter == NULL)
+    {
+        return;
+    }
+
+    SDL_zerop(teleporter);
+    teleporter->source_bounds = source_bounds;
+    teleporter->destination = destination;
+    teleporter->teleporter_id = teleporter_id;
+    teleporter->signal_id = SDL3D_SIGNAL_TELEPORT;
+    teleporter->cooldown_seconds = SDL3D_TELEPORT_DEFAULT_COOLDOWN;
+    teleporter->enabled = true;
+}
+
+bool sdl3d_teleporter_update(sdl3d_teleporter *teleporter, sdl3d_vec3 sample_position, float dt, sdl3d_signal_bus *bus)
+{
+    bool inside;
+    bool emitted = false;
+
+    if (teleporter == NULL)
+    {
+        return false;
+    }
+
+    if (dt > 0.0f && teleporter->cooldown_remaining > 0.0f)
+    {
+        teleporter->cooldown_remaining -= dt;
+        if (teleporter->cooldown_remaining < 0.0f)
+        {
+            teleporter->cooldown_remaining = 0.0f;
+        }
+    }
+
+    inside = teleporter->enabled && point_inside_bounds(teleporter->source_bounds, sample_position);
+    if (inside && !teleporter->was_inside && teleporter->cooldown_remaining <= 0.0f)
+    {
+        emitted = emit_teleport_signal(teleporter, bus);
+        if (emitted && teleporter->cooldown_seconds > 0.0f)
+        {
+            teleporter->cooldown_remaining = teleporter->cooldown_seconds;
+        }
+    }
+
+    teleporter->was_inside = inside;
+    return emitted;
+}
+
+void sdl3d_teleporter_reset(sdl3d_teleporter *teleporter)
+{
+    if (teleporter == NULL)
+    {
+        return;
+    }
+
+    teleporter->was_inside = false;
+    teleporter->cooldown_remaining = 0.0f;
+}
+
+bool sdl3d_teleport_destination_from_payload(const sdl3d_properties *payload,
+                                             sdl3d_teleport_destination *out_destination)
+{
+    if (payload == NULL || out_destination == NULL || !sdl3d_properties_has(payload, "destination"))
+    {
+        return false;
+    }
+
+    out_destination->position = sdl3d_properties_get_vec3(payload, "destination", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    out_destination->yaw = sdl3d_properties_get_float(payload, "destination_yaw", 0.0f);
+    out_destination->pitch = sdl3d_properties_get_float(payload, "destination_pitch", 0.0f);
+    out_destination->use_yaw = sdl3d_properties_get_bool(payload, "use_yaw", false);
+    out_destination->use_pitch = sdl3d_properties_get_bool(payload, "use_pitch", false);
+    return true;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SDL3D_TEST_SOURCES
     test_timer_pool.cpp
     test_fps_mover.cpp
     test_sprite_actor.cpp
+    test_teleporter.cpp
 )
 
 # Tests that read filesystem fixtures via SDL3D_TEST_ASSETS_DIR are desktop-only.
@@ -206,6 +207,7 @@ else()
     target_sources(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level/backend.c)
     target_include_directories(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level)
     sdl3d_add_test(sdl3d_sprite_actor_test test_sprite_actor.cpp unit)
+    sdl3d_add_test(sdl3d_teleporter_test test_teleporter.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
 

--- a/tests/test_teleporter.cpp
+++ b/tests/test_teleporter.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/fps_mover.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/teleporter.h"
+}
+
+namespace
+{
+struct TeleportCapture
+{
+    int count = 0;
+    int signal_id = 0;
+    int teleporter_id = -1;
+    sdl3d_teleport_destination destination{};
+};
+
+sdl3d_bounding_box make_bounds()
+{
+    return {sdl3d_vec3_make(-1.0f, 0.0f, -1.0f), sdl3d_vec3_make(1.0f, 2.0f, 1.0f)};
+}
+
+sdl3d_teleport_destination make_destination()
+{
+    sdl3d_teleport_destination destination{};
+    destination.position = sdl3d_vec3_make(10.0f, 3.0f, 20.0f);
+    destination.yaw = 1.5f;
+    destination.pitch = -0.25f;
+    destination.use_yaw = true;
+    destination.use_pitch = true;
+    return destination;
+}
+
+void capture_teleport(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    auto *capture = static_cast<TeleportCapture *>(userdata);
+    capture->count++;
+    capture->signal_id = signal_id;
+    capture->teleporter_id = sdl3d_properties_get_int(payload, "teleporter_id", -1);
+    EXPECT_TRUE(sdl3d_teleport_destination_from_payload(payload, &capture->destination));
+}
+} // namespace
+
+TEST(SDL3DTeleporter, InitSetsExpectedDefaults)
+{
+    sdl3d_teleporter teleporter{};
+    sdl3d_teleporter_init(&teleporter, 7, make_bounds(), make_destination());
+
+    EXPECT_TRUE(teleporter.enabled);
+    EXPECT_EQ(SDL3D_SIGNAL_TELEPORT, teleporter.signal_id);
+    EXPECT_EQ(7, teleporter.teleporter_id);
+    EXPECT_GT(teleporter.cooldown_seconds, 0.0f);
+    EXPECT_FALSE(teleporter.was_inside);
+}
+
+TEST(SDL3DTeleporter, EmitsOnceWhenPointEnters)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(nullptr, bus);
+
+    TeleportCapture capture;
+    ASSERT_NE(0, sdl3d_signal_connect(bus, SDL3D_SIGNAL_TELEPORT, capture_teleport, &capture));
+
+    sdl3d_teleporter teleporter{};
+    sdl3d_teleporter_init(&teleporter, 42, make_bounds(), make_destination());
+
+    EXPECT_FALSE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(-2.0f, 1.0f, 0.0f), 0.016f, bus));
+    EXPECT_TRUE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.016f, bus));
+    EXPECT_FALSE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.25f, 1.0f, 0.0f), 0.016f, bus));
+
+    EXPECT_EQ(1, capture.count);
+    EXPECT_EQ(SDL3D_SIGNAL_TELEPORT, capture.signal_id);
+    EXPECT_EQ(42, capture.teleporter_id);
+    EXPECT_FLOAT_EQ(10.0f, capture.destination.position.x);
+    EXPECT_FLOAT_EQ(3.0f, capture.destination.position.y);
+    EXPECT_FLOAT_EQ(20.0f, capture.destination.position.z);
+    EXPECT_FLOAT_EQ(1.5f, capture.destination.yaw);
+    EXPECT_FLOAT_EQ(-0.25f, capture.destination.pitch);
+    EXPECT_TRUE(capture.destination.use_yaw);
+    EXPECT_TRUE(capture.destination.use_pitch);
+
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SDL3DTeleporter, CooldownBlocksImmediateReentry)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(nullptr, bus);
+
+    TeleportCapture capture;
+    ASSERT_NE(0, sdl3d_signal_connect(bus, SDL3D_SIGNAL_TELEPORT, capture_teleport, &capture));
+
+    sdl3d_teleporter teleporter{};
+    sdl3d_teleporter_init(&teleporter, 1, make_bounds(), make_destination());
+    teleporter.cooldown_seconds = 0.5f;
+
+    EXPECT_TRUE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, bus));
+    EXPECT_FALSE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(2.0f, 1.0f, 0.0f), 0.1f, bus));
+    EXPECT_FALSE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.1f, bus));
+    EXPECT_FALSE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(2.0f, 1.0f, 0.0f), 0.3f, bus));
+    EXPECT_TRUE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.2f, bus));
+
+    EXPECT_EQ(2, capture.count);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SDL3DTeleporter, ResetAllowsReemitWithoutLeaving)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(nullptr, bus);
+
+    TeleportCapture capture;
+    ASSERT_NE(0, sdl3d_signal_connect(bus, SDL3D_SIGNAL_TELEPORT, capture_teleport, &capture));
+
+    sdl3d_teleporter teleporter{};
+    sdl3d_teleporter_init(&teleporter, 1, make_bounds(), make_destination());
+    teleporter.cooldown_seconds = 0.0f;
+
+    EXPECT_TRUE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, bus));
+    sdl3d_teleporter_reset(&teleporter);
+    EXPECT_TRUE(sdl3d_teleporter_update(&teleporter, sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, bus));
+
+    EXPECT_EQ(2, capture.count);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(SDL3DTeleporter, PayloadDecodeRejectsMissingDestination)
+{
+    sdl3d_teleport_destination destination{};
+    sdl3d_properties *payload = sdl3d_properties_create();
+    ASSERT_NE(nullptr, payload);
+
+    EXPECT_FALSE(sdl3d_teleport_destination_from_payload(nullptr, &destination));
+    EXPECT_FALSE(sdl3d_teleport_destination_from_payload(payload, nullptr));
+    EXPECT_FALSE(sdl3d_teleport_destination_from_payload(payload, &destination));
+
+    sdl3d_properties_destroy(payload);
+}
+
+TEST(SDL3DFpsMoverTeleport, ResetsMotionStateAndOptionallyFacing)
+{
+    sdl3d_fps_mover_config config{};
+    config.player_height = 1.6f;
+    sdl3d_fps_mover mover{};
+    sdl3d_fps_mover_init(&mover, &config, sdl3d_vec3_make(1.0f, 2.0f, 3.0f), 0.25f);
+
+    mover.pitch = 0.1f;
+    mover.vertical_velocity = 12.0f;
+    mover.view_smooth = -0.5f;
+    mover.current_sector = 4;
+
+    sdl3d_fps_mover_teleport(&mover, sdl3d_vec3_make(10.0f, 3.0f, 20.0f), true, 1.5f, false, 0.8f);
+
+    EXPECT_FLOAT_EQ(10.0f, mover.position.x);
+    EXPECT_FLOAT_EQ(3.0f, mover.position.y);
+    EXPECT_FLOAT_EQ(20.0f, mover.position.z);
+    EXPECT_FLOAT_EQ(1.5f, mover.yaw);
+    EXPECT_FLOAT_EQ(0.1f, mover.pitch);
+    EXPECT_FLOAT_EQ(0.0f, mover.vertical_velocity);
+    EXPECT_FLOAT_EQ(0.0f, mover.view_smooth);
+    EXPECT_FALSE(mover.on_ground);
+    EXPECT_EQ(-1, mover.current_sector);
+}


### PR DESCRIPTION
## Summary
- Add public signal-driven teleporter API with Doxygen docs and payload decoding helpers
- Add FPS mover teleport helper that resets movement recovery state correctly
- Add a dragon-room teleporter in the doom_level demo with source/destination visual feedback

## Verification
- ./scripts/check_clang_format.sh
- cmake --build build/default -j 8
- ./build/default/tests/sdl3d_teleporter_test
- ./build/default/tests/sdl3d_fps_mover_test
- ctest --test-dir build/default --output-on-failure