### PR TITLE
Add sector conveyor belts

### DIFF
--- a/demos/doom_level/level_data.c
+++ b/demos/doom_level/level_data.c
@@ -26,8 +26,8 @@ static const sdl3d_level_material g_mats[] = {
  *      |                               |
  *   [2] Nukage Basin -- [3] East Passage -- [4] Courtyard -- [10] Storage -- [12] Secret Annex
  *      |                                       |
- *   [6] West Alcove                           [5] Exit Room -- [11] Reactor Hall -- [13] Exterior Yard
- *                                                                                 |
+ *   [6] West Alcove                           [5] Exit Room -- [11] Reactor Hall -- [35] Conveyor -- [13] Exterior Yard
+ *                                                                                                  |
  *                                                 [31] Lift Bay -- [32] Lift -- [33] Upper Deck
  */
 static const sdl3d_sector g_base_sectors[] = {
@@ -44,7 +44,7 @@ static const sdl3d_sector g_base_sectors[] = {
     {{{28, 12}, {34, 12}, {34, 24}, {28, 24}}, 4, 0.0f, 4.0f, 0, 1, 2},
     {{{18, 32}, {30, 32}, {30, 44}, {18, 44}}, 4, 0.0f, 5.5f, 5, 1, 4},
     {{{32, 24}, {40, 24}, {40, 30}, {32, 30}}, 4, 0.0f, 3.0f, 0, 1, 2},
-    {{{-2, 44}, {50, 44}, {50, 104}, {-2, 104}}, 4, 0.0f, 12.0f, 5, -1, 2},
+    {{{-2, 58}, {50, 58}, {50, 104}, {-2, 104}}, 4, 0.0f, 12.0f, 5, -1, 2},
     /* Stairwell */
     {{{34, 20}, {40, 20}, {40, 24}, {34, 24}}, 4, 0.0f, 10.0f, 0, -1, 4},
     {{{34, 18}, {40, 18}, {40, 20}, {34, 20}}, 4, 1.0f, 10.0f, 0, -1, 4},
@@ -68,6 +68,20 @@ static const sdl3d_sector g_base_sectors[] = {
     {{{54, 57}, {60, 57}, {60, 69}, {54, 69}}, 4, 2.5f, 12.0f, 5, -1, 2},
     {{{60, 57}, {68, 57}, {68, 69}, {60, 69}}, 4, 0.0f, 12.0f, 0, -1, 4},
     {{{68, 57}, {78, 57}, {78, 69}, {68, 69}}, 4, 2.5f, 12.0f, 5, -1, 2},
+    /* Dragon-room conveyor belt: +X sector push demonstrates reusable currents. */
+    {{{-2, 44}, {8, 44}, {8, 58}, {-2, 58}}, 4, 0.0f, 12.0f, 5, -1, 2},
+    {{{8, 44}, {30, 44}, {30, 58}, {8, 58}},
+     4,
+     0.0f,
+     12.0f,
+     4,
+     -1,
+     2,
+     {0.0f, 0.0f, 0.0f},
+     {0.0f, 0.0f, 0.0f},
+     0,
+     {8.0f, 0.0f, 0.0f}},
+    {{{30, 44}, {50, 44}, {50, 58}, {30, 58}}, 4, 0.0f, 12.0f, 5, -1, 2},
 };
 sdl3d_sector g_sectors[SDL_arraysize(g_base_sectors)];
 const int g_sector_count = (int)SDL_arraysize(g_base_sectors);

--- a/demos/doom_level/level_data.h
+++ b/demos/doom_level/level_data.h
@@ -18,6 +18,7 @@ typedef struct level_data
 #define DOOM_DYNAMIC_LIFT_SECTOR 32
 #define DOOM_AMBIENT_DEMO_SECTOR 33
 #define DOOM_AMBIENT_DEMO_SOUND_ID 1
+#define DOOM_CONVEYOR_SECTOR 35
 
 /* Sector and light arrays are exposed so the player/renderer can query them. */
 extern sdl3d_sector g_sectors[];

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -186,6 +186,16 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     sdl3d_draw_cube(ctx, sdl3d_vec3_make(72.0f, 2.85f, 63.0f), sdl3d_vec3_make(0.8f, 0.7f, 0.8f),
                     teleport_feedback_active ? (sdl3d_color){255, 210, 60, 255} : (sdl3d_color){80, 120, 255, 255});
 
+    /* Conveyor direction marker in the dragon room. */
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(19.0f, 0.04f, 51.0f), sdl3d_vec3_make(21.0f, 0.08f, 12.0f),
+                    (sdl3d_color){30, 35, 40, 255});
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(19.0f, 0.12f, 51.0f), sdl3d_vec3_make(13.0f, 0.08f, 0.8f),
+                    (sdl3d_color){70, 210, 230, 255});
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(26.0f, 0.13f, 49.4f), sdl3d_vec3_make(3.0f, 0.1f, 0.8f),
+                    (sdl3d_color){70, 210, 230, 255});
+    sdl3d_draw_cube(ctx, sdl3d_vec3_make(26.0f, 0.13f, 52.6f), sdl3d_vec3_make(3.0f, 0.1f, 0.8f),
+                    (sdl3d_color){70, 210, 230, 255});
+
     /* Sprites */
     {
         for (int i = 0; i < ent->sprites.count; ++i)

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -57,9 +57,10 @@ extern "C"
         int floor_material; /* index into material palette, or -1 to omit floor geometry */
         int ceil_material;  /* index into material palette, or -1 to omit ceiling geometry */
         int wall_material;
-        float floor_normal[3]; /**< Floor plane normal. Zero defaults to (0, 1, 0). */
-        float ceil_normal[3];  /**< Ceiling plane normal. Zero defaults to (0, -1, 0). */
-        int ambient_sound_id;  /**< Ambient zone id. Zero means no ambient zone. */
+        float floor_normal[3];  /**< Floor plane normal. Zero defaults to (0, 1, 0). */
+        float ceil_normal[3];   /**< Ceiling plane normal. Zero defaults to (0, -1, 0). */
+        int ambient_sound_id;   /**< Ambient zone id. Zero means no ambient zone. */
+        float push_velocity[3]; /**< World-space sector velocity in units per second. */
     } sdl3d_sector;
 
     /**
@@ -201,6 +202,16 @@ extern "C"
      * with normal (0, -1, 0). Safe with NULL.
      */
     sdl3d_vec3 sdl3d_sector_ceil_normal(const sdl3d_sector *sector);
