### PR TITLE
Add game adapter logic actions

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -22,6 +22,8 @@
 #include "surveillance.h"
 
 #define SIG_FADE_OUT_DONE 2001
+#define SIG_SURVEILLANCE_ENTER 2002
+#define SIG_SURVEILLANCE_EXIT 2003
 #define LIFT_FLOOR_MIN_Y 0.0f
 #define LIFT_FLOOR_MAX_Y 2.5f
 #define LIFT_CEIL_Y 12.0f
@@ -51,6 +53,7 @@ typedef struct doom_state
     sdl3d_ui_context *ui;
     sdl3d_demo_player *demo_player;
     sdl3d_audio_engine *audio;
+    sdl3d_logic_world *logic;
     sdl3d_sector_watcher sector_watcher;
     sdl3d_teleporter dragon_teleporter;
     doom_surveillance_camera surveillance;
@@ -79,6 +82,8 @@ typedef struct doom_state
 
 static void doom_state_cleanup(doom_state *state)
 {
+    sdl3d_logic_world_destroy(state->logic);
+    state->logic = NULL;
     render_state_free(&state->render);
     doom_hazard_particles_free(&state->hazards);
     if (state->entities_ready)
@@ -159,24 +164,54 @@ static void on_entered_sector(void *userdata, int signal_id, const sdl3d_propert
     }
 }
 
-static void on_teleport(void *userdata, int signal_id, const sdl3d_properties *payload)
+static bool doom_logic_teleport_player(void *userdata, const sdl3d_teleport_destination *destination,
+                                       const sdl3d_properties *payload)
 {
-    (void)signal_id;
     doom_state *state = (doom_state *)userdata;
-    sdl3d_teleport_destination destination;
 
-    if (state == NULL || !sdl3d_teleport_destination_from_payload(payload, &destination))
+    if (state == NULL || destination == NULL)
     {
-        return;
+        return false;
     }
 
-    sdl3d_fps_mover_teleport(&state->player.mover, destination.position, destination.use_yaw, destination.yaw,
-                             destination.use_pitch, destination.pitch);
+    sdl3d_fps_mover_teleport(&state->player.mover, destination->position, destination->use_yaw, destination->yaw,
+                             destination->use_pitch, destination->pitch);
     state->player.proj_active = false;
     state->teleport_feedback_timer = TELEPORT_FEEDBACK_SECONDS;
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Teleporter %d moved player to %.1f %.1f %.1f",
-                sdl3d_properties_get_int(payload, "teleporter_id", -1), destination.position.x, destination.position.y,
-                destination.position.z);
+                sdl3d_properties_get_int(payload, "teleporter_id", -1), destination->position.x,
+                destination->position.y, destination->position.z);
+    return true;
+}
+
+static bool doom_logic_set_active_camera(void *userdata, const char *camera_name, const sdl3d_camera3d *camera,
+                                         const sdl3d_properties *payload)
+{
+    (void)payload;
+    doom_state *state = (doom_state *)userdata;
+    if (state == NULL || camera == NULL)
+    {
+        return false;
+    }
+
+    state->surveillance.camera = *camera;
+    state->surveillance.active = true;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Activated surveillance camera '%s'",
+                camera_name != NULL ? camera_name : "unnamed");
+    return true;
+}
+
+static bool doom_logic_restore_camera(void *userdata, const sdl3d_properties *payload)
+{
+    (void)payload;
+    doom_state *state = (doom_state *)userdata;
+    if (state == NULL)
+    {
+        return false;
+    }
+
+    state->surveillance.active = false;
+    return true;
 }
 
 static void init_dragon_teleporter(doom_state *state)
@@ -210,7 +245,45 @@ static void init_surveillance_camera(doom_state *state)
     camera.fovy = 70.0f;
     camera.projection = SDL3D_CAMERA_PERSPECTIVE;
 
