### PR TITLE
Add nukage hazard particle effects

### DIFF
--- a/demos/doom_level/CMakeLists.txt
+++ b/demos/doom_level/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(doom_level
     main.c
     backend.c
     entities.c
+    hazard_effects.c
     level_data.c
     player.c
     renderer.c)

--- a/demos/doom_level/hazard_effects.c
+++ b/demos/doom_level/hazard_effects.c
@@ -206,17 +206,19 @@ static void pulse_nukage_emitter(sdl3d_particle_emitter *emitter, float pulse, b
         return;
     }
 
+    const float opacity = pulse * pulse;
     sdl3d_particle_config next = *current;
     if (mote)
     {
-        next.color_start = (sdl3d_color){(Uint8)(55.0f + pulse * 55.0f), 255, (Uint8)(45.0f + pulse * 45.0f),
-                                         (Uint8)(175.0f + pulse * 65.0f)};
+        const Uint8 alpha = (Uint8)(70.0f + opacity * 170.0f);
+        next.color_start = (sdl3d_color){(Uint8)(55.0f + pulse * 55.0f), 255, (Uint8)(45.0f + pulse * 45.0f), alpha};
         next.color_end = (sdl3d_color){0, (Uint8)(180.0f + pulse * 55.0f), 45, 0};
     }
     else
     {
+        const Uint8 alpha = (Uint8)(42.0f + opacity * 145.0f);
         next.color_start = (sdl3d_color){(Uint8)(15.0f + pulse * 40.0f), (Uint8)(215.0f + pulse * 40.0f),
-                                         (Uint8)(35.0f + pulse * 45.0f), (Uint8)(110.0f + pulse * 65.0f)};
+                                         (Uint8)(35.0f + pulse * 45.0f), alpha};
         next.color_end = (sdl3d_color){0, (Uint8)(150.0f + pulse * 55.0f), 45, 0};
     }
 

--- a/demos/doom_level/hazard_effects.c
+++ b/demos/doom_level/hazard_effects.c
@@ -13,7 +13,7 @@
 #define SOFT_PARTICLE_SIZE 32
 #define NUKAGE_VAPOR_MAX_PARTICLES 560
 #define NUKAGE_MOTE_MAX_PARTICLES 120
-#define NUKAGE_PULSE_HZ 1.4f
+#define NUKAGE_PULSE_HZ 3.2f
 
 static float clamp01(float value)
 {
@@ -210,13 +210,13 @@ static void pulse_nukage_emitter(sdl3d_particle_emitter *emitter, float pulse, b
     sdl3d_particle_config next = *current;
     if (mote)
     {
-        const Uint8 alpha = (Uint8)(70.0f + opacity * 170.0f);
+        const Uint8 alpha = (Uint8)(35.0f + opacity * 210.0f);
         next.color_start = (sdl3d_color){(Uint8)(55.0f + pulse * 55.0f), 255, (Uint8)(45.0f + pulse * 45.0f), alpha};
         next.color_end = (sdl3d_color){0, (Uint8)(180.0f + pulse * 55.0f), 45, 0};
     }
     else
     {
-        const Uint8 alpha = (Uint8)(42.0f + opacity * 145.0f);
+        const Uint8 alpha = (Uint8)(18.0f + opacity * 205.0f);
         next.color_start = (sdl3d_color){(Uint8)(15.0f + pulse * 40.0f), (Uint8)(215.0f + pulse * 40.0f),
                                          (Uint8)(35.0f + pulse * 45.0f), alpha};
         next.color_end = (sdl3d_color){0, (Uint8)(150.0f + pulse * 55.0f), 45, 0};

--- a/demos/doom_level/hazard_effects.c
+++ b/demos/doom_level/hazard_effects.c
@@ -11,8 +11,9 @@
 #include "level_data.h"
 
 #define SOFT_PARTICLE_SIZE 32
-#define NUKAGE_VAPOR_MAX_PARTICLES 900
-#define NUKAGE_MOTE_MAX_PARTICLES 220
+#define NUKAGE_VAPOR_MAX_PARTICLES 560
+#define NUKAGE_MOTE_MAX_PARTICLES 120
+#define NUKAGE_PULSE_HZ 1.4f
 
 static float clamp01(float value)
 {
@@ -50,9 +51,9 @@ static bool create_soft_particle_texture(sdl3d_texture2d *out_texture)
             const float core = falloff * falloff;
             Uint8 *pixel = &image.pixels[((y * image.width) + x) * 4];
 
-            pixel[0] = (Uint8)(190.0f + core * 65.0f);
+            pixel[0] = (Uint8)(70.0f + core * 80.0f);
             pixel[1] = 255;
-            pixel[2] = (Uint8)(35.0f + core * 95.0f);
+            pixel[2] = (Uint8)(35.0f + core * 65.0f);
             pixel[3] = dist <= 1.0f ? (Uint8)(core * 255.0f + 0.5f) : 0;
         }
     }
@@ -136,23 +137,22 @@ bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_le
 
     sdl3d_particle_config vapor;
     SDL_zero(vapor);
-    vapor.position = sdl3d_vec3_make(center_x, floor_y + 0.18f, center_z);
-    vapor.direction = sdl3d_vec3_make(0.08f, 1.0f, -0.04f);
-    vapor.spread = 1.25f;
-    vapor.speed_min = 0.18f;
-    vapor.speed_max = 0.75f;
-    vapor.lifetime_min = 1.4f;
-    vapor.lifetime_max = 3.0f;
-    vapor.size_start = 0.10f;
-    vapor.size_end = 0.32f;
-    vapor.color_start = (sdl3d_color){120, 255, 40, 210};
-    vapor.color_end = (sdl3d_color){25, 210, 70, 0};
-    vapor.gravity = -0.08f;
+    vapor.position = sdl3d_vec3_make(center_x, floor_y + 0.14f, center_z);
+    vapor.direction = sdl3d_vec3_make(0.04f, 1.0f, -0.03f);
+    vapor.spread = 1.15f;
+    vapor.speed_min = 0.35f;
+    vapor.speed_max = 1.05f;
+    vapor.lifetime_min = 2.4f;
+    vapor.lifetime_max = 4.6f;
+    vapor.size_start = 0.045f;
+    vapor.size_end = 0.16f;
+    vapor.color_start = (sdl3d_color){35, 245, 45, 155};
+    vapor.color_end = (sdl3d_color){0, 185, 55, 0};
+    vapor.gravity = -0.16f;
     vapor.max_particles = NUKAGE_VAPOR_MAX_PARTICLES;
-    vapor.emit_rate = 260.0f;
+    vapor.emit_rate = 150.0f;
     vapor.shape = SDL3D_PARTICLE_EMITTER_BOX;
     vapor.extents = sdl3d_vec3_make(half_x * 0.88f, 0.05f, half_z * 0.88f);
-    vapor.emissive_intensity = 1.1f;
     vapor.camera_facing = true;
     vapor.depth_test = true;
     vapor.additive_blend = true;
@@ -167,23 +167,22 @@ bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_le
 
     sdl3d_particle_config motes;
     SDL_zero(motes);
-    motes.position = sdl3d_vec3_make(center_x, floor_y + 0.28f, center_z);
-    motes.direction = sdl3d_vec3_make(-0.05f, 1.0f, 0.1f);
-    motes.spread = 1.8f;
-    motes.speed_min = 0.45f;
-    motes.speed_max = 1.8f;
-    motes.lifetime_min = 0.45f;
-    motes.lifetime_max = 1.2f;
-    motes.size_start = 0.055f;
-    motes.size_end = 0.015f;
-    motes.color_start = (sdl3d_color){245, 255, 80, 255};
-    motes.color_end = (sdl3d_color){80, 255, 50, 0};
-    motes.gravity = 0.04f;
+    motes.position = sdl3d_vec3_make(center_x, floor_y + 0.22f, center_z);
+    motes.direction = sdl3d_vec3_make(-0.04f, 1.0f, 0.08f);
+    motes.spread = 1.65f;
+    motes.speed_min = 0.8f;
+    motes.speed_max = 2.2f;
+    motes.lifetime_min = 0.9f;
+    motes.lifetime_max = 1.8f;
+    motes.size_start = 0.026f;
+    motes.size_end = 0.008f;
+    motes.color_start = (sdl3d_color){95, 255, 55, 230};
+    motes.color_end = (sdl3d_color){10, 230, 45, 0};
+    motes.gravity = -0.08f;
     motes.max_particles = NUKAGE_MOTE_MAX_PARTICLES;
-    motes.emit_rate = 80.0f;
+    motes.emit_rate = 38.0f;
     motes.shape = SDL3D_PARTICLE_EMITTER_BOX;
     motes.extents = sdl3d_vec3_make(half_x * 0.82f, 0.05f, half_z * 0.82f);
-    motes.emissive_intensity = 2.2f;
     motes.camera_facing = true;
     motes.depth_test = true;
     motes.additive_blend = true;
@@ -197,6 +196,35 @@ bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_le
     }
 
     return true;
+}
+
+static void pulse_nukage_emitter(sdl3d_particle_emitter *emitter, float pulse, bool mote)
+{
+    const sdl3d_particle_config *current = sdl3d_particle_emitter_get_config(emitter);
+    if (current == NULL)
+    {
+        return;
+    }
+
+    sdl3d_particle_config next = *current;
+    if (mote)
+    {
+        next.color_start = (sdl3d_color){(Uint8)(55.0f + pulse * 55.0f), 255, (Uint8)(45.0f + pulse * 45.0f),
+                                         (Uint8)(175.0f + pulse * 65.0f)};
+        next.color_end = (sdl3d_color){0, (Uint8)(180.0f + pulse * 55.0f), 45, 0};
+    }
+    else
+    {
+        next.color_start = (sdl3d_color){(Uint8)(15.0f + pulse * 40.0f), (Uint8)(215.0f + pulse * 40.0f),
+                                         (Uint8)(35.0f + pulse * 45.0f), (Uint8)(110.0f + pulse * 65.0f)};
+        next.color_end = (sdl3d_color){0, (Uint8)(150.0f + pulse * 55.0f), 45, 0};
+    }
+
+    if (!sdl3d_particle_emitter_set_config(emitter, &next))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Nukage particle pulse update failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
 }
 
 void doom_hazard_particles_free(doom_hazard_particles *particles)
