### PR TITLE
Migrate demo mechanics to logic primitives

### DIFF
--- a/demos/doom_level/entities.c
+++ b/demos/doom_level/entities.c
@@ -291,6 +291,7 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
                 config.signals.idle_started = DOOM_SIGNAL_ROBOT_IDLE_STARTED;
                 config.signals.walk_started = DOOM_SIGNAL_ROBOT_WALK_STARTED;
                 sdl3d_actor_patrol_controller_init(&npc->patrol, robot_number, npc->actor_id, &config);
+                sdl3d_actor_patrol_controller_set_enabled(&npc->patrol, false);
                 sdl3d_actor_patrol_controller_add_waypoint(&npc->patrol, a->position);
                 sdl3d_actor_patrol_controller_add_waypoint(
                     &npc->patrol,

--- a/demos/doom_level/hazard_effects.c
+++ b/demos/doom_level/hazard_effects.c
@@ -109,6 +109,7 @@ bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_le
     }
 
     SDL_zerop(particles);
+    particles->enabled = true;
     if (DOOM_NUKAGE_BASIN_SECTOR < 0 || DOOM_NUKAGE_BASIN_SECTOR >= level->sector_count)
     {
         return SDL_SetError("Nukage basin sector is out of range.");
@@ -242,9 +243,22 @@ void doom_hazard_particles_free(doom_hazard_particles *particles)
     SDL_zerop(particles);
 }
 
