### PR TITLE
Add reusable actor patrol controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ target_sources(
     sdl3d
     PRIVATE
         src/action.c
+        src/actor_controller.c
         src/actor_registry.c
         src/app.c
         src/animation.c

--- a/demos/doom_level/entities.c
+++ b/demos/doom_level/entities.c
@@ -11,6 +11,10 @@
 #define ROBOT_GROUND_STEP_HEIGHT 1.1f
 #define ROBOT_COLLISION_HEIGHT 2.0f
 #define ROBOT_DEFAULT_ARRIVAL_RADIUS 0.12f
+#define DOOM_SIGNAL_ROBOT_WAYPOINT_REACHED 6201
+#define DOOM_SIGNAL_ROBOT_LOOP_COMPLETED 6202
+#define DOOM_SIGNAL_ROBOT_IDLE_STARTED 6203
+#define DOOM_SIGNAL_ROBOT_WALK_STARTED 6204
 
 static void configure_sprite_texture(sdl3d_texture2d *texture)
 {
@@ -35,114 +39,114 @@ static sdl3d_vec2 normalized_walk_direction(float x, float z)
     return (sdl3d_vec2){x * inv_length, z * inv_length};
 }
 
-static void robot_enter_idle(sdl3d_sprite_actor *actor, doom_robot_npc *npc)
+static doom_robot_npc *find_robot_by_actor_id(entities *e, int actor_id)
 {
-    if (actor == NULL || npc == NULL)
-        return;
-    npc->state = DOOM_ROBOT_AI_IDLE;
-    npc->state_timer = npc->idle_duration;
-    sdl3d_sprite_actor_stop_animation(actor);
+    if (e == NULL || actor_id <= 0)
+        return NULL;
+    for (int i = 0; i < e->robot_count; ++i)
+    {
+        if (e->robots[i].actor_id == actor_id)
+            return &e->robots[i];
+    }
+    return NULL;
 }
 
-static void robot_enter_walk(entities *e, sdl3d_sprite_actor *actor, doom_robot_npc *npc)
+typedef struct robot_patrol_move_context
 {
-    if (e == NULL || actor == NULL || npc == NULL)
-        return;
-    npc->state = DOOM_ROBOT_AI_WALK;
-    npc->state_timer = npc->walk_duration;
-    sdl3d_sprite_actor_play_animation(actor, e->enemy_walk_rotations, DOOM_ROBOT_WALK_FRAME_COUNT, 8.0f, true);
-}
+    entities *entities;
+    const sdl3d_level *level;
+} robot_patrol_move_context;
 
-static bool robot_move_toward_target(sdl3d_sprite_actor *actor, doom_robot_npc *npc, const sdl3d_level *level, float dt)
+static bool robot_patrol_move(void *userdata, const sdl3d_actor_patrol_controller *controller,
+                              sdl3d_registered_actor *registered_actor, sdl3d_vec3 desired_position,
+                              sdl3d_vec3 *out_position)
 {
-    if (actor == NULL || npc == NULL || level == NULL || npc->target_patrol_point < 0 ||
-        npc->target_patrol_point >= DOOM_ROBOT_PATROL_POINT_COUNT)
+    robot_patrol_move_context *context = (robot_patrol_move_context *)userdata;
+    if (context == NULL || context->entities == NULL || controller == NULL || registered_actor == NULL ||
+        out_position == NULL)
+        return false;
+
+    doom_robot_npc *npc = find_robot_by_actor_id(context->entities, controller->actor_id);
+    if (npc == NULL || npc->sprite_index < 0 || npc->sprite_index >= context->entities->sprites.count)
+        return false;
+
+    sdl3d_sprite_actor *sprite = &context->entities->sprites.actors[npc->sprite_index];
+    sprite->position = registered_actor->position;
+
+    float floor_y = registered_actor->position.y;
+    if (!sdl3d_sprite_actor_can_stand_at(sprite, context->level, g_sectors, desired_position.x, desired_position.z,
+                                         ROBOT_GROUND_STEP_HEIGHT, ROBOT_COLLISION_HEIGHT, &floor_y))
     {
         return false;
     }
 
-    sdl3d_vec3 target = npc->patrol_points[npc->target_patrol_point];
-    float dx = target.x - actor->position.x;
-    float dz = target.z - actor->position.z;
-    float distance_sq = dx * dx + dz * dz;
-    float arrival_radius_sq = npc->arrival_radius * npc->arrival_radius;
-    if (distance_sq <= arrival_radius_sq)
-        return false;
+    out_position->x = desired_position.x;
+    out_position->y = floor_y;
+    out_position->z = desired_position.z;
 
-    float distance = SDL_sqrtf(distance_sq);
-    float step = npc->speed * dt;
-    if (step > distance)
-        step = distance;
-
-    float move_x = dx / distance;
-    float move_z = dz / distance;
-    float next_x = actor->position.x + move_x * step;
-    float next_z = actor->position.z + move_z * step;
-    float floor_y = actor->position.y;
-    if (!sdl3d_sprite_actor_can_stand_at(actor, level, g_sectors, next_x, next_z, ROBOT_GROUND_STEP_HEIGHT,
-                                         ROBOT_COLLISION_HEIGHT, &floor_y))
-    {
-        return false;
-    }
-
-    actor->position = sdl3d_vec3_make(next_x, floor_y, next_z);
-    sdl3d_sprite_actor_set_facing_direction(actor, move_x, move_z);
+    sdl3d_sprite_actor_set_facing_direction(sprite, desired_position.x - registered_actor->position.x,
+                                            desired_position.z - registered_actor->position.z);
     return true;
 }
 
