### PR TITLE
Add ergonomic Lua gameplay API

### DIFF
--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -4,70 +4,60 @@ local HALF_HEIGHT = 5.0
 local MAX_SERVE_ANGLE = 0.52
 local MAX_REFLECT_ANGLE = 1.05
 
-local function clamp(value, lo, hi)
-    if value < lo then
-        return lo
-    end
-    if value > hi then
-        return hi
-    end
-    return value
-end
+function pong.serve_random(ball, _, ctx)
+    local base_speed = ball:get_float("base_speed", 5.6)
+    local direction = ctx:random() < 0.5 and -1.0 or 1.0
+    local angle = (ctx:random() * 2.0 - 1.0) * MAX_SERVE_ANGLE
 
-function pong.serve_random(target)
-    local base_speed = sdl3d.get_float(target, "base_speed", 5.6)
-    local direction = sdl3d.random() < 0.5 and -1.0 or 1.0
-    local angle = (sdl3d.random() * 2.0 - 1.0) * MAX_SERVE_ANGLE
-
-    sdl3d.set_position(target, 0.0, 0.0, 0.12)
-    sdl3d.set_vec3(target, "velocity", math.cos(angle) * direction * base_speed, math.sin(angle) * base_speed, 0.0)
+    ball.position = Vec3(0.0, 0.0, 0.12)
+    ball.velocity = Vec3(math.cos(angle) * direction * base_speed, math.sin(angle) * base_speed, 0.0)
     return true
 end
 
-function pong.reflect_from_paddle(target, payload)
-    local paddle = payload.other_actor_name
-    if paddle == nil or paddle == "" then
+function pong.reflect_from_paddle(ball, payload, ctx)
+    local paddle = ctx:actor(payload.other_actor_name)
+    if paddle == nil then
         return false
     end
 
-    local ball_x, ball_y = sdl3d.get_position(target)
-    local paddle_x, paddle_y = sdl3d.get_position(paddle)
-    if ball_x == nil or paddle_x == nil then
+    local ball_position = ball.position
+    local paddle_position = paddle.position
+    if ball_position == nil or paddle_position == nil then
         return false
     end
 
-    local paddle_half_width = sdl3d.get_float(paddle, "half_width", 0.18)
-    local paddle_half_height = sdl3d.get_float(paddle, "half_height", 0.95)
-    local ball_radius = sdl3d.get_float(target, "radius", 0.22)
-    local base_speed = sdl3d.get_float(target, "base_speed", 5.6)
-    local max_speed = sdl3d.get_float(target, "max_speed", 10.0)
-    local speedup = sdl3d.get_float(target, "speedup_per_hit", 0.28)
-    local velocity_x, velocity_y = sdl3d.get_vec3(target, "velocity")
+    local paddle_half_width = paddle:get_float("half_width", 0.18)
+    local paddle_half_height = paddle:get_float("half_height", 0.95)
+    local ball_radius = ball:get_float("radius", 0.22)
+    local base_speed = ball:get_float("base_speed", 5.6)
+    local max_speed = ball:get_float("max_speed", 10.0)
+    local speedup = ball:get_float("speedup_per_hit", 0.28)
+    local velocity = ball.velocity
 
-    local speed = clamp(math.sqrt(velocity_x * velocity_x + velocity_y * velocity_y) + speedup, base_speed, max_speed)
-    local impact = clamp((ball_y - paddle_y) / paddle_half_height, -1.0, 1.0)
-    local direction = paddle_x < 0.0 and 1.0 or -1.0
+    local speed = math.clamp(Vec3.length(velocity) + speedup, base_speed, max_speed)
+    local impact = math.clamp((ball_position.y - paddle_position.y) / paddle_half_height, -1.0, 1.0)
+    local direction = paddle_position.x < 0.0 and 1.0 or -1.0
     local angle = impact * MAX_REFLECT_ANGLE
 
-    sdl3d.set_vec3(target, "velocity", math.cos(angle) * direction * speed, math.sin(angle) * speed, 0.0)
-    sdl3d.set_position(target, paddle_x + direction * (paddle_half_width + ball_radius + 0.01), ball_y, 0.12)
+    ball.velocity = Vec3(math.cos(angle) * direction * speed, math.sin(angle) * speed, 0.0)
+    ball.position = Vec3(paddle_position.x + direction * (paddle_half_width + ball_radius + 0.01), ball_position.y, 0.12)
     return true
 end
 