+void doom_hazard_particles_set_enabled(doom_hazard_particles *particles, bool enabled)
+{
+    if (particles != NULL)
+    {
+        particles->enabled = enabled;
+    }
+}
+
+bool doom_hazard_particles_enabled(const doom_hazard_particles *particles)
+{
+    return particles != NULL && particles->enabled;
+}
+
 void doom_hazard_particles_update(doom_hazard_particles *particles, float dt)
 {
-    if (particles == NULL)
+    if (particles == NULL || !particles->enabled)
     {
         return;
     }
@@ -265,7 +279,7 @@ void doom_hazard_particles_update(doom_hazard_particles *particles, float dt)
 
 bool doom_hazard_particles_draw(const doom_hazard_particles *particles, sdl3d_render_context *context)
 {
-    if (particles == NULL)
+    if (particles == NULL || !particles->enabled)
     {
         return true;
     }

--- a/demos/doom_level/hazard_effects.h
+++ b/demos/doom_level/hazard_effects.h
@@ -16,11 +16,14 @@ typedef struct doom_hazard_particles
     sdl3d_texture2d soft_particle_tex;
     float pulse_timer;
     bool has_soft_particle_tex;
+    bool enabled;
 } doom_hazard_particles;
 
 bool doom_hazard_particles_init(doom_hazard_particles *particles, const sdl3d_level *level,
                                 const sdl3d_sector *sectors);
 void doom_hazard_particles_free(doom_hazard_particles *particles);
+void doom_hazard_particles_set_enabled(doom_hazard_particles *particles, bool enabled);
+bool doom_hazard_particles_enabled(const doom_hazard_particles *particles);
 void doom_hazard_particles_update(doom_hazard_particles *particles, float dt);
 bool doom_hazard_particles_draw(const doom_hazard_particles *particles, sdl3d_render_context *context);
 

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -29,6 +29,9 @@
 #define SIG_AMBIENT_FEEDBACK_SKIP 2005
 #define SIG_DOOR_INTERACT 2006
 #define SIG_LAUNCHER_ENTER 2007
+#define SIG_DRAGON_TELEPORT_ENTER 2008
+#define SIG_DAMAGE_FLOOR_TICK 2009
+#define SIG_LOGIC_STARTUP 2010
 #define LIFT_FLOOR_MIN_Y 0.0f
 #define LIFT_FLOOR_MAX_Y 2.5f
 #define LIFT_CEIL_Y 12.0f
@@ -52,6 +55,8 @@
 #define LAUNCHER_PAD_X 38.0f
 #define LAUNCHER_PAD_Z 68.0f
 #define FEEDBACK_AMBIENT_ZONE "ambient_zone"
+#define FEEDBACK_DAMAGE_FLOOR "damage_floor"
+#define EFFECT_NUKAGE_PARTICLES "nukage_particles"
 
 typedef struct doom_state
 {
@@ -69,9 +74,10 @@ typedef struct doom_state
     sdl3d_logic_world *logic;
     sdl3d_logic_branch ambient_feedback_branch;
     sdl3d_logic_sector_platform dynamic_lift;
+    sdl3d_logic_sector_damage_sensor damage_sensor;
     sdl3d_logic_contact_sensor launcher_sensor;
+    sdl3d_logic_contact_sensor dragon_teleport_sensor;
     sdl3d_sector_watcher sector_watcher;
-    sdl3d_teleporter dragon_teleporter;
     doom_surveillance_camera surveillance;
     sdl3d_backend current_backend;
     doom_render_profile render_profile;
@@ -79,6 +85,7 @@ typedef struct doom_state
     float teleport_feedback_timer;
     float launcher_feedback_timer;
     float damage_feedback_strength;
+    float damage_feedback_target_strength;
     float damage_pulse_timer;
     int action_pause;
     int action_menu;
@@ -96,6 +103,8 @@ typedef struct doom_state
     bool doors_ready;
     bool quit_pending;
 } doom_state;
+
+static float clamp01(float value);
 
 static void doom_state_cleanup(doom_state *state)
 {
@@ -191,7 +200,6 @@ static bool doom_logic_set_ambient(void *userdata, int ambient_id, float fade_se
 static bool doom_logic_trigger_feedback(void *userdata, const char *feedback_name, float duration_seconds,
                                         const sdl3d_properties *payload)
 {
-    (void)payload;
     doom_state *state = (doom_state *)userdata;
     if (state == NULL || feedback_name == NULL)
     {
@@ -201,6 +209,41 @@ static bool doom_logic_trigger_feedback(void *userdata, const char *feedback_nam
     if (SDL_strcmp(feedback_name, FEEDBACK_AMBIENT_ZONE) == 0)
     {
         state->ambient_feedback_timer = duration_seconds;
+        return true;
+    }
+
+    if (SDL_strcmp(feedback_name, FEEDBACK_DAMAGE_FLOOR) == 0)
+    {
+        const float damage_per_second =
+            payload != NULL ? sdl3d_properties_get_float(payload, "damage_per_second", 0.0f) : 0.0f;
+        if (damage_per_second <= 0.0f)
+        {
+            state->damage_feedback_target_strength = 0.0f;
+            return true;
+        }
+
+        state->damage_feedback_target_strength =
+            DAMAGE_FEEDBACK_MIN_STRENGTH +
+            clamp01(damage_per_second / DAMAGE_FEEDBACK_REFERENCE_DPS) * (1.0f - DAMAGE_FEEDBACK_MIN_STRENGTH);
+        return true;
+    }
+
+    return false;
+}
+
+static bool doom_logic_set_effect_active(void *userdata, const char *effect_name, bool active,
+                                         const sdl3d_properties *payload)
+{
+    (void)payload;
+    doom_state *state = (doom_state *)userdata;
+    if (state == NULL || effect_name == NULL)
+    {
+        return false;
+    }
+
+    if (SDL_strcmp(effect_name, EFFECT_NUKAGE_PARTICLES) == 0)
+    {
+        doom_hazard_particles_set_enabled(&state->hazards, active);
         return true;
     }
 
@@ -268,9 +311,12 @@ static bool doom_logic_teleport_player(void *userdata, const sdl3d_teleport_dest
                              destination->use_pitch, destination->pitch);
     state->player.proj_active = false;
     state->teleport_feedback_timer = TELEPORT_FEEDBACK_SECONDS;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Teleporter %d moved player to %.1f %.1f %.1f",
-                sdl3d_properties_get_int(payload, "teleporter_id", -1), destination->position.x,
-                destination->position.y, destination->position.z);
+    const int trigger_id =
+        payload != NULL
+            ? sdl3d_properties_get_int(payload, "teleporter_id", sdl3d_properties_get_int(payload, "sensor_id", -1))
+            : -1;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Teleport trigger %d moved player to %.1f %.1f %.1f", trigger_id,
+                destination->position.x, destination->position.y, destination->position.z);
     return true;
 }
 
@@ -304,12 +350,8 @@ static bool doom_logic_restore_camera(void *userdata, const sdl3d_properties *pa
     return true;
 }
 
-static void init_dragon_teleporter(doom_state *state)
+static sdl3d_teleport_destination dragon_teleport_destination(void)
 {
-    sdl3d_bounding_box source = {
-        sdl3d_vec3_make(22.5f, 0.0f, 86.5f),
-        sdl3d_vec3_make(25.5f, 2.4f, 89.5f),
-    };
     sdl3d_teleport_destination destination;
     SDL_zero(destination);
     destination.position = sdl3d_vec3_make(72.0f, 2.5f + PLAYER_HEIGHT, 63.0f);
@@ -317,8 +359,17 @@ static void init_dragon_teleporter(doom_state *state)
     destination.pitch = 0.0f;
     destination.use_yaw = true;
     destination.use_pitch = true;
+    return destination;
+}
 
-    sdl3d_teleporter_init(&state->dragon_teleporter, DRAGON_TELEPORTER_ID, source, destination);
+static void init_dragon_teleport_sensor(doom_state *state)
+{
+    const sdl3d_bounding_box source = {
+        sdl3d_vec3_make(22.5f, 0.0f, 86.5f),
+        sdl3d_vec3_make(25.5f, 2.4f, 89.5f),
+    };
+    sdl3d_logic_contact_sensor_init(&state->dragon_teleport_sensor, DRAGON_TELEPORTER_ID, source,
+                                    SIG_DRAGON_TELEPORT_ENTER, SDL3D_TRIGGER_EDGE_ENTER);
 }
 
 static void init_surveillance_camera(doom_state *state)
@@ -356,6 +407,11 @@ static void init_launcher_sensor(doom_state *state)
     sdl3d_logic_contact_sensor_init(&state->launcher_sensor, 1, bounds, SIG_LAUNCHER_ENTER, SDL3D_TRIGGER_EDGE_ENTER);
 }
 
+static void init_damage_sensor(doom_state *state)
+{
+    sdl3d_logic_sector_damage_sensor_init(&state->damage_sensor, 1, SIG_DAMAGE_FLOOR_TICK, 0.0f);
+}
+
 static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
 {
     state->logic = sdl3d_logic_world_create(ctx->bus, ctx->timers);
@@ -375,6 +431,7 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     adapters.door_command = doom_logic_door_command;
     adapters.set_sector_geometry = doom_logic_set_sector_geometry;
     adapters.launch_player = doom_logic_launch_player;
+    adapters.set_effect_active = doom_logic_set_effect_active;
     sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
 
     sdl3d_logic_target_context target_context;
@@ -415,6 +472,12 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
         return false;
     }
 
+    sdl3d_logic_action dragon_teleport_action = sdl3d_logic_action_make_teleport_player(dragon_teleport_destination());
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_DRAGON_TELEPORT_ENTER, &dragon_teleport_action) == 0)
+    {
+        return false;
+    }
+
     sdl3d_logic_action camera_action =
         sdl3d_logic_action_make_set_active_camera("nukage_surveillance", &state->surveillance.camera);
     if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_SURVEILLANCE_ENTER, &camera_action) == 0)