@@ -218,6 +246,16 @@ void doom_hazard_particles_update(doom_hazard_particles *particles, float dt)
     {
         return;
     }
+
+    particles->pulse_timer += dt * NUKAGE_PULSE_HZ;
+    while (particles->pulse_timer >= 1.0f)
+    {
+        particles->pulse_timer -= 1.0f;
+    }
+
+    const float pulse = 0.5f + 0.5f * SDL_sinf(particles->pulse_timer * SDL_PI_F * 2.0f);
+    pulse_nukage_emitter(particles->nukage_vapor, pulse, false);
+    pulse_nukage_emitter(particles->nukage_motes, pulse, true);
 
     sdl3d_particle_emitter_update(particles->nukage_vapor, dt);
     sdl3d_particle_emitter_update(particles->nukage_motes, dt);

--- a/demos/doom_level/hazard_effects.c
+++ b/demos/doom_level/hazard_effects.c
@@ -1,0 +1,235 @@
+/* Hazard particle effects for the doom_level demo. */
+#include "hazard_effects.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/image.h"
+#include "sdl3d/math.h"
+
+#include "level_data.h"
+
+#define SOFT_PARTICLE_SIZE 32
+#define NUKAGE_VAPOR_MAX_PARTICLES 900
+#define NUKAGE_MOTE_MAX_PARTICLES 220
+
+static float clamp01(float value)
+{
+    if (value < 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value > 1.0f)
+    {
+        return 1.0f;
+    }
+    return value;
+}
+
+static bool create_soft_particle_texture(sdl3d_texture2d *out_texture)
+{
+    sdl3d_image image;
+    SDL_zero(image);
+    image.width = SOFT_PARTICLE_SIZE;
+    image.height = SOFT_PARTICLE_SIZE;
+    image.pixels = (Uint8 *)SDL_calloc((size_t)image.width * (size_t)image.height * 4u, 1);
+    if (image.pixels == NULL)
+    {
+        return SDL_OutOfMemory();
+    }
+
+    for (int y = 0; y < image.height; ++y)
+    {
+        for (int x = 0; x < image.width; ++x)
+        {
+            const float fx = (((float)x + 0.5f) / (float)image.width) * 2.0f - 1.0f;
+            const float fy = (((float)y + 0.5f) / (float)image.height) * 2.0f - 1.0f;
+            const float dist = SDL_sqrtf(fx * fx + fy * fy);
+            const float falloff = clamp01(1.0f - dist);
+            const float core = falloff * falloff;
+            Uint8 *pixel = &image.pixels[((y * image.width) + x) * 4];
+
+            pixel[0] = (Uint8)(190.0f + core * 65.0f);
+            pixel[1] = 255;
+            pixel[2] = (Uint8)(35.0f + core * 95.0f);
+            pixel[3] = dist <= 1.0f ? (Uint8)(core * 255.0f + 0.5f) : 0;
+        }
+    }
+
+    const bool ok = sdl3d_create_texture_from_image(&image, out_texture);
+    SDL_free(image.pixels);
+    if (ok)
+    {
+        sdl3d_set_texture_filter(out_texture, SDL3D_TEXTURE_FILTER_BILINEAR);
+        sdl3d_set_texture_wrap(out_texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP);
+    }
+    return ok;
+}
+
+static bool sector_bounds(const sdl3d_sector *sector, float *out_min_x, float *out_max_x, float *out_min_z,
+                          float *out_max_z)
+{
+    if (sector == NULL || sector->num_points <= 0)
+    {
+        return false;
+    }
+
+    float min_x = sector->points[0][0];
+    float max_x = sector->points[0][0];
+    float min_z = sector->points[0][1];
+    float max_z = sector->points[0][1];
+    for (int i = 1; i < sector->num_points; ++i)
+    {
+        const float x = sector->points[i][0];
+        const float z = sector->points[i][1];
+        if (x < min_x)
+            min_x = x;
+        if (x > max_x)
+            max_x = x;
+        if (z < min_z)
+            min_z = z;
+        if (z > max_z)
+            max_z = z;
+    }
+
+    *out_min_x = min_x;
+    *out_max_x = max_x;
+    *out_min_z = min_z;
+    *out_max_z = max_z;
+    return true;
+}
+
+bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_level *level, const sdl3d_sector *sectors)
+{
+    if (particles == NULL || level == NULL || sectors == NULL)
+    {
+        return SDL_InvalidParamError("particles");
+    }
+
+    SDL_zerop(particles);
+    if (DOOM_NUKAGE_BASIN_SECTOR < 0 || DOOM_NUKAGE_BASIN_SECTOR >= level->sector_count)
+    {
+        return SDL_SetError("Nukage basin sector is out of range.");
+    }
+
+    const sdl3d_sector *sector = &sectors[DOOM_NUKAGE_BASIN_SECTOR];
+    float min_x, max_x, min_z, max_z;
+    if (!sector_bounds(sector, &min_x, &max_x, &min_z, &max_z))
+    {
+        return SDL_SetError("Nukage basin sector has no valid bounds.");
+    }
+
+    particles->has_soft_particle_tex = create_soft_particle_texture(&particles->soft_particle_tex);
+    if (!particles->has_soft_particle_tex)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Soft particle texture creation failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
+
+    const float center_x = (min_x + max_x) * 0.5f;
+    const float center_z = (min_z + max_z) * 0.5f;
+    const float half_x = (max_x - min_x) * 0.5f;
+    const float half_z = (max_z - min_z) * 0.5f;
+    const float floor_y = sdl3d_sector_floor_at(sector, center_x, center_z);
+    const sdl3d_texture2d *texture = particles->has_soft_particle_tex ? &particles->soft_particle_tex : NULL;
+
+    sdl3d_particle_config vapor;
+    SDL_zero(vapor);
+    vapor.position = sdl3d_vec3_make(center_x, floor_y + 0.18f, center_z);
+    vapor.direction = sdl3d_vec3_make(0.08f, 1.0f, -0.04f);
+    vapor.spread = 1.25f;
+    vapor.speed_min = 0.18f;
+    vapor.speed_max = 0.75f;
+    vapor.lifetime_min = 1.4f;
+    vapor.lifetime_max = 3.0f;
+    vapor.size_start = 0.10f;
+    vapor.size_end = 0.32f;
+    vapor.color_start = (sdl3d_color){120, 255, 40, 210};
+    vapor.color_end = (sdl3d_color){25, 210, 70, 0};
+    vapor.gravity = -0.08f;
+    vapor.max_particles = NUKAGE_VAPOR_MAX_PARTICLES;
+    vapor.emit_rate = 260.0f;
+    vapor.shape = SDL3D_PARTICLE_EMITTER_BOX;
+    vapor.extents = sdl3d_vec3_make(half_x * 0.88f, 0.05f, half_z * 0.88f);
+    vapor.emissive_intensity = 1.1f;
+    vapor.camera_facing = true;
+    vapor.depth_test = true;
+    vapor.additive_blend = true;
+    vapor.texture = texture;
+    vapor.random_seed = 0x51D3D00Du;
+    particles->nukage_vapor = sdl3d_create_particle_emitter(&vapor);
+    if (particles->nukage_vapor == NULL)
+    {
+        doom_hazard_particles_free(particles);
+        return false;
+    }
+
+    sdl3d_particle_config motes;
+    SDL_zero(motes);
+    motes.position = sdl3d_vec3_make(center_x, floor_y + 0.28f, center_z);
+    motes.direction = sdl3d_vec3_make(-0.05f, 1.0f, 0.1f);
+    motes.spread = 1.8f;
+    motes.speed_min = 0.45f;
+    motes.speed_max = 1.8f;
+    motes.lifetime_min = 0.45f;
+    motes.lifetime_max = 1.2f;
+    motes.size_start = 0.055f;
+    motes.size_end = 0.015f;
+    motes.color_start = (sdl3d_color){245, 255, 80, 255};
+    motes.color_end = (sdl3d_color){80, 255, 50, 0};
+    motes.gravity = 0.04f;
+    motes.max_particles = NUKAGE_MOTE_MAX_PARTICLES;
+    motes.emit_rate = 80.0f;
+    motes.shape = SDL3D_PARTICLE_EMITTER_BOX;
+    motes.extents = sdl3d_vec3_make(half_x * 0.82f, 0.05f, half_z * 0.82f);
+    motes.emissive_intensity = 2.2f;
+    motes.camera_facing = true;
+    motes.depth_test = true;
+    motes.additive_blend = true;
+    motes.texture = texture;
+    motes.random_seed = 0xA11CE5u;
+    particles->nukage_motes = sdl3d_create_particle_emitter(&motes);
+    if (particles->nukage_motes == NULL)
+    {
+        doom_hazard_particles_free(particles);
+        return false;
+    }
+
+    return true;
+}
+
+void doom_hazard_particles_free(doom_hazard_particles *particles)
+{
+    if (particles == NULL)
+    {
+        return;
+    }
+
+    sdl3d_destroy_particle_emitter(particles->nukage_vapor);
+    sdl3d_destroy_particle_emitter(particles->nukage_motes);
+    sdl3d_free_texture(&particles->soft_particle_tex);
+    SDL_zerop(particles);
+}
+
+void doom_hazard_particles_update(doom_hazard_particles *particles, float dt)
+{
+    if (particles == NULL)
+    {
+        return;
+    }
+
+    sdl3d_particle_emitter_update(particles->nukage_vapor, dt);
+    sdl3d_particle_emitter_update(particles->nukage_motes, dt);
+}
+
+bool doom_hazard_particles_draw(const doom_hazard_particles *particles, sdl3d_render_context *context)
+{
+    if (particles == NULL)
+    {
+        return true;
+    }
+
+    return sdl3d_draw_particles(context, particles->nukage_vapor) &&
+           sdl3d_draw_particles(context, particles->nukage_motes);
+}