-function pong.cpu_track_ball(target, payload)
-    local ball = payload.target_actor_name or "entity.ball"
-    local _, ball_y = sdl3d.get_position(ball)
-    local paddle_x, paddle_y, paddle_z = sdl3d.get_position(target)
-    if ball_y == nil or paddle_y == nil then
+function pong.cpu_track_ball(paddle, payload, ctx)
+    local ball = ctx:actor(payload.target_actor_name or "entity.ball")
+    local ball_position = ball ~= nil and ball.position or nil
+    local paddle_position = paddle.position
+    if ball_position == nil or paddle_position == nil then
         return false
     end
 
-    local speed = sdl3d.get_float(target, "speed", 5.5)
-    local half_height = sdl3d.get_float(target, "half_height", 0.95)
-    local max_step = speed * sdl3d.dt()
-    local step = clamp(ball_y - paddle_y, -max_step, max_step)
-    local next_y = clamp(paddle_y + step, -HALF_HEIGHT + half_height, HALF_HEIGHT - half_height)
-    sdl3d.set_position(target, paddle_x, next_y, paddle_z or 0.0)
+    local speed = paddle:get_float("speed", 5.5)
+    local half_height = paddle:get_float("half_height", 0.95)
+    local max_step = speed * ctx.dt
+    local step = math.clamp(ball_position.y - paddle_position.y, -max_step, max_step)
+    local next_y = math.clamp(paddle_position.y + step, -HALF_HEIGHT + half_height, HALF_HEIGHT - half_height)
+    paddle.position = Vec3(paddle_position.x, next_y, paddle_position.z)
     return true
 end
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -188,13 +188,35 @@ Lua modules should avoid global namespace ownership. A typical module returns a 
 ```lua
 local rules = {}
 
-function rules.reflect_from_paddle(target, payload)
+function rules.reflect_from_paddle(ball, payload, ctx)
+  local paddle = ctx:actor(payload.other_actor_name)
+  if paddle == nil then
+    return false
+  end
+
   -- game-specific rule code
+  ball.velocity = Vec3(7.0, 1.5, 0.0)
   return true
 end
 
 return rules
 ```
+
+Lua adapters receive `(target, payload, ctx)`:
+
+- `target` is an actor wrapper for the authored action/component target, or `nil`.
+- `payload` is a table copied from the signal payload or component payload.
+- `ctx` provides adapter context: `ctx.adapter`, `ctx.dt`, `ctx:actor(name)`, `ctx:random()`, and `ctx:log(message)`.
+
+The preferred Lua API is intentionally game-script oriented. Scripts can check `sdl3d.api`, currently `sdl3d.lua.v1`, when they need to guard version-specific behavior:
+
+```lua
+local speed = ball:get_float("base_speed", 5.6)
+ball.position = Vec3(0, 0, 0.12)
+ball.velocity = Vec3.normalize(ball.velocity) * speed
+```
+
+Actor wrappers expose property helpers (`get_float`, `set_float`, `get_int`, `set_int`, `get_bool`, `set_bool`, `get_vec3`, `set_vec3`) plus `position` and `velocity` convenience fields. `Vec3` provides `new`, `length`, `normalize`, `clamp`, and arithmetic operators. `math.clamp` and `math.lerp` are also available. The lower-level `sdl3d.get_*` and `sdl3d.set_*` functions remain available as implementation primitives, but gameplay scripts should prefer the wrapper API.
 
 Native C registration remains available for host applications that need engine-facing integrations or highly optimized behavior; re-registering an adapter name overrides the authored Lua binding.
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -216,7 +216,17 @@ static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
 
 static sdl3d_registered_actor *lua_actor_arg(lua_State *lua, sdl3d_game_data_runtime *runtime, int index)
 {
-    const char *actor_name = luaL_checkstring(lua, index);
+    const char *actor_name = NULL;
+    if (lua_istable(lua, index))
+    {
+        lua_getfield(lua, index, "_name");
+        actor_name = lua_tostring(lua, -1);
+        lua_pop(lua, 1);
+    }
+    else
+    {
+        actor_name = luaL_checkstring(lua, index);
+    }
     return sdl3d_game_data_find_actor(runtime, actor_name);
 }
 
