### PR TITLE
Add game data validation diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ target_sources(
         src/fbx_loader.c
         src/game.c
         src/game_data.c
+        src/game_data_validation.c
         src/gltf_loader.c
         src/gl_renderer.c
         src/image.c

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -214,6 +214,22 @@ Bad Pong adapters:
 
 Those are generic actions and should remain data.
 
+## Validation
+
+Game data is validated before runtime state is instantiated. Host tools can call `sdl3d_game_data_validate_file()` directly to collect diagnostics without creating actors, input bindings, timers, or signal handlers. `sdl3d_game_data_load_file()` runs the same validation pass before loading scripts and wiring logic.
+
+Diagnostics are designed for authored content. Errors include the source file, a best-effort JSON path, and the referenced name when a reference cannot be resolved. For example, a binding action that targets a missing entity reports the action path and the missing entity name. Validation currently checks:
+
+- schema support
+- duplicate names within entity, signal, script, adapter, input action, timer, camera, and sensor namespaces
+- script ids, modules, dependencies, dependency cycles, and script file existence
+- input binding structure
+- sensor, timer, binding, action, component, adapter, and camera references
+- supported generic logic action types and required action payloads
+- warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types
+
+Validation warnings are non-fatal by default. Tooling can set `treat_warnings_as_errors` in `sdl3d_game_data_validation_options` when strict authoring is desired.
+
 ## Pong Data Proof
 
 `demos/pong/data/pong.game.json` is the first concrete file using this format. It is loaded by the Pong demo through `sdl3d_game_data_load_file()`, which instantiates the authored actors, input actions, signals, timers, sensors, and bindings into the managed game session.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -29,6 +29,38 @@ extern "C"
     /** @brief Opaque runtime created from one game JSON document. */
     typedef struct sdl3d_game_data_runtime sdl3d_game_data_runtime;
 
+    /** @brief Authored game data diagnostic severity. */
+    typedef enum sdl3d_game_data_diagnostic_severity
+    {
+        /** @brief Non-fatal issue that authors should review. */
+        SDL3D_GAME_DATA_DIAGNOSTIC_WARNING = 1,
+        /** @brief Fatal issue that prevents the data from loading. */
+        SDL3D_GAME_DATA_DIAGNOSTIC_ERROR = 2,
+    } sdl3d_game_data_diagnostic_severity;
+
+    /**
+     * @brief Callback for authored game data validation diagnostics.
+     *
+     * @p json_path is a best-effort JSON path to the authored object or field
+     * that produced the diagnostic. @p message is a human-readable description
+     * intended to be actionable without stepping through engine code.
+     */
+    typedef void (*sdl3d_game_data_diagnostic_fn)(void *userdata, sdl3d_game_data_diagnostic_severity severity,
+                                                  const char *json_path, const char *message);
+
+    /**
+     * @brief Options controlling authored game data validation.
+     */
+    typedef struct sdl3d_game_data_validation_options
+    {
+        /** @brief Optional diagnostic callback. */
+        sdl3d_game_data_diagnostic_fn diagnostic;
+        /** @brief User pointer passed to @p diagnostic. */
+        void *userdata;
+        /** @brief When true, warnings also make validation fail. */
+        bool treat_warnings_as_errors;
+    } sdl3d_game_data_validation_options;
+
     /**
      * @brief Named game-specific callback invoked by JSON actions/components.
      *
@@ -61,6 +93,23 @@ extern "C"
      */
     bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sdl3d_game_data_runtime **out_runtime,
                                    char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Validate a JSON game data file without instantiating runtime state.
+     *
+     * Validation checks schema, authored names, references, supported generic
+     * logic primitives, script manifest structure, dependency cycles, and script
+     * file existence. It can emit warnings for suspicious but non-fatal data,
+     * such as unused adapters or unsupported component types.
+     *
+     * @param path JSON file path.
+     * @param options Optional validation options and diagnostic callback.
+     * @param error_buffer Optional buffer for the first fatal diagnostic.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when no fatal validation error was found.
+     */
+    bool sdl3d_game_data_validate_file(const char *path, const sdl3d_game_data_validation_options *options,
+                                       char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Destroy a loaded game data runtime.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9,6 +9,7 @@
 #include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include "game_data_validation.h"
 #include "lauxlib.h"
 #include "lua.h"
 #include "script_internal.h"
@@ -1696,6 +1697,11 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
     {
         sdl3d_game_data_destroy(runtime);
         set_error(error_buffer, error_buffer_size, "failed to resolve game data base directory");
+        return false;
+    }
+    if (!sdl3d_game_data_validate_document(root, path, runtime->base_dir, NULL, error_buffer, error_buffer_size))
+    {
+        sdl3d_game_data_destroy(runtime);
         return false;
     }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1,0 +1,1097 @@
+/**
+ * @file game_data_validation.c
+ * @brief Validation for JSON-authored game data.
+ */
+
+#include "game_data_validation.h"
+
+#include <stdarg.h>
+
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_stdinc.h>
+
+#define PATH_BUFFER_SIZE 256
+
+typedef struct name_table
+{
+    const char **names;
+    const char **paths;
+    int count;
+} name_table;
+
+typedef struct script_manifest
+{
+    const char *id;
+    const char *path;
+    const char *module;
+    const char *json_path;
+    const char **dependencies;
+    int dependency_count;
+    bool visiting;
+    bool visited;
+} script_manifest;
+
+typedef struct validation_context
+{
+    const sdl3d_game_data_validation_options *options;
+    const char *source_path;
+    const char *base_dir;
+    char *error_buffer;
+    int error_buffer_size;
+    bool failed;
+} validation_context;
+
+typedef struct validation_names
+{
+    name_table entities;
+    name_table signals;
+    name_table scripts;
+    name_table script_modules;
+    name_table adapters;
+    name_table actions;
+    name_table timers;
+    name_table cameras;
+    name_table sensors;
+    name_table used_adapters;
+    name_table used_scripts;
+    script_manifest *script_manifests;
+    int script_count;
+} validation_names;
+
+static yyjson_val *obj_get(yyjson_val *object, const char *key)
+{
+    return yyjson_is_obj(object) ? yyjson_obj_get(object, key) : NULL;
+}
+
+static const char *json_string(yyjson_val *object, const char *key)
+{
+    yyjson_val *value = obj_get(object, key);
+    return yyjson_is_str(value) ? yyjson_get_str(value) : NULL;
+}
+
+static bool is_non_empty_string(yyjson_val *object, const char *key)
+{
+    const char *value = json_string(object, key);
+    return value != NULL && value[0] != '\0';
+}
+
+static void set_first_error(validation_context *ctx, const char *json_path, const char *message)
+{
+    if (ctx->error_buffer == NULL || ctx->error_buffer_size <= 0 || ctx->error_buffer[0] != '\0')
+    {
+        return;
+    }
+
+    SDL_snprintf(ctx->error_buffer, (size_t)ctx->error_buffer_size, "%s: %s: %s",
+                 ctx->source_path != NULL ? ctx->source_path : "<game-data>", json_path != NULL ? json_path : "$",
+                 message != NULL ? message : "unknown validation error");
+}
+
+static bool emit_diagnostic(validation_context *ctx, sdl3d_game_data_diagnostic_severity severity,
+                            const char *json_path, const char *format, ...)
+{
+    char message[384];
+    va_list args;
+    va_start(args, format);
+    SDL_vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+
+    if (ctx->options != NULL && ctx->options->diagnostic != NULL)
+    {
+        ctx->options->diagnostic(ctx->options->userdata, severity, json_path != NULL ? json_path : "$", message);
+    }
+
+    if (severity == SDL3D_GAME_DATA_DIAGNOSTIC_ERROR ||
+        (severity == SDL3D_GAME_DATA_DIAGNOSTIC_WARNING && ctx->options != NULL &&
+         ctx->options->treat_warnings_as_errors))
+    {
+        ctx->failed = true;
+        set_first_error(ctx, json_path, message);
+        return false;
+    }
+    return true;
+}
+
+static bool validation_error(validation_context *ctx, const char *json_path, const char *format, ...)
+{
+    char message[384];
+    va_list args;
+    va_start(args, format);
+    SDL_vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+    return emit_diagnostic(ctx, SDL3D_GAME_DATA_DIAGNOSTIC_ERROR, json_path, "%s", message);
+}
+
+static bool validation_warning(validation_context *ctx, const char *json_path, const char *format, ...)
+{
+    char message[384];
+    va_list args;
+    va_start(args, format);
+    SDL_vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+    return emit_diagnostic(ctx, SDL3D_GAME_DATA_DIAGNOSTIC_WARNING, json_path, "%s", message);
+}
+
+static void format_path(char *buffer, size_t buffer_size, const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    SDL_vsnprintf(buffer, buffer_size, format, args);
+    va_end(args);
+}
+
+static void name_table_destroy(name_table *table)
+{
+    if (table == NULL)
+        return;
+    for (int i = 0; i < table->count; ++i)
+        SDL_free((void *)table->paths[i]);
+    SDL_free(table->names);
+    SDL_free(table->paths);
+    table->names = NULL;
+    table->paths = NULL;
+    table->count = 0;
+}
+
+static bool name_table_contains(const name_table *table, const char *name)
+{
+    if (table == NULL || name == NULL)
+        return false;
+    for (int i = 0; i < table->count; ++i)
+    {
+        if (SDL_strcmp(table->names[i], name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static const char *name_table_path(const name_table *table, const char *name)
+{
+    if (table == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < table->count; ++i)
+    {
+        if (SDL_strcmp(table->names[i], name) == 0)
+            return table->paths[i];
+    }
+    return NULL;
+}
+
+static bool name_table_add(name_table *table, const char *name, const char *json_path)
+{
+    char *path_copy = SDL_strdup(json_path != NULL ? json_path : "$");
+    if (path_copy == NULL)
+        return false;
+
+    const int next_count = table->count + 1;
+    const char **names = (const char **)SDL_realloc(table->names, (size_t)next_count * sizeof(*names));
+    if (names == NULL)
+    {
+        SDL_free(path_copy);
+        return false;
+    }
+    table->names = names;
+
+    const char **paths = (const char **)SDL_realloc(table->paths, (size_t)next_count * sizeof(*paths));
+    if (paths == NULL)
+    {
+        SDL_free(path_copy);
+        return false;
+    }
+    table->paths = paths;
+
+    table->names[table->count] = name;
+    table->paths[table->count] = path_copy;
+    table->count = next_count;
+    return true;
+}
+
+static bool require_unique_name(validation_context *ctx, name_table *table, const char *kind, const char *name,
+                                const char *json_path)
+{
+    if (name == NULL || name[0] == '\0')
+    {
+        return validation_error(ctx, json_path, "%s requires a non-empty name", kind);
+    }
+    if (name_table_contains(table, name))
+    {
+        return validation_error(ctx, json_path, "duplicate %s '%s' previously declared at %s", kind, name,
+                                name_table_path(table, name));
+    }
+    if (!name_table_add(table, name, json_path))
+    {
+        return validation_error(ctx, json_path, "failed to allocate validation name table for %s '%s'", kind, name);
+    }
+    return true;
+}
+
+static bool require_ref(validation_context *ctx, const name_table *table, const char *kind, const char *name,
+                        const char *json_path)
+{
+    if (name == NULL || name[0] == '\0')
+    {
+        return validation_error(ctx, json_path, "missing %s reference", kind);
+    }
+    if (!name_table_contains(table, name))
+    {
+        return validation_error(ctx, json_path, "unknown %s reference '%s'", kind, name);
+    }
+    return true;
+}
+
+static bool note_name(name_table *table, const char *name, const char *json_path)
+{
+    if (name == NULL || name[0] == '\0' || name_table_contains(table, name))
+        return true;
+    return name_table_add(table, name, json_path);
+}
+
+static bool path_is_absolute(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+    if (path[0] == '/' || path[0] == '\\')
+        return true;
+    return SDL_strlen(path) > 2 && path[1] == ':';
+}
+
+static char *path_dirname(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+
+    const char *last = NULL;
+    for (const char *p = path; *p != '\0'; ++p)
+    {
+        if (*p == '/' || *p == '\\')
+            last = p;
+    }
+
+    if (last == NULL)
+        return SDL_strdup(".");
+
+    const size_t length = (size_t)(last - path);
+    if (length == 0)
+        return SDL_strdup(path[0] == '\\' ? "\\" : "/");
+
+    char *dir = (char *)SDL_malloc(length + 1);
+    if (dir == NULL)
+        return NULL;
+    SDL_memcpy(dir, path, length);
+    dir[length] = '\0';
+    return dir;
+}
+
+static char *path_join(const char *base_dir, const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    if (path_is_absolute(path) || base_dir == NULL || base_dir[0] == '\0')
+        return SDL_strdup(path);
+
+    const size_t base_len = SDL_strlen(base_dir);
+    const size_t path_len = SDL_strlen(path);
+    const bool needs_sep = base_len > 0 && base_dir[base_len - 1] != '/' && base_dir[base_len - 1] != '\\';
+    char *joined = (char *)SDL_malloc(base_len + (needs_sep ? 1u : 0u) + path_len + 1u);
+    if (joined == NULL)
+        return NULL;
+
+    SDL_memcpy(joined, base_dir, base_len);
+    size_t offset = base_len;
+    if (needs_sep)
+        joined[offset++] = '/';
+    SDL_memcpy(joined + offset, path, path_len);
+    joined[offset + path_len] = '\0';
+    return joined;
+}
+
+static bool script_path_exists(validation_context *ctx, const char *script_path, const char *json_path)
+{
+    char *resolved = path_join(ctx->base_dir, script_path);
+    if (resolved == NULL)
+    {
+        return validation_error(ctx, json_path, "failed to resolve script path '%s'", script_path);
+    }
+
+    SDL_IOStream *io = SDL_IOFromFile(resolved, "rb");
+    if (io == NULL)
+    {
+        const bool ok = validation_error(ctx, json_path, "script file '%s' does not exist", script_path);
+        SDL_free(resolved);
+        return ok;
+    }
+
+    SDL_CloseIO(io);
+    SDL_free(resolved);
+    return true;
+}
+
+static bool is_axis_name(const char *axis)
+{
+    return axis != NULL && (SDL_strcmp(axis, "x") == 0 || SDL_strcmp(axis, "y") == 0 || SDL_strcmp(axis, "z") == 0);
+}
+
+static bool is_side_name(const char *side)
+{
+    return side != NULL && (SDL_strcmp(side, "min") == 0 || SDL_strcmp(side, "max") == 0);
+}
+
+static bool is_compare_op(const char *op)
+{
+    return op != NULL && (SDL_strcmp(op, ">=") == 0 || SDL_strcmp(op, ">") == 0 || SDL_strcmp(op, "<=") == 0 ||
+                          SDL_strcmp(op, "<") == 0 || SDL_strcmp(op, "==") == 0);
+}
+
+static bool is_vec_array(yyjson_val *value, size_t min_count)
+{
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < min_count)
+        return false;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        if (!yyjson_is_num(yyjson_arr_get(value, i)))
+            return false;
+    }
+    return true;
+}
+
+static bool is_supported_component_type(const char *type)
+{
+    const char *known[] = {
+        "adapter.controller", "collision.aabb",    "collision.circle", "control.axis_1d",
+        "motion.velocity_2d", "particles.emitter", "render.cube",      "render.sphere",
+    };
+
+    if (type == NULL)
+        return false;
+    for (size_t i = 0; i < SDL_arraysize(known); ++i)
+    {
+        if (SDL_strcmp(type, known[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool validate_script_cycle(validation_context *ctx, validation_names *names, script_manifest *script);
+
+static script_manifest *find_script_manifest(validation_names *names, const char *id)
+{
+    if (names == NULL || id == NULL)
+        return NULL;
+    for (int i = 0; i < names->script_count; ++i)
+    {
+        if (SDL_strcmp(names->script_manifests[i].id, id) == 0)
+            return &names->script_manifests[i];
+    }
+    return NULL;
+}
+
+static bool validate_script_dependency(validation_context *ctx, validation_names *names, script_manifest *script,
+                                       const char *dependency)
+{
+    script_manifest *target = find_script_manifest(names, dependency);
+    if (target == NULL)
+    {
+        return validation_error(ctx, script->json_path, "script '%s' depends on unknown script '%s'", script->id,
+                                dependency);
+    }
+    return validate_script_cycle(ctx, names, target);
+}
+
+static bool validate_script_cycle(validation_context *ctx, validation_names *names, script_manifest *script)
+{
+    if (script->visited)
+        return true;
+    if (script->visiting)
+    {
+        return validation_error(ctx, script->json_path, "script dependency cycle reaches '%s'", script->id);
+    }
+
+    script->visiting = true;
+    for (int i = 0; i < script->dependency_count; ++i)
+    {
+        if (!validate_script_dependency(ctx, names, script, script->dependencies[i]))
+            return false;
+    }
+    script->visiting = false;
+    script->visited = true;
+    return true;
+}
+
+static bool collect_signals(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *signals = obj_get(root, "signals");
+    if (signals == NULL)
+        return true;
+    if (!yyjson_is_arr(signals))
+        return validation_error(ctx, "$.signals", "signals must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(signals); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.signals[%zu]", i);
+        yyjson_val *signal = yyjson_arr_get(signals, i);
+        if (!yyjson_is_str(signal) || yyjson_get_str(signal)[0] == '\0')
+            return validation_error(ctx, path, "signal entries must be non-empty strings");
+        if (!require_unique_name(ctx, &names->signals, "signal", yyjson_get_str(signal), path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_entities(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *entities = obj_get(root, "entities");
+    if (entities == NULL)
+        return true;
+    if (!yyjson_is_arr(entities))
+        return validation_error(ctx, "$.entities", "entities must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(entities); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.entities[%zu]", i);
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        if (!yyjson_is_obj(entity))
+            return validation_error(ctx, path, "entity entries must be objects");
+        if (!require_unique_name(ctx, &names->entities, "entity", json_string(entity, "name"), path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_cameras(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *cameras = obj_get(obj_get(root, "world"), "cameras");
+    if (cameras == NULL)
+        return true;
+    if (!yyjson_is_arr(cameras))
+        return validation_error(ctx, "$.world.cameras", "world cameras must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(cameras); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.world.cameras[%zu]", i);
+        yyjson_val *camera = yyjson_arr_get(cameras, i);
+        if (!yyjson_is_obj(camera))
+            return validation_error(ctx, path, "camera entries must be objects");
+        if (!require_unique_name(ctx, &names->cameras, "camera", json_string(camera, "name"), path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_input_actions(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *contexts = obj_get(obj_get(root, "input"), "contexts");
+    if (contexts == NULL)
+        return true;
+    if (!yyjson_is_arr(contexts))
+        return validation_error(ctx, "$.input.contexts", "input contexts must be an array");
+
+    for (size_t c = 0; c < yyjson_arr_size(contexts); ++c)
+    {
+        yyjson_val *context = yyjson_arr_get(contexts, c);
+        yyjson_val *actions = obj_get(context, "actions");
+        if (actions == NULL)
+            continue;
+        if (!yyjson_is_arr(actions))
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.input.contexts[%zu].actions", c);
+            return validation_error(ctx, path, "input context actions must be an array");
+        }
+        for (size_t a = 0; a < yyjson_arr_size(actions); ++a)
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.input.contexts[%zu].actions[%zu]", c, a);
+            yyjson_val *action = yyjson_arr_get(actions, a);
+            if (!yyjson_is_obj(action))
+                return validation_error(ctx, path, "input actions must be objects");
+            if (!require_unique_name(ctx, &names->actions, "input action", json_string(action, "name"), path))
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool collect_timers(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *timers = obj_get(obj_get(root, "logic"), "timers");
+    if (timers == NULL)
+        return true;
+    if (!yyjson_is_arr(timers))
+        return validation_error(ctx, "$.logic.timers", "logic timers must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(timers); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.logic.timers[%zu]", i);
+        yyjson_val *timer = yyjson_arr_get(timers, i);
+        if (!yyjson_is_obj(timer))
+            return validation_error(ctx, path, "timer entries must be objects");
+        if (!require_unique_name(ctx, &names->timers, "timer", json_string(timer, "name"), path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_adapters(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *adapters = obj_get(root, "adapters");
+    if (adapters == NULL)
+        return true;
+    if (!yyjson_is_arr(adapters))
+        return validation_error(ctx, "$.adapters", "adapters must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(adapters); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.adapters[%zu]", i);
+        yyjson_val *adapter = yyjson_arr_get(adapters, i);
+        if (!yyjson_is_obj(adapter))
+            return validation_error(ctx, path, "adapter entries must be objects");
+        if (!require_unique_name(ctx, &names->adapters, "adapter", json_string(adapter, "name"), path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_scripts(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *scripts = obj_get(root, "scripts");
+    if (scripts == NULL)
+        return true;
+    if (!yyjson_is_arr(scripts))
+        return validation_error(ctx, "$.scripts", "scripts must be an array");
+
+    names->script_count = (int)yyjson_arr_size(scripts);
+    names->script_manifests =
+        (script_manifest *)SDL_calloc((size_t)names->script_count, sizeof(*names->script_manifests));
+    if (names->script_manifests == NULL && names->script_count > 0)
+        return validation_error(ctx, "$.scripts", "failed to allocate script validation table");
+
+    for (int i = 0; i < names->script_count; ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.scripts[%d]", i);
+        yyjson_val *script = yyjson_arr_get(scripts, (size_t)i);
+        script_manifest *manifest = &names->script_manifests[i];
+        if (!yyjson_is_obj(script))
+            return validation_error(ctx, path, "script entries must be objects");
+
+        manifest->id = json_string(script, "id");
+        manifest->path = json_string(script, "path");
+        manifest->module = json_string(script, "module");
+
+        if (!require_unique_name(ctx, &names->scripts, "script id", manifest->id, path))
+            return false;
+        manifest->json_path = names->scripts.paths[names->scripts.count - 1];
+        if (!require_unique_name(ctx, &names->script_modules, "script module", manifest->module, path))
+            return false;
+        if (manifest->path == NULL || manifest->path[0] == '\0')
+            return validation_error(ctx, path, "script '%s' requires a non-empty path", manifest->id);
+        if (!script_path_exists(ctx, manifest->path, path))
+            return false;
+
+        yyjson_val *dependencies = obj_get(script, "dependencies");
+        if (dependencies == NULL)
+            continue;
+        if (!yyjson_is_arr(dependencies))
+            return validation_error(ctx, path, "script '%s' dependencies must be an array", manifest->id);
+
+        manifest->dependency_count = (int)yyjson_arr_size(dependencies);
+        manifest->dependencies =
+            (const char **)SDL_calloc((size_t)manifest->dependency_count, sizeof(*manifest->dependencies));
+        if (manifest->dependencies == NULL && manifest->dependency_count > 0)
+            return validation_error(ctx, path, "failed to allocate dependencies for script '%s'", manifest->id);
+        for (int d = 0; d < manifest->dependency_count; ++d)
+        {
+            char dep_path[PATH_BUFFER_SIZE];
+            format_path(dep_path, sizeof(dep_path), "%s.dependencies[%d]", path, d);
+            yyjson_val *dependency = yyjson_arr_get(dependencies, (size_t)d);
+            if (!yyjson_is_str(dependency) || yyjson_get_str(dependency)[0] == '\0')
+                return validation_error(ctx, dep_path, "script dependencies must be non-empty strings");
+            manifest->dependencies[d] = yyjson_get_str(dependency);
+        }
+    }
+
+    for (int i = 0; i < names->script_count; ++i)
+    {
+        if (!validate_script_cycle(ctx, names, &names->script_manifests[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_sensors(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *sensors = obj_get(obj_get(root, "logic"), "sensors");
+    if (sensors == NULL)
+        return true;
+    if (!yyjson_is_arr(sensors))
+        return validation_error(ctx, "$.logic.sensors", "logic sensors must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(sensors); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.logic.sensors[%zu]", i);
+        yyjson_val *sensor = yyjson_arr_get(sensors, i);
+        if (!yyjson_is_obj(sensor))
+            return validation_error(ctx, path, "sensor entries must be objects");
+        const char *name = json_string(sensor, "name");
+        if (name != NULL && name[0] != '\0' && !require_unique_name(ctx, &names->sensors, "sensor", name, path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_names(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
+           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
+           collect_input_actions(ctx, root, names) && collect_cameras(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
+}
+
+static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *contexts = obj_get(obj_get(root, "input"), "contexts");
+    for (size_t c = 0; yyjson_is_arr(contexts) && c < yyjson_arr_size(contexts); ++c)
+    {
+        yyjson_val *actions = obj_get(yyjson_arr_get(contexts, c), "actions");
+        for (size_t a = 0; yyjson_is_arr(actions) && a < yyjson_arr_size(actions); ++a)
+        {
+            yyjson_val *action = yyjson_arr_get(actions, a);
+            yyjson_val *bindings = obj_get(action, "bindings");
+            if (bindings == NULL)
+                continue;
+            if (!yyjson_is_arr(bindings))
+            {
+                char path[PATH_BUFFER_SIZE];
+                format_path(path, sizeof(path), "$.input.contexts[%zu].actions[%zu].bindings", c, a);
+                return validation_error(ctx, path, "input action bindings must be an array");
+            }
+
+            for (size_t b = 0; b < yyjson_arr_size(bindings); ++b)
+            {
+                char path[PATH_BUFFER_SIZE];
+                format_path(path, sizeof(path), "$.input.contexts[%zu].actions[%zu].bindings[%zu]", c, a, b);
+                yyjson_val *binding = yyjson_arr_get(bindings, b);
+                const char *device = json_string(binding, "device");
+                if (SDL_strcmp(device != NULL ? device : "", "keyboard") == 0)
+                {
+                    if (!is_non_empty_string(binding, "key"))
+                        return validation_error(ctx, path, "keyboard binding requires a non-empty key");
+                }
+                else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
+                {
+                    if (!is_non_empty_string(binding, "axis") && !is_non_empty_string(binding, "button"))
+                        return validation_error(ctx, path, "gamepad binding requires an axis or button");
+                }
+                else
+                {
+                    return validation_error(ctx, path, "unsupported input binding device '%s'",
+                                            device != NULL ? device : "<missing>");
+                }
+            }
+        }
+    }
+    return true;
+}
+
+static bool validate_components(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *entities = obj_get(root, "entities");
+    for (size_t e = 0; yyjson_is_arr(entities) && e < yyjson_arr_size(entities); ++e)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, e);
+        yyjson_val *components = obj_get(entity, "components");
+        if (components == NULL)
+            continue;
+        if (!yyjson_is_arr(components))
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.entities[%zu].components", e);
+            return validation_error(ctx, path, "entity components must be an array");
+        }
+
+        for (size_t c = 0; c < yyjson_arr_size(components); ++c)
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.entities[%zu].components[%zu]", e, c);
+            yyjson_val *component = yyjson_arr_get(components, c);
+            const char *type = json_string(component, "type");
+            if (type == NULL || type[0] == '\0')
+                return validation_error(ctx, path, "component requires a non-empty type");
+            if (!is_supported_component_type(type) &&
+                !validation_warning(ctx, path, "unsupported component type '%s'", type))
+            {
+                return false;
+            }
+            if (SDL_strcmp(type, "control.axis_1d") == 0)
+            {
+                if (!is_axis_name(json_string(component, "axis")))
+                    return validation_error(ctx, path, "control.axis_1d requires axis x, y, or z");
+                if (!require_ref(ctx, &names->actions, "input action", json_string(component, "negative"), path) ||
+                    !require_ref(ctx, &names->actions, "input action", json_string(component, "positive"), path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "adapter.controller") == 0)
+            {
+                const char *adapter = json_string(component, "adapter");
+                if (!require_ref(ctx, &names->adapters, "adapter", adapter, path))
+                    return false;
+                if (!note_name(&names->used_adapters, adapter, path))
+                    return validation_error(ctx, path, "failed to record adapter use");
+                if (json_string(component, "target") != NULL &&
+                    !require_ref(ctx, &names->entities, "entity", json_string(component, "target"), path))
+                    return false;
+            }
+        }
+    }
+    return true;
+}
+
+static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
+                                  validation_names *names);
+
+static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                validation_names *names)
+{
+    if (!yyjson_is_obj(action))
+        return validation_error(ctx, json_path, "logic action must be an object");
+    const char *type = json_string(action, "type");
+    if (type == NULL || type[0] == '\0')
+        return validation_error(ctx, json_path, "logic action requires a non-empty type");
+
+    if (SDL_strcmp(type, "signal.emit") == 0)
+        return require_ref(ctx, &names->signals, "signal", json_string(action, "signal"), json_path);
+    if (SDL_strcmp(type, "timer.start") == 0)
+        return require_ref(ctx, &names->timers, "timer", json_string(action, "timer"), json_path);
+    if (SDL_strcmp(type, "property.set") == 0 || SDL_strcmp(type, "property.add") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        if (!is_non_empty_string(action, "key"))
+            return validation_error(ctx, json_path, "%s requires a non-empty key", type);
+        if (obj_get(action, "value") == NULL)
+            return validation_error(ctx, json_path, "%s requires a value", type);
+        return true;
+    }
+    if (SDL_strcmp(type, "transform.set_position") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        if (!is_vec_array(obj_get(action, "position"), 2))
+            return validation_error(ctx, json_path, "transform.set_position requires a numeric position array");
+        return true;
+    }
+    if (SDL_strcmp(type, "camera.toggle") == 0)
+    {
+        return require_ref(ctx, &names->cameras, "camera", json_string(action, "camera"), json_path) &&
+               require_ref(ctx, &names->cameras, "camera", json_string(action, "fallback"), json_path);
+    }
+    if (SDL_strcmp(type, "adapter.invoke") == 0)
+    {
+        const char *adapter = json_string(action, "adapter");
+        if (!require_ref(ctx, &names->adapters, "adapter", adapter, json_path))
+            return false;
+        if (!note_name(&names->used_adapters, adapter, json_path))
+            return validation_error(ctx, json_path, "failed to record adapter use");
+        if (json_string(action, "target") != NULL &&
+            !require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        return true;
+    }
+    if (SDL_strcmp(type, "branch") == 0)
+    {
+        yyjson_val *condition = obj_get(action, "if");
+        if (!yyjson_is_obj(condition))
+            return validation_error(ctx, json_path, "branch requires an object 'if' condition");
+        if (SDL_strcmp(json_string(condition, "type") != NULL ? json_string(condition, "type") : "",
+                       "property.compare") != 0)
+            return validation_error(ctx, json_path, "branch currently supports only property.compare conditions");
+        if (!require_ref(ctx, &names->entities, "entity", json_string(condition, "target"), json_path))
+            return false;
+        if (!is_non_empty_string(condition, "key"))
+            return validation_error(ctx, json_path, "property.compare requires a non-empty key");
+        if (!is_compare_op(json_string(condition, "op")))
+            return validation_error(ctx, json_path, "property.compare requires a supported comparison operator");
+        if (obj_get(condition, "value") == NULL)
+            return validation_error(ctx, json_path, "property.compare requires a value");
+        char then_path[PATH_BUFFER_SIZE];
+        char else_path[PATH_BUFFER_SIZE];
+        format_path(then_path, sizeof(then_path), "%s.then", json_path);
+        format_path(else_path, sizeof(else_path), "%s.else", json_path);
+        return validate_action_array(ctx, obj_get(action, "then"), then_path, names) &&
+               validate_action_array(ctx, obj_get(action, "else"), else_path, names);
+    }
+
+    return validation_error(ctx, json_path, "unsupported logic action type '%s'", type);
+}
+
+static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
+                                  validation_names *names)
+{
+    if (!yyjson_is_arr(actions))
+        return validation_error(ctx, json_path, "logic action list must be an array");
+    for (size_t i = 0; i < yyjson_arr_size(actions); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        if (!validate_one_action(ctx, yyjson_arr_get(actions, i), path, names))
+            return false;
+    }
+    return true;
+}
+
+static bool validate_logic(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *logic = obj_get(root, "logic");
+    yyjson_val *timers = obj_get(logic, "timers");
+    for (size_t i = 0; yyjson_is_arr(timers) && i < yyjson_arr_size(timers); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.logic.timers[%zu]", i);
+        yyjson_val *timer = yyjson_arr_get(timers, i);
+        if (!require_ref(ctx, &names->signals, "signal", json_string(timer, "signal"), path))
+            return false;
+    }
+
+    yyjson_val *sensors = obj_get(logic, "sensors");
+    for (size_t i = 0; yyjson_is_arr(sensors) && i < yyjson_arr_size(sensors); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.logic.sensors[%zu]", i);
+        yyjson_val *sensor = yyjson_arr_get(sensors, i);
+        const char *type = json_string(sensor, "type");
+        if (type == NULL || type[0] == '\0')
+            return validation_error(ctx, path, "sensor requires a non-empty type");
+        if (SDL_strcmp(type, "sensor.bounds_exit") == 0)
+        {
+            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "entity"), path) ||
+                !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_enter"), path) ||
+                (!is_axis_name(json_string(sensor, "axis")) &&
+                 !validation_error(ctx, path, "sensor.bounds_exit requires axis x, y, or z")) ||
+                (!is_side_name(json_string(sensor, "side")) &&
+                 !validation_error(ctx, path, "sensor.bounds_exit requires side min or max")))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.bounds_reflect") == 0)
+        {
+            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "entity"), path) ||
+                !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_reflect"), path) ||
+                (!is_axis_name(json_string(sensor, "axis")) &&
+                 !validation_error(ctx, path, "sensor.bounds_reflect requires axis x, y, or z")))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.contact_2d") == 0)
+        {
+            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "a"), path) ||
+                !require_ref(ctx, &names->entities, "entity", json_string(sensor, "b"), path) ||
+                !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_enter"), path))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.input_pressed") == 0)
+        {
+            if (!require_ref(ctx, &names->actions, "input action", json_string(sensor, "action"), path) ||
+                !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_pressed"), path))
+                return false;
+            continue;
+        }
+        return validation_error(ctx, path, "unsupported sensor type '%s'", type);
+    }
+
+    yyjson_val *bindings = obj_get(logic, "bindings");
+    if (bindings != NULL && !yyjson_is_arr(bindings))
+        return validation_error(ctx, "$.logic.bindings", "logic bindings must be an array");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.logic.bindings[%zu]", i);
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (!yyjson_is_obj(binding))
+            return validation_error(ctx, path, "logic binding must be an object");
+        if (!require_ref(ctx, &names->signals, "signal", json_string(binding, "signal"), path))
+            return false;
+        char actions_path[PATH_BUFFER_SIZE];
+        format_path(actions_path, sizeof(actions_path), "%s.actions", path);
+        if (!validate_action_array(ctx, obj_get(binding, "actions"), actions_path, names))
+            return false;
+    }
+    return true;
+}
+
+static bool note_script_use_recursive(validation_context *ctx, validation_names *names, const char *script_id,
+                                      const char *json_path)
+{
+    script_manifest *script = find_script_manifest(names, script_id);
+    if (script == NULL)
+        return validation_error(ctx, json_path, "unknown script reference '%s'", script_id);
+    if (!note_name(&names->used_scripts, script_id, json_path))
+        return validation_error(ctx, json_path, "failed to record script use");
+    for (int i = 0; i < script->dependency_count; ++i)
+    {
+        if (!note_script_use_recursive(ctx, names, script->dependencies[i], json_path))
+            return false;
+    }
+    return true;
+}
+
+static bool validate_adapters(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *adapters = obj_get(root, "adapters");
+    for (size_t i = 0; yyjson_is_arr(adapters) && i < yyjson_arr_size(adapters); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.adapters[%zu]", i);
+        yyjson_val *adapter = yyjson_arr_get(adapters, i);
+        const char *script = json_string(adapter, "script");
+        const char *function = json_string(adapter, "function");
+        const char *name = json_string(adapter, "name");
+        if (function != NULL && function[0] != '\0')
+        {
+            if (!require_ref(ctx, &names->scripts, "script", script, path))
+                return false;
+            if (name_table_contains(&names->used_adapters, name) &&
+                !note_script_use_recursive(ctx, names, script, path))
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool validate_cameras(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *cameras = obj_get(obj_get(root, "world"), "cameras");
+    for (size_t i = 0; yyjson_is_arr(cameras) && i < yyjson_arr_size(cameras); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.world.cameras[%zu]", i);
+        yyjson_val *camera = yyjson_arr_get(cameras, i);
+        const char *type = json_string(camera, "type");
+        if (SDL_strcmp(type != NULL ? type : "", "adapter") == 0)
+        {
+            const char *adapter = json_string(camera, "adapter");
+            if (!require_ref(ctx, &names->adapters, "adapter", adapter, path))
+                return false;
+            if (!note_name(&names->used_adapters, adapter, path))
+                return validation_error(ctx, path, "failed to record adapter use");
+            if (json_string(camera, "target_entity") != NULL &&
+                !require_ref(ctx, &names->entities, "entity", json_string(camera, "target_entity"), path))
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool warn_unused(validation_context *ctx, const name_table *declared, const name_table *used, const char *kind)
+{
+    for (int i = 0; i < declared->count; ++i)
+    {
+        if (!name_table_contains(used, declared->names[i]) &&
+            !validation_warning(ctx, declared->paths[i], "unused %s '%s'", kind, declared->names[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+           validate_cameras(ctx, root, names) && validate_logic(ctx, root, names) &&
+           validate_adapters(ctx, root, names) &&
+           warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
+           warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
+}
+
+static void validation_names_destroy(validation_names *names)
+{
+    if (names == NULL)
+        return;
+    for (int i = 0; i < names->script_count; ++i)
+        SDL_free(names->script_manifests[i].dependencies);
+    SDL_free(names->script_manifests);
+    name_table_destroy(&names->entities);
+    name_table_destroy(&names->signals);
+    name_table_destroy(&names->scripts);
+    name_table_destroy(&names->script_modules);
+    name_table_destroy(&names->adapters);
+    name_table_destroy(&names->actions);
+    name_table_destroy(&names->timers);
+    name_table_destroy(&names->cameras);
+    name_table_destroy(&names->sensors);
+    name_table_destroy(&names->used_adapters);
+    name_table_destroy(&names->used_scripts);
+}
+
+bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path, const char *base_dir,
+                                       const sdl3d_game_data_validation_options *options, char *error_buffer,
+                                       int error_buffer_size)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        error_buffer[0] = '\0';
+
+    validation_context ctx = {
+        .options = options,
+        .source_path = source_path,
+        .base_dir = base_dir,
+        .error_buffer = error_buffer,
+        .error_buffer_size = error_buffer_size,
+        .failed = false,
+    };
+
+    if (!yyjson_is_obj(root))
+        return validation_error(&ctx, "$", "root must be an object");
+    if (SDL_strcmp(json_string(root, "schema") != NULL ? json_string(root, "schema") : "", "sdl3d.game.v0") != 0)
+        return validation_error(&ctx, "$.schema", "unsupported or missing game data schema");
+
+    validation_names names;
+    SDL_zero(names);
+    const bool ok = collect_names(&ctx, root, &names) && validate_details(&ctx, root, &names) && !ctx.failed;
+    validation_names_destroy(&names);
+    return ok;
+}
+
+bool sdl3d_game_data_validate_file(const char *path, const sdl3d_game_data_validation_options *options,
+                                   char *error_buffer, int error_buffer_size)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        error_buffer[0] = '\0';
+    if (path == NULL || path[0] == '\0')
+    {
+        validation_context ctx = {
+            .options = options,
+            .source_path = "<game-data>",
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "invalid game data validation path");
+    }
+
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_file(path, YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        validation_context ctx = {
+            .options = options,
+            .source_path = path,
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "yyjson error %u at byte %llu: %s", err.code, (unsigned long long)err.pos,
+                                err.msg != NULL ? err.msg : "");
+    }
+
+    char *base_dir = path_dirname(path);
+    const bool ok = sdl3d_game_data_validate_document(yyjson_doc_get_root(doc), path, base_dir, options, error_buffer,
+                                                      error_buffer_size);
+    SDL_free(base_dir);
+    yyjson_doc_free(doc);
+    return ok;
+}

--- a/src/game_data_validation.h
+++ b/src/game_data_validation.h
@@ -1,0 +1,16 @@
+/**
+ * @file game_data_validation.h
+ * @brief Internal JSON game data validation entry points.
+ */
+
+#ifndef SDL3D_GAME_DATA_VALIDATION_H
+#define SDL3D_GAME_DATA_VALIDATION_H
+
+#include "sdl3d/game_data.h"
+#include "yyjson.h"
+
+bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path, const char *base_dir,
+                                       const sdl3d_game_data_validation_options *options, char *error_buffer,
+                                       int error_buffer_size);
+
+#endif /* SDL3D_GAME_DATA_VALIDATION_H */

--- a/tests/assets/game_data/bad_reference.game.json
+++ b/tests/assets/game_data/bad_reference.game.json
@@ -1,0 +1,29 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Bad Reference",
+    "id": "test.bad_reference",
+    "version": "0.1.0"
+  },
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": [
+    {
+      "name": "entity.target",
+      "active": true
+    }
+  ],
+  "signals": ["signal.run"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.run",
+        "actions": [
+          { "type": "property.set", "target": "entity.missing", "key": "active", "value": true }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/assets/game_data/warning_unsupported_component.game.json
+++ b/tests/assets/game_data/warning_unsupported_component.game.json
@@ -1,0 +1,20 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Unsupported Component Warning",
+    "id": "test.warning_unsupported_component",
+    "version": "0.1.0"
+  },
+  "world": {
+    "name": "world.test",
+    "kind": "fixed_screen"
+  },
+  "entities": [
+    {
+      "name": "entity.future",
+      "components": [
+        { "type": "custom.future_component" }
+      ]
+    }
+  ]
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <vector>
 
 extern "C"
 {
@@ -21,6 +22,18 @@ struct AdapterCapture
     int calls = 0;
 };
 
+struct CapturedDiagnostic
+{
+    sdl3d_game_data_diagnostic_severity severity = SDL3D_GAME_DATA_DIAGNOSTIC_WARNING;
+    std::string path;
+    std::string message;
+};
+
+struct DiagnosticCapture
+{
+    std::vector<CapturedDiagnostic> diagnostics;
+};
+
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                    sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -32,6 +45,14 @@ bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char 
     sdl3d_properties_set_vec3(target->props, "velocity", sdl3d_vec3_make(3.0f, 1.0f, 0.0f));
     capture->calls++;
     return true;
+}
+
+void capture_diagnostic(void *userdata, sdl3d_game_data_diagnostic_severity severity, const char *json_path,
+                        const char *message)
+{
+    auto *capture = static_cast<DiagnosticCapture *>(userdata);
+    capture->diagnostics.push_back(
+        {severity, json_path != nullptr ? json_path : "", message != nullptr ? message : ""});
 }
 
 std::string fixture_path(const char *filename)
@@ -194,6 +215,56 @@ TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, ValidatesPongDataWithoutDiagnostics)
+{
+    DiagnosticCapture capture;
+    sdl3d_game_data_validation_options options{};
+    options.diagnostic = capture_diagnostic;
+    options.userdata = &capture;
+
+    char error[512]{};
+    EXPECT_TRUE(sdl3d_game_data_validate_file(SDL3D_PONG_DATA_PATH, &options, error, sizeof(error))) << error;
+    EXPECT_TRUE(capture.diagnostics.empty());
+    EXPECT_EQ(error[0], '\0');
+}
+
+TEST(GameDataRuntime, ValidationReportsJsonPathAndMissingReference)
+{
+    DiagnosticCapture capture;
+    sdl3d_game_data_validation_options options{};
+    options.diagnostic = capture_diagnostic;
+    options.userdata = &capture;
+
+    char error[512]{};
+    const std::string path = fixture_path("bad_reference.game.json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file(path.c_str(), &options, error, sizeof(error)));
+    ASSERT_FALSE(capture.diagnostics.empty());
+    EXPECT_EQ(capture.diagnostics[0].severity, SDL3D_GAME_DATA_DIAGNOSTIC_ERROR);
+    EXPECT_NE(capture.diagnostics[0].path.find("$.logic.bindings[0].actions[0]"), std::string::npos);
+    EXPECT_NE(capture.diagnostics[0].message.find("entity.missing"), std::string::npos);
+    EXPECT_NE(std::string(error).find("$.logic.bindings[0].actions[0]"), std::string::npos);
+}
+
+TEST(GameDataRuntime, ValidationReportsWarningsWithoutFailingByDefault)
+{
+    DiagnosticCapture capture;
+    sdl3d_game_data_validation_options options{};
+    options.diagnostic = capture_diagnostic;
+    options.userdata = &capture;
+
+    char error[512]{};
+    const std::string path = fixture_path("warning_unsupported_component.game.json");
+    EXPECT_TRUE(sdl3d_game_data_validate_file(path.c_str(), &options, error, sizeof(error))) << error;
+    ASSERT_EQ(capture.diagnostics.size(), 1u);
+    EXPECT_EQ(capture.diagnostics[0].severity, SDL3D_GAME_DATA_DIAGNOSTIC_WARNING);
+    EXPECT_NE(capture.diagnostics[0].message.find("unsupported component type"), std::string::npos);
+    EXPECT_EQ(error[0], '\0');
+
+    options.treat_warnings_as_errors = true;
+    EXPECT_FALSE(sdl3d_game_data_validate_file(path.c_str(), &options, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unsupported component type"), std::string::npos);
 }
 
 TEST(GameDataRuntime, RejectsLuaScriptManifestErrorsBeforeGameplay)


### PR DESCRIPTION
## Summary
- add a public `sdl3d_game_data_validate_file()` API with Doxygen-documented diagnostic callbacks, severities, and strict warning handling
- add a dedicated validation module that runs before game-data runtime instantiation
- validate authored namespaces, references, script dependency structure, script file existence, supported logic actions, component payloads, sensors, timers, cameras, and input bindings
- report warnings for suspicious data such as unused scripts/adapters and unsupported component types
- add Pong-focused validation fixtures for clean data, missing references, warnings, and warning-as-error behavior
- document validation guarantees in `docs/game-data-json.md`

## Tests
- make format
- cmake --build build/default --target sdl3d_game_data_test game_data_json_test pong_demo -j 8
- ./build/default/tests/sdl3d_game_data_test
- ./build/default/tests/game_data_json_test
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Refs #123
