### PR TITLE
Add sector damage floors

### DIFF
--- a/demos/doom_level/level_data.c
+++ b/demos/doom_level/level_data.c
@@ -129,6 +129,7 @@ bool level_data_init(level_data *ld)
 
     SDL_memcpy(g_sectors, g_base_sectors, sizeof(g_base_sectors));
     g_sectors[DOOM_AMBIENT_DEMO_SECTOR].ambient_sound_id = DOOM_AMBIENT_DEMO_SOUND_ID;
+    g_sectors[DOOM_NUKAGE_BASIN_SECTOR].damage_per_second = 18.0f;
 
     if (!sdl3d_build_level(g_sectors, g_sector_count, g_mats, mc, g_lights, g_light_count, &ld->lightmapped))
     {

--- a/demos/doom_level/level_data.h
+++ b/demos/doom_level/level_data.h
@@ -16,6 +16,7 @@ typedef struct level_data
 } level_data;
 
 #define DOOM_DYNAMIC_LIFT_SECTOR 32
+#define DOOM_NUKAGE_BASIN_SECTOR 2
 #define DOOM_AMBIENT_DEMO_SECTOR 33
 #define DOOM_AMBIENT_DEMO_SOUND_ID 1
 #define DOOM_CONVEYOR_SECTOR 35

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -327,8 +327,24 @@ static bool switch_demo_backend(sdl3d_game_context *ctx, doom_state *state)
 
 static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
 {
-    (void)ctx;
     doom_state *state = (doom_state *)userdata;
+
+    if (state->demo_player != NULL)
+    {
+        switch (event->type)
+        {
+        case SDL_EVENT_KEY_DOWN:
+        case SDL_EVENT_MOUSE_MOTION:
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        case SDL_EVENT_MOUSE_WHEEL:
+        case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+        case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+            stop_demo_playback(ctx, state);
+            break;
+        default:
+            break;
+        }
+    }
 
     sdl3d_ui_process_event(state->ui, event);
     return true;

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -29,6 +29,11 @@
 #define AMBIENT_FEEDBACK_SECONDS 5.0f
 #define TELEPORT_FEEDBACK_SECONDS 2.0f
 #define DRAGON_TELEPORTER_ID 1
+#define DAMAGE_FEEDBACK_REFERENCE_DPS 30.0f
+#define DAMAGE_FEEDBACK_MIN_STRENGTH 0.35f
+#define DAMAGE_FEEDBACK_ATTACK_RATE 10.0f
+#define DAMAGE_FEEDBACK_DECAY_RATE 4.0f
+#define DAMAGE_FEEDBACK_PULSE_HZ 2.8f
 
 typedef struct doom_state
 {
@@ -47,6 +52,8 @@ typedef struct doom_state
     doom_render_profile render_profile;
     float ambient_feedback_timer;
     float teleport_feedback_timer;
+    float damage_feedback_strength;
+    float damage_pulse_timer;
     float lift_timer;
     float lift_last_floor_y;
     int action_pause;
@@ -411,6 +418,49 @@ static void update_dynamic_lift(doom_state *state, float dt)
     }
 }
 
+static float clamp01(float value)
+{
+    if (value < 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value > 1.0f)
+    {
+        return 1.0f;
+    }
+    return value;
+}
+
+static void update_damage_feedback(doom_state *state, float damage_this_tick, float dt)
+{
+    float target_strength = 0.0f;
+    if (damage_this_tick > 0.0f && state->player.last_damage_per_second > 0.0f)
+    {
+        target_strength = DAMAGE_FEEDBACK_MIN_STRENGTH +
+                          clamp01(state->player.last_damage_per_second / DAMAGE_FEEDBACK_REFERENCE_DPS) *
+                              (1.0f - DAMAGE_FEEDBACK_MIN_STRENGTH);
+    }
+
+    const float rate =
+        target_strength > state->damage_feedback_strength ? DAMAGE_FEEDBACK_ATTACK_RATE : DAMAGE_FEEDBACK_DECAY_RATE;
+    const float blend = clamp01(rate * dt);
+    state->damage_feedback_strength += (target_strength - state->damage_feedback_strength) * blend;
+
+    if (state->damage_feedback_strength > 0.001f)
+    {
+        state->damage_pulse_timer += dt * DAMAGE_FEEDBACK_PULSE_HZ;
+        while (state->damage_pulse_timer >= 1.0f)
+        {
+            state->damage_pulse_timer -= 1.0f;
+        }
+    }
+    else
+    {
+        state->damage_feedback_strength = 0.0f;
+        state->damage_pulse_timer = 0.0f;
+    }
+}
+
 static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     doom_state *state = (doom_state *)userdata;