--- a/demos/doom_level/hazard_effects.h
+++ b/demos/doom_level/hazard_effects.h
@@ -1,0 +1,26 @@
+/* Hazard particle effects for the doom_level demo. */
+#ifndef DOOM_HAZARD_EFFECTS_H
+#define DOOM_HAZARD_EFFECTS_H
+
+#include "sdl3d/effects.h"
+#include "sdl3d/level.h"
+#include "sdl3d/render_context.h"
+#include "sdl3d/texture.h"
+
+#include <stdbool.h>
+
+typedef struct doom_hazard_particles
+{
+    sdl3d_particle_emitter *nukage_vapor;
+    sdl3d_particle_emitter *nukage_motes;
+    sdl3d_texture2d soft_particle_tex;
+    bool has_soft_particle_tex;
+} doom_hazard_particles;
+
+bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_level *level,
+                                const sdl3d_sector *sectors);
+void doom_hazard_particles_free(doom_hazard_particles *particles);
+void doom_hazard_particles_update(doom_hazard_particles *particles, float dt);
+bool doom_hazard_particles_draw(const doom_hazard_particles *particles, sdl3d_render_context *context);
+
+#endif

--- a/demos/doom_level/hazard_effects.h
+++ b/demos/doom_level/hazard_effects.h
@@ -14,6 +14,7 @@ typedef struct doom_hazard_particles
     sdl3d_particle_emitter *nukage_vapor;
     sdl3d_particle_emitter *nukage_motes;
     sdl3d_texture2d soft_particle_tex;
+    float pulse_timer;
     bool has_soft_particle_tex;
 } doom_hazard_particles;
 

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -15,6 +15,7 @@
 
 #include "backend.h"
 #include "entities.h"
+#include "hazard_effects.h"
 #include "level_data.h"
 #include "player.h"
 #include "renderer.h"
@@ -39,6 +40,7 @@ typedef struct doom_state
 {
     level_data level;
     entities ent;
+    doom_hazard_particles hazards;
     player_state player;
     render_state render;
     sdl3d_transition transition;
@@ -74,6 +76,7 @@ typedef struct doom_state
 static void doom_state_cleanup(doom_state *state)
 {
     render_state_free(&state->render);
+    doom_hazard_particles_free(&state->hazards);
     if (state->entities_ready)
     {
         entities_free(&state->ent);
@@ -288,6 +291,12 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     }
     state->entities_ready = true;
 
+    if (!doom_hazard_particles_init(&state->hazards, &state->level.unlit, g_sectors))
+    {
+        doom_state_cleanup(state);
+        return false;
+    }
+
     player_init(&state->player, ctx->input);
     init_dragon_teleporter(state);
     render_state_init(&state->render);
@@ -498,6 +507,7 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 
     sdl3d_transition_update(&state->transition, ctx->bus, dt);
     update_dynamic_lift(state, dt);
+    doom_hazard_particles_update(&state->hazards, dt);
     entities_update(&state->ent, &state->level.unlit, dt, state->player.mover.position);
     if (!player_update(&state->player, ctx->input, &state->level.unlit, g_sectors, dt))
     {
@@ -637,7 +647,7 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     const float frame_dt = sdl3d_time_get_unscaled_delta_time();
 
     render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
-                      &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt,
+                      &state->level, &state->ent, &state->hazards, &state->player, WINDOW_W, WINDOW_H, frame_dt,
                       backend_profile_name(state->render_profile), state->ambient_feedback_timer > 0.0f,
                       state->teleport_feedback_timer > 0.0f);
     sdl3d_transition_draw(&state->transition, ctx->renderer);

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -84,9 +84,9 @@ static bool render_state_ensure_sector_capacity(render_state *rs, int sector_cou
 }
 
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
-                       level_data *ld, entities *ent, const player_state *player, int backbuffer_w, int backbuffer_h,
-                       float dt, const char *render_profile_name, bool ambient_feedback_active,
-                       bool teleport_feedback_active)
+                       level_data *ld, entities *ent, const doom_hazard_particles *hazards, const player_state *player,
+                       int backbuffer_w, int backbuffer_h, float dt, const char *render_profile_name,
+                       bool ambient_feedback_active, bool teleport_feedback_active)
 {
     const sdl3d_fps_mover *mover = &player->mover;
     sdl3d_level *active = level_data_active(ld);
@@ -208,6 +208,13 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
                 rs->portal_culling ? sdl3d_level_find_sector(active, g_sectors, sa->position.x, sa->position.z) : -1;
         }
         sdl3d_sprite_scene_draw(&ent->sprites, ctx, cam.position, rs->portal_culling ? &rs->vis : NULL);
+    }
+
+    /* Sector hazard particles */
+    if (!doom_hazard_particles_draw(hazards, ctx))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Hazard particle draw failed: %s", SDL_GetError());
+        SDL_ClearError();
     }
 
     /* Projectile */

--- a/demos/doom_level/renderer.h
+++ b/demos/doom_level/renderer.h
@@ -7,6 +7,7 @@
 #include "sdl3d/ui.h"
 
 #include "entities.h"
+#include "hazard_effects.h"
 #include "level_data.h"
 #include "player.h"
 
@@ -26,8 +27,8 @@ void render_state_free(render_state *rs);
 
 /* Draw one complete frame. Presentation is owned by the managed game loop. */
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
-                       level_data *ld, entities *ent, const player_state *player, int backbuffer_w, int backbuffer_h,
-                       float dt, const char *render_profile_name, bool ambient_feedback_active,
-                       bool teleport_feedback_active);
+                       level_data *ld, entities *ent, const doom_hazard_particles *hazards, const player_state *player,
+                       int backbuffer_w, int backbuffer_h, float dt, const char *render_profile_name,
+                       bool ambient_feedback_active, bool teleport_feedback_active);
 
 #endif

--- a/include/sdl3d/effects.h
+++ b/include/sdl3d/effects.h
@@ -16,40 +16,146 @@ extern "C"
     /* Particle system                                                */
     /* ============================================================== */
 
