### PR TITLE
Add target-aware logic actions

### DIFF
--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -104,6 +104,78 @@ extern "C"
     } sdl3d_logic_resolved_target;
 
     /**
+     * @brief Target-aware action type for designer-authored gameplay logic.
+     *
+     * These actions extend the lower-level sdl3d_action vocabulary with effects
+     * that need logic-world target resolution. Existing sdl3d_action values are
+     * still supported through SDL3D_LOGIC_ACTION_CORE.
+     */
+    typedef enum sdl3d_logic_action_type
+    {
+        SDL3D_LOGIC_ACTION_NONE = 0,                /**< Invalid/no action. */
+        SDL3D_LOGIC_ACTION_CORE = 1,                /**< Execute an embedded sdl3d_action. */
+        SDL3D_LOGIC_ACTION_SET_ACTOR_ACTIVE = 2,    /**< Set a resolved actor's active flag. */
+        SDL3D_LOGIC_ACTION_TOGGLE_ACTOR_ACTIVE = 3, /**< Toggle a resolved actor's active flag. */
+        SDL3D_LOGIC_ACTION_SET_ACTOR_PROPERTY = 4,  /**< Set a property on a resolved actor. */
+        SDL3D_LOGIC_ACTION_SET_SECTOR_PUSH = 5,     /**< Set a sector push/current velocity. */
+        SDL3D_LOGIC_ACTION_SET_SECTOR_DAMAGE = 6,   /**< Set non-negative sector damage per second. */
+        SDL3D_LOGIC_ACTION_SET_SECTOR_AMBIENT = 7,  /**< Set a non-negative ambient sound id. */
+    } sdl3d_logic_action_type;
+
+    /**
+     * @brief Target-aware action executed by a logic world.
+     *
+     * Like sdl3d_action, this is a plain value type. It owns no pointers:
+     * target names, property keys, and string property values must remain valid
+     * until execution. Property bags copy string values when the action runs.
+     */
+    typedef struct sdl3d_logic_action
+    {
+        sdl3d_logic_action_type type;
+
+        union {
+            /** @brief Embedded low-level action. */
+            sdl3d_action core;
+
+            /** @brief Set or toggle actor active state. */
+            struct
+            {
+                sdl3d_logic_target_ref target;
+                bool active;
+            } actor_active;
+
+            /** @brief Set a property on a resolved actor's property bag. */
+            struct
+            {
+                sdl3d_logic_target_ref target;
+                const char *key;
+                sdl3d_value value;
+            } actor_property;
+
+            /** @brief Set world-space sector push/current velocity. */
+            struct
+            {
+                sdl3d_logic_target_ref target;
+                sdl3d_vec3 velocity;
+            } sector_push;
+
+            /** @brief Set sector damage per second. Negative values clamp to zero. */
+            struct
+            {
+                sdl3d_logic_target_ref target;
+                float damage_per_second;
+            } sector_damage;
+
+            /** @brief Set sector ambient sound id. Negative values clamp to zero. */
+            struct
+            {
+                sdl3d_logic_target_ref target;
+                int ambient_sound_id;
+            } sector_ambient;
+        };
+    } sdl3d_logic_action;
+
+    /**
      * @brief Create a logic world that listens to a signal bus.
      *
      * The logic world references @p bus and @p timers but does not own either
@@ -198,6 +270,58 @@ extern "C"
     bool sdl3d_logic_world_resolve_target(const sdl3d_logic_world *world, const sdl3d_logic_target_ref *ref,
                                           sdl3d_logic_resolved_target *out_target);
 
+    /* ================================================================== */
+    /* Target-aware actions                                               */
+    /* ================================================================== */
+
+    /** @brief Wrap an existing low-level sdl3d_action as a logic action. */
+    sdl3d_logic_action sdl3d_logic_action_make_core(sdl3d_action action);
+
+    /** @brief Create an action that sets a resolved actor's active flag. */
+    sdl3d_logic_action sdl3d_logic_action_make_set_actor_active(sdl3d_logic_target_ref target, bool active);
+
+    /** @brief Create an action that toggles a resolved actor's active flag. */
+    sdl3d_logic_action sdl3d_logic_action_make_toggle_actor_active(sdl3d_logic_target_ref target);
+
+    /**
+     * @brief Create an action that sets a property on a resolved actor.
+     *
+     * The key pointer and any string value pointer are not copied into the
+     * action; they must remain valid until execution.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_actor_property(sdl3d_logic_target_ref target, const char *key,
+                                                                  sdl3d_value value);
+
+    /** @brief Create an action that sets a sector's push/current velocity. */
+    sdl3d_logic_action sdl3d_logic_action_make_set_sector_push(sdl3d_logic_target_ref target, sdl3d_vec3 velocity);
+
+    /**
+     * @brief Create an action that sets sector damage per second.
+     *
+     * Negative values are clamped to zero during execution.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_sector_damage(sdl3d_logic_target_ref target,
+                                                                 float damage_per_second);
+
+    /**
+     * @brief Create an action that sets a sector ambient sound id.
+     *
+     * Negative values are clamped to zero during execution.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_sector_ambient(sdl3d_logic_target_ref target, int ambient_sound_id);
+
+    /**
+     * @brief Execute a target-aware action immediately.
+     *
+     * Core actions execute through sdl3d_action_execute using the world's signal
+     * bus and timer pool. Target-aware actions resolve their target against the
+     * world's current target context.
+     *
+     * @return true when the action was valid and applied, false when the action
+     *         or target was invalid.
+     */
+    bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action);
+
     /**
      * @brief Bind one action to a signal.
      *
@@ -215,6 +339,16 @@ extern "C"
      * @return A binding id greater than zero, or zero on failure.
      */
     int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action);
