### PR TITLE
Scale Lua scripts with module manifests

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -37,7 +37,10 @@
   "scripts": [
     {
       "id": "script.pong",
-      "path": "scripts/pong.lua"
+      "path": "scripts/pong.lua",
+      "module": "pong.rules",
+      "dependencies": [],
+      "autoload": true
     }
   ],
   "input": {
@@ -418,28 +421,28 @@
       "name": "adapter.pong.serve_random",
       "kind": "action",
       "script": "script.pong",
-      "function": "pong.serve_random",
+      "function": "serve_random",
       "description": "Choose a non-extreme random serve vector for the ball."
     },
     {
       "name": "adapter.pong.reflect_from_paddle",
       "kind": "action",
       "script": "script.pong",
-      "function": "pong.reflect_from_paddle",
+      "function": "reflect_from_paddle",
       "description": "Reflect ball velocity using Pong-specific hit-offset deflection."
     },
     {
       "name": "adapter.pong.cpu_track_ball",
       "kind": "controller",
       "script": "script.pong",
-      "function": "pong.cpu_track_ball",
+      "function": "cpu_track_ball",
       "description": "Move the CPU paddle toward the current ball position."
     },
     {
       "name": "adapter.pong.ball_chase_camera",
       "kind": "camera",
       "script": "script.pong",
-      "function": "pong.ball_chase_camera",
+      "function": "ball_chase_camera",
       "description": "Build a third-person camera from the ball position and velocity."
     }
   ]

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -75,4 +75,4 @@ function pong.ball_chase_camera()
     return true
 end
 
-_G.pong = pong
+return pong

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -163,19 +163,40 @@ Lua-backed adapters are loaded from top-level scripts:
 
 ```json
 "scripts": [
-  { "id": "script.pong", "path": "scripts/pong.lua" }
+  {
+    "id": "script.pong",
+    "path": "scripts/pong.lua",
+    "module": "pong.rules",
+    "dependencies": [],
+    "autoload": true
+  }
 ],
 "adapters": [
   {
     "name": "adapter.pong.reflect_from_paddle",
     "kind": "action",
     "script": "script.pong",
-    "function": "pong.reflect_from_paddle"
+    "function": "reflect_from_paddle"
   }
 ]
 ```
 
-The loader resolves script paths relative to the JSON file, loads them into the embedded Lua runtime, and resolves dotted function names when an adapter is invoked. Native C registration remains available for host applications that need engine-facing integrations or highly optimized behavior; re-registering an adapter name overrides the authored Lua binding.
+The loader resolves script paths relative to the JSON file, validates script ids/modules/dependencies, loads modules in deterministic dependency order, and requires each Lua module file to return a table. Adapter functions are resolved from that module table at load time and stored as Lua registry references, so per-frame adapter calls do not perform dotted global string lookup.
+
+Lua modules should avoid global namespace ownership. A typical module returns a table:
+
+```lua
+local rules = {}
+
+function rules.reflect_from_paddle(target, payload)
+  -- game-specific rule code
+  return true
+end
+
+return rules
+```
+
+Native C registration remains available for host applications that need engine-facing integrations or highly optimized behavior; re-registering an adapter name overrides the authored Lua binding.
 
 Good Pong adapters:
 
@@ -221,6 +242,7 @@ The first runtime loader should:
 - parse `schema` and reject unsupported versions
 - reject duplicate entity, signal, timer, sensor, and binding names
 - validate references before gameplay starts
+- validate script ids, modules, dependency order, and adapter function references before gameplay starts
 - validate component/action payload types
 - preserve unknown properties under entity property bags
 - allow unknown component types only when configured for permissive tooling mode

--- a/include/sdl3d/script.h
+++ b/include/sdl3d/script.h
@@ -22,6 +22,17 @@ extern "C"
     typedef struct sdl3d_script_engine sdl3d_script_engine;
 
     /**
+     * @brief Opaque reference to a Lua value owned by a script engine.
+     *
+     * References remain valid until explicitly released with
+     * sdl3d_script_engine_unref() or until the script engine is destroyed.
+     */
+    typedef int sdl3d_script_ref;
+
+    /** @brief Invalid script reference value. */
+#define SDL3D_SCRIPT_REF_INVALID 0
+
+    /**
      * @brief Create a Lua script engine.
      *
      * The engine is isolated from other SDL3D systems until a caller registers
@@ -49,6 +60,55 @@ extern "C"
      */
     bool sdl3d_script_engine_load_file(sdl3d_script_engine *engine, const char *path, char *error_buffer,
                                        int error_buffer_size);
