### PR TITLE
Migrate ambient zones to logic actions

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -24,6 +24,8 @@
 #define SIG_FADE_OUT_DONE 2001
 #define SIG_SURVEILLANCE_ENTER 2002
 #define SIG_SURVEILLANCE_EXIT 2003
+#define SIG_AMBIENT_FEEDBACK 2004
+#define SIG_AMBIENT_FEEDBACK_SKIP 2005
 #define LIFT_FLOOR_MIN_Y 0.0f
 #define LIFT_FLOOR_MAX_Y 2.5f
 #define LIFT_CEIL_Y 12.0f
@@ -40,6 +42,7 @@
 #define DAMAGE_FEEDBACK_PULSE_HZ 2.8f
 #define SURVEILLANCE_BUTTON_X 43.0f
 #define SURVEILLANCE_BUTTON_Z 89.0f
+#define FEEDBACK_AMBIENT_ZONE "ambient_zone"
 
 typedef struct doom_state
 {
@@ -54,6 +57,7 @@ typedef struct doom_state
     sdl3d_demo_player *demo_player;
     sdl3d_audio_engine *audio;
     sdl3d_logic_world *logic;
+    sdl3d_logic_branch ambient_feedback_branch;
     sdl3d_sector_watcher sector_watcher;
     sdl3d_teleporter dragon_teleporter;
     doom_surveillance_camera surveillance;
@@ -136,32 +140,53 @@ static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properti
     ctx->quit_requested = true;
 }
 
-static void on_entered_sector(void *userdata, int signal_id, const sdl3d_properties *payload)
+static bool doom_logic_set_ambient(void *userdata, int ambient_id, float fade_seconds, const sdl3d_properties *payload)
 {
-    (void)signal_id;
+    (void)payload;
     doom_state *state = (doom_state *)userdata;
     static const sdl3d_audio_ambient ambient_zones[] = {
         {0, NULL, 0.0f, false},
         {DOOM_AMBIENT_DEMO_SOUND_ID, SDL3D_MEDIA_DIR "/audio/ambient_zone.wav", 0.45f, true},
     };
-    const int ambient_id = sdl3d_properties_get_int(payload, "ambient_sound_id", 0);
 
     if (state == NULL)
     {
-        return;
+        return false;
     }
 
-    if (state->audio != NULL && !sdl3d_audio_set_ambient(state->audio, ambient_zones, (int)SDL_arraysize(ambient_zones),
-                                                         ambient_id, AMBIENT_FADE_SECONDS))
+    if (state->audio == NULL)
+    {
+        return true;
+    }
+
+    if (!sdl3d_audio_set_ambient(state->audio, ambient_zones, (int)SDL_arraysize(ambient_zones), ambient_id,
+                                 fade_seconds))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Ambient transition failed: %s", SDL_GetError());
         SDL_ClearError();
+        return false;
     }
 