-static void robot_advance_patrol_target(doom_robot_npc *npc)
-{
-    if (npc == NULL)
-        return;
-    npc->target_patrol_point = (npc->target_patrol_point + 1) % DOOM_ROBOT_PATROL_POINT_COUNT;
-}
-
-static void robot_update_npc(entities *e, doom_robot_npc *npc, const sdl3d_level *level, float dt)
-{
-    if (e == NULL || npc == NULL || npc->sprite_index < 0 || npc->sprite_index >= e->sprites.count)
-        return;
-
-    sdl3d_sprite_actor *actor = &e->sprites.actors[npc->sprite_index];
-    robot_set_floor_position(actor, level);
-
-    if (npc->state == DOOM_ROBOT_AI_WALK)
-    {
-        if (!robot_move_toward_target(actor, npc, level, dt))
-        {
-            robot_advance_patrol_target(npc);
-            robot_enter_idle(actor, npc);
-            return;
-        }
-    }
-
-    npc->state_timer -= dt;
-    if (npc->state_timer > 0.0f)
-        return;
-
-    if (npc->state == DOOM_ROBOT_AI_IDLE)
-    {
-        robot_enter_walk(e, actor, npc);
-    }
-    else
-    {
-        robot_enter_idle(actor, npc);
-    }
-}
-
-static void register_robot(entities *e, int robot_number, const sdl3d_sprite_actor *actor)
+static sdl3d_registered_actor *register_robot(entities *e, int robot_number, const sdl3d_sprite_actor *actor)
 {
     if (e == NULL || e->registry == NULL || actor == NULL)
-        return;
+        return NULL;
 
     char name[32];
     SDL_snprintf(name, sizeof(name), "robot_%d", robot_number);
     sdl3d_registered_actor *ra = sdl3d_actor_registry_add(e->registry, name);
     if (ra == NULL)
-        return;
+        return NULL;
 
     ra->position = actor->position;
     sdl3d_properties_set_string(ra->props, "classname", "npc_robot");
     sdl3d_properties_set_int(ra->props, "health", 100);
+    return ra;
+}
+
+static void robot_update_visual_state(entities *e, doom_robot_npc *npc, const sdl3d_registered_actor *registered_actor)
+{
+    if (e == NULL || npc == NULL || registered_actor == NULL || npc->sprite_index < 0 ||
+        npc->sprite_index >= e->sprites.count)
+    {
+        return;
+    }
+
+    sdl3d_sprite_actor *sprite = &e->sprites.actors[npc->sprite_index];
+    sprite->position = registered_actor->position;
+
+    if (npc->last_visual_state == npc->patrol.state)
+        return;
+
+    npc->last_visual_state = npc->patrol.state;
+    if (npc->patrol.state == SDL3D_ACTOR_PATROL_WALK)
+        sdl3d_sprite_actor_play_animation(sprite, e->enemy_walk_rotations, DOOM_ROBOT_WALK_FRAME_COUNT, 8.0f, true);
+    else
+        sdl3d_sprite_actor_stop_animation(sprite);
+}
+
+static void robot_update_npc(entities *e, doom_robot_npc *npc, const sdl3d_level *level, float dt)
+{
+    if (e == NULL || npc == NULL || npc->sprite_index < 0 || npc->sprite_index >= e->sprites.count ||
+        e->registry == NULL)
+    {
+        return;
+    }
+
+    sdl3d_registered_actor *registered_actor = sdl3d_actor_registry_get(e->registry, npc->actor_id);
+    if (registered_actor == NULL)
+        return;
+
+    sdl3d_sprite_actor *sprite = &e->sprites.actors[npc->sprite_index];
+    sprite->position = registered_actor->position;
+    robot_set_floor_position(sprite, level);
+    registered_actor->position = sprite->position;
+
+    robot_patrol_move_context move_context = {e, level};
+    sdl3d_actor_patrol_controller_update(&npc->patrol, e->registry, e->bus, dt, robot_patrol_move, &move_context);
+    robot_update_visual_state(e, npc, registered_actor);
 }
 
 bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *registry, sdl3d_signal_bus *bus)
@@ -233,23 +237,18 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
         const sdl3d_sprite_rotation_set *rot;
         float x, y, z, w, h, amp, spd;
         bool robot;