+
+    /**
+     * @brief Load a Lua file as a named module table.
+     *
+     * The file is executed and must return a table. That table is stored in the
+     * Lua registry and also published under @p module_name in the global
+     * environment for optional interactive/debug access. Prefer this API for
+     * game data scripts because it avoids large projects sharing one global
+     * namespace.
+     *
+     * @param engine Script engine.
+     * @param path Lua file path to load.
+     * @param module_name Stable module name, such as "pong.rules".
+     * @param out_module_ref Receives a registry reference to the returned table.
+     * @param error_buffer Optional human-readable error output.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the file loaded, returned a table, and was registered.
+     */
+    bool sdl3d_script_engine_load_module_file(sdl3d_script_engine *engine, const char *path, const char *module_name,
+                                              sdl3d_script_ref *out_module_ref, char *error_buffer,
+                                              int error_buffer_size);
+
+    /**
+     * @brief Resolve a function from a loaded module table.
+     *
+     * @p function_name may name a direct table field, such as "serve", or a
+     * dotted nested field, such as "rules.serve". The returned function
+     * reference is pre-resolved and can be called repeatedly without string path
+     * lookup.
+     *
+     * @param engine Script engine.
+     * @param module_ref Registry reference returned by
+     * sdl3d_script_engine_load_module_file().
+     * @param function_name Function path inside the module table.
+     * @param out_function_ref Receives a registry reference to the function.
+     * @param error_buffer Optional human-readable error output.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the function was found and referenced.
+     */
+    bool sdl3d_script_engine_ref_module_function(sdl3d_script_engine *engine, sdl3d_script_ref module_ref,
+                                                 const char *function_name, sdl3d_script_ref *out_function_ref,
+                                                 char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Release a script registry reference.
+     *
+     * Safe to call with SDL3D_SCRIPT_REF_INVALID.
+     */
+    void sdl3d_script_engine_unref(sdl3d_script_engine *engine, sdl3d_script_ref ref);
 
 #ifdef __cplusplus
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -54,9 +54,23 @@ typedef struct adapter_entry
 {
     char *name;
     char *lua_function;
+    sdl3d_script_ref lua_function_ref;
     sdl3d_game_data_adapter_fn callback;
     void *userdata;
 } adapter_entry;
+
+typedef struct script_entry
+{
+    const char *id;
+    const char *path;
+    const char *module;
+    const char **dependencies;
+    int dependency_count;
+    sdl3d_script_ref module_ref;
+    bool autoload;
+    bool loading;
+    bool loaded;
+} script_entry;
 
 typedef struct binding_entry
 {
@@ -97,6 +111,8 @@ typedef struct sdl3d_game_data_runtime
     sensor_entry *sensors;
     int sensor_count;
     sdl3d_script_engine *scripts;
+    script_entry *script_entries;
+    int script_count;
     char *base_dir;
     const char *active_camera;
     float current_dt;
@@ -552,6 +568,18 @@ static adapter_entry *find_adapter(sdl3d_game_data_runtime *runtime, const char 
     return NULL;
 }
 
+static script_entry *find_script(sdl3d_game_data_runtime *runtime, const char *id)
+{
+    if (runtime == NULL || id == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->script_count; ++i)
+    {
+        if (SDL_strcmp(runtime->script_entries[i].id, id) == 0)
+            return &runtime->script_entries[i];
+    }
+    return NULL;
+}
+
 static bool append_adapter(sdl3d_game_data_runtime *runtime, const char *name, sdl3d_game_data_adapter_fn callback,
                            void *userdata)
 {
@@ -572,9 +600,11 @@ static bool append_adapter(sdl3d_game_data_runtime *runtime, const char *name, s
     return true;
 }
 
-static bool set_adapter_lua_function(sdl3d_game_data_runtime *runtime, const char *name, const char *function_name)
+static bool set_adapter_lua_function(sdl3d_game_data_runtime *runtime, const char *name, const char *function_name,
+                                     sdl3d_script_ref function_ref)
 {
-    if (runtime == NULL || name == NULL || name[0] == '\0' || function_name == NULL || function_name[0] == '\0')
+    if (runtime == NULL || name == NULL || name[0] == '\0' || function_name == NULL || function_name[0] == '\0' ||
+        function_ref == SDL3D_SCRIPT_REF_INVALID)
         return false;
 
     adapter_entry *entry = find_adapter(runtime, name);
@@ -592,41 +622,10 @@ static bool set_adapter_lua_function(sdl3d_game_data_runtime *runtime, const cha
         return false;
     SDL_free(entry->lua_function);
     entry->lua_function = copy;
+    if (entry->lua_function_ref != SDL3D_SCRIPT_REF_INVALID)
+        sdl3d_script_engine_unref(runtime->scripts, entry->lua_function_ref);
+    entry->lua_function_ref = function_ref;
     return true;
-}
-
-static bool lua_push_function_path(lua_State *lua, const char *function_name)
-{
-    if (lua == NULL || function_name == NULL || function_name[0] == '\0')
-        return false;
-
-    char *copy = SDL_strdup(function_name);
-    if (copy == NULL)
-    {
-        lua_pushnil(lua);
-        return false;
-    }
-
-    char *save = NULL;
-    char *part = SDL_strtok_r(copy, ".", &save);
-    if (part == NULL)
-    {
-        SDL_free(copy);
-        lua_pushnil(lua);
-        return false;
-    }
-
-    lua_getglobal(lua, part);
-    part = SDL_strtok_r(NULL, ".", &save);
-    while (part != NULL && !lua_isnil(lua, -1))
-    {
-        lua_getfield(lua, -1, part);
-        lua_remove(lua, -2);
-        part = SDL_strtok_r(NULL, ".", &save);
-    }
-
-    SDL_free(copy);
-    return lua_isfunction(lua, -1);
 }
 
 static void lua_push_property_value(lua_State *lua, const sdl3d_value *value)
@@ -694,16 +693,13 @@ static void lua_push_payload(lua_State *lua, const sdl3d_properties *payload)
 static bool call_lua_adapter(sdl3d_game_data_runtime *runtime, const adapter_entry *adapter,
                              sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
-    if (runtime == NULL || runtime->scripts == NULL || adapter == NULL || adapter->lua_function == NULL)
+    if (runtime == NULL || runtime->scripts == NULL || adapter == NULL ||
+        adapter->lua_function_ref == SDL3D_SCRIPT_REF_INVALID)
         return false;
 
     lua_State *lua = sdl3d_script_engine_lua_state(runtime->scripts);
-    if (lua == NULL || !lua_push_function_path(lua, adapter->lua_function))
-    {
-        if (lua != NULL)
-            lua_pop(lua, 1);
+    if (lua == NULL || !sdl3d_script_engine_push_ref(runtime->scripts, adapter->lua_function_ref))
         return false;
-    }
 
     lua_pushstring(lua, target != NULL ? target->name : "");
     lua_push_payload(lua, payload);
@@ -970,11 +966,159 @@ static bool load_timers(sdl3d_game_data_runtime *runtime, yyjson_val *logic, cha
     return true;
 }
 
+static bool load_script_entry(sdl3d_game_data_runtime *runtime, script_entry *entry, char *error_buffer,
+                              int error_buffer_size)
+{
+    if (entry == NULL)
+        return false;
+    if (entry->loaded)
+        return true;
+    if (entry->loading)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua script dependency cycle at %s", entry->id);
+        }
+        return false;
+    }
+
+    entry->loading = true;
+    for (int i = 0; i < entry->dependency_count; ++i)
+    {
+        script_entry *dependency = find_script(runtime, entry->dependencies[i]);
+        if (dependency == NULL)
+        {
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua script %s depends on missing script %s",
+                             entry->id, entry->dependencies[i]);
+            }
+            entry->loading = false;
+            return false;
+        }
+        if (!load_script_entry(runtime, dependency, error_buffer, error_buffer_size))
+        {
+            entry->loading = false;
+            return false;
+        }
+    }
+
+    char *resolved = path_join(runtime->base_dir, entry->path);
+    if (resolved == NULL)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to resolve script path for %s", entry->id);
+        }
+        entry->loading = false;
+        return false;
+    }
+
+    char script_error[512];
+    const bool ok = sdl3d_script_engine_load_module_file(runtime->scripts, resolved, entry->module, &entry->module_ref,
+                                                         script_error, (int)sizeof(script_error));
+    SDL_free(resolved);
+    if (!ok)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua script %s (%s) failed: %s", entry->id,
+                         entry->path, script_error);
+        }
+        entry->loading = false;
+        return false;
+    }
+
+    entry->loaded = true;
+    entry->loading = false;
+    return true;
+}
+
 static bool load_scripts(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *scripts = obj_get(root, "scripts");
     if (!yyjson_is_arr(scripts) || yyjson_arr_size(scripts) == 0)
         return true;
+
+    runtime->script_count = (int)yyjson_arr_size(scripts);
+    runtime->script_entries =
+        (script_entry *)SDL_calloc((size_t)runtime->script_count, sizeof(*runtime->script_entries));
+    if (runtime->script_entries == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate script manifest");
+        return false;
+    }
+
+    for (int i = 0; i < runtime->script_count; ++i)
+    {
+        yyjson_val *script = yyjson_arr_get(scripts, (size_t)i);
+        script_entry *entry = &runtime->script_entries[i];
+        entry->id = json_string(script, "id", NULL);
+        entry->path = json_string(script, "path", NULL);
+        entry->module = json_string(script, "module", NULL);
+        entry->autoload = json_bool(script, "autoload", true);
+        entry->module_ref = SDL3D_SCRIPT_REF_INVALID;
+        if (entry->id == NULL || entry->id[0] == '\0' || entry->path == NULL || entry->path[0] == '\0' ||
+            entry->module == NULL || entry->module[0] == '\0')
+        {
+            set_error(error_buffer, error_buffer_size, "script entry requires non-empty id, path, and module");
+            return false;
+        }
+
+        for (int prior = 0; prior < i; ++prior)
+        {
+            if (SDL_strcmp(runtime->script_entries[prior].id, entry->id) == 0)
+            {
+                set_error(error_buffer, error_buffer_size, "duplicate script id");
+                return false;
+            }
+            if (SDL_strcmp(runtime->script_entries[prior].module, entry->module) == 0)
+            {
+                set_error(error_buffer, error_buffer_size, "duplicate script module");
+                return false;
+            }
+        }
+
+        yyjson_val *dependencies = obj_get(script, "dependencies");
+        if (yyjson_is_arr(dependencies) && yyjson_arr_size(dependencies) > 0)
+        {
+            entry->dependency_count = (int)yyjson_arr_size(dependencies);
+            entry->dependencies =
+                (const char **)SDL_calloc((size_t)entry->dependency_count, sizeof(*entry->dependencies));
+            if (entry->dependencies == NULL)
+            {
+                set_error(error_buffer, error_buffer_size, "failed to allocate script dependencies");
+                return false;
+            }
+            for (int dep = 0; dep < entry->dependency_count; ++dep)
+            {
+                yyjson_val *dependency = yyjson_arr_get(dependencies, (size_t)dep);
+                if (!yyjson_is_str(dependency) || yyjson_get_str(dependency)[0] == '\0')
+                {
+                    set_error(error_buffer, error_buffer_size, "script dependencies must be non-empty strings");
+                    return false;
+                }
+                entry->dependencies[dep] = yyjson_get_str(dependency);
+            }
+        }
+    }
+
+    for (int i = 0; i < runtime->script_count; ++i)
+    {
+        script_entry *entry = &runtime->script_entries[i];
+        for (int dep = 0; dep < entry->dependency_count; ++dep)
+        {
+            if (find_script(runtime, entry->dependencies[dep]) == NULL)
+            {
+                if (error_buffer != NULL && error_buffer_size > 0)
+                {
+                    SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua script %s depends on missing script %s",
+                                 entry->id, entry->dependencies[dep]);
+                }
+                return false;
+            }
+        }
+    }
 
     runtime->scripts = sdl3d_script_engine_create();
     if (runtime->scripts == NULL)