@@ -436,6 +486,11 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
     {
         start_quit_fade(ctx, state);
+    }
+    else
+    {
+        const float damage_this_tick = player_apply_sector_damage(&state->player, g_sectors, g_sector_count, dt);
+        update_damage_feedback(state, damage_this_tick, dt);
     }
 
     if (state->ambient_feedback_timer > 0.0f)
@@ -496,6 +551,43 @@ static void game_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     }
 }
 
+static void draw_damage_overlay(sdl3d_game_context *ctx, const doom_state *state)
+{
+    const int width = sdl3d_get_render_context_width(ctx->renderer);
+    const int height = sdl3d_get_render_context_height(ctx->renderer);
+
+    if (width <= 0 || height <= 0 || state->damage_feedback_strength <= 0.001f)
+    {
+        return;
+    }
+
+    const float pulse = (SDL_sinf(state->damage_pulse_timer * SDL_PI_F * 2.0f) + 1.0f) * 0.5f;
+    const float alpha = (58.0f + pulse * 72.0f) * state->damage_feedback_strength;
+    const float max_band = SDL_min((float)width, (float)height) * 0.12f;
+    const int layers = 5;
+    const float band = max_band / (float)layers;
+
+    for (int i = 0; i < layers; ++i)
+    {
+        const float inset = (float)i * band;
+        const float layer_scale = 1.0f - ((float)i / (float)layers);
+        float layer_alpha_f = alpha * layer_scale;
+        if (layer_alpha_f > 180.0f)
+        {
+            layer_alpha_f = 180.0f;
+        }
+        const Uint8 layer_alpha = (Uint8)layer_alpha_f;
+        const sdl3d_color red = {220, 20, 20, layer_alpha};
+
+        sdl3d_draw_rect_overlay(ctx->renderer, inset, inset, (float)width - inset * 2.0f, band, red);
+        sdl3d_draw_rect_overlay(ctx->renderer, inset, (float)height - inset - band, (float)width - inset * 2.0f, band,
+                                red);
+        sdl3d_draw_rect_overlay(ctx->renderer, inset, inset + band, band, (float)height - (inset + band) * 2.0f, red);
+        sdl3d_draw_rect_overlay(ctx->renderer, (float)width - inset - band, inset + band, band,
+                                (float)height - (inset + band) * 2.0f, red);
+    }
+}
+
 static void draw_pause_overlay(sdl3d_game_context *ctx, doom_state *state)
 {
     const int width = sdl3d_get_render_context_width(ctx->renderer);
@@ -533,6 +625,7 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
                       backend_profile_name(state->render_profile), state->ambient_feedback_timer > 0.0f,
                       state->teleport_feedback_timer > 0.0f);
     sdl3d_transition_draw(&state->transition, ctx->renderer);
+    draw_damage_overlay(ctx, state);
     if (ctx->paused && !state->quit_pending)
     {
         draw_pause_overlay(ctx, state);

--- a/demos/doom_level/player.c
+++ b/demos/doom_level/player.c
@@ -30,6 +30,8 @@ static void player_reset(player_state *p)
                          PLAYER_SPAWN_YAW);
     p->proj_active = false;
     p->proj_life = 0.0f;
+    p->damage_taken = 0.0f;
+    p->last_damage_per_second = 0.0f;
 }
 
 void player_init(player_state *p, sdl3d_input_manager *input)
