### PR TITLE
Add composable logic entities

### DIFF
--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -27,6 +27,8 @@
 #include "sdl3d/timer_pool.h"
 #include "sdl3d/trigger.h"
 
+#define SDL3D_LOGIC_MAX_ENTITY_OUTPUTS 8
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -249,6 +251,131 @@ extern "C"
     } sdl3d_logic_proximity_sensor;
 
     /**
+     * @brief Result returned by a logic entity activation.
+     */
+    typedef struct sdl3d_logic_entity_result
+    {
+        bool emitted;     /**< Whether the entity emitted a signal. */
+        int signal_id;    /**< Last emitted signal, or 0 when none. */
+        int output_index; /**< Output slot selected, or -1 when none. */
+    } sdl3d_logic_entity_result;
+
+    /**
+     * @brief Relay entity that emits each configured output in order.
+     *
+     * Relays are useful for fan-out composition: one input signal can trigger
+     * several downstream signals/actions without a bespoke callback.
+     */
+    typedef struct sdl3d_logic_relay
+    {
+        int entity_id;                               /**< Stable editor/game id included in generated payloads. */
+        int outputs[SDL3D_LOGIC_MAX_ENTITY_OUTPUTS]; /**< Signals emitted by activation. */
+        int output_count;                            /**< Number of active entries in @p outputs. */
+        bool enabled;                                /**< Disabled relays emit nothing. */
+    } sdl3d_logic_relay;
+
+    /**
+     * @brief Toggle entity that flips boolean state and emits on/off signals.
+     */
+    typedef struct sdl3d_logic_toggle
+    {
+        int entity_id;  /**< Stable editor/game id included in payloads. */
+        int on_signal;  /**< Signal emitted when state becomes true. */
+        int off_signal; /**< Signal emitted when state becomes false. */
+        bool state;     /**< Current toggle state. */
+        bool enabled;   /**< Disabled toggles ignore activation. */
+    } sdl3d_logic_toggle;
+
+    /**
+     * @brief Counter entity that emits when a threshold is reached.
+     */
+    typedef struct sdl3d_logic_counter
+    {
+        int entity_id;      /**< Stable editor/game id included in payloads. */
+        int threshold;      /**< Activations required to emit. Values less than 1 clamp to 1. */
+        int count;          /**< Current activation count. */
+        int output_signal;  /**< Signal emitted at the threshold. */
+        bool reset_on_fire; /**< If true, count resets after each emission. */
+        bool fired;         /**< True after a non-resetting counter has emitted. */
+        bool enabled;       /**< Disabled counters ignore activation. */
+    } sdl3d_logic_counter;
+
+    /**
+     * @brief Branch entity that compares a property value and emits true/false.
+     *
+     * The property bag, key pointer, and string value pointer are borrowed and
+     * must remain valid until activation. The entity does not own them.
+     */
+    typedef struct sdl3d_logic_branch
+    {
+        int entity_id;                 /**< Stable editor/game id included in payloads. */
+        const sdl3d_properties *props; /**< Property bag to inspect. */
+        const char *key;               /**< Property key to compare. */
+        sdl3d_value expected;          /**< Expected value. String pointer is borrowed. */
+        int true_signal;               /**< Signal emitted when comparison succeeds. */
+        int false_signal;              /**< Signal emitted when comparison fails. */
+        bool enabled;                  /**< Disabled branches ignore activation. */
+    } sdl3d_logic_branch;
+
+    /**
+     * @brief Deterministic random selector that emits one configured output.
+     *
+     * Uses an internal deterministic PRNG state so seeded selectors are stable
+     * in tests, demos, and recorded playback.
+     */
+    typedef struct sdl3d_logic_random
+    {
+        int entity_id;                               /**< Stable editor/game id included in payloads. */
+        int outputs[SDL3D_LOGIC_MAX_ENTITY_OUTPUTS]; /**< Candidate output signals. */
+        int output_count;                            /**< Number of active entries in @p outputs. */
+        unsigned int state;                          /**< Deterministic PRNG state. */
+        bool enabled;                                /**< Disabled selectors emit nothing. */
+    } sdl3d_logic_random;
+
+    /**
+     * @brief Sequence entity that emits outputs in authored order.
+     */
+    typedef struct sdl3d_logic_sequence
+    {
+        int entity_id;                               /**< Stable editor/game id included in payloads. */
+        int outputs[SDL3D_LOGIC_MAX_ENTITY_OUTPUTS]; /**< Ordered output signals. */
+        int output_count;                            /**< Number of active entries in @p outputs. */
+        int next_index;                              /**< Next output slot to emit. */
+        bool loop;                                   /**< If true, wraps to the first output after the last. */
+        bool enabled;                                /**< Disabled sequences emit nothing. */
+    } sdl3d_logic_sequence;
+
+    /**
+     * @brief Once gate that passes only the first activation until reset.
+     */
+    typedef struct sdl3d_logic_once
+    {
+        int entity_id;     /**< Stable editor/game id included in payloads. */
+        int output_signal; /**< Signal emitted on the first activation. */
+        bool fired;        /**< True after the first successful activation. */
+        bool enabled;      /**< Disabled gates emit nothing. */
+    } sdl3d_logic_once;
+
+    /**
+     * @brief Stateful timer entity that emits when its countdown expires.
+     *
+     * This is intended for authored logic graphs that need a timer as an
+     * inspectable entity. It emits at most once per update call, matching the
+     * timer pool's spiral-of-death guard behavior.
+     */
+    typedef struct sdl3d_logic_timer
+    {
+        int entity_id;     /**< Stable editor/game id included in payloads. */
+        float delay;       /**< Initial delay in seconds. Must be > 0 to start. */
+        float remaining;   /**< Remaining countdown while active. */
+        int output_signal; /**< Signal emitted when the timer expires. */
+        bool repeating;    /**< Whether the timer repeats. */
+        float interval;    /**< Repeat interval in seconds. Must be > 0 when repeating. */
+        bool active;       /**< Whether the timer is currently counting down. */
+        bool enabled;      /**< Disabled timers cannot be started or updated. */
+    } sdl3d_logic_timer;
+
+    /**
      * @brief Create a logic world that listens to a signal bus.
      *
      * The logic world references @p bus and @p timers but does not own either
@@ -460,6 +587,181 @@ extern "C"
      * @brief Reset a proximity sensor's edge state.
      */
     void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor);