@@ -984,30 +1128,11 @@ static bool load_scripts(sdl3d_game_data_runtime *runtime, yyjson_val *root, cha
     }
 
     register_lua_api(runtime);
-    for (size_t i = 0; i < yyjson_arr_size(scripts); ++i)
+    for (int i = 0; i < runtime->script_count; ++i)
     {
-        yyjson_val *script = yyjson_arr_get(scripts, i);
-        const char *path = json_string(script, "path", NULL);
-        if (path == NULL || path[0] == '\0')
+        if (runtime->script_entries[i].autoload &&
+            !load_script_entry(runtime, &runtime->script_entries[i], error_buffer, error_buffer_size))
         {
-            set_error(error_buffer, error_buffer_size, "script entry is missing a non-empty path");
-            return false;
-        }
-
-        char *resolved = path_join(runtime->base_dir, path);
-        if (resolved == NULL)
-        {
-            set_error(error_buffer, error_buffer_size, "failed to resolve script path");
-            return false;
-        }
-
-        char script_error[512];
-        const bool ok =
-            sdl3d_script_engine_load_file(runtime->scripts, resolved, script_error, (int)sizeof(script_error));
-        SDL_free(resolved);
-        if (!ok)
-        {
-            set_error(error_buffer, error_buffer_size, script_error);
             return false;
         }
     }