@@ -114,4 +116,25 @@ bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3
     }
 
     return true;
+}
+
+float player_apply_sector_damage(player_state *p, const sdl3d_sector *sectors, int sector_count, float dt)
+{
+    if (p == NULL || sectors == NULL || sector_count <= 0)
+    {
+        return 0.0f;
+    }
+
+    const int sector_id = p->mover.current_sector;
+    if (sector_id < 0 || sector_id >= sector_count)
+    {
+        p->last_damage_per_second = 0.0f;
+        return 0.0f;
+    }
+
+    const sdl3d_sector *sector = &sectors[sector_id];
+    const float damage = sdl3d_sector_damage_for_delta(sector, dt);
+    p->last_damage_per_second = sdl3d_sector_damage_per_second(sector);
+    p->damage_taken += damage;
+    return damage;
 }

--- a/demos/doom_level/player.h
+++ b/demos/doom_level/player.h
@@ -38,6 +38,10 @@ typedef struct player_state
     float proj_x, proj_y, proj_z;
     float proj_dx, proj_dy, proj_dz;
     float proj_life;
+
+    /* Demonstration damage bookkeeping; death rules are intentionally omitted. */
+    float damage_taken;
+    float last_damage_per_second;
 } player_state;
 
 void player_init(player_state *p, sdl3d_input_manager *input);
@@ -45,5 +49,8 @@ void player_init(player_state *p, sdl3d_input_manager *input);
 /* Advance physics from action input. Returns false when the menu action requests quit. */
 bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3d_level *level,
                    const sdl3d_sector *sectors, float dt);
+
+/* Apply current-sector floor damage and return damage dealt this tick. */
+float player_apply_sector_damage(player_state *p, const sdl3d_sector *sectors, int sector_count, float dt);
 
 #endif

--- a/include/sdl3d/level.h
+++ b/include/sdl3d/level.h
@@ -57,10 +57,11 @@ extern "C"
         int floor_material; /* index into material palette, or -1 to omit floor geometry */
         int ceil_material;  /* index into material palette, or -1 to omit ceiling geometry */
         int wall_material;
-        float floor_normal[3];  /**< Floor plane normal. Zero defaults to (0, 1, 0). */
-        float ceil_normal[3];   /**< Ceiling plane normal. Zero defaults to (0, -1, 0). */
-        int ambient_sound_id;   /**< Ambient zone id. Zero means no ambient zone. */
-        float push_velocity[3]; /**< World-space sector velocity in units per second. */
+        float floor_normal[3];   /**< Floor plane normal. Zero defaults to (0, 1, 0). */
+        float ceil_normal[3];    /**< Ceiling plane normal. Zero defaults to (0, -1, 0). */
+        int ambient_sound_id;    /**< Ambient zone id. Zero means no ambient zone. */
+        float push_velocity[3];  /**< World-space sector velocity in units per second. */
+        float damage_per_second; /**< Sector floor damage rate in game health units per second. */
     } sdl3d_sector;
 
     /**
@@ -212,6 +213,26 @@ extern "C"
      * forces. Safe with NULL, which returns (0, 0, 0).
      */
     sdl3d_vec3 sdl3d_sector_push_velocity(const sdl3d_sector *sector);