-    if (ambient_id == DOOM_AMBIENT_DEMO_SOUND_ID)
+    return true;
+}
+
+static bool doom_logic_trigger_feedback(void *userdata, const char *feedback_name, float duration_seconds,
+                                        const sdl3d_properties *payload)
+{
+    (void)payload;
+    doom_state *state = (doom_state *)userdata;
+    if (state == NULL || feedback_name == NULL)
     {
-        state->ambient_feedback_timer = AMBIENT_FEEDBACK_SECONDS;
+        return false;
     }
+
+    if (SDL_strcmp(feedback_name, FEEDBACK_AMBIENT_ZONE) == 0)
+    {
+        state->ambient_feedback_timer = duration_seconds;
+        return true;
+    }
+
+    return false;
 }
 
 static bool doom_logic_teleport_player(void *userdata, const sdl3d_teleport_destination *destination,
@@ -262,7 +287,34 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     adapters.teleport_player = doom_logic_teleport_player;
     adapters.set_active_camera = doom_logic_set_active_camera;
     adapters.restore_camera = doom_logic_restore_camera;
+    adapters.set_ambient = doom_logic_set_ambient;
+    adapters.trigger_feedback = doom_logic_trigger_feedback;
     sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
+
+    sdl3d_logic_action ambient_action =
+        sdl3d_logic_action_make_set_ambient_from_payload("ambient_sound_id", AMBIENT_FADE_SECONDS);
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SDL3D_SIGNAL_ENTERED_SECTOR, &ambient_action) == 0)
+    {
+        return false;
+    }
+
+    sdl3d_value ambient_expected;
+    SDL_zero(ambient_expected);
+    ambient_expected.type = SDL3D_VALUE_INT;
+    ambient_expected.as_int = DOOM_AMBIENT_DEMO_SOUND_ID;
+    sdl3d_logic_branch_init_payload(&state->ambient_feedback_branch, 1, "ambient_sound_id", ambient_expected,
+                                    SIG_AMBIENT_FEEDBACK, SIG_AMBIENT_FEEDBACK_SKIP);
+    if (sdl3d_logic_world_bind_branch(state->logic, SDL3D_SIGNAL_ENTERED_SECTOR, &state->ambient_feedback_branch) == 0)
+    {
+        return false;
+    }
+
+    sdl3d_logic_action ambient_feedback_action =
+        sdl3d_logic_action_make_trigger_feedback(FEEDBACK_AMBIENT_ZONE, AMBIENT_FEEDBACK_SECONDS);
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_AMBIENT_FEEDBACK, &ambient_feedback_action) == 0)
+    {
+        return false;
+    }
 
     sdl3d_logic_action teleport_action = sdl3d_logic_action_make_teleport_player_from_payload();
     if (sdl3d_logic_world_bind_logic_action(state->logic, SDL3D_SIGNAL_TELEPORT, &teleport_action) == 0)
@@ -349,10 +401,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     apply_window_defaults(ctx, state);
 
     if (sdl3d_signal_connect(ctx->bus, SIG_FADE_OUT_DONE, on_fade_out_done, ctx) == 0)
-    {
-        return false;
-    }
-    if (sdl3d_signal_connect(ctx->bus, SDL3D_SIGNAL_ENTERED_SECTOR, on_entered_sector, state) == 0)
     {
         return false;
     }

--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -128,6 +128,8 @@ extern "C"
         SDL3D_LOGIC_ACTION_TELEPORT_PLAYER = 8,     /**< Request a game-owned player teleport. */
         SDL3D_LOGIC_ACTION_SET_ACTIVE_CAMERA = 9,   /**< Request a game-owned active camera override. */
         SDL3D_LOGIC_ACTION_RESTORE_CAMERA = 10,     /**< Request restoration of the game-owned camera. */
+        SDL3D_LOGIC_ACTION_SET_AMBIENT = 11,        /**< Request a game-owned ambient audio transition. */
+        SDL3D_LOGIC_ACTION_TRIGGER_FEEDBACK = 12,   /**< Request a named game-owned feedback cue. */
     } sdl3d_logic_action_type;
 
     /**
@@ -162,6 +164,28 @@ extern "C"
     typedef bool (*sdl3d_logic_restore_camera_fn)(void *userdata, const sdl3d_properties *payload);
 
     /**
+     * @brief Callback used by logic actions that request an ambient transition.
+     *
+     * The logic world does not own audio zone tables, so games provide this
+     * adapter to map an ambient id to their own ambient definitions.
+     *
+     * @return true when the game accepted the ambient request.
+     */
+    typedef bool (*sdl3d_logic_set_ambient_fn)(void *userdata, int ambient_id, float fade_seconds,
+                                               const sdl3d_properties *payload);
+
+    /**
+     * @brief Callback used by logic actions that request a named feedback cue.
+     *
+     * Feedback cues are intentionally game-owned because they may be UI flashes,
+     * material changes, lights, particles, sounds, or any combination of those.
+     *
+     * @return true when the game accepted the feedback request.
+     */
+    typedef bool (*sdl3d_logic_trigger_feedback_fn)(void *userdata, const char *feedback_name, float duration_seconds,
+                                                    const sdl3d_properties *payload);
+
+    /**
      * @brief Game-owned operations exposed to generic logic actions.
      *
      * These callbacks keep the logic world open for game-specific effects
@@ -175,6 +199,8 @@ extern "C"
         sdl3d_logic_teleport_player_fn teleport_player;     /**< Optional player teleport adapter. */
         sdl3d_logic_set_active_camera_fn set_active_camera; /**< Optional camera override adapter. */
         sdl3d_logic_restore_camera_fn restore_camera;       /**< Optional camera restore adapter. */
