### PR TITLE
Add logic sensor primitives

### DIFF
--- a/demos/doom_level/surveillance.c
+++ b/demos/doom_level/surveillance.c
@@ -3,12 +3,6 @@
 
 #include <SDL3/SDL_stdinc.h>
 
-static bool point_inside_bounds(sdl3d_bounding_box bounds, sdl3d_vec3 point)
-{
-    return point.x >= bounds.min.x && point.x <= bounds.max.x && point.y >= bounds.min.y && point.y <= bounds.max.y &&
-           point.z >= bounds.min.z && point.z <= bounds.max.z;
-}
-
 void doom_surveillance_init(doom_surveillance_camera *surveillance, sdl3d_bounding_box button_bounds,
                             sdl3d_camera3d camera)
 {
@@ -19,6 +13,7 @@ void doom_surveillance_init(doom_surveillance_camera *surveillance, sdl3d_boundi
 
     SDL_zerop(surveillance);
     surveillance->button_bounds = button_bounds;
+    sdl3d_logic_contact_sensor_init(&surveillance->button_sensor, 0, button_bounds, 0, SDL3D_TRIGGER_LEVEL);
     surveillance->camera = camera;
     surveillance->enabled = true;
 }
@@ -30,7 +25,9 @@ bool doom_surveillance_update(doom_surveillance_camera *surveillance, sdl3d_vec3
         return false;
     }
 
-    surveillance->active = surveillance->enabled && point_inside_bounds(surveillance->button_bounds, sample_position);
+    surveillance->button_sensor.enabled = surveillance->enabled;
+    surveillance->active =
+        sdl3d_logic_contact_sensor_update(&surveillance->button_sensor, NULL, sample_position).active;
     return surveillance->active;
 }
 

--- a/demos/doom_level/surveillance.h
+++ b/demos/doom_level/surveillance.h
@@ -5,11 +5,13 @@
 #include <stdbool.h>
 
 #include "sdl3d/camera.h"
+#include "sdl3d/logic.h"
 #include "sdl3d/types.h"
 
 typedef struct doom_surveillance_camera
 {
     sdl3d_bounding_box button_bounds;
+    sdl3d_logic_contact_sensor button_sensor;
     sdl3d_camera3d camera;
     bool enabled;
     bool active;

--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -25,6 +25,7 @@
 #include "sdl3d/level.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/timer_pool.h"
+#include "sdl3d/trigger.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -176,6 +177,78 @@ extern "C"
     } sdl3d_logic_action;
 
     /**
+     * @brief Sensor event emitted by logic sensors.
+     */
+    typedef enum sdl3d_logic_sensor_event
+    {
+        SDL3D_LOGIC_SENSOR_EVENT_NONE = 0,  /**< No signal was emitted. */
+        SDL3D_LOGIC_SENSOR_EVENT_ENTER = 1, /**< Sensor condition became true. */
+        SDL3D_LOGIC_SENSOR_EVENT_EXIT = 2,  /**< Sensor condition became false. */
+        SDL3D_LOGIC_SENSOR_EVENT_LEVEL = 3, /**< Sensor condition is true for this update. */
+    } sdl3d_logic_sensor_event;
+
+    /**
+     * @brief Result returned by a sensor update.
+     */
+    typedef struct sdl3d_logic_sensor_result
+    {
+        bool emitted;                   /**< Whether a signal was emitted. */
+        bool active;                    /**< Sensor condition after the update. */
+        sdl3d_logic_sensor_event event; /**< Event kind emitted, or NONE. */
+    } sdl3d_logic_sensor_result;
+
+    /**
+     * @brief AABB contact sensor for point-in-volume mechanics.
+     *
+     * This is a reusable building block for pressure plates, surveillance
+     * buttons, proximity boxes, item pickup zones, and trigger volumes.
+     */
+    typedef struct sdl3d_logic_contact_sensor
+    {
+        int sensor_id;             /**< Stable editor/game id included in payloads. */
+        sdl3d_bounding_box bounds; /**< World-space sensor volume. */
+        int signal_id;             /**< Signal emitted when edge rules match. */
+        sdl3d_trigger_edge edge;   /**< Enter/exit/both/level emission mode. */
+        bool enabled;              /**< Disabled sensors never emit. */
+        bool was_inside;           /**< Previous contact state, managed by update/reset. */
+    } sdl3d_logic_contact_sensor;
+
+    /**
+     * @brief Sector occupancy sensor for sector-specific enter/exit/level logic.
+     *
+     * The sector target can be a sector index or a sector name registered on the
+     * logic world. The sample point is treated as a world-space point; pass an
+     * actor's feet position when floor occupancy matters.
+     */
+    typedef struct sdl3d_logic_sector_sensor
+    {
+        int sensor_id;                 /**< Stable editor/game id included in payloads. */
+        sdl3d_logic_target_ref sector; /**< Sector index/name target. */
+        int signal_id;                 /**< Signal emitted when edge rules match. */
+        sdl3d_trigger_edge edge;       /**< Enter/exit/both/level emission mode. */
+        bool enabled;                  /**< Disabled sensors never emit. */
+        bool was_inside;               /**< Previous occupancy state, managed by update/reset. */
+    } sdl3d_logic_sector_sensor;
+
+    /**
+     * @brief Actor proximity sensor for distance-based mechanics.
+     *
+     * The actor target resolves through the logic world's actor registry. The
+     * sensor is active when the sample point is within @p radius of the actor's
+     * registered world position.
+     */
+    typedef struct sdl3d_logic_proximity_sensor
+    {
+        int sensor_id;                /**< Stable editor/game id included in payloads. */
+        sdl3d_logic_target_ref actor; /**< Actor id/name target. */
+        float radius;                 /**< Non-negative trigger radius in world units. */
+        int signal_id;                /**< Signal emitted when edge rules match. */
+        sdl3d_trigger_edge edge;      /**< Enter/exit/both/level emission mode. */
+        bool enabled;                 /**< Disabled sensors never emit. */
+        bool was_inside;              /**< Previous proximity state, managed by update/reset. */
+    } sdl3d_logic_proximity_sensor;
+
+    /**
      * @brief Create a logic world that listens to a signal bus.
      *
      * The logic world references @p bus and @p timers but does not own either
@@ -321,6 +394,72 @@ extern "C"
      *         or target was invalid.
      */
     bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action);