-    doom_surveillance_init(&state->surveillance, button_bounds, camera);
+    doom_surveillance_init(&state->surveillance, button_bounds, camera, SIG_SURVEILLANCE_ENTER, SIG_SURVEILLANCE_EXIT);
+}
+
+static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
+{
+    state->logic = sdl3d_logic_world_create(ctx->bus, ctx->timers);
+    if (state->logic == NULL)
+    {
+        return false;
+    }
+
+    sdl3d_logic_game_adapters adapters;
+    SDL_zero(adapters);
+    adapters.userdata = state;
+    adapters.teleport_player = doom_logic_teleport_player;
+    adapters.set_active_camera = doom_logic_set_active_camera;
+    adapters.restore_camera = doom_logic_restore_camera;
+    sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
+
+    sdl3d_logic_action teleport_action = sdl3d_logic_action_make_teleport_player_from_payload();
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SDL3D_SIGNAL_TELEPORT, &teleport_action) == 0)
+    {
+        return false;
+    }
+
+    sdl3d_logic_action camera_action =
+        sdl3d_logic_action_make_set_active_camera("nukage_surveillance", &state->surveillance.camera);
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_SURVEILLANCE_ENTER, &camera_action) == 0)
+    {
+        return false;
+    }
+
+    sdl3d_logic_action restore_camera_action = sdl3d_logic_action_make_restore_camera();
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_SURVEILLANCE_EXIT, &restore_camera_action) == 0)
+    {
+        return false;
+    }
+
+    return true;
 }
 
 static void start_quit_fade(sdl3d_game_context *ctx, doom_state *state)
@@ -283,11 +356,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     {
         return false;
     }
-    if (sdl3d_signal_connect(ctx->bus, SDL3D_SIGNAL_TELEPORT, on_teleport, state) == 0)
-    {
-        return false;
-    }
-
     state->has_font = sdl3d_load_font(SDL3D_MEDIA_DIR "/fonts/Roboto.ttf", 40.0f, &state->debug_font);
     if (!sdl3d_ui_create(state->has_font ? &state->debug_font : NULL, &state->ui))
     {
@@ -321,6 +389,11 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     player_init(&state->player, ctx->input);
     init_dragon_teleporter(state);
     init_surveillance_camera(state);
+    if (!bind_doom_logic(ctx, state))
+    {
+        doom_state_cleanup(state);
+        return false;
+    }
     render_state_init(&state->render);
     sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, (sdl3d_color){0, 0, 0, 255},
                            1.0f, -1);
@@ -564,9 +637,10 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
                                             state->player.mover.position.z),
                             dt, ctx->bus);
 