@@ -359,6 +369,117 @@ static int lua_log(lua_State *lua)
     return 0;
 }
 
+static void install_lua_helpers(lua_State *lua)
+{
+    static const char *source =
+        "local Actor = {}\n"
+        "local Vec3 = {}\n"
+        "local Vec3_mt = { __index = Vec3 }\n"
+        "local function as_vec3(value, fallback)\n"
+        "    if value == nil then return fallback or Vec3(0, 0, 0) end\n"
+        "    if getmetatable(value) == Vec3_mt then return value end\n"
+        "    return Vec3(value.x or value[1] or 0, value.y or value[2] or 0, value.z or value[3] or 0)\n"
+        "end\n"
+        "function Vec3.new(x, y, z)\n"
+        "    return setmetatable({ x = x or 0, y = y or 0, z = z or 0 }, Vec3_mt)\n"
+        "end\n"
+        "setmetatable(Vec3, { __call = function(_, x, y, z) return Vec3.new(x, y, z) end })\n"
+        "function Vec3.length(v)\n"
+        "    v = as_vec3(v)\n"
+        "    return math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z)\n"
+        "end\n"
+        "function Vec3.normalize(v)\n"
+        "    v = as_vec3(v)\n"
+        "    local len = Vec3.length(v)\n"
+        "    if len <= 0.000001 then return Vec3(0, 0, 0) end\n"
+        "    return Vec3(v.x / len, v.y / len, v.z / len)\n"
+        "end\n"
+        "function Vec3.clamp(v, lo, hi)\n"
+        "    v = as_vec3(v)\n"
+        "    return Vec3(math.clamp(v.x, lo, hi), math.clamp(v.y, lo, hi), math.clamp(v.z, lo, hi))\n"
+        "end\n"
+        "function Vec3_mt.__add(a, b)\n"
+        "    a, b = as_vec3(a), as_vec3(b)\n"
+        "    return Vec3(a.x + b.x, a.y + b.y, a.z + b.z)\n"
+        "end\n"
+        "function Vec3_mt.__sub(a, b)\n"
+        "    a, b = as_vec3(a), as_vec3(b)\n"
+        "    return Vec3(a.x - b.x, a.y - b.y, a.z - b.z)\n"
+        "end\n"
+        "function Vec3_mt.__mul(a, b)\n"
+        "    if type(a) == 'number' then return Vec3(a * b.x, a * b.y, a * b.z) end\n"
+        "    if type(b) == 'number' then return Vec3(a.x * b, a.y * b, a.z * b) end\n"
+        "    return Vec3(a.x * b.x, a.y * b.y, a.z * b.z)\n"
+        "end\n"
+        "function math.clamp(value, lo, hi)\n"
+        "    if value < lo then return lo end\n"
+        "    if value > hi then return hi end\n"
+        "    return value\n"
+        "end\n"
+        "function math.lerp(a, b, t)\n"
+        "    return a + (b - a) * t\n"
+        "end\n"
+        "function Actor:get_float(key, fallback) return sdl3d.get_float(self, key, fallback or 0) end\n"
+        "function Actor:set_float(key, value) sdl3d.set_float(self, key, value) end\n"
+        "function Actor:get_int(key, fallback) return sdl3d.get_int(self, key, fallback or 0) end\n"
+        "function Actor:set_int(key, value) sdl3d.set_int(self, key, value) end\n"
+        "function Actor:get_bool(key, fallback) return sdl3d.get_bool(self, key, fallback or false) end\n"
+        "function Actor:set_bool(key, value) sdl3d.set_bool(self, key, value and true or false) end\n"
+        "function Actor:get_vec3(key, fallback)\n"
+        "    local x, y, z = sdl3d.get_vec3(self, key)\n"
+        "    if x == nil then return fallback end\n"
+        "    return Vec3(x, y, z)\n"
+        "end\n"
+        "function Actor:set_vec3(key, value)\n"
+        "    value = as_vec3(value)\n"
+        "    sdl3d.set_vec3(self, key, value.x, value.y, value.z)\n"
+        "end\n"
+        "function Actor:get_position()\n"
+        "    local x, y, z = sdl3d.get_position(self)\n"
+        "    if x == nil then return nil end\n"
+        "    return Vec3(x, y, z)\n"
+        "end\n"
+        "function Actor:set_position(value)\n"
+        "    value = as_vec3(value)\n"
+        "    sdl3d.set_position(self, value.x, value.y, value.z)\n"
+        "end\n"
+        "Actor.__index = function(self, key)\n"
+        "    if key == 'name' then return rawget(self, '_name') end\n"
+        "    if key == 'position' then return Actor.get_position(self) end\n"
+        "    if key == 'velocity' then return Actor.get_vec3(self, 'velocity', Vec3(0, 0, 0)) end\n"
+        "    return Actor[key]\n"
+        "end\n"
+        "Actor.__newindex = function(self, key, value)\n"
+        "    if key == 'position' then Actor.set_position(self, value); return end\n"
+        "    if key == 'velocity' then Actor.set_vec3(self, 'velocity', value); return end\n"
+        "    rawset(self, key, value)\n"
+        "end\n"
+        "function sdl3d.actor(name)\n"
+        "    if name == nil or name == '' then return nil end\n"
+        "    return setmetatable({ _name = name }, Actor)\n"
+        "end\n"
+        "function sdl3d._context(adapter, dt)\n"
+        "    return {\n"
+        "        adapter = adapter,\n"
+        "        name = adapter,\n"
+        "        dt = dt or 0,\n"
+        "        actor = function(self_or_name, maybe_name) return sdl3d.actor(maybe_name or self_or_name) end,\n"
+        "        random = function(_) return sdl3d.random() end,\n"
+        "        log = function(self_or_message, maybe_message) sdl3d.log(maybe_message or self_or_message) end,\n"
+        "    }\n"
+        "end\n"
+        "sdl3d.Actor = Actor\n"
+        "sdl3d.Vec3 = Vec3\n"
+        "sdl3d.api = 'sdl3d.lua.v1'\n"
+        "_G.Vec3 = Vec3\n";
+
+    if (luaL_dostring(lua, source) != LUA_OK)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[lua] failed to install gameplay API: %s", lua_tostring(lua, -1));
+        lua_pop(lua, 1);
+    }
+}
+
 static void register_lua_api(sdl3d_game_data_runtime *runtime)
 {
     if (runtime == NULL || runtime->scripts == NULL)
@@ -391,6 +512,7 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime)
     SDL3D_LUA_BIND("log", lua_log);
 #undef SDL3D_LUA_BIND
     lua_setglobal(lua, "sdl3d");
