### PR TITLE
Add logic target resolution

### DIFF
--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -21,6 +21,8 @@
 #include <stdbool.h>
 
 #include "sdl3d/action.h"
+#include "sdl3d/actor_registry.h"
+#include "sdl3d/level.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/timer_pool.h"
 
@@ -31,6 +33,75 @@ extern "C"
 
     /** @brief Opaque signal-to-action binding runtime. */
     typedef struct sdl3d_logic_world sdl3d_logic_world;
+
+    /**
+     * @brief Kind of authored target reference.
+     *
+     * Target references are stable, serializable handles that can be resolved
+     * at runtime against the logic world's target context. Actor references
+     * reuse the existing actor registry. Sector references use level sector
+     * indices directly or names registered with sdl3d_logic_world_set_sector_name().
+     */
+    typedef enum sdl3d_logic_target_kind
+    {
+        SDL3D_LOGIC_TARGET_NONE = 0,         /**< Invalid/no target. */
+        SDL3D_LOGIC_TARGET_ACTOR_ID = 1,     /**< Actor registry id. */
+        SDL3D_LOGIC_TARGET_ACTOR_NAME = 2,   /**< Actor registry name. */
+        SDL3D_LOGIC_TARGET_SECTOR_INDEX = 3, /**< Sector index in the active level. */
+        SDL3D_LOGIC_TARGET_SECTOR_NAME = 4,  /**< Name registered for a sector index. */
+    } sdl3d_logic_target_kind;
+
+    /**
+     * @brief Authored target reference.
+     *
+     * Name pointers are not copied into the reference. They must remain valid
+     * until resolution, or come from persistent level/editor data.
+     */
+    typedef struct sdl3d_logic_target_ref
+    {
+        sdl3d_logic_target_kind kind;
+        union {
+            int actor_id;            /**< Used by SDL3D_LOGIC_TARGET_ACTOR_ID. */
+            const char *actor_name;  /**< Used by SDL3D_LOGIC_TARGET_ACTOR_NAME. */
+            int sector_index;        /**< Used by SDL3D_LOGIC_TARGET_SECTOR_INDEX. */
+            const char *sector_name; /**< Used by SDL3D_LOGIC_TARGET_SECTOR_NAME. */
+        };
+    } sdl3d_logic_target_ref;
+
+    /**
+     * @brief Mutable target data available to a logic world.
+     *
+     * The logic world copies this struct by value and never owns the pointers.
+     * The caller must keep pointed-to objects valid while resolving targets.
+     */
+    typedef struct sdl3d_logic_target_context
+    {
+        sdl3d_actor_registry *registry; /**< Actor registry for actor references. May be NULL. */
+        sdl3d_level *level;             /**< Active level for sector references. May be NULL. */
+        sdl3d_sector *sectors;          /**< Mutable sector definitions matching @p level. May be NULL. */
+        int sector_count;               /**< Number of entries in @p sectors. */
+    } sdl3d_logic_target_context;
+
+    /**
+     * @brief Runtime result of resolving a target reference.
+     *
+     * Returned pointers are borrowed. Actor pointers remain valid until the
+     * registry is mutated. Sector pointers remain valid while the caller-owned
+     * sector array remains alive and unmoved.
+     */
+    typedef struct sdl3d_logic_resolved_target
+    {
+        sdl3d_logic_target_kind kind;
+        union {
+            sdl3d_registered_actor *actor; /**< Resolved actor for actor references. */
+            struct
+            {
+                sdl3d_level *level;   /**< Level supplied in the target context. */
+                sdl3d_sector *sector; /**< Resolved sector definition. */
+                int sector_index;     /**< Resolved sector index. */
+            } sector;
+        };
+    } sdl3d_logic_resolved_target;
 
     /**
      * @brief Create a logic world that listens to a signal bus.
@@ -55,6 +126,77 @@ extern "C"
      * signal handler: callers should avoid doing so while the bus is emitting.
      */
     void sdl3d_logic_world_destroy(sdl3d_logic_world *world);