-        float walk_x, walk_z, patrol_distance, speed, idle_duration, walk_duration;
+        float walk_x, walk_z, patrol_distance, speed, idle_duration;
     } defs[] = {
-        {NULL, &e->enemy_rotations, 5.8f, 0.0f, 6.8f, 3.4f, 5.2f, 0.0f, 0.0f, true, 1.0f, 0.0f, 2.4f, 0.75f, 1.4f,
-         2.4f},
-        {&e->health_tex, NULL, 5.0f, 0.25f, 10.8f, 1.0f, 1.0f, 0.12f, 1.8f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 4.2f, 0.0f, 21.5f, 3.2f, 4.8f, 0.0f, 0.0f, true, 1.0f, 0.0f, 3.0f, 0.65f, 1.8f,
-         2.8f},
-        {&e->health_tex, NULL, 24.0f, 0.25f, 4.5f, 1.0f, 1.0f, 0.15f, 1.5f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 19.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.8f, 1.2f,
-         2.0f},
-        {&e->health_tex, NULL, 24.0f, 0.25f, 28.5f, 1.0f, 1.0f, 0.12f, 2.1f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 37.5f, 3.4f, 5.2f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.7f, 1.6f,
-         2.6f},
-        {&e->health_tex, NULL, 35.5f, 0.25f, 27.0f, 1.0f, 1.0f, 0.1f, 1.7f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 72.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 1.0f, 0.0f, 8.0f, 1.0f, 1.5f,
-         3.0f},
-        {&e->health_tex, NULL, 10.0f, 0.25f, 84.0f, 1.0f, 1.0f, 0.14f, 1.6f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {NULL, &e->enemy_rotations, 5.8f, 0.0f, 6.8f, 3.4f, 5.2f, 0.0f, 0.0f, true, 1.0f, 0.0f, 2.4f, 0.75f, 1.4f},
+        {&e->health_tex, NULL, 5.0f, 0.25f, 10.8f, 1.0f, 1.0f, 0.12f, 1.8f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {NULL, &e->enemy_rotations, 4.2f, 0.0f, 21.5f, 3.2f, 4.8f, 0.0f, 0.0f, true, 1.0f, 0.0f, 3.0f, 0.65f, 1.8f},
+        {&e->health_tex, NULL, 24.0f, 0.25f, 4.5f, 1.0f, 1.0f, 0.15f, 1.5f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 19.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.8f, 1.2f},
+        {&e->health_tex, NULL, 24.0f, 0.25f, 28.5f, 1.0f, 1.0f, 0.12f, 2.1f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 37.5f, 3.4f, 5.2f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.7f, 1.6f},
+        {&e->health_tex, NULL, 35.5f, 0.25f, 27.0f, 1.0f, 1.0f, 0.1f, 1.7f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 72.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 1.0f, 0.0f, 8.0f, 1.0f, 1.5f},
+        {&e->health_tex, NULL, 10.0f, 0.25f, 84.0f, 1.0f, 1.0f, 0.14f, 1.6f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     };
     for (int i = 0; i < (int)SDL_arraysize(defs); ++i)
     {
@@ -274,21 +273,32 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
             if (e->robot_count < DOOM_ROBOT_NPC_COUNT)
             {
                 doom_robot_npc *npc = &e->robots[e->robot_count];
+                const int robot_number = e->robot_count + 1;
+                sdl3d_registered_actor *registered_actor = register_robot(e, robot_number, a);
                 npc->sprite_index = i;
-                npc->state = DOOM_ROBOT_AI_IDLE;
-                npc->state_timer = defs[i].idle_duration;
-                npc->idle_duration = defs[i].idle_duration;
-                npc->walk_duration = defs[i].walk_duration;
-                npc->speed = defs[i].speed;
-                npc->walk_direction = normalized_walk_direction(defs[i].walk_x, defs[i].walk_z);
-                npc->patrol_points[0] = a->position;
-                npc->patrol_points[1] =
-                    sdl3d_vec3_make(a->position.x + npc->walk_direction.x * defs[i].patrol_distance, a->position.y,
-                                    a->position.z + npc->walk_direction.y * defs[i].patrol_distance);
-                npc->target_patrol_point = 1;
-                npc->arrival_radius = ROBOT_DEFAULT_ARRIVAL_RADIUS;
+                npc->actor_id = registered_actor != NULL ? registered_actor->id : 0;
+                npc->last_visual_state = SDL3D_ACTOR_PATROL_IDLE;
+
+                sdl3d_vec2 walk_direction = normalized_walk_direction(defs[i].walk_x, defs[i].walk_z);
+                sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+                config.speed = defs[i].speed;
+                config.wait_time = defs[i].idle_duration;
+                config.arrival_radius = ROBOT_DEFAULT_ARRIVAL_RADIUS;
+                config.mode = SDL3D_ACTOR_PATROL_LOOP;
+                config.start_idle = true;
+                config.signals.waypoint_reached = DOOM_SIGNAL_ROBOT_WAYPOINT_REACHED;
+                config.signals.loop_completed = DOOM_SIGNAL_ROBOT_LOOP_COMPLETED;
+                config.signals.idle_started = DOOM_SIGNAL_ROBOT_IDLE_STARTED;
+                config.signals.walk_started = DOOM_SIGNAL_ROBOT_WALK_STARTED;
+                sdl3d_actor_patrol_controller_init(&npc->patrol, robot_number, npc->actor_id, &config);
+                sdl3d_actor_patrol_controller_add_waypoint(&npc->patrol, a->position);
+                sdl3d_actor_patrol_controller_add_waypoint(
+                    &npc->patrol,
+                    sdl3d_vec3_make(a->position.x + walk_direction.x * defs[i].patrol_distance, a->position.y,
+                                    a->position.z + walk_direction.y * defs[i].patrol_distance));
+                if (registered_actor != NULL)
+                    sdl3d_actor_patrol_controller_sync_properties(&npc->patrol, registered_actor);
                 e->robot_count++;
-                register_robot(e, e->robot_count, a);
             }
         }
     }
@@ -375,21 +385,6 @@ void entities_update(entities *e, const sdl3d_level *level, float dt, sdl3d_vec3
             sdl3d_actor *a = sdl3d_scene_get_actor_at(e->scene, i);
             if (a)
                 sdl3d_actor_advance_animation(a, dt);
-        }
-    }
-    if (e->registry)
-    {
-        for (int i = 0; i < e->robot_count; ++i)
-        {
-            const doom_robot_npc *npc = &e->robots[i];
-            if (npc->sprite_index < 0 || npc->sprite_index >= e->sprites.count)
-                continue;
-
-            char name[32];
-            SDL_snprintf(name, sizeof(name), "robot_%d", i + 1);
-            sdl3d_registered_actor *ra = sdl3d_actor_registry_find(e->registry, name);
-            if (ra)
-                ra->position = e->sprites.actors[npc->sprite_index].position;
         }
     }
     sdl3d_actor_registry_update(e->registry, e->bus, player_position);

--- a/demos/doom_level/entities.h
+++ b/demos/doom_level/entities.h
@@ -2,6 +2,7 @@
 #ifndef DOOM_ENTITIES_H
 #define DOOM_ENTITIES_H
 
+#include "sdl3d/actor_controller.h"
 #include "sdl3d/actor_registry.h"
 #include "sdl3d/model.h"
 #include "sdl3d/scene.h"
@@ -15,26 +16,13 @@
 
 #define DOOM_ROBOT_WALK_FRAME_COUNT 6
 #define DOOM_ROBOT_NPC_COUNT 5
-#define DOOM_ROBOT_PATROL_POINT_COUNT 2
-
-typedef enum doom_robot_ai_state
-{
-    DOOM_ROBOT_AI_IDLE = 0,
-    DOOM_ROBOT_AI_WALK
-} doom_robot_ai_state;
 
 typedef struct doom_robot_npc
 {
     int sprite_index;
-    doom_robot_ai_state state;
-    float state_timer;
-    float idle_duration;
-    float walk_duration;
-    float speed;
-    sdl3d_vec2 walk_direction;
-    sdl3d_vec3 patrol_points[DOOM_ROBOT_PATROL_POINT_COUNT];
-    int target_patrol_point;
-    float arrival_radius;
+    int actor_id;
+    sdl3d_actor_patrol_state last_visual_state;
+    sdl3d_actor_patrol_controller patrol;
 } doom_robot_npc;
 
 typedef struct entities

--- a/include/sdl3d/actor_controller.h
+++ b/include/sdl3d/actor_controller.h
@@ -1,0 +1,195 @@
+/**
+ * @file actor_controller.h
+ * @brief Reusable actor controller primitives for gameplay logic.
+ *
+ * Actor controllers update registered actor state without owning rendering.
+ * This keeps gameplay state in sdl3d_actor_registry while allowing callers to
+ * adapt visuals, physics, and game-specific movement through narrow callbacks.
+ */
+
+#ifndef SDL3D_ACTOR_CONTROLLER_H
+#define SDL3D_ACTOR_CONTROLLER_H
+
+#include <stdbool.h>
+
+#include "sdl3d/actor_registry.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define SDL3D_ACTOR_PATROL_MAX_WAYPOINTS 16
+
+    typedef struct sdl3d_actor_patrol_controller sdl3d_actor_patrol_controller;
+
+    /** @brief Patrol path traversal mode. */
+    typedef enum sdl3d_actor_patrol_mode
+    {
+        SDL3D_ACTOR_PATROL_LOOP = 0,     /**< After the last waypoint, continue at waypoint 0. */
+        SDL3D_ACTOR_PATROL_PING_PONG = 1 /**< Reverse direction at each endpoint. */
+    } sdl3d_actor_patrol_mode;
+
+    /** @brief Runtime patrol state exposed through actor properties. */
+    typedef enum sdl3d_actor_patrol_state
+    {
+        SDL3D_ACTOR_PATROL_IDLE = 0, /**< Actor is waiting before the next movement segment. */
+        SDL3D_ACTOR_PATROL_WALK = 1  /**< Actor is moving toward target_waypoint. */
+    } sdl3d_actor_patrol_state;
+
+    /**
+     * @brief Signal ids emitted by a patrol controller.
+     *
+     * Signal ids <= 0 are treated as disabled. Payloads include
+     * controller_id, actor_id, actor_name, state, target_waypoint, and
+     * waypoint_index when a waypoint is involved.
+     */
+    typedef struct sdl3d_actor_patrol_signals
+    {
+        int waypoint_reached; /**< Emitted after reaching a waypoint. */
+        int loop_completed;   /**< Emitted after completing a full patrol cycle. */
+        int idle_started;     /**< Emitted after transitioning to idle. */
+        int walk_started;     /**< Emitted after transitioning to walk. */
+    } sdl3d_actor_patrol_signals;
+
+    /**
+     * @brief Authored patrol configuration.
+     */
+    typedef struct sdl3d_actor_patrol_config
+    {
+        float speed;                        /**< Movement speed in world units per second. */
+        float wait_time;                    /**< Idle wait before each movement segment, in seconds. */
+        float arrival_radius;               /**< Distance at which a waypoint is considered reached. */
+        sdl3d_actor_patrol_mode mode;       /**< Loop or ping-pong traversal. */
+        bool start_idle;                    /**< True to start in idle before first movement. */
+        sdl3d_actor_patrol_signals signals; /**< Optional signal ids for controller events. */
+    } sdl3d_actor_patrol_config;
+
+    /**
+     * @brief Stateful patrol controller for a registered actor.
+     *
+     * The controller owns no actor, registry, or signal bus. The actor_id is
+     * resolved through the registry on each update, so the controller remains
+     * stable across registry pointer changes as long as the actor id exists.
+     */
+    struct sdl3d_actor_patrol_controller
+    {
+        int controller_id; /**< Stable editor/game id included in signal payloads. */
+        int actor_id;      /**< Registered actor id controlled by this patrol. */
+        bool enabled;      /**< Disabled controllers keep state but do not move or emit. */
+
+        sdl3d_vec3 waypoints[SDL3D_ACTOR_PATROL_MAX_WAYPOINTS]; /**< Authored path waypoints. */
+        int waypoint_count;                                     /**< Number of configured waypoints. */
+        int target_waypoint;                                    /**< Current waypoint index being approached. */
+        int direction;                                          /**< Traversal direction, normally +1 or -1. */
+
+        float speed;          /**< Movement speed in world units per second. */
+        float wait_time;      /**< Idle wait before walking. */
+        float arrival_radius; /**< Distance at which a waypoint is reached. */
+        float wait_remaining; /**< Runtime idle countdown. */
+
+        sdl3d_actor_patrol_mode mode;       /**< Path traversal mode. */
+        sdl3d_actor_patrol_state state;     /**< Current patrol state. */
+        sdl3d_actor_patrol_signals signals; /**< Optional signal ids. */
+        bool has_left_start;                /**< Internal cycle-completion tracking. */
+    };
+
+    /**
+     * @brief Result returned from one patrol update.
+     */
+    typedef struct sdl3d_actor_patrol_result
+    {
+        bool updated;                   /**< True when a valid actor/controller was processed. */
+        bool moved;                     /**< True when actor position changed. */
+        bool state_changed;             /**< True when idle/walk state changed. */
+        bool waypoint_reached;          /**< True when a waypoint was reached this update. */
+        bool loop_completed;            /**< True when a full patrol cycle completed. */
+        int reached_waypoint;           /**< Reached waypoint index, or -1 when none. */
+        sdl3d_actor_patrol_state state; /**< Controller state after the update. */
+        sdl3d_vec3 previous_position;   /**< Actor position before movement. */
+        sdl3d_vec3 position;            /**< Actor position after movement. */
+        sdl3d_vec3 movement_delta;      /**< position - previous_position. */
+    } sdl3d_actor_patrol_result;
+
+    /**
+     * @brief Optional movement adapter for patrol controllers.
+     *
+     * The controller computes desired_position. The adapter may validate it
+     * against game geometry, adjust floor height, or reject movement. Returning
+     * false keeps the actor at its current position and does not mark the
+     * waypoint reached.
+     */
+    typedef bool (*sdl3d_actor_patrol_move_fn)(void *userdata, const sdl3d_actor_patrol_controller *controller,
+                                               sdl3d_registered_actor *actor, sdl3d_vec3 desired_position,
+                                               sdl3d_vec3 *out_position);
+
+    /**
+     * @brief Return a conservative default patrol configuration.
+     */
+    sdl3d_actor_patrol_config sdl3d_actor_patrol_default_config(void);
+
+    /**
+     * @brief Initialize a patrol controller.
+     *
+     * The controller starts with no waypoints. Add at least two waypoints
+     * before update for movement to occur. Passing NULL for config uses
+     * sdl3d_actor_patrol_default_config().
+     */
+    void sdl3d_actor_patrol_controller_init(sdl3d_actor_patrol_controller *controller, int controller_id, int actor_id,
+                                            const sdl3d_actor_patrol_config *config);
+
+    /**
+     * @brief Remove all waypoints and reset target state.
+     */
+    void sdl3d_actor_patrol_controller_clear_waypoints(sdl3d_actor_patrol_controller *controller);
+
+    /**
+     * @brief Add a waypoint to the patrol path.
+     * @return true on success, false if the controller is NULL or full.
+     */
+    bool sdl3d_actor_patrol_controller_add_waypoint(sdl3d_actor_patrol_controller *controller, sdl3d_vec3 waypoint);
+
+    /**
+     * @brief Restart runtime state without changing configuration or waypoints.
+     */
+    void sdl3d_actor_patrol_controller_reset(sdl3d_actor_patrol_controller *controller, bool start_idle);
+
+    /**
+     * @brief Enable or disable the patrol controller.
+     */
+    void sdl3d_actor_patrol_controller_set_enabled(sdl3d_actor_patrol_controller *controller, bool enabled);
+
+    /**
+     * @brief Return a stable lowercase name for a patrol state.
+     */
+    const char *sdl3d_actor_patrol_state_name(sdl3d_actor_patrol_state state);
+
+    /**
+     * @brief Update actor properties that expose patrol state.
+     *
+     * Exposed keys are: state, target_waypoint, enabled, alerted, patrol_mode,
+     * patrol_speed, and patrol_wait_remaining. alerted is initialized to false
+     * only if the actor does not already define it.
+     */
+    void sdl3d_actor_patrol_controller_sync_properties(const sdl3d_actor_patrol_controller *controller,
+                                                       sdl3d_registered_actor *actor);
+
+    /**
+     * @brief Advance a patrol controller and update its registered actor.
+     *
+     * The registry and actor are not owned. The signal bus is optional; when
+     * NULL, state and movement still update but no controller signals emit.
+     */
+    sdl3d_actor_patrol_result sdl3d_actor_patrol_controller_update(sdl3d_actor_patrol_controller *controller,
+                                                                   sdl3d_actor_registry *registry,
+                                                                   sdl3d_signal_bus *bus, float dt,
+                                                                   sdl3d_actor_patrol_move_fn move_fn,
+                                                                   void *move_userdata);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_ACTOR_CONTROLLER_H */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -6,6 +6,7 @@
 
 #include <SDL3/SDL_log.h>
 
+#include "sdl3d/actor_controller.h"
 #include "sdl3d/animation.h"
 #include "sdl3d/audio.h"
 #include "sdl3d/camera.h"

--- a/src/actor_controller.c
+++ b/src/actor_controller.c
@@ -1,0 +1,302 @@
+#include "sdl3d/actor_controller.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
+
+#define SDL3D_PATROL_DEFAULT_SPEED 1.0f
+#define SDL3D_PATROL_DEFAULT_WAIT_TIME 0.0f
+#define SDL3D_PATROL_DEFAULT_ARRIVAL_RADIUS 0.1f
+
+static sdl3d_actor_patrol_result patrol_result(const sdl3d_actor_patrol_controller *controller,
+                                               const sdl3d_registered_actor *actor)
+{
+    sdl3d_actor_patrol_result result;
+    SDL_zero(result);
+    result.reached_waypoint = -1;
+    result.state = controller != NULL ? controller->state : SDL3D_ACTOR_PATROL_IDLE;
+    if (actor != NULL)
+    {
+        result.previous_position = actor->position;
+        result.position = actor->position;
+    }
+    return result;
+}
+
+static float clamp_positive(float value, float fallback)
+{
+    return value > 0.0f ? value : fallback;
+}
+
+static float distance_xz_sq(sdl3d_vec3 a, sdl3d_vec3 b)
+{
+    const float dx = b.x - a.x;
+    const float dz = b.z - a.z;
+    return dx * dx + dz * dz;
+}
+
+static void emit_patrol_signal(sdl3d_signal_bus *bus, int signal_id, const sdl3d_actor_patrol_controller *controller,
+                               const sdl3d_registered_actor *actor, int waypoint_index)
+{
+    if (bus == NULL || signal_id <= 0 || controller == NULL || actor == NULL)
+        return;
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return;
+
+    sdl3d_properties_set_int(payload, "controller_id", controller->controller_id);
+    sdl3d_properties_set_int(payload, "actor_id", actor->id);
+    sdl3d_properties_set_string(payload, "actor_name", actor->name != NULL ? actor->name : "");
+    sdl3d_properties_set_string(payload, "state", sdl3d_actor_patrol_state_name(controller->state));
+    sdl3d_properties_set_int(payload, "target_waypoint", controller->target_waypoint);
+    if (waypoint_index >= 0)
+        sdl3d_properties_set_int(payload, "waypoint_index", waypoint_index);
+
+    sdl3d_signal_emit(bus, signal_id, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void enter_state(sdl3d_actor_patrol_controller *controller, sdl3d_registered_actor *actor, sdl3d_signal_bus *bus,
+                        sdl3d_actor_patrol_state state, sdl3d_actor_patrol_result *result)
+{
+    if (controller == NULL || actor == NULL || controller->state == state)
+        return;
+
+    controller->state = state;
+    if (state == SDL3D_ACTOR_PATROL_IDLE)
+        controller->wait_remaining = controller->wait_time;
+    result->state_changed = true;
+    result->state = state;
+    sdl3d_actor_patrol_controller_sync_properties(controller, actor);
+
+    const int signal_id =
+        state == SDL3D_ACTOR_PATROL_IDLE ? controller->signals.idle_started : controller->signals.walk_started;
+    emit_patrol_signal(bus, signal_id, controller, actor, -1);
+}
+
+static bool compute_next_target(sdl3d_actor_patrol_controller *controller, int reached_waypoint)
+{
+    if (controller == NULL || controller->waypoint_count <= 1)
+        return false;
+
+    if (reached_waypoint != 0)
+        controller->has_left_start = true;
+
+    bool completed_cycle = reached_waypoint == 0 && controller->has_left_start;
+    if (completed_cycle)
+        controller->has_left_start = false;
+
+    if (controller->mode == SDL3D_ACTOR_PATROL_PING_PONG)
+    {
+        if (reached_waypoint >= controller->waypoint_count - 1)
+            controller->direction = -1;
+        else if (reached_waypoint <= 0)
+            controller->direction = 1;
+
+        controller->target_waypoint = reached_waypoint + controller->direction;
+    }
+    else
+    {
+        controller->direction = 1;
+        controller->target_waypoint = (reached_waypoint + 1) % controller->waypoint_count;
+    }
+
+    if (controller->target_waypoint < 0)
+        controller->target_waypoint = 0;
+    if (controller->target_waypoint >= controller->waypoint_count)
+        controller->target_waypoint = controller->waypoint_count - 1;
+
+    return completed_cycle;
+}
+
+sdl3d_actor_patrol_config sdl3d_actor_patrol_default_config(void)
+{
+    sdl3d_actor_patrol_config config;
+    SDL_zero(config);
+    config.speed = SDL3D_PATROL_DEFAULT_SPEED;
+    config.wait_time = SDL3D_PATROL_DEFAULT_WAIT_TIME;
+    config.arrival_radius = SDL3D_PATROL_DEFAULT_ARRIVAL_RADIUS;
+    config.mode = SDL3D_ACTOR_PATROL_LOOP;
+    config.start_idle = true;
+    return config;
+}
+
+void sdl3d_actor_patrol_controller_init(sdl3d_actor_patrol_controller *controller, int controller_id, int actor_id,
+                                        const sdl3d_actor_patrol_config *config)
+{
+    if (controller == NULL)
+        return;
+
+    sdl3d_actor_patrol_config defaults = sdl3d_actor_patrol_default_config();
+    if (config == NULL)
+        config = &defaults;
+
+    SDL_zerop(controller);
+    controller->controller_id = controller_id;
+    controller->actor_id = actor_id;
+    controller->enabled = true;
+    controller->speed = clamp_positive(config->speed, SDL3D_PATROL_DEFAULT_SPEED);
+    controller->wait_time = config->wait_time > 0.0f ? config->wait_time : 0.0f;
+    controller->arrival_radius = clamp_positive(config->arrival_radius, SDL3D_PATROL_DEFAULT_ARRIVAL_RADIUS);
+    controller->mode = config->mode;
+    controller->signals = config->signals;
+    sdl3d_actor_patrol_controller_reset(controller, config->start_idle);
+}
+
+void sdl3d_actor_patrol_controller_clear_waypoints(sdl3d_actor_patrol_controller *controller)
+{
+    if (controller == NULL)
+        return;
+
+    controller->waypoint_count = 0;
+    controller->target_waypoint = 0;
+    controller->direction = 1;
+    controller->has_left_start = false;
+}
+
+bool sdl3d_actor_patrol_controller_add_waypoint(sdl3d_actor_patrol_controller *controller, sdl3d_vec3 waypoint)
+{
+    if (controller == NULL || controller->waypoint_count >= SDL3D_ACTOR_PATROL_MAX_WAYPOINTS)
+        return false;
+
+    controller->waypoints[controller->waypoint_count++] = waypoint;
+    if (controller->waypoint_count == 2 && controller->target_waypoint == 0)
+        controller->target_waypoint = 1;
+    return true;
+}
+
+void sdl3d_actor_patrol_controller_reset(sdl3d_actor_patrol_controller *controller, bool start_idle)
+{
+    if (controller == NULL)
+        return;
+
+    controller->direction = 1;
+    controller->target_waypoint = controller->waypoint_count > 1 ? 1 : 0;
+    controller->state = start_idle ? SDL3D_ACTOR_PATROL_IDLE : SDL3D_ACTOR_PATROL_WALK;
+    controller->wait_remaining = start_idle ? controller->wait_time : 0.0f;
+    controller->has_left_start = false;
+}
+
+void sdl3d_actor_patrol_controller_set_enabled(sdl3d_actor_patrol_controller *controller, bool enabled)
+{
+    if (controller != NULL)
+        controller->enabled = enabled;
+}
+
+const char *sdl3d_actor_patrol_state_name(sdl3d_actor_patrol_state state)
+{
+    switch (state)
+    {
+    case SDL3D_ACTOR_PATROL_IDLE:
+        return "idle";
+    case SDL3D_ACTOR_PATROL_WALK:
+        return "walk";
+    }
+    return "unknown";
+}
+
+void sdl3d_actor_patrol_controller_sync_properties(const sdl3d_actor_patrol_controller *controller,
+                                                   sdl3d_registered_actor *actor)
+{
+    if (controller == NULL || actor == NULL || actor->props == NULL)
+        return;
+
+    sdl3d_properties_set_string(actor->props, "state", sdl3d_actor_patrol_state_name(controller->state));
+    sdl3d_properties_set_int(actor->props, "target_waypoint", controller->target_waypoint);
+    sdl3d_properties_set_bool(actor->props, "enabled", controller->enabled);
+    if (!sdl3d_properties_has(actor->props, "alerted"))
+        sdl3d_properties_set_bool(actor->props, "alerted", false);
+    sdl3d_properties_set_string(actor->props, "patrol_mode",
+                                controller->mode == SDL3D_ACTOR_PATROL_PING_PONG ? "ping_pong" : "loop");
+    sdl3d_properties_set_float(actor->props, "patrol_speed", controller->speed);
+    sdl3d_properties_set_float(actor->props, "patrol_wait_remaining", controller->wait_remaining);
+}
+
+sdl3d_actor_patrol_result sdl3d_actor_patrol_controller_update(sdl3d_actor_patrol_controller *controller,
+                                                               sdl3d_actor_registry *registry, sdl3d_signal_bus *bus,
+                                                               float dt, sdl3d_actor_patrol_move_fn move_fn,
+                                                               void *move_userdata)
+{
+    sdl3d_registered_actor *actor =
+        controller != NULL ? sdl3d_actor_registry_get(registry, controller->actor_id) : NULL;
+    sdl3d_actor_patrol_result result = patrol_result(controller, actor);
+    if (controller == NULL || actor == NULL || dt < 0.0f)
+        return result;
+
+    result.updated = true;
+    sdl3d_actor_patrol_controller_sync_properties(controller, actor);
+    if (!controller->enabled || !actor->active || controller->waypoint_count < 2 || controller->speed <= 0.0f)
+        return result;
+
+    if (controller->target_waypoint < 0 || controller->target_waypoint >= controller->waypoint_count)
+        controller->target_waypoint = controller->waypoint_count > 1 ? 1 : 0;
+
+    if (controller->state == SDL3D_ACTOR_PATROL_IDLE)
+    {
+        controller->wait_remaining -= dt;
+        if (controller->wait_remaining <= 0.0f)
+        {
+            controller->wait_remaining = 0.0f;
+            enter_state(controller, actor, bus, SDL3D_ACTOR_PATROL_WALK, &result);
+        }
+        sdl3d_actor_patrol_controller_sync_properties(controller, actor);
+        return result;
+    }
+
+    const int target_index = controller->target_waypoint;
+    const sdl3d_vec3 target = controller->waypoints[target_index];
+    const float arrival_radius_sq = controller->arrival_radius * controller->arrival_radius;
+    float distance_sq = distance_xz_sq(actor->position, target);
+
+    if (distance_sq > arrival_radius_sq)
+    {
+        const float distance = SDL_sqrtf(distance_sq);
+        float step = controller->speed * dt;
+        if (step > distance)
+            step = distance;
+
+        const float move_x = (target.x - actor->position.x) / distance;
+        const float move_z = (target.z - actor->position.z) / distance;
+        sdl3d_vec3 desired = actor->position;
+        desired.x += move_x * step;
+        desired.z += move_z * step;
+        desired.y = target.y;
+
+        sdl3d_vec3 accepted = desired;
+        bool accepted_move = true;
+        if (move_fn != NULL)
+            accepted_move = move_fn(move_userdata, controller, actor, desired, &accepted);
+
+        if (!accepted_move)
+        {
+            sdl3d_actor_patrol_controller_sync_properties(controller, actor);
+            return result;
+        }
+
+        actor->position = accepted;
+        result.moved = distance_xz_sq(result.previous_position, actor->position) > 0.000001f;
+        result.position = actor->position;
+        result.movement_delta = sdl3d_vec3_make(actor->position.x - result.previous_position.x,
+                                                actor->position.y - result.previous_position.y,
+                                                actor->position.z - result.previous_position.z);
+        distance_sq = distance_xz_sq(actor->position, target);
+    }
+
+    if (distance_sq <= arrival_radius_sq)
+    {
+        result.waypoint_reached = true;
+        result.reached_waypoint = target_index;
+        emit_patrol_signal(bus, controller->signals.waypoint_reached, controller, actor, target_index);
+        result.loop_completed = compute_next_target(controller, target_index);
+        if (result.loop_completed)
+            emit_patrol_signal(bus, controller->signals.loop_completed, controller, actor, target_index);
+        enter_state(controller, actor, bus, SDL3D_ACTOR_PATROL_IDLE, &result);
+    }
+
+    sdl3d_actor_patrol_controller_sync_properties(controller, actor);
+    result.state = controller->state;
+    result.position = actor->position;
+    return result;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ endfunction()
 
 set(SDL3D_TEST_SOURCES
     test_api.cpp
+    test_actor_controller.cpp
     test_math.cpp
     test_rasterizer.cpp
     test_render_context_unit.cpp
@@ -191,6 +192,7 @@ else()
     sdl3d_add_test(sdl3d_scene_test test_scene.cpp unit)
     sdl3d_add_test(sdl3d_collision_test test_collision.cpp unit)
     sdl3d_add_test(sdl3d_action_test test_action.cpp unit)
+    sdl3d_add_test(sdl3d_actor_controller_test test_actor_controller.cpp unit)
     sdl3d_add_test(sdl3d_actor_registry_test test_actor_registry.cpp unit)
     sdl3d_add_test(sdl3d_animation_test test_animation.cpp unit)
     sdl3d_add_test(sdl3d_audio_test test_audio.cpp unit)

--- a/tests/test_actor_controller.cpp
+++ b/tests/test_actor_controller.cpp
@@ -1,0 +1,310 @@
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/actor_controller.h"
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
+
+struct patrol_signal_capture
+{
+    int count = 0;
+    int last_signal = 0;
+    int controller_id = 0;
+    int actor_id = 0;
+    int waypoint_index = -1;
+    int target_waypoint = -1;
+    char actor_name[64] = {};
+    char state[32] = {};
+};
+
+static void capture_patrol_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    patrol_signal_capture *capture = (patrol_signal_capture *)userdata;
+    capture->count++;
+    capture->last_signal = signal_id;
+    capture->controller_id = sdl3d_properties_get_int(payload, "controller_id", 0);
+    capture->actor_id = sdl3d_properties_get_int(payload, "actor_id", 0);
+    capture->waypoint_index = sdl3d_properties_get_int(payload, "waypoint_index", -1);
+    capture->target_waypoint = sdl3d_properties_get_int(payload, "target_waypoint", -1);
+    SDL_snprintf(capture->actor_name, sizeof(capture->actor_name), "%s",
+                 sdl3d_properties_get_string(payload, "actor_name", ""));
+    SDL_snprintf(capture->state, sizeof(capture->state), "%s", sdl3d_properties_get_string(payload, "state", ""));
+}
+
+static sdl3d_registered_actor *add_actor(sdl3d_actor_registry *registry)
+{
+    sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, "robot");
+    if (actor != nullptr)
+        actor->position = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    return actor;
+}
+
+TEST(ActorPatrolController, DefaultConfigIsConservative)
+{
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+
+    EXPECT_GT(config.speed, 0.0f);
+    EXPECT_GE(config.wait_time, 0.0f);
+    EXPECT_GT(config.arrival_radius, 0.0f);
+    EXPECT_EQ(config.mode, SDL3D_ACTOR_PATROL_LOOP);
+    EXPECT_TRUE(config.start_idle);
+}
+
+TEST(ActorPatrolController, MovesRegisteredActorTowardWaypoint)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    ASSERT_NE(registry, nullptr);
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.speed = 2.0f;
+    config.wait_time = 0.0f;
+    config.start_idle = false;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 7, actor->id, &config);
+    ASSERT_TRUE(sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    ASSERT_TRUE(sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(4.0f, 0.0f, 0.0f)));
+
+    sdl3d_actor_patrol_result result =
+        sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 0.5f, nullptr, nullptr);
+
+    EXPECT_TRUE(result.updated);
+    EXPECT_TRUE(result.moved);
+    EXPECT_FLOAT_EQ(actor->position.x, 1.0f);
+    EXPECT_FLOAT_EQ(actor->position.z, 0.0f);
+    EXPECT_STREQ(sdl3d_properties_get_string(actor->props, "state", ""), "walk");
+    EXPECT_EQ(sdl3d_properties_get_int(actor->props, "target_waypoint", -1), 1);
+    EXPECT_TRUE(sdl3d_properties_get_bool(actor->props, "enabled", false));
+    EXPECT_FALSE(sdl3d_properties_get_bool(actor->props, "alerted", true));
+
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, IdleTransitionsToWalkAndEmitsSignal)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(registry, nullptr);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    patrol_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 103, capture_patrol_signal, &capture), 0);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.wait_time = 0.25f;
+    config.signals.walk_started = 103;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 8, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+
+    EXPECT_EQ(controller.state, SDL3D_ACTOR_PATROL_IDLE);
+    EXPECT_FALSE(
+        sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.1f, nullptr, nullptr).state_changed);
+    sdl3d_actor_patrol_result result =
+        sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.15f, nullptr, nullptr);
+
+    EXPECT_TRUE(result.state_changed);
+    EXPECT_EQ(controller.state, SDL3D_ACTOR_PATROL_WALK);
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.last_signal, 103);
+    EXPECT_EQ(capture.controller_id, 8);
+    EXPECT_EQ(capture.actor_id, actor->id);
+    EXPECT_STREQ(capture.actor_name, "robot");
+    EXPECT_STREQ(capture.state, "walk");
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, ReachingWaypointEmitsAndIdles)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    ASSERT_NE(registry, nullptr);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    patrol_signal_capture reached{};
+    patrol_signal_capture idle{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 111, capture_patrol_signal, &reached), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 112, capture_patrol_signal, &idle), 0);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.speed = 10.0f;
+    config.wait_time = 0.5f;
+    config.start_idle = false;
+    config.signals.waypoint_reached = 111;
+    config.signals.idle_started = 112;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 9, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+
+    sdl3d_actor_patrol_result result =
+        sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.2f, nullptr, nullptr);
+
+    EXPECT_TRUE(result.waypoint_reached);
+    EXPECT_EQ(result.reached_waypoint, 1);
+    EXPECT_EQ(controller.state, SDL3D_ACTOR_PATROL_IDLE);
+    EXPECT_EQ(controller.target_waypoint, 0);
+    EXPECT_EQ(reached.count, 1);
+    EXPECT_EQ(reached.waypoint_index, 1);
+    EXPECT_EQ(idle.count, 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(actor->props, "state", ""), "idle");
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(actor->props, "patrol_wait_remaining", 0.0f), 0.5f);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, LoopCompletionEmitsAfterReturningToStart)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    patrol_signal_capture loop{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 121, capture_patrol_signal, &loop), 0);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.speed = 10.0f;
+    config.wait_time = 0.0f;
+    config.start_idle = false;
+    config.signals.loop_completed = 121;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 10, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+
+    EXPECT_TRUE(
+        sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.2f, nullptr, nullptr).waypoint_reached);
+    EXPECT_EQ(loop.count, 0);
+    EXPECT_TRUE(sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.0f, nullptr, nullptr).state_changed);
+    sdl3d_actor_patrol_result returned =
+        sdl3d_actor_patrol_controller_update(&controller, registry, bus, 0.2f, nullptr, nullptr);
+
+    EXPECT_TRUE(returned.loop_completed);
+    EXPECT_EQ(loop.count, 1);
+    EXPECT_EQ(loop.waypoint_index, 0);
+
+    sdl3d_signal_bus_destroy(bus);
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, PingPongReversesAtEndpoints)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.mode = SDL3D_ACTOR_PATROL_PING_PONG;
+    config.speed = 10.0f;
+    config.start_idle = false;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 11, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(2.0f, 0.0f, 0.0f));
+
+    sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 0.2f, nullptr, nullptr);
+    EXPECT_EQ(controller.target_waypoint, 2);
+    sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 0.0f, nullptr, nullptr);
+    sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 0.2f, nullptr, nullptr);
+    EXPECT_EQ(controller.direction, -1);
+    EXPECT_EQ(controller.target_waypoint, 1);
+
+    sdl3d_actor_registry_destroy(registry);
+}
+
+struct move_adapter_context
+{
+    bool allow = true;
+    float floor_y = 3.0f;
+};
+
+static bool test_move_adapter(void *userdata, const sdl3d_actor_patrol_controller *controller,
+                              sdl3d_registered_actor *actor, sdl3d_vec3 desired_position, sdl3d_vec3 *out_position)
+{
+    (void)controller;
+    (void)actor;
+    move_adapter_context *context = (move_adapter_context *)userdata;
+    if (!context->allow)
+        return false;
+    *out_position = desired_position;
+    out_position->y = context->floor_y;
+    return true;
+}
+
+TEST(ActorPatrolController, MovementAdapterCanAdjustOrRejectMovement)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.start_idle = false;
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 12, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(4.0f, 0.0f, 0.0f));
+
+    move_adapter_context context{};
+    sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 1.0f, test_move_adapter, &context);
+    EXPECT_FLOAT_EQ(actor->position.x, 1.0f);
+    EXPECT_FLOAT_EQ(actor->position.y, 3.0f);
+
+    context.allow = false;
+    sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 1.0f, test_move_adapter, &context);
+    EXPECT_FLOAT_EQ(actor->position.x, 1.0f);
+
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, DisabledAndInvalidControllersAreSafe)
+{
+    EXPECT_STREQ(sdl3d_actor_patrol_state_name(SDL3D_ACTOR_PATROL_IDLE), "idle");
+    EXPECT_STREQ(sdl3d_actor_patrol_state_name(SDL3D_ACTOR_PATROL_WALK), "walk");
+
+    sdl3d_actor_patrol_controller_init(nullptr, 1, 1, nullptr);
+    sdl3d_actor_patrol_controller_clear_waypoints(nullptr);
+    EXPECT_FALSE(sdl3d_actor_patrol_controller_add_waypoint(nullptr, sdl3d_vec3_make(0, 0, 0)));
+    sdl3d_actor_patrol_controller_reset(nullptr, true);
+    sdl3d_actor_patrol_controller_set_enabled(nullptr, false);
+    sdl3d_actor_patrol_controller_sync_properties(nullptr, nullptr);
+
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 13, actor->id, nullptr);
+    sdl3d_actor_patrol_controller_set_enabled(&controller, false);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(2.0f, 0.0f, 0.0f));
+
+    sdl3d_actor_patrol_result disabled =
+        sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 1.0f, nullptr, nullptr);
+    EXPECT_TRUE(disabled.updated);
+    EXPECT_FALSE(disabled.moved);
+    EXPECT_FLOAT_EQ(actor->position.x, 0.0f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(actor->props, "enabled", true));
+
+    sdl3d_actor_patrol_result missing =
+        sdl3d_actor_patrol_controller_update(&controller, nullptr, nullptr, 1.0f, nullptr, nullptr);
+    EXPECT_FALSE(missing.updated);
+
+    sdl3d_actor_registry_destroy(registry);
+}


### PR DESCRIPTION
## Summary
- add a public patrol controller API for registered actors, with waypoint paths, speed, wait time, loop/ping-pong traversal, movement adapters, state properties, and patrol event signals
- migrate Doom-level skeletal robots from demo-local AI state to the reusable patrol controller while keeping sprite animation/facing/floor snapping in the demo visual layer
- add actor-controller unit tests covering movement, idle/walk transitions, signal payloads, loop completion, ping-pong traversal, movement adapter behavior, disabled state, and null safety

## Tests
- ./build/release/tests/sdl3d_actor_controller_test
- ./scripts/check_clang_format.sh
- git diff --check
- cmake --build build/release
- ctest --test-dir build/release --output-on-failure

Issue: #109