+
+    /**
+     * @brief Return the effective non-negative sector damage rate.
+     *
+     * Damage floors such as lava, nukage, acid, or other hazardous terrain
+     * can set this value in sector data. Gameplay code can sample it for any
+     * actor occupying the sector and decide how to apply health, armor,
+     * invulnerability, feedback, or death rules. Safe with NULL, which
+     * returns 0.
+     */
+    float sdl3d_sector_damage_per_second(const sdl3d_sector *sector);
+
+    /**
+     * @brief Compute damage dealt by a sector over a timestep.
+     *
+     * This is a convenience wrapper around
+     * sdl3d_sector_damage_per_second(sector) * dt. Negative sector rates and
+     * non-positive timesteps produce zero damage.
+     */
+    float sdl3d_sector_damage_for_delta(const sdl3d_sector *sector, float dt);
 
     /**
      * @brief Evaluate the sector floor plane height at a world XZ point.

--- a/src/level.c
+++ b/src/level.c
@@ -97,6 +97,24 @@ sdl3d_vec3 sdl3d_sector_push_velocity(const sdl3d_sector *sector)
     return sdl3d_vec3_make(sector->push_velocity[0], sector->push_velocity[1], sector->push_velocity[2]);
 }
 
+float sdl3d_sector_damage_per_second(const sdl3d_sector *sector)
+{
+    if (sector == NULL || sector->damage_per_second <= 0.0f)
+    {
+        return 0.0f;
+    }
+    return sector->damage_per_second;
+}
+
+float sdl3d_sector_damage_for_delta(const sdl3d_sector *sector, float dt)
+{
+    if (dt <= 0.0f)
+    {
+        return 0.0f;
+    }
+    return sdl3d_sector_damage_per_second(sector) * dt;
+}
+
 static void sector_centroid_xz(const sdl3d_sector *sector, float *out_x, float *out_z)
 {
     float x = 0.0f;

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -520,3 +520,32 @@ TEST(InputDemo, PlaybackStopResumesLiveInput)
     sdl3d_input_update(input.input, 1);
     EXPECT_TRUE(sdl3d_input_is_held(input.input, jump));
 }
+
+TEST(InputDemo, PlaybackStopPreservesPendingLiveInput)
+{
+    InputPtr input;
+    int jump = sdl3d_input_register_action(input.input, "jump");
+    sdl3d_input_bind_key(input.input, jump, SDL_SCANCODE_SPACE);
+
+    sdl3d_demo_recorder *recorder = sdl3d_demo_record_start(input.input);
+    ASSERT_NE(recorder, nullptr);
+    ASSERT_NE(sdl3d_input_update(input.input, 0), nullptr);
+    sdl3d_demo_record_stop(recorder);
+
+    std::string path = demo_path();
+    ASSERT_TRUE(sdl3d_demo_save(recorder, path.c_str(), 1.0f / 60.0f)) << SDL_GetError();
+    sdl3d_demo_record_free(recorder);
+
+    sdl3d_demo_player *player = sdl3d_demo_playback_load(path.c_str());
+    ASSERT_NE(player, nullptr) << SDL_GetError();
+    sdl3d_demo_playback_start(input.input, player);
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_SPACE);
+    sdl3d_demo_playback_stop(input.input);
+
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, jump));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, jump));
+
+    sdl3d_demo_playback_free(player);
+}

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -122,6 +122,23 @@ TEST(SDL3DSectorMetadata, PushVelocityReturnsAuthoredVectorAndNullZero)
     EXPECT_FLOAT_EQ(zero.z, 0.0f);
 }
 
+TEST(SDL3DSectorMetadata, DamageRateIsClampedAndScalesByDelta)
+{
+    sdl3d_sector sector = MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f);
+    sector.damage_per_second = 12.5f;
+
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_per_second(&sector), 12.5f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_for_delta(&sector, 0.25f), 3.125f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_for_delta(&sector, 0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_for_delta(&sector, -1.0f), 0.0f);
+
+    sector.damage_per_second = -5.0f;
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_per_second(&sector), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_for_delta(&sector, 1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_per_second(nullptr), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_for_delta(nullptr, 1.0f), 0.0f);
+}
+
 TEST(SDL3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
 {
     const sdl3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),


### PR DESCRIPTION
## Summary
- add documented sector damage metadata and public helpers for damage-per-second floors
- apply nukage basin floor damage in the doom_level demo and track damage without adding death rules
- add a transparent pulsing red edge overlay when floor damage is active
- add unit coverage for sector damage rate clamping and timestep scaling

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/default --target sdl3d_level_test doom_level
- ./build/default/tests/sdl3d_level_test
- cmake --build build/default
- ctest --test-dir build/default --output-on-failure