+    /**
+     * @brief Particle spawn volume.
+     *
+     * Point emitters preserve the original cone-emitter behavior. Box and
+     * circle emitters are useful for sector hazards, smoke banks, dust, and
+     * other effects that should originate from an area instead of a single
+     * point.
+     */
+    typedef enum sdl3d_particle_emitter_shape
+    {
+        SDL3D_PARTICLE_EMITTER_POINT = 0,  /**< Spawn at `position`. */
+        SDL3D_PARTICLE_EMITTER_BOX = 1,    /**< Spawn inside `position +/- extents`. */
+        SDL3D_PARTICLE_EMITTER_CIRCLE = 2, /**< Spawn inside an XZ circle centered on `position`. */
+    } sdl3d_particle_emitter_shape;
+
+    /**
+     * @brief Particle emitter configuration.
+     *
+     * Existing point-emitter fields keep their original meaning. Newly added
+     * fields default to conservative behavior when zero-initialized:
+     * point emitter, no texture, upright camera-facing quads, depth tested,
+     * no additive blending, and non-deterministic SDL randomness.
+     */
     typedef struct sdl3d_particle_config
     {
-        sdl3d_vec3 position;
-        sdl3d_vec3 direction;
-        float spread; /* cone half-angle in radians */
-        float speed_min;
-        float speed_max;
-        float lifetime_min;
-        float lifetime_max;
-        float size_start;
-        float size_end;
-        sdl3d_color color_start;
-        sdl3d_color color_end;
-        float gravity;
-        int max_particles;
-        float emit_rate; /* particles per second */
+        sdl3d_vec3 position;     /**< Emitter origin or volume center in world units. */
+        sdl3d_vec3 direction;    /**< Preferred particle travel direction. Zero means straight up. */
+        float spread;            /**< Cone half-angle in radians around `direction`. */
+        float speed_min;         /**< Minimum spawn speed in world units per second. */
+        float speed_max;         /**< Maximum spawn speed in world units per second. */
+        float lifetime_min;      /**< Minimum particle lifetime in seconds. */
+        float lifetime_max;      /**< Maximum particle lifetime in seconds. */
+        float size_start;        /**< Particle width/height at birth in world units. */
+        float size_end;          /**< Particle width/height at death in world units. */
+        sdl3d_color color_start; /**< Particle tint at birth. */
+        sdl3d_color color_end;   /**< Particle tint at death. */
+        float gravity;           /**< Downward acceleration in world units per second squared. */
+        int max_particles;       /**< Maximum live/storage particles; defaults to 128 when <= 0. */
+        float emit_rate;         /**< Continuous emission rate in particles per second. */
+
+        sdl3d_particle_emitter_shape shape; /**< Spawn volume shape. */
+        sdl3d_vec3 extents;                 /**< Half-size for SDL3D_PARTICLE_EMITTER_BOX. */
+        float radius;                       /**< XZ radius for SDL3D_PARTICLE_EMITTER_CIRCLE. */
+        float emissive_intensity;           /**< Temporary emissive scale while drawing particles. */
+        bool camera_facing;                 /**< True for spherical billboards, false for upright billboards. */
+        bool depth_test;                    /**< Reserved for future renderer support; currently depth-tested. */
+        bool additive_blend;            /**< Reserved for future renderer support; currently normal geometry path. */
+        const sdl3d_texture2d *texture; /**< Optional RGBA particle texture; NULL draws colored quads. */
+        Uint32 random_seed;             /**< Nonzero seed makes particle spawning deterministic per emitter. */
     } sdl3d_particle_config;
 
+    /**
+     * @brief Opaque CPU particle emitter.
+     */
     typedef struct sdl3d_particle_emitter sdl3d_particle_emitter;
 
+    /**
+     * @brief Read-only particle state for tests, tools, and debug views.
+     */
+    typedef struct sdl3d_particle_snapshot
+    {
+        sdl3d_vec3 position; /**< Current world-space particle center. */
+        sdl3d_vec3 velocity; /**< Current world-space particle velocity. */
+        float lifetime;      /**< Seconds since spawn. */
+        float max_lifetime;  /**< Seconds before expiration. */
+        bool alive;          /**< Whether this slot is currently live. */
+    } sdl3d_particle_snapshot;
+
+    /**
+     * @brief Create a particle emitter from `config`.
+     *
+     * Returns NULL and sets SDL_GetError() on invalid input or allocation
+     * failure. The config is copied, so callers may keep it on the stack.
+     */
     sdl3d_particle_emitter *sdl3d_create_particle_emitter(const sdl3d_particle_config *config);
+
+    /**
+     * @brief Destroy an emitter. Safe with NULL.
+     */
     void sdl3d_destroy_particle_emitter(sdl3d_particle_emitter *emitter);
 
+    /**
+     * @brief Replace an emitter's configuration.
+     *
+     * Reallocates particle storage if `config->max_particles` changes. On
+     * failure the emitter remains unchanged and SDL_GetError() describes the
+     * problem.
+     */
+    bool sdl3d_particle_emitter_set_config(sdl3d_particle_emitter *emitter, const sdl3d_particle_config *config);
+
+    /**
+     * @brief Return the emitter's current copied configuration, or NULL.
+     */
+    const sdl3d_particle_config *sdl3d_particle_emitter_get_config(const sdl3d_particle_emitter *emitter);
+
+    /**
+     * @brief Remove all live particles and reset continuous emission debt.
+     */
+    void sdl3d_particle_emitter_clear(sdl3d_particle_emitter *emitter);
+
+    /**
+     * @brief Advance particle simulation and continuous emission.
+     */
     void sdl3d_particle_emitter_update(sdl3d_particle_emitter *emitter, float delta_time);
+
+    /**
+     * @brief Emit up to `count` particles immediately.
+     */
     void sdl3d_particle_emitter_emit(sdl3d_particle_emitter *emitter, int count);
+
+    /**
+     * @brief Move the emitter origin or volume center without altering live particles.
+     */
     void sdl3d_particle_emitter_set_position(sdl3d_particle_emitter *emitter, sdl3d_vec3 position);
 
-    /*
-     * Draw all live particles as camera-facing billboards.
-     * Must be called between begin_mode_3d / end_mode_3d.
+    /**
+     * @brief Draw all live particles as camera-facing quads.
+     *
+     * Must be called between sdl3d_begin_mode_3d() and sdl3d_end_mode_3d().
+     * The current implementation is depth-tested through the regular geometry
+     * path. `additive_blend` and `depth_test` are carried in the public config
+     * so callers can author effects against stable API while backend blending
+     * support evolves.
      */
     bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_emitter *emitter);
 
+    /**
+     * @brief Return the number of currently live particles. Safe with NULL.
+     */
     int sdl3d_particle_emitter_get_count(const sdl3d_particle_emitter *emitter);
+
+    /**
+     * @brief Copy live particle state into `out_particles`.
+     *
+     * Returns the total number of live particles, even when `max_particles` is
+     * smaller than that count or `out_particles` is NULL. This lets callers
+     * size a buffer with a first pass.
+     */
+    int sdl3d_particle_emitter_snapshot(const sdl3d_particle_emitter *emitter, sdl3d_particle_snapshot *out_particles,
+                                        int max_particles);
 
     /* ============================================================== */
     /* Skybox                                                         */

--- a/include/sdl3d/effects.h
+++ b/include/sdl3d/effects.h
@@ -59,7 +59,7 @@ extern "C"
         sdl3d_particle_emitter_shape shape; /**< Spawn volume shape. */
         sdl3d_vec3 extents;                 /**< Half-size for SDL3D_PARTICLE_EMITTER_BOX. */
         float radius;                       /**< XZ radius for SDL3D_PARTICLE_EMITTER_CIRCLE. */
-        float emissive_intensity;           /**< Temporary emissive scale while drawing particles. */
+        float emissive_intensity;           /**< Extra unlit brightness scale while drawing particles. */
         bool camera_facing;                 /**< True for spherical billboards, false for upright billboards. */
         bool depth_test;                    /**< Reserved for future renderer support; currently depth-tested. */
         bool additive_blend;            /**< Reserved for future renderer support; currently normal geometry path. */

--- a/src/effects.c
+++ b/src/effects.c
@@ -4,7 +4,6 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/drawing3d.h"
-#include "sdl3d/lighting.h"
 #include "sdl3d/math.h"
 
 #include "render_context_internal.h"
@@ -176,9 +175,15 @@ static bool sdl3d_particle_emitter_apply_config(sdl3d_particle_emitter *emitter,
         emitter->count = 0;
     }
 
-    emitter->config = normalized;
-    emitter->deterministic_rng = normalized.random_seed != 0;
-    emitter->rng_state = normalized.random_seed != 0 ? normalized.random_seed : 0;
+    {
+        const bool keep_rng_state = preserve_particles && normalized.random_seed == emitter->config.random_seed;
+        emitter->config = normalized;
+        if (!keep_rng_state)
+        {
+            emitter->deterministic_rng = normalized.random_seed != 0;
+            emitter->rng_state = normalized.random_seed != 0 ? normalized.random_seed : 0;
+        }
+    }
     if (!preserve_particles)
     {
         emitter->emit_accumulator = 0.0f;
@@ -438,15 +443,27 @@ static Uint8 sdl3d_particle_lerp_u8(Uint8 a, Uint8 b, float t)
     return (Uint8)((float)a + ((float)b - (float)a) * t + 0.5f);
 }
 
+static Uint8 sdl3d_particle_scale_u8(Uint8 value, float scale)
+{
+    const float scaled = (float)value * scale;
+    if (scaled <= 0.0f)
+    {
+        return 0;
+    }
+    if (scaled >= 255.0f)
+    {
+        return 255;
+    }
+    return (Uint8)(scaled + 0.5f);
+}
+
 static bool sdl3d_draw_particle_quad(sdl3d_render_context *context, const sdl3d_particle_config *config,
                                      const sdl3d_particle *particle, float size, sdl3d_color color)
 {
     sdl3d_vec3 right = sdl3d_effects_camera_right(context);
     sdl3d_vec3 up;
-    sdl3d_vec3 normal;
     const float half = size * 0.5f;
     float positions[12];
-    float normals[12];
     float uvs[8] = {0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f};
     float colors[16];
     unsigned int indices[12] = {0, 1, 2, 2, 1, 3, 2, 1, 0, 3, 1, 2};
@@ -481,7 +498,6 @@ static bool sdl3d_draw_particle_quad(sdl3d_render_context *context, const sdl3d_
         }
         up = world_up;
     }