@@ -440,6 +503,37 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_LAUNCHER_ENTER, &launcher_action) == 0)
     {
         return false;
+    }
+
+    sdl3d_logic_action damage_feedback_action = sdl3d_logic_action_make_trigger_feedback(FEEDBACK_DAMAGE_FLOOR, 0.0f);
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_DAMAGE_FLOOR_TICK, &damage_feedback_action) == 0)
+    {
+        return false;
+    }
+
+    sdl3d_logic_action particles_action = sdl3d_logic_action_make_set_effect_active(EFFECT_NUKAGE_PARTICLES, true);
+    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_LOGIC_STARTUP, &particles_action) == 0)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < state->ent.robot_count; ++i)
+    {
+        if (state->ent.robots[i].actor_id <= 0)
+        {
+            continue;
+        }
+
+        sdl3d_value enabled;
+        SDL_zero(enabled);
+        enabled.type = SDL3D_VALUE_BOOL;
+        enabled.as_bool = true;
+        sdl3d_logic_action patrol_action = sdl3d_logic_action_make_set_actor_property(
+            sdl3d_logic_target_actor_id(state->ent.robots[i].actor_id), "patrol_enabled", enabled);
+        if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_LOGIC_STARTUP, &patrol_action) == 0)
+        {
+            return false;
+        }
     }
 
     return true;
@@ -540,6 +634,7 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
         doom_state_cleanup(state);
         return false;
     }
+    doom_hazard_particles_set_enabled(&state->hazards, false);
 
     if (!doom_doors_init(&state->doors))
     {
@@ -549,10 +644,16 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     state->doors_ready = true;
 
     player_init(&state->player, ctx->input);
-    init_dragon_teleporter(state);
+    init_dragon_teleport_sensor(state);
     init_surveillance_camera(state);
     init_launcher_sensor(state);
+    init_damage_sensor(state);
     if (!bind_doom_logic(ctx, state))
+    {
+        doom_state_cleanup(state);
+        return false;
+    }
+    if (!sdl3d_logic_world_emit_signal(state->logic, SIG_LOGIC_STARTUP, NULL))
     {
         doom_state_cleanup(state);
         return false;
@@ -691,16 +792,9 @@ static float clamp01(float value)
     return value;
 }
 
-static void update_damage_feedback(doom_state *state, float damage_this_tick, float dt)
+static void update_damage_feedback(doom_state *state, float dt)
 {
-    float target_strength = 0.0f;
-    if (damage_this_tick > 0.0f && state->player.last_damage_per_second > 0.0f)
-    {
-        target_strength = DAMAGE_FEEDBACK_MIN_STRENGTH +
-                          clamp01(state->player.last_damage_per_second / DAMAGE_FEEDBACK_REFERENCE_DPS) *
-                              (1.0f - DAMAGE_FEEDBACK_MIN_STRENGTH);
-    }
-
+    const float target_strength = state->damage_feedback_target_strength;
     const float rate =
         target_strength > state->damage_feedback_strength ? DAMAGE_FEEDBACK_ATTACK_RATE : DAMAGE_FEEDBACK_DECAY_RATE;
     const float blend = clamp01(rate * dt);
@@ -719,6 +813,8 @@ static void update_damage_feedback(doom_state *state, float damage_this_tick, fl
         state->damage_feedback_strength = 0.0f;
         state->damage_pulse_timer = 0.0f;
     }
+
+    state->damage_feedback_target_strength = 0.0f;
 }
 
 static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
@@ -761,8 +857,13 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
                                           sdl3d_vec3_make(state->player.mover.position.x,
                                                           state->player.mover.position.y - PLAYER_HEIGHT,
                                                           state->player.mover.position.z));
-        const float damage_this_tick = player_apply_sector_damage(&state->player, g_sectors, g_sector_count, dt);
-        update_damage_feedback(state, damage_this_tick, dt);
+        player_apply_sector_damage(&state->player, g_sectors, g_sector_count, dt);
+        sdl3d_logic_sector_damage_sensor_update(&state->damage_sensor, state->logic,
+                                                sdl3d_vec3_make(state->player.mover.position.x,
+                                                                state->player.mover.position.y - PLAYER_HEIGHT,
+                                                                state->player.mover.position.z),
+                                                dt);
+        update_damage_feedback(state, dt);
     }
 
     if (state->ambient_feedback_timer > 0.0f)
@@ -790,11 +891,10 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
         }
     }
 