+
+    /**
+     * @brief Bind one target-aware logic action to a signal.
+     *
+     * The action is copied by value. Pointers stored inside the action are not
+     * copied and must remain valid while the binding can execute.
+     *
+     * @return A binding id greater than zero, or zero on failure.
+     */
+    int sdl3d_logic_world_bind_logic_action(sdl3d_logic_world *world, int signal_id, const sdl3d_logic_action *action);
 
     /**
      * @brief Remove a binding by id.

--- a/src/logic.c
+++ b/src/logic.c
@@ -13,7 +13,7 @@ typedef struct logic_binding
     int id;
     int signal_id;
     int connection_id;
-    sdl3d_action action;
+    sdl3d_logic_action action;
     bool enabled;
     struct logic_binding *next;
 } logic_binding;
@@ -102,6 +102,58 @@ static bool sector_index_is_valid(const sdl3d_logic_target_context *context, int
            sector_index < context->sector_count && sector_index < context->level->sector_count;
 }
 
+static bool resolved_target_is_actor(const sdl3d_logic_resolved_target *target)
+{
+    return target != NULL &&
+           (target->kind == SDL3D_LOGIC_TARGET_ACTOR_ID || target->kind == SDL3D_LOGIC_TARGET_ACTOR_NAME) &&
+           target->actor != NULL;
+}
+
+static bool resolved_target_is_sector(const sdl3d_logic_resolved_target *target)
+{
+    return target != NULL &&
+           (target->kind == SDL3D_LOGIC_TARGET_SECTOR_INDEX || target->kind == SDL3D_LOGIC_TARGET_SECTOR_NAME) &&
+           target->sector.sector != NULL;
+}
+
+static float clamp_non_negative_float(float value)
+{
+    return value > 0.0f ? value : 0.0f;
+}
+
+static int clamp_non_negative_int(int value)
+{
+    return value > 0 ? value : 0;
+}
+
+static void set_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
+{
+    if (target == NULL || key == NULL || value == NULL)
+        return;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        sdl3d_properties_set_int(target, key, value->as_int);
+        break;
+    case SDL3D_VALUE_FLOAT:
+        sdl3d_properties_set_float(target, key, value->as_float);
+        break;
+    case SDL3D_VALUE_BOOL:
+        sdl3d_properties_set_bool(target, key, value->as_bool);
+        break;
+    case SDL3D_VALUE_VEC3:
+        sdl3d_properties_set_vec3(target, key, value->as_vec3);
+        break;
+    case SDL3D_VALUE_STRING:
+        sdl3d_properties_set_string(target, key, value->as_string);
+        break;
+    case SDL3D_VALUE_COLOR:
+        sdl3d_properties_set_color(target, key, value->as_color);
+        break;
+    }
+}
+
 static void execute_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
     (void)payload;
@@ -110,12 +162,8 @@ static void execute_binding(void *userdata, int signal_id, const sdl3d_propertie
     if (binding == NULL || !binding->enabled || binding->signal_id != signal_id)
         return;
 
-    /*
-     * Current action types do not consume signal payloads. Payload-aware actions
-     * can be added without changing the binding dispatch model.
-     */
     sdl3d_logic_world *world = binding->owner;
