### PR TITLE
Add virtual asset resolver and pack-backed game data loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(
         src/actor_controller.c
         src/actor_registry.c
         src/app.c
+        src/asset.c
         src/animation.c
         src/audio.c
         src/camera.c

--- a/include/sdl3d/asset.h
+++ b/include/sdl3d/asset.h
@@ -1,0 +1,125 @@
+/**
+ * @file asset.h
+ * @brief Virtual asset resolver for source-tree, packed, and embedded data.
+ *
+ * SDL3D game data should refer to stable virtual paths such as
+ * asset://scripts/pong.lua instead of assuming a particular filesystem layout.
+ * A resolver maps those paths to mounted directories, packed archives, or
+ * memory-backed archives. This keeps development builds convenient while
+ * preserving a clean path toward single-file or archive-based shipping builds.
+ */
+
+#ifndef SDL3D_ASSET_H
+#define SDL3D_ASSET_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque virtual asset resolver. */
+    typedef struct sdl3d_asset_resolver sdl3d_asset_resolver;
+
+    /**
+     * @brief Owned bytes returned by an asset read.
+     *
+     * The buffer is not guaranteed to be text or null-terminated. Free it with
+     * sdl3d_asset_buffer_free() when finished.
+     */
+    typedef struct sdl3d_asset_buffer
+    {
+        /** @brief Owned byte buffer, or NULL when empty or invalid. */
+        void *data;
+        /** @brief Number of valid bytes in @p data. */
+        size_t size;
+    } sdl3d_asset_buffer;
+
+    /**
+     * @brief Create an empty asset resolver.
+     *
+     * Mount directories and packs before attempting to read assets. Later mounts
+     * take precedence over earlier mounts, leaving room for future patch or mod
+     * overlays without changing authored paths.
+     */
+    sdl3d_asset_resolver *sdl3d_asset_resolver_create(void);
+
+    /**
+     * @brief Destroy an asset resolver and all mounted pack metadata.
+     *
+     * Safe to call with NULL. Buffers already returned by
+     * sdl3d_asset_resolver_read_file() remain caller-owned and must still be
+     * freed by the caller.
+     */
+    void sdl3d_asset_resolver_destroy(sdl3d_asset_resolver *resolver);
+
+    /**
+     * @brief Mount a filesystem directory as an asset root.
+     *
+     * An authored path like asset://scripts/pong.lua resolves to
+     * @p root_directory/scripts/pong.lua. The root path is copied by the
+     * resolver.
+     *
+     * @return true when the directory mount was recorded.
+     */
+    bool sdl3d_asset_resolver_mount_directory(sdl3d_asset_resolver *resolver, const char *root_directory,
+                                              char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Mount an SDL3D pack file from disk.
+     *
+     * The pack is loaded into memory and parsed immediately. The current pack
+     * format is intentionally small and uncompressed; compression, encryption,
+     * and patch layering can be added behind the same resolver API later.
+     *
+     * @return true when the pack was read and mounted.
+     */
+    bool sdl3d_asset_resolver_mount_pack_file(sdl3d_asset_resolver *resolver, const char *pack_path, char *error_buffer,
+                                              int error_buffer_size);
+
+    /**
+     * @brief Mount an SDL3D pack already present in memory.
+     *
+     * The resolver copies @p data, so callers may release their source memory
+     * after this call succeeds. This is the preferred entry point for
+     * CMake-generated embedded packs.
+     *
+     * @return true when the pack was copied, parsed, and mounted.
+     */
+    bool sdl3d_asset_resolver_mount_memory_pack(sdl3d_asset_resolver *resolver, const void *data, size_t size,
+                                                const char *debug_name, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Return whether an asset path resolves to any mounted source.
+     *
+     * This is intended for validation and diagnostics. Use
+     * sdl3d_asset_resolver_read_file() when the bytes are needed.
+     */
+    bool sdl3d_asset_resolver_exists(const sdl3d_asset_resolver *resolver, const char *asset_path);
+
+    /**
+     * @brief Read an asset by virtual path.
+     *
+     * @p asset_path may use the asset:// URI scheme or a plain relative virtual
+     * path. The resolver rejects absolute paths, parent-directory traversal, and
+     * unknown URI schemes to keep authored content portable.
+     *
+     * @return true when the file was found and copied into @p out_buffer.
+     */
+    bool sdl3d_asset_resolver_read_file(const sdl3d_asset_resolver *resolver, const char *asset_path,
+                                        sdl3d_asset_buffer *out_buffer, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Free bytes returned by sdl3d_asset_resolver_read_file().
+     *
+     * Safe to call with NULL or an already empty buffer.
+     */
+    void sdl3d_asset_buffer_free(sdl3d_asset_buffer *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_ASSET_H */

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 
 #include "sdl3d/actor_registry.h"
+#include "sdl3d/asset.h"
 #include "sdl3d/game.h"
 #include "sdl3d/properties.h"
 
@@ -95,6 +96,24 @@ extern "C"
                                    char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Load a JSON game data asset through a resolver.
+     *
+     * This is the preferred loading entry point for games that may ship data in
+     * source directories, packed archives, or embedded packs. Script paths in
+     * the JSON are resolved relative to @p asset_path through the same resolver.
+     *
+     * @param assets Resolver containing the JSON asset and referenced scripts.
+     * @param asset_path Virtual path, such as asset://pong.game.json.
+     * @param session Target session whose services receive the authored data.
+     * @param out_runtime Receives the created runtime on success.
+     * @param error_buffer Optional buffer for a human-readable error.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true on success.
+     */
+    bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,
+                                    sdl3d_game_data_runtime **out_runtime, char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Validate a JSON game data file without instantiating runtime state.
      *
      * Validation checks schema, authored names, references, supported generic
@@ -110,6 +129,24 @@ extern "C"
      */
     bool sdl3d_game_data_validate_file(const char *path, const sdl3d_game_data_validation_options *options,
                                        char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Validate a JSON game data asset through a resolver.
+     *
+     * Validation reads the JSON and referenced script files from @p assets, so
+     * authored data can be checked the same way whether it comes from a source
+     * tree, packed archive, or embedded pack.
+     *
+     * @param assets Resolver containing the JSON asset and referenced scripts.
+     * @param asset_path Virtual path, such as asset://pong.game.json.
+     * @param options Optional validation options and diagnostic callback.
+     * @param error_buffer Optional buffer for the first fatal diagnostic.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when no fatal validation error was found.
+     */
+    bool sdl3d_game_data_validate_asset(sdl3d_asset_resolver *assets, const char *asset_path,
+                                        const sdl3d_game_data_validation_options *options, char *error_buffer,
+                                        int error_buffer_size);
 
     /**
      * @brief Destroy a loaded game data runtime.

--- a/include/sdl3d/script.h
+++ b/include/sdl3d/script.h
@@ -12,6 +12,7 @@
 #define SDL3D_SCRIPT_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -81,6 +82,29 @@ extern "C"
     bool sdl3d_script_engine_load_module_file(sdl3d_script_engine *engine, const char *path, const char *module_name,
                                               sdl3d_script_ref *out_module_ref, char *error_buffer,
                                               int error_buffer_size);
+
+    /**
+     * @brief Load Lua source bytes as a named module table.
+     *
+     * This is equivalent to sdl3d_script_engine_load_module_file(), but the
+     * caller supplies already-resolved bytes and a chunk name for diagnostics.
+     * Use this when loading scripts through an asset resolver, packed archive,
+     * or embedded resource.
+     *
+     * @param engine Script engine.
+     * @param source Lua source bytes.
+     * @param source_size Number of bytes in @p source.
+     * @param chunk_name Human-readable source name for Lua error messages.
+     * @param module_name Stable module name, such as "pong.rules".
+     * @param out_module_ref Receives a registry reference to the returned table.
+     * @param error_buffer Optional human-readable error output.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the source loaded, returned a table, and was registered.
+     */
+    bool sdl3d_script_engine_load_module_buffer(sdl3d_script_engine *engine, const void *source, size_t source_size,
+                                                const char *chunk_name, const char *module_name,
+                                                sdl3d_script_ref *out_module_ref, char *error_buffer,
+                                                int error_buffer_size);
 
     /**
      * @brief Resolve a function from a loaded module table.

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -8,6 +8,7 @@
 
 #include "sdl3d/actor_controller.h"
 #include "sdl3d/animation.h"
+#include "sdl3d/asset.h"
 #include "sdl3d/audio.h"
 #include "sdl3d/camera.h"
 #include "sdl3d/collision.h"

--- a/src/asset.c
+++ b/src/asset.c
@@ -1,0 +1,521 @@
+/**
+ * @file asset.c
+ * @brief Virtual asset resolver implementation.
+ */
+
+#include "sdl3d/asset.h"
+
+#include <stdint.h>
+
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_stdinc.h>
+
+#define SDL3D_PACK_MAGIC "S3DPAK1"
+#define SDL3D_PACK_MAGIC_SIZE 8u
+#define SDL3D_PACK_VERSION 1u
+#define SDL3D_PACK_HEADER_SIZE 24u
+#define SDL3D_PACK_ENTRY_FIXED_SIZE 18u
+
+typedef enum asset_mount_type
+{
+    ASSET_MOUNT_DIRECTORY,
+    ASSET_MOUNT_PACK,
+} asset_mount_type;
+
+typedef struct asset_pack_entry
+{
+    char *path;
+    uint64_t offset;
+    uint64_t size;
+} asset_pack_entry;
+
+typedef struct asset_pack
+{
+    char *name;
+    uint8_t *data;
+    size_t size;
+    asset_pack_entry *entries;
+    int entry_count;
+} asset_pack;
+
+typedef struct asset_mount
+{
+    asset_mount_type type;
+    char *directory;
+    asset_pack pack;
+} asset_mount;
+
+struct sdl3d_asset_resolver
+{
+    asset_mount *mounts;
+    int mount_count;
+};
+
+static void set_asset_error(char *buffer, int buffer_size, const char *message)
+{
+    if (buffer != NULL && buffer_size > 0)
+        SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown asset error");
+}
+
+static uint16_t read_u16le(const uint8_t *data)
+{
+    return (uint16_t)data[0] | (uint16_t)((uint16_t)data[1] << 8u);
+}
+
+static uint32_t read_u32le(const uint8_t *data)
+{
+    return (uint32_t)data[0] | ((uint32_t)data[1] << 8u) | ((uint32_t)data[2] << 16u) | ((uint32_t)data[3] << 24u);
+}
+
+static uint64_t read_u64le(const uint8_t *data)
+{
+    return (uint64_t)read_u32le(data) | ((uint64_t)read_u32le(data + 4) << 32u);
+}
+
+static bool has_uri_scheme(const char *path)
+{
+    return path != NULL && SDL_strstr(path, "://") != NULL;
+}
+
+static char *normalize_asset_path(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return NULL;
+
+    const char *input = path;
+    if (SDL_strncmp(input, "asset://", 8) == 0)
+        input += 8;
+    else if (has_uri_scheme(input))
+        return NULL;
+
+    while (*input == '/' || *input == '\\')
+        ++input;
+    if (input[0] == '\0')
+        return NULL;
+
+    const size_t input_len = SDL_strlen(input);
+    char *normalized = (char *)SDL_malloc(input_len + 1u);
+    if (normalized == NULL)
+        return NULL;
+
+    size_t out_len = 0;
+    const char *segment = input;
+    while (*segment != '\0')
+    {
+        while (*segment == '/' || *segment == '\\')
+            ++segment;
+        const char *end = segment;
+        while (*end != '\0' && *end != '/' && *end != '\\')
+            ++end;
+
+        const size_t segment_len = (size_t)(end - segment);
+        if (segment_len == 0u || (segment_len == 1u && segment[0] == '.'))
+        {
+            segment = end;
+            continue;
+        }
+        if ((segment_len == 2u && segment[0] == '.' && segment[1] == '.') || (segment_len >= 2u && segment[1] == ':'))
+        {
+            SDL_free(normalized);
+            return NULL;
+        }
+
+        if (out_len > 0u)
+            normalized[out_len++] = '/';
+        SDL_memcpy(normalized + out_len, segment, segment_len);
+        out_len += segment_len;
+        segment = end;
+    }
+
+    if (out_len == 0u)
+    {
+        SDL_free(normalized);
+        return NULL;
+    }
+    normalized[out_len] = '\0';
+    return normalized;
+}
+
+static char *join_directory_path(const char *root, const char *asset_path)
+{
+    if (root == NULL || root[0] == '\0' || asset_path == NULL || asset_path[0] == '\0')
+        return NULL;
+
+    const size_t root_len = SDL_strlen(root);
+    const size_t path_len = SDL_strlen(asset_path);
+    const bool needs_sep = root_len > 0u && root[root_len - 1u] != '/' && root[root_len - 1u] != '\\';
+    char *joined = (char *)SDL_malloc(root_len + (needs_sep ? 1u : 0u) + path_len + 1u);
+    if (joined == NULL)
+        return NULL;
+
+    SDL_memcpy(joined, root, root_len);
+    size_t offset = root_len;
+    if (needs_sep)
+        joined[offset++] = '/';
+    SDL_memcpy(joined + offset, asset_path, path_len);
+    joined[offset + path_len] = '\0';
+    return joined;
+}
+
+static void destroy_pack(asset_pack *pack)
+{
+    if (pack == NULL)
+        return;
+    for (int i = 0; i < pack->entry_count; ++i)
+        SDL_free(pack->entries[i].path);
+    SDL_free(pack->entries);
+    SDL_free(pack->data);
+    SDL_free(pack->name);
+    SDL_zero(*pack);
+}
+
+static bool append_mount(sdl3d_asset_resolver *resolver, asset_mount **out_mount)
+{
+    if (out_mount != NULL)
+        *out_mount = NULL;
+    if (resolver == NULL || out_mount == NULL)
+        return false;
+
+    asset_mount *mounts =
+        (asset_mount *)SDL_realloc(resolver->mounts, (size_t)(resolver->mount_count + 1) * sizeof(*mounts));
+    if (mounts == NULL)
+        return false;
+    resolver->mounts = mounts;
+
+    asset_mount *mount = &resolver->mounts[resolver->mount_count];
+    SDL_zero(*mount);
+    resolver->mount_count++;
+    *out_mount = mount;
+    return true;
+}
+
+static bool parse_pack_entries(asset_pack *pack, char *error_buffer, int error_buffer_size)
+{
+    if (pack == NULL || pack->data == NULL || pack->size < SDL3D_PACK_HEADER_SIZE)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "pack is too small");
+        return false;
+    }
+    if (SDL_memcmp(pack->data, SDL3D_PACK_MAGIC, SDL3D_PACK_MAGIC_SIZE - 1u) != 0 || pack->data[7] != '\0')
+    {
+        set_asset_error(error_buffer, error_buffer_size, "pack has invalid magic");
+        return false;
+    }
+
+    const uint32_t version = read_u32le(pack->data + 8);
+    const uint32_t entry_count = read_u32le(pack->data + 12);
+    const uint64_t table_offset = read_u64le(pack->data + 16);
+    if (version != SDL3D_PACK_VERSION)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "unsupported pack version");
+        return false;
+    }
+    if (entry_count > (uint32_t)INT32_MAX || table_offset < SDL3D_PACK_HEADER_SIZE ||
+        table_offset > (uint64_t)pack->size)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "pack table header is invalid");
+        return false;
+    }
+
+    pack->entry_count = (int)entry_count;
+    pack->entries = (asset_pack_entry *)SDL_calloc((size_t)pack->entry_count, sizeof(*pack->entries));
+    if (pack->entries == NULL && pack->entry_count > 0)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "failed to allocate pack entries");
+        return false;
+    }
+
+    size_t cursor = (size_t)table_offset;
+    for (int i = 0; i < pack->entry_count; ++i)
+    {
+        if (cursor > pack->size || pack->size - cursor < SDL3D_PACK_ENTRY_FIXED_SIZE)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "pack table is truncated");
+            return false;
+        }
+
+        const uint16_t path_len = read_u16le(pack->data + cursor);
+        const uint64_t offset = read_u64le(pack->data + cursor + 2u);
+        const uint64_t size = read_u64le(pack->data + cursor + 10u);
+        cursor += SDL3D_PACK_ENTRY_FIXED_SIZE;
+
+        if (path_len == 0u || cursor > pack->size || pack->size - cursor < (size_t)path_len ||
+            offset > (uint64_t)pack->size || size > (uint64_t)pack->size || offset > (uint64_t)pack->size - size ||
+            offset > (uint64_t)SIZE_MAX || size > (uint64_t)SIZE_MAX)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "pack entry is invalid");
+            return false;
+        }
+
+        char *raw_path = (char *)SDL_malloc((size_t)path_len + 1u);
+        if (raw_path == NULL)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "failed to allocate pack path");
+            return false;
+        }
+        SDL_memcpy(raw_path, pack->data + cursor, path_len);
+        raw_path[path_len] = '\0';
+        cursor += path_len;
+
+        char *normalized = normalize_asset_path(raw_path);
+        SDL_free(raw_path);
+        if (normalized == NULL)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "pack entry path is invalid");
+            return false;
+        }
+
+        pack->entries[i].path = normalized;
+        pack->entries[i].offset = offset;
+        pack->entries[i].size = size;
+    }
+
+    return true;
+}
+
+static bool mount_owned_pack(sdl3d_asset_resolver *resolver, uint8_t *data, size_t size, const char *debug_name,
+                             char *error_buffer, int error_buffer_size)
+{
+    asset_mount *mount = NULL;
+    if (!append_mount(resolver, &mount))
+    {
+        SDL_free(data);
+        set_asset_error(error_buffer, error_buffer_size, "failed to allocate asset mount");
+        return false;
+    }
+
+    mount->type = ASSET_MOUNT_PACK;
+    mount->pack.data = data;
+    mount->pack.size = size;
+    mount->pack.name = SDL_strdup(debug_name != NULL ? debug_name : "<memory-pack>");
+    if (mount->pack.name == NULL)
+    {
+        resolver->mount_count--;
+        SDL_free(data);
+        set_asset_error(error_buffer, error_buffer_size, "failed to copy pack name");
+        return false;
+    }
+    if (!parse_pack_entries(&mount->pack, error_buffer, error_buffer_size))
+    {
+        destroy_pack(&mount->pack);
+        resolver->mount_count--;
+        return false;
+    }
+    return true;
+}
+
+static const asset_pack_entry *find_pack_entry(const asset_pack *pack, const char *normalized_path)
+{
+    if (pack == NULL || normalized_path == NULL)
+        return NULL;
+    for (int i = 0; i < pack->entry_count; ++i)
+    {
+        if (SDL_strcmp(pack->entries[i].path, normalized_path) == 0)
+            return &pack->entries[i];
+    }
+    return NULL;
+}
+
+static bool read_directory_asset(const asset_mount *mount, const char *normalized_path, sdl3d_asset_buffer *out_buffer)
+{
+    char *path = join_directory_path(mount->directory, normalized_path);
+    if (path == NULL)
+        return false;
+
+    size_t bytes = 0u;
+    void *data = SDL_LoadFile(path, &bytes);
+    SDL_free(path);
+    if (data == NULL)
+        return false;
+
+    out_buffer->data = data;
+    out_buffer->size = bytes;
+    return true;
+}
+
+static bool directory_asset_exists(const asset_mount *mount, const char *normalized_path)
+{
+    char *path = join_directory_path(mount->directory, normalized_path);
+    if (path == NULL)
+        return false;
+
+    SDL_IOStream *io = SDL_IOFromFile(path, "rb");
+    SDL_free(path);
+    if (io == NULL)
+        return false;
+
+    SDL_CloseIO(io);
+    return true;
+}
+
+sdl3d_asset_resolver *sdl3d_asset_resolver_create(void)
+{
+    return (sdl3d_asset_resolver *)SDL_calloc(1, sizeof(sdl3d_asset_resolver));
+}
+
+void sdl3d_asset_resolver_destroy(sdl3d_asset_resolver *resolver)
+{
+    if (resolver == NULL)
+        return;
+    for (int i = 0; i < resolver->mount_count; ++i)
+    {
+        if (resolver->mounts[i].type == ASSET_MOUNT_DIRECTORY)
+            SDL_free(resolver->mounts[i].directory);
+        else
+            destroy_pack(&resolver->mounts[i].pack);
+    }
+    SDL_free(resolver->mounts);
+    SDL_free(resolver);
+}
+
+bool sdl3d_asset_resolver_mount_directory(sdl3d_asset_resolver *resolver, const char *root_directory,
+                                          char *error_buffer, int error_buffer_size)
+{
+    if (resolver == NULL || root_directory == NULL || root_directory[0] == '\0')
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid directory mount arguments");
+        return false;
+    }
+
+    asset_mount *mount = NULL;
+    if (!append_mount(resolver, &mount))
+    {
+        set_asset_error(error_buffer, error_buffer_size, "failed to allocate directory mount");
+        return false;
+    }
+    mount->type = ASSET_MOUNT_DIRECTORY;
+    mount->directory = SDL_strdup(root_directory);
+    if (mount->directory == NULL)
+    {
+        resolver->mount_count--;
+        set_asset_error(error_buffer, error_buffer_size, "failed to copy directory mount path");
+        return false;
+    }
+    return true;
+}
+
+bool sdl3d_asset_resolver_mount_pack_file(sdl3d_asset_resolver *resolver, const char *pack_path, char *error_buffer,
+                                          int error_buffer_size)
+{
+    if (resolver == NULL || pack_path == NULL || pack_path[0] == '\0')
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid pack file mount arguments");
+        return false;
+    }
+
+    size_t bytes = 0u;
+    uint8_t *data = (uint8_t *)SDL_LoadFile(pack_path, &bytes);
+    if (data == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, SDL_GetError());
+        return false;
+    }
+    return mount_owned_pack(resolver, data, bytes, pack_path, error_buffer, error_buffer_size);
+}
+
+bool sdl3d_asset_resolver_mount_memory_pack(sdl3d_asset_resolver *resolver, const void *data, size_t size,
+                                            const char *debug_name, char *error_buffer, int error_buffer_size)
+{
+    if (resolver == NULL || data == NULL || size == 0u)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid memory pack mount arguments");
+        return false;
+    }
+
+    uint8_t *copy = (uint8_t *)SDL_malloc(size);
+    if (copy == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "failed to copy memory pack");
+        return false;
+    }
+    SDL_memcpy(copy, data, size);
+    return mount_owned_pack(resolver, copy, size, debug_name, error_buffer, error_buffer_size);
+}
+
+bool sdl3d_asset_resolver_exists(const sdl3d_asset_resolver *resolver, const char *asset_path)
+{
+    if (resolver == NULL)
+        return false;
+
+    char *normalized = normalize_asset_path(asset_path);
+    if (normalized == NULL)
+        return false;
+
+    for (int i = resolver->mount_count - 1; i >= 0; --i)
+    {
+        const asset_mount *mount = &resolver->mounts[i];
+        const bool exists = mount->type == ASSET_MOUNT_DIRECTORY ? directory_asset_exists(mount, normalized)
+                                                                 : find_pack_entry(&mount->pack, normalized) != NULL;
+        if (exists)
+        {
+            SDL_free(normalized);
+            return true;
+        }
+    }
+
+    SDL_free(normalized);
+    return false;
+}
+
+bool sdl3d_asset_resolver_read_file(const sdl3d_asset_resolver *resolver, const char *asset_path,
+                                    sdl3d_asset_buffer *out_buffer, char *error_buffer, int error_buffer_size)
+{
+    if (out_buffer != NULL)
+        SDL_zero(*out_buffer);
+    if (resolver == NULL || out_buffer == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid asset read arguments");
+        return false;
+    }
+
+    char *normalized = normalize_asset_path(asset_path);
+    if (normalized == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid asset path");
+        return false;
+    }
+
+    for (int i = resolver->mount_count - 1; i >= 0; --i)
+    {
+        const asset_mount *mount = &resolver->mounts[i];
+        if (mount->type == ASSET_MOUNT_DIRECTORY)
+        {
+            if (read_directory_asset(mount, normalized, out_buffer))
+            {
+                SDL_free(normalized);
+                return true;
+            }
+            continue;
+        }
+
+        const asset_pack_entry *entry = find_pack_entry(&mount->pack, normalized);
+        if (entry == NULL)
+            continue;
+        void *copy = SDL_malloc((size_t)entry->size);
+        if (copy == NULL && entry->size > 0u)
+        {
+            SDL_free(normalized);
+            set_asset_error(error_buffer, error_buffer_size, "failed to allocate asset buffer");
+            return false;
+        }
+        if (entry->size > 0u)
+            SDL_memcpy(copy, mount->pack.data + (size_t)entry->offset, (size_t)entry->size);
+        out_buffer->data = copy;
+        out_buffer->size = (size_t)entry->size;
+        SDL_free(normalized);
+        return true;
+    }
+
+    SDL_free(normalized);
+    set_asset_error(error_buffer, error_buffer_size, "asset was not found");
+    return false;
+}
+
+void sdl3d_asset_buffer_free(sdl3d_asset_buffer *buffer)
+{
+    if (buffer == NULL)
+        return;
+    SDL_free(buffer->data);
+    buffer->data = NULL;
+    buffer->size = 0u;
+}

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -13,6 +13,7 @@
 #include "lauxlib.h"
 #include "lua.h"
 #include "script_internal.h"