+
+    /* ================================================================== */
+    /* Target references                                                  */
+    /* ================================================================== */
+
+    /** @brief Create an actor-id target reference. */
+    sdl3d_logic_target_ref sdl3d_logic_target_actor_id(int actor_id);
+
+    /**
+     * @brief Create an actor-name target reference.
+     *
+     * The name pointer is not copied into the reference.
+     */
+    sdl3d_logic_target_ref sdl3d_logic_target_actor_name(const char *actor_name);
+
+    /** @brief Create a sector-index target reference. */
+    sdl3d_logic_target_ref sdl3d_logic_target_sector_index(int sector_index);
+
+    /**
+     * @brief Create a sector-name target reference.
+     *
+     * The name pointer is not copied into the reference. Register sector names
+     * on the world with sdl3d_logic_world_set_sector_name().
+     */
+    sdl3d_logic_target_ref sdl3d_logic_target_sector_name(const char *sector_name);
+
+    /**
+     * @brief Set or clear the target context used for resolution.
+     *
+     * Passing NULL clears the context. The context pointers are borrowed and
+     * must remain valid while target resolution is used.
+     */
+    void sdl3d_logic_world_set_target_context(sdl3d_logic_world *world, const sdl3d_logic_target_context *context);
+
+    /**
+     * @brief Return the current copied target context, or NULL.
+     */
+    const sdl3d_logic_target_context *sdl3d_logic_world_get_target_context(const sdl3d_logic_world *world);
+
+    /**
+     * @brief Assign a stable editor-facing name to a sector index.
+     *
+     * The name is copied by the logic world. Names are unique: assigning an
+     * existing name to a new index moves that name, and assigning a new name to
+     * an existing index replaces the previous name for that index.
+     *
+     * @return true on success, false on invalid input or allocation failure.
+     */
+    bool sdl3d_logic_world_set_sector_name(sdl3d_logic_world *world, int sector_index, const char *name);
+
+    /**
+     * @brief Remove all sector name aliases from the logic world.
+     */
+    void sdl3d_logic_world_clear_sector_names(sdl3d_logic_world *world);
+
+    /**
+     * @brief Find a sector index by registered sector name.
+     *
+     * @return The sector index, or -1 if the name is missing or invalid.
+     */
+    int sdl3d_logic_world_find_sector_index(const sdl3d_logic_world *world, const char *name);
+
+    /**
+     * @brief Resolve an authored target reference against the world context.
+     *
+     * On failure, @p out_target is reset to SDL3D_LOGIC_TARGET_NONE when
+     * non-NULL. Resolution fails when required context is missing, the target
+     * does not exist, or a sector index is outside the current sector count.
+     */
+    bool sdl3d_logic_world_resolve_target(const sdl3d_logic_world *world, const sdl3d_logic_target_ref *ref,
+                                          sdl3d_logic_resolved_target *out_target);
 
     /**
      * @brief Bind one action to a signal.

--- a/src/logic.c
+++ b/src/logic.c
@@ -18,13 +18,24 @@ typedef struct logic_binding
     struct logic_binding *next;
 } logic_binding;
 
+typedef struct sector_alias
+{
+    int sector_index;
+    char *name;
+} sector_alias;
+
 struct sdl3d_logic_world
 {
     sdl3d_signal_bus *bus;
     sdl3d_timer_pool *timers;
     logic_binding *bindings;
+    sdl3d_logic_target_context target_context;
+    sector_alias *sector_aliases;
     int binding_count;
+    int sector_alias_count;
+    int sector_alias_capacity;
     int next_binding_id;
+    bool has_target_context;
 };
 
 static logic_binding *find_binding(const sdl3d_logic_world *world, int binding_id)
@@ -38,6 +49,57 @@ static logic_binding *find_binding(const sdl3d_logic_world *world, int binding_i
             return binding;
     }
     return NULL;
+}
+
+static void clear_resolved_target(sdl3d_logic_resolved_target *target)
+{
+    if (target != NULL)
+        SDL_zerop(target);
+}
+
+static void clear_sector_aliases(sdl3d_logic_world *world)
+{
+    if (world == NULL)
+        return;
+
+    for (int i = 0; i < world->sector_alias_count; ++i)
+        SDL_free(world->sector_aliases[i].name);
+    SDL_free(world->sector_aliases);
+    world->sector_aliases = NULL;
+    world->sector_alias_count = 0;
+    world->sector_alias_capacity = 0;
+}
+
+static bool ensure_sector_alias_capacity(sdl3d_logic_world *world)
+{
+    if (world->sector_alias_count < world->sector_alias_capacity)
+        return true;
+
+    const int new_capacity = world->sector_alias_capacity < 8 ? 8 : world->sector_alias_capacity * 2;
+    sector_alias *aliases = (sector_alias *)SDL_realloc(world->sector_aliases, (size_t)new_capacity * sizeof(*aliases));
+    if (aliases == NULL)
+        return false;
+
+    world->sector_aliases = aliases;
+    world->sector_alias_capacity = new_capacity;
+    return true;
+}
+
+static void remove_sector_alias_at(sdl3d_logic_world *world, int index)
+{
+    if (world == NULL || index < 0 || index >= world->sector_alias_count)
+        return;
+
+    SDL_free(world->sector_aliases[index].name);
+    world->sector_alias_count--;
+    if (index < world->sector_alias_count)
+        world->sector_aliases[index] = world->sector_aliases[world->sector_alias_count];
+}
+
+static bool sector_index_is_valid(const sdl3d_logic_target_context *context, int sector_index)
+{
+    return context != NULL && context->level != NULL && context->sectors != NULL && sector_index >= 0 &&
+           sector_index < context->sector_count && sector_index < context->level->sector_count;
 }
 
 static void execute_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -85,7 +147,175 @@ void sdl3d_logic_world_destroy(sdl3d_logic_world *world)
         SDL_free(binding);
         binding = next;
     }
+    clear_sector_aliases(world);
     SDL_free(world);
+}
+
+sdl3d_logic_target_ref sdl3d_logic_target_actor_id(int actor_id)
+{
+    sdl3d_logic_target_ref ref;
+    SDL_zero(ref);
+    ref.kind = SDL3D_LOGIC_TARGET_ACTOR_ID;
+    ref.actor_id = actor_id;
+    return ref;
+}
+
+sdl3d_logic_target_ref sdl3d_logic_target_actor_name(const char *actor_name)
+{
+    sdl3d_logic_target_ref ref;
+    SDL_zero(ref);
+    ref.kind = SDL3D_LOGIC_TARGET_ACTOR_NAME;
+    ref.actor_name = actor_name;
+    return ref;
+}
+
+sdl3d_logic_target_ref sdl3d_logic_target_sector_index(int sector_index)
+{
+    sdl3d_logic_target_ref ref;
+    SDL_zero(ref);
+    ref.kind = SDL3D_LOGIC_TARGET_SECTOR_INDEX;
+    ref.sector_index = sector_index;
+    return ref;
+}
+
+sdl3d_logic_target_ref sdl3d_logic_target_sector_name(const char *sector_name)
+{
+    sdl3d_logic_target_ref ref;
+    SDL_zero(ref);
+    ref.kind = SDL3D_LOGIC_TARGET_SECTOR_NAME;
+    ref.sector_name = sector_name;
+    return ref;
+}
+
+void sdl3d_logic_world_set_target_context(sdl3d_logic_world *world, const sdl3d_logic_target_context *context)
+{
+    if (world == NULL)
+        return;
+
+    if (context == NULL)
+    {
+        SDL_zero(world->target_context);
+        world->has_target_context = false;
+        return;
+    }
+
+    world->target_context = *context;
+    world->has_target_context = true;
+}
+
+const sdl3d_logic_target_context *sdl3d_logic_world_get_target_context(const sdl3d_logic_world *world)
+{
+    return world != NULL && world->has_target_context ? &world->target_context : NULL;
+}
+
+bool sdl3d_logic_world_set_sector_name(sdl3d_logic_world *world, int sector_index, const char *name)
+{
+    if (world == NULL || sector_index < 0 || name == NULL || name[0] == '\0')
+        return false;
+
+    char *name_copy = SDL_strdup(name);
+    if (name_copy == NULL)
+        return false;
+
+    for (int i = world->sector_alias_count - 1; i >= 0; --i)
+    {
+        if (world->sector_aliases[i].sector_index == sector_index ||
+            SDL_strcmp(world->sector_aliases[i].name, name) == 0)
+        {
+            remove_sector_alias_at(world, i);
+        }
+    }
+
+    if (!ensure_sector_alias_capacity(world))
+    {
+        SDL_free(name_copy);
+        return false;
+    }
+
+    sector_alias *alias = &world->sector_aliases[world->sector_alias_count++];
+    alias->sector_index = sector_index;
+    alias->name = name_copy;
+    return true;
+}
+
+void sdl3d_logic_world_clear_sector_names(sdl3d_logic_world *world)
+{
+    clear_sector_aliases(world);
+}
+
+int sdl3d_logic_world_find_sector_index(const sdl3d_logic_world *world, const char *name)
+{
+    if (world == NULL || name == NULL || name[0] == '\0')
+        return -1;
+
+    for (int i = 0; i < world->sector_alias_count; ++i)
+    {
+        if (SDL_strcmp(world->sector_aliases[i].name, name) == 0)
+            return world->sector_aliases[i].sector_index;
+    }
+    return -1;
+}
+
+bool sdl3d_logic_world_resolve_target(const sdl3d_logic_world *world, const sdl3d_logic_target_ref *ref,
+                                      sdl3d_logic_resolved_target *out_target)
+{
+    clear_resolved_target(out_target);
+
+    const sdl3d_logic_target_context *context = sdl3d_logic_world_get_target_context(world);
+    if (context == NULL || ref == NULL || out_target == NULL)
+        return false;
+
+    switch (ref->kind)
+    {
+    case SDL3D_LOGIC_TARGET_ACTOR_ID:
+        if (context->registry == NULL || ref->actor_id <= 0)
+            return false;
+        out_target->actor = sdl3d_actor_registry_get(context->registry, ref->actor_id);
+        if (out_target->actor == NULL)
+        {
+            clear_resolved_target(out_target);
+            return false;
+        }
+        out_target->kind = SDL3D_LOGIC_TARGET_ACTOR_ID;
+        return true;
+
+    case SDL3D_LOGIC_TARGET_ACTOR_NAME:
+        if (context->registry == NULL || ref->actor_name == NULL || ref->actor_name[0] == '\0')
+            return false;
+        out_target->actor = sdl3d_actor_registry_find(context->registry, ref->actor_name);
+        if (out_target->actor == NULL)
+        {
+            clear_resolved_target(out_target);
+            return false;
+        }
+        out_target->kind = SDL3D_LOGIC_TARGET_ACTOR_NAME;
+        return true;
+
+    case SDL3D_LOGIC_TARGET_SECTOR_INDEX:
+        if (!sector_index_is_valid(context, ref->sector_index))
+            return false;
+        out_target->kind = SDL3D_LOGIC_TARGET_SECTOR_INDEX;
+        out_target->sector.level = context->level;
+        out_target->sector.sector = &context->sectors[ref->sector_index];
+        out_target->sector.sector_index = ref->sector_index;
+        return true;
+
+    case SDL3D_LOGIC_TARGET_SECTOR_NAME: {
+        const int sector_index = sdl3d_logic_world_find_sector_index(world, ref->sector_name);
+        if (!sector_index_is_valid(context, sector_index))
+            return false;
+        out_target->kind = SDL3D_LOGIC_TARGET_SECTOR_NAME;
+        out_target->sector.level = context->level;
+        out_target->sector.sector = &context->sectors[sector_index];
+        out_target->sector.sector_index = sector_index;
+        return true;
+    }
+
+    case SDL3D_LOGIC_TARGET_NONE:
+        break;
+    }
+
+    return false;
 }
 
 int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action)

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -7,8 +7,18 @@
 
 extern "C"
 {
+#include "sdl3d/actor_registry.h"
+#include "sdl3d/level.h"
 #include "sdl3d/logic.h"
 #include "sdl3d/properties.h"
+}
+
+static sdl3d_logic_world *make_logic_world(sdl3d_signal_bus **out_bus)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    if (out_bus != nullptr)
+        *out_bus = bus;
+    return sdl3d_logic_world_create(bus, nullptr);
 }
 
 TEST(LogicWorld, CreateAndDestroy)
@@ -233,6 +243,239 @@ TEST(LogicWorld, InvalidOperationsAreSafe)
     sdl3d_logic_world_unbind_action(nullptr, 1);
     sdl3d_logic_world_unbind_action(world, 999);
     sdl3d_logic_world_unbind_action(world, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, TargetContextCanBeSetAndCleared)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    const sdl3d_logic_target_context *stored = sdl3d_logic_world_get_target_context(world);
+    ASSERT_NE(stored, nullptr);
+    EXPECT_EQ(stored->registry, registry);
+
+    sdl3d_logic_world_set_target_context(world, nullptr);
+    EXPECT_EQ(sdl3d_logic_world_get_target_context(world), nullptr);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, ResolveActorById)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "door_1");
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_actor_id(actor->id);
+    sdl3d_logic_resolved_target resolved{};
+    ASSERT_TRUE(sdl3d_logic_world_resolve_target(world, &ref, &resolved));
+    EXPECT_EQ(resolved.kind, SDL3D_LOGIC_TARGET_ACTOR_ID);
+    EXPECT_EQ(resolved.actor, actor);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, ResolveActorByName)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "lift_button");
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_actor_name("lift_button");
+    sdl3d_logic_resolved_target resolved{};
+    ASSERT_TRUE(sdl3d_logic_world_resolve_target(world, &ref, &resolved));
+    EXPECT_EQ(resolved.kind, SDL3D_LOGIC_TARGET_ACTOR_NAME);
+    EXPECT_EQ(resolved.actor, actor);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, MissingActorResolutionFailsAndClearsOutput)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_actor_name("missing");
+    sdl3d_logic_resolved_target resolved{};
+    resolved.kind = SDL3D_LOGIC_TARGET_ACTOR_NAME;
+    resolved.actor = (sdl3d_registered_actor *)0x1;
+
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, &ref, &resolved));
+    EXPECT_EQ(resolved.kind, SDL3D_LOGIC_TARGET_NONE);
+    EXPECT_EQ(resolved.actor, nullptr);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, ResolveSectorByIndex)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[2]{};
+    level.sector_count = 2;
+    sectors[1].damage_per_second = 12.0f;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 2;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_sector_index(1);
+    sdl3d_logic_resolved_target resolved{};
+    ASSERT_TRUE(sdl3d_logic_world_resolve_target(world, &ref, &resolved));
+    EXPECT_EQ(resolved.kind, SDL3D_LOGIC_TARGET_SECTOR_INDEX);
+    EXPECT_EQ(resolved.sector.level, &level);
+    EXPECT_EQ(resolved.sector.sector, &sectors[1]);
+    EXPECT_EQ(resolved.sector.sector_index, 1);
+    EXPECT_FLOAT_EQ(resolved.sector.sector->damage_per_second, 12.0f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, InvalidSectorIndexFails)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[1]{};
+    level.sector_count = 1;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 1;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_target_ref negative = sdl3d_logic_target_sector_index(-1);
+    sdl3d_logic_target_ref too_high = sdl3d_logic_target_sector_index(1);
+    sdl3d_logic_resolved_target resolved{};
+
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, &negative, &resolved));
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, &too_high, &resolved));
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, ResolveSectorByRegisteredName)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[3]{};
+    level.sector_count = 3;
+    sectors[2].push_velocity[0] = 4.0f;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 3;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 2, "dragon_conveyor"));
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "dragon_conveyor"), 2);
+
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_sector_name("dragon_conveyor");
+    sdl3d_logic_resolved_target resolved{};
+    ASSERT_TRUE(sdl3d_logic_world_resolve_target(world, &ref, &resolved));
+    EXPECT_EQ(resolved.kind, SDL3D_LOGIC_TARGET_SECTOR_NAME);
+    EXPECT_EQ(resolved.sector.sector, &sectors[2]);
+    EXPECT_EQ(resolved.sector.sector_index, 2);
+    EXPECT_FLOAT_EQ(resolved.sector.sector->push_velocity[0], 4.0f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, SectorNamesAreUniqueByNameAndIndex)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 1, "lift"));
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 2, "lift"));
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "lift"), 2);
+
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 2, "platform"));
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "lift"), -1);
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "platform"), 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, ClearSectorNamesRemovesAliases)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 0, "nukage"));
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "nukage"), 0);
+
+    sdl3d_logic_world_clear_sector_names(world);
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, "nukage"), -1);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldTargets, InvalidTargetOperationsAreSafe)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_logic_target_ref ref = sdl3d_logic_target_actor_id(1);
+    sdl3d_logic_resolved_target resolved{};
+
+    sdl3d_logic_world_set_target_context(nullptr, nullptr);
+    EXPECT_EQ(sdl3d_logic_world_get_target_context(nullptr), nullptr);
+    EXPECT_FALSE(sdl3d_logic_world_set_sector_name(nullptr, 0, "sector"));
+    EXPECT_FALSE(sdl3d_logic_world_set_sector_name(world, -1, "sector"));
+    EXPECT_FALSE(sdl3d_logic_world_set_sector_name(world, 0, nullptr));
+    EXPECT_FALSE(sdl3d_logic_world_set_sector_name(world, 0, ""));
+    sdl3d_logic_world_clear_sector_names(nullptr);
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(nullptr, "sector"), -1);
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, nullptr), -1);
+    EXPECT_EQ(sdl3d_logic_world_find_sector_index(world, ""), -1);
+
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(nullptr, &ref, &resolved));
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, nullptr, &resolved));
+    EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, &ref, nullptr));
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add logic target references for actor ids, actor names, sector indices, and sector names
- add a borrowed target context to `sdl3d_logic_world` for resolving against the existing actor registry and active level/sector array
- add sector-name aliases owned by the logic world so authored data can refer to sectors without changing the level data model yet
- document ownership and lifetime rules in the public Doxygen API

## Correctness
- actor resolution reuses `sdl3d_actor_registry_get` and `sdl3d_actor_registry_find`
- sector resolution validates the caller-provided sector array count and the active level sector count
- sector aliases are unique by both name and index; reassigning either replaces the prior alias
- failed resolutions clear the output target to `SDL3D_LOGIC_TARGET_NONE`

## Tests
- `./build/release/tests/sdl3d_logic_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/release`
- `ctest --test-dir build/release --output-on-failure`