@@ -1034,21 +1159,40 @@ static bool load_lua_adapters(sdl3d_game_data_runtime *runtime, yyjson_val *root
         }
 
         const char *name = json_string(adapter, "name", NULL);
-        if (!set_adapter_lua_function(runtime, name, function_name))
+        const char *script_id = json_string(adapter, "script", NULL);
+        script_entry *script = find_script(runtime, script_id);
+        if (script == NULL)
         {
-            set_error(error_buffer, error_buffer_size, "failed to register Lua adapter");
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua adapter %s references missing script %s",
+                             name != NULL ? name : "<unnamed>", script_id != NULL ? script_id : "<null>");
+            }
+            return false;
+        }
+        if (!load_script_entry(runtime, script, error_buffer, error_buffer_size))
+            return false;
+
+        sdl3d_script_ref function_ref = SDL3D_SCRIPT_REF_INVALID;
+        char script_error[256];
+        if (!sdl3d_script_engine_ref_module_function(runtime->scripts, script->module_ref, function_name, &function_ref,
+                                                     script_error, (int)sizeof(script_error)))
+        {
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size,
+                             "Lua adapter %s function %s in script %s failed: %s", name != NULL ? name : "<unnamed>",
+                             function_name, script->id, script_error);
+            }
             return false;
         }
 