+#include "sdl3d/asset.h"
 #include "sdl3d/input.h"
 #include "sdl3d/math.h"
 #include "sdl3d/script.h"
@@ -114,6 +115,7 @@ typedef struct sdl3d_game_data_runtime
     sdl3d_script_engine *scripts;
     script_entry *script_entries;
     int script_count;
+    sdl3d_asset_resolver *assets;
     char *base_dir;
     const char *active_camera;
     float current_dt;
@@ -162,6 +164,25 @@ static char *path_dirname(const char *path)
     SDL_memcpy(dir, path, length);
     dir[length] = '\0';
     return dir;
+}
+
+static char *path_basename(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+
+    const char *base = path;
+    for (const char *p = path; *p != '\0'; ++p)
+    {
+        if (*p == '/' || *p == '\\')
+            base = p + 1;
+    }
+    return SDL_strdup(base);
+}
+
+static const char *asset_path_without_scheme(const char *path)
+{
+    return path != NULL && SDL_strncmp(path, "asset://", 8) == 0 ? path + 8 : path;
 }
 
 static char *path_join(const char *base_dir, const char *path)
@@ -1188,8 +1209,8 @@ static bool load_script_entry(sdl3d_game_data_runtime *runtime, script_entry *en
         }
     }
 
-    char *resolved = path_join(runtime->base_dir, entry->path);
-    if (resolved == NULL)
+    char *resolved_path = path_join(runtime->base_dir, entry->path);
+    if (resolved_path == NULL)
     {
         if (error_buffer != NULL && error_buffer_size > 0)
         {
@@ -1199,10 +1220,28 @@ static bool load_script_entry(sdl3d_game_data_runtime *runtime, script_entry *en
         return false;
     }
 
+    sdl3d_asset_buffer script_buffer;
+    SDL_zero(script_buffer);
+    char asset_error[256];
+    if (!sdl3d_asset_resolver_read_file(runtime->assets, resolved_path, &script_buffer, asset_error,
+                                        (int)sizeof(asset_error)))
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "Lua script %s (%s) could not be read: %s", entry->id,
+                         entry->path, asset_error);
+        }
+        SDL_free(resolved_path);
+        entry->loading = false;
+        return false;
+    }
+
     char script_error[512];