-    sdl3d_teleporter_update(&state->dragon_teleporter,
-                            sdl3d_vec3_make(state->player.mover.position.x,
-                                            state->player.mover.position.y - PLAYER_HEIGHT,
-                                            state->player.mover.position.z),
-                            dt, ctx->bus);
+    sdl3d_logic_contact_sensor_update(&state->dragon_teleport_sensor, state->logic,
+                                      sdl3d_vec3_make(state->player.mover.position.x,
+                                                      state->player.mover.position.y - PLAYER_HEIGHT,
+                                                      state->player.mover.position.z));
 
     doom_surveillance_update(&state->surveillance, state->logic,
                              sdl3d_vec3_make(state->player.mover.position.x,

--- a/include/sdl3d/actor_controller.h
+++ b/include/sdl3d/actor_controller.h
@@ -169,12 +169,27 @@ extern "C"
     /**
      * @brief Update actor properties that expose patrol state.
      *
-     * Exposed keys are: state, target_waypoint, enabled, alerted, patrol_mode,
-     * patrol_speed, and patrol_wait_remaining. alerted is initialized to false
-     * only if the actor does not already define it.
+     * Exposed keys are: state, target_waypoint, patrol_enabled, enabled,
+     * alerted, patrol_mode, patrol_speed, patrol_wait_time, and
+     * patrol_wait_remaining. alerted is initialized to false only if the actor
+     * does not already define it.
      */
     void sdl3d_actor_patrol_controller_sync_properties(const sdl3d_actor_patrol_controller *controller,
                                                        sdl3d_registered_actor *actor);
+
+    /**
+     * @brief Apply actor-authored patrol properties to a controller.
+     *
+     * This lets logic actions drive patrol behavior by setting properties on
+     * the controlled actor. Recognized properties are:
+     * - patrol_enabled: bool
+     * - patrol_speed: positive float
+     * - patrol_wait_time: non-negative float
+     *
+     * Missing properties leave the current controller values unchanged.
+     */
+    void sdl3d_actor_patrol_controller_apply_actor_properties(sdl3d_actor_patrol_controller *controller,
+                                                              const sdl3d_registered_actor *actor);
 
     /**
      * @brief Advance a patrol controller and update its registered actor.

--- a/include/sdl3d/logic.h
+++ b/include/sdl3d/logic.h
@@ -132,7 +132,8 @@ extern "C"
         SDL3D_LOGIC_ACTION_TRIGGER_FEEDBACK = 12,    /**< Request a named game-owned feedback cue. */
         SDL3D_LOGIC_ACTION_DOOR_COMMAND = 13,        /**< Request a game-owned door command. */
         SDL3D_LOGIC_ACTION_SET_SECTOR_GEOMETRY = 14, /**< Request a game-owned sector geometry change. */
-        SDL3D_LOGIC_ACTION_LAUNCH_PLAYER = 15        /**< Request a game-owned player launch impulse. */
+        SDL3D_LOGIC_ACTION_LAUNCH_PLAYER = 15,       /**< Request a game-owned player launch impulse. */
+        SDL3D_LOGIC_ACTION_SET_EFFECT_ACTIVE = 16    /**< Request a game-owned named effect enable/disable. */
     } sdl3d_logic_action_type;
 
     /**
@@ -239,6 +240,17 @@ extern "C"
     typedef bool (*sdl3d_logic_launch_player_fn)(void *userdata, sdl3d_vec3 velocity, const sdl3d_properties *payload);
 
     /**
+     * @brief Callback used by logic actions that enable or disable a named effect.
+     *
+     * Effects are intentionally game-owned. A name may map to particles,
+     * lights, post-processing, decals, sound emitters, or any combination.
+     *
+     * @return true when the game recognized and applied the effect state.
+     */
+    typedef bool (*sdl3d_logic_set_effect_active_fn)(void *userdata, const char *effect_name, bool active,
+                                                     const sdl3d_properties *payload);
+
+    /**
      * @brief Game-owned operations exposed to generic logic actions.
      *
      * These callbacks keep the logic world open for game-specific effects
@@ -257,6 +269,7 @@ extern "C"
         sdl3d_logic_door_command_fn door_command;               /**< Optional door command adapter. */
         sdl3d_logic_set_sector_geometry_fn set_sector_geometry; /**< Optional sector geometry adapter. */
         sdl3d_logic_launch_player_fn launch_player;             /**< Optional player launch adapter. */
+        sdl3d_logic_set_effect_active_fn set_effect_active;     /**< Optional named effect adapter. */
     } sdl3d_logic_game_adapters;
 
     /**
@@ -362,6 +375,13 @@ extern "C"
             {
                 sdl3d_vec3 velocity;
             } launch_player;
+
+            /** @brief Request a game-owned named effect state. */
+            struct
+            {
+                const char *effect_name;
+                bool active;
+            } effect;
         };
     } sdl3d_logic_action;
 
@@ -436,6 +456,23 @@ extern "C"
         bool enabled;                 /**< Disabled sensors never emit. */
         bool was_inside;              /**< Previous proximity state, managed by update/reset. */
     } sdl3d_logic_proximity_sensor;
+
+    /**
+     * @brief Sector damage sensor for floor hazards.
+     *
+     * The sensor samples the logic world's active sector context and emits
+     * every update while @p sample_position occupies a sector whose
+     * damage_per_second is greater than or equal to @p minimum_damage_per_second.
+     * Payloads include sensor_id, event, inside, sample_position, sector_index,
+     * damage_per_second, damage_amount, and dt.
+     */
+    typedef struct sdl3d_logic_sector_damage_sensor
+    {
+        int sensor_id;                   /**< Stable editor/game id included in payloads. */
+        int signal_id;                   /**< Signal emitted for damaging floor contact. */
+        float minimum_damage_per_second; /**< Non-negative minimum damage rate required to emit. */
+        bool enabled;                    /**< Disabled sensors never emit. */
+    } sdl3d_logic_sector_damage_sensor;
 
     /**
      * @brief Result returned by a logic entity activation.
@@ -857,6 +894,15 @@ extern "C"
     sdl3d_logic_action sdl3d_logic_action_make_launch_player(sdl3d_vec3 velocity);
 
     /**
+     * @brief Create an action that enables or disables a named game-owned effect.
+     *
+     * Execution requires a set_effect_active game adapter on the logic world.
+     * The effect_name pointer is borrowed and must remain valid while the
+     * action may execute.
+     */
+    sdl3d_logic_action sdl3d_logic_action_make_set_effect_active(const char *effect_name, bool active);
+
+    /**
      * @brief Execute a target-aware action immediately.
      *
      * Core actions execute through sdl3d_action_execute using the world's signal
@@ -946,6 +992,25 @@ extern "C"
      * @brief Reset a proximity sensor's edge state.
      */
     void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor);
