### PR TITLE
Add build-time asset packaging workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SDL3D_USING_FETCHED_SDL3 OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SDL3DCompilerWarnings)
 include(SDL3DSanitizers)
+include(SDL3DAssets)
 
 if(NOT TARGET SDL3::SDL3)
     find_package(SDL3 3.2 CONFIG QUIET COMPONENTS SDL3)
@@ -204,6 +205,14 @@ sdl3d_enable_sanitizers(sdl3d)
 
 if(MSVC)
     target_compile_options(sdl3d PRIVATE /permissive-)
+endif()
+
+if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
+    add_executable(sdl3d_pack tools/sdl3d_pack.c)
+    target_link_libraries(sdl3d_pack PRIVATE SDL3D::sdl3d)
+    target_compile_features(sdl3d_pack PRIVATE c_std_17)
+    sdl3d_enable_warnings(sdl3d_pack)
+    sdl3d_enable_sanitizers(sdl3d_pack)
 endif()
 
 if(SDL3D_BUILD_TESTS)

--- a/cmake/SDL3DAssets.cmake
+++ b/cmake/SDL3DAssets.cmake
@@ -1,0 +1,78 @@
+function(sdl3d_add_asset_pack target_name)
+    set(options)
+    set(one_value_args ROOT OUTPUT)
+    set(multi_value_args FILES)
+    cmake_parse_arguments(SDL3D_PACK "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    if(NOT SDL3D_PACK_ROOT OR NOT SDL3D_PACK_OUTPUT OR NOT SDL3D_PACK_FILES)
+        message(FATAL_ERROR "sdl3d_add_asset_pack requires ROOT, OUTPUT, and FILES")
+    endif()
+    if(NOT TARGET sdl3d_pack)
+        message(FATAL_ERROR "sdl3d_add_asset_pack requires the native sdl3d_pack tool target")
+    endif()
+
+    set(_pack_args)
+    set(_pack_deps)
+    foreach(_file IN LISTS SDL3D_PACK_FILES)
+        list(APPEND _pack_args --file "${_file}")
+        list(APPEND _pack_deps "${SDL3D_PACK_ROOT}/${_file}")
+    endforeach()
+    get_filename_component(_pack_output_dir "${SDL3D_PACK_OUTPUT}" DIRECTORY)
+
+    add_custom_command(
+        OUTPUT "${SDL3D_PACK_OUTPUT}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_pack_output_dir}"
+        COMMAND $<TARGET_FILE:sdl3d_pack> --output "${SDL3D_PACK_OUTPUT}" --root "${SDL3D_PACK_ROOT}" ${_pack_args}
+        DEPENDS sdl3d_pack ${_pack_deps}
+        COMMAND_EXPAND_LISTS
+        VERBATIM
+        COMMENT "Packing SDL3D assets: ${SDL3D_PACK_OUTPUT}"
+    )
+    add_custom_target(${target_name} DEPENDS "${SDL3D_PACK_OUTPUT}")
+endfunction()
+
+function(sdl3d_add_embedded_asset_pack target_name)
+    set(options)
+    set(one_value_args ROOT SYMBOL OUTPUT_DIR)
+    set(multi_value_args FILES)
+    cmake_parse_arguments(SDL3D_EMBED "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    if(NOT SDL3D_EMBED_ROOT OR NOT SDL3D_EMBED_SYMBOL OR NOT SDL3D_EMBED_FILES)
+        message(FATAL_ERROR "sdl3d_add_embedded_asset_pack requires ROOT, SYMBOL, and FILES")
+    endif()
+    if(NOT SDL3D_EMBED_OUTPUT_DIR)
+        set(SDL3D_EMBED_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/${target_name}_generated")
+    endif()
+
+    set(_embed_c "${SDL3D_EMBED_OUTPUT_DIR}/${SDL3D_EMBED_SYMBOL}.c")
+    set(_embed_h "${SDL3D_EMBED_OUTPUT_DIR}/${SDL3D_EMBED_SYMBOL}.h")
+    set(_embed_deps)
+    foreach(_file IN LISTS SDL3D_EMBED_FILES)
+        list(APPEND _embed_deps "${SDL3D_EMBED_ROOT}/${_file}")
+    endforeach()
+    string(REPLACE ";" "|" _embed_files_arg "${SDL3D_EMBED_FILES}")
+
+    add_custom_command(
+        OUTPUT "${_embed_c}" "${_embed_h}"
+        COMMAND
+            ${CMAKE_COMMAND}
+            "-DOUTPUT_C=${_embed_c}"
+            "-DOUTPUT_H=${_embed_h}"
+            "-DSYMBOL=${SDL3D_EMBED_SYMBOL}"
+            "-DROOT=${SDL3D_EMBED_ROOT}"
+            "-DFILES=${_embed_files_arg}"
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/SDL3DEmbedAssetPack.cmake"
+        DEPENDS ${_embed_deps} "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/SDL3DEmbedAssetPack.cmake"
+        VERBATIM
+        COMMENT "Embedding SDL3D assets: ${SDL3D_EMBED_SYMBOL}"
+    )
+
+    add_library(${target_name} OBJECT "${_embed_c}")
+    target_include_directories(${target_name} PUBLIC "${SDL3D_EMBED_OUTPUT_DIR}")
+endfunction()
+
+function(sdl3d_target_preload_asset_directory target_name source_dir mount_dir)
+    if(EMSCRIPTEN)
+        target_link_options(${target_name} PRIVATE "--preload-file=${source_dir}@${mount_dir}")
+    endif()
+endfunction()

--- a/cmake/SDL3DEmbedAssetPack.cmake
+++ b/cmake/SDL3DEmbedAssetPack.cmake
@@ -1,0 +1,137 @@
+function(_sdl3d_append_le out_var value byte_count)
+    set(_bytes ${${out_var}})
+    math(EXPR _last "${byte_count} - 1")
+    foreach(_i RANGE 0 ${_last})
+        math(EXPR _byte "(${value} >> (${_i} * 8)) & 255")
+        list(APPEND _bytes "${_byte}")
+    endforeach()
+    set(${out_var} ${_bytes} PARENT_SCOPE)
+endfunction()
+
+function(_sdl3d_append_hex out_var hex)
+    set(_bytes ${${out_var}})
+    string(LENGTH "${hex}" _hex_len)
+    if(_hex_len GREATER 0)
+        math(EXPR _last "${_hex_len} - 2")
+        foreach(_i RANGE 0 ${_last} 2)
+            string(SUBSTRING "${hex}" ${_i} 2 _pair)
+            list(APPEND _bytes "0x${_pair}")
+        endforeach()
+    endif()
+    set(${out_var} ${_bytes} PARENT_SCOPE)
+endfunction()
+
+function(_sdl3d_append_ascii out_var text)
+    string(HEX "${text}" _hex)
+    _sdl3d_append_hex(${out_var} "${_hex}")
+    set(${out_var} ${${out_var}} PARENT_SCOPE)
+endfunction()
+
+function(_sdl3d_bytes_to_c_array out_var)
+    set(_line "    ")
+    set(_out "")
+    set(_column 0)
+    foreach(_byte IN LISTS ARGN)
+        if(_byte MATCHES "^0x")
+            set(_literal "${_byte}")
+        else()
+            set(_literal "${_byte}")
+        endif()
+        string(APPEND _line "${_literal}, ")
+        math(EXPR _column "${_column} + 1")
+        if(_column EQUAL 12)
+            string(APPEND _out "${_line}\n")
+            set(_line "    ")
+            set(_column 0)
+        endif()
+    endforeach()
+    if(NOT _line STREQUAL "    ")
+        string(APPEND _out "${_line}\n")
+    endif()
+    set(${out_var} "${_out}" PARENT_SCOPE)
+endfunction()
+
+if(NOT OUTPUT_C OR NOT OUTPUT_H OR NOT SYMBOL OR NOT ROOT OR NOT FILES)
+    message(FATAL_ERROR "SDL3DEmbedAssetPack.cmake requires OUTPUT_C, OUTPUT_H, SYMBOL, ROOT, and FILES")
+endif()
+
+string(REPLACE "|" ";" _files "${FILES}")
+list(SORT _files)
+
+set(_last_file "")
+set(_table_size 0)
+foreach(_file IN LISTS _files)
+    if(_file MATCHES "://" OR _file MATCHES "^/" OR _file MATCHES "^[A-Za-z]:" OR _file MATCHES "(^|/|\\\\)\\.\\.($|/|\\\\)")
+        message(FATAL_ERROR "Unsafe embedded asset path: ${_file}")
+    endif()
+    if(_last_file STREQUAL _file)
+        message(FATAL_ERROR "Duplicate embedded asset path: ${_file}")
+    endif()
+    set(_last_file "${_file}")
+
+    string(HEX "${_file}" _path_hex)
+    string(LENGTH "${_path_hex}" _path_hex_len)
+    math(EXPR _path_len "${_path_hex_len} / 2")
+    if(_path_len EQUAL 0 OR _path_len GREATER 65535)
+        message(FATAL_ERROR "Invalid embedded asset path: ${_file}")
+    endif()
+    math(EXPR _table_size "${_table_size} + 18 + ${_path_len}")
+endforeach()
+
+set(_bytes)
+_sdl3d_append_ascii(_bytes "S3DPAK1")
+list(APPEND _bytes 0)
+_sdl3d_append_le(_bytes 1 4)
+list(LENGTH _files _entry_count)
+_sdl3d_append_le(_bytes ${_entry_count} 4)
+_sdl3d_append_le(_bytes 24 8)
+
+math(EXPR _data_offset "24 + ${_table_size}")
+set(_data_chunks)
+foreach(_file IN LISTS _files)
+    string(HEX "${_file}" _path_hex)
+    string(LENGTH "${_path_hex}" _path_hex_len)
+    math(EXPR _path_len "${_path_hex_len} / 2")
+    set(_source "${ROOT}/${_file}")
+    if(NOT EXISTS "${_source}")
+        message(FATAL_ERROR "Embedded asset source does not exist: ${_source}")
+    endif()
+    file(SIZE "${_source}" _file_size)
+    file(READ "${_source}" _file_hex HEX)
+
+    _sdl3d_append_le(_bytes ${_path_len} 2)
+    _sdl3d_append_le(_bytes ${_data_offset} 8)
+    _sdl3d_append_le(_bytes ${_file_size} 8)
+    _sdl3d_append_hex(_bytes "${_path_hex}")
+
+    list(APPEND _data_chunks "${_file_hex}")
+    math(EXPR _data_offset "${_data_offset} + ${_file_size}")
+endforeach()
+
+foreach(_chunk IN LISTS _data_chunks)
+    _sdl3d_append_hex(_bytes "${_chunk}")
+endforeach()
+
+_sdl3d_bytes_to_c_array(_array ${_bytes})
+get_filename_component(_output_c_dir "${OUTPUT_C}" DIRECTORY)
+get_filename_component(_output_h_dir "${OUTPUT_H}" DIRECTORY)
+file(MAKE_DIRECTORY "${_output_c_dir}")
+file(MAKE_DIRECTORY "${_output_h_dir}")
+
+string(TOUPPER "${SYMBOL}_H" _guard)
+string(REGEX REPLACE "[^A-Z0-9_]" "_" _guard "${_guard}")
+
+file(WRITE "${OUTPUT_H}"
+"#ifndef ${_guard}\n"
+"#define ${_guard}\n\n"
+"#include <stddef.h>\n\n"
+"extern const unsigned char ${SYMBOL}[];\n"
+"extern const size_t ${SYMBOL}_size;\n\n"
+"#endif /* ${_guard} */\n")
+
+file(WRITE "${OUTPUT_C}"
+"#include \"${SYMBOL}.h\"\n\n"
+"const unsigned char ${SYMBOL}[] = {\n"
+"${_array}"
+"};\n\n"
+"const size_t ${SYMBOL}_size = sizeof(${SYMBOL});\n")

--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -1,12 +1,32 @@
+set(SDL3D_PONG_ASSET_FILES
+    pong.game.json
+    scripts/pong.lua)
+
+sdl3d_add_embedded_asset_pack(pong_assets
+    ROOT "${CMAKE_CURRENT_SOURCE_DIR}/data"
+    SYMBOL sdl3d_pong_assets
+    FILES ${SDL3D_PONG_ASSET_FILES})
+
 add_executable(pong_demo
     main.c)
 target_link_libraries(pong_demo PRIVATE SDL3D::sdl3d)
+target_link_libraries(pong_demo PRIVATE pong_assets)
 target_compile_features(pong_demo PRIVATE c_std_17)
 target_compile_definitions(pong_demo PRIVATE
     SDL3D_MEDIA_DIR="${CMAKE_SOURCE_DIR}/media"
-    SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json")
+    SDL3D_PONG_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data"
+    SDL3D_PONG_DATA_ASSET_PATH="asset://pong.game.json"
+    SDL3D_PONG_EMBEDDED_ASSETS=1)
 set_target_properties(pong_demo PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/demos/pong")
+
+if(TARGET sdl3d_pack)
+    sdl3d_add_asset_pack(pong_asset_pack
+        ROOT "${CMAKE_CURRENT_SOURCE_DIR}/data"
+        OUTPUT "${CMAKE_BINARY_DIR}/demos/pong/pong.sdl3dpak"
+        FILES ${SDL3D_PONG_ASSET_FILES})
+    add_dependencies(pong_demo pong_asset_pack)
+endif()
 
 if(NOT WIN32)
     target_link_libraries(pong_demo PRIVATE m)

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -5,6 +5,7 @@
 
 #include <stdbool.h>
 
+#include "sdl3d/asset.h"
 #include "sdl3d/camera.h"
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/effects.h"
@@ -19,6 +20,10 @@
 #include "sdl3d/shapes.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/transition.h"
+
+#if SDL3D_PONG_EMBEDDED_ASSETS
+#include "sdl3d_pong_assets.h"
+#endif
 
 #define PONG_WINDOW_WIDTH 1280
 #define PONG_WINDOW_HEIGHT 720
@@ -266,12 +271,37 @@ static void on_match_finished(void *userdata, int signal_id, const sdl3d_propert
 
 static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
 {
-    char error[512];
-    if (!sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, ctx->session, &state->data, error, (int)sizeof(error)))
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (assets == NULL)
     {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong data load failed: %s", error);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong asset resolver allocation failed");
         return false;
     }
+
+    char error[512];
+#if SDL3D_PONG_EMBEDDED_ASSETS
+    bool assets_ready = sdl3d_asset_resolver_mount_memory_pack(assets, sdl3d_pong_assets, sdl3d_pong_assets_size,
+                                                               "pong.embedded", error, (int)sizeof(error));
+#elif defined(SDL3D_PONG_PACK_PATH)
+    bool assets_ready = sdl3d_asset_resolver_mount_pack_file(assets, SDL3D_PONG_PACK_PATH, error, (int)sizeof(error));
+#else
+    bool assets_ready = sdl3d_asset_resolver_mount_directory(assets, SDL3D_PONG_DATA_DIR, error, (int)sizeof(error));
+#endif
+    if (!assets_ready)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong asset mount failed: %s", error);
+        sdl3d_asset_resolver_destroy(assets);
+        return false;
+    }
+
+    if (!sdl3d_game_data_load_asset(assets, SDL3D_PONG_DATA_ASSET_PATH, ctx->session, &state->data, error,
+                                    (int)sizeof(error)))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong data load failed: %s", error);
+        sdl3d_asset_resolver_destroy(assets);
+        return false;
+    }
+    sdl3d_asset_resolver_destroy(assets);
 
     state->actions.up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
     state->actions.down = sdl3d_game_data_find_action(state->data, "action.paddle.down");

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,66 @@
+# SDL3D Assets
+
+SDL3D game data should use stable virtual paths such as `asset://scripts/pong.lua`.
+At runtime, `sdl3d_asset_resolver` maps those paths to mounted source
+directories, `.sdl3dpak` files, or embedded memory packs.
+
+The resolver is intentionally read-only. Build-time tools create packs; runtime
+code mounts and reads them.
+
+## Runtime Loading
+
+Use a resolver when loading data-driven games:
+
+```c
+sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+sdl3d_asset_resolver_mount_pack_file(assets, "game.sdl3dpak", error, sizeof(error));
+sdl3d_game_data_load_asset(assets, "asset://pong.game.json", session, &runtime, error, sizeof(error));
+sdl3d_asset_resolver_destroy(assets);
+```
+
+Later mounts override earlier mounts. This gives the engine a clean path for
+future patch or mod overlays without changing authored asset paths.
+
+## Pack Files
+
+`sdl3d_asset_pack_write_file()` writes deterministic uncompressed packs from an
+explicit list of files. It normalizes and sorts asset paths, rejects duplicates,
+and writes explicit little-endian metadata instead of raw C structs.
+
+The format currently defers compression, encryption, and patch metadata. Those
+features should be added behind the pack writer/resolver boundary.
+
+## CMake Workflow
+
+Include `SDL3DAssets.cmake` through the top-level build and use:
+
+```cmake
+sdl3d_add_embedded_asset_pack(my_assets
+    ROOT "${CMAKE_CURRENT_SOURCE_DIR}/data"
+    SYMBOL my_game_assets
+    FILES
+        game.game.json
+        scripts/rules.lua)
+
+target_link_libraries(my_demo PRIVATE my_assets)
+```
+
+This creates a generated object library containing `my_game_assets` and
+`my_game_assets_size`, suitable for `sdl3d_asset_resolver_mount_memory_pack()`.
+
+For native build-time `.sdl3dpak` files:
+
+```cmake
+sdl3d_add_asset_pack(my_asset_pack
+    ROOT "${CMAKE_CURRENT_SOURCE_DIR}/data"
+    OUTPUT "${CMAKE_BINARY_DIR}/my_game.sdl3dpak"
+    FILES
+        game.game.json
+        scripts/rules.lua)
+```
+
+For Emscripten tests or demos that still use loose source directories:
+
+```cmake
+sdl3d_target_preload_asset_directory(my_target "${CMAKE_CURRENT_SOURCE_DIR}/data" "/data")
+```

--- a/include/sdl3d/asset.h
+++ b/include/sdl3d/asset.h
@@ -38,6 +38,21 @@ extern "C"
     } sdl3d_asset_buffer;
 
     /**
+     * @brief Source file entry used when writing an SDL3D asset pack.
+     *
+     * @p asset_path is the stable virtual path stored in the pack, such as
+     * scripts/pong.lua. @p source_path is the filesystem path read at build
+     * time. The writer copies both strings only for the duration of the call.
+     */
+    typedef struct sdl3d_asset_pack_source
+    {
+        /** @brief Stable virtual path stored in the pack. */
+        const char *asset_path;
+        /** @brief Filesystem path whose bytes are stored for @p asset_path. */
+        const char *source_path;
+    } sdl3d_asset_pack_source;
+
+    /**
      * @brief Create an empty asset resolver.
      *
      * Mount directories and packs before attempting to read assets. Later mounts
@@ -117,6 +132,25 @@ extern "C"
      * Safe to call with NULL or an already empty buffer.
      */
     void sdl3d_asset_buffer_free(sdl3d_asset_buffer *buffer);
+
+    /**
+     * @brief Write an SDL3D asset pack from explicit source files.
+     *
+     * Entries are normalized, sorted by asset path for deterministic output,
+     * checked for duplicates, and written with explicit little-endian integers.
+     * The format is currently uncompressed and unencrypted by design; future
+     * compression, encryption, and patch metadata can be added while preserving
+     * this API shape and the resolver abstraction.
+     *
+     * @param pack_path Filesystem output path to create or replace.
+     * @param entries Source files to include.
+     * @param entry_count Number of entries in @p entries.
+     * @param error_buffer Optional human-readable error output.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the pack was written successfully.
+     */
+    bool sdl3d_asset_pack_write_file(const char *pack_path, const sdl3d_asset_pack_source *entries, int entry_count,
+                                     char *error_buffer, int error_buffer_size);
 
 #ifdef __cplusplus
 }