-    sdl3d_action_execute(&binding->action, world != NULL ? world->bus : NULL, world != NULL ? world->timers : NULL);
+    sdl3d_logic_world_execute_action(world, &binding->action);
 }
 
 sdl3d_logic_world *sdl3d_logic_world_create(sdl3d_signal_bus *bus, sdl3d_timer_pool *timers)
@@ -318,9 +366,164 @@ bool sdl3d_logic_world_resolve_target(const sdl3d_logic_world *world, const sdl3
     return false;
 }
 
+sdl3d_logic_action sdl3d_logic_action_make_core(sdl3d_action action)
+{
+    sdl3d_logic_action logic_action;
+    SDL_zero(logic_action);
+    logic_action.type = SDL3D_LOGIC_ACTION_CORE;
+    logic_action.core = action;
+    return logic_action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_actor_active(sdl3d_logic_target_ref target, bool active)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_ACTOR_ACTIVE;
+    action.actor_active.target = target;
+    action.actor_active.active = active;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_toggle_actor_active(sdl3d_logic_target_ref target)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_TOGGLE_ACTOR_ACTIVE;
+    action.actor_active.target = target;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_actor_property(sdl3d_logic_target_ref target, const char *key,
+                                                              sdl3d_value value)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_ACTOR_PROPERTY;
+    action.actor_property.target = target;
+    action.actor_property.key = key;
+    action.actor_property.value = value;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_sector_push(sdl3d_logic_target_ref target, sdl3d_vec3 velocity)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_SECTOR_PUSH;
+    action.sector_push.target = target;
+    action.sector_push.velocity = velocity;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_sector_damage(sdl3d_logic_target_ref target, float damage_per_second)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_SECTOR_DAMAGE;
+    action.sector_damage.target = target;
+    action.sector_damage.damage_per_second = damage_per_second;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_sector_ambient(sdl3d_logic_target_ref target, int ambient_sound_id)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_SECTOR_AMBIENT;
+    action.sector_ambient.target = target;
+    action.sector_ambient.ambient_sound_id = ambient_sound_id;
+    return action;
+}
+
+bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action)
+{
+    if (world == NULL || action == NULL)
+        return false;
+
+    sdl3d_logic_resolved_target target;
+    switch (action->type)
+    {
+    case SDL3D_LOGIC_ACTION_CORE:
+        sdl3d_action_execute(&action->core, world->bus, world->timers);
+        return true;
+
+    case SDL3D_LOGIC_ACTION_SET_ACTOR_ACTIVE:
+        if (!sdl3d_logic_world_resolve_target(world, &action->actor_active.target, &target) ||
+            !resolved_target_is_actor(&target))
+        {
+            return false;
+        }
+        target.actor->active = action->actor_active.active;
+        return true;
+
+    case SDL3D_LOGIC_ACTION_TOGGLE_ACTOR_ACTIVE:
+        if (!sdl3d_logic_world_resolve_target(world, &action->actor_active.target, &target) ||
+            !resolved_target_is_actor(&target))
+        {
+            return false;
+        }
+        target.actor->active = !target.actor->active;
+        return true;
+
+    case SDL3D_LOGIC_ACTION_SET_ACTOR_PROPERTY:
+        if (action->actor_property.key == NULL ||
+            !sdl3d_logic_world_resolve_target(world, &action->actor_property.target, &target) ||
+            !resolved_target_is_actor(&target))
+        {
+            return false;
+        }
+        set_property_value(target.actor->props, action->actor_property.key, &action->actor_property.value);
+        return true;
+
+    case SDL3D_LOGIC_ACTION_SET_SECTOR_PUSH:
+        if (!sdl3d_logic_world_resolve_target(world, &action->sector_push.target, &target) ||
+            !resolved_target_is_sector(&target))
+        {
+            return false;
+        }
+        target.sector.sector->push_velocity[0] = action->sector_push.velocity.x;
+        target.sector.sector->push_velocity[1] = action->sector_push.velocity.y;
+        target.sector.sector->push_velocity[2] = action->sector_push.velocity.z;
+        return true;
+
+    case SDL3D_LOGIC_ACTION_SET_SECTOR_DAMAGE:
+        if (!sdl3d_logic_world_resolve_target(world, &action->sector_damage.target, &target) ||
+            !resolved_target_is_sector(&target))
+        {
+            return false;
+        }
+        target.sector.sector->damage_per_second = clamp_non_negative_float(action->sector_damage.damage_per_second);
+        return true;
+
+    case SDL3D_LOGIC_ACTION_SET_SECTOR_AMBIENT:
+        if (!sdl3d_logic_world_resolve_target(world, &action->sector_ambient.target, &target) ||
+            !resolved_target_is_sector(&target))
+        {
+            return false;
+        }
+        target.sector.sector->ambient_sound_id = clamp_non_negative_int(action->sector_ambient.ambient_sound_id);
+        return true;
+
+    case SDL3D_LOGIC_ACTION_NONE:
+        break;
+    }
+
+    return false;
+}
+
 int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action)
 {
-    if (world == NULL || world->bus == NULL || action == NULL)
+    if (action == NULL)
+        return 0;
+
+    sdl3d_logic_action logic_action = sdl3d_logic_action_make_core(*action);
+    return sdl3d_logic_world_bind_logic_action(world, signal_id, &logic_action);
+}
+
+int sdl3d_logic_world_bind_logic_action(sdl3d_logic_world *world, int signal_id, const sdl3d_logic_action *action)
+{
+    if (world == NULL || world->bus == NULL || action == NULL || action->type == SDL3D_LOGIC_ACTION_NONE)
         return 0;
 
     logic_binding *binding = (logic_binding *)SDL_calloc(1, sizeof(logic_binding));

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -10,6 +10,7 @@ extern "C"
 #include "sdl3d/actor_registry.h"
 #include "sdl3d/level.h"
 #include "sdl3d/logic.h"
+#include "sdl3d/math.h"
 #include "sdl3d/properties.h"
 }
 