+
+    /**
+     * @brief Initialize a sector damage sensor.
+     *
+     * The sensor emits level-style events while the sampled point is in a
+     * damaging sector. @p minimum_damage_per_second is clamped to zero.
+     */
+    void sdl3d_logic_sector_damage_sensor_init(sdl3d_logic_sector_damage_sensor *sensor, int sensor_id, int signal_id,
+                                               float minimum_damage_per_second);
+
+    /**
+     * @brief Update a sector damage sensor and emit through @p world when needed.
+     *
+     * @param dt Simulation timestep used to compute damage_amount. Non-positive
+     *        dt prevents emission because no damage is dealt.
+     */
+    sdl3d_logic_sensor_result sdl3d_logic_sector_damage_sensor_update(sdl3d_logic_sector_damage_sensor *sensor,
+                                                                      sdl3d_logic_world *world,
+                                                                      sdl3d_vec3 sample_position, float dt);
 
     /* ================================================================== */
     /* Logic entities                                                     */

--- a/src/actor_controller.c
+++ b/src/actor_controller.c
@@ -205,13 +205,40 @@ void sdl3d_actor_patrol_controller_sync_properties(const sdl3d_actor_patrol_cont
 
     sdl3d_properties_set_string(actor->props, "state", sdl3d_actor_patrol_state_name(controller->state));
     sdl3d_properties_set_int(actor->props, "target_waypoint", controller->target_waypoint);
+    sdl3d_properties_set_bool(actor->props, "patrol_enabled", controller->enabled);
     sdl3d_properties_set_bool(actor->props, "enabled", controller->enabled);
     if (!sdl3d_properties_has(actor->props, "alerted"))
         sdl3d_properties_set_bool(actor->props, "alerted", false);
     sdl3d_properties_set_string(actor->props, "patrol_mode",
                                 controller->mode == SDL3D_ACTOR_PATROL_PING_PONG ? "ping_pong" : "loop");
     sdl3d_properties_set_float(actor->props, "patrol_speed", controller->speed);
+    sdl3d_properties_set_float(actor->props, "patrol_wait_time", controller->wait_time);
     sdl3d_properties_set_float(actor->props, "patrol_wait_remaining", controller->wait_remaining);
+}
+
+void sdl3d_actor_patrol_controller_apply_actor_properties(sdl3d_actor_patrol_controller *controller,
+                                                          const sdl3d_registered_actor *actor)
+{
+    if (controller == NULL || actor == NULL || actor->props == NULL)
+        return;
+
+    if (sdl3d_properties_has(actor->props, "patrol_enabled"))
+        controller->enabled = sdl3d_properties_get_bool(actor->props, "patrol_enabled", controller->enabled);
+
+    if (sdl3d_properties_has(actor->props, "patrol_speed"))
+    {
+        const float speed = sdl3d_properties_get_float(actor->props, "patrol_speed", controller->speed);
+        if (speed > 0.0f)
+            controller->speed = speed;
+    }
+
+    if (sdl3d_properties_has(actor->props, "patrol_wait_time"))
+    {
+        const float wait_time = sdl3d_properties_get_float(actor->props, "patrol_wait_time", controller->wait_time);
+        controller->wait_time = wait_time > 0.0f ? wait_time : 0.0f;
+        if (controller->state == SDL3D_ACTOR_PATROL_IDLE && controller->wait_remaining > controller->wait_time)
+            controller->wait_remaining = controller->wait_time;
+    }
 }
 
 sdl3d_actor_patrol_result sdl3d_actor_patrol_controller_update(sdl3d_actor_patrol_controller *controller,
@@ -226,6 +253,7 @@ sdl3d_actor_patrol_result sdl3d_actor_patrol_controller_update(sdl3d_actor_patro
         return result;
 
     result.updated = true;
+    sdl3d_actor_patrol_controller_apply_actor_properties(controller, actor);
     sdl3d_actor_patrol_controller_sync_properties(controller, actor);
     if (!controller->enabled || !actor->active || controller->waypoint_count < 2 || controller->speed <= 0.0f)
         return result;

--- a/src/logic.c
+++ b/src/logic.c
@@ -793,6 +793,16 @@ sdl3d_logic_action sdl3d_logic_action_make_launch_player(sdl3d_vec3 velocity)
     return action;
 }
 
+sdl3d_logic_action sdl3d_logic_action_make_set_effect_active(const char *effect_name, bool active)
+{
+    sdl3d_logic_action action;
+    SDL_zero(action);
+    action.type = SDL3D_LOGIC_ACTION_SET_EFFECT_ACTIVE;
+    action.effect.effect_name = effect_name;
+    action.effect.active = active;
+    return action;
+}
+
 bool sdl3d_logic_world_execute_action(sdl3d_logic_world *world, const sdl3d_logic_action *action)
 {
     return sdl3d_logic_world_execute_action_with_payload(world, action, NULL);
@@ -977,6 +987,14 @@ bool sdl3d_logic_world_execute_action_with_payload(sdl3d_logic_world *world, con
         }
         return adapters->launch_player(adapters->userdata, action->launch_player.velocity, payload);
 
+    case SDL3D_LOGIC_ACTION_SET_EFFECT_ACTIVE:
+        if (adapters == NULL || adapters->set_effect_active == NULL || action->effect.effect_name == NULL)
+        {
+            return false;
+        }
+        return adapters->set_effect_active(adapters->userdata, action->effect.effect_name, action->effect.active,
+                                           payload);
+
     case SDL3D_LOGIC_ACTION_NONE:
         break;
     }
@@ -1114,6 +1132,59 @@ void sdl3d_logic_proximity_sensor_reset(sdl3d_logic_proximity_sensor *sensor)
 {
     if (sensor != NULL)
         sensor->was_inside = false;
+}
+
+void sdl3d_logic_sector_damage_sensor_init(sdl3d_logic_sector_damage_sensor *sensor, int sensor_id, int signal_id,
+                                           float minimum_damage_per_second)
+{
+    if (sensor == NULL)
+        return;
+
+    SDL_zerop(sensor);
+    sensor->sensor_id = sensor_id;
+    sensor->signal_id = signal_id;
+    sensor->minimum_damage_per_second = clamp_non_negative_float(minimum_damage_per_second);
+    sensor->enabled = true;
+}
+
+sdl3d_logic_sensor_result sdl3d_logic_sector_damage_sensor_update(sdl3d_logic_sector_damage_sensor *sensor,
+                                                                  sdl3d_logic_world *world, sdl3d_vec3 sample_position,
+                                                                  float dt)
+{
+    if (sensor == NULL || world == NULL || !sensor->enabled || dt <= 0.0f)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const sdl3d_logic_target_context *context = sdl3d_logic_world_get_target_context(world);
+    if (context == NULL || context->level == NULL || context->sectors == NULL)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const int sector_index = sdl3d_level_find_sector_at(context->level, context->sectors, sample_position.x,
+                                                        sample_position.z, sample_position.y);
+    if (sector_index < 0 || sector_index >= context->sector_count)
+        return sensor_result(false, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    const float damage_per_second = sdl3d_sector_damage_per_second(&context->sectors[sector_index]);
+    const bool active = damage_per_second > 0.0f && damage_per_second >= sensor->minimum_damage_per_second;
+    if (!active || world->bus == NULL)
+        return sensor_result(active, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return sensor_result(active, SDL3D_LOGIC_SENSOR_EVENT_NONE);
+
+    sdl3d_properties_set_int(payload, "sensor_id", sensor->sensor_id);
+    sdl3d_properties_set_int(payload, "event", (int)SDL3D_LOGIC_SENSOR_EVENT_LEVEL);
+    sdl3d_properties_set_bool(payload, "inside", true);
+    sdl3d_properties_set_vec3(payload, "sample_position", sample_position);
+    sdl3d_properties_set_int(payload, "sector_index", sector_index);
+    sdl3d_properties_set_float(payload, "damage_per_second", damage_per_second);
+    sdl3d_properties_set_float(payload, "damage_amount",
+                               sdl3d_sector_damage_for_delta(&context->sectors[sector_index], dt));
+    sdl3d_properties_set_float(payload, "dt", dt);
+
+    sdl3d_signal_emit(world->bus, sensor->signal_id, payload);
+    sdl3d_properties_destroy(payload);
+    return sensor_result(true, SDL3D_LOGIC_SENSOR_EVENT_LEVEL);
 }
 
 bool sdl3d_logic_world_emit_signal(sdl3d_logic_world *world, int signal_id, const sdl3d_properties *payload)

--- a/tests/test_actor_controller.cpp
+++ b/tests/test_actor_controller.cpp
@@ -78,7 +78,46 @@ TEST(ActorPatrolController, MovesRegisteredActorTowardWaypoint)
     EXPECT_STREQ(sdl3d_properties_get_string(actor->props, "state", ""), "walk");
     EXPECT_EQ(sdl3d_properties_get_int(actor->props, "target_waypoint", -1), 1);
     EXPECT_TRUE(sdl3d_properties_get_bool(actor->props, "enabled", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(actor->props, "patrol_enabled", false));
     EXPECT_FALSE(sdl3d_properties_get_bool(actor->props, "alerted", true));
+
+    sdl3d_actor_registry_destroy(registry);
+}
+
+TEST(ActorPatrolController, ActorPropertiesCanDrivePatrolRuntimeConfig)
+{
+    sdl3d_actor_registry *registry = sdl3d_actor_registry_create();
+    ASSERT_NE(registry, nullptr);
+    sdl3d_registered_actor *actor = add_actor(registry);
+    ASSERT_NE(actor, nullptr);
+
+    sdl3d_actor_patrol_config config = sdl3d_actor_patrol_default_config();
+    config.start_idle = false;
+    config.speed = 1.0f;
+
+    sdl3d_actor_patrol_controller controller{};
+    sdl3d_actor_patrol_controller_init(&controller, 14, actor->id, &config);
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_actor_patrol_controller_add_waypoint(&controller, sdl3d_vec3_make(10.0f, 0.0f, 0.0f));
+
+    sdl3d_properties_set_bool(actor->props, "patrol_enabled", false);
+    sdl3d_actor_patrol_result disabled =
+        sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 1.0f, nullptr, nullptr);
+    EXPECT_TRUE(disabled.updated);
+    EXPECT_FALSE(disabled.moved);
+    EXPECT_FALSE(controller.enabled);
+    EXPECT_FLOAT_EQ(actor->position.x, 0.0f);
+
+    sdl3d_properties_set_bool(actor->props, "patrol_enabled", true);
+    sdl3d_properties_set_float(actor->props, "patrol_speed", 4.0f);
+    sdl3d_properties_set_float(actor->props, "patrol_wait_time", 0.75f);
+    sdl3d_actor_patrol_result moved =
+        sdl3d_actor_patrol_controller_update(&controller, registry, nullptr, 0.5f, nullptr, nullptr);
+    EXPECT_TRUE(moved.moved);
+    EXPECT_TRUE(controller.enabled);
+    EXPECT_FLOAT_EQ(controller.speed, 4.0f);
+    EXPECT_FLOAT_EQ(controller.wait_time, 0.75f);
+    EXPECT_FLOAT_EQ(actor->position.x, 2.0f);
 
     sdl3d_actor_registry_destroy(registry);
 }

--- a/tests/test_logic.cpp
+++ b/tests/test_logic.cpp
@@ -40,6 +40,9 @@ struct logic_signal_capture
     bool state = false;
     bool matched = false;
     float distance = -1.0f;
+    float damage_per_second = 0.0f;
+    float damage_amount = 0.0f;
+    float dt = 0.0f;
     sdl3d_vec3 sample_position = {};
     char actor_name[64] = {};
     char entity_type[32] = {};
@@ -60,6 +63,9 @@ static void capture_logic_signal(void *userdata, int signal_id, const sdl3d_prop
     capture->count_value = sdl3d_properties_get_int(payload, "count", -1);
     capture->threshold = sdl3d_properties_get_int(payload, "threshold", -1);
     capture->distance = sdl3d_properties_get_float(payload, "distance", -1.0f);
+    capture->damage_per_second = sdl3d_properties_get_float(payload, "damage_per_second", 0.0f);
+    capture->damage_amount = sdl3d_properties_get_float(payload, "damage_amount", 0.0f);
+    capture->dt = sdl3d_properties_get_float(payload, "dt", 0.0f);
     capture->state = sdl3d_properties_get_bool(payload, "state", false);
     capture->matched = sdl3d_properties_get_bool(payload, "matched", false);
     capture->sample_position = sdl3d_properties_get_vec3(payload, "sample_position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
@@ -79,6 +85,7 @@ struct logic_adapter_capture
     int door_command_count = 0;
     int set_sector_geometry_count = 0;
     int launch_player_count = 0;
+    int set_effect_active_count = 0;
     int last_teleporter_id = -1;
     int last_ambient_id = -1;
     int last_door_id = -1;
@@ -94,6 +101,8 @@ struct logic_adapter_capture
     sdl3d_camera3d last_camera = {};
     sdl3d_sector_geometry last_geometry = {};
     sdl3d_vec3 last_launch_velocity = {};
+    bool last_effect_active = false;
+    char last_effect_name[64] = {};
 };
 
 static bool capture_teleport_player(void *userdata, const sdl3d_teleport_destination *destination,
@@ -217,6 +226,22 @@ static bool capture_launch_player(void *userdata, sdl3d_vec3 velocity, const sdl
 
     capture->launch_player_count++;
     capture->last_launch_velocity = velocity;
+    return true;
+}
+
+static bool capture_set_effect_active(void *userdata, const char *effect_name, bool active,
+                                      const sdl3d_properties *payload)
+{
+    (void)payload;
+    logic_adapter_capture *capture = (logic_adapter_capture *)userdata;
+    if (capture == nullptr || effect_name == nullptr)
+    {
+        return false;
+    }
+
+    capture->set_effect_active_count++;
+    capture->last_effect_active = active;
+    SDL_snprintf(capture->last_effect_name, sizeof(capture->last_effect_name), "%s", effect_name);
     return true;
 }
 
@@ -1254,7 +1279,33 @@ TEST(LogicWorldActions, LaunchPlayerUsesGameAdapter)
     sdl3d_signal_bus_destroy(bus);
 }
 
-TEST(LogicWorldActions, DoorSectorGeometryAndLaunchRejectMissingInputs)
+TEST(LogicWorldActions, SetEffectActiveUsesGameAdapter)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_adapter_capture capture{};
+    sdl3d_logic_game_adapters adapters{};
+    adapters.userdata = &capture;
+    adapters.set_effect_active = capture_set_effect_active;
+    sdl3d_logic_world_set_game_adapters(world, &adapters);
+
+    sdl3d_logic_action enable = sdl3d_logic_action_make_set_effect_active("nukage_particles", true);
+    sdl3d_logic_action disable = sdl3d_logic_action_make_set_effect_active("nukage_particles", false);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &enable));
+    EXPECT_EQ(capture.set_effect_active_count, 1);
+    EXPECT_STREQ(capture.last_effect_name, "nukage_particles");
+    EXPECT_TRUE(capture.last_effect_active);
+
+    EXPECT_TRUE(sdl3d_logic_world_execute_action(world, &disable));
+    EXPECT_EQ(capture.set_effect_active_count, 2);
+    EXPECT_FALSE(capture.last_effect_active);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
+TEST(LogicWorldActions, DoorSectorGeometryLaunchAndEffectRejectMissingInputs)
 {
     sdl3d_signal_bus *bus = nullptr;
     sdl3d_logic_world *world = make_logic_world(&bus);
@@ -1262,25 +1313,31 @@ TEST(LogicWorldActions, DoorSectorGeometryAndLaunchRejectMissingInputs)
     sdl3d_logic_action lift =
         sdl3d_logic_action_make_set_sector_geometry(sdl3d_logic_target_sector_index(0), sdl3d_sector_geometry{});
     sdl3d_logic_action launch = sdl3d_logic_action_make_launch_player(sdl3d_vec3_make(0.0f, 12.0f, 0.0f));
+    sdl3d_logic_action effect = sdl3d_logic_action_make_set_effect_active("nukage_particles", true);
+    sdl3d_logic_action unnamed_effect = sdl3d_logic_action_make_set_effect_active(nullptr, true);
 
     EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &door, nullptr));
     EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &lift));
     EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &launch));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &effect));
 
     logic_adapter_capture capture{};
     sdl3d_logic_game_adapters adapters{};
     adapters.userdata = &capture;
     adapters.door_command = capture_door_command;
     adapters.set_sector_geometry = capture_set_sector_geometry;