--- a/src/asset.c
+++ b/src/asset.c
@@ -6,6 +6,7 @@
 #include "sdl3d/asset.h"
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_stdinc.h>
@@ -28,6 +29,15 @@ typedef struct asset_pack_entry
     uint64_t offset;
     uint64_t size;
 } asset_pack_entry;
+
+typedef struct asset_pack_write_entry
+{
+    char *asset_path;
+    const char *source_path;
+    uint8_t *data;
+    size_t size;
+    uint64_t offset;
+} asset_pack_write_entry;
 
 typedef struct asset_pack
 {
@@ -70,6 +80,26 @@ static uint32_t read_u32le(const uint8_t *data)
 static uint64_t read_u64le(const uint8_t *data)
 {
     return (uint64_t)read_u32le(data) | ((uint64_t)read_u32le(data + 4) << 32u);
+}
+
+static void write_u16le(uint8_t *data, uint16_t value)
+{
+    data[0] = (uint8_t)(value & 0xFFu);
+    data[1] = (uint8_t)((value >> 8u) & 0xFFu);
+}
+
+static void write_u32le(uint8_t *data, uint32_t value)
+{
+    data[0] = (uint8_t)(value & 0xFFu);
+    data[1] = (uint8_t)((value >> 8u) & 0xFFu);
+    data[2] = (uint8_t)((value >> 16u) & 0xFFu);
+    data[3] = (uint8_t)((value >> 24u) & 0xFFu);
+}
+
+static void write_u64le(uint8_t *data, uint64_t value)
+{
+    write_u32le(data, (uint32_t)(value & UINT32_MAX));
+    write_u32le(data + 4, (uint32_t)(value >> 32u));
 }
 
 static bool has_uri_scheme(const char *path)
@@ -169,6 +199,25 @@ static void destroy_pack(asset_pack *pack)
     SDL_zero(*pack);
 }
 