+        sdl3d_logic_set_ambient_fn set_ambient;             /**< Optional ambient audio adapter. */
+        sdl3d_logic_trigger_feedback_fn trigger_feedback;   /**< Optional named feedback adapter. */
     } sdl3d_logic_game_adapters;
 
     /**
@@ -241,6 +267,22 @@ extern "C"
                 const char *camera_name;
                 sdl3d_camera3d camera;
             } camera;
+
+            /** @brief Request a game-owned ambient transition. */
+            struct
+            {
+                const char *payload_key;
+                int ambient_id;
+                float fade_seconds;
+                bool use_signal_payload;
+            } ambient;
+
+            /** @brief Request a named game-owned feedback cue. */
+            struct
+            {
+                const char *feedback_name;
+                float duration_seconds;
+            } feedback;
         };
     } sdl3d_logic_action;
 
@@ -367,10 +409,11 @@ extern "C"
     } sdl3d_logic_counter;
 
     /**
-     * @brief Branch entity that compares a property value and emits true/false.
+     * @brief Branch entity that compares a property or payload value and emits true/false.
      *
      * The property bag, key pointer, and string value pointer are borrowed and
-     * must remain valid until activation. The entity does not own them.
+     * must remain valid until activation. Payload branches inspect the payload
+     * passed to sdl3d_logic_branch_activate_with_payload().
      */
     typedef struct sdl3d_logic_branch
     {
@@ -381,6 +424,7 @@ extern "C"
         int true_signal;               /**< Signal emitted when comparison succeeds. */
         int false_signal;              /**< Signal emitted when comparison fails. */
         bool enabled;                  /**< Disabled branches ignore activation. */
+        bool use_activation_payload;   /**< If true, compare the activation payload instead of @p props. */
     } sdl3d_logic_branch;
 
     /**
@@ -618,6 +662,31 @@ extern "C"
     sdl3d_logic_action sdl3d_logic_action_make_restore_camera(void);
 
     /**
+     * @brief Create an action that requests a fixed ambient id.
+     *
+     * Execution requires a set_ambient game adapter on the logic world.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_ambient(int ambient_id, float fade_seconds);
+
+    /**
+     * @brief Create an action that requests an ambient id from the signal payload.
+     *
+     * The action reads @p payload_key as an int. Missing payloads or missing
+     * keys cause execution to fail rather than silently choosing a fallback.
+     * Execution requires a set_ambient game adapter on the logic world.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_ambient_from_payload(const char *payload_key, float fade_seconds);
+
+    /**
+     * @brief Create an action that requests a named game-owned feedback cue.
+     *
+     * The feedback_name pointer is borrowed and must remain valid while the
+     * action can execute. Negative durations are clamped to zero during
+     * execution.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_trigger_feedback(const char *feedback_name, float duration_seconds);
+
+    /**
      * @brief Execute a target-aware action immediately.
      *
      * Core actions execute through sdl3d_action_execute using the world's signal
@@ -764,8 +833,17 @@ extern "C"
     void sdl3d_logic_branch_init(sdl3d_logic_branch *branch, int entity_id, const sdl3d_properties *props,
                                  const char *key, sdl3d_value expected, int true_signal, int false_signal);
 
+    /** @brief Initialize a branch entity that compares the activation payload. */
+    void sdl3d_logic_branch_init_payload(sdl3d_logic_branch *branch, int entity_id, const char *key,
+                                         sdl3d_value expected, int true_signal, int false_signal);
+
     /** @brief Activate a branch and emit true_signal or false_signal. */
     sdl3d_logic_entity_result sdl3d_logic_branch_activate(sdl3d_logic_world *world, sdl3d_logic_branch *branch);
+
+    /** @brief Activate a branch with an optional signal payload. */
+    sdl3d_logic_entity_result sdl3d_logic_branch_activate_with_payload(sdl3d_logic_world *world,
+                                                                       sdl3d_logic_branch *branch,
+                                                                       const sdl3d_properties *payload);
 
     /** @brief Initialize a deterministic random selector. */
     void sdl3d_logic_random_init(sdl3d_logic_random *random, int entity_id, unsigned int seed);