+    adapters.set_effect_active = capture_set_effect_active;
     sdl3d_logic_world_set_game_adapters(world, &adapters);
 
     sdl3d_properties *payload = sdl3d_properties_create();
     EXPECT_FALSE(sdl3d_logic_world_execute_action_with_payload(world, &door, payload));
     EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &lift));
     EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &launch));
+    EXPECT_FALSE(sdl3d_logic_world_execute_action(world, &unnamed_effect));
     EXPECT_EQ(capture.door_command_count, 0);
     EXPECT_EQ(capture.set_sector_geometry_count, 0);
     EXPECT_EQ(capture.launch_player_count, 0);
+    EXPECT_EQ(capture.set_effect_active_count, 0);
 
     sdl3d_properties_destroy(payload);
     sdl3d_logic_world_destroy(world);
@@ -1596,6 +1653,49 @@ TEST(LogicWorldSensors, ProximitySensorEnterExitWithActorPayload)
     sdl3d_signal_bus_destroy(bus);
 }
 
+TEST(LogicWorldSensors, SectorDamageSensorEmitsDamagePayload)
+{
+    sdl3d_signal_bus *bus = nullptr;
+    sdl3d_logic_world *world = make_logic_world(&bus);
+    logic_signal_capture capture{};
+    ASSERT_GT(sdl3d_signal_connect(bus, 230, capture_logic_signal, &capture), 0);
+
+    sdl3d_level level{};
+    sdl3d_sector sectors[2]{};
+    level.sector_count = 2;
+    sectors[0] = make_square_sector(0.0f, 0.0f, 10.0f, 10.0f);
+    sectors[1] = make_square_sector(10.0f, 0.0f, 20.0f, 10.0f);
+    sectors[1].damage_per_second = 12.0f;
+
+    sdl3d_logic_target_context context{};
+    context.level = &level;
+    context.sectors = sectors;
+    context.sector_count = 2;
+    sdl3d_logic_world_set_target_context(world, &context);
+
+    sdl3d_logic_sector_damage_sensor sensor{};
+    sdl3d_logic_sector_damage_sensor_init(&sensor, 31, 230, 1.0f);
+
+    EXPECT_FALSE(
+        sdl3d_logic_sector_damage_sensor_update(&sensor, world, sdl3d_vec3_make(5.0f, 1.0f, 5.0f), 0.25f).emitted);
+    sdl3d_logic_sensor_result damaged =
+        sdl3d_logic_sector_damage_sensor_update(&sensor, world, sdl3d_vec3_make(15.0f, 1.0f, 5.0f), 0.25f);
+
+    EXPECT_TRUE(damaged.active);
+    EXPECT_TRUE(damaged.emitted);
+    EXPECT_EQ(damaged.event, SDL3D_LOGIC_SENSOR_EVENT_LEVEL);
+    ASSERT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.sensor_id, 31);
+    EXPECT_EQ(capture.sector_index, 1);
+    EXPECT_TRUE(capture.inside);
+    EXPECT_FLOAT_EQ(capture.damage_per_second, 12.0f);
+    EXPECT_FLOAT_EQ(capture.damage_amount, 3.0f);
+    EXPECT_FLOAT_EQ(capture.dt, 0.25f);
+
+    sdl3d_logic_world_destroy(world);
+    sdl3d_signal_bus_destroy(bus);
+}
+
 TEST(LogicWorldSensors, InvalidSensorsAreSafe)
 {
     sdl3d_signal_bus *bus = nullptr;
@@ -1628,6 +1728,15 @@ TEST(LogicWorldSensors, InvalidSensorsAreSafe)
                                       SDL3D_TRIGGER_EDGE_ENTER);
     EXPECT_FALSE(sdl3d_logic_proximity_sensor_update(&proximity, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)).emitted);
     sdl3d_logic_proximity_sensor_reset(nullptr);