+static void destroy_write_entries(asset_pack_write_entry *entries, int count)
+{
+    if (entries == NULL)
+        return;
+    for (int i = 0; i < count; ++i)
+    {
+        SDL_free(entries[i].asset_path);
+        SDL_free(entries[i].data);
+    }
+    SDL_free(entries);
+}
+
+static int compare_write_entries(const void *a, const void *b)
+{
+    const asset_pack_write_entry *left = (const asset_pack_write_entry *)a;
+    const asset_pack_write_entry *right = (const asset_pack_write_entry *)b;
+    return SDL_strcmp(left->asset_path, right->asset_path);
+}
+
 static bool append_mount(sdl3d_asset_resolver *resolver, asset_mount **out_mount)
 {
     if (out_mount != NULL)
@@ -187,6 +236,13 @@ static bool append_mount(sdl3d_asset_resolver *resolver, asset_mount **out_mount
     resolver->mount_count++;
     *out_mount = mount;
     return true;
+}
+
+static bool write_all(SDL_IOStream *io, const void *data, size_t size)
+{
+    if (size == 0u)
+        return true;
+    return SDL_WriteIO(io, data, size) == size;
 }
 
 static bool parse_pack_entries(asset_pack *pack, char *error_buffer, int error_buffer_size)
@@ -518,4 +574,138 @@ void sdl3d_asset_buffer_free(sdl3d_asset_buffer *buffer)
     SDL_free(buffer->data);
     buffer->data = NULL;
     buffer->size = 0u;
+}
+
+bool sdl3d_asset_pack_write_file(const char *pack_path, const sdl3d_asset_pack_source *entries, int entry_count,
+                                 char *error_buffer, int error_buffer_size)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        error_buffer[0] = '\0';
+    if (pack_path == NULL || pack_path[0] == '\0' || entries == NULL || entry_count <= 0)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid asset pack write arguments");
+        return false;
+    }
+
+    asset_pack_write_entry *write_entries =
+        (asset_pack_write_entry *)SDL_calloc((size_t)entry_count, sizeof(*write_entries));
+    if (write_entries == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "failed to allocate asset pack entries");
+        return false;
+    }
+
+    bool ok = true;
+    uint64_t table_size = 0u;
+    for (int i = 0; i < entry_count && ok; ++i)
+    {
+        if (entries[i].asset_path == NULL || entries[i].source_path == NULL || entries[i].source_path[0] == '\0')
+        {
+            set_asset_error(error_buffer, error_buffer_size, "asset pack entry is missing a path");
+            ok = false;
+            break;
+        }
+
+        write_entries[i].asset_path = normalize_asset_path(entries[i].asset_path);
+        write_entries[i].source_path = entries[i].source_path;
+        if (write_entries[i].asset_path == NULL)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "asset pack entry has an invalid asset path");
+            ok = false;
+            break;
+        }
+
+        const size_t path_len = SDL_strlen(write_entries[i].asset_path);
+        if (path_len == 0u || path_len > UINT16_MAX)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "asset pack entry path is too long");
+            ok = false;
+            break;
+        }
+
+        size_t bytes = 0u;
+        write_entries[i].data = (uint8_t *)SDL_LoadFile(entries[i].source_path, &bytes);
+        if (write_entries[i].data == NULL)
+        {
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to read asset source '%s': %s",
+                             entries[i].source_path, SDL_GetError());
+            }
+            ok = false;
+            break;
+        }
+        write_entries[i].size = bytes;
+        table_size += SDL3D_PACK_ENTRY_FIXED_SIZE + path_len;
+    }
+
+    if (ok)
+    {
+        qsort(write_entries, (size_t)entry_count, sizeof(*write_entries), compare_write_entries);
+        for (int i = 1; i < entry_count; ++i)
+        {
+            if (SDL_strcmp(write_entries[i - 1].asset_path, write_entries[i].asset_path) == 0)
+            {
+                set_asset_error(error_buffer, error_buffer_size, "asset pack contains duplicate asset paths");
+                ok = false;
+                break;
+            }
+        }
+    }
+
+    uint64_t data_offset = SDL3D_PACK_HEADER_SIZE + table_size;
+    for (int i = 0; i < entry_count && ok; ++i)
+    {
+        if (data_offset > UINT64_MAX - (uint64_t)write_entries[i].size)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "asset pack is too large");
+            ok = false;
+            break;
+        }
+        write_entries[i].offset = data_offset;
+        data_offset += (uint64_t)write_entries[i].size;
+    }
+
+    SDL_IOStream *io = NULL;
+    if (ok)
+    {
+        io = SDL_IOFromFile(pack_path, "wb");
+        if (io == NULL)
+        {
+            set_asset_error(error_buffer, error_buffer_size, SDL_GetError());
+            ok = false;
+        }
+    }
+
+    if (ok)
+    {
+        uint8_t header[SDL3D_PACK_HEADER_SIZE];
+        SDL_zeroa(header);
+        SDL_memcpy(header, SDL3D_PACK_MAGIC, SDL3D_PACK_MAGIC_SIZE - 1u);
+        write_u32le(header + 8, SDL3D_PACK_VERSION);
+        write_u32le(header + 12, (uint32_t)entry_count);
+        write_u64le(header + 16, SDL3D_PACK_HEADER_SIZE);
+        ok = write_all(io, header, sizeof(header));
+    }
+
+    for (int i = 0; i < entry_count && ok; ++i)
+    {
+        const size_t path_len = SDL_strlen(write_entries[i].asset_path);
+        uint8_t entry_header[SDL3D_PACK_ENTRY_FIXED_SIZE];
+        write_u16le(entry_header, (uint16_t)path_len);
+        write_u64le(entry_header + 2, write_entries[i].offset);
+        write_u64le(entry_header + 10, (uint64_t)write_entries[i].size);
+        ok = write_all(io, entry_header, sizeof(entry_header)) && write_all(io, write_entries[i].asset_path, path_len);
+    }
+
+    for (int i = 0; i < entry_count && ok; ++i)
+        ok = write_all(io, write_entries[i].data, write_entries[i].size);
+
+    if (io != NULL && !SDL_CloseIO(io))
+        ok = false;
+    if (!ok && error_buffer != NULL && error_buffer_size > 0 && error_buffer[0] == '\0')
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to write asset pack '%s'", pack_path);
+
+    destroy_write_entries(write_entries, entry_count);
+    return ok;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,16 +207,12 @@ else()
         target_compile_definitions(
             sdl3d_game_data_test
             PRIVATE
-                SDL3D_PONG_DATA_PATH="/pong.game.json"
+                SDL3D_PONG_DATA_PATH="/pong/pong.game.json"
                 SDL3D_GAME_DATA_FIXTURE_DIR="/game_data"
         )
