### PR TITLE
Add signal-to-action logic world

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources(
         src/image.c
         src/input.c
         src/lighting.c
+        src/logic.c
         src/math.c
         src/font.c
         src/fps_mover.c

--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -1,0 +1,111 @@
+/**
+ * @file logic.h
+ * @brief Signal-to-action binding runtime for designer-composable gameplay.
+ *
+ * The logic world is the orchestration layer above the existing signal bus,
+ * action system, and timer pool. It does not replace those systems: it owns a
+ * set of bindings that say "when this signal is emitted, execute this action".
+ *
+ * This lets gameplay be expressed as data:
+ * - sensors and triggers emit signals,
+ * - logic bindings execute ordered actions,
+ * - actions mutate properties, emit more signals, or start timers.
+ *
+ * The logic world does not own the signal bus or timer pool passed at
+ * creation. They must remain valid for the lifetime of the logic world.
+ */
+
+#ifndef SDL3D_LOGIC_H
+#define SDL3D_LOGIC_H
+
+#include <stdbool.h>
+
+#include "sdl3d/action.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/timer_pool.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque signal-to-action binding runtime. */
+    typedef struct sdl3d_logic_world sdl3d_logic_world;
+
+    /**
+     * @brief Create a logic world that listens to a signal bus.
+     *
+     * The logic world references @p bus and @p timers but does not own either
+     * object. @p bus is required because bindings are implemented as signal
+     * handlers. @p timers may be NULL; START_TIMER actions then become no-ops,
+     * matching sdl3d_action_execute semantics.
+     *
+     * @param bus Signal bus used for binding dispatch. Must not be NULL.
+     * @param timers Optional timer pool used by START_TIMER actions.
+     * @return A new logic world, or NULL on invalid input or allocation failure.
+     */
+    sdl3d_logic_world *sdl3d_logic_world_create(sdl3d_signal_bus *bus, sdl3d_timer_pool *timers);
+
+    /**
+     * @brief Destroy a logic world and disconnect all of its bindings.
+     *
+     * The referenced signal bus and timer pool are not destroyed. Safe to call
+     * with NULL. Destroying a logic world from inside an active signal emission
+     * follows the same lifetime restrictions as destroying user data for any
+     * signal handler: callers should avoid doing so while the bus is emitting.
+     */
+    void sdl3d_logic_world_destroy(sdl3d_logic_world *world);
+
+    /**
+     * @brief Bind one action to a signal.
+     *
+     * The action is copied by value. Pointer fields inside the action, such as
+     * property bags and strings, are still caller-owned and must remain valid
+     * for as long as the binding can execute.
+     *
+     * Bindings execute in the same deterministic order as signal-bus
+     * connections: the order in which they were successfully added, interleaved
+     * with any other handlers connected directly to the same signal.
+     *
+     * @param world Logic world that owns the binding.
+     * @param signal_id Signal that should execute the action.
+     * @param action Action to copy into the binding. Must not be NULL.
+     * @return A binding id greater than zero, or zero on failure.
+     */
+    int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action);
+
+    /**
+     * @brief Remove a binding by id.
+     *
+     * Disconnects the binding from the signal bus. No-op if @p binding_id is
+     * invalid or has already been removed.
+     */
+    void sdl3d_logic_world_unbind_action(sdl3d_logic_world *world, int binding_id);
+
+    /**
+     * @brief Enable or disable an existing binding.
+     *
+     * Disabled bindings remain connected and keep their deterministic order, but
+     * they skip action execution while disabled.
+     *
+     * @return true if the binding was found, false otherwise.
+     */
+    bool sdl3d_logic_world_set_binding_enabled(sdl3d_logic_world *world, int binding_id, bool enabled);
+
+    /**
+     * @brief Return whether a binding is currently enabled.
+     *
+     * @return false when the world or binding id is invalid.
+     */
+    bool sdl3d_logic_world_binding_enabled(const sdl3d_logic_world *world, int binding_id);
+
+    /**
+     * @brief Return the number of live bindings in the logic world.
+     */
+    int sdl3d_logic_world_binding_count(const sdl3d_logic_world *world);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_LOGIC_H */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -16,6 +16,7 @@
 #include "sdl3d/image.h"
 #include "sdl3d/input.h"
 #include "sdl3d/lighting.h"