-    normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(right, up));
 
     {
         const sdl3d_vec3 scaled_right = sdl3d_vec3_scale(right, half);
@@ -498,9 +514,6 @@ static bool sdl3d_draw_particle_quad(sdl3d_render_context *context, const sdl3d_
             positions[i * 3 + 0] = verts[i].x;
             positions[i * 3 + 1] = verts[i].y;
             positions[i * 3 + 2] = verts[i].z;
-            normals[i * 3 + 0] = normal.x;
-            normals[i * 3 + 1] = normal.y;
-            normals[i * 3 + 2] = normal.z;
             colors[i * 4 + 0] = (float)color.r / 255.0f;
             colors[i * 4 + 1] = (float)color.g / 255.0f;
             colors[i * 4 + 2] = (float)color.b / 255.0f;
@@ -510,7 +523,6 @@ static bool sdl3d_draw_particle_quad(sdl3d_render_context *context, const sdl3d_
 
     SDL_zero(mesh);
     mesh.positions = positions;
-    mesh.normals = normals;
     mesh.uvs = uvs;
     mesh.colors = colors;
     mesh.vertex_count = 4;
@@ -529,13 +541,6 @@ bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_em
     if (emitter == NULL)
     {
         return true;
-    }
-
-    const float previous_emissive[3] = {context->emissive[0], context->emissive[1], context->emissive[2]};
-    if (emitter->config.emissive_intensity > 0.0f)
-    {
-        sdl3d_set_emissive(context, emitter->config.emissive_intensity, emitter->config.emissive_intensity,
-                           emitter->config.emissive_intensity);
     }
 
     bool ok = true;
@@ -558,13 +563,15 @@ bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_em
         color.g = sdl3d_particle_lerp_u8(emitter->config.color_start.g, emitter->config.color_end.g, t);
         color.b = sdl3d_particle_lerp_u8(emitter->config.color_start.b, emitter->config.color_end.b, t);
         color.a = sdl3d_particle_lerp_u8(emitter->config.color_start.a, emitter->config.color_end.a, t);
+        if (emitter->config.emissive_intensity > 0.0f)
+        {
+            const float scale = 1.0f + emitter->config.emissive_intensity;
+            color.r = sdl3d_particle_scale_u8(color.r, scale);
+            color.g = sdl3d_particle_scale_u8(color.g, scale);
+            color.b = sdl3d_particle_scale_u8(color.b, scale);
+        }
 
         ok = sdl3d_draw_particle_quad(context, &emitter->config, p, size, color) && ok;
-    }
-
-    if (emitter->config.emissive_intensity > 0.0f)
-    {
-        sdl3d_set_emissive(context, previous_emissive[0], previous_emissive[1], previous_emissive[2]);
     }
 
     return ok;

--- a/src/effects.c
+++ b/src/effects.c
@@ -4,8 +4,8 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/drawing3d.h"
+#include "sdl3d/lighting.h"
 #include "sdl3d/math.h"
-#include "sdl3d/shapes.h"
 
 #include "render_context_internal.h"
 
@@ -31,22 +31,164 @@ struct sdl3d_particle_emitter
     sdl3d_particle *particles;
     int count;
     float emit_accumulator;
+    Uint32 rng_state;
+    bool deterministic_rng;
 };
+
+static sdl3d_vec3 sdl3d_effects_camera_right(const sdl3d_render_context *context);
+static sdl3d_vec3 sdl3d_effects_camera_up(const sdl3d_render_context *context);
+static sdl3d_vec3 sdl3d_effects_camera_forward(const sdl3d_render_context *context);
+
+static float sdl3d_effects_absf(float value)
+{
+    return value < 0.0f ? -value : value;
+}
+
+static float sdl3d_effects_maxf(float a, float b)
+{
+    return a > b ? a : b;
+}
+
+static float sdl3d_effects_clampf(float value, float lo, float hi)
+{
+    if (value < lo)
+    {
+        return lo;
+    }
+    if (value > hi)
+    {
+        return hi;
+    }
+    return value;
+}
 
 static float sdl3d_randf(void)
 {
     return (float)SDL_rand(1000000) / 1000000.0f;
 }
 
-static float sdl3d_randf_range(float lo, float hi)
+static Uint32 sdl3d_particle_next_random_u32(sdl3d_particle_emitter *emitter)
 {
-    return lo + sdl3d_randf() * (hi - lo);
+    if (emitter == NULL || !emitter->deterministic_rng)
+    {
+        return (Uint32)SDL_rand_bits();
+    }
+
+    emitter->rng_state = emitter->rng_state * 1664525u + 1013904223u;
+    return emitter->rng_state;
+}
+
+static float sdl3d_particle_randf(sdl3d_particle_emitter *emitter)
+{
+    if (emitter == NULL || !emitter->deterministic_rng)
+    {
+        return sdl3d_randf();
+    }
+
+    return (float)(sdl3d_particle_next_random_u32(emitter) >> 8) * (1.0f / 16777216.0f);
+}
+
+static float sdl3d_randf_range(sdl3d_particle_emitter *emitter, float lo, float hi)
+{
+    return lo + sdl3d_particle_randf(emitter) * (hi - lo);
+}
+
+static sdl3d_particle_config sdl3d_particle_config_normalized(const sdl3d_particle_config *config)
+{
+    sdl3d_particle_config normalized = *config;
+
+    if (normalized.max_particles <= 0)
+    {
+        normalized.max_particles = 128;
+    }
+    if (normalized.speed_min > normalized.speed_max)
+    {
+        const float tmp = normalized.speed_min;
+        normalized.speed_min = normalized.speed_max;
+        normalized.speed_max = tmp;
+    }
+    if (normalized.lifetime_min > normalized.lifetime_max)
+    {
+        const float tmp = normalized.lifetime_min;
+        normalized.lifetime_min = normalized.lifetime_max;
+        normalized.lifetime_max = tmp;
+    }
+    normalized.lifetime_min = sdl3d_effects_maxf(normalized.lifetime_min, 0.001f);
+    normalized.lifetime_max = sdl3d_effects_maxf(normalized.lifetime_max, normalized.lifetime_min);
+    normalized.size_start = sdl3d_effects_maxf(normalized.size_start, 0.0f);
+    normalized.size_end = sdl3d_effects_maxf(normalized.size_end, 0.0f);
+    normalized.emit_rate = sdl3d_effects_maxf(normalized.emit_rate, 0.0f);
+    normalized.spread = sdl3d_effects_clampf(normalized.spread, 0.0f, SDL_PI_F);
+    normalized.extents.x = sdl3d_effects_absf(normalized.extents.x);
+    normalized.extents.y = sdl3d_effects_absf(normalized.extents.y);
+    normalized.extents.z = sdl3d_effects_absf(normalized.extents.z);
+    normalized.radius = sdl3d_effects_absf(normalized.radius);
+    normalized.emissive_intensity = sdl3d_effects_maxf(normalized.emissive_intensity, 0.0f);
+    if (normalized.shape < SDL3D_PARTICLE_EMITTER_POINT || normalized.shape > SDL3D_PARTICLE_EMITTER_CIRCLE)
+    {
+        normalized.shape = SDL3D_PARTICLE_EMITTER_POINT;
+    }
+    return normalized;
+}
+
+static bool sdl3d_particle_emitter_apply_config(sdl3d_particle_emitter *emitter, const sdl3d_particle_config *config,
+                                                bool preserve_particles)
+{
+    sdl3d_particle_config normalized;
+    sdl3d_particle *particles = NULL;
+
+    if (emitter == NULL)
+    {
+        return SDL_InvalidParamError("emitter");
+    }
+    if (config == NULL)
+    {
+        return SDL_InvalidParamError("config");
+    }
+
+    normalized = sdl3d_particle_config_normalized(config);
+    if (normalized.max_particles != emitter->config.max_particles)
+    {
+        particles = (sdl3d_particle *)SDL_calloc((size_t)normalized.max_particles, sizeof(*particles));
+        if (particles == NULL)
+        {
+            return SDL_OutOfMemory();
+        }
+
+        if (preserve_particles && emitter->particles != NULL)
+        {
+            const int copy_count =
+                emitter->count < normalized.max_particles ? emitter->count : normalized.max_particles;
+            SDL_memcpy(particles, emitter->particles, (size_t)copy_count * sizeof(*particles));
+            emitter->count = copy_count;
+        }
+        else
+        {
+            emitter->count = 0;
+        }
+
+        SDL_free(emitter->particles);
+        emitter->particles = particles;
+    }
+    else if (!preserve_particles)
+    {
+        SDL_memset(emitter->particles, 0, (size_t)normalized.max_particles * sizeof(*emitter->particles));
+        emitter->count = 0;
+    }
+
+    emitter->config = normalized;
+    emitter->deterministic_rng = normalized.random_seed != 0;
+    emitter->rng_state = normalized.random_seed != 0 ? normalized.random_seed : 0;
+    if (!preserve_particles)
+    {
+        emitter->emit_accumulator = 0.0f;
+    }
+    return true;
 }
 
 sdl3d_particle_emitter *sdl3d_create_particle_emitter(const sdl3d_particle_config *config)
 {
     sdl3d_particle_emitter *em;
-    int max;
 
     if (config == NULL)
     {
@@ -61,17 +203,12 @@ sdl3d_particle_emitter *sdl3d_create_particle_emitter(const sdl3d_particle_confi
         return NULL;
     }
 
-    em->config = *config;
-    max = config->max_particles > 0 ? config->max_particles : 128;
-    em->particles = (sdl3d_particle *)SDL_calloc((size_t)max, sizeof(sdl3d_particle));
-    if (em->particles == NULL)
+    if (!sdl3d_particle_emitter_apply_config(em, config, false))
     {
         SDL_free(em);
-        SDL_OutOfMemory();
         return NULL;
     }
 
-    em->config.max_particles = max;
     return em;
 }
 
@@ -93,6 +230,54 @@ void sdl3d_particle_emitter_set_position(sdl3d_particle_emitter *emitter, sdl3d_
     }
 }
 
+bool sdl3d_particle_emitter_set_config(sdl3d_particle_emitter *emitter, const sdl3d_particle_config *config)
+{
+    return sdl3d_particle_emitter_apply_config(emitter, config, true);
+}
+
+const sdl3d_particle_config *sdl3d_particle_emitter_get_config(const sdl3d_particle_emitter *emitter)
+{
+    return emitter != NULL ? &emitter->config : NULL;
+}
+
+void sdl3d_particle_emitter_clear(sdl3d_particle_emitter *emitter)
+{
+    if (emitter == NULL)
+    {
+        return;
+    }
+
+    SDL_memset(emitter->particles, 0, (size_t)emitter->config.max_particles * sizeof(*emitter->particles));
+    emitter->count = 0;
+    emitter->emit_accumulator = 0.0f;
+}
+
+static sdl3d_vec3 sdl3d_particle_spawn_position(sdl3d_particle_emitter *em)
+{
+    sdl3d_vec3 position = em->config.position;
+
+    switch (em->config.shape)
+    {
+    case SDL3D_PARTICLE_EMITTER_BOX:
+        position.x += sdl3d_randf_range(em, -em->config.extents.x, em->config.extents.x);
+        position.y += sdl3d_randf_range(em, -em->config.extents.y, em->config.extents.y);
+        position.z += sdl3d_randf_range(em, -em->config.extents.z, em->config.extents.z);
+        break;
+    case SDL3D_PARTICLE_EMITTER_CIRCLE: {
+        const float angle = sdl3d_particle_randf(em) * SDL_PI_F * 2.0f;
+        const float radius = SDL_sqrtf(sdl3d_particle_randf(em)) * em->config.radius;
+        position.x += SDL_cosf(angle) * radius;
+        position.z += SDL_sinf(angle) * radius;
+        break;
+    }
+    case SDL3D_PARTICLE_EMITTER_POINT:
+    default:
+        break;
+    }
+
+    return position;
+}
+
 static void sdl3d_emit_one(sdl3d_particle_emitter *em)
 {
     int i;
@@ -110,12 +295,16 @@ static void sdl3d_emit_one(sdl3d_particle_emitter *em)
 
     {
         sdl3d_particle *p = &em->particles[i];
-        float speed = sdl3d_randf_range(em->config.speed_min, em->config.speed_max);
-        float theta = sdl3d_randf() * 6.28318f;
-        float phi = sdl3d_randf() * em->config.spread;
+        float speed = sdl3d_randf_range(em, em->config.speed_min, em->config.speed_max);
+        float theta = sdl3d_particle_randf(em) * SDL_PI_F * 2.0f;
+        float phi = sdl3d_particle_randf(em) * em->config.spread;
         float sp = SDL_sinf(phi);
 
         sdl3d_vec3 dir = sdl3d_vec3_normalize(em->config.direction);
+        if (sdl3d_vec3_length_squared(dir) <= 0.000001f)
+        {
+            dir = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+        }
         /* Build a random direction within the cone. */
         sdl3d_vec3 up = (SDL_fabsf(dir.y) < 0.99f) ? sdl3d_vec3_make(0, 1, 0) : sdl3d_vec3_make(1, 0, 0);
         sdl3d_vec3 right = sdl3d_vec3_normalize(sdl3d_vec3_cross(up, dir));
@@ -126,10 +315,10 @@ static void sdl3d_emit_one(sdl3d_particle_emitter *em)
         offset.y = dir.y * SDL_cosf(phi) + right.y * sp * SDL_cosf(theta) + fwd.y * sp * SDL_sinf(theta);
         offset.z = dir.z * SDL_cosf(phi) + right.z * sp * SDL_cosf(theta) + fwd.z * sp * SDL_sinf(theta);
 
-        p->position = em->config.position;
+        p->position = sdl3d_particle_spawn_position(em);
         p->velocity = sdl3d_vec3_scale(offset, speed);
         p->lifetime = 0.0f;
-        p->max_lifetime = sdl3d_randf_range(em->config.lifetime_min, em->config.lifetime_max);
+        p->max_lifetime = sdl3d_randf_range(em, em->config.lifetime_min, em->config.lifetime_max);
         if (p->max_lifetime < 0.001f)
         {
             p->max_lifetime = 0.001f;
@@ -210,6 +399,127 @@ int sdl3d_particle_emitter_get_count(const sdl3d_particle_emitter *emitter)
     return live;
 }
 
+int sdl3d_particle_emitter_snapshot(const sdl3d_particle_emitter *emitter, sdl3d_particle_snapshot *out_particles,
+                                    int max_particles)
+{
+    int live = 0;
+    int copied = 0;
+
+    if (emitter == NULL)
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < emitter->count; ++i)
+    {
+        const sdl3d_particle *p = &emitter->particles[i];
+        if (!p->alive)
+        {
+            continue;
+        }
+
+        if (out_particles != NULL && copied < max_particles)
+        {
+            out_particles[copied].position = p->position;
+            out_particles[copied].velocity = p->velocity;
+            out_particles[copied].lifetime = p->lifetime;
+            out_particles[copied].max_lifetime = p->max_lifetime;
+            out_particles[copied].alive = p->alive;
+            ++copied;
+        }
+        ++live;
+    }
+
+    return live;
+}
+
+static Uint8 sdl3d_particle_lerp_u8(Uint8 a, Uint8 b, float t)
+{
+    return (Uint8)((float)a + ((float)b - (float)a) * t + 0.5f);
+}
+
+static bool sdl3d_draw_particle_quad(sdl3d_render_context *context, const sdl3d_particle_config *config,
+                                     const sdl3d_particle *particle, float size, sdl3d_color color)
+{
+    sdl3d_vec3 right = sdl3d_effects_camera_right(context);
+    sdl3d_vec3 up;
+    sdl3d_vec3 normal;
+    const float half = size * 0.5f;
+    float positions[12];
+    float normals[12];
+    float uvs[8] = {0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f};
+    float colors[16];
+    unsigned int indices[12] = {0, 1, 2, 2, 1, 3, 2, 1, 0, 3, 1, 2};
+    sdl3d_mesh mesh;
+
+    if (size <= 0.0f || color.a == 0)
+    {
+        return true;
+    }
+
+    if (config->camera_facing)
+    {
+        up = sdl3d_effects_camera_up(context);
+    }
+    else
+    {
+        const sdl3d_vec3 world_up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+        sdl3d_vec3 forward = sdl3d_effects_camera_forward(context);
+        forward.y = 0.0f;
+        if (sdl3d_vec3_length_squared(forward) <= 0.000001f)
+        {
+            forward = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
+        }
+        else
+        {
+            forward = sdl3d_vec3_normalize(forward);
+        }
+        right = sdl3d_vec3_normalize(sdl3d_vec3_cross(forward, world_up));
+        if (sdl3d_vec3_length_squared(right) <= 0.000001f)
+        {
+            right = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+        }
+        up = world_up;
+    }
+    normal = sdl3d_vec3_normalize(sdl3d_vec3_cross(right, up));
+
+    {
+        const sdl3d_vec3 scaled_right = sdl3d_vec3_scale(right, half);
+        const sdl3d_vec3 scaled_up = sdl3d_vec3_scale(up, half);
+        const sdl3d_vec3 verts[4] = {
+            sdl3d_vec3_sub(sdl3d_vec3_sub(particle->position, scaled_right), scaled_up),
+            sdl3d_vec3_add(sdl3d_vec3_sub(particle->position, scaled_right), scaled_up),
+            sdl3d_vec3_sub(sdl3d_vec3_add(particle->position, scaled_right), scaled_up),
+            sdl3d_vec3_add(sdl3d_vec3_add(particle->position, scaled_right), scaled_up),
+        };
+
+        for (int i = 0; i < 4; ++i)
+        {
+            positions[i * 3 + 0] = verts[i].x;
+            positions[i * 3 + 1] = verts[i].y;
+            positions[i * 3 + 2] = verts[i].z;
+            normals[i * 3 + 0] = normal.x;
+            normals[i * 3 + 1] = normal.y;
+            normals[i * 3 + 2] = normal.z;
+            colors[i * 4 + 0] = (float)color.r / 255.0f;
+            colors[i * 4 + 1] = (float)color.g / 255.0f;
+            colors[i * 4 + 2] = (float)color.b / 255.0f;
+            colors[i * 4 + 3] = (float)color.a / 255.0f;
+        }
+    }
+
+    SDL_zero(mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.uvs = uvs;
+    mesh.colors = colors;
+    mesh.vertex_count = 4;
+    mesh.indices = indices;
+    mesh.index_count = 12;
+
+    return sdl3d_draw_mesh(context, &mesh, config->texture, (sdl3d_color){255, 255, 255, 255});
+}
+
 bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_emitter *emitter)
 {
     if (context == NULL)
@@ -221,6 +531,14 @@ bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_em
         return true;
     }
 
+    const float previous_emissive[3] = {context->emissive[0], context->emissive[1], context->emissive[2]};
+    if (emitter->config.emissive_intensity > 0.0f)
+    {
+        sdl3d_set_emissive(context, emitter->config.emissive_intensity, emitter->config.emissive_intensity,
+                           emitter->config.emissive_intensity);
+    }
+
+    bool ok = true;
     for (int i = 0; i < emitter->count; ++i)
     {
         const sdl3d_particle *p = &emitter->particles[i];
@@ -233,22 +551,23 @@ bool sdl3d_draw_particles(sdl3d_render_context *context, const sdl3d_particle_em
         }
 
         t = p->lifetime / p->max_lifetime;
+        t = sdl3d_effects_clampf(t, 0.0f, 1.0f);
         size = emitter->config.size_start + (emitter->config.size_end - emitter->config.size_start) * t;
 
-        color.r = (Uint8)((float)emitter->config.color_start.r +
-                          (float)(emitter->config.color_end.r - emitter->config.color_start.r) * t);
-        color.g = (Uint8)((float)emitter->config.color_start.g +
-                          (float)(emitter->config.color_end.g - emitter->config.color_start.g) * t);
-        color.b = (Uint8)((float)emitter->config.color_start.b +
-                          (float)(emitter->config.color_end.b - emitter->config.color_start.b) * t);
-        color.a = (Uint8)((float)emitter->config.color_start.a +
-                          (float)(emitter->config.color_end.a - emitter->config.color_start.a) * t);
+        color.r = sdl3d_particle_lerp_u8(emitter->config.color_start.r, emitter->config.color_end.r, t);
+        color.g = sdl3d_particle_lerp_u8(emitter->config.color_start.g, emitter->config.color_end.g, t);
+        color.b = sdl3d_particle_lerp_u8(emitter->config.color_start.b, emitter->config.color_end.b, t);
+        color.a = sdl3d_particle_lerp_u8(emitter->config.color_start.a, emitter->config.color_end.a, t);
 
-        /* Draw as a small cube billboard (cheap, visible from all angles). */
-        sdl3d_draw_cube(context, p->position, sdl3d_vec3_make(size, size, size), color);
+        ok = sdl3d_draw_particle_quad(context, &emitter->config, p, size, color) && ok;
     }
 
-    return true;
+    if (emitter->config.emissive_intensity > 0.0f)
+    {
+        sdl3d_set_emissive(context, previous_emissive[0], previous_emissive[1], previous_emissive[2]);
+    }
+
+    return ok;
 }
 
 /* ------------------------------------------------------------------ */

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -4,11 +4,108 @@
 
 #include <gtest/gtest.h>
 
+#define SDL_MAIN_HANDLED
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+#include <vector>
+
 extern "C"
 {
 #include "sdl3d/effects.h"
 #include "sdl3d/math.h"
+#include "sdl3d/sdl3d.h"
 }
+
+#include <memory>
+
+namespace
+{
+
+class SDLEffectsFixture : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        SDL_SetMainReady();
+        SDL_ClearError();
+        ASSERT_TRUE(SDL_Init(SDL_INIT_VIDEO)) << SDL_GetError();
+    }
+
+    void TearDown() override
+    {
+        SDL_Quit();
+    }
+};
+
+class WindowRenderer
+{
+  public:
+    WindowRenderer(int width = 128, int height = 128)
+        : window_(nullptr, SDL_DestroyWindow), renderer_(nullptr, SDL_DestroyRenderer)
+    {
+        SDL_Window *window = nullptr;
+        SDL_Renderer *renderer = nullptr;
+        if (!SDL_CreateWindowAndRenderer("SDL3D Effects Test", width, height, 0, &window, &renderer))
+        {
+            ADD_FAILURE() << SDL_GetError();
+            return;
+        }
+        window_.reset(window);
+        renderer_.reset(renderer);
+    }
+
+    bool ok() const
+    {
+        return window_ != nullptr && renderer_ != nullptr;
+    }
+
+    SDL_Window *window() const
+    {
+        return window_.get();
+    }
+
+    SDL_Renderer *renderer() const
+    {
+        return renderer_.get();
+    }
+
+  private:
+    std::unique_ptr<SDL_Window, decltype(&SDL_DestroyWindow)> window_;
+    std::unique_ptr<SDL_Renderer, decltype(&SDL_DestroyRenderer)> renderer_;
+};
+
+sdl3d_camera3d MakeCamera()
+{
+    sdl3d_camera3d cam{};
+    cam.position = sdl3d_vec3_make(0.0f, 0.0f, 4.0f);
+    cam.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 60.0f;
+    cam.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return cam;
+}
+
+int CountNonBlackPixels(sdl3d_render_context *ctx)
+{
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    int count = 0;
+    for (int y = 0; y < h; ++y)
+    {
+        for (int x = 0; x < w; ++x)
+        {
+            sdl3d_color px{};
+            if (sdl3d_get_framebuffer_pixel(ctx, x, y, &px) && (px.r > 20 || px.g > 20 || px.b > 20))
+            {
+                ++count;
+            }
+        }
+    }
+    return count;
+}
+
+} // namespace
 
 /* ================================================================== */
 /* Particle system                                                    */