--- a/src/logic.c
+++ b/src/logic.c
@@ -347,7 +347,7 @@ static void execute_entity_binding(void *userdata, int signal_id, const sdl3d_pr
         sdl3d_logic_counter_activate(world, (sdl3d_logic_counter *)binding->entity);
         break;
     case LOGIC_ENTITY_BINDING_BRANCH:
-        sdl3d_logic_branch_activate(world, (sdl3d_logic_branch *)binding->entity);
+        sdl3d_logic_branch_activate_with_payload(world, (sdl3d_logic_branch *)binding->entity, payload);
         break;
     case LOGIC_ENTITY_BINDING_RANDOM:
         sdl3d_logic_random_activate(world, (sdl3d_logic_random *)binding->entity);
@@ -703,6 +703,38 @@ sdl3d_logic_action sdl3d_logic_action_make_restore_camera(void)
     return action;
 }
 
+sdl3d_logic_action sdl3d_logic_action_make_set_ambient(int ambient_id, float fade_seconds)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_AMBIENT;
+    action.ambient.ambient_id = ambient_id;
+    action.ambient.fade_seconds = fade_seconds;
+    action.ambient.use_signal_payload = false;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_set_ambient_from_payload(const char *payload_key, float fade_seconds)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_AMBIENT;
+    action.ambient.payload_key = payload_key;
+    action.ambient.fade_seconds = fade_seconds;
+    action.ambient.use_signal_payload = true;
+    return action;
+}
+
+sdl3d_logic_action sdl3d_logic_action_make_trigger_feedback(const char *feedback_name, float duration_seconds)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_TRIGGER_FEEDBACK;
+    action.feedback.feedback_name = feedback_name;
+    action.feedback.duration_seconds = duration_seconds;
+    return action;
+}
+
 bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action)
 {
     return sdl3d_logic_world_execute_action_with_payload(world, action, NULL);
@@ -809,6 +841,40 @@ bool sdl3d_logic_world_execute_action_with_payload(sdl3d_logic_world *world, con
             return false;
         }
         return adapters->restore_camera(adapters->userdata, payload);
+
+    case SDL3D_LOGIC_ACTION_SET_AMBIENT: {
+        if (adapters == NULL || adapters->set_ambient == NULL)
+        {
+            return false;
+        }
+
+        int ambient_id = action->ambient.ambient_id;
+        if (action->ambient.use_signal_payload)
+        {
+            if (payload == NULL || action->ambient.payload_key == NULL)
+            {
+                return false;
+            }
+
+            const sdl3d_value *value = sdl3d_properties_get_value(payload, action->ambient.payload_key);
+            if (value == NULL || value->type != SDL3D_VALUE_INT)
+            {
+                return false;
+            }
+            ambient_id = value->as_int;
+        }
+
+        return adapters->set_ambient(adapters->userdata, ambient_id,
+                                     clamp_non_negative_float(action->ambient.fade_seconds), payload);
+    }
+
+    case SDL3D_LOGIC_ACTION_TRIGGER_FEEDBACK:
+        if (adapters == NULL || adapters->trigger_feedback == NULL || action->feedback.feedback_name == NULL)
+        {
+            return false;
+        }
+        return adapters->trigger_feedback(adapters->userdata, action->feedback.feedback_name,
+                                          clamp_non_negative_float(action->feedback.duration_seconds), payload);
 
     case SDL3D_LOGIC_ACTION_NONE:
         break;
@@ -1103,21 +1169,38 @@ void sdl3d_logic_branch_init(sdl3d_logic_branch *branch, int entity_id, const sd
     branch->enabled = true;
 }
 
+void sdl3d_logic_branch_init_payload(sdl3d_logic_branch *branch, int entity_id, const char *key, sdl3d_value expected,
+                                     int true_signal, int false_signal)
+{
+    if (branch == NULL)
+        return;
+
+    sdl3d_logic_branch_init(branch, entity_id, NULL, key, expected, true_signal, false_signal);
+    branch->use_activation_payload = true;
+}
+
 sdl3d_logic_entity_result sdl3d_logic_branch_activate(sdl3d_logic_world *world, sdl3d_logic_branch *branch)
+{
+    return sdl3d_logic_branch_activate_with_payload(world, branch, NULL);
+}
+
+sdl3d_logic_entity_result sdl3d_logic_branch_activate_with_payload(sdl3d_logic_world *world, sdl3d_logic_branch *branch,
+                                                                   const sdl3d_properties *payload)
 {
     if (branch == NULL || !branch->enabled)
         return entity_result(false, 0, -1);
 
-    const sdl3d_value *actual = sdl3d_properties_get_value(branch->props, branch->key);
+    const sdl3d_properties *source = branch->use_activation_payload ? payload : branch->props;
+    const sdl3d_value *actual = sdl3d_properties_get_value(source, branch->key);
     const bool matched = value_equals(actual, &branch->expected);
     const int signal_id = matched ? branch->true_signal : branch->false_signal;
-    sdl3d_properties *payload = create_entity_payload(branch->entity_id, "branch");
-    if (payload == NULL)
+    sdl3d_properties *branch_payload = create_entity_payload(branch->entity_id, "branch");
+    if (branch_payload == NULL)
         return entity_result(false, 0, -1);
 
-    sdl3d_properties_set_bool(payload, "matched", matched);
-    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, payload);
-    sdl3d_properties_destroy(payload);
+    sdl3d_properties_set_bool(branch_payload, "matched", matched);
+    const bool emitted = sdl3d_logic_world_emit_signal(world, signal_id, branch_payload);
+    sdl3d_properties_destroy(branch_payload);
     return entity_result(emitted, signal_id, matched ? 0 : 1);
 }
 

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -74,8 +74,14 @@ struct logic_adapter_capture
     int teleport_count = 0;
     int set_camera_count = 0;
     int restore_camera_count = 0;