+
+    /* ================================================================== */
+    /* Sensors                                                            */
+    /* ================================================================== */
+
+    /**
+     * @brief Initialize an AABB contact sensor.
+     */
+    void sdl3d_logic_contact_sensor_init(sdl3d_logic_contact_sensor *sensor, int sensor_id, sdl3d_bounding_box bounds,
+                                         int signal_id, sdl3d_trigger_edge edge);
+
+    /**
+     * @brief Update a contact sensor and emit through @p world when needed.
+     *
+     * @p world may be NULL when the caller only needs the returned active
+     * state and does not need signal emission.
+     *
+     * Payload keys: sensor_id, event, inside, sample_position.
+     */
+    sdl3d_logic_sensor_result sdl3d_logic_contact_sensor_update(sdl3d_logic_contact_sensor *sensor,
+                                                                sdl3d_logic_world *world, sdl3d_vec3 sample_position);
+
+    /**
+     * @brief Reset a contact sensor's edge state.
+     */
+    void sdl3d_logic_contact_sensor_reset(sdl3d_logic_contact_sensor *sensor);
+
+    /**
+     * @brief Initialize a sector occupancy sensor.
+     */
+    void sdl3d_logic_sector_sensor_init(sdl3d_logic_sector_sensor *sensor, int sensor_id, sdl3d_logic_target_ref sector,
+                                        int signal_id, sdl3d_trigger_edge edge);
+
+    /**
+     * @brief Update a sector sensor and emit through @p world when needed.
+     *
+     * Payload keys: sensor_id, event, inside, sample_position, sector_index.
+     */
+    sdl3d_logic_sensor_result sdl3d_logic_sector_sensor_update(sdl3d_logic_sector_sensor *sensor,
+                                                               sdl3d_logic_world *world, sdl3d_vec3 sample_position);
+
+    /**
+     * @brief Reset a sector sensor's edge state.
+     */
+    void sdl3d_logic_sector_sensor_reset(sdl3d_logic_sector_sensor *sensor);
+
+    /**
+     * @brief Initialize an actor proximity sensor.
+     */
+    void sdl3d_logic_proximity_sensor_init(sdl3d_logic_proximity_sensor *sensor, int sensor_id,
+                                           sdl3d_logic_target_ref actor, float radius, int signal_id,
+                                           sdl3d_trigger_edge edge);
+
+    /**
+     * @brief Update a proximity sensor and emit through @p world when needed.
+     *
+     * Payload keys: sensor_id, event, inside, sample_position, actor_id,
+     * actor_name, distance.
+     */
+    sdl3d_logic_sensor_result sdl3d_logic_proximity_sensor_update(sdl3d_logic_proximity_sensor *sensor,
+                                                                  sdl3d_logic_world *world, sdl3d_vec3 sample_position);
+
+    /**
+     * @brief Reset a proximity sensor's edge state.
+     */
+    void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor);
 
     /**
      * @brief Bind one action to a signal.

--- a/src/logic.c
+++ b/src/logic.c
@@ -126,6 +126,72 @@ static int clamp_non_negative_int(int value)
     return value > 0 ? value : 0;
 }
 
+static sdl3d_logic_sensor_result sensor_result(bool active, sdl3d_logic_sensor_event event)
+{
+    sdl3d_logic_sensor_result result;
+    SDL_zero(result);
+    result.active = active;
+    result.event = event;
+    result.emitted = event != SDL3D_LOGIC_SENSOR_EVENT_NONE;
+    return result;
+}
+
+static sdl3d_logic_sensor_event sensor_event_for_state(sdl3d_trigger_edge edge, bool was_active, bool active)
+{
+    switch (edge)
+    {
+    case SDL3D_TRIGGER_EDGE_ENTER:
+        return active && !was_active ? SDL3D_LOGIC_SENSOR_EVENT_ENTER : SDL3D_LOGIC_SENSOR_EVENT_NONE;
+    case SDL3D_TRIGGER_EDGE_EXIT:
+        return !active && was_active ? SDL3D_LOGIC_SENSOR_EVENT_EXIT : SDL3D_LOGIC_SENSOR_EVENT_NONE;
+    case SDL3D_TRIGGER_EDGE_BOTH:
+        if (active && !was_active)
+            return SDL3D_LOGIC_SENSOR_EVENT_ENTER;
+        if (!active && was_active)
+            return SDL3D_LOGIC_SENSOR_EVENT_EXIT;
+        return SDL3D_LOGIC_SENSOR_EVENT_NONE;
+    case SDL3D_TRIGGER_LEVEL:
+        return active ? SDL3D_LOGIC_SENSOR_EVENT_LEVEL : SDL3D_LOGIC_SENSOR_EVENT_NONE;
+    }
+    return SDL3D_LOGIC_SENSOR_EVENT_NONE;
+}
+
+static bool point_inside_bounds(sdl3d_bounding_box bounds, sdl3d_vec3 point)
+{
+    return point.x >= bounds.min.x && point.x <= bounds.max.x && point.y >= bounds.min.y && point.y <= bounds.max.y &&
+           point.z >= bounds.min.z && point.z <= bounds.max.z;
+}
+
+static bool emit_sensor_payload(sdl3d_logic_world *world, int signal_id, int sensor_id, sdl3d_logic_sensor_event event,
+                                bool active, sdl3d_vec3 sample_position, int sector_index,
+                                const sdl3d_registered_actor *actor, float distance)
+{
+    if (world == NULL || world->bus == NULL || event == SDL3D_LOGIC_SENSOR_EVENT_NONE)
+        return false;
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return false;
+
+    sdl3d_properties_set_int(payload, "sensor_id", sensor_id);
+    sdl3d_properties_set_int(payload, "event", (int)event);
+    sdl3d_properties_set_bool(payload, "inside", active);
+    sdl3d_properties_set_vec3(payload, "sample_position", sample_position);
+    if (sector_index >= 0)
+        sdl3d_properties_set_int(payload, "sector_index", sector_index);
+    if (actor != NULL)
+    {
+        sdl3d_properties_set_int(payload, "actor_id", actor->id);
+        if (actor->name != NULL)
+            sdl3d_properties_set_string(payload, "actor_name", actor->name);
+        sdl3d_properties_set_float(payload, "distance", distance);
+    }
+
+    sdl3d_signal_emit(world->bus, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+    return true;
+}
+
 static void set_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
 {
     if (target == NULL || key == NULL || value == NULL)
@@ -510,6 +576,138 @@ bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logi
     }
 
     return false;
+}
+
+void sdl3d_logic_contact_sensor_init(sdl3d_logic_contact_sensor *sensor, int sensor_id, sdl3d_bounding_box bounds,
+                                     int signal_id, sdl3d_trigger_edge edge)
+{
+    if (sensor == NULL)
+        return;
+
+    SDL_zerop(sensor);
+    sensor->sensor_id = sensor_id;
+    sensor->bounds = bounds;
+    sensor->signal_id = signal_id;
+    sensor->edge = edge;
+    sensor->enabled = true;
+}
+
+sdl3d_logic_sensor_result sdl3d_logic_contact_sensor_update(sdl3d_logic_contact_sensor *sensor,
+                                                            sdl3d_logic_world *world, sdl3d_vec3 sample_position)
+{
+    if (sensor == NULL || !sensor->enabled)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const bool active = point_inside_bounds(sensor->bounds, sample_position);
+    const sdl3d_logic_sensor_event event = sensor_event_for_state(sensor->edge, sensor->was_inside, active);
+    sensor->was_inside = active;
+
+    if (emit_sensor_payload(world, sensor->signal_id, sensor->sensor_id, event, active, sample_position, -1, NULL,
+                            0.0f))
+    {
+        return sensor_result(active, event);
+    }
+    return sensor_result(active, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+}
+
+void sdl3d_logic_contact_sensor_reset(sdl3d_logic_contact_sensor *sensor)
+{
+    if (sensor != NULL)
+        sensor->was_inside = false;
+}
+
+void sdl3d_logic_sector_sensor_init(sdl3d_logic_sector_sensor *sensor, int sensor_id, sdl3d_logic_target_ref sector,
+                                    int signal_id, sdl3d_trigger_edge edge)
+{
+    if (sensor == NULL)
+        return;
+
+    SDL_zerop(sensor);
+    sensor->sensor_id = sensor_id;
+    sensor->sector = sector;
+    sensor->signal_id = signal_id;
+    sensor->edge = edge;
+    sensor->enabled = true;
+}
+
+sdl3d_logic_sensor_result sdl3d_logic_sector_sensor_update(sdl3d_logic_sector_sensor *sensor, sdl3d_logic_world *world,
+                                                           sdl3d_vec3 sample_position)
+{
+    if (sensor == NULL || world == NULL || !sensor->enabled)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    sdl3d_logic_resolved_target target;
+    if (!sdl3d_logic_world_resolve_target(world, &sensor->sector, &target) || !resolved_target_is_sector(&target))
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const sdl3d_logic_target_context *context = sdl3d_logic_world_get_target_context(world);
+    const int current_sector = sdl3d_level_find_sector_at(context->level, context->sectors, sample_position.x,
+                                                          sample_position.z, sample_position.y);
+    const bool active = current_sector == target.sector.sector_index;
+    const sdl3d_logic_sensor_event event = sensor_event_for_state(sensor->edge, sensor->was_inside, active);
+    sensor->was_inside = active;
+
+    if (emit_sensor_payload(world, sensor->signal_id, sensor->sensor_id, event, active, sample_position,
+                            target.sector.sector_index, NULL, 0.0f))
+    {
+        return sensor_result(active, event);
+    }
+    return sensor_result(active, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+}
+
+void sdl3d_logic_sector_sensor_reset(sdl3d_logic_sector_sensor *sensor)
+{
+    if (sensor != NULL)
+        sensor->was_inside = false;
+}
+
+void sdl3d_logic_proximity_sensor_init(sdl3d_logic_proximity_sensor *sensor, int sensor_id,
+                                       sdl3d_logic_target_ref actor, float radius, int signal_id,
+                                       sdl3d_trigger_edge edge)
+{
+    if (sensor == NULL)
+        return;
+
+    SDL_zerop(sensor);
+    sensor->sensor_id = sensor_id;
+    sensor->actor = actor;
+    sensor->radius = clamp_non_negative_float(radius);
+    sensor->signal_id = signal_id;
+    sensor->edge = edge;
+    sensor->enabled = true;
+}
+
+sdl3d_logic_sensor_result sdl3d_logic_proximity_sensor_update(sdl3d_logic_proximity_sensor *sensor,
+                                                              sdl3d_logic_world *world, sdl3d_vec3 sample_position)
+{
+    if (sensor == NULL || world == NULL || !sensor->enabled)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    sdl3d_logic_resolved_target target;
+    if (!sdl3d_logic_world_resolve_target(world, &sensor->actor, &target) || !resolved_target_is_actor(&target))
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const float dx = sample_position.x - target.actor->position.x;
+    const float dy = sample_position.y - target.actor->position.y;
+    const float dz = sample_position.z - target.actor->position.z;
+    const float distance_sq = dx * dx + dy * dy + dz * dz;
+    const float radius = clamp_non_negative_float(sensor->radius);
+    const bool active = distance_sq <= radius * radius;
+    const sdl3d_logic_sensor_event event = sensor_event_for_state(sensor->edge, sensor->was_inside, active);
+    sensor->was_inside = active;
+
+    if (emit_sensor_payload(world, sensor->signal_id, sensor->sensor_id, event, active, sample_position, -1,
+                            target.actor, SDL_sqrtf(distance_sq)))
+    {
+        return sensor_result(active, event);
+    }
+    return sensor_result(active, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+}
+
+void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor)
+{
+    if (sensor != NULL)
+        sensor->was_inside = false;
 }
 
 int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action)

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <SDL3/SDL_stdinc.h>
+
 extern "C"
 {
 #include "sdl3d/actor_registry.h"
@@ -20,6 +22,53 @@ static sdl3d_logic_world *make_logic_world(sdl3d_signal_bus **out_bus)
     if (out_bus != nullptr)
         *out_bus = bus;
     return sdl3d_logic_world_create(bus, nullptr);
+}
+
+struct logic_signal_capture
+{
+    int count = 0;
+    int signal_id = 0;
+    int sensor_id = -1;
+    int event = 0;
+    int sector_index = -1;
+    int actor_id = -1;
+    bool inside = false;
+    float distance = -1.0f;
+    sdl3d_vec3 sample_position = {};
+    char actor_name[64] = {};
+};
+
+static void capture_logic_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    logic_signal_capture *capture = (logic_signal_capture *)userdata;
+    capture->count++;
+    capture->signal_id = signal_id;
+    capture->sensor_id = sdl3d_properties_get_int(payload, "sensor_id", -1);
+    capture->event = sdl3d_properties_get_int(payload, "event", 0);
+    capture->inside = sdl3d_properties_get_bool(payload, "inside", false);
+    capture->sector_index = sdl3d_properties_get_int(payload, "sector_index", -1);
+    capture->actor_id = sdl3d_properties_get_int(payload, "actor_id", -1);
+    capture->distance = sdl3d_properties_get_float(payload, "distance", -1.0f);
+    capture->sample_position = sdl3d_properties_get_vec3(payload, "sample_position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const char *actor_name = sdl3d_properties_get_string(payload, "actor_name", "");
+    SDL_snprintf(capture->actor_name, sizeof(capture->actor_name), "%s", actor_name);
+}
+
+static sdl3d_sector make_square_sector(float min_x, float min_z, float max_x, float max_z)
+{
+    sdl3d_sector sector{};
+    sector.points[0][0] = min_x;
+    sector.points[0][1] = min_z;
+    sector.points[1][0] = max_x;
+    sector.points[1][1] = min_z;
+    sector.points[2][0] = max_x;
+    sector.points[2][1] = max_z;
+    sector.points[3][0] = min_x;
+    sector.points[3][1] = max_z;
+    sector.num_points = 4;
+    sector.floor_y = 0.0f;
+    sector.ceil_y = 3.0f;
+    return sector;
 }
 
 TEST(LogicWorld, CreateAndDestroy)
@@ -696,6 +745,301 @@ TEST(LogicWorldActions, InvalidLogicActionsAreRejected)
     EXPECT_EQ(sdl3d_logic_world_bind_logic_action(nullptr, 1, &none), 0);
     EXPECT_EQ(sdl3d_logic_world_bind_logic_action(world, 1, nullptr), 0);
     EXPECT_EQ(sdl3d_logic_world_bind_logic_action(world, 1, &none), 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ContactSensorEnterEmitsPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 200, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_contact_sensor sensor{};
+    sdl3d_logic_contact_sensor_init(
+        &sensor, 7, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(2.0f, 2.0f, 2.0f)}, 200,
+        SDL3D_TRIGGER_EDGE_ENTER);
+
+    sdl3d_logic_sensor_result outside =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(-1.0f, 1.0f, 1.0f));
+    EXPECT_FALSE(outside.active);
+    EXPECT_FALSE(outside.emitted);
+    EXPECT_EQ(capture.count, 0);
+
+    sdl3d_logic_sensor_result inside =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+    EXPECT_TRUE(inside.active);
+    EXPECT_TRUE(inside.emitted);
+    EXPECT_EQ(inside.event, SDL3D_LOGIC_SENSOR_EVENT_ENTER);
+    ASSERT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.signal_id, 200);
+    EXPECT_EQ(capture.sensor_id, 7);
+    EXPECT_EQ(capture.event, SDL3D_LOGIC_SENSOR_EVENT_ENTER);
+    EXPECT_TRUE(capture.inside);
+    EXPECT_FLOAT_EQ(capture.sample_position.x, 1.0f);
+    EXPECT_FLOAT_EQ(capture.sample_position.y, 1.0f);
+    EXPECT_FLOAT_EQ(capture.sample_position.z, 1.0f);
+
+    sdl3d_logic_sensor_result still_inside =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.5f, 1.0f, 1.0f));
+    EXPECT_TRUE(still_inside.active);
+    EXPECT_FALSE(still_inside.emitted);
+    EXPECT_EQ(capture.count, 1);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ContactSensorBothEmitsExit)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 201, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_contact_sensor sensor{};
+    sdl3d_logic_contact_sensor_init(
+        &sensor, 8, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(2.0f, 2.0f, 2.0f)}, 201,
+        SDL3D_TRIGGER_EDGE_BOTH);
+
+    EXPECT_TRUE(sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f)).emitted);
+    sdl3d_logic_sensor_result exit =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(3.0f, 1.0f, 1.0f));
+
+    EXPECT_FALSE(exit.active);
+    EXPECT_TRUE(exit.emitted);
+    EXPECT_EQ(exit.event, SDL3D_LOGIC_SENSOR_EVENT_EXIT);
+    ASSERT_EQ(capture.count, 2);
+    EXPECT_EQ(capture.sensor_id, 8);
+    EXPECT_EQ(capture.event, SDL3D_LOGIC_SENSOR_EVENT_EXIT);
+    EXPECT_FALSE(capture.inside);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ContactSensorLevelEmitsEveryInsideUpdate)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 202, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_contact_sensor sensor{};
+    sdl3d_logic_contact_sensor_init(
+        &sensor, 9, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(2.0f, 2.0f, 2.0f)}, 202,
+        SDL3D_TRIGGER_LEVEL);
+
+    sdl3d_logic_sensor_result first =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+    sdl3d_logic_sensor_result second =
+        sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.5f, 1.0f, 1.0f));
+
+    EXPECT_TRUE(first.emitted);
+    EXPECT_TRUE(second.emitted);
+    EXPECT_EQ(first.event, SDL3D_LOGIC_SENSOR_EVENT_LEVEL);
+    EXPECT_EQ(second.event, SDL3D_LOGIC_SENSOR_EVENT_LEVEL);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ContactSensorResetAllowsEnterAgain)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 203, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_contact_sensor sensor{};
+    sdl3d_logic_contact_sensor_init(
+        &sensor, 10, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(2.0f, 2.0f, 2.0f)}, 203,
+        SDL3D_TRIGGER_EDGE_ENTER);
+
+    EXPECT_TRUE(sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f)).emitted);
+    EXPECT_FALSE(sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f)).emitted);
+
+    sdl3d_logic_contact_sensor_reset(&sensor);
+    EXPECT_TRUE(sdl3d_logic_contact_sensor_update(&sensor, world, sdl3d_vec3_make(1.0f, 1.0f, 1.0f)).emitted);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ContactSensorCanEvaluateWithoutWorld)
+{
+    sdl3d_logic_contact_sensor sensor{};
+    sdl3d_logic_contact_sensor_init(
+        &sensor, 17, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(2.0f, 2.0f, 2.0f)}, 204,
+        SDL3D_TRIGGER_EDGE_ENTER);
+
+    sdl3d_logic_sensor_result result =
+        sdl3d_logic_contact_sensor_update(&sensor, nullptr, sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+
+    EXPECT_TRUE(result.active);
+    EXPECT_FALSE(result.emitted);
+    EXPECT_EQ(result.event, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+    EXPECT_TRUE(sensor.was_inside);
+}
+
+TEST(LogicWorldSensors, SectorSensorEnterByName)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 210, capture_logic_signal, &capture), 0);
+
+    sdl3d_level level{};
+    sdl3d_sector sectors[2]{};
+    level.sector_count = 2;
+    sectors[0] = make_square_sector(0.0f, 0.0f, 10.0f, 10.0f);
+    sectors[1] = make_square_sector(10.0f, 0.0f, 20.0f, 10.0f);
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 2;
+    sdl3d_logic_world_set_target_context(world, &context);
+    ASSERT_TRUE(sdl3d_logic_world_set_sector_name(world, 1, "target_room"));
+
+    sdl3d_logic_sector_sensor sensor{};
+    sdl3d_logic_sector_sensor_init(&sensor, 11, sdl3d_logic_target_sector_name("target_room"), 210,
+                                   SDL3D_TRIGGER_EDGE_ENTER);
+
+    sdl3d_logic_sensor_result result =
+        sdl3d_logic_sector_sensor_update(&sensor, world, sdl3d_vec3_make(15.0f, 1.0f, 5.0f));
+
+    EXPECT_TRUE(result.active);
+    EXPECT_TRUE(result.emitted);
+    EXPECT_EQ(result.event, SDL3D_LOGIC_SENSOR_EVENT_ENTER);
+    ASSERT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.sensor_id, 11);
+    EXPECT_EQ(capture.sector_index, 1);
+    EXPECT_TRUE(capture.inside);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, SectorSensorExitReportsTargetSector)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 211, capture_logic_signal, &capture), 0);
+
+    sdl3d_level level{};
+    sdl3d_sector sectors[2]{};
+    level.sector_count = 2;
+    sectors[0] = make_square_sector(0.0f, 0.0f, 10.0f, 10.0f);
+    sectors[1] = make_square_sector(10.0f, 0.0f, 20.0f, 10.0f);
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 2;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_sector_sensor sensor{};
+    sdl3d_logic_sector_sensor_init(&sensor, 12, sdl3d_logic_target_sector_index(1), 211, SDL3D_TRIGGER_EDGE_BOTH);
+
+    EXPECT_TRUE(sdl3d_logic_sector_sensor_update(&sensor, world, sdl3d_vec3_make(15.0f, 1.0f, 5.0f)).emitted);
+    sdl3d_logic_sensor_result exit =
+        sdl3d_logic_sector_sensor_update(&sensor, world, sdl3d_vec3_make(5.0f, 1.0f, 5.0f));
+
+    EXPECT_FALSE(exit.active);
+    EXPECT_TRUE(exit.emitted);
+    EXPECT_EQ(exit.event, SDL3D_LOGIC_SENSOR_EVENT_EXIT);
+    ASSERT_EQ(capture.count, 2);
+    EXPECT_EQ(capture.sensor_id, 12);
+    EXPECT_EQ(capture.sector_index, 1);
+    EXPECT_FALSE(capture.inside);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, ProximitySensorEnterExitWithActorPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 220, capture_logic_signal, &capture), 0);
+
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "robot");
+    ASSERT_NE(actor, nullptr);
+    actor->position = sdl3d_vec3_make(10.0f, 0.0f, 0.0f);
+
+    sdl3d_logic_target_context context{};
+    context.registry = registry;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_proximity_sensor sensor{};
+    sdl3d_logic_proximity_sensor_init(&sensor, 13, sdl3d_logic_target_actor_name("robot"), 3.0f, 220,
+                                      SDL3D_TRIGGER_EDGE_BOTH);
+
+    EXPECT_FALSE(sdl3d_logic_proximity_sensor_update(&sensor, world, sdl3d_vec3_make(20.0f, 0.0f, 0.0f)).emitted);
+    sdl3d_logic_sensor_result enter =
+        sdl3d_logic_proximity_sensor_update(&sensor, world, sdl3d_vec3_make(12.0f, 0.0f, 0.0f));
+    EXPECT_TRUE(enter.active);
+    EXPECT_TRUE(enter.emitted);
+    EXPECT_EQ(enter.event, SDL3D_LOGIC_SENSOR_EVENT_ENTER);
+    ASSERT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.actor_id, actor->id);
+    EXPECT_STREQ(capture.actor_name, "robot");
+    EXPECT_FLOAT_EQ(capture.distance, 2.0f);
+
+    sdl3d_logic_sensor_result exit =
+        sdl3d_logic_proximity_sensor_update(&sensor, world, sdl3d_vec3_make(20.0f, 0.0f, 0.0f));
+    EXPECT_FALSE(exit.active);
+    EXPECT_TRUE(exit.emitted);
+    EXPECT_EQ(exit.event, SDL3D_LOGIC_SENSOR_EVENT_EXIT);
+    ASSERT_EQ(capture.count, 2);
+    EXPECT_FALSE(capture.inside);
+    EXPECT_EQ(capture.actor_id, actor->id);
+
+    sdl3d_actor_registry_destroy(registry);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldSensors, InvalidSensorsAreSafe)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+
+    sdl3d_logic_contact_sensor contact{};
+    sdl3d_logic_contact_sensor_init(
+        &contact, 14, sdl3d_bounding_box{sdl3d_vec3_make(0.0f, 0.0f, 0.0f), sdl3d_vec3_make(1.0f, 1.0f, 1.0f)}, 230,
+        SDL3D_TRIGGER_EDGE_ENTER);
+
+    EXPECT_FALSE(sdl3d_logic_contact_sensor_update(&contact, nullptr, sdl3d_vec3_make(0.5f, 0.5f, 0.5f)).emitted);
+    EXPECT_TRUE(contact.was_inside);
+    EXPECT_FALSE(sdl3d_logic_contact_sensor_update(nullptr, world, sdl3d_vec3_make(0.5f, 0.5f, 0.5f)).emitted);
+    sdl3d_logic_contact_sensor_reset(nullptr);
+
+    contact.enabled = false;
+    sdl3d_logic_sensor_result disabled =
+        sdl3d_logic_contact_sensor_update(&contact, world, sdl3d_vec3_make(0.5f, 0.5f, 0.5f));
+    EXPECT_FALSE(disabled.active);
+    EXPECT_FALSE(disabled.emitted);
+
+    sdl3d_logic_sector_sensor sector{};
+    sdl3d_logic_sector_sensor_init(&sector, 15, sdl3d_logic_target_sector_name("missing"), 231,
+                                   SDL3D_TRIGGER_EDGE_ENTER);
+    EXPECT_FALSE(sdl3d_logic_sector_sensor_update(&sector, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)).emitted);
+    sdl3d_logic_sector_sensor_reset(nullptr);
+
+    sdl3d_logic_proximity_sensor proximity{};
+    sdl3d_logic_proximity_sensor_init(&proximity, 16, sdl3d_logic_target_actor_name("missing"), 1.0f, 232,
+                                      SDL3D_TRIGGER_EDGE_ENTER);
+    EXPECT_FALSE(sdl3d_logic_proximity_sensor_update(&proximity, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)).emitted);
+    sdl3d_logic_proximity_sensor_reset(nullptr);
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add public logic sensor primitives for AABB contact, sector occupancy, and actor proximity
- emit deterministic sensor payloads with edge semantics for enter, exit, both, and level modes
- migrate the Doom surveillance button to reuse the public contact sensor instead of bespoke AABB polling

## Tests
- ./build/release/tests/sdl3d_logic_test
- ./build/release/tests/doom_surveillance_test
- ./scripts/check_clang_format.sh
- git diff --check
- cmake --build build/release
- ctest --test-dir build/release --output-on-failure

Issue: #109