+
+    /**
+     * @brief Return the sector's world-space push/current velocity.
+     *
+     * This velocity is authored in world units per second. Movement systems
+     * can add it to their own velocity before collision resolution to create
+     * conveyor belts, water currents, wind tunnels, or similar sector-local
+     * forces. Safe with NULL, which returns (0, 0, 0).
+     */
+    sdl3d_vec3 sdl3d_sector_push_velocity(const sdl3d_sector *sector);
 
     /**
      * @brief Evaluate the sector floor plane height at a world XZ point.

--- a/src/fps_mover.c
+++ b/src/fps_mover.c
@@ -263,6 +263,12 @@ static sdl3d_vec2 project_wish_to_walkable_floor(sdl3d_vec2 wish_dir, const sdl3
     return projected;
 }
 
+static sdl3d_vec2 sector_push_velocity_xz(const sdl3d_sector *sector)
+{
+    sdl3d_vec3 push = sdl3d_sector_push_velocity(sector);
+    return (sdl3d_vec2){push.x, push.z};
+}
+
 static bool try_horizontal_move(sdl3d_fps_mover *mover, const sdl3d_level *level, const sdl3d_sector *sectors,
                                 float feet_y, bool grounded, float move_x, float move_z, int *out_sector)
 {
@@ -452,27 +458,39 @@ void sdl3d_fps_mover_update(sdl3d_fps_mover *mover, const sdl3d_level *level, co
             current_floor = sdl3d_sector_floor_at(&sectors[current_sector], mover->position.x, mover->position.z);
         }
 
+        sdl3d_vec2 sector_push = {0.0f, 0.0f};
+        if (current_sector >= 0)
+        {
+            sector_push = sector_push_velocity_xz(&sectors[current_sector]);
+        }
+
         float wish_len = SDL_sqrtf(wish_dir.x * wish_dir.x + wish_dir.y * wish_dir.y);
         if (wish_len > 1.0f)
         {
             wish_dir.x /= wish_len;
             wish_dir.y /= wish_len;
+            wish_len = 1.0f;
         }
 
+        float input_velocity_x = 0.0f;
+        float input_velocity_z = 0.0f;
         if (wish_len > 0.001f)
         {
             if (mover->on_ground && current_sector >= 0 && sector_floor_is_walkable(&sectors[current_sector]))
             {
                 wish_dir = project_wish_to_walkable_floor(wish_dir, &sectors[current_sector]);
             }
-            float move_x = wish_dir.x * mover->config.move_speed * dt;
-            float move_z = wish_dir.y * mover->config.move_speed * dt;
-            int candidate = -1;
+            input_velocity_x = wish_dir.x * mover->config.move_speed;
+            input_velocity_z = wish_dir.y * mover->config.move_speed;
+        }
 
+        float move_x = (input_velocity_x + sector_push.x) * dt;
+        float move_z = (input_velocity_z + sector_push.y) * dt;
+        if (move_x * move_x + move_z * move_z > SDL3D_FPS_COLLISION_EPSILON)
+        {
+            int candidate = -1;
             if (try_horizontal_move(mover, level, sectors, feet_y, mover->on_ground, move_x, move_z, &candidate))
-            {
                 current_sector = candidate;
-            }
         }
 
         /* Step-up onto a higher floor when on solid ground. */