-    doom_surveillance_update(&state->surveillance, sdl3d_vec3_make(state->player.mover.position.x,
-                                                                   state->player.mover.position.y - PLAYER_HEIGHT,
-                                                                   state->player.mover.position.z));
+    doom_surveillance_update(&state->surveillance, state->logic,
+                             sdl3d_vec3_make(state->player.mover.position.x,
+                                             state->player.mover.position.y - PLAYER_HEIGHT,
+                                             state->player.mover.position.z));
 
     sdl3d_sector_watcher_update(&state->sector_watcher, &state->level.unlit, g_sectors,
                                 sdl3d_vec3_make(state->player.mover.position.x,

--- a/demos/doom_level/surveillance.c
+++ b/demos/doom_level/surveillance.c
@@ -4,7 +4,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 void doom_surveillance_init(doom_surveillance_camera *surveillance, sdl3d_bounding_box button_bounds,
-                            sdl3d_camera3d camera)
+                            sdl3d_camera3d camera, int enter_signal_id, int exit_signal_id)
 {
     if (surveillance == NULL)
     {
@@ -13,21 +13,26 @@ void doom_surveillance_init(doom_surveillance_camera *surveillance, sdl3d_boundi
 
     SDL_zerop(surveillance);
     surveillance->button_bounds = button_bounds;
-    sdl3d_logic_contact_sensor_init(&surveillance->button_sensor, 0, button_bounds, 0, SDL3D_TRIGGER_LEVEL);
+    sdl3d_logic_contact_sensor_init(&surveillance->enter_sensor, 0, button_bounds, enter_signal_id,
+                                    SDL3D_TRIGGER_EDGE_ENTER);
+    sdl3d_logic_contact_sensor_init(&surveillance->exit_sensor, 0, button_bounds, exit_signal_id,
+                                    SDL3D_TRIGGER_EDGE_EXIT);
     surveillance->camera = camera;
     surveillance->enabled = true;
 }
 
-bool doom_surveillance_update(doom_surveillance_camera *surveillance, sdl3d_vec3 sample_position)
+bool doom_surveillance_update(doom_surveillance_camera *surveillance, sdl3d_logic_world *world,
+                              sdl3d_vec3 sample_position)
 {
     if (surveillance == NULL)
     {
         return false;
     }
 
-    surveillance->button_sensor.enabled = surveillance->enabled;
-    surveillance->active =
-        sdl3d_logic_contact_sensor_update(&surveillance->button_sensor, NULL, sample_position).active;
+    surveillance->enter_sensor.enabled = surveillance->enabled;
+    surveillance->exit_sensor.enabled = surveillance->enabled;
+    sdl3d_logic_contact_sensor_update(&surveillance->enter_sensor, world, sample_position);
+    sdl3d_logic_contact_sensor_update(&surveillance->exit_sensor, world, sample_position);
     return surveillance->active;
 }
 

--- a/demos/doom_level/surveillance.h
+++ b/demos/doom_level/surveillance.h
@@ -11,15 +11,17 @@
 typedef struct doom_surveillance_camera
 {
     sdl3d_bounding_box button_bounds;
-    sdl3d_logic_contact_sensor button_sensor;
+    sdl3d_logic_contact_sensor enter_sensor;
+    sdl3d_logic_contact_sensor exit_sensor;
     sdl3d_camera3d camera;
     bool enabled;
     bool active;
 } doom_surveillance_camera;
 
 void doom_surveillance_init(doom_surveillance_camera *surveillance, sdl3d_bounding_box button_bounds,
-                            sdl3d_camera3d camera);
-bool doom_surveillance_update(doom_surveillance_camera *surveillance, sdl3d_vec3 sample_position);
+                            sdl3d_camera3d camera, int enter_signal_id, int exit_signal_id);
+bool doom_surveillance_update(doom_surveillance_camera *surveillance, sdl3d_logic_world *world,
+                              sdl3d_vec3 sample_position);
 bool doom_surveillance_is_active(const doom_surveillance_camera *surveillance);
 const sdl3d_camera3d *doom_surveillance_active_camera(const doom_surveillance_camera *surveillance);
 

--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -22,8 +22,10 @@
 
 #include "sdl3d/action.h"
 #include "sdl3d/actor_registry.h"
+#include "sdl3d/camera.h"
 #include "sdl3d/level.h"
 #include "sdl3d/signal_bus.h"
+#include "sdl3d/teleporter.h"
 #include "sdl3d/timer_pool.h"
 #include "sdl3d/trigger.h"
 
@@ -123,7 +125,57 @@ extern "C"
         SDL3D_LOGIC_ACTION_SET_SECTOR_PUSH = 5,     /**< Set a sector push/current velocity. */
         SDL3D_LOGIC_ACTION_SET_SECTOR_DAMAGE = 6,   /**< Set non-negative sector damage per second. */
         SDL3D_LOGIC_ACTION_SET_SECTOR_AMBIENT = 7,  /**< Set a non-negative ambient sound id. */
+        SDL3D_LOGIC_ACTION_TELEPORT_PLAYER = 8,     /**< Request a game-owned player teleport. */
+        SDL3D_LOGIC_ACTION_SET_ACTIVE_CAMERA = 9,   /**< Request a game-owned active camera override. */
+        SDL3D_LOGIC_ACTION_RESTORE_CAMERA = 10,     /**< Request restoration of the game-owned camera. */
     } sdl3d_logic_action_type;
+
+    /**
+     * @brief Callback used by logic actions that request a player teleport.
+     *
+     * The logic world does not own player movement state, so games provide this
+     * adapter when they want designer-authored signals to move the player. The
+     * payload pointer is borrowed from the signal emission that triggered the
+     * action and may be NULL for immediate/static execution.
+     *
+     * @return true when the game accepted and applied the teleport.
+     */
+    typedef bool (*sdl3d_logic_teleport_player_fn)(void *userdata, const sdl3d_teleport_destination *destination,
+                                                   const sdl3d_properties *payload);
+
+    /**
+     * @brief Callback used by logic actions that request a camera override.
+     *
+     * @p camera_name may be NULL. @p camera points at the camera copied into
+     * the action. The game decides how that override affects rendering.
+     *
+     * @return true when the game accepted and applied the camera override.
+     */
+    typedef bool (*sdl3d_logic_set_active_camera_fn)(void *userdata, const char *camera_name,
+                                                     const sdl3d_camera3d *camera, const sdl3d_properties *payload);
+
+    /**
+     * @brief Callback used by logic actions that request camera restoration.
+     *
+     * @return true when the game accepted and restored normal camera behavior.
+     */
+    typedef bool (*sdl3d_logic_restore_camera_fn)(void *userdata, const sdl3d_properties *payload);
+
+    /**
+     * @brief Game-owned operations exposed to generic logic actions.
+     *
+     * These callbacks keep the logic world open for game-specific effects
+     * without coupling it to a particular player controller, render camera, UI,
+     * inventory, or health model. The struct is copied by value into the world;
+     * userdata remains caller-owned.
+     */
+    typedef struct sdl3d_logic_game_adapters
+    {
+        void *userdata;                                     /**< Caller-owned data passed to every callback. */
+        sdl3d_logic_teleport_player_fn teleport_player;     /**< Optional player teleport adapter. */
+        sdl3d_logic_set_active_camera_fn set_active_camera; /**< Optional camera override adapter. */
+        sdl3d_logic_restore_camera_fn restore_camera;       /**< Optional camera restore adapter. */
+    } sdl3d_logic_game_adapters;
 
     /**
      * @brief Target-aware action executed by a logic world.
@@ -175,6 +227,20 @@ extern "C"
                 sdl3d_logic_target_ref target;
                 int ambient_sound_id;
             } sector_ambient;
+
+            /** @brief Request a game-owned player teleport. */
+            struct
+            {
+                sdl3d_teleport_destination destination;
+                bool use_signal_payload;
+            } teleport_player;
+
+            /** @brief Request a game-owned camera override. */
+            struct
+            {
+                const char *camera_name;
+                sdl3d_camera3d camera;
+            } camera;
         };
     } sdl3d_logic_action;
 