+
+    sdl3d_logic_sector_damage_sensor damage{};
+    sdl3d_logic_sector_damage_sensor_init(&damage, 17, 233, -1.0f);
+    EXPECT_FALSE(
+        sdl3d_logic_sector_damage_sensor_update(nullptr, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 0.1f).emitted);
+    EXPECT_FALSE(
+        sdl3d_logic_sector_damage_sensor_update(&damage, nullptr, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 0.1f).emitted);
+    EXPECT_FALSE(
+        sdl3d_logic_sector_damage_sensor_update(&damage, world, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 0.0f).emitted);
 
     sdl3d_logic_world_destroy(world);
     sdl3d_signal_bus_destroy(bus);


### PR DESCRIPTION
## Summary
- add logic-owned named effect actions and sector damage sensors
- let patrol controllers apply actor properties so logic can drive robot patrol enable/config
- migrate doom demo damage feedback, nukage particles, robot patrol startup, and dragon teleporter to logic signals/actions
- replace doom teleporter helper usage with a generic contact sensor bound to a static teleport action

## Verification
- git diff --check
- cmake --build build/default --target sdl3d_logic_test sdl3d_actor_controller_test doom_level -j 8
- build/default/tests/sdl3d_logic_test
- build/default/tests/sdl3d_actor_controller_test
- ctest --test-dir build/default --output-on-failure -L unit