+    int set_ambient_count = 0;
+    int trigger_feedback_count = 0;
     int last_teleporter_id = -1;
+    int last_ambient_id = -1;
+    float last_ambient_fade = -1.0f;
+    float last_feedback_duration = -1.0f;
     char last_camera_name[64] = {};
+    char last_feedback_name[64] = {};
     sdl3d_teleport_destination last_destination = {};
     sdl3d_camera3d last_camera = {};
 };
@@ -122,6 +128,37 @@ static bool capture_restore_camera(void *userdata, const sdl3d_properties *paylo
     }
 
     capture->restore_camera_count++;
+    return true;
+}
+
+static bool capture_set_ambient(void *userdata, int ambient_id, float fade_seconds, const sdl3d_properties *payload)
+{
+    (void)payload;
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr)
+    {
+        return false;
+    }
+
+    capture->set_ambient_count++;
+    capture->last_ambient_id = ambient_id;
+    capture->last_ambient_fade = fade_seconds;
+    return true;
+}
+
+static bool capture_trigger_feedback(void *userdata, const char *feedback_name, float duration_seconds,
+                                     const sdl3d_properties *payload)
+{
+    (void)payload;
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr || feedback_name == nullptr)
+    {
+        return false;
+    }
+
+    capture->trigger_feedback_count++;
+    capture->last_feedback_duration = duration_seconds;
+    SDL_snprintf(capture->last_feedback_name, sizeof(capture->last_feedback_name), "%s", feedback_name);
     return true;
 }
 
@@ -957,6 +994,87 @@ TEST(LogicWorldActions, CameraActionsRejectMissingAdapters)
     sdl3d_signal_bus_destroy(bus);
 }
 