@@ -438,6 +504,19 @@ extern "C"
     const sdl3d_logic_target_context *sdl3d_logic_world_get_target_context(const sdl3d_logic_world *world);
 
     /**
+     * @brief Set callbacks for game-owned logic actions.
+     *
+     * Passing NULL clears all adapters. The world copies the struct by value and
+     * never owns @p adapters->userdata.
+     */
+    void sdl3d_logic_world_set_game_adapters(sdl3d_logic_world *world, const sdl3d_logic_game_adapters *adapters);
+
+    /**
+     * @brief Return the currently configured game adapters, or NULL.
+     */
+    const sdl3d_logic_game_adapters *sdl3d_logic_world_get_game_adapters(const sdl3d_logic_world *world);
+
+    /**
      * @brief Assign a stable editor-facing name to a sector index.
      *
      * The name is copied by the logic world. Names are unique: assigning an
@@ -511,6 +590,34 @@ extern "C"
     sdl3d_logic_action sdl3d_logic_action_make_set_sector_ambient(sdl3d_logic_target_ref target, int ambient_sound_id);
 
     /**
+     * @brief Create an action that teleports the player to a fixed destination.
+     *
+     * Execution requires a teleport_player game adapter on the logic world.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_teleport_player(sdl3d_teleport_destination destination);
+
+    /**
+     * @brief Create an action that teleports the player from the signal payload.
+     *
+     * The action decodes the payload with sdl3d_teleport_destination_from_payload().
+     * Execution fails if no payload or no teleport_player adapter is available.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_teleport_player_from_payload(void);
+
+    /**
+     * @brief Create an action that requests a game-owned camera override.
+     *
+     * The camera value is copied into the action. The camera_name pointer is
+     * borrowed and must remain valid while the action can execute.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_active_camera(const char *camera_name, const sdl3d_camera3d *camera);
+
+    /**
+     * @brief Create an action that requests restoration of normal camera behavior.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_restore_camera(void);
+
+    /**
      * @brief Execute a target-aware action immediately.
      *
      * Core actions execute through sdl3d_action_execute using the world's signal
@@ -521,6 +628,19 @@ extern "C"
      *         or target was invalid.
      */
     bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action);
+
+    /**
+     * @brief Execute a target-aware action with an optional signal payload.
+     *
+     * This is the immediate-execution equivalent of a signal binding. It is
+     * mainly useful for actions that consume event payloads, such as
+     * SDL3D_LOGIC_ACTION_TELEPORT_PLAYER actions created with
+     * sdl3d_logic_action_make_teleport_player_from_payload().
+     *
+     * @return true when the action was valid and applied, false otherwise.
+     */
+    bool sdl3d_logic_world_execute_action_with_payload(sdl3d_logic_world *world, const sdl3d_logic_action *action,
+                                                       const sdl3d_properties *payload);
 
     /* ================================================================== */
     /* Sensors                                                            */

--- a/src/logic.c
+++ b/src/logic.c
@@ -54,6 +54,7 @@ struct sdl3d_logic_world
     logic_binding *bindings;
     logic_entity_binding *entity_bindings;
     sdl3d_logic_target_context target_context;
+    sdl3d_logic_game_adapters game_adapters;
     sector_alias *sector_aliases;
     int binding_count;
     int entity_binding_count;