@@ -476,6 +477,225 @@ TEST(LogicWorldTargets, InvalidTargetOperationsAreSafe)
     EXPECT_FALSE(sdl3d_logic_world_resolve_target(nullptr, &ref, &resolved));
     EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, nullptr, &resolved));
     EXPECT_FALSE(sdl3d_logic_world_resolve_target(world, &ref, nullptr));
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, ExecuteCoreActionUsesExistingActionSystem)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_properties *props = sdl3d_properties_create();
+
+    sdl3d_action core = sdl3d_action_make_set_bool(props, "opened", true);
+    sdl3d_logic_action action = sdl3d_logic_action_make_core(core);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "opened", false));
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, BindLogicActionSetsActorActive)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "robot_1");
+    ASSERT_NE(actor, nullptr);
+    actor->active = false;
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_action action =
+        sdl3d_logic_action_make_set_actor_active(sdl3d_logic_target_actor_name("robot_1"), true);
+    ASSERT_GT(sdl3d_logic_world_bind_logic_action(world, 77, &action), 0);
+
+    sdl3d_signal_emit(bus, 77, nullptr);
+    EXPECT_TRUE(actor->active);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, ToggleActorActive)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "door");
+    ASSERT_NE(actor, nullptr);
+    actor->active = true;
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_toggle_actor_active(sdl3d_logic_target_actor_id(actor->id));
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_FALSE(actor->active);
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_TRUE(actor->active);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, SetActorProperty)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "alert_light");
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_value color{};
+    color.type = SDL3D_VALUE_STRING;
+    color.as_string = (char *)"red";
+    sdl3d_logic_action action =
+        sdl3d_logic_action_make_set_actor_property(sdl3d_logic_target_actor_name("alert_light"), "state", color);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_STREQ(sdl3d_properties_get_string(actor->props, "state", ""), "red");
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, SetSectorPushByName)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[2]{};
+    level.sector_count = 2;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 2;
+    sdl3d_logic_world_set_target_context(world, &context);
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 1, "conveyor"));
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_set_sector_push(sdl3d_logic_target_sector_name("conveyor"),
+                                                                        sdl3d_vec3_make(3.0f, 0.0f, -1.5f));
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_FLOAT_EQ(sectors[1].push_velocity[0], 3.0f);
+    EXPECT_FLOAT_EQ(sectors[1].push_velocity[1], 0.0f);
+    EXPECT_FLOAT_EQ(sectors[1].push_velocity[2], -1.5f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, SetSectorDamageClampsNegativeToZero)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[1]{};
+    level.sector_count = 1;
+    sectors[0].damage_per_second = 9.0f;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 1;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_set_sector_damage(sdl3d_logic_target_sector_index(0), -5.0f);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_FLOAT_EQ(sectors[0].damage_per_second, 0.0f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, SetSectorAmbientClampsNegativeToZero)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_level level{};
+    sdl3d_sector sectors[1]{};
+    level.sector_count = 1;
+    sectors[0].ambient_sound_id = 4;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 1;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_set_sector_ambient(sdl3d_logic_target_sector_index(0), -1);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+    EXPECT_EQ(sectors[0].ambient_sound_id, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, WrongTargetKindFailsWithoutMutation)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "actor");
+    ASSERT_NE(actor, nullptr);
+    sdl3d_level level{};
+    sdl3d_sector sectors[1]{};
+    level.sector_count = 1;
+    sectors[0].damage_per_second = 7.0f;
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 1;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_action actor_action =
+        sdl3d_logic_action_make_set_actor_active(sdl3d_logic_target_sector_index(0), false);
+    sdl3d_logic_action sector_action =
+        sdl3d_logic_action_make_set_sector_damage(sdl3d_logic_target_actor_id(actor->id), 12.0f);
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &actor_action));
+    EXPECT_TRUE(actor->active);
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &sector_action));
+    EXPECT_FLOAT_EQ(sectors[0].damage_per_second, 7.0f);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, InvalidLogicActionsAreRejected)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_logic_action none{};
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(nullptr, &none));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, nullptr));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &none));
+    EXPECT_EQ(sdl3d_logic_world_bind_logic_action(nullptr, 1, &none), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_logic_action(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_logic_action(world, 1, &none), 0);
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add `sdl3d_logic_action`, a target-aware action vocabulary executed by `sdl3d_logic_world`
- keep existing `sdl3d_action` support through `SDL3D_LOGIC_ACTION_CORE` and the existing bind API
- add target-aware actor actions: set active, toggle active, set actor property
- add target-aware sector actions: set push velocity, set damage per second, set ambient sound id
- add direct execution and signal binding APIs for logic actions

## Correctness
- actor actions require actor targets and reject sector targets
- sector actions require sector targets and reject actor targets
- sector damage and ambient ids clamp negative values to zero
- bound logic actions reuse the same deterministic signal-bus dispatch path as existing action bindings
- public API documents pointer ownership and lifetime rules

## Tests
- `./build/release/tests/sdl3d_logic_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/release`
- `ctest --test-dir build/release --output-on-failure`