+    install_lua_helpers(lua);
 }
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
@@ -691,6 +813,68 @@ static void lua_push_payload(lua_State *lua, const sdl3d_properties *payload)
     }
 }
 
+static void lua_push_actor_wrapper(lua_State *lua, const sdl3d_registered_actor *actor)
+{
+    if (actor == NULL)
+    {
+        lua_pushnil(lua);
+        return;
+    }
+
+    lua_getglobal(lua, "sdl3d");
+    if (!lua_istable(lua, -1))
+    {
+        lua_pop(lua, 1);
+        lua_pushnil(lua);
+        return;
+    }
+    lua_getfield(lua, -1, "actor");
+    if (!lua_isfunction(lua, -1))
+    {
+        lua_pop(lua, 2);
+        lua_pushnil(lua);
+        return;
+    }
+    lua_pushstring(lua, actor->name);
+    if (lua_pcall(lua, 1, 1, 0) != LUA_OK)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[lua] actor wrapper creation failed: %s", lua_tostring(lua, -1));
+        lua_pop(lua, 2);
+        lua_pushnil(lua);
+        return;
+    }
+    lua_remove(lua, -2);
+}
+
+static void lua_push_adapter_context(lua_State *lua, const sdl3d_game_data_runtime *runtime,
+                                     const adapter_entry *adapter)
+{
+    lua_getglobal(lua, "sdl3d");
+    if (!lua_istable(lua, -1))
+    {
+        lua_pop(lua, 1);
+        lua_newtable(lua);
+        return;
+    }
+    lua_getfield(lua, -1, "_context");
+    if (!lua_isfunction(lua, -1))
+    {
+        lua_pop(lua, 2);
+        lua_newtable(lua);
+        return;
+    }
+    lua_pushstring(lua, adapter != NULL ? adapter->name : "");
+    lua_pushnumber(lua, runtime != NULL ? runtime->current_dt : 0.0f);
+    if (lua_pcall(lua, 2, 1, 0) != LUA_OK)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[lua] adapter context creation failed: %s", lua_tostring(lua, -1));
+        lua_pop(lua, 2);
+        lua_newtable(lua);
+        return;
+    }
+    lua_remove(lua, -2);
+}
+
 static bool call_lua_adapter(sdl3d_game_data_runtime *runtime, const adapter_entry *adapter,
                              sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -702,9 +886,9 @@ static bool call_lua_adapter(sdl3d_game_data_runtime *runtime, const adapter_ent
     if (lua == NULL || !sdl3d_script_engine_push_ref(runtime->scripts, adapter->lua_function_ref))
         return false;
 
-    lua_pushstring(lua, target != NULL ? target->name : "");
+    lua_push_actor_wrapper(lua, target);
     lua_push_payload(lua, payload);
-    lua_pushstring(lua, adapter->name);
+    lua_push_adapter_context(lua, runtime, adapter);
 
     if (lua_pcall(lua, 3, 1, 0) != LUA_OK)
     {

--- a/tests/assets/game_data/scripts/rules.lua
+++ b/tests/assets/game_data/scripts/rules.lua
@@ -1,7 +1,11 @@
 local rules = {}
 
-function rules.run(target)
-    sdl3d.set_vec3(target, "velocity", test.shared.speed(), 2.0, 0.0)
+function rules.run(target, _, ctx)
+    target.position = Vec3(1.0, 2.0, 3.0)
+    target.velocity = Vec3(test.shared.speed(), 2.0, 0.0)
+    target:set_float("speed_length", Vec3.length(target.velocity))
+    ctx:actor("entity.target"):set_bool("ctx_ok", ctx.adapter == "adapter.test.run" and ctx.dt >= 0.0)
+    target:set_float("random_value", ctx:random())
     return true
 end
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -210,8 +210,29 @@ TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
     sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, "entity.target");
     ASSERT_NE(target, nullptr);
     const sdl3d_vec3 velocity = sdl3d_properties_get_vec3(target->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const float speed_length = sdl3d_properties_get_float(target->props, "speed_length", 0.0f);
+    const float random_value = sdl3d_properties_get_float(target->props, "random_value", -1.0f);
+    EXPECT_FLOAT_EQ(target->position.x, 1.0f);
+    EXPECT_FLOAT_EQ(target->position.y, 2.0f);
+    EXPECT_FLOAT_EQ(target->position.z, 3.0f);
     EXPECT_FLOAT_EQ(velocity.x, 7.0f);
     EXPECT_FLOAT_EQ(velocity.y, 2.0f);
+    EXPECT_NEAR(speed_length, SDL_sqrtf(53.0f), 0.0001f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "ctx_ok", false));
+    EXPECT_GE(random_value, 0.0f);
+    EXPECT_LT(random_value, 1.0f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(path.c_str(), session, &runtime, error, sizeof(error))) << error;
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), sdl3d_game_data_find_signal(runtime, "signal.run"),
+                      nullptr);
+    target = sdl3d_game_data_find_actor(runtime, "entity.target");
+    ASSERT_NE(target, nullptr);
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(target->props, "random_value", -1.0f), random_value);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add high-level Lua actor wrappers, adapter context objects, Vec3 helpers, math helpers, and `sdl3d.api = "sdl3d.lua.v1"`
- pass Lua adapters `(target, payload, ctx)` where target is an actor wrapper and ctx exposes `dt`, `adapter`, `actor`, `random`, and `log`
- keep the lower-level `sdl3d.get_*` / `set_*` primitives available while making wrappers the preferred gameplay API
- migrate Pong Lua adapters away from actor-name plumbing to wrapper-style code
- extend game-data tests to cover wrapper position/property mutation, Vec3 length, context lookup, and deterministic runtime RNG
- document the Lua gameplay API in `docs/game-data-json.md`

## Tests
- make format
- cmake --build build/default --target sdl3d_game_data_test game_data_json_test pong_demo -j 8
- ./build/default/tests/sdl3d_game_data_test
- ./build/default/tests/game_data_json_test
- cmake --build build/default -j 8
- ctest --test-dir build/default --output-on-failure

Refs #123