@@ -61,6 +62,7 @@ struct sdl3d_logic_world
     int sector_alias_capacity;
     int next_binding_id;
     bool has_target_context;
+    bool has_game_adapters;
 };
 
 static logic_binding *find_binding(const sdl3d_logic_world *world, int binding_id)
@@ -318,14 +320,12 @@ static void set_property_value(sdl3d_properties *target, const char *key, const 
 
 static void execute_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
-    (void)payload;
-
     logic_binding *binding = (logic_binding *)userdata;
     if (binding == NULL || !binding->enabled || binding->signal_id != signal_id)
         return;
 
     sdl3d_logic_world *world = binding->owner;
-    sdl3d_logic_world_execute_action(world, &binding->action);
+    sdl3d_logic_world_execute_action_with_payload(world, &binding->action, payload);
 }
 
 static void execute_entity_binding(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -460,6 +460,27 @@ void sdl3d_logic_world_set_target_context(sdl3d_logic_world *world, const sdl3d_
 const sdl3d_logic_target_context *sdl3d_logic_world_get_target_context(const sdl3d_logic_world *world)
 {
     return world != NULL && world->has_target_context ? &world->target_context : NULL;
+}
+
+void sdl3d_logic_world_set_game_adapters(sdl3d_logic_world *world, const sdl3d_logic_game_adapters *adapters)
+{
+    if (world == NULL)
+        return;
+
+    if (adapters == NULL)
+    {
+        SDL_zero(world->game_adapters);
+        world->has_game_adapters = false;
+        return;
+    }
+
+    world->game_adapters = *adapters;
+    world->has_game_adapters = true;
+}
+
+const sdl3d_logic_game_adapters *sdl3d_logic_world_get_game_adapters(const sdl3d_logic_world *world)
+{
+    return world != NULL && world->has_game_adapters ? &world->game_adapters : NULL;
 }
 
 bool sdl3d_logic_world_set_sector_name(sdl3d_logic_world *world, int sector_index, const char *name)
@@ -642,12 +663,59 @@ sdl3d_logic_action sdl3d_logic_action_make_set_sector_ambient(sdl3d_logic_target
     return action;
 }
 
+sdl3d_logic_action sdl3d_logic_action_make_teleport_player(sdl3d_teleport_destination destination)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_TELEPORT_PLAYER;
+    action.teleport_player.destination = destination;
+    action.teleport_player.use_signal_payload = false;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_teleport_player_from_payload(void)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_TELEPORT_PLAYER;
+    action.teleport_player.use_signal_payload = true;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_active_camera(const char *camera_name, const sdl3d_camera3d *camera)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_ACTIVE_CAMERA;
+    action.camera.camera_name = camera_name;
+    if (camera != NULL)
+    {
+        action.camera.camera = *camera;
+    }
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_restore_camera(void)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_RESTORE_CAMERA;
+    return action;
+}
+
 bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action)
+{
+    return sdl3d_logic_world_execute_action_with_payload(world, action, NULL);
+}
+
+bool sdl3d_logic_world_execute_action_with_payload(sdl3d_logic_world *world, const sdl3d_logic_action *action,
+                                                   const sdl3d_properties *payload)
 {
     if (world == NULL || action == NULL)
         return false;
 
     sdl3d_logic_resolved_target target;
+    const sdl3d_logic_game_adapters *adapters = sdl3d_logic_world_get_game_adapters(world);
     switch (action->type)
     {
     case SDL3D_LOGIC_ACTION_CORE:
@@ -710,6 +778,37 @@ bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logi
         }
         target.sector.sector->ambient_sound_id = clamp_non_negative_int(action->sector_ambient.ambient_sound_id);
         return true;
+
+    case SDL3D_LOGIC_ACTION_TELEPORT_PLAYER: {
+        if (adapters == NULL || adapters->teleport_player == NULL)
+        {
+            return false;
+        }
+
+        sdl3d_teleport_destination destination = action->teleport_player.destination;
+        if (action->teleport_player.use_signal_payload &&
+            !sdl3d_teleport_destination_from_payload(payload, &destination))
+        {
+            return false;
+        }
+
+        return adapters->teleport_player(adapters->userdata, &destination, payload);
+    }
+
+    case SDL3D_LOGIC_ACTION_SET_ACTIVE_CAMERA:
+        if (adapters == NULL || adapters->set_active_camera == NULL)
+        {
+            return false;
+        }
+        return adapters->set_active_camera(adapters->userdata, action->camera.camera_name, &action->camera.camera,
+                                           payload);
+
+    case SDL3D_LOGIC_ACTION_RESTORE_CAMERA:
+        if (adapters == NULL || adapters->restore_camera == NULL)
+        {
+            return false;
+        }
+        return adapters->restore_camera(adapters->userdata, payload);
 
     case SDL3D_LOGIC_ACTION_NONE:
         break;

--- a/tests/test_doom_surveillance.cpp
+++ b/tests/test_doom_surveillance.cpp
@@ -21,11 +21,28 @@ static sdl3d_camera3d camera()
     return cam;
 }
 