-        lua_State *lua = sdl3d_script_engine_lua_state(runtime->scripts);
-        if (lua == NULL || !lua_push_function_path(lua, function_name))
+        if (!set_adapter_lua_function(runtime, name, function_name, function_ref))
         {
-            if (lua != NULL)
-                lua_pop(lua, 1);
-            set_error(error_buffer, error_buffer_size, "Lua adapter function was not found");
+            sdl3d_script_engine_unref(runtime->scripts, function_ref);
+            set_error(error_buffer, error_buffer_size, "failed to register Lua adapter");
             return false;
         }
-        lua_pop(lua, 1);
     }
     return true;
 }
@@ -1496,6 +1640,11 @@ bool sdl3d_game_data_register_adapter(sdl3d_game_data_runtime *runtime, const ch
     {
         SDL_free(entry->lua_function);
         entry->lua_function = NULL;
+        if (entry->lua_function_ref != SDL3D_SCRIPT_REF_INVALID)
+        {
+            sdl3d_script_engine_unref(runtime->scripts, entry->lua_function_ref);
+            entry->lua_function_ref = SDL3D_SCRIPT_REF_INVALID;
+        }
         entry->callback = callback;
         entry->userdata = userdata;
         return true;
@@ -1584,10 +1733,17 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     {
         SDL_free(runtime->adapters[i].name);
         SDL_free(runtime->adapters[i].lua_function);
+        sdl3d_script_engine_unref(runtime->scripts, runtime->adapters[i].lua_function_ref);
+    }
+    for (int i = 0; i < runtime->script_count; ++i)
+    {
+        sdl3d_script_engine_unref(runtime->scripts, runtime->script_entries[i].module_ref);
+        SDL_free(runtime->script_entries[i].dependencies);
     }
 
     sdl3d_script_engine_destroy(runtime->scripts);
     SDL_free(runtime->base_dir);
+    SDL_free(runtime->script_entries);
     SDL_free(runtime->signals);
     SDL_free(runtime->timers);
     SDL_free(runtime->actions);

--- a/src/script.c
+++ b/src/script.c
@@ -8,6 +8,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "lauxlib.h"
+#include "lua.h"
 #include "lualib.h"
 #include "script_internal.h"
 
@@ -22,6 +23,85 @@ static void set_script_error(char *buffer, int buffer_size, const char *message)
     {
         SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown Lua error");
     }
+}
+
+static bool push_module_table(lua_State *lua, sdl3d_script_ref module_ref)
+{
+    if (lua == NULL || module_ref == SDL3D_SCRIPT_REF_INVALID)
+    {
+        return false;
+    }
+
+    lua_rawgeti(lua, LUA_REGISTRYINDEX, module_ref);
+    if (!lua_istable(lua, -1))
+    {
+        lua_pop(lua, 1);
+        return false;
+    }
+    return true;
+}
+
+static bool publish_module_global(lua_State *lua, const char *module_name)
+{
+    if (lua == NULL || module_name == NULL || module_name[0] == '\0' || !lua_istable(lua, -1))
+    {
+        return false;
+    }
+
+    char *copy = SDL_strdup(module_name);
+    if (copy == NULL)
+    {
+        return false;
+    }
+
+    char *save = NULL;
+    char *part = SDL_strtok_r(copy, ".", &save);
+    if (part == NULL)
+    {
+        SDL_free(copy);
+        return false;
+    }
+
+    char *next = SDL_strtok_r(NULL, ".", &save);
+    if (next == NULL)
+    {
+        lua_pushvalue(lua, -1);
+        lua_setglobal(lua, part);
+        SDL_free(copy);
+        return true;
+    }
+
+    lua_getglobal(lua, part);
+    if (!lua_istable(lua, -1))
+    {
+        lua_pop(lua, 1);
+        lua_newtable(lua);
+        lua_pushvalue(lua, -1);
+        lua_setglobal(lua, part);
+    }
+
+    part = next;
+    next = SDL_strtok_r(NULL, ".", &save);
+    while (next != NULL)
+    {
+        lua_getfield(lua, -1, part);
+        if (!lua_istable(lua, -1))
+        {
+            lua_pop(lua, 1);
+            lua_newtable(lua);
+            lua_pushvalue(lua, -1);
+            lua_setfield(lua, -3, part);
+        }
+        lua_remove(lua, -2);
+        part = next;
+        next = SDL_strtok_r(NULL, ".", &save);
+    }
+
+    lua_pushvalue(lua, -2);
+    lua_setfield(lua, -2, part);
+    lua_pop(lua, 1);
+    SDL_free(copy);
+    return true;
 }
 
 sdl3d_script_engine *sdl3d_script_engine_create(void)
@@ -86,7 +166,133 @@ bool sdl3d_script_engine_load_file(sdl3d_script_engine *engine, const char *path
     return true;
 }
 
+bool sdl3d_script_engine_load_module_file(sdl3d_script_engine *engine, const char *path, const char *module_name,
+                                          sdl3d_script_ref *out_module_ref, char *error_buffer, int error_buffer_size)
+{
+    if (out_module_ref != NULL)
+    {
+        *out_module_ref = SDL3D_SCRIPT_REF_INVALID;
+    }
+    if (engine == NULL || engine->lua == NULL || path == NULL || path[0] == '\0' || module_name == NULL ||
+        module_name[0] == '\0' || out_module_ref == NULL)
+    {
+        set_script_error(error_buffer, error_buffer_size, "invalid Lua module load arguments");
+        return false;
+    }
+
+    int result = luaL_loadfile(engine->lua, path);
+    if (result == LUA_OK)
+    {
+        result = lua_pcall(engine->lua, 0, 1, 0);
+    }
+    if (result != LUA_OK)
+    {
+        set_script_error(error_buffer, error_buffer_size, lua_tostring(engine->lua, -1));
+        lua_pop(engine->lua, 1);
+        return false;
+    }
+
+    if (!lua_istable(engine->lua, -1))
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "Lua module must return a table");
+        return false;
+    }
+
+    if (!publish_module_global(engine->lua, module_name))
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "failed to publish Lua module");
+        return false;
+    }
+
+    *out_module_ref = luaL_ref(engine->lua, LUA_REGISTRYINDEX);
+    if (*out_module_ref == LUA_NOREF || *out_module_ref == LUA_REFNIL)
+    {
+        *out_module_ref = SDL3D_SCRIPT_REF_INVALID;
+        set_script_error(error_buffer, error_buffer_size, "failed to store Lua module reference");
+        return false;
+    }
+
+    return true;
+}
+
+bool sdl3d_script_engine_ref_module_function(sdl3d_script_engine *engine, sdl3d_script_ref module_ref,
+                                             const char *function_name, sdl3d_script_ref *out_function_ref,
+                                             char *error_buffer, int error_buffer_size)
+{
+    if (out_function_ref != NULL)
+    {
+        *out_function_ref = SDL3D_SCRIPT_REF_INVALID;
+    }
+    if (engine == NULL || engine->lua == NULL || function_name == NULL || function_name[0] == '\0' ||
+        out_function_ref == NULL || !push_module_table(engine->lua, module_ref))
+    {
+        set_script_error(error_buffer, error_buffer_size, "invalid Lua function reference arguments");
+        return false;
+    }
+
+    char *copy = SDL_strdup(function_name);
+    if (copy == NULL)
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "failed to copy Lua function name");
+        return false;
+    }
+
+    char *save = NULL;
+    char *part = SDL_strtok_r(copy, ".", &save);
+    while (part != NULL && !lua_isnil(engine->lua, -1))
+    {
+        lua_getfield(engine->lua, -1, part);
+        lua_remove(engine->lua, -2);
+        part = SDL_strtok_r(NULL, ".", &save);
+    }
+    SDL_free(copy);
+
+    if (!lua_isfunction(engine->lua, -1))
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "Lua module function was not found");
+        return false;
+    }
+
+    *out_function_ref = luaL_ref(engine->lua, LUA_REGISTRYINDEX);
+    if (*out_function_ref == LUA_NOREF || *out_function_ref == LUA_REFNIL)
+    {
+        *out_function_ref = SDL3D_SCRIPT_REF_INVALID;
+        set_script_error(error_buffer, error_buffer_size, "failed to store Lua function reference");
+        return false;
+    }
+
+    return true;
+}
+
+void sdl3d_script_engine_unref(sdl3d_script_engine *engine, sdl3d_script_ref ref)
+{
+    if (engine == NULL || engine->lua == NULL || ref == SDL3D_SCRIPT_REF_INVALID)
+    {
+        return;
+    }
+    luaL_unref(engine->lua, LUA_REGISTRYINDEX, ref);
+}
+
 lua_State *sdl3d_script_engine_lua_state(sdl3d_script_engine *engine)
 {
     return engine != NULL ? engine->lua : NULL;
+}
+
+bool sdl3d_script_engine_push_ref(sdl3d_script_engine *engine, sdl3d_script_ref ref)
+{
+    if (engine == NULL || engine->lua == NULL || ref == SDL3D_SCRIPT_REF_INVALID)
+    {
+        return false;
+    }
+    lua_rawgeti(engine->lua, LUA_REGISTRYINDEX, ref);
+    if (lua_isnil(engine->lua, -1))
+    {
+        lua_pop(engine->lua, 1);
+        return false;
+    }
+    return true;
 }