@@ -31,6 +128,7 @@ static sdl3d_particle_config default_config(void)
     c.gravity = 9.8f;
     c.max_particles = 64;
     c.emit_rate = 10.0f;
+    c.camera_facing = true;
     return c;
 }
 
@@ -111,6 +209,170 @@ TEST(SDL3DParticles, GetCountNullReturnsZero)
     EXPECT_EQ(sdl3d_particle_emitter_get_count(nullptr), 0);
 }
 
+TEST(SDL3DParticles, ClearRemovesLiveParticles)
+{
+    sdl3d_particle_config c = default_config();
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+    sdl3d_particle_emitter_emit(em, 8);
+    ASSERT_GT(sdl3d_particle_emitter_get_count(em), 0);
+
+    sdl3d_particle_emitter_clear(em);
+    EXPECT_EQ(sdl3d_particle_emitter_get_count(em), 0);
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, GetConfigReturnsNormalizedConfig)
+{
+    sdl3d_particle_config c = default_config();
+    c.max_particles = 0;
+    c.speed_min = 5.0f;
+    c.speed_max = 2.0f;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+
+    const sdl3d_particle_config *stored = sdl3d_particle_emitter_get_config(em);
+    ASSERT_NE(stored, nullptr);
+    EXPECT_EQ(stored->max_particles, 128);
+    EXPECT_FLOAT_EQ(stored->speed_min, 2.0f);
+    EXPECT_FLOAT_EQ(stored->speed_max, 5.0f);
+    EXPECT_EQ(sdl3d_particle_emitter_get_config(nullptr), nullptr);
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, SetConfigReallocatesCapacitySafely)
+{
+    sdl3d_particle_config c = default_config();
+    c.max_particles = 4;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+    sdl3d_particle_emitter_emit(em, 4);
+    EXPECT_EQ(sdl3d_particle_emitter_get_count(em), 4);
+
+    c.max_particles = 2;
+    ASSERT_TRUE(sdl3d_particle_emitter_set_config(em, &c));
+    EXPECT_LE(sdl3d_particle_emitter_get_count(em), 2);
+
+    c.max_particles = 6;
+    ASSERT_TRUE(sdl3d_particle_emitter_set_config(em, &c));
+    sdl3d_particle_emitter_emit(em, 10);
+    EXPECT_LE(sdl3d_particle_emitter_get_count(em), 6);
+    EXPECT_FALSE(sdl3d_particle_emitter_set_config(nullptr, &c));
+    EXPECT_FALSE(sdl3d_particle_emitter_set_config(em, nullptr));
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, SnapshotCopiesOnlyLiveParticles)
+{
+    sdl3d_particle_config c = default_config();
+    c.max_particles = 6;
+    c.emit_rate = 0.0f;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+    sdl3d_particle_emitter_emit(em, 5);
+
+    sdl3d_particle_snapshot snapshots[3]{};
+    EXPECT_EQ(sdl3d_particle_emitter_snapshot(em, snapshots, 3), 5);
+    for (const sdl3d_particle_snapshot &snapshot : snapshots)
+    {
+        EXPECT_TRUE(snapshot.alive);
+        EXPECT_GT(snapshot.max_lifetime, 0.0f);
+    }
+    EXPECT_EQ(sdl3d_particle_emitter_snapshot(em, nullptr, 0), 5);
+    EXPECT_EQ(sdl3d_particle_emitter_snapshot(nullptr, snapshots, 3), 0);
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, BoxEmitterSpawnsWithinExtents)
+{
+    sdl3d_particle_config c = default_config();
+    c.shape = SDL3D_PARTICLE_EMITTER_BOX;
+    c.position = sdl3d_vec3_make(10.0f, 3.0f, -4.0f);
+    c.extents = sdl3d_vec3_make(2.0f, 0.5f, 1.5f);
+    c.speed_min = 0.0f;
+    c.speed_max = 0.0f;
+    c.max_particles = 32;
+    c.random_seed = 1234;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+
+    sdl3d_particle_emitter_emit(em, 32);
+    std::vector<sdl3d_particle_snapshot> snapshots(32);
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(em, snapshots.data(), (int)snapshots.size()), 32);
+    for (const sdl3d_particle_snapshot &snapshot : snapshots)
+    {
+        EXPECT_GE(snapshot.position.x, 8.0f);
+        EXPECT_LE(snapshot.position.x, 12.0f);
+        EXPECT_GE(snapshot.position.y, 2.5f);
+        EXPECT_LE(snapshot.position.y, 3.5f);
+        EXPECT_GE(snapshot.position.z, -5.5f);
+        EXPECT_LE(snapshot.position.z, -2.5f);
+    }
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, CircleEmitterSpawnsWithinRadius)
+{
+    sdl3d_particle_config c = default_config();
+    c.shape = SDL3D_PARTICLE_EMITTER_CIRCLE;
+    c.position = sdl3d_vec3_make(-2.0f, 1.0f, 7.0f);
+    c.radius = 3.0f;
+    c.speed_min = 0.0f;
+    c.speed_max = 0.0f;
+    c.max_particles = 32;
+    c.random_seed = 5678;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+
+    sdl3d_particle_emitter_emit(em, 32);
+    std::vector<sdl3d_particle_snapshot> snapshots(32);
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(em, snapshots.data(), (int)snapshots.size()), 32);
+    for (const sdl3d_particle_snapshot &snapshot : snapshots)
+    {
+        const float dx = snapshot.position.x + 2.0f;
+        const float dz = snapshot.position.z - 7.0f;
+        EXPECT_LE(dx * dx + dz * dz, 9.0001f);
+        EXPECT_FLOAT_EQ(snapshot.position.y, 1.0f);
+    }
+    sdl3d_destroy_particle_emitter(em);
+}
+
+TEST(SDL3DParticles, SeededEmitterIsDeterministic)
+{
+    sdl3d_particle_config c = default_config();
+    c.shape = SDL3D_PARTICLE_EMITTER_BOX;
+    c.extents = sdl3d_vec3_make(2.0f, 1.0f, 2.0f);
+    c.random_seed = 42;
+    c.max_particles = 16;
+    c.emit_rate = 0.0f;
+
+    sdl3d_particle_emitter *a = sdl3d_create_particle_emitter(&c);
+    sdl3d_particle_emitter *b = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+
+    sdl3d_particle_emitter_emit(a, 16);
+    sdl3d_particle_emitter_emit(b, 16);
+    std::vector<sdl3d_particle_snapshot> sa(16);
+    std::vector<sdl3d_particle_snapshot> sb(16);
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(a, sa.data(), (int)sa.size()), 16);
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(b, sb.data(), (int)sb.size()), 16);
+
+    for (int i = 0; i < 16; ++i)
+    {
+        EXPECT_FLOAT_EQ(sa[i].position.x, sb[i].position.x);
+        EXPECT_FLOAT_EQ(sa[i].position.y, sb[i].position.y);
+        EXPECT_FLOAT_EQ(sa[i].position.z, sb[i].position.z);
+        EXPECT_FLOAT_EQ(sa[i].velocity.x, sb[i].velocity.x);
+        EXPECT_FLOAT_EQ(sa[i].velocity.y, sb[i].velocity.y);
+        EXPECT_FLOAT_EQ(sa[i].velocity.z, sb[i].velocity.z);
+        EXPECT_FLOAT_EQ(sa[i].max_lifetime, sb[i].max_lifetime);
+    }
+
+    sdl3d_destroy_particle_emitter(a);
+    sdl3d_destroy_particle_emitter(b);
+}
+
 TEST(SDL3DParticles, DrawNullContextFails)
 {
     EXPECT_FALSE(sdl3d_draw_particles(nullptr, nullptr));
@@ -120,6 +382,41 @@ TEST(SDL3DParticles, DrawNullEmitterSucceeds)
 {
     /* Drawing null emitter is a no-op, not an error. */
     /* Can't test without a context, but verify the API exists. */
+}
+
+TEST_F(SDLEffectsFixture, ParticleQuadDrawsInSoftwareRenderer)
+{
+    WindowRenderer wr(96, 96);
+    ASSERT_TRUE(wr.ok());
+
+    sdl3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx)) << SDL_GetError();
+
+    sdl3d_particle_config c = default_config();
+    c.max_particles = 1;
+    c.emit_rate = 0.0f;
+    c.speed_min = 0.0f;
+    c.speed_max = 0.0f;
+    c.lifetime_min = 5.0f;
+    c.lifetime_max = 5.0f;
+    c.size_start = 1.0f;
+    c.size_end = 1.0f;
+    c.color_start = {255, 40, 20, 255};
+    c.color_end = {255, 40, 20, 255};
+    c.random_seed = 99;
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+    sdl3d_particle_emitter_emit(em, 1);
+
+    ASSERT_TRUE(sdl3d_set_shading_mode(ctx, SDL3D_SHADING_UNLIT));
+    ASSERT_TRUE(sdl3d_clear_render_context(ctx, {0, 0, 0, 255}));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(ctx, MakeCamera()));
+    EXPECT_TRUE(sdl3d_draw_particles(ctx, em)) << SDL_GetError();
+    ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
+    EXPECT_GT(CountNonBlackPixels(ctx), 0);
+
+    sdl3d_destroy_particle_emitter(em);
+    sdl3d_destroy_render_context(ctx);
 }
 
 /* ================================================================== */