+struct signal_capture
+{
+    int count = 0;
+    int signal_id = 0;
+    int event = 0;
+    bool inside = false;
+};
+
+static void capture_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    signal_capture *capture = (signal_capture *)userdata;
+    capture->count++;
+    capture->signal_id = signal_id;
+    capture->event = sdl3d_properties_get_int(payload, "event", 0);
+    capture->inside = sdl3d_properties_get_bool(payload, "inside", false);
+}
+
 TEST(DoomSurveillance, InitStartsEnabledInactive)
 {
     doom_surveillance_camera surveillance{};
     sdl3d_camera3d cam = camera();
-    doom_surveillance_init(&surveillance, bounds(), cam);
+    doom_surveillance_init(&surveillance, bounds(), cam, 100, 101);
 
     EXPECT_TRUE(surveillance.enabled);
     EXPECT_FALSE(doom_surveillance_is_active(&surveillance));
@@ -33,38 +50,69 @@ TEST(DoomSurveillance, InitStartsEnabledInactive)
     EXPECT_FLOAT_EQ(cam.position.z, surveillance.camera.position.z);
 }
 
-TEST(DoomSurveillance, ActiveWhileSampleInsideButtonBounds)
+TEST(DoomSurveillance, EmitsEnterAndExitSignals)
 {
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    signal_capture enter{};
+    signal_capture exit{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 100, capture_signal, &enter), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 101, capture_signal, &exit), 0);
     doom_surveillance_camera surveillance{};
-    doom_surveillance_init(&surveillance, bounds(), camera());
+    doom_surveillance_init(&surveillance, bounds(), camera(), 100, 101);
 
-    EXPECT_FALSE(doom_surveillance_update(&surveillance, sdl3d_vec3_make(2.0f, 1.0f, 0.0f)));
+    EXPECT_FALSE(doom_surveillance_update(&surveillance, world, sdl3d_vec3_make(2.0f, 1.0f, 0.0f)));
     EXPECT_FALSE(doom_surveillance_is_active(&surveillance));
-    EXPECT_EQ(nullptr, doom_surveillance_active_camera(&surveillance));
+    EXPECT_EQ(enter.count, 0);
+    EXPECT_EQ(exit.count, 0);
 