--- a/src/script_internal.h
+++ b/src/script_internal.h
@@ -6,5 +6,6 @@
 #include "lua.h"
 
 lua_State *sdl3d_script_engine_lua_state(sdl3d_script_engine *engine);
+bool sdl3d_script_engine_push_ref(sdl3d_script_engine *engine, sdl3d_script_ref ref);
 
 #endif /* SDL3D_SCRIPT_INTERNAL_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -204,18 +204,25 @@ else()
     sdl3d_add_test(sdl3d_game_session_test test_game_session.cpp unit)
     sdl3d_add_test(sdl3d_game_data_test test_game_data.cpp unit)
     if(EMSCRIPTEN)
-        target_compile_definitions(sdl3d_game_data_test PRIVATE SDL3D_PONG_DATA_PATH="/pong.game.json")
+        target_compile_definitions(
+            sdl3d_game_data_test
+            PRIVATE
+                SDL3D_PONG_DATA_PATH="/pong.game.json"
+                SDL3D_GAME_DATA_FIXTURE_DIR="/game_data"
+        )
         target_link_options(
             sdl3d_game_data_test
             PRIVATE
                 "--preload-file=${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json@/pong.game.json"
                 "--preload-file=${CMAKE_SOURCE_DIR}/demos/pong/data/scripts/pong.lua@/scripts/pong.lua"
+                "--preload-file=${CMAKE_SOURCE_DIR}/tests/assets/game_data@/game_data"
         )
     else()
         target_compile_definitions(
             sdl3d_game_data_test
             PRIVATE
                 SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+                SDL3D_GAME_DATA_FIXTURE_DIR="${CMAKE_SOURCE_DIR}/tests/assets/game_data"
         )
     endif()
     sdl3d_add_test(sdl3d_input_test test_input.cpp unit)