-    const bool ok = sdl3d_script_engine_load_module_file(runtime->scripts, resolved, entry->module, &entry->module_ref,
-                                                         script_error, (int)sizeof(script_error));
-    SDL_free(resolved);
+    const bool ok = sdl3d_script_engine_load_module_buffer(runtime->scripts, script_buffer.data, script_buffer.size,
+                                                           resolved_path, entry->module, &entry->module_ref,
+                                                           script_error, (int)sizeof(script_error));
+    sdl3d_asset_buffer_free(&script_buffer);
+    SDL_free(resolved_path);
     if (!ok)
     {
         if (error_buffer != NULL && error_buffer_size > 0)
@@ -1837,19 +1876,31 @@ bool sdl3d_game_data_register_adapter(sdl3d_game_data_runtime *runtime, const ch
     return append_adapter(runtime, name, callback, userdata);
 }
 
-bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sdl3d_game_data_runtime **out_runtime,
-                               char *error_buffer, int error_buffer_size)
+bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,
+                                sdl3d_game_data_runtime **out_runtime, char *error_buffer, int error_buffer_size)
 {
     if (out_runtime != NULL)
         *out_runtime = NULL;
-    if (path == NULL || session == NULL || out_runtime == NULL)
+    if (assets == NULL || asset_path == NULL || asset_path[0] == '\0' || session == NULL || out_runtime == NULL)
     {
         set_error(error_buffer, error_buffer_size, "invalid game data load arguments");
         return false;
     }
 
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+    char asset_error[256];
+    if (!sdl3d_asset_resolver_read_file(assets, asset_path, &buffer, asset_error, (int)sizeof(asset_error)))
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to read game data asset %s: %s", asset_path,
+                         asset_error);
+        return false;
+    }
+
     yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_file(path, YYJSON_READ_NOFLAG, NULL, &err);
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, &err);
+    sdl3d_asset_buffer_free(&buffer);
     if (doc == NULL)
     {
         if (error_buffer != NULL && error_buffer_size > 0)
@@ -1875,7 +1926,8 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
     }
     runtime->doc = doc;
     runtime->session = session;