--- a/tests/test_effects.cpp
+++ b/tests/test_effects.cpp
@@ -105,6 +105,25 @@ int CountNonBlackPixels(sdl3d_render_context *ctx)
     return count;
 }
 
+int CountGreenDominantPixels(sdl3d_render_context *ctx)
+{
+    const int w = sdl3d_get_render_context_width(ctx);
+    const int h = sdl3d_get_render_context_height(ctx);
+    int count = 0;
+    for (int y = 0; y < h; ++y)
+    {
+        for (int x = 0; x < w; ++x)
+        {
+            sdl3d_color px{};
+            if (sdl3d_get_framebuffer_pixel(ctx, x, y, &px) && px.g > px.r + 30 && px.g > px.b + 30)
+            {
+                ++count;
+            }
+        }
+    }
+    return count;
+}
+
 } // namespace
 
 /* ================================================================== */
@@ -373,6 +392,32 @@ TEST(SDL3DParticles, SeededEmitterIsDeterministic)
     sdl3d_destroy_particle_emitter(b);
 }
 
+TEST(SDL3DParticles, SetConfigWithSameSeedDoesNotRestartRandomSequence)
+{
+    sdl3d_particle_config c = default_config();
+    c.shape = SDL3D_PARTICLE_EMITTER_BOX;
+    c.extents = sdl3d_vec3_make(1.0f, 1.0f, 1.0f);
+    c.random_seed = 123;
+    c.max_particles = 2;
+    c.emit_rate = 0.0f;
+
+    sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
+    ASSERT_NE(em, nullptr);
+    sdl3d_particle_emitter_emit(em, 1);
+
+    sdl3d_particle_snapshot first{};
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(em, &first, 1), 1);
+    c.color_start = {10, 255, 10, 255};
+    ASSERT_TRUE(sdl3d_particle_emitter_set_config(em, &c));
+    sdl3d_particle_emitter_emit(em, 1);
+
+    sdl3d_particle_snapshot snapshots[2]{};
+    ASSERT_EQ(sdl3d_particle_emitter_snapshot(em, snapshots, 2), 2);
+    EXPECT_FLOAT_EQ(snapshots[0].position.x, first.position.x);
+    EXPECT_NE(snapshots[1].position.x, first.position.x);
+    sdl3d_destroy_particle_emitter(em);
+}
+
 TEST(SDL3DParticles, DrawNullContextFails)
 {
     EXPECT_FALSE(sdl3d_draw_particles(nullptr, nullptr));
@@ -401,8 +446,8 @@ TEST_F(SDLEffectsFixture, ParticleQuadDrawsInSoftwareRenderer)
     c.lifetime_max = 5.0f;
     c.size_start = 1.0f;
     c.size_end = 1.0f;
-    c.color_start = {255, 40, 20, 255};
-    c.color_end = {255, 40, 20, 255};
+    c.color_start = {20, 255, 20, 255};
+    c.color_end = {20, 255, 20, 255};
     c.random_seed = 99;
     sdl3d_particle_emitter *em = sdl3d_create_particle_emitter(&c);
     ASSERT_NE(em, nullptr);
@@ -414,6 +459,7 @@ TEST_F(SDLEffectsFixture, ParticleQuadDrawsInSoftwareRenderer)
     EXPECT_TRUE(sdl3d_draw_particles(ctx, em)) << SDL_GetError();
     ASSERT_TRUE(sdl3d_end_mode_3d(ctx));
     EXPECT_GT(CountNonBlackPixels(ctx), 0);
+    EXPECT_GT(CountGreenDominantPixels(ctx), 0);
 
     sdl3d_destroy_particle_emitter(em);
     sdl3d_destroy_render_context(ctx);


### PR DESCRIPTION
## Summary
- expands the public particle API with documented emitter shapes, deterministic seeds, config/snapshot/clear helpers, textured camera-facing quads, and emitter-local RNG
- adds a doom_level hazard particle manager for dense radioactive nukage vapor and bright motes in the Nukage Basin
- wires hazard particle update/draw into the managed doom_level loop without moving simulation logic into the renderer

## Tests
- ./scripts/check_clang_format.sh
- git diff --check
- cmake --build build/default --target sdl3d_effects_test doom_level
- ./build/default/tests/sdl3d_effects_test
- ctest --test-dir build/default --output-on-failure
- cmake --build build/default