--- a/tests/assets/game_data/dependency_cycle.game.json
+++ b/tests/assets/game_data/dependency_cycle.game.json
@@ -1,0 +1,27 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Dependency Cycle",
+    "id": "test.dependency_cycle",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.a",
+      "path": "scripts/shared.lua",
+      "module": "test.a",
+      "dependencies": ["script.b"]
+    },
+    {
+      "id": "script.b",
+      "path": "scripts/rules.lua",
+      "module": "test.b",
+      "dependencies": ["script.a"]
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": []
+}

--- a/tests/assets/game_data/missing_dependency.game.json
+++ b/tests/assets/game_data/missing_dependency.game.json
@@ -1,0 +1,21 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Missing Dependency",
+    "id": "test.missing_dependency",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.rules",
+      "path": "scripts/rules.lua",
+      "module": "test.rules",
+      "dependencies": ["script.missing"]
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": []
+}

--- a/tests/assets/game_data/missing_file.game.json
+++ b/tests/assets/game_data/missing_file.game.json
@@ -1,0 +1,19 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Missing Script File",
+    "id": "test.missing_file",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.missing",
+      "path": "scripts/does_not_exist.lua",
+      "module": "test.missing"
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  }
+}

--- a/tests/assets/game_data/missing_function.game.json
+++ b/tests/assets/game_data/missing_function.game.json
@@ -1,0 +1,28 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Missing Function",
+    "id": "test.missing_function",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.rules",
+      "path": "scripts/rules.lua",
+      "module": "test.rules"
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": [],
+  "adapters": [
+    {
+      "name": "adapter.test.missing",
+      "kind": "action",
+      "script": "script.rules",
+      "function": "missing"
+    }
+  ]
+}

--- a/tests/assets/game_data/module_success.game.json
+++ b/tests/assets/game_data/module_success.game.json
@@ -1,0 +1,54 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Module Success",
+    "id": "test.module_success",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.shared",
+      "path": "scripts/shared.lua",
+      "module": "test.shared"
+    },
+    {
+      "id": "script.rules",
+      "path": "scripts/rules.lua",
+      "module": "test.rules",
+      "dependencies": ["script.shared"],
+      "autoload": false
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": [
+    {
+      "name": "entity.target",
+      "active": true,
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] }
+      }
+    }
+  ],
+  "signals": ["signal.run"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.run",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.test.run", "target": "entity.target" }
+        ]
+      }
+    ]
+  },
+  "adapters": [
+    {
+      "name": "adapter.test.run",
+      "kind": "action",
+      "script": "script.rules",
+      "function": "run"
+    }
+  ]
+}

--- a/tests/assets/game_data/no_table.game.json
+++ b/tests/assets/game_data/no_table.game.json
@@ -1,0 +1,20 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "No Table",
+    "id": "test.no_table",
+    "version": "0.1.0"
+  },
+  "scripts": [
+    {
+      "id": "script.bad",
+      "path": "scripts/no_table.lua",
+      "module": "test.bad"
+    }
+  ],
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": []
+}