-    runtime->base_dir = path_dirname(path);
+    runtime->assets = assets;
+    runtime->base_dir = path_dirname(asset_path_without_scheme(asset_path));
     runtime->rng_state = 0xC0FFEEu;
     if (runtime->base_dir == NULL)
     {
@@ -1883,7 +1935,8 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
         set_error(error_buffer, error_buffer_size, "failed to resolve game data base directory");
         return false;
     }
-    if (!sdl3d_game_data_validate_document(root, path, runtime->base_dir, NULL, error_buffer, error_buffer_size))
+    if (!sdl3d_game_data_validate_document(root, asset_path, runtime->base_dir, assets, NULL, error_buffer,
+                                           error_buffer_size))
     {
         sdl3d_game_data_destroy(runtime);
         return false;
@@ -1904,8 +1957,53 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
     }
 
     load_active_camera(runtime, root);
+    runtime->assets = NULL;
     *out_runtime = runtime;
     return true;
+}
+
+bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sdl3d_game_data_runtime **out_runtime,
+                               char *error_buffer, int error_buffer_size)
+{
+    if (out_runtime != NULL)
+        *out_runtime = NULL;
+    if (path == NULL || path[0] == '\0' || session == NULL || out_runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "invalid game data load arguments");
+        return false;
+    }
+
+    char *base_dir = path_dirname(path);
+    char *asset_name = path_basename(path);
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (base_dir == NULL || asset_name == NULL || assets == NULL)
+    {
+        SDL_free(base_dir);
+        SDL_free(asset_name);
+        sdl3d_asset_resolver_destroy(assets);
+        set_error(error_buffer, error_buffer_size, "failed to create game data asset resolver");
+        return false;
+    }
+
+    char asset_error[256];
+    const bool mounted = sdl3d_asset_resolver_mount_directory(assets, base_dir, asset_error, (int)sizeof(asset_error));
+    if (!mounted)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to mount game data directory: %s",
+                         asset_error);
+        SDL_free(base_dir);
+        SDL_free(asset_name);
+        sdl3d_asset_resolver_destroy(assets);
+        return false;
+    }
+
+    const bool ok =
+        sdl3d_game_data_load_asset(assets, asset_name, session, out_runtime, error_buffer, error_buffer_size);
+    SDL_free(base_dir);
+    SDL_free(asset_name);
+    sdl3d_asset_resolver_destroy(assets);
+    return ok;
 }
 
 void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -36,6 +36,7 @@ typedef struct validation_context
     const sdl3d_game_data_validation_options *options;
     const char *source_path;
     const char *base_dir;