--- a/src/level.c
+++ b/src/level.c
@@ -88,6 +88,15 @@ sdl3d_vec3 sdl3d_sector_ceil_normal(const sdl3d_sector *sector)
                           : sdl3d_vec3_make(0.0f, -1.0f, 0.0f);
 }
 
+sdl3d_vec3 sdl3d_sector_push_velocity(const sdl3d_sector *sector)
+{
+    if (sector == NULL)
+    {
+        return sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    }
+    return sdl3d_vec3_make(sector->push_velocity[0], sector->push_velocity[1], sector->push_velocity[2]);
+}
+
 static void sector_centroid_xz(const sdl3d_sector *sector, float *out_x, float *out_z)
 {
     float x = 0.0f;

--- a/tests/test_fps_mover.cpp
+++ b/tests/test_fps_mover.cpp
@@ -118,6 +118,16 @@ class FpsMoverFixture : public ::testing::Test
             << SDL_GetError();
     }
 
+    void BuildConveyor(float push_x, float push_z)
+    {
+        sectors = {MakeSquareSector(-50, -10, 50, 10, 0.0f, 5.0f)};
+        sectors[0].push_velocity[0] = push_x;
+        sectors[0].push_velocity[2] = push_z;
+        const sdl3d_level_material mats[] = {MakeMaterial(), MakeMaterial(), MakeMaterial()};
+        ASSERT_TRUE(sdl3d_build_level(sectors.data(), (int)sectors.size(), mats, 3, nullptr, 0, &level))
+            << SDL_GetError();
+    }
+
     void TearDown() override
     {
         sdl3d_free_level(&level);
@@ -214,6 +224,51 @@ TEST_F(FpsMoverFixture, WishDirectionAdvancesPosition)
     EXPECT_GT(m.position.x, 5.0f);
     EXPECT_LT(m.position.x, 13.0f);
     EXPECT_NEAR(m.position.z, 0.0f, 0.01f);
+}
+
+TEST_F(FpsMoverFixture, SectorPushVelocityMovesPlayerWithoutInput)
+{
+    BuildConveyor(8.0f, 0.0f);
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_fps_mover m;
+    sdl3d_fps_mover_init(&m, &cfg, sdl3d_vec3_make(0.0f, cfg.player_height, 0.0f), 0);
+
+    sdl3d_vec2 zero{0.0f, 0.0f};
+    for (int i = 0; i < 60; ++i)
+    {
+        sdl3d_fps_mover_update(&m, &level, sectors.data(), zero, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+
+    EXPECT_GT(m.position.x, 7.5f);
+    EXPECT_LT(m.position.x, 8.5f);
+    EXPECT_NEAR(m.position.z, 0.0f, 0.01f);
+    EXPECT_TRUE(m.on_ground);
+}
+
+TEST_F(FpsMoverFixture, SectorPushVelocityCombinesWithInput)
+{
+    BuildConveyor(8.0f, 0.0f);
+    sdl3d_fps_mover_config cfg = DefaultConfig();
+    sdl3d_vec2 with_conveyor{1.0f, 0.0f};
+    sdl3d_vec2 against_conveyor{-1.0f, 0.0f};
+
+    sdl3d_fps_mover with;
+    sdl3d_fps_mover_init(&with, &cfg, sdl3d_vec3_make(0.0f, cfg.player_height, 0.0f), 0);
+    for (int i = 0; i < 60; ++i)
+    {
+        sdl3d_fps_mover_update(&with, &level, sectors.data(), with_conveyor, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+
+    sdl3d_fps_mover against;
+    sdl3d_fps_mover_init(&against, &cfg, sdl3d_vec3_make(0.0f, cfg.player_height, 0.0f), 0);
+    for (int i = 0; i < 60; ++i)
+    {
+        sdl3d_fps_mover_update(&against, &level, sectors.data(), against_conveyor, 0, 0, 0.002f, 1.0f / 60.0f);
+    }
+
+    EXPECT_GT(with.position.x, 19.0f);
+    EXPECT_LT(against.position.x, -3.0f);
+    EXPECT_LT(SDL_fabsf(against.position.x), with.position.x * 0.5f);
 }
 
 TEST_F(FpsMoverFixture, SolidWallMaintainsPlayerRadius)

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -104,6 +104,24 @@ TestVec3 Normalize(TestVec3 v)
 
 } // namespace
 
+TEST(SDL3DSectorMetadata, PushVelocityReturnsAuthoredVectorAndNullZero)
+{
+    sdl3d_sector sector = MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f);
+    sector.push_velocity[0] = 1.25f;
+    sector.push_velocity[1] = -0.5f;
+    sector.push_velocity[2] = 3.0f;
+
+    sdl3d_vec3 velocity = sdl3d_sector_push_velocity(&sector);
+    EXPECT_FLOAT_EQ(velocity.x, 1.25f);
+    EXPECT_FLOAT_EQ(velocity.y, -0.5f);
+    EXPECT_FLOAT_EQ(velocity.z, 3.0f);
+
+    sdl3d_vec3 zero = sdl3d_sector_push_velocity(nullptr);
+    EXPECT_FLOAT_EQ(zero.x, 0.0f);
+    EXPECT_FLOAT_EQ(zero.y, 0.0f);
+    EXPECT_FLOAT_EQ(zero.z, 0.0f);
+}
+
 TEST(SDL3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),


### PR DESCRIPTION
## Summary
- add public sector push velocity metadata and helper for conveyor/current-style movement
- apply sector push velocity in the FPS mover before collision resolution so conveyors combine with player input
- add a visible conveyor sector in the doom_level dragon room and tests for sector metadata plus mover behavior

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/default --target sdl3d_fps_mover_test sdl3d_level_test doom_level
- ./build/default/tests/sdl3d_fps_mover_test && ./build/default/tests/sdl3d_level_test
- cmake --build build/default
- ctest --test-dir build/default --output-on-failure