-    EXPECT_TRUE(doom_surveillance_update(&surveillance, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    EXPECT_FALSE(doom_surveillance_update(&surveillance, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    EXPECT_EQ(enter.count, 1);
+    EXPECT_EQ(enter.signal_id, 100);
+    EXPECT_EQ(enter.event, SDL3D_LOGIC_SENSOR_EVENT_ENTER);
+    EXPECT_TRUE(enter.inside);
+    EXPECT_EQ(exit.count, 0);
+
+    surveillance.active = true;
     EXPECT_TRUE(doom_surveillance_is_active(&surveillance));
     ASSERT_NE(nullptr, doom_surveillance_active_camera(&surveillance));
     EXPECT_FLOAT_EQ(70.0f, doom_surveillance_active_camera(&surveillance)->fovy);
 
-    EXPECT_FALSE(doom_surveillance_update(&surveillance, sdl3d_vec3_make(0.0f, 2.5f, 0.0f)));
+    EXPECT_TRUE(doom_surveillance_update(&surveillance, world, sdl3d_vec3_make(0.0f, 2.5f, 0.0f)));
+    EXPECT_EQ(exit.count, 1);
+    EXPECT_EQ(exit.signal_id, 101);
+    EXPECT_EQ(exit.event, SDL3D_LOGIC_SENSOR_EVENT_EXIT);
+    EXPECT_FALSE(exit.inside);
+
+    surveillance.active = false;
     EXPECT_FALSE(doom_surveillance_is_active(&surveillance));
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
 }
 
-TEST(DoomSurveillance, DisabledCameraNeverActivates)
+TEST(DoomSurveillance, DisabledCameraEmitsNoSignals)
 {
+    sdl3d_signal_bus *bus = sdl3d_signal_bus_create();
+    sdl3d_logic_world *world = sdl3d_logic_world_create(bus, nullptr);
+    signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 100, capture_signal, &capture), 0);
     doom_surveillance_camera surveillance{};
-    doom_surveillance_init(&surveillance, bounds(), camera());
+    doom_surveillance_init(&surveillance, bounds(), camera(), 100, 101);
     surveillance.enabled = false;
 
-    EXPECT_FALSE(doom_surveillance_update(&surveillance, sdl3d_vec3_make(0.0f, 1.0f, 0.0f)));
+    EXPECT_FALSE(doom_surveillance_update(&surveillance, world, sdl3d_vec3_make(0.0f, 1.0f, 0.0f)));
     EXPECT_FALSE(doom_surveillance_is_active(&surveillance));
+    EXPECT_EQ(capture.count, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
 }
 
 TEST(DoomSurveillance, NullSafe)
 {
-    doom_surveillance_init(nullptr, bounds(), camera());
-    EXPECT_FALSE(doom_surveillance_update(nullptr, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    doom_surveillance_init(nullptr, bounds(), camera(), 100, 101);
+    EXPECT_FALSE(doom_surveillance_update(nullptr, nullptr, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
     EXPECT_FALSE(doom_surveillance_is_active(nullptr));
     EXPECT_EQ(nullptr, doom_surveillance_active_camera(nullptr));
 }

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -69,6 +69,62 @@ static void capture_logic_signal(void *userdata, int signal_id, const sdl3d_prop
     SDL_snprintf(capture->entity_type, sizeof(capture->entity_type), "%s", entity_type);
 }
 
+struct logic_adapter_capture
+{
+    int teleport_count = 0;
+    int set_camera_count = 0;
+    int restore_camera_count = 0;
+    int last_teleporter_id = -1;
+    char last_camera_name[64] = {};
+    sdl3d_teleport_destination last_destination = {};
+    sdl3d_camera3d last_camera = {};
+};
+
+static bool capture_teleport_player(void *userdata, const sdl3d_teleport_destination *destination,
+                                    const sdl3d_properties *payload)
+{
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr || destination == nullptr)
+    {
+        return false;
+    }
+
+    capture->teleport_count++;
+    capture->last_destination = *destination;
+    capture->last_teleporter_id = sdl3d_properties_get_int(payload, "teleporter_id", -1);
+    return true;
+}
+
+static bool capture_set_active_camera(void *userdata, const char *camera_name, const sdl3d_camera3d *camera,
+                                      const sdl3d_properties *payload)
+{
+    (void)payload;
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr || camera == nullptr)
+    {
+        return false;
+    }
+
+    capture->set_camera_count++;
+    capture->last_camera = *camera;
+    SDL_snprintf(capture->last_camera_name, sizeof(capture->last_camera_name), "%s",
+                 camera_name != nullptr ? camera_name : "");
+    return true;
+}
+
+static bool capture_restore_camera(void *userdata, const sdl3d_properties *payload)
+{
+    (void)payload;
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr)
+    {
+        return false;
+    }
+
+    capture->restore_camera_count++;
+    return true;
+}
+
 struct ordered_signal_capture
 {
     int count = 0;
@@ -130,6 +186,33 @@ TEST(LogicWorld, CreateRequiresBus)
 TEST(LogicWorld, DestroyNullIsSafe)
 {
     sdl3d_logic_world_destroy(nullptr);
+}
+
+TEST(LogicWorld, GameAdaptersCanBeSetAndCleared)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+
+    EXPECT_EQ(sdl3d_logic_world_get_game_adapters(world), nullptr);
+    sdl3d_logic_world_set_game_adapters(nullptr, nullptr);
+
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.teleport_player = capture_teleport_player;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    const sdl3d_logic_game_adapters *stored = sdl3d_logic_world_get_game_adapters(world);
+    ASSERT_NE(stored, nullptr);
+    EXPECT_EQ(stored->userdata, &capture);
+    EXPECT_EQ(stored->teleport_player, capture_teleport_player);
+
+    sdl3d_logic_world_set_game_adapters(world, nullptr);
+    EXPECT_EQ(sdl3d_logic_world_get_game_adapters(world), nullptr);
+    EXPECT_EQ(sdl3d_logic_world_get_game_adapters(nullptr), nullptr);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
 }
 
 TEST(LogicWorld, BoundActionExecutesWhenSignalIsEmitted)
@@ -729,6 +812,146 @@ TEST(LogicWorldActions, SetSectorAmbientClampsNegativeToZero)
 
     EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
     EXPECT_EQ(sectors[0].ambient_sound_id, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, TeleportPlayerFromPayloadForwardsSignalPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.teleport_player = capture_teleport_player;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_teleport_player_from_payload();
+    ASSERT_GT(sdl3d_logic_world_bind_logic_action(world, 81, &action), 0);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "teleporter_id", 17);
+    sdl3d_properties_set_vec3(payload, "destination", sdl3d_vec3_make(4.0f, 5.0f, 6.0f));
+    sdl3d_properties_set_float(payload, "destination_yaw", 1.25f);
+    sdl3d_properties_set_float(payload, "destination_pitch", -0.125f);
+    sdl3d_properties_set_bool(payload, "use_yaw", true);
+    sdl3d_properties_set_bool(payload, "use_pitch", true);
+
+    sdl3d_signal_emit(bus, 81, payload);
+
+    EXPECT_EQ(capture.teleport_count, 1);
+    EXPECT_EQ(capture.last_teleporter_id, 17);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.x, 4.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.y, 5.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.z, 6.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.yaw, 1.25f);
+    EXPECT_FLOAT_EQ(capture.last_destination.pitch, -0.125f);
+    EXPECT_TRUE(capture.last_destination.use_yaw);
+    EXPECT_TRUE(capture.last_destination.use_pitch);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, StaticTeleportPlayerUsesConfiguredDestination)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.teleport_player = capture_teleport_player;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_teleport_destination destination{};
+    destination.position = sdl3d_vec3_make(-2.0f, 3.0f, 8.0f);
+    destination.yaw = 0.5f;
+    destination.use_yaw = true;
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_teleport_player(destination);
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &action));
+
+    EXPECT_EQ(capture.teleport_count, 1);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.x, -2.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.y, 3.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.position.z, 8.0f);
+    EXPECT_FLOAT_EQ(capture.last_destination.yaw, 0.5f);
+    EXPECT_TRUE(capture.last_destination.use_yaw);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, TeleportPlayerRejectsMissingAdapterOrPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_logic_action action = sdl3d_logic_action_make_teleport_player_from_payload();
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &action, nullptr));
+
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.teleport_player = capture_teleport_player;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &action, nullptr));
+    EXPECT_EQ(capture.teleport_count, 0);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, CameraActionsUseGameAdaptersInSignalOrder)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.set_active_camera = capture_set_active_camera;
+    adapters.restore_camera = capture_restore_camera;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_camera3d camera{};
+    camera.position = sdl3d_vec3_make(1.0f, 2.0f, 3.0f);
+    camera.target = sdl3d_vec3_make(4.0f, 5.0f, 6.0f);
+    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.fovy = 75.0f;
+    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
+
+    sdl3d_logic_action set_camera = sdl3d_logic_action_make_set_active_camera("security", &camera);
+    sdl3d_logic_action restore_camera = sdl3d_logic_action_make_restore_camera();
+    ASSERT_GT(sdl3d_logic_world_bind_logic_action(world, 91, &set_camera), 0);
+    ASSERT_GT(sdl3d_logic_world_bind_logic_action(world, 91, &restore_camera), 0);
+
+    sdl3d_signal_emit(bus, 91, nullptr);
+
+    EXPECT_EQ(capture.set_camera_count, 1);
+    EXPECT_EQ(capture.restore_camera_count, 1);
+    EXPECT_STREQ(capture.last_camera_name, "security");
+    EXPECT_FLOAT_EQ(capture.last_camera.position.x, 1.0f);
+    EXPECT_FLOAT_EQ(capture.last_camera.position.y, 2.0f);
+    EXPECT_FLOAT_EQ(capture.last_camera.position.z, 3.0f);
+    EXPECT_FLOAT_EQ(capture.last_camera.fovy, 75.0f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, CameraActionsRejectMissingAdapters)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_camera3d camera{};
+    sdl3d_logic_action set_camera = sdl3d_logic_action_make_set_active_camera("missing", &camera);
+    sdl3d_logic_action restore_camera = sdl3d_logic_action_make_restore_camera();
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &set_camera));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &restore_camera));
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add payload-aware logic action execution and public game adapter callbacks for game-owned operations
- add logic actions for player teleport, camera override, and camera restore
- migrate Doom level teleporter and surveillance camera activation onto logic bindings

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/release
- ./build/release/tests/sdl3d_logic_test
- ./build/release/tests/doom_surveillance_test
- ctest --test-dir build/release --output-on-failure --quiet

Refs #109