+    const sdl3d_asset_resolver *assets;
     char *error_buffer;
     int error_buffer_size;
     bool failed;
@@ -305,12 +306,26 @@ static char *path_join(const char *base_dir, const char *path)
     return joined;
 }
 
+static const char *asset_path_without_scheme(const char *path)
+{
+    return path != NULL && SDL_strncmp(path, "asset://", 8) == 0 ? path + 8 : path;
+}
+
 static bool script_path_exists(validation_context *ctx, const char *script_path, const char *json_path)
 {
     char *resolved = path_join(ctx->base_dir, script_path);
     if (resolved == NULL)
     {
         return validation_error(ctx, json_path, "failed to resolve script path '%s'", script_path);
+    }
+
+    if (ctx->assets != NULL)
+    {
+        const bool exists = sdl3d_asset_resolver_exists(ctx->assets, resolved);
+        SDL_free(resolved);
+        if (!exists)
+            return validation_error(ctx, json_path, "script asset '%s' does not exist", script_path);
+        return true;
     }
 
     SDL_IOStream *io = SDL_IOFromFile(resolved, "rb");
@@ -1031,6 +1046,7 @@ static void validation_names_destroy(validation_names *names)
 }
 
 bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path, const char *base_dir,
+                                       const sdl3d_asset_resolver *assets,
                                        const sdl3d_game_data_validation_options *options, char *error_buffer,
                                        int error_buffer_size)
 {
@@ -1041,6 +1057,7 @@ bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path
         .options = options,
         .source_path = source_path,
         .base_dir = base_dir,
+        .assets = assets,
         .error_buffer = error_buffer,
         .error_buffer_size = error_buffer_size,
         .failed = false,
@@ -1074,13 +1091,86 @@ bool sdl3d_game_data_validate_file(const char *path, const sdl3d_game_data_valid
         return validation_error(&ctx, "$", "invalid game data validation path");
     }
 
-    yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_file(path, YYJSON_READ_NOFLAG, NULL, &err);
-    if (doc == NULL)
+    char *base_dir = path_dirname(path);
+    const char *asset_name = path;
+    for (const char *p = path; *p != '\0'; ++p)
     {
+        if (*p == '/' || *p == '\\')
+            asset_name = p + 1;
+    }
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (base_dir == NULL || assets == NULL)
+    {
+        SDL_free(base_dir);
+        sdl3d_asset_resolver_destroy(assets);
         validation_context ctx = {
             .options = options,
             .source_path = path,
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "failed to create validation asset resolver");
+    }
+
+    char asset_error[256];
+    if (!sdl3d_asset_resolver_mount_directory(assets, base_dir, asset_error, (int)sizeof(asset_error)))
+    {
+        SDL_free(base_dir);
+        sdl3d_asset_resolver_destroy(assets);
+        validation_context ctx = {
+            .options = options,
+            .source_path = path,
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "failed to mount validation directory: %s", asset_error);
+    }
+
+    const bool ok = sdl3d_game_data_validate_asset(assets, asset_name, options, error_buffer, error_buffer_size);
+    SDL_free(base_dir);
+    sdl3d_asset_resolver_destroy(assets);
+    return ok;
+}
+
+bool sdl3d_game_data_validate_asset(sdl3d_asset_resolver *assets, const char *asset_path,
+                                    const sdl3d_game_data_validation_options *options, char *error_buffer,
+                                    int error_buffer_size)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        error_buffer[0] = '\0';
+    if (assets == NULL || asset_path == NULL || asset_path[0] == '\0')
+    {
+        validation_context ctx = {
+            .options = options,
+            .source_path = asset_path != NULL ? asset_path : "<game-data>",
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "invalid game data asset validation arguments");
+    }
+
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+    char asset_error[256];
+    if (!sdl3d_asset_resolver_read_file(assets, asset_path, &buffer, asset_error, (int)sizeof(asset_error)))
+    {
+        validation_context ctx = {
+            .options = options,
+            .source_path = asset_path,
+            .error_buffer = error_buffer,
+            .error_buffer_size = error_buffer_size,
+        };
+        return validation_error(&ctx, "$", "failed to read game data asset: %s", asset_error);
+    }
+
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        sdl3d_asset_buffer_free(&buffer);
+        validation_context ctx = {
+            .options = options,
+            .source_path = asset_path,
             .error_buffer = error_buffer,
             .error_buffer_size = error_buffer_size,
         };