--- a/tests/assets/game_data/scripts/no_table.lua
+++ b/tests/assets/game_data/scripts/no_table.lua
@@ -1,0 +1,1 @@
+return true

--- a/tests/assets/game_data/scripts/rules.lua
+++ b/tests/assets/game_data/scripts/rules.lua
@@ -1,0 +1,8 @@
+local rules = {}
+
+function rules.run(target)
+    sdl3d.set_vec3(target, "velocity", test.shared.speed(), 2.0, 0.0)
+    return true
+end
+
+return rules

--- a/tests/assets/game_data/scripts/shared.lua
+++ b/tests/assets/game_data/scripts/shared.lua
@@ -1,0 +1,7 @@
+local shared = {}
+
+function shared.speed()
+    return 7.0
+end
+
+return shared

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <string>
+
 extern "C"
 {
 #include <SDL3/SDL_stdinc.h>
@@ -30,6 +32,11 @@ bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char 
     sdl3d_properties_set_vec3(target->props, "velocity", sdl3d_vec3_make(3.0f, 1.0f, 0.0f));
     capture->calls++;
     return true;
+}
+
+std::string fixture_path(const char *filename)
+{
+    return std::string(SDL3D_GAME_DATA_FIXTURE_DIR) + "/" + filename;
 }
 
 } // namespace
@@ -163,6 +170,54 @@ TEST(GameDataRuntime, RegisteredCAdaptersOverrideLuaAdapters)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    const std::string path = fixture_path("module_success.game.json");
+    ASSERT_TRUE(sdl3d_game_data_load_file(path.c_str(), session, &runtime, error, sizeof(error))) << error;
+
+    const int run_signal = sdl3d_game_data_find_signal(runtime, "signal.run");
+    ASSERT_GE(run_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), run_signal, nullptr);
+
+    sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, "entity.target");
+    ASSERT_NE(target, nullptr);
+    const sdl3d_vec3 velocity = sdl3d_properties_get_vec3(target->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_FLOAT_EQ(velocity.x, 7.0f);
+    EXPECT_FLOAT_EQ(velocity.y, 2.0f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, RejectsLuaScriptManifestErrorsBeforeGameplay)
+{
+    const char *bad_files[] = {
+        "missing_dependency.game.json", "missing_file.game.json", "dependency_cycle.game.json",
+        "missing_function.game.json",   "no_table.game.json",
+    };
+
+    for (const char *file : bad_files)
+    {
+        sdl3d_game_session *session = nullptr;
+        ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+        char error[512]{};
+        sdl3d_game_data_runtime *runtime = nullptr;
+        const std::string path = fixture_path(file);
+        EXPECT_FALSE(sdl3d_game_data_load_file(path.c_str(), session, &runtime, error, sizeof(error))) << file;
+        EXPECT_NE(error[0], '\0') << file;
+        EXPECT_EQ(runtime, nullptr);
+
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+    }
 }
 
 TEST(GameDataRuntime, AuthoredGoalSensorDrivesScoreBinding)

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -245,6 +245,15 @@ TEST(GameDataJson, PongLogicReferencesKnownEntitiesSignalsTimersCamerasAndAdapte
     collect_named_objects(required_array(doc.root(), "scripts"), "id", &scripts);
 
     yyjson_val *adapter_array = required_array(doc.root(), "adapters");
+    yyjson_val *script_array = required_array(doc.root(), "scripts");
+    for (size_t i = 0; i < yyjson_arr_size(script_array); ++i)
+    {
+        yyjson_val *script = yyjson_arr_get(script_array, i);
+        ASSERT_TRUE(yyjson_is_obj(script));
+        EXPECT_FALSE(required_string(script, "module").empty());
+        EXPECT_FALSE(required_string(script, "path").empty());
+    }
+
     for (size_t i = 0; i < yyjson_arr_size(adapter_array); ++i)
     {
         yyjson_val *adapter = yyjson_arr_get(adapter_array, i);


### PR DESCRIPTION
## Summary
- add a script manifest model with ids, modules, dependencies, autoload, deterministic dependency loading, and duplicate/missing/cycle validation
- load Lua scripts as returned module tables and resolve adapter functions to Lua registry refs at load time
- migrate Pong to module-table Lua adapters and document the JSON/script contract
- add game-data fixtures covering dependency order, missing dependency, missing file, cycle, missing function, non-table module, and native C adapter override

## Tests
- make format
- cmake --build build/default --target sdl3d_game_data_test game_data_json_test pong_demo -j 8
- ./build/default/tests/sdl3d_game_data_test
- ./build/default/tests/game_data_json_test
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Refs #123