+TEST(LogicWorldActions, SetAmbientFromPayloadUsesGameAdapter)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.set_ambient = capture_set_ambient;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_logic_action action = sdl3d_logic_action_make_set_ambient_from_payload("ambient_sound_id", 1.25f);
+    ASSERT_GT(sdl3d_logic_world_bind_logic_action(world, 92, &action), 0);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "ambient_sound_id", 7);
+    sdl3d_signal_emit(bus, 92, payload);
+
+    EXPECT_EQ(capture.set_ambient_count, 1);
+    EXPECT_EQ(capture.last_ambient_id, 7);
+    EXPECT_FLOAT_EQ(capture.last_ambient_fade, 1.25f);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, StaticAmbientAndFeedbackActionsUseGameAdapters)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.set_ambient = capture_set_ambient;
+    adapters.trigger_feedback = capture_trigger_feedback;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_logic_action ambient = sdl3d_logic_action_make_set_ambient(3, -1.0f);
+    sdl3d_logic_action feedback = sdl3d_logic_action_make_trigger_feedback("ambient_zone", -2.0f);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &ambient));
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &feedback));
+    EXPECT_EQ(capture.set_ambient_count, 1);
+    EXPECT_EQ(capture.last_ambient_id, 3);
+    EXPECT_FLOAT_EQ(capture.last_ambient_fade, 0.0f);
+    EXPECT_EQ(capture.trigger_feedback_count, 1);
+    EXPECT_STREQ(capture.last_feedback_name, "ambient_zone");
+    EXPECT_FLOAT_EQ(capture.last_feedback_duration, 0.0f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, AmbientAndFeedbackRejectMissingInputs)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    sdl3d_logic_action ambient = sdl3d_logic_action_make_set_ambient_from_payload("ambient_sound_id", 1.0f);
+    sdl3d_logic_action feedback = sdl3d_logic_action_make_trigger_feedback(nullptr, 1.0f);
+
+    EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &ambient, nullptr));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &feedback));
+
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.set_ambient = capture_set_ambient;
+    adapters.trigger_feedback = capture_trigger_feedback;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &ambient, payload));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &feedback));
+    EXPECT_EQ(capture.set_ambient_count, 0);
+    EXPECT_EQ(capture.trigger_feedback_count, 0);
+
+    sdl3d_properties_destroy(payload);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
 TEST(LogicWorldActions, WrongTargetKindFailsWithoutMutation)
 {
     sdl3d_signal_bus *bus = nullptr;
@@ -1453,6 +1571,42 @@ TEST(LogicWorldEntities, BranchComparesPropertyValues)
     EXPECT_FALSE(capture.matched);
 
     sdl3d_properties_destroy(props);
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldEntities, PayloadBranchComparesActivationPayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 332, capture_logic_signal, &capture), 0);
+    ASSERT_GT(sdl3d_signal_connect(bus, 333, capture_logic_signal, &capture), 0);
+
+    sdl3d_value expected{};
+    expected.type = SDL3D_VALUE_INT;
+    expected.as_int = 11;
+    sdl3d_logic_branch branch{};
+    sdl3d_logic_branch_init_payload(&branch, 26, "ambient_sound_id", expected, 332, 333);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    sdl3d_properties_set_int(payload, "ambient_sound_id", 11);
+    EXPECT_TRUE(sdl3d_logic_branch_activate_with_payload(world, &branch, payload).emitted);
+    EXPECT_EQ(capture.signal_id, 332);
+    EXPECT_TRUE(capture.matched);
+
+    sdl3d_properties_set_int(payload, "ambient_sound_id", 0);
+    EXPECT_TRUE(sdl3d_logic_branch_activate_with_payload(world, &branch, payload).emitted);
+    EXPECT_EQ(capture.signal_id, 333);
+    EXPECT_FALSE(capture.matched);
+
+    ASSERT_GT(sdl3d_logic_world_bind_branch(world, 334, &branch), 0);
+    sdl3d_properties_set_int(payload, "ambient_sound_id", 11);
+    sdl3d_signal_emit(bus, 334, payload);
+    EXPECT_EQ(capture.signal_id, 332);
+    EXPECT_TRUE(capture.matched);
+
+    sdl3d_properties_destroy(payload);
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);
 }


### PR DESCRIPTION
## Summary
- add public logic actions and adapters for ambient audio transitions and named feedback cues
- add payload-aware branch activation so logic entities can branch on signal payload values
- migrate Doom ambient-zone audio and feedback from a bespoke sector callback into logic bindings

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/release --target sdl3d_logic_test doom_level
- ./build/release/tests/sdl3d_logic_test
- cmake --build build/release
- ctest --test-dir build/release --output-on-failure --quiet

Refs #109