@@ -1088,10 +1178,11 @@ bool sdl3d_game_data_validate_file(const char *path, const sdl3d_game_data_valid
                                 err.msg != NULL ? err.msg : "");
     }
 
-    char *base_dir = path_dirname(path);
-    const bool ok = sdl3d_game_data_validate_document(yyjson_doc_get_root(doc), path, base_dir, options, error_buffer,
-                                                      error_buffer_size);
+    char *base_dir = path_dirname(asset_path_without_scheme(asset_path));
+    const bool ok = sdl3d_game_data_validate_document(yyjson_doc_get_root(doc), asset_path, base_dir, assets, options,
+                                                      error_buffer, error_buffer_size);
     SDL_free(base_dir);
     yyjson_doc_free(doc);
+    sdl3d_asset_buffer_free(&buffer);
     return ok;
 }

--- a/src/game_data_validation.h
+++ b/src/game_data_validation.h
@@ -6,10 +6,12 @@
 #ifndef SDL3D_GAME_DATA_VALIDATION_H
 #define SDL3D_GAME_DATA_VALIDATION_H
 
+#include "sdl3d/asset.h"
 #include "sdl3d/game_data.h"
 #include "yyjson.h"
 
 bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path, const char *base_dir,
+                                       const sdl3d_asset_resolver *assets,
                                        const sdl3d_game_data_validation_options *options, char *error_buffer,
                                        int error_buffer_size);
 