+
+    /* ================================================================== */
+    /* Logic entities                                                     */
+    /* ================================================================== */
+
+    /**
+     * @brief Emit a signal through a logic world's signal bus.
+     *
+     * This is a small convenience for gameplay code that owns a logic world
+     * but should not need direct access to the underlying signal bus pointer.
+     *
+     * @return true when the signal was emitted, false on invalid input.
+     */
+    bool sdl3d_logic_world_emit_signal(sdl3d_logic_world *world, int signal_id, const sdl3d_properties *payload);
+
+    /** @brief Initialize an empty relay entity. */
+    void sdl3d_logic_relay_init(sdl3d_logic_relay *relay, int entity_id);
+
+    /**
+     * @brief Add an output signal to a relay.
+     * @return true on success, false if the relay is NULL or full.
+     */
+    bool sdl3d_logic_relay_add_output(sdl3d_logic_relay *relay, int signal_id);
+
+    /**
+     * @brief Activate a relay, emitting each output in configured order.
+     *
+     * Relays forward @p payload unchanged to each output. The returned result
+     * reports the last signal emitted.
+     */
+    sdl3d_logic_entity_result sdl3d_logic_relay_activate(sdl3d_logic_world *world, sdl3d_logic_relay *relay,
+                                                         const sdl3d_properties *payload);
+
+    /** @brief Initialize a toggle entity. */
+    void sdl3d_logic_toggle_init(sdl3d_logic_toggle *toggle, int entity_id, bool initial_state, int on_signal,
+                                 int off_signal);
+
+    /** @brief Activate a toggle, flipping state and emitting on/off. */
+    sdl3d_logic_entity_result sdl3d_logic_toggle_activate(sdl3d_logic_world *world, sdl3d_logic_toggle *toggle);
+
+    /** @brief Reset a toggle to an explicit state without emitting. */
+    void sdl3d_logic_toggle_reset(sdl3d_logic_toggle *toggle, bool state);
+
+    /** @brief Initialize a counter entity. */
+    void sdl3d_logic_counter_init(sdl3d_logic_counter *counter, int entity_id, int threshold, int output_signal,
+                                  bool reset_on_fire);
+
+    /** @brief Activate a counter and emit when its threshold is reached. */
+    sdl3d_logic_entity_result sdl3d_logic_counter_activate(sdl3d_logic_world *world, sdl3d_logic_counter *counter);
+
+    /** @brief Reset a counter to zero and clear its fired state. */
+    void sdl3d_logic_counter_reset(sdl3d_logic_counter *counter);
+
+    /** @brief Initialize a property branch entity. */
+    void sdl3d_logic_branch_init(sdl3d_logic_branch *branch, int entity_id, const sdl3d_properties *props,
+                                 const char *key, sdl3d_value expected, int true_signal, int false_signal);
+
+    /** @brief Activate a branch and emit true_signal or false_signal. */
+    sdl3d_logic_entity_result sdl3d_logic_branch_activate(sdl3d_logic_world *world, sdl3d_logic_branch *branch);
+
+    /** @brief Initialize a deterministic random selector. */
+    void sdl3d_logic_random_init(sdl3d_logic_random *random, int entity_id, unsigned int seed);
+
+    /**
+     * @brief Add a candidate output signal to a random selector.
+     * @return true on success, false if the selector is NULL or full.
+     */
+    bool sdl3d_logic_random_add_output(sdl3d_logic_random *random, int signal_id);
+
+    /** @brief Activate a random selector and emit one candidate output. */
+    sdl3d_logic_entity_result sdl3d_logic_random_activate(sdl3d_logic_world *world, sdl3d_logic_random *random);
+
+    /** @brief Reset a random selector's deterministic PRNG seed. */
+    void sdl3d_logic_random_reset(sdl3d_logic_random *random, unsigned int seed);
+
+    /** @brief Initialize an ordered sequence entity. */
+    void sdl3d_logic_sequence_init(sdl3d_logic_sequence *sequence, int entity_id, bool loop);
+
+    /**
+     * @brief Add an output signal to a sequence.
+     * @return true on success, false if the sequence is NULL or full.
+     */
+    bool sdl3d_logic_sequence_add_output(sdl3d_logic_sequence *sequence, int signal_id);
+
+    /** @brief Activate a sequence and emit its next output. */
+    sdl3d_logic_entity_result sdl3d_logic_sequence_activate(sdl3d_logic_world *world, sdl3d_logic_sequence *sequence);
+
+    /** @brief Reset a sequence to its first output without emitting. */
+    void sdl3d_logic_sequence_reset(sdl3d_logic_sequence *sequence);
+
+    /** @brief Initialize a once gate. */
+    void sdl3d_logic_once_init(sdl3d_logic_once *once, int entity_id, int output_signal);
+
+    /** @brief Activate a once gate. Emits only the first time until reset. */
+    sdl3d_logic_entity_result sdl3d_logic_once_activate(sdl3d_logic_world *world, sdl3d_logic_once *once);
+
+    /** @brief Reset a once gate so it can emit again. */
+    void sdl3d_logic_once_reset(sdl3d_logic_once *once);
+
+    /** @brief Initialize a timer entity. */
+    void sdl3d_logic_timer_init(sdl3d_logic_timer *timer, int entity_id, float delay, int output_signal, bool repeating,
+                                float interval);
+
+    /**
+     * @brief Start or restart a timer entity.
+     * @return true when the timer was started, false on invalid input.
+     */
+    bool sdl3d_logic_timer_start(sdl3d_logic_timer *timer);
+
+    /**
+     * @brief Update a timer entity by elapsed seconds and emit on expiry.
+     */
+    sdl3d_logic_entity_result sdl3d_logic_timer_update(sdl3d_logic_world *world, sdl3d_logic_timer *timer, float dt);
+
+    /** @brief Stop an active timer entity without emitting. */
+    void sdl3d_logic_timer_stop(sdl3d_logic_timer *timer);
+
+    /** @brief Return whether the timer entity is currently counting down. */
+    bool sdl3d_logic_timer_active(const sdl3d_logic_timer *timer);
+
+    /**
+     * @brief Bind a relay entity to activate when a signal is emitted.
+     *
+     * The entity pointer is borrowed and must remain valid while the binding is
+     * live. Entity bindings execute in signal connection order.
+     *
+     * @return A binding id greater than zero, or zero on failure.
+     */
+    int sdl3d_logic_world_bind_relay(sdl3d_logic_world *world, int signal_id, sdl3d_logic_relay *relay);
+
+    /** @brief Bind a toggle entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_toggle(sdl3d_logic_world *world, int signal_id, sdl3d_logic_toggle *toggle);
+
+    /** @brief Bind a counter entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_counter(sdl3d_logic_world *world, int signal_id, sdl3d_logic_counter *counter);
+
+    /** @brief Bind a branch entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_branch(sdl3d_logic_world *world, int signal_id, sdl3d_logic_branch *branch);
+
+    /** @brief Bind a random selector entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_random(sdl3d_logic_world *world, int signal_id, sdl3d_logic_random *random);
+
+    /** @brief Bind a sequence entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_sequence(sdl3d_logic_world *world, int signal_id, sdl3d_logic_sequence *sequence);
+
+    /** @brief Bind a once gate entity to activate when a signal is emitted. */
+    int sdl3d_logic_world_bind_once(sdl3d_logic_world *world, int signal_id, sdl3d_logic_once *once);
+
+    /**
+     * @brief Remove an entity binding by id.
+     *
+     * Disconnects the binding from the signal bus. No-op if @p binding_id is
+     * invalid or has already been removed.
+     */
+    void sdl3d_logic_world_unbind_entity(sdl3d_logic_world *world, int binding_id);
+
+    /**
+     * @brief Enable or disable an entity binding.
+     *
+     * Disabled entity bindings remain connected and keep their deterministic
+     * order, but they skip entity activation while disabled.
+     */
+    bool sdl3d_logic_world_set_entity_binding_enabled(sdl3d_logic_world *world, int binding_id, bool enabled);
+
+    /**
+     * @brief Return whether an entity binding is currently enabled.
+     *
+     * @return false when the world or binding id is invalid.
+     */
+    bool sdl3d_logic_world_entity_binding_enabled(const sdl3d_logic_world *world, int binding_id);
+
+    /**
+     * @brief Return the number of live entity bindings in the logic world.
+     */
+    int sdl3d_logic_world_entity_binding_count(const sdl3d_logic_world *world);
 
     /**
      * @brief Bind one action to a signal.

--- a/src/logic.c
+++ b/src/logic.c
@@ -18,6 +18,29 @@ typedef struct logic_binding
     struct logic_binding *next;
 } logic_binding;
 
+typedef enum logic_entity_binding_kind
+{
+    LOGIC_ENTITY_BINDING_RELAY,
+    LOGIC_ENTITY_BINDING_TOGGLE,
+    LOGIC_ENTITY_BINDING_COUNTER,
+    LOGIC_ENTITY_BINDING_BRANCH,
+    LOGIC_ENTITY_BINDING_RANDOM,
+    LOGIC_ENTITY_BINDING_SEQUENCE,
+    LOGIC_ENTITY_BINDING_ONCE,
+} logic_entity_binding_kind;
+
+typedef struct logic_entity_binding
+{
+    struct sdl3d_logic_world *owner;
+    int id;
+    int signal_id;
+    int connection_id;
+    logic_entity_binding_kind kind;
+    void *entity;
+    bool enabled;
+    struct logic_entity_binding *next;
+} logic_entity_binding;
+
 typedef struct sector_alias
 {
     int sector_index;
@@ -29,9 +52,11 @@ struct sdl3d_logic_world
     sdl3d_signal_bus *bus;
     sdl3d_timer_pool *timers;
     logic_binding *bindings;
+    logic_entity_binding *entity_bindings;
     sdl3d_logic_target_context target_context;
     sector_alias *sector_aliases;
     int binding_count;
+    int entity_binding_count;
     int sector_alias_count;
     int sector_alias_capacity;
     int next_binding_id;
@@ -44,6 +69,19 @@ static logic_binding *find_binding(const sdl3d_logic_world *world, int binding_i
         return NULL;
 
     for (logic_binding *binding = world->bindings; binding != NULL; binding = binding->next)
+    {
+        if (binding->id == binding_id)
+            return binding;
+    }
+    return NULL;
+}
+
+static logic_entity_binding *find_entity_binding(const sdl3d_logic_world *world, int binding_id)
+{
+    if (world == NULL || binding_id <= 0)
+        return NULL;
+
+    for (logic_entity_binding *binding = world->entity_bindings; binding != NULL; binding = binding->next)
     {
         if (binding->id == binding_id)
             return binding;
@@ -136,6 +174,16 @@ static sdl3d_logic_sensor_result sensor_result(bool active, sdl3d_logic_sensor_e
     return result;
 }
 
+static sdl3d_logic_entity_result entity_result(bool emitted, int signal_id, int output_index)
+{
+    sdl3d_logic_entity_result result;
+    SDL_zero(result);
+    result.emitted = emitted;
+    result.signal_id = emitted ? signal_id : 0;
+    result.output_index = emitted ? output_index : -1;
+    return result;
+}
+
 static sdl3d_logic_sensor_event sensor_event_for_state(sdl3d_trigger_edge edge, bool was_active, bool active)
 {
     switch (edge)
@@ -192,6 +240,54 @@ static bool emit_sensor_payload(sdl3d_logic_world *world, int signal_id, int sen
     return true;
 }
 
+static sdl3d_properties *create_entity_payload(int entity_id, const char *entity_type)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    sdl3d_properties_set_int(payload, "entity_id", entity_id);
+    sdl3d_properties_set_string(payload, "entity_type", entity_type != NULL ? entity_type : "");
+    return payload;
+}
+
+static bool value_equals(const sdl3d_value *left, const sdl3d_value *right)
+{
+    if (left == NULL || right == NULL || left->type != right->type)
+        return false;
+
+    switch (left->type)
+    {
+    case SDL3D_VALUE_INT:
+        return left->as_int == right->as_int;
+    case SDL3D_VALUE_FLOAT:
+        return left->as_float == right->as_float;
+    case SDL3D_VALUE_BOOL:
+        return left->as_bool == right->as_bool;
+    case SDL3D_VALUE_VEC3:
+        return left->as_vec3.x == right->as_vec3.x && left->as_vec3.y == right->as_vec3.y &&
+               left->as_vec3.z == right->as_vec3.z;
+    case SDL3D_VALUE_STRING:
+        return SDL_strcmp(left->as_string != NULL ? left->as_string : "",
+                          right->as_string != NULL ? right->as_string : "") == 0;
+    case SDL3D_VALUE_COLOR:
+        return left->as_color.r == right->as_color.r && left->as_color.g == right->as_color.g &&
+               left->as_color.b == right->as_color.b && left->as_color.a == right->as_color.a;
+    }
+
+    return false;
+}
+
+static unsigned int normalized_seed(unsigned int seed)
+{
+    return seed != 0 ? seed : 1u;
+}
+
+static unsigned int next_random_state(unsigned int state)
+{
+    return state * 1664525u + 1013904223u;
+}
+
 static void set_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
 {
     if (target == NULL || key == NULL || value == NULL)
@@ -232,6 +328,39 @@ static void execute_binding(void *userdata, int signal_id, const sdl3d_propertie
     sdl3d_logic_world_execute_action(world, &binding->action);
 }
 
+static void execute_entity_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    logic_entity_binding *binding = (logic_entity_binding *)userdata;
+    if (binding == NULL || !binding->enabled || binding->signal_id != signal_id || binding->entity == NULL)
+        return;
+
+    sdl3d_logic_world *world = binding->owner;
+    switch (binding->kind)
+    {
+    case LOGIC_ENTITY_BINDING_RELAY:
+        sdl3d_logic_relay_activate(world, (sdl3d_logic_relay *)binding->entity, payload);
+        break;
+    case LOGIC_ENTITY_BINDING_TOGGLE:
+        sdl3d_logic_toggle_activate(world, (sdl3d_logic_toggle *)binding->entity);
+        break;
+    case LOGIC_ENTITY_BINDING_COUNTER:
+        sdl3d_logic_counter_activate(world, (sdl3d_logic_counter *)binding->entity);
+        break;
+    case LOGIC_ENTITY_BINDING_BRANCH:
+        sdl3d_logic_branch_activate(world, (sdl3d_logic_branch *)binding->entity);
+        break;
+    case LOGIC_ENTITY_BINDING_RANDOM:
+        sdl3d_logic_random_activate(world, (sdl3d_logic_random *)binding->entity);
+        break;
+    case LOGIC_ENTITY_BINDING_SEQUENCE:
+        sdl3d_logic_sequence_activate(world, (sdl3d_logic_sequence *)binding->entity);
+        break;
+    case LOGIC_ENTITY_BINDING_ONCE:
+        sdl3d_logic_once_activate(world, (sdl3d_logic_once *)binding->entity);
+        break;
+    }
+}
+
 sdl3d_logic_world *sdl3d_logic_world_create(sdl3d_signal_bus *bus, sdl3d_timer_pool *timers)
 {
     if (bus == NULL)
@@ -261,6 +390,17 @@ void sdl3d_logic_world_destroy(sdl3d_logic_world *world)
         SDL_free(binding);
         binding = next;
     }
+
+    logic_entity_binding *entity_binding = world->entity_bindings;
+    while (entity_binding != NULL)
+    {
+        logic_entity_binding *next = entity_binding->next;
+        if (world->bus != NULL && entity_binding->connection_id > 0)
+            sdl3d_signal_disconnect(world->bus, entity_binding->connection_id);
+        SDL_free(entity_binding);
+        entity_binding = next;
+    }
+
     clear_sector_aliases(world);
     SDL_free(world);
 }
@@ -708,6 +848,492 @@ void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor)
 {
     if (sensor != NULL)
         sensor->was_inside = false;
+}
+
+bool sdl3d_logic_world_emit_signal(sdl3d_logic_world *world, int signal_id, const sdl3d_properties *payload)
+{
+    if (world == NULL || world->bus == NULL)
+        return false;
+
+    sdl3d_signal_emit(world->bus, signal_id, payload);
+    return true;
+}
+
+void sdl3d_logic_relay_init(sdl3d_logic_relay *relay, int entity_id)
+{
+    if (relay == NULL)
+        return;
+
+    SDL_zerop(relay);
+    relay->entity_id = entity_id;
+    relay->enabled = true;
+}
+
+bool sdl3d_logic_relay_add_output(sdl3d_logic_relay *relay, int signal_id)
+{
+    if (relay == NULL || relay->output_count >= SDL3D_LOGIC_MAX_ENTITY_OUTPUTS)
+        return false;
+
+    relay->outputs[relay->output_count++] = signal_id;
+    return true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_relay_activate(sdl3d_logic_world *world, sdl3d_logic_relay *relay,
+                                                     const sdl3d_properties *payload)
+{
+    if (relay == NULL || !relay->enabled || relay->output_count <= 0)
+        return entity_result(false, 0, -1);
+
+    sdl3d_logic_entity_result result = entity_result(false, 0, -1);
+    for (int i = 0; i < relay->output_count; ++i)
+    {
+        if (sdl3d_logic_world_emit_signal(world, relay->outputs[i], payload))
+            result = entity_result(true, relay->outputs[i], i);
+    }
+    return result;
+}
+
+void sdl3d_logic_toggle_init(sdl3d_logic_toggle *toggle, int entity_id, bool initial_state, int on_signal,
+                             int off_signal)
+{
+    if (toggle == NULL)
+        return;
+
+    SDL_zerop(toggle);
+    toggle->entity_id = entity_id;
+    toggle->state = initial_state;
+    toggle->on_signal = on_signal;
+    toggle->off_signal = off_signal;
+    toggle->enabled = true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_toggle_activate(sdl3d_logic_world *world, sdl3d_logic_toggle *toggle)
+{
+    if (toggle == NULL || !toggle->enabled)
+        return entity_result(false, 0, -1);
+
+    toggle->state = !toggle->state;
+    const int signal_id = toggle->state ? toggle->on_signal : toggle->off_signal;
+    sdl3d_properties *payload = create_entity_payload(toggle->entity_id, "toggle");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_bool(payload, "state", toggle->state);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+    return entity_result(emitted, signal_id, 0);
+}
+
+void sdl3d_logic_toggle_reset(sdl3d_logic_toggle *toggle, bool state)
+{
+    if (toggle != NULL)
+        toggle->state = state;
+}
+
+void sdl3d_logic_counter_init(sdl3d_logic_counter *counter, int entity_id, int threshold, int output_signal,
+                              bool reset_on_fire)
+{
+    if (counter == NULL)
+        return;
+
+    SDL_zerop(counter);
+    counter->entity_id = entity_id;
+    counter->threshold = threshold > 1 ? threshold : 1;
+    counter->output_signal = output_signal;
+    counter->reset_on_fire = reset_on_fire;
+    counter->enabled = true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_counter_activate(sdl3d_logic_world *world, sdl3d_logic_counter *counter)
+{
+    if (counter == NULL || !counter->enabled)
+        return entity_result(false, 0, -1);
+
+    if (!counter->fired)
+        counter->count++;
+    if (counter->count < counter->threshold || counter->fired)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties *payload = create_entity_payload(counter->entity_id, "counter");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_int(payload, "count", counter->count);
+    sdl3d_properties_set_int(payload, "threshold", counter->threshold);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, counter->output_signal, payload);
+    sdl3d_properties_destroy(payload);
+
+    if (emitted)
+    {
+        if (counter->reset_on_fire)
+        {
+            counter->count = 0;
+            counter->fired = false;
+        }
+        else
+        {
+            counter->fired = true;
+        }
+    }
+
+    return entity_result(emitted, counter->output_signal, 0);
+}
+
+void sdl3d_logic_counter_reset(sdl3d_logic_counter *counter)
+{
+    if (counter == NULL)
+        return;
+
+    counter->count = 0;
+    counter->fired = false;
+}
+
+void sdl3d_logic_branch_init(sdl3d_logic_branch *branch, int entity_id, const sdl3d_properties *props, const char *key,
+                             sdl3d_value expected, int true_signal, int false_signal)
+{
+    if (branch == NULL)
+        return;
+
+    SDL_zerop(branch);
+    branch->entity_id = entity_id;
+    branch->props = props;
+    branch->key = key;
+    branch->expected = expected;
+    branch->true_signal = true_signal;
+    branch->false_signal = false_signal;
+    branch->enabled = true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_branch_activate(sdl3d_logic_world *world, sdl3d_logic_branch *branch)
+{
+    if (branch == NULL || !branch->enabled)
+        return entity_result(false, 0, -1);
+
+    const sdl3d_value *actual = sdl3d_properties_get_value(branch->props, branch->key);
+    const bool matched = value_equals(actual, &branch->expected);
+    const int signal_id = matched ? branch->true_signal : branch->false_signal;
+    sdl3d_properties *payload = create_entity_payload(branch->entity_id, "branch");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_bool(payload, "matched", matched);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+    return entity_result(emitted, signal_id, matched ? 0 : 1);
+}
+
+void sdl3d_logic_random_init(sdl3d_logic_random *random, int entity_id, unsigned int seed)
+{
+    if (random == NULL)
+        return;
+
+    SDL_zerop(random);
+    random->entity_id = entity_id;
+    random->state = normalized_seed(seed);
+    random->enabled = true;
+}
+
+bool sdl3d_logic_random_add_output(sdl3d_logic_random *random, int signal_id)
+{
+    if (random == NULL || random->output_count >= SDL3D_LOGIC_MAX_ENTITY_OUTPUTS)
+        return false;
+
+    random->outputs[random->output_count++] = signal_id;
+    return true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_random_activate(sdl3d_logic_world *world, sdl3d_logic_random *random)
+{
+    if (random == NULL || !random->enabled || random->output_count <= 0)
+        return entity_result(false, 0, -1);
+
+    random->state = next_random_state(random->state);
+    const int output_index = (int)(random->state % (unsigned int)random->output_count);
+    const int signal_id = random->outputs[output_index];
+    sdl3d_properties *payload = create_entity_payload(random->entity_id, "random");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_int(payload, "output_index", output_index);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+    return entity_result(emitted, signal_id, output_index);
+}
+
+void sdl3d_logic_random_reset(sdl3d_logic_random *random, unsigned int seed)
+{
+    if (random != NULL)
+        random->state = normalized_seed(seed);
+}
+
+void sdl3d_logic_sequence_init(sdl3d_logic_sequence *sequence, int entity_id, bool loop)
+{
+    if (sequence == NULL)
+        return;
+
+    SDL_zerop(sequence);
+    sequence->entity_id = entity_id;
+    sequence->loop = loop;
+    sequence->enabled = true;
+}
+
+bool sdl3d_logic_sequence_add_output(sdl3d_logic_sequence *sequence, int signal_id)
+{
+    if (sequence == NULL || sequence->output_count >= SDL3D_LOGIC_MAX_ENTITY_OUTPUTS)
+        return false;
+
+    sequence->outputs[sequence->output_count++] = signal_id;
+    return true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_sequence_activate(sdl3d_logic_world *world, sdl3d_logic_sequence *sequence)
+{
+    if (sequence == NULL || !sequence->enabled || sequence->output_count <= 0 || sequence->next_index < 0 ||
+        sequence->next_index >= sequence->output_count)
+    {
+        return entity_result(false, 0, -1);
+    }
+
+    const int output_index = sequence->next_index;
+    const int signal_id = sequence->outputs[output_index];
+    sdl3d_properties *payload = create_entity_payload(sequence->entity_id, "sequence");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_int(payload, "output_index", output_index);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+
+    if (emitted)
+    {
+        sequence->next_index++;
+        if (sequence->next_index >= sequence->output_count && sequence->loop)
+            sequence->next_index = 0;
+    }
+
+    return entity_result(emitted, signal_id, output_index);
+}
+
+void sdl3d_logic_sequence_reset(sdl3d_logic_sequence *sequence)
+{
+    if (sequence != NULL)
+        sequence->next_index = 0;
+}
+
+void sdl3d_logic_once_init(sdl3d_logic_once *once, int entity_id, int output_signal)
+{
+    if (once == NULL)
+        return;
+
+    SDL_zerop(once);
+    once->entity_id = entity_id;
+    once->output_signal = output_signal;
+    once->enabled = true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_once_activate(sdl3d_logic_world *world, sdl3d_logic_once *once)
+{
+    if (once == NULL || !once->enabled || once->fired)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties *payload = create_entity_payload(once->entity_id, "once");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    const bool emitted = sdl3d_logic_world_emit_signal(world, once->output_signal, payload);
+    sdl3d_properties_destroy(payload);
+    if (emitted)
+        once->fired = true;
+    return entity_result(emitted, once->output_signal, 0);
+}
+
+void sdl3d_logic_once_reset(sdl3d_logic_once *once)
+{
+    if (once != NULL)
+        once->fired = false;
+}
+
+void sdl3d_logic_timer_init(sdl3d_logic_timer *timer, int entity_id, float delay, int output_signal, bool repeating,
+                            float interval)
+{
+    if (timer == NULL)
+        return;
+
+    SDL_zerop(timer);
+    timer->entity_id = entity_id;
+    timer->delay = delay;
+    timer->remaining = delay;
+    timer->output_signal = output_signal;
+    timer->repeating = repeating;
+    timer->interval = interval;
+    timer->enabled = true;
+}
+
+bool sdl3d_logic_timer_start(sdl3d_logic_timer *timer)
+{
+    if (timer == NULL || !timer->enabled || timer->delay <= 0.0f)
+        return false;
+    if (timer->repeating && timer->interval <= 0.0f)
+        return false;
+
+    timer->remaining = timer->delay;
+    timer->active = true;
+    return true;
+}
+
+sdl3d_logic_entity_result sdl3d_logic_timer_update(sdl3d_logic_world *world, sdl3d_logic_timer *timer, float dt)
+{
+    if (timer == NULL || !timer->enabled || !timer->active || dt < 0.0f)
+        return entity_result(false, 0, -1);
+
+    timer->remaining -= dt;
+    if (timer->remaining > 0.0f)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties *payload = create_entity_payload(timer->entity_id, "timer");
+    if (payload == NULL)
+        return entity_result(false, 0, -1);
+
+    sdl3d_properties_set_bool(payload, "repeating", timer->repeating);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, timer->output_signal, payload);
+    sdl3d_properties_destroy(payload);
+
+    if (emitted)
+    {
+        if (timer->repeating)
+        {
+            timer->remaining += timer->interval;
+            if (timer->remaining <= 0.0f)
+                timer->remaining = timer->interval;
+        }
+        else
+        {
+            timer->active = false;
+            timer->remaining = 0.0f;
+        }
+    }
+
+    return entity_result(emitted, timer->output_signal, 0);
+}
+
+void sdl3d_logic_timer_stop(sdl3d_logic_timer *timer)
+{
+    if (timer == NULL)
+        return;
+
+    timer->active = false;
+    timer->remaining = timer->delay;
+}
+
+bool sdl3d_logic_timer_active(const sdl3d_logic_timer *timer)
+{
+    return timer != NULL && timer->active;
+}
+
+static int bind_entity(sdl3d_logic_world *world, int signal_id, logic_entity_binding_kind kind, void *entity)
+{
+    if (world == NULL || world->bus == NULL || entity == NULL)
+        return 0;
+
+    logic_entity_binding *binding = (logic_entity_binding *)SDL_calloc(1, sizeof(logic_entity_binding));
+    if (binding == NULL)
+        return 0;
+
+    binding->id = world->next_binding_id++;
+    binding->owner = world;
+    binding->signal_id = signal_id;
+    binding->kind = kind;
+    binding->entity = entity;
+    binding->enabled = true;
+    binding->connection_id = sdl3d_signal_connect(world->bus, signal_id, execute_entity_binding, binding);
+    if (binding->connection_id == 0)
+    {
+        SDL_free(binding);
+        return 0;
+    }
+
+    binding->next = world->entity_bindings;
+    world->entity_bindings = binding;
+    world->entity_binding_count++;
+    return binding->id;
+}
+
+int sdl3d_logic_world_bind_relay(sdl3d_logic_world *world, int signal_id, sdl3d_logic_relay *relay)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_RELAY, relay);
+}
+
+int sdl3d_logic_world_bind_toggle(sdl3d_logic_world *world, int signal_id, sdl3d_logic_toggle *toggle)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_TOGGLE, toggle);
+}
+
+int sdl3d_logic_world_bind_counter(sdl3d_logic_world *world, int signal_id, sdl3d_logic_counter *counter)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_COUNTER, counter);
+}
+
+int sdl3d_logic_world_bind_branch(sdl3d_logic_world *world, int signal_id, sdl3d_logic_branch *branch)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_BRANCH, branch);
+}
+
+int sdl3d_logic_world_bind_random(sdl3d_logic_world *world, int signal_id, sdl3d_logic_random *random)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_RANDOM, random);
+}
+
+int sdl3d_logic_world_bind_sequence(sdl3d_logic_world *world, int signal_id, sdl3d_logic_sequence *sequence)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_SEQUENCE, sequence);
+}
+
+int sdl3d_logic_world_bind_once(sdl3d_logic_world *world, int signal_id, sdl3d_logic_once *once)
+{
+    return bind_entity(world, signal_id, LOGIC_ENTITY_BINDING_ONCE, once);
+}
+
+void sdl3d_logic_world_unbind_entity(sdl3d_logic_world *world, int binding_id)
+{
+    if (world == NULL || binding_id <= 0)
+        return;
+
+    logic_entity_binding **cursor = &world->entity_bindings;
+    while (*cursor != NULL)
+    {
+        logic_entity_binding *binding = *cursor;
+        if (binding->id == binding_id)
+        {
+            *cursor = binding->next;
+            if (world->bus != NULL && binding->connection_id > 0)
+                sdl3d_signal_disconnect(world->bus, binding->connection_id);
+            SDL_free(binding);
+            world->entity_binding_count--;
+            return;
+        }
+        cursor = &binding->next;
+    }
+}
+
+bool sdl3d_logic_world_set_entity_binding_enabled(sdl3d_logic_world *world, int binding_id, bool enabled)
+{
+    logic_entity_binding *binding = find_entity_binding(world, binding_id);
+    if (binding == NULL)
+        return false;
+
+    binding->enabled = enabled;
+    return true;
+}
+
+bool sdl3d_logic_world_entity_binding_enabled(const sdl3d_logic_world *world, int binding_id)
+{
+    const logic_entity_binding *binding = find_entity_binding(world, binding_id);
+    return binding != NULL && binding->enabled;
+}
+
+int sdl3d_logic_world_entity_binding_count(const sdl3d_logic_world *world)
+{
+    return world != NULL ? world->entity_binding_count : 0;
 }
 
 int sdl3d_logic_world_bind_action(sdl3d_logic_world *world, int signal_id, const sdl3d_action *action)

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -32,10 +32,17 @@ struct logic_signal_capture
     int event = 0;
     int sector_index = -1;
     int actor_id = -1;
+    int entity_id = -1;
+    int output_index = -1;
+    int count_value = -1;
+    int threshold = -1;
     bool inside = false;
+    bool state = false;
+    bool matched = false;
     float distance = -1.0f;
     sdl3d_vec3 sample_position = {};
     char actor_name[64] = {};
+    char entity_type[32] = {};
 };
 
 static void capture_logic_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -48,10 +55,38 @@ static void capture_logic_signal(void *userdata, int signal_id, const sdl3d_prop
     capture->inside = sdl3d_properties_get_bool(payload, "inside", false);
     capture->sector_index = sdl3d_properties_get_int(payload, "sector_index", -1);
     capture->actor_id = sdl3d_properties_get_int(payload, "actor_id", -1);
+    capture->entity_id = sdl3d_properties_get_int(payload, "entity_id", -1);
+    capture->output_index = sdl3d_properties_get_int(payload, "output_index", -1);
+    capture->count_value = sdl3d_properties_get_int(payload, "count", -1);
+    capture->threshold = sdl3d_properties_get_int(payload, "threshold", -1);
     capture->distance = sdl3d_properties_get_float(payload, "distance", -1.0f);
+    capture->state = sdl3d_properties_get_bool(payload, "state", false);
+    capture->matched = sdl3d_properties_get_bool(payload, "matched", false);
     capture->sample_position = sdl3d_properties_get_vec3(payload, "sample_position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
     const char *actor_name = sdl3d_properties_get_string(payload, "actor_name", "");
     SDL_snprintf(capture->actor_name, sizeof(capture->actor_name), "%s", actor_name);
+    const char *entity_type = sdl3d_properties_get_string(payload, "entity_type", "");
+    SDL_snprintf(capture->entity_type, sizeof(capture->entity_type), "%s", entity_type);
+}
+
+struct ordered_signal_capture
+{
+    int count = 0;
+    int signals[16] = {};
+    int entity_ids[16] = {};
+    int payload_value[16] = {};
+};
+
+static void capture_ordered_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    ordered_signal_capture *capture = (ordered_signal_capture *)userdata;
+    if (capture->count >= (int)SDL_arraysize(capture->signals))
+        return;
+
+    const int index = capture->count++;
+    capture->signals[index] = signal_id;
+    capture->entity_ids[index] = sdl3d_properties_get_int(payload, "entity_id", -1);
+    capture->payload_value[index] = sdl3d_properties_get_int(payload, "payload_value", -1);
 }
 
 static sdl3d_sector make_square_sector(float min_x, float min_z, float max_x, float max_z)
@@ -1040,6 +1075,431 @@ TEST(LogicWorldSensors, InvalidSensorsAreSafe)
                                       SDL3D_TRIGGER_EDGE_ENTER);
     EXPECT_FALSE(sdl3d_logic_proximity_sensor_update(&proximity, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)).emitted);
     sdl3d_logic_proximity_sensor_reset(nullptr);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, RelayEmitsOutputsInOrderAndForwardsPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    ordered_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 300, capture_ordered_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 301, capture_ordered_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 302, capture_ordered_signal, &capture), 0);
+
+    sdl3d_logic_relay relay{};
+    sdl3d_logic_relay_init(&relay, 21);
+    ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, 300));
+    ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, 301));
+    ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, 302));
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "payload_value", 99);
+    sdl3d_logic_entity_result result = sdl3d_logic_relay_activate(world, &relay, payload);
+
+    EXPECT_TRUE(result.emitted);
+    EXPECT_EQ(result.signal_id, 302);
+    EXPECT_EQ(result.output_index, 2);
+    ASSERT_EQ(capture.count, 3);
+    EXPECT_EQ(capture.signals[0], 300);
+    EXPECT_EQ(capture.signals[1], 301);
+    EXPECT_EQ(capture.signals[2], 302);
+    EXPECT_EQ(capture.payload_value[0], 99);
+    EXPECT_EQ(capture.payload_value[1], 99);
+    EXPECT_EQ(capture.payload_value[2], 99);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, ToggleFlipsAndEmitsStatePayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 310, capture_logic_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 311, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_toggle toggle{};
+    sdl3d_logic_toggle_init(&toggle, 22, false, 310, 311);
+
+    sdl3d_logic_entity_result on = sdl3d_logic_toggle_activate(world, &toggle);
+    EXPECT_TRUE(on.emitted);
+    EXPECT_EQ(on.signal_id, 310);
+    EXPECT_TRUE(toggle.state);
+    EXPECT_EQ(capture.entity_id, 22);
+    EXPECT_STREQ(capture.entity_type, "toggle");
+    EXPECT_TRUE(capture.state);
+
+    sdl3d_logic_entity_result off = sdl3d_logic_toggle_activate(world, &toggle);
+    EXPECT_TRUE(off.emitted);
+    EXPECT_EQ(off.signal_id, 311);
+    EXPECT_FALSE(toggle.state);
+    EXPECT_FALSE(capture.state);
+
+    sdl3d_logic_toggle_reset(&toggle, true);
+    EXPECT_TRUE(toggle.state);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, CounterEmitsAtThresholdAndCanResetOnFire)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 320, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_counter counter{};
+    sdl3d_logic_counter_init(&counter, 23, 3, 320, true);
+
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    sdl3d_logic_entity_result fired = sdl3d_logic_counter_activate(world, &counter);
+    EXPECT_TRUE(fired.emitted);
+    EXPECT_EQ(fired.signal_id, 320);
+    EXPECT_EQ(counter.count, 0);
+    EXPECT_EQ(capture.entity_id, 23);
+    EXPECT_STREQ(capture.entity_type, "counter");
+    EXPECT_EQ(capture.count_value, 3);
+    EXPECT_EQ(capture.threshold, 3);
+
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_TRUE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, NonResettingCounterFiresOnceUntilReset)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 321, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_counter counter{};
+    sdl3d_logic_counter_init(&counter, 24, 2, 321, false);
+
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_TRUE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_TRUE(counter.fired);
+
+    sdl3d_logic_counter_reset(&counter);
+    EXPECT_FALSE(counter.fired);
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_TRUE(sdl3d_logic_counter_activate(world, &counter).emitted);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, BranchComparesPropertyValues)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 330, capture_logic_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 331, capture_logic_signal, &capture), 0);
+
+    sdl3d_properties *props = sdl3d_properties_create();
+    sdl3d_properties_set_bool(props, "locked", true);
+    sdl3d_value expected{};
+    expected.type = SDL3D_VALUE_BOOL;
+    expected.as_bool = true;
+
+    sdl3d_logic_branch branch{};
+    sdl3d_logic_branch_init(&branch, 25, props, "locked", expected, 330, 331);
+
+    EXPECT_TRUE(sdl3d_logic_branch_activate(world, &branch).emitted);
+    EXPECT_EQ(capture.signal_id, 330);
+    EXPECT_TRUE(capture.matched);
+
+    sdl3d_properties_set_bool(props, "locked", false);
+    EXPECT_TRUE(sdl3d_logic_branch_activate(world, &branch).emitted);
+    EXPECT_EQ(capture.signal_id, 331);
+    EXPECT_FALSE(capture.matched);
+
+    sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, RandomSelectorIsDeterministicAfterReset)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    ordered_signal_capture first{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 340, capture_ordered_signal, &first), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 341, capture_ordered_signal, &first), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 342, capture_ordered_signal, &first), 0);
+
+    sdl3d_logic_random selector{};
+    sdl3d_logic_random_init(&selector, 26, 123);
+    ASSERT_TRUE(sdl3d_logic_random_add_output(&selector, 340));
+    ASSERT_TRUE(sdl3d_logic_random_add_output(&selector, 341));
+    ASSERT_TRUE(sdl3d_logic_random_add_output(&selector, 342));
+
+    int expected[5] = {};
+    for (int i = 0; i < 5; ++i)
+    {
+        sdl3d_logic_entity_result result = sdl3d_logic_random_activate(world, &selector);
+        ASSERT_TRUE(result.emitted);
+        expected[i] = result.signal_id;
+    }
+
+    sdl3d_logic_random_reset(&selector, 123);
+    for (int i = 0; i < 5; ++i)
+    {
+        sdl3d_logic_entity_result result = sdl3d_logic_random_activate(world, &selector);
+        ASSERT_TRUE(result.emitted);
+        EXPECT_EQ(result.signal_id, expected[i]);
+    }
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, SequenceEmitsInOrderThenStopsUntilReset)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    ordered_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 350, capture_ordered_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 351, capture_ordered_signal, &capture), 0);
+
+    sdl3d_logic_sequence sequence{};
+    sdl3d_logic_sequence_init(&sequence, 27, false);
+    ASSERT_TRUE(sdl3d_logic_sequence_add_output(&sequence, 350));
+    ASSERT_TRUE(sdl3d_logic_sequence_add_output(&sequence, 351));
+
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 350);
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 351);
+    EXPECT_FALSE(sdl3d_logic_sequence_activate(world, &sequence).emitted);
+    ASSERT_EQ(capture.count, 2);
+    EXPECT_EQ(capture.signals[0], 350);
+    EXPECT_EQ(capture.signals[1], 351);
+
+    sdl3d_logic_sequence_reset(&sequence);
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 350);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, LoopingSequenceWraps)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    ordered_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 352, capture_ordered_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 353, capture_ordered_signal, &capture), 0);
+
+    sdl3d_logic_sequence sequence{};
+    sdl3d_logic_sequence_init(&sequence, 28, true);
+    ASSERT_TRUE(sdl3d_logic_sequence_add_output(&sequence, 352));
+    ASSERT_TRUE(sdl3d_logic_sequence_add_output(&sequence, 353));
+
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 352);
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 353);
+    EXPECT_EQ(sdl3d_logic_sequence_activate(world, &sequence).signal_id, 352);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, OnceGatePassesFirstActivationUntilReset)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 360, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_once once{};
+    sdl3d_logic_once_init(&once, 29, 360);
+
+    EXPECT_TRUE(sdl3d_logic_once_activate(world, &once).emitted);
+    EXPECT_FALSE(sdl3d_logic_once_activate(world, &once).emitted);
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_TRUE(once.fired);
+
+    sdl3d_logic_once_reset(&once);
+    EXPECT_TRUE(sdl3d_logic_once_activate(world, &once).emitted);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, TimerEntityUpdatesAndStopsAccurately)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 370, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_timer timer{};
+    sdl3d_logic_timer_init(&timer, 30, 0.5f, 370, false, 0.0f);
+    EXPECT_TRUE(sdl3d_logic_timer_start(&timer));
+    EXPECT_TRUE(sdl3d_logic_timer_active(&timer));
+
+    EXPECT_FALSE(sdl3d_logic_timer_update(world, &timer, 0.49f).emitted);
+    EXPECT_EQ(capture.count, 0);
+    sdl3d_logic_entity_result fired = sdl3d_logic_timer_update(world, &timer, 0.01f);
+    EXPECT_TRUE(fired.emitted);
+    EXPECT_FALSE(sdl3d_logic_timer_active(&timer));
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.entity_id, 30);
+    EXPECT_STREQ(capture.entity_type, "timer");
+
+    EXPECT_TRUE(sdl3d_logic_timer_start(&timer));
+    sdl3d_logic_timer_stop(&timer);
+    EXPECT_FALSE(sdl3d_logic_timer_active(&timer));
+    EXPECT_FALSE(sdl3d_logic_timer_update(world, &timer, 0.5f).emitted);
+    EXPECT_EQ(capture.count, 1);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, RepeatingTimerEmitsAtMostOncePerUpdateAndStaysActive)
+{
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 371, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_timer timer{};
+    sdl3d_logic_timer_init(&timer, 31, 0.25f, 371, true, 0.25f);
+    ASSERT_TRUE(sdl3d_logic_timer_start(&timer));
+
+    EXPECT_TRUE(sdl3d_logic_timer_update(world, &timer, 1.0f).emitted);
+    EXPECT_TRUE(sdl3d_logic_timer_active(&timer));
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_FLOAT_EQ(timer.remaining, 0.25f);
+
+    EXPECT_TRUE(sdl3d_logic_timer_update(world, &timer, 0.25f).emitted);
+    EXPECT_EQ(capture.count, 2);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, EntityBindingActivatesRelayFromSignal)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    ordered_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 401, capture_ordered_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 402, capture_ordered_signal, &capture), 0);
+
+    sdl3d_logic_relay relay{};
+    sdl3d_logic_relay_init(&relay, 32);
+    ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, 401));
+    ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, 402));
+    int binding_id = sdl3d_logic_world_bind_relay(world, 400, &relay);
+    ASSERT_GT(binding_id, 0);
+    EXPECT_EQ(sdl3d_logic_world_entity_binding_count(world), 1);
+    EXPECT_TRUE(sdl3d_logic_world_entity_binding_enabled(world, binding_id));
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "payload_value", 123);
+    sdl3d_signal_emit(bus, 400, payload);
+
+    ASSERT_EQ(capture.count, 2);
+    EXPECT_EQ(capture.signals[0], 401);
+    EXPECT_EQ(capture.signals[1], 402);
+    EXPECT_EQ(capture.payload_value[0], 123);
+    EXPECT_EQ(capture.payload_value[1], 123);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, EntityBindingCanBeDisabledAndUnbound)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 411, capture_logic_signal, &capture), 0);
+
+    sdl3d_logic_toggle toggle{};
+    sdl3d_logic_toggle_init(&toggle, 33, false, 411, 412);
+    int binding_id = sdl3d_logic_world_bind_toggle(world, 410, &toggle);
+    ASSERT_GT(binding_id, 0);
+
+    EXPECT_TRUE(sdl3d_logic_world_set_entity_binding_enabled(world, binding_id, false));
+    EXPECT_FALSE(sdl3d_logic_world_entity_binding_enabled(world, binding_id));
+    sdl3d_signal_emit(bus, 410, nullptr);
+    EXPECT_FALSE(toggle.state);
+    EXPECT_EQ(capture.count, 0);
+
+    EXPECT_TRUE(sdl3d_logic_world_set_entity_binding_enabled(world, binding_id, true));
+    sdl3d_signal_emit(bus, 410, nullptr);
+    EXPECT_TRUE(toggle.state);
+    EXPECT_EQ(capture.count, 1);
+
+    sdl3d_logic_world_unbind_entity(world, binding_id);
+    EXPECT_EQ(sdl3d_logic_world_entity_binding_count(world), 0);
+    sdl3d_signal_emit(bus, 410, nullptr);
+    EXPECT_TRUE(toggle.state);
+    EXPECT_EQ(capture.count, 1);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, InvalidEntityOperationsAreSafe)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+
+    EXPECT_FALSE(sdl3d_logic_world_emit_signal(nullptr, 1, nullptr));
+    EXPECT_FALSE(sdl3d_logic_relay_add_output(nullptr, 1));
+    EXPECT_FALSE(sdl3d_logic_relay_activate(world, nullptr, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_toggle_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_counter_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_branch_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_random_add_output(nullptr, 1));
+    EXPECT_FALSE(sdl3d_logic_random_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_sequence_add_output(nullptr, 1));
+    EXPECT_FALSE(sdl3d_logic_sequence_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_once_activate(world, nullptr).emitted);
+    EXPECT_FALSE(sdl3d_logic_timer_start(nullptr));
+    EXPECT_FALSE(sdl3d_logic_timer_update(world, nullptr, 1.0f).emitted);
+    sdl3d_logic_timer_stop(nullptr);
+    EXPECT_FALSE(sdl3d_logic_timer_active(nullptr));
+    EXPECT_EQ(sdl3d_logic_world_bind_relay(nullptr, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_relay(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_toggle(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_counter(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_branch(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_random(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_sequence(world, 1, nullptr), 0);
+    EXPECT_EQ(sdl3d_logic_world_bind_once(world, 1, nullptr), 0);
+    sdl3d_logic_world_unbind_entity(nullptr, 1);
+    sdl3d_logic_world_unbind_entity(world, 999);
+    EXPECT_FALSE(sdl3d_logic_world_set_entity_binding_enabled(nullptr, 1, true));
+    EXPECT_FALSE(sdl3d_logic_world_set_entity_binding_enabled(world, 999, true));
+    EXPECT_FALSE(sdl3d_logic_world_entity_binding_enabled(nullptr, 1));
+    EXPECT_FALSE(sdl3d_logic_world_entity_binding_enabled(world, 999));
+    EXPECT_EQ(sdl3d_logic_world_entity_binding_count(nullptr), 0);
+
+    sdl3d_logic_relay relay{};
+    sdl3d_logic_relay_init(&relay, 31);
+    for (int i = 0; i < SDL3D_LOGIC_MAX_ENTITY_OUTPUTS; ++i)
+        ASSERT_TRUE(sdl3d_logic_relay_add_output(&relay, i + 1));
+    EXPECT_FALSE(sdl3d_logic_relay_add_output(&relay, 99));
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add public composable logic entities: relay, toggle, counter, branch, random selector, sequence, once gate, and timer
- add signal-to-entity bindings so signals can activate stateful logic entities without bespoke callbacks
- cover deterministic entity behavior, reset behavior, payloads, timer behavior, and binding enable/unbind paths

## Tests
- ./build/release/tests/sdl3d_logic_test
- ./scripts/check_clang_format.sh
- git diff --check
- cmake --build build/release
- ctest --test-dir build/release --output-on-failure

Issue: #109