+#include "sdl3d/logic.h"
 #include "sdl3d/math.h"
 #include "sdl3d/model.h"
 #include "sdl3d/render_context.h"

--- a/src/logic.c
+++ b/src/logic.c
@@ -1,0 +1,160 @@
+/**
+ * @file logic.c
+ * @brief Signal-to-action binding runtime implementation.
+ */
+
+#include "sdl3d/logic.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+typedef struct logic_binding
+{
+    struct sdl3d_logic_world *owner;
+    int id;
+    int signal_id;
+    int connection_id;
+    sdl3d_action action;
+    bool enabled;
+    struct logic_binding *next;
+} logic_binding;
+
+struct sdl3d_logic_world
+{
+    sdl3d_signal_bus *bus;
+    sdl3d_timer_pool *timers;
+    logic_binding *bindings;
+    int binding_count;
+    int next_binding_id;
+};
+
+static logic_binding *find_binding(const sdl3d_logic_world *world, int binding_id)
+{
+    if (world == NULL || binding_id <= 0)
+        return NULL;
+
+    for (logic_binding *binding = world->bindings; binding != NULL; binding = binding->next)
+    {
+        if (binding->id == binding_id)
+            return binding;
+    }
+    return NULL;
+}
+
+static void execute_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    (void)payload;
+
+    logic_binding *binding = (logic_binding *)userdata;
+    if (binding == NULL || !binding->enabled || binding->signal_id != signal_id)
+        return;
+
+    /*
+     * Current action types do not consume signal payloads. Payload-aware actions
+     * can be added without changing the binding dispatch model.
+     */
+    sdl3d_logic_world *world = binding->owner;
+    sdl3d_action_execute(&binding->action, world != NULL ? world->bus : NULL, world != NULL ? world->timers : NULL);
+}
+
+sdl3d_logic_world *sdl3d_logic_world_create(sdl3d_signal_bus *bus, sdl3d_timer_pool *timers)
+{
+    if (bus == NULL)
+        return NULL;
+
+    sdl3d_logic_world *world = (sdl3d_logic_world *)SDL_calloc(1, sizeof(sdl3d_logic_world));
+    if (world == NULL)
+        return NULL;
+
+    world->bus = bus;
+    world->timers = timers;
+    world->next_binding_id = 1;
+    return world;
+}
+
+void sdl3d_logic_world_destroy(sdl3d_logic_world *world)
+{
+    if (world == NULL)
+        return;
+
+    logic_binding *binding = world->bindings;
+    while (binding != NULL)
+    {
+        logic_binding *next = binding->next;
+        if (world->bus != NULL && binding->connection_id > 0)
+            sdl3d_signal_disconnect(world->bus, binding->connection_id);
+        SDL_free(binding);
+        binding = next;
+    }
+    SDL_free(world);
+}
+
+int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action)
+{
+    if (world == NULL || world->bus == NULL || action == NULL)
+        return 0;
+
+    logic_binding *binding = (logic_binding *)SDL_calloc(1, sizeof(logic_binding));
+    if (binding == NULL)
+        return 0;
+
+    binding->id = world->next_binding_id++;
+    binding->owner = world;
+    binding->signal_id = signal_id;
+    binding->action = *action;
+    binding->enabled = true;
+
+    binding->connection_id = sdl3d_signal_connect(world->bus, signal_id, execute_binding, binding);
+    if (binding->connection_id == 0)
+    {
+        SDL_free(binding);
+        return 0;
+    }
+
+    binding->next = world->bindings;
+    world->bindings = binding;
+    world->binding_count++;
+    return binding->id;
+}
+
+void sdl3d_logic_world_unbind_action(sdl3d_logic_world *world, int binding_id)
+{
+    if (world == NULL || binding_id <= 0)
+        return;
+
+    logic_binding **cursor = &world->bindings;
+    while (*cursor != NULL)
+    {
+        logic_binding *binding = *cursor;
+        if (binding->id == binding_id)
+        {
+            *cursor = binding->next;
+            if (world->bus != NULL && binding->connection_id > 0)
+                sdl3d_signal_disconnect(world->bus, binding->connection_id);
+            SDL_free(binding);
+            world->binding_count--;
+            return;
+        }
+        cursor = &binding->next;
+    }
+}
+
+bool sdl3d_logic_world_set_binding_enabled(sdl3d_logic_world *world, int binding_id, bool enabled)
+{
+    logic_binding *binding = find_binding(world, binding_id);
+    if (binding == NULL)
+        return false;
+
+    binding->enabled = enabled;
+    return true;
+}
+
+bool sdl3d_logic_world_binding_enabled(const sdl3d_logic_world *world, int binding_id)
+{
+    const logic_binding *binding = find_binding(world, binding_id);
+    return binding != NULL && binding->enabled;
+}
+
+int sdl3d_logic_world_binding_count(const sdl3d_logic_world *world)
+{
+    return world != NULL ? world->binding_count : 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SDL3D_TEST_SOURCES
     test_texture.cpp
     test_textured_rendering.cpp
     test_lighting.cpp
+    test_logic.cpp
     test_scene.cpp
     test_collision.cpp
     test_action.cpp
@@ -186,6 +187,7 @@ else()
     sdl3d_add_test(sdl3d_textured_rendering_test test_textured_rendering.cpp render)
     sdl3d_add_test(sdl3d_lighting_test test_lighting.cpp render)
     target_include_directories(sdl3d_lighting_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    sdl3d_add_test(sdl3d_logic_test test_logic.cpp unit)
     sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
     sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
     sdl3d_add_test(sdl3d_action_test test_action.cpp unit)

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -1,0 +1,239 @@
+/**
+ * @file test_logic.cpp
+ * @brief Unit tests for sdl3d_logic_world signal-to-action bindings.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "sdl3d/logic.h"
+#include "sdl3d/properties.h"
+}
+
+TEST(LogicWorld, CreateAndDestroy)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_timer_pool *timers = sdl3d_timer_pool_create();
+
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, timers);
+    ASSERT_NE(world, nullptr);
+    EXPECT_EQ(sdl3d_logic_world_binding_count(world), 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_timer_pool_destroy(timers);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, CreateRequiresBus)
+{
+    sdl3d_timer_pool *timers = sdl3d_timer_pool_create();
+    EXPECT_EQ(sdl3d_logic_world_create(nullptr, timers), nullptr);
+    sdl3d_timer_pool_destroy(timers);
+}
+
+TEST(LogicWorld, DestroyNullIsSafe)
+{
+    sdl3d_logic_world_destroy(nullptr);
+}
+
+TEST(LogicWorld, BoundActionExecutesWhenSignalIsEmitted)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action action = sdl3d_action_make_set_bool(props, "opened", true);
+    int binding_id = sdl3d_logic_world_bind_action(world, 100, &action);
+    EXPECT_GT(binding_id, 0);
+    EXPECT_EQ(sdl3d_logic_world_binding_count(world), 1);
+
+    sdl3d_signal_emit(bus, 100, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "opened", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, BoundActionIgnoresDifferentSignals)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action action = sdl3d_action_make_set_bool(props, "opened", true);
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 100, &action), 0);
+
+    sdl3d_signal_emit(bus, 101, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(props, "opened", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, BindingsExecuteInSignalConnectionOrder)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action first = sdl3d_action_make_set_int(props, "value", 1);
+    sdl3d_action second = sdl3d_action_make_set_int(props, "value", 2);
+
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 7, &first), 0);
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 7, &second), 0);
+
+    sdl3d_signal_emit(bus, 7, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(props, "value", 0), 2);
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, DisabledBindingDoesNotExecuteAndCanBeReenabled)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action action = sdl3d_action_make_set_bool(props, "armed", true);
+    int binding_id = sdl3d_logic_world_bind_action(world, 42, &action);
+    ASSERT_GT(binding_id, 0);
+
+    EXPECT_TRUE(sdl3d_logic_world_set_binding_enabled(world, binding_id, false));
+    EXPECT_FALSE(sdl3d_logic_world_binding_enabled(world, binding_id));
+    sdl3d_signal_emit(bus, 42, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(props, "armed", false));
+
+    EXPECT_TRUE(sdl3d_logic_world_set_binding_enabled(world, binding_id, true));
+    EXPECT_TRUE(sdl3d_logic_world_binding_enabled(world, binding_id));
+    sdl3d_signal_emit(bus, 42, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "armed", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, UnbindRemovesBindingAndDisconnectsHandler)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action action = sdl3d_action_make_set_bool(props, "active", true);
+    int binding_id = sdl3d_logic_world_bind_action(world, 12, &action);
+    ASSERT_GT(binding_id, 0);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 1);
+
+    sdl3d_logic_world_unbind_action(world, binding_id);
+    EXPECT_EQ(sdl3d_logic_world_binding_count(world), 0);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 0);
+
+    sdl3d_signal_emit(bus, 12, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(props, "active", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, EmitSignalActionCanChainToAnotherBinding)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action emit_second = sdl3d_action_make_emit_signal(2);
+    sdl3d_action set_done = sdl3d_action_make_set_bool(props, "done", true);
+
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 1, &emit_second), 0);
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 2, &set_done), 0);
+
+    sdl3d_signal_emit(bus, 1, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "done", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, StartTimerActionUsesWorldTimerPool)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_timer_pool *timers = sdl3d_timer_pool_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, timers);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action start_timer{};
+    start_timer.type = SDL3D_ACTION_START_TIMER;
+    start_timer.start_timer.delay = 0.5f;
+    start_timer.start_timer.signal_id = 2;
+    start_timer.start_timer.repeating = false;
+    start_timer.start_timer.interval = 0.0f;
+
+    sdl3d_action set_done = sdl3d_action_make_set_bool(props, "done", true);
+
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 1, &start_timer), 0);
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 2, &set_done), 0);
+
+    sdl3d_signal_emit(bus, 1, nullptr);
+    EXPECT_EQ(sdl3d_timer_pool_active_count(timers), 1);
+
+    sdl3d_timer_pool_update(timers, bus, 0.25f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(props, "done", false));
+
+    sdl3d_timer_pool_update(timers, bus, 0.25f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "done", false));
+    EXPECT_EQ(sdl3d_timer_pool_active_count(timers), 0);
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_timer_pool_destroy(timers);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, DestroyDisconnectsBindingsButLeavesBusAlive)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action action = sdl3d_action_make_set_bool(props, "active", true);
+    ASSERT_GT(sdl3d_logic_world_bind_action(world, 5, &action), 0);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 1);
+
+    sdl3d_logic_world_destroy(world);
+    EXPECT_EQ(sdl3d_signal_bus_connection_count(bus), 0);
+
+    sdl3d_signal_emit(bus, 5, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(props, "active", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorld, InvalidOperationsAreSafe)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    sdl3d_action action = sdl3d_action_make_log("safe");
+
+    EXPECT_EQ(sdl3d_logic_world_bind_action(nullptr, 1, &action), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_action(world, 1, nullptr), 0);
+    EXPECT_FALSE(sdl3d_logic_world_set_binding_enabled(nullptr, 1, true));
+    EXPECT_FALSE(sdl3d_logic_world_set_binding_enabled(world, 999, true));
+    EXPECT_FALSE(sdl3d_logic_world_binding_enabled(nullptr, 1));
+    EXPECT_FALSE(sdl3d_logic_world_binding_enabled(world, 999));
+    EXPECT_EQ(sdl3d_logic_world_binding_count(nullptr), 0);
+
+    sdl3d_logic_world_unbind_action(nullptr, 1);
+    sdl3d_logic_world_unbind_action(world, 999);
+    sdl3d_logic_world_unbind_action(world, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}


### PR DESCRIPTION
## Summary
- add public `sdl3d_logic_world` API for binding signals to ordered action execution
- reuse the existing signal bus, action system, and timer pool instead of duplicating gameplay plumbing
- expose binding lifecycle controls: bind, unbind, enable/disable, enabled query, and binding count
- include the new public header through `sdl3d/sdl3d.h`

## Correctness
- bindings execute through `sdl3d_signal_connect`, preserving signal-bus dispatch order
- actions receive the logic world's bus and timer pool, so chained signal actions and timer actions work
- disabled bindings stay connected but skip execution, preserving order when re-enabled
- destroy/unbind disconnects signal handlers without owning or destroying the bus/timer pool

## Tests
- `./build/release/tests/sdl3d_logic_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/release`
- `ctest --test-dir build/release --output-on-failure`