--- a/src/script.c
+++ b/src/script.c
@@ -182,9 +182,56 @@ bool sdl3d_script_engine_load_module_file(sdl3d_script_engine *engine, const cha
 
     int result = luaL_loadfile(engine->lua, path);
     if (result == LUA_OK)
-    {
         result = lua_pcall(engine->lua, 0, 1, 0);
+    if (result != LUA_OK)
+    {
+        set_script_error(error_buffer, error_buffer_size, lua_tostring(engine->lua, -1));
+        lua_pop(engine->lua, 1);
+        return false;
     }
+
+    if (!lua_istable(engine->lua, -1))
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "Lua module must return a table");
+        return false;
+    }
+
+    if (!publish_module_global(engine->lua, module_name))
+    {
+        lua_pop(engine->lua, 1);
+        set_script_error(error_buffer, error_buffer_size, "failed to publish Lua module");
+        return false;
+    }
+
+    *out_module_ref = luaL_ref(engine->lua, LUA_REGISTRYINDEX);
+    if (*out_module_ref == LUA_NOREF || *out_module_ref == LUA_REFNIL)
+    {
+        *out_module_ref = SDL3D_SCRIPT_REF_INVALID;
+        set_script_error(error_buffer, error_buffer_size, "failed to store Lua module reference");
+        return false;
+    }
+
+    return true;
+}
+
+bool sdl3d_script_engine_load_module_buffer(sdl3d_script_engine *engine, const void *source, size_t source_size,
+                                            const char *chunk_name, const char *module_name,
+                                            sdl3d_script_ref *out_module_ref, char *error_buffer, int error_buffer_size)
+{
+    if (out_module_ref != NULL)
+        *out_module_ref = SDL3D_SCRIPT_REF_INVALID;
+    if (engine == NULL || engine->lua == NULL || source == NULL || source_size == 0u || module_name == NULL ||
+        module_name[0] == '\0' || out_module_ref == NULL)
+    {
+        set_script_error(error_buffer, error_buffer_size, "invalid Lua module load arguments");
+        return false;
+    }
+
+    const char *name = chunk_name != NULL && chunk_name[0] != '\0' ? chunk_name : module_name;
+    int result = luaL_loadbufferx(engine->lua, (const char *)source, source_size, name, NULL);
+    if (result == LUA_OK)
+        result = lua_pcall(engine->lua, 0, 1, 0);
     if (result != LUA_OK)
     {
         set_script_error(error_buffer, error_buffer_size, lua_tostring(engine->lua, -1));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -262,6 +262,7 @@ else()
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
 
     if(NOT EMSCRIPTEN)
+        sdl3d_add_test(sdl3d_asset_test test_asset.cpp unit)
         sdl3d_add_test(sdl3d_image_test test_image.cpp unit)
         sdl3d_add_test(sdl3d_font_test test_font.cpp unit)
         sdl3d_add_test(sdl3d_time_test test_time.cpp unit)

--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+extern "C"
+{
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/asset.h"
+}
+
+namespace
+{
+
+void append_u16(std::vector<std::uint8_t> &bytes, std::uint16_t value)
+{
+    bytes.push_back(static_cast<std::uint8_t>(value & 0xFFu));
+    bytes.push_back(static_cast<std::uint8_t>((value >> 8u) & 0xFFu));
+}
+
+void append_u32(std::vector<std::uint8_t> &bytes, std::uint32_t value)
+{
+    for (int i = 0; i < 4; ++i)
+        bytes.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFFu));
+}
+
+void append_u64(std::vector<std::uint8_t> &bytes, std::uint64_t value)
+{
+    for (int i = 0; i < 8; ++i)
+        bytes.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFFu));
+}
+
+std::vector<std::uint8_t> make_pack(const std::vector<std::pair<std::string, std::string>> &entries)
+{
+    std::uint64_t table_size = 0;
+    for (const auto &entry : entries)
+        table_size += 18u + static_cast<std::uint64_t>(entry.first.size());
+
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', '3', 'D', 'P', 'A', 'K', '1', '\0'});
+    append_u32(bytes, 1);
+    append_u32(bytes, static_cast<std::uint32_t>(entries.size()));
+    append_u64(bytes, 24);
+
+    std::uint64_t data_offset = 24u + table_size;
+    for (const auto &entry : entries)
+    {
+        append_u16(bytes, static_cast<std::uint16_t>(entry.first.size()));
+        append_u64(bytes, data_offset);
+        append_u64(bytes, static_cast<std::uint64_t>(entry.second.size()));
+        bytes.insert(bytes.end(), entry.first.begin(), entry.first.end());
+        data_offset += static_cast<std::uint64_t>(entry.second.size());
+    }
+
+    for (const auto &entry : entries)
+        bytes.insert(bytes.end(), entry.second.begin(), entry.second.end());
+    return bytes;
+}
+
+std::string buffer_string(const sdl3d_asset_buffer &buffer)
+{
+    return std::string(static_cast<const char *>(buffer.data), buffer.size);
+}
+
+} // namespace
+
+TEST(AssetResolver, ReadsFromMountedDirectory)
+{
+    sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
+    ASSERT_NE(resolver, nullptr);
+
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_directory(resolver, SDL3D_TEST_ASSETS_DIR, error, sizeof(error))) << error;
+    EXPECT_TRUE(sdl3d_asset_resolver_exists(resolver, "asset://game_data/module_success.game.json"));
+    EXPECT_FALSE(sdl3d_asset_resolver_exists(resolver, "asset://../CMakeLists.txt"));
+
+    sdl3d_asset_buffer buffer{};
+    ASSERT_TRUE(sdl3d_asset_resolver_read_file(resolver, "game_data/scripts/shared.lua", &buffer, error, sizeof(error)))
+        << error;
+    EXPECT_NE(buffer_string(buffer).find("function shared.speed"), std::string::npos);
+    sdl3d_asset_buffer_free(&buffer);
+
+    sdl3d_asset_resolver_destroy(resolver);
+}
+
+TEST(AssetResolver, ReadsFromMemoryPack)
+{
+    const std::vector<std::uint8_t> pack =
+        make_pack({{"scripts/rules.lua", "return { value = 42 }\n"}, {"data/config.json", "{\"ok\":true}\n"}});
+    sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
+    ASSERT_NE(resolver, nullptr);
+
+    char error[256]{};
+    ASSERT_TRUE(
+        sdl3d_asset_resolver_mount_memory_pack(resolver, pack.data(), pack.size(), "unit-pack", error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(sdl3d_asset_resolver_exists(resolver, "asset://scripts/rules.lua"));
+
+    sdl3d_asset_buffer buffer{};
+    ASSERT_TRUE(sdl3d_asset_resolver_read_file(resolver, "asset://data/config.json", &buffer, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(buffer_string(buffer), "{\"ok\":true}\n");
+    sdl3d_asset_buffer_free(&buffer);
+
+    sdl3d_asset_resolver_destroy(resolver);
+}
+
+TEST(AssetResolver, LaterMountsOverrideEarlierMounts)
+{
+    const std::vector<std::uint8_t> base_pack = make_pack({{"data/value.txt", "base"}});
+    const std::vector<std::uint8_t> patch_pack = make_pack({{"data/value.txt", "patch"}});
+    sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
+    ASSERT_NE(resolver, nullptr);
+
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_memory_pack(resolver, base_pack.data(), base_pack.size(), "base", error,
+                                                       sizeof(error)))
+        << error;
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_memory_pack(resolver, patch_pack.data(), patch_pack.size(), "patch", error,
+                                                       sizeof(error)))
+        << error;
+
+    sdl3d_asset_buffer buffer{};
+    ASSERT_TRUE(sdl3d_asset_resolver_read_file(resolver, "data/value.txt", &buffer, error, sizeof(error))) << error;
+    EXPECT_EQ(buffer_string(buffer), "patch");
+    sdl3d_asset_buffer_free(&buffer);
+
+    sdl3d_asset_resolver_destroy(resolver);
+}
+
+TEST(AssetResolver, RejectsUnsafeAndUnknownSchemePaths)
+{
+    const std::vector<std::uint8_t> pack = make_pack({{"safe.txt", "ok"}});
+    sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
+    ASSERT_NE(resolver, nullptr);
+
+    char error[256]{};
+    ASSERT_TRUE(
+        sdl3d_asset_resolver_mount_memory_pack(resolver, pack.data(), pack.size(), "safe", error, sizeof(error)))
+        << error;
+
+    sdl3d_asset_buffer buffer{};
+    EXPECT_FALSE(sdl3d_asset_resolver_read_file(resolver, "asset://../safe.txt", &buffer, error, sizeof(error)));
+    EXPECT_FALSE(
+        sdl3d_asset_resolver_read_file(resolver, "http://example.com/safe.txt", &buffer, error, sizeof(error)));
+    EXPECT_FALSE(sdl3d_asset_resolver_read_file(resolver, "C:/safe.txt", &buffer, error, sizeof(error)));
+
+    sdl3d_asset_resolver_destroy(resolver);
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1,12 +1,17 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <fstream>
+#include <iterator>
 #include <string>
+#include <utility>
 #include <vector>
 
 extern "C"
 {
 #include <SDL3/SDL_stdinc.h>
 
+#include "sdl3d/asset.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
 #include "sdl3d/math.h"
@@ -58,6 +63,57 @@ void capture_diagnostic(void *userdata, sdl3d_game_data_diagnostic_severity seve
 std::string fixture_path(const char *filename)
 {
     return std::string(SDL3D_GAME_DATA_FIXTURE_DIR) + "/" + filename;
+}
+
+std::string read_fixture_file(const char *filename)
+{
+    std::ifstream in(fixture_path(filename), std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+void append_u16(std::vector<std::uint8_t> &bytes, std::uint16_t value)
+{
+    bytes.push_back(static_cast<std::uint8_t>(value & 0xFFu));
+    bytes.push_back(static_cast<std::uint8_t>((value >> 8u) & 0xFFu));
+}
+
+void append_u32(std::vector<std::uint8_t> &bytes, std::uint32_t value)
+{
+    for (int i = 0; i < 4; ++i)
+        bytes.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFFu));
+}
+
+void append_u64(std::vector<std::uint8_t> &bytes, std::uint64_t value)
+{
+    for (int i = 0; i < 8; ++i)
+        bytes.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFFu));
+}
+
+std::vector<std::uint8_t> make_pack(const std::vector<std::pair<std::string, std::string>> &entries)
+{
+    std::uint64_t table_size = 0;
+    for (const auto &entry : entries)
+        table_size += 18u + static_cast<std::uint64_t>(entry.first.size());
+
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', '3', 'D', 'P', 'A', 'K', '1', '\0'});
+    append_u32(bytes, 1);
+    append_u32(bytes, static_cast<std::uint32_t>(entries.size()));
+    append_u64(bytes, 24);
+
+    std::uint64_t data_offset = 24u + table_size;
+    for (const auto &entry : entries)
+    {
+        append_u16(bytes, static_cast<std::uint16_t>(entry.first.size()));
+        append_u64(bytes, data_offset);
+        append_u64(bytes, static_cast<std::uint64_t>(entry.second.size()));
+        bytes.insert(bytes.end(), entry.first.begin(), entry.first.end());
+        data_offset += static_cast<std::uint64_t>(entry.second.size());
+    }
+
+    for (const auto &entry : entries)
+        bytes.insert(bytes.end(), entry.second.begin(), entry.second.end());
+    return bytes;
 }
 
 } // namespace
@@ -236,6 +292,54 @@ TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, LoadsLuaBackedGameDataFromMemoryPack)
+{
+    const std::string game_json = read_fixture_file("module_success.game.json");
+    const std::string shared_lua = read_fixture_file("scripts/shared.lua");
+    const std::string rules_lua = read_fixture_file("scripts/rules.lua");
+    ASSERT_FALSE(game_json.empty());
+    ASSERT_FALSE(shared_lua.empty());
+    ASSERT_FALSE(rules_lua.empty());
+
+    const std::vector<std::uint8_t> pack = make_pack({
+        {"module_success.game.json", game_json},
+        {"scripts/shared.lua", shared_lua},
+        {"scripts/rules.lua", rules_lua},
+    });
+
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    ASSERT_NE(assets, nullptr);
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_memory_pack(assets, pack.data(), pack.size(), "module-fixture", error,
+                                                       sizeof(error)))
+        << error;
+    EXPECT_TRUE(
+        sdl3d_game_data_validate_asset(assets, "asset://module_success.game.json", nullptr, error, sizeof(error)))
+        << error;
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(
+        sdl3d_game_data_load_asset(assets, "asset://module_success.game.json", session, &runtime, error, sizeof(error)))
+        << error;
+
+    const int run_signal = sdl3d_game_data_find_signal(runtime, "signal.run");
+    ASSERT_GE(run_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), run_signal, nullptr);
+
+    sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, "entity.target");
+    ASSERT_NE(target, nullptr);
+    EXPECT_FLOAT_EQ(target->position.x, 1.0f);
+    EXPECT_FLOAT_EQ(target->position.y, 2.0f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "ctx_ok", false));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    sdl3d_asset_resolver_destroy(assets);
 }
 
 TEST(GameDataRuntime, ValidatesPongDataWithoutDiagnostics)


### PR DESCRIPTION
## Summary
- add a public virtual asset resolver with directory, pack-file, and memory-pack mounts
- route game-data JSON validation/loading and Lua module loading through resolver-backed bytes
- add tests for resolver path safety, mount precedence, memory packs, and Lua-backed game data loading from a pack

## Verification
- make format
- cmake --build build/default
- ctest --test-dir build/default --output-on-failure (939/939 passed; 1 existing optional GPU test skipped)