-        target_link_options(
-            sdl3d_game_data_test
-            PRIVATE
-                "--preload-file=${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json@/pong.game.json"
-                "--preload-file=${CMAKE_SOURCE_DIR}/demos/pong/data/scripts/pong.lua@/scripts/pong.lua"
-                "--preload-file=${CMAKE_SOURCE_DIR}/tests/assets/game_data@/game_data"
-        )
+        sdl3d_target_preload_asset_directory(sdl3d_game_data_test "${CMAKE_SOURCE_DIR}/demos/pong/data" "/pong")
+        sdl3d_target_preload_asset_directory(sdl3d_game_data_test "${CMAKE_SOURCE_DIR}/tests/assets/game_data"
+                                             "/game_data")
     else()
         target_compile_definitions(
             sdl3d_game_data_test
@@ -242,12 +238,8 @@ else()
     target_include_directories(doom_surveillance_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level)
     sdl3d_add_test(game_data_json_test test_game_data_json.cpp unit)
     if(EMSCRIPTEN)
-        target_compile_definitions(game_data_json_test PRIVATE SDL3D_PONG_DATA_PATH="/pong.game.json")
-        target_link_options(
-            game_data_json_test
-            PRIVATE
-                "--preload-file=${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json@/pong.game.json"
-        )
+        target_compile_definitions(game_data_json_test PRIVATE SDL3D_PONG_DATA_PATH="/pong/pong.game.json")
+        sdl3d_target_preload_asset_directory(game_data_json_test "${CMAKE_SOURCE_DIR}/demos/pong/data" "/pong")
     else()
         target_compile_definitions(
             game_data_json_test

--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <utility>
 #include <vector>
@@ -63,6 +66,22 @@ std::vector<std::uint8_t> make_pack(const std::vector<std::pair<std::string, std
 std::string buffer_string(const sdl3d_asset_buffer &buffer)
 {
     return std::string(static_cast<const char *>(buffer.data), buffer.size);
+}
+
+std::filesystem::path unique_test_dir(const char *name)
+{
+    const std::filesystem::path dir =
+        std::filesystem::temp_directory_path() / ("sdl3d_asset_test_" + std::string(name));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+void write_text(const std::filesystem::path &path, const char *text)
+{
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << text;
 }
 
 } // namespace
@@ -149,4 +168,79 @@ TEST(AssetResolver, RejectsUnsafeAndUnknownSchemePaths)
     EXPECT_FALSE(sdl3d_asset_resolver_read_file(resolver, "C:/safe.txt", &buffer, error, sizeof(error)));
 
     sdl3d_asset_resolver_destroy(resolver);
+}
+
+TEST(AssetPackWriter, WritesDeterministicPackReadableByResolver)
+{
+    const std::filesystem::path dir = unique_test_dir("round_trip");
+    write_text(dir / "sources" / "a.txt", "alpha");
+    write_text(dir / "sources" / "b.txt", "bravo");
+
+    const std::filesystem::path pack_a = dir / "a.sdl3dpak";
+    const std::filesystem::path pack_b = dir / "b.sdl3dpak";
+    const std::string source_a = (dir / "sources" / "a.txt").string();
+    const std::string source_b = (dir / "sources" / "b.txt").string();
+    const sdl3d_asset_pack_source sources[] = {
+        {"text/b.txt", source_b.c_str()},
+        {"text/a.txt", source_a.c_str()},
+    };
+
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_asset_pack_write_file(pack_a.string().c_str(), sources, 2, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_asset_pack_write_file(pack_b.string().c_str(), sources, 2, error, sizeof(error))) << error;
+
+    std::ifstream a(pack_a, std::ios::binary);
+    std::ifstream b(pack_b, std::ios::binary);
+    const std::string bytes_a{std::istreambuf_iterator<char>(a), std::istreambuf_iterator<char>()};
+    const std::string bytes_b{std::istreambuf_iterator<char>(b), std::istreambuf_iterator<char>()};
+    EXPECT_EQ(bytes_a, bytes_b);
+
+    sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
+    ASSERT_NE(resolver, nullptr);
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_pack_file(resolver, pack_a.string().c_str(), error, sizeof(error))) << error;
+
+    sdl3d_asset_buffer buffer{};
+    ASSERT_TRUE(sdl3d_asset_resolver_read_file(resolver, "asset://text/a.txt", &buffer, error, sizeof(error))) << error;
+    EXPECT_EQ(buffer_string(buffer), "alpha");
+    sdl3d_asset_buffer_free(&buffer);
+
+    sdl3d_asset_resolver_destroy(resolver);
+    std::filesystem::remove_all(dir);
+}
+
+TEST(AssetPackWriter, RejectsDuplicateNormalizedPaths)
+{
+    const std::filesystem::path dir = unique_test_dir("duplicates");
+    write_text(dir / "one.txt", "one");
+    write_text(dir / "two.txt", "two");
+
+    const std::string one = (dir / "one.txt").string();
+    const std::string two = (dir / "two.txt").string();
+    const sdl3d_asset_pack_source sources[] = {
+        {"text/one.txt", one.c_str()},
+        {"asset://text/./one.txt", two.c_str()},
+    };
+
+    char error[256]{};
+    EXPECT_FALSE(
+        sdl3d_asset_pack_write_file((dir / "bad.sdl3dpak").string().c_str(), sources, 2, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("duplicate"), std::string::npos);
+    std::filesystem::remove_all(dir);
+}
+
+TEST(AssetPackWriter, RejectsUnsafeAssetPaths)
+{
+    const std::filesystem::path dir = unique_test_dir("unsafe");
+    write_text(dir / "source.txt", "source");
+
+    const std::string source = (dir / "source.txt").string();
+    const sdl3d_asset_pack_source sources[] = {
+        {"../outside.txt", source.c_str()},
+    };
+
+    char error[256]{};
+    EXPECT_FALSE(
+        sdl3d_asset_pack_write_file((dir / "bad.sdl3dpak").string().c_str(), sources, 1, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("invalid"), std::string::npos);
+    std::filesystem::remove_all(dir);
 }

--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -70,11 +72,23 @@ std::string buffer_string(const sdl3d_asset_buffer &buffer)
 
 std::filesystem::path unique_test_dir(const char *name)
 {
-    const std::filesystem::path dir =
-        std::filesystem::temp_directory_path() / ("sdl3d_asset_test_" + std::string(name));
-    std::filesystem::remove_all(dir);
-    std::filesystem::create_directories(dir);
-    return dir;
+    const std::filesystem::path root = std::filesystem::temp_directory_path();
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    for (int attempt = 0; attempt < 100; ++attempt)
+    {
+        const std::filesystem::path dir = root / ("sdl3d_asset_test_" + std::string(name) + "_" + std::to_string(now) +
+                                                  "_" + std::to_string(attempt));
+        std::error_code error;
+        if (std::filesystem::create_directories(dir, error))
+            return dir;
+    }
+    throw std::runtime_error("failed to create unique asset test directory");
+}
+
+void remove_test_dir(const std::filesystem::path &dir)
+{
+    std::error_code error;
+    std::filesystem::remove_all(dir, error);
 }
 
 void write_text(const std::filesystem::path &path, const char *text)
@@ -82,6 +96,12 @@ void write_text(const std::filesystem::path &path, const char *text)
     std::filesystem::create_directories(path.parent_path());
     std::ofstream out(path, std::ios::binary);
     out << text;
+}
+
+std::string read_binary_file(const std::filesystem::path &path)
+{
+    std::ifstream in(path, std::ios::binary);
+    return std::string{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
 }
 
 } // namespace
@@ -189,10 +209,10 @@ TEST(AssetPackWriter, WritesDeterministicPackReadableByResolver)
     ASSERT_TRUE(sdl3d_asset_pack_write_file(pack_a.string().c_str(), sources, 2, error, sizeof(error))) << error;
     ASSERT_TRUE(sdl3d_asset_pack_write_file(pack_b.string().c_str(), sources, 2, error, sizeof(error))) << error;
 
-    std::ifstream a(pack_a, std::ios::binary);
-    std::ifstream b(pack_b, std::ios::binary);
-    const std::string bytes_a{std::istreambuf_iterator<char>(a), std::istreambuf_iterator<char>()};
-    const std::string bytes_b{std::istreambuf_iterator<char>(b), std::istreambuf_iterator<char>()};
+    const std::string bytes_a = read_binary_file(pack_a);
+    const std::string bytes_b = read_binary_file(pack_b);
+    ASSERT_FALSE(bytes_a.empty());
+    ASSERT_FALSE(bytes_b.empty());
     EXPECT_EQ(bytes_a, bytes_b);
 
     sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
@@ -205,7 +225,7 @@ TEST(AssetPackWriter, WritesDeterministicPackReadableByResolver)
     sdl3d_asset_buffer_free(&buffer);
 
     sdl3d_asset_resolver_destroy(resolver);
-    std::filesystem::remove_all(dir);
+    remove_test_dir(dir);
 }
 
 TEST(AssetPackWriter, RejectsDuplicateNormalizedPaths)
@@ -225,7 +245,7 @@ TEST(AssetPackWriter, RejectsDuplicateNormalizedPaths)
     EXPECT_FALSE(
         sdl3d_asset_pack_write_file((dir / "bad.sdl3dpak").string().c_str(), sources, 2, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("duplicate"), std::string::npos);
-    std::filesystem::remove_all(dir);
+    remove_test_dir(dir);
 }
 
 TEST(AssetPackWriter, RejectsUnsafeAssetPaths)
@@ -242,5 +262,5 @@ TEST(AssetPackWriter, RejectsUnsafeAssetPaths)
     EXPECT_FALSE(
         sdl3d_asset_pack_write_file((dir / "bad.sdl3dpak").string().c_str(), sources, 1, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("invalid"), std::string::npos);
-    std::filesystem::remove_all(dir);
+    remove_test_dir(dir);
 }

--- a/tools/sdl3d_pack.c
+++ b/tools/sdl3d_pack.c
@@ -1,0 +1,123 @@
+/**
+ * @file sdl3d_pack.c
+ * @brief Build-time SDL3D asset pack writer.
+ */
+
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include <stdio.h>
+
+#include "sdl3d/asset.h"
+
+typedef struct pack_args
+{
+    const char *output;
+    const char *root;
+    const char **files;
+    int file_count;
+} pack_args;
+
+static void print_usage(const char *argv0)
+{
+    fprintf(stderr, "Usage: %s --output <pack.sdl3dpak> --root <asset-root> --file <relative-path> [--file ...]\n",
+            argv0 != NULL ? argv0 : "sdl3d_pack");
+}
+
+static bool append_file_arg(pack_args *args, const char *file)
+{
+    const char **files = (const char **)SDL_realloc(args->files, (size_t)(args->file_count + 1) * sizeof(*files));
+    if (files == NULL)
+        return false;
+    args->files = files;
+    args->files[args->file_count++] = file;
+    return true;
+}
+
+static bool parse_args(int argc, char **argv, pack_args *args)
+{
+    SDL_zero(*args);
+    for (int i = 1; i < argc; ++i)
+    {
+        if (SDL_strcmp(argv[i], "--output") == 0 && i + 1 < argc)
+        {
+            args->output = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--root") == 0 && i + 1 < argc)
+        {
+            args->root = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--file") == 0 && i + 1 < argc)
+        {
+            if (!append_file_arg(args, argv[++i]))
+                return false;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    return args->output != NULL && args->root != NULL && args->file_count > 0;
+}
+
+static char *join_path(const char *root, const char *relative)
+{
+    const size_t root_len = SDL_strlen(root);
+    const size_t rel_len = SDL_strlen(relative);
+    const bool needs_sep = root_len > 0u && root[root_len - 1u] != '/' && root[root_len - 1u] != '\\';
+    char *joined = (char *)SDL_malloc(root_len + (needs_sep ? 1u : 0u) + rel_len + 1u);
+    if (joined == NULL)
+        return NULL;
+
+    SDL_memcpy(joined, root, root_len);
+    size_t offset = root_len;
+    if (needs_sep)
+        joined[offset++] = '/';
+    SDL_memcpy(joined + offset, relative, rel_len);
+    joined[offset + rel_len] = '\0';
+    return joined;
+}
+
+int main(int argc, char **argv)
+{
+    pack_args args;
+    if (!parse_args(argc, argv, &args))
+    {
+        print_usage(argc > 0 ? argv[0] : NULL);
+        SDL_free(args.files);
+        return 2;
+    }
+
+    sdl3d_asset_pack_source *sources = (sdl3d_asset_pack_source *)SDL_calloc((size_t)args.file_count, sizeof(*sources));
+    if (sources == NULL)
+    {
+        fprintf(stderr, "sdl3d_pack: failed to allocate source table\n");
+        SDL_free(args.files);
+        return 1;
+    }
+
+    bool ok = true;
+    for (int i = 0; i < args.file_count; ++i)
+    {
+        sources[i].asset_path = args.files[i];
+        sources[i].source_path = join_path(args.root, args.files[i]);
+        if (sources[i].source_path == NULL)
+        {
+            ok = false;
+            break;
+        }
+    }
+
+    char error[512] = "";
+    if (ok)
+        ok = sdl3d_asset_pack_write_file(args.output, sources, args.file_count, error, (int)sizeof(error));
+    if (!ok)
+        fprintf(stderr, "sdl3d_pack: %s\n", error[0] != '\0' ? error : "failed to write pack");
+
+    for (int i = 0; i < args.file_count; ++i)
+        SDL_free((void *)sources[i].source_path);
+    SDL_free(sources);
+    SDL_free(args.files);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add a public deterministic SDL3D pack writer API and native sdl3d_pack build tool
- add CMake helpers for .sdl3dpak generation, embedded memory-pack generation, and centralized Emscripten asset preloads
- update Pong to load game data through an embedded asset pack while also producing a standalone pong.sdl3dpak in native builds
- document the asset resolver, pack, and embedding workflow

## Verification
- make format
- cmake --build build/default
- cmake --build build/default --target sdl3d_pack pong_demo
- ctest --test-dir build/default --output-on-failure (942/942 passed; 1 existing optional GPU test skipped)