### PR TITLE
Move Pong match flow into authored logic

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -198,6 +198,8 @@
         "base_speed": { "type": "float", "value": 5.6 },
         "speedup_per_hit": { "type": "float", "value": 0.28 },
         "max_speed": { "type": "float", "value": 10.0 },
+        "max_serve_angle": { "type": "float", "value": 0.52 },
+        "max_reflect_angle": { "type": "float", "value": 1.05 },
         "active_motion": { "type": "bool", "value": false }
       },
       "components": [
@@ -220,6 +222,25 @@
       "tags": ["score", "cpu"],
       "properties": {
         "value": { "type": "int", "value": 0 }
+      }
+    },
+    {
+      "name": "entity.match",
+      "active": true,
+      "tags": ["state", "match"],
+      "properties": {
+        "finished": { "type": "bool", "value": false },
+        "winner": { "type": "string", "value": "none" },
+        "field_half_height": { "type": "float", "value": 5.0 }
+      }
+    },
+    {
+      "name": "entity.presentation",
+      "active": true,
+      "tags": ["state", "presentation"],
+      "properties": {
+        "border_flash": { "type": "float", "value": 0.0 },
+        "paddle_flash": { "type": "float", "value": 0.0 }
       }
     },
     {
@@ -252,6 +273,7 @@
     "signal.round.reset",
     "signal.match.player_won",
     "signal.match.cpu_won",
+    "signal.match.restart",
     "signal.camera.ball.toggle",
     "signal.presentation.flash_border"
   ],
@@ -303,6 +325,12 @@
         "type": "sensor.input_pressed",
         "action": "action.camera.ball.toggle",
         "on_pressed": "signal.camera.ball.toggle"
+      },
+      {
+        "name": "logic.match.restart_input",
+        "type": "sensor.input_pressed",
+        "action": "action.restart",
+        "on_pressed": "signal.match.restart"
       }
     ],
     "timers": [
@@ -338,6 +366,13 @@
         "signal": "signal.ball.hit_wall",
         "actions": [
           { "type": "signal.emit", "signal": "signal.presentation.flash_border" }
+        ]
+      },
+      {
+        "signal": "signal.presentation.flash_border",
+        "actions": [
+          { "type": "property.set", "target": "entity.presentation", "key": "border_flash", "value": 1.0 },
+          { "type": "property.set", "target": "entity.presentation", "key": "paddle_flash", "value": 1.0 }
         ]
       },
       {
@@ -399,6 +434,20 @@
         ]
       },
       {
+        "signal": "signal.match.player_won",
+        "actions": [
+          { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
+          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "player" }
+        ]
+      },
+      {
+        "signal": "signal.match.cpu_won",
+        "actions": [
+          { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
+          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "cpu" }
+        ]
+      },
+      {
         "signal": "signal.round.reset",
         "actions": [
           { "type": "property.set", "target": "entity.ball", "key": "active_motion", "value": false },
@@ -406,6 +455,32 @@
           { "type": "transform.set_position", "target": "entity.ball", "position": [0.0, 0.0, 0.12] },
           { "type": "transform.set_position", "target": "entity.paddle.player", "position": [-8.0, 0.0, 0.0] },
           { "type": "transform.set_position", "target": "entity.paddle.cpu", "position": [8.0, 0.0, 0.0] }
+        ]
+      },
+      {
+        "signal": "signal.match.restart",
+        "actions": [
+          {
+            "type": "branch",
+            "if": {
+              "type": "property.compare",
+              "target": "entity.match",
+              "key": "finished",
+              "op": "==",
+              "value": true
+            },
+            "then": [
+              { "type": "property.set", "target": "entity.score.player", "key": "value", "value": 0 },
+              { "type": "property.set", "target": "entity.score.cpu", "key": "value", "value": 0 },
+              { "type": "property.set", "target": "entity.match", "key": "finished", "value": false },
+              { "type": "property.set", "target": "entity.match", "key": "winner", "value": "none" },
+              { "type": "property.set", "target": "entity.presentation", "key": "border_flash", "value": 0.0 },
+              { "type": "property.set", "target": "entity.presentation", "key": "paddle_flash", "value": 0.0 },
+              { "type": "signal.emit", "signal": "signal.round.reset" },
+              { "type": "signal.emit", "signal": "signal.game.start" }
+            ],
+            "else": []
+          }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -6,6 +6,37 @@
     "version": "0.1.0",
     "description": "Fixed-screen arcade proof that SDL3D gameplay rules can be authored through generic entities, sensors, signals, timers, and actions."
   },
+  "app": {
+    "title": "SDL3D Pong",
+    "width": 1280,
+    "height": 720,
+    "backend": "auto",
+    "tick_rate": 0.008333333,
+    "max_ticks_per_frame": 12,
+    "enable_audio": false
+  },
+  "render": {
+    "clear_color": [3, 4, 8, 255],
+    "lighting": true,
+    "bloom": true,
+    "ssao": true,
+    "tonemap": "aces"
+  },
+  "transitions": {
+    "startup": {
+      "type": "fade",
+      "direction": "in",
+      "color": [0, 0, 0, 255],
+      "duration": 0.7
+    },
+    "quit": {
+      "type": "fade",
+      "direction": "out",
+      "color": [0, 0, 0, 255],
+      "duration": 0.45,
+      "done_signal": "signal.app.quit_fade_done"
+    }
+  },
   "profiles": [
     {
       "name": "profile.fixed_screen_arcade",
@@ -31,6 +62,95 @@
         "id": "font.hud",
         "builtin": "Inter",
         "size": 34
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.debug.frame_counter",
+        "font": "font.hud",
+        "source": "debug.fps_frame",
+        "format": "FPS %.0f  Frame %llu",
+        "x": 18.0,
+        "y": 16.0,
+        "color": [170, 190, 220, 230]
+      },
+      {
+        "name": "ui.camera.ball_label",
+        "font": "font.hud",
+        "visible": "camera.ball_chase",
+        "text": "BALL CAM",
+        "x": 18.0,
+        "y": 56.0,
+        "color": [255, 222, 140, 235]
+      },
+      {
+        "name": "ui.score",
+        "font": "font.hud",
+        "source": "score.player_cpu",
+        "format": "%02d   %02d",
+        "x": 0.5,
+        "y": 22.0,
+        "normalized": true,
+        "centered": true,
+        "color": [235, 242, 255, 255]
+      },
+      {
+        "name": "ui.match.player_won",
+        "font": "font.hud",
+        "visible": "match.player_won",
+        "text": "You win!",
+        "x": 0.5,
+        "y": 0.40,
+        "normalized": true,
+        "centered": true,
+        "color": [255, 255, 255, 255]
+      },
+      {
+        "name": "ui.match.cpu_won",
+        "font": "font.hud",
+        "visible": "match.cpu_won",
+        "text": "You lose!",
+        "x": 0.5,
+        "y": 0.40,
+        "normalized": true,
+        "centered": true,
+        "color": [255, 255, 255, 255]
+      },
+      {
+        "name": "ui.match.restart",
+        "font": "font.hud",
+        "visible": "match.finished",
+        "text": "Press enter to play again",
+        "x": 0.5,
+        "y": 0.49,
+        "normalized": true,
+        "centered": true,
+        "color": [200, 220, 255, 235]
+      },
+      {
+        "name": "ui.pause",
+        "font": "font.hud",
+        "visible": "paused",
+        "text": "PAUSED",
+        "x": 0.5,
+        "y": 0.44,
+        "normalized": true,
+        "centered": true,
+        "pulse_alpha": true,
+        "color": [245, 248, 255, 255]
+      },
+      {
+        "name": "ui.ready",
+        "font": "font.hud",
+        "visible": "round.waiting_to_serve",
+        "text": "Get ready",
+        "x": 0.5,
+        "y": 0.44,
+        "normalized": true,
+        "centered": true,
+        "color": [210, 225, 255, 190]
       }
     ]
   },
@@ -323,13 +443,7 @@
         "paddle_flash": { "type": "float", "value": 0.0 },
         "border_flash_decay": { "type": "float", "value": 2.8 },
         "paddle_flash_decay": { "type": "float", "value": 4.0 },
-        "pause_flash_speed": { "type": "float", "value": 3.0 },
-        "pause_text": { "type": "string", "value": "PAUSED" },
-        "ready_text": { "type": "string", "value": "Get ready" },
-        "restart_text": { "type": "string", "value": "Press enter to play again" },
-        "player_win_text": { "type": "string", "value": "You win!" },
-        "cpu_win_text": { "type": "string", "value": "You lose!" },
-        "ball_camera_label": { "type": "string", "value": "BALL CAM" }
+        "pause_flash_speed": { "type": "float", "value": 3.0 }
       }
     },
     {
@@ -377,7 +491,8 @@
     "signal.match.cpu_won",
     "signal.match.restart",
     "signal.camera.ball.toggle",
-    "signal.presentation.flash_border"
+    "signal.presentation.flash_border",
+    "signal.app.quit_fade_done"
   ],
   "logic": {
     "sensors": [

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -13,7 +13,15 @@
     "backend": "auto",
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
-    "enable_audio": false
+    "enable_audio": false,
+    "start_signal": "signal.game.start",
+    "pause_action": "action.pause",
+    "startup_transition": "startup",
+    "quit": {
+      "action": "action.exit",
+      "transition": "quit",
+      "quit_signal": "signal.app.quit_fade_done"
+    }
   },
   "render": {
     "clear_color": [3, 4, 8, 255],
@@ -70,8 +78,11 @@
       {
         "name": "ui.debug.frame_counter",
         "font": "font.hud",
-        "source": "debug.fps_frame",
         "format": "FPS %.0f  Frame %llu",
+        "bindings": [
+          { "type": "metric", "metric": "fps" },
+          { "type": "metric", "metric": "frame" }
+        ],
         "x": 18.0,
         "y": 16.0,
         "color": [170, 190, 220, 230]
@@ -79,7 +90,7 @@
       {
         "name": "ui.camera.ball_label",
         "font": "font.hud",
-        "visible": "camera.ball_chase",
+        "visible_if": { "type": "camera.active", "camera": "camera.ball_chase" },
         "text": "BALL CAM",
         "x": 18.0,
         "y": 56.0,
@@ -88,8 +99,11 @@
       {
         "name": "ui.score",
         "font": "font.hud",
-        "source": "score.player_cpu",
         "format": "%02d   %02d",
+        "bindings": [
+          { "type": "property", "entity": "entity.score.player", "key": "value" },
+          { "type": "property", "entity": "entity.score.cpu", "key": "value" }
+        ],
         "x": 0.5,
         "y": 22.0,
         "normalized": true,
@@ -99,7 +113,13 @@
       {
         "name": "ui.match.player_won",
         "font": "font.hud",
-        "visible": "match.player_won",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "player" }
+          ]
+        },
         "text": "You win!",
         "x": 0.5,
         "y": 0.40,
@@ -110,7 +130,13 @@
       {
         "name": "ui.match.cpu_won",
         "font": "font.hud",
-        "visible": "match.cpu_won",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "cpu" }
+          ]
+        },
         "text": "You lose!",
         "x": 0.5,
         "y": 0.40,
@@ -121,7 +147,7 @@
       {
         "name": "ui.match.restart",
         "font": "font.hud",
-        "visible": "match.finished",
+        "visible_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
         "text": "Press enter to play again",
         "x": 0.5,
         "y": 0.49,
@@ -132,7 +158,13 @@
       {
         "name": "ui.pause",
         "font": "font.hud",
-        "visible": "paused",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": true },
+            { "type": "not", "condition": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true } }
+          ]
+        },
         "text": "PAUSED",
         "x": 0.5,
         "y": 0.44,
@@ -144,7 +176,14 @@
       {
         "name": "ui.ready",
         "font": "font.hud",
-        "visible": "round.waiting_to_serve",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": false },
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false },
+            { "type": "property.compare", "target": "entity.ball", "key": "active_motion", "op": "==", "value": false }
+          ]
+        },
         "text": "Get ready",
         "x": 0.5,
         "y": 0.44,
@@ -242,17 +281,16 @@
       },
       {
         "name": "camera.ball_chase",
-        "type": "adapter",
-        "adapter": "adapter.pong.ball_chase_camera",
+        "type": "chase",
         "target_entity": "entity.ball",
-        "properties": {
-          "chase_distance": 2.6,
-          "height": 1.35,
-          "lookahead": 4.4,
-          "fovy": 68.0,
-          "ball_z_offset": 0.22,
-          "target_z_offset": -0.05
-        },
+        "velocity_property": "velocity",
+        "chase_distance": 2.6,
+        "height": 1.57,
+        "lookahead": 4.4,
+        "fovy": 68.0,
+        "target_offset": [0.0, 0.0, 0.22],
+        "target_z_offset": -0.05,
+        "up": [0.0, 0.0, 1.0],
         "active": false
       }
     ],
@@ -308,7 +346,15 @@
       "tags": ["render", "field", "border"],
       "transform": { "position": [0.0, 5.12, 0.0] },
       "components": [
-        { "type": "render.cube", "size": [18.35, 0.12, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+        {
+          "type": "render.cube",
+          "size": [18.35, 0.12, 0.18],
+          "color": [62, 72, 92, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [210, 235, 255, 255], "size_add": [0.06, 0.06, 0.0], "size_mode": "minor_axis", "emissive": [0.55, 0.70, 1.0] }
+          ]
+        }
       ]
     },
     {
@@ -317,7 +363,15 @@
       "tags": ["render", "field", "border"],
       "transform": { "position": [0.0, -5.12, 0.0] },
       "components": [
-        { "type": "render.cube", "size": [18.35, 0.12, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+        {
+          "type": "render.cube",
+          "size": [18.35, 0.12, 0.18],
+          "color": [62, 72, 92, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [210, 235, 255, 255], "size_add": [0.06, 0.06, 0.0], "size_mode": "minor_axis", "emissive": [0.55, 0.70, 1.0] }
+          ]
+        }
       ]
     },
     {
@@ -326,7 +380,15 @@
       "tags": ["render", "field", "border"],
       "transform": { "position": [-9.12, 0.0, 0.0] },
       "components": [
-        { "type": "render.cube", "size": [0.12, 10.35, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+        {
+          "type": "render.cube",
+          "size": [0.12, 10.35, 0.18],
+          "color": [62, 72, 92, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [210, 235, 255, 255], "size_add": [0.06, 0.06, 0.0], "size_mode": "minor_axis", "emissive": [0.55, 0.70, 1.0] }
+          ]
+        }
       ]
     },
     {
@@ -335,7 +397,15 @@
       "tags": ["render", "field", "border"],
       "transform": { "position": [9.12, 0.0, 0.0] },
       "components": [
-        { "type": "render.cube", "size": [0.12, 10.35, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+        {
+          "type": "render.cube",
+          "size": [0.12, 10.35, 0.18],
+          "color": [62, 72, 92, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [210, 235, 255, 255], "size_add": [0.06, 0.06, 0.0], "size_mode": "minor_axis", "emissive": [0.55, 0.70, 1.0] }
+          ]
+        }
       ]
     },
     {
@@ -344,15 +414,15 @@
       "tags": ["render", "field", "centerline"],
       "transform": { "position": [0.0, 0.0, 0.02] },
       "components": [
-        { "type": "render.cube", "offset": [0.0, -4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, -3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, -2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, -1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, 0.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, 1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, 2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, 3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
-        { "type": "render.cube", "offset": [0.0, 4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true }
+        { "type": "render.cube", "offset": [0.0, -4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, -3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, -2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, -1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, 0.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, 1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, 2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, 3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] },
+        { "type": "render.cube", "offset": [0.0, 4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true, "effects": [{ "type": "emissive", "color": [0.10, 0.12, 0.16] }] }
       ]
     },
     {
@@ -366,7 +436,14 @@
         "speed": { "type": "float", "value": 7.5 }
       },
       "components": [
-        { "type": "render.cube", "size": [0.36, 1.9, 0.28], "color": [205, 230, 255, 255] },
+        {
+          "type": "render.cube",
+          "size": [0.36, 1.9, 0.28],
+          "color": [205, 230, 255, 255],
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [255, 255, 255, 255], "emissive": [0.35, 0.42, 0.50] }
+          ]
+        },
         { "type": "collision.aabb", "half_extents": [0.18, 0.95, 0.14] },
         { "type": "control.axis_1d", "axis": "y", "negative": "action.paddle.down", "positive": "action.paddle.up" }
       ]
@@ -382,7 +459,14 @@
         "speed": { "type": "float", "value": 5.5 }
       },
       "components": [
-        { "type": "render.cube", "size": [0.36, 1.9, 0.28], "color": [195, 255, 212, 255] },
+        {
+          "type": "render.cube",
+          "size": [0.36, 1.9, 0.28],
+          "color": [195, 255, 212, 255],
+          "effects": [
+            { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [255, 255, 255, 255], "emissive": [0.35, 0.42, 0.50] }
+          ]
+        },
         { "type": "collision.aabb", "half_extents": [0.18, 0.95, 0.14] },
         { "type": "adapter.controller", "adapter": "adapter.pong.cpu_track_ball", "target": "entity.ball" }
       ]
@@ -403,7 +487,17 @@
         "active_motion": { "type": "bool", "value": false }
       },
       "components": [
-        { "type": "render.sphere", "radius": 0.22, "rings": 12, "slices": 18, "color": [255, 184, 82, 255], "emissive": true },
+        {
+          "type": "render.sphere",
+          "radius": 0.22,
+          "rings": 12,
+          "slices": 18,
+          "color": [255, 184, 82, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 9.0, "color": [255, 245, 156, 255], "emissive_base": [0.75, 0.48, 0.08], "emissive_add": [0.65, 0.30, 0.0] }
+          ]
+        },
         { "type": "collision.circle", "radius": 0.22 },
         { "type": "motion.velocity_2d", "property": "velocity" }
       ]
@@ -472,6 +566,7 @@
           "emissive_intensity": 1.35,
           "camera_facing": true,
           "depth_test": true,
+          "draw_emissive": [0.8, 0.9, 1.0],
           "random_seed": 19088743
         }
       ]
@@ -729,13 +824,6 @@
       "script": "script.pong",
       "function": "cpu_track_ball",
       "description": "Move the CPU paddle toward the current ball position."
-    },
-    {
-      "name": "adapter.pong.ball_chase_camera",
-      "kind": "camera",
-      "script": "script.pong",
-      "function": "ball_chase_camera",
-      "description": "Build a third-person camera from the ball position and velocity."
     }
   ]
 }

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -109,6 +109,7 @@
       "min": [-9.0, -5.0, -1.0],
       "max": [9.0, 5.0, 2.0]
     },
+    "ambient_light": [0.015, 0.018, 0.026],
     "cameras": [
       {
         "name": "camera.overhead",
@@ -124,6 +125,14 @@
         "type": "adapter",
         "adapter": "adapter.pong.ball_chase_camera",
         "target_entity": "entity.ball",
+        "properties": {
+          "chase_distance": 2.6,
+          "height": 1.35,
+          "lookahead": 4.4,
+          "fovy": 68.0,
+          "ball_z_offset": 0.22,
+          "target_z_offset": -0.05
+        },
         "active": false
       }
     ],
@@ -151,10 +160,81 @@
         "color": [0.14, 0.34, 1.0],
         "intensity": 2.9,
         "range": 12.0
+      },
+      {
+        "name": "light.ball",
+        "type": "point",
+        "target_entity": "entity.ball",
+        "offset": [0.0, 0.0, 1.2],
+        "color": [1.0, 0.86, 0.34],
+        "intensity": 3.1,
+        "range": 5.0
       }
     ]
   },
   "entities": [
+    {
+      "name": "entity.field.base",
+      "active": true,
+      "tags": ["render", "field"],
+      "transform": { "position": [0.0, 0.0, -0.45] },
+      "components": [
+        { "type": "render.cube", "size": [18.8, 10.8, 0.10], "color": [42, 48, 62, 255] }
+      ]
+    },
+    {
+      "name": "entity.field.border.top",
+      "active": true,
+      "tags": ["render", "field", "border"],
+      "transform": { "position": [0.0, 5.12, 0.0] },
+      "components": [
+        { "type": "render.cube", "size": [18.35, 0.12, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.field.border.bottom",
+      "active": true,
+      "tags": ["render", "field", "border"],
+      "transform": { "position": [0.0, -5.12, 0.0] },
+      "components": [
+        { "type": "render.cube", "size": [18.35, 0.12, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.field.border.left",
+      "active": true,
+      "tags": ["render", "field", "border"],
+      "transform": { "position": [-9.12, 0.0, 0.0] },
+      "components": [
+        { "type": "render.cube", "size": [0.12, 10.35, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.field.border.right",
+      "active": true,
+      "tags": ["render", "field", "border"],
+      "transform": { "position": [9.12, 0.0, 0.0] },
+      "components": [
+        { "type": "render.cube", "size": [0.12, 10.35, 0.18], "color": [62, 72, 92, 255], "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.field.center_ticks",
+      "active": true,
+      "tags": ["render", "field", "centerline"],
+      "transform": { "position": [0.0, 0.0, 0.02] },
+      "components": [
+        { "type": "render.cube", "offset": [0.0, -4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, -3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, -2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, -1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, 0.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, 1.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, 2.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, 3.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true },
+        { "type": "render.cube", "offset": [0.0, 4.0, 0.0], "size": [0.055, 0.42, 0.08], "color": [115, 132, 162, 180], "emissive": true }
+      ]
+    },
     {
       "name": "entity.paddle.player",
       "active": true,
@@ -203,7 +283,7 @@
         "active_motion": { "type": "bool", "value": false }
       },
       "components": [
-        { "type": "render.sphere", "radius": 0.22, "rings": 12, "slices": 18, "emissive": true },
+        { "type": "render.sphere", "radius": 0.22, "rings": 12, "slices": 18, "color": [255, 184, 82, 255], "emissive": true },
         { "type": "collision.circle", "radius": 0.22 },
         { "type": "motion.velocity_2d", "property": "velocity" }
       ]
@@ -240,7 +320,16 @@
       "tags": ["state", "presentation"],
       "properties": {
         "border_flash": { "type": "float", "value": 0.0 },
-        "paddle_flash": { "type": "float", "value": 0.0 }
+        "paddle_flash": { "type": "float", "value": 0.0 },
+        "border_flash_decay": { "type": "float", "value": 2.8 },
+        "paddle_flash_decay": { "type": "float", "value": 4.0 },
+        "pause_flash_speed": { "type": "float", "value": 3.0 },
+        "pause_text": { "type": "string", "value": "PAUSED" },
+        "ready_text": { "type": "string", "value": "Get ready" },
+        "restart_text": { "type": "string", "value": "Press enter to play again" },
+        "player_win_text": { "type": "string", "value": "You win!" },
+        "cpu_win_text": { "type": "string", "value": "You lose!" },
+        "ball_camera_label": { "type": "string", "value": "BALL CAM" }
       }
     },
     {
@@ -253,10 +342,23 @@
           "type": "particles.emitter",
           "shape": "box",
           "extents": [8.8, 4.8, 0.18],
+          "direction": [0.0, 1.0, 0.0],
+          "spread": 1.1,
+          "speed_min": 0.08,
+          "speed_max": 0.45,
+          "lifetime_min": 2.5,
+          "lifetime_max": 5.0,
+          "size_start": 0.035,
+          "size_end": 0.012,
+          "gravity": 0.0,
           "max_particles": 360,
           "emit_rate": 95.0,
           "color_start": [220, 235, 255, 105],
-          "color_end": [255, 255, 255, 0]
+          "color_end": [255, 255, 255, 0],
+          "emissive_intensity": 1.35,
+          "camera_facing": true,
+          "depth_test": true,
+          "random_seed": 19088743
         }
       ]
     }

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -1,15 +1,13 @@
 local pong = {}
 
-local HALF_HEIGHT = 5.0
-local MAX_SERVE_ANGLE = 0.52
-local MAX_REFLECT_ANGLE = 1.05
-
 function pong.serve_random(ball, _, ctx)
     local base_speed = ball:get_float("base_speed", 5.6)
+    local max_angle = ball:get_float("max_serve_angle", 0.52)
     local direction = ctx:random() < 0.5 and -1.0 or 1.0
-    local angle = (ctx:random() * 2.0 - 1.0) * MAX_SERVE_ANGLE
+    local angle = (ctx:random() * 2.0 - 1.0) * max_angle
+    local position = ball.position or Vec3(0.0, 0.0, 0.12)
 
-    ball.position = Vec3(0.0, 0.0, 0.12)
+    ball.position = Vec3(0.0, 0.0, position.z)
     ball.velocity = Vec3(math.cos(angle) * direction * base_speed, math.sin(angle) * base_speed, 0.0)
     return true
 end
@@ -32,15 +30,16 @@ function pong.reflect_from_paddle(ball, payload, ctx)
     local base_speed = ball:get_float("base_speed", 5.6)
     local max_speed = ball:get_float("max_speed", 10.0)
     local speedup = ball:get_float("speedup_per_hit", 0.28)
+    local max_angle = ball:get_float("max_reflect_angle", 1.05)
     local velocity = ball.velocity
 
     local speed = math.clamp(Vec3.length(velocity) + speedup, base_speed, max_speed)
     local impact = math.clamp((ball_position.y - paddle_position.y) / paddle_half_height, -1.0, 1.0)
     local direction = paddle_position.x < 0.0 and 1.0 or -1.0
-    local angle = impact * MAX_REFLECT_ANGLE
+    local angle = impact * max_angle
 
     ball.velocity = Vec3(math.cos(angle) * direction * speed, math.sin(angle) * speed, 0.0)
-    ball.position = Vec3(paddle_position.x + direction * (paddle_half_width + ball_radius + 0.01), ball_position.y, 0.12)
+    ball.position = Vec3(paddle_position.x + direction * (paddle_half_width + ball_radius + 0.01), ball_position.y, ball_position.z)
     return true
 end
 
@@ -54,9 +53,11 @@ function pong.cpu_track_ball(paddle, payload, ctx)
 
     local speed = paddle:get_float("speed", 5.5)
     local half_height = paddle:get_float("half_height", 0.95)
+    local match = ctx:actor("entity.match")
+    local field_half_height = match ~= nil and match:get_float("field_half_height", 5.0) or 5.0
     local max_step = speed * ctx.dt
     local step = math.clamp(ball_position.y - paddle_position.y, -max_step, max_step)
-    local next_y = math.clamp(paddle_position.y + step, -HALF_HEIGHT + half_height, HALF_HEIGHT - half_height)
+    local next_y = math.clamp(paddle_position.y + step, -field_half_height + half_height, field_half_height - half_height)
     paddle.position = Vec3(paddle_position.x, next_y, paddle_position.z)
     return true
 end

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -44,7 +44,7 @@ function pong.reflect_from_paddle(ball, payload, ctx)
 end
 
 function pong.cpu_track_ball(paddle, payload, ctx)
-    local ball = ctx:actor(payload.target_actor_name or "entity.ball")
+    local ball = payload.target_actor_name and ctx:actor(payload.target_actor_name) or ctx:actor_with_tags("ball")
     local ball_position = ball ~= nil and ball.position or nil
     local paddle_position = paddle.position
     if ball_position == nil or paddle_position == nil then
@@ -53,16 +53,12 @@ function pong.cpu_track_ball(paddle, payload, ctx)
 
     local speed = paddle:get_float("speed", 5.5)
     local half_height = paddle:get_float("half_height", 0.95)
-    local match = ctx:actor("entity.match")
+    local match = ctx:actor_with_tags("state", "match")
     local field_half_height = match ~= nil and match:get_float("field_half_height", 5.0) or 5.0
     local max_step = speed * ctx.dt
     local step = math.clamp(ball_position.y - paddle_position.y, -max_step, max_step)
     local next_y = math.clamp(paddle_position.y + step, -field_half_height + half_height, field_half_height - half_height)
     paddle.position = Vec3(paddle_position.x, next_y, paddle_position.z)
-    return true
-end
-
-function pong.ball_chase_camera()
     return true
 end
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -25,15 +25,6 @@
 #include "sdl3d_pong_assets.h"
 #endif
 
-#define PONG_WINDOW_WIDTH 1280
-#define PONG_WINDOW_HEIGHT 720
-#define PONG_TICK_RATE (1.0f / 120.0f)
-
-enum
-{
-    SIG_PONG_FADE_OUT_DONE = 9000
-};
-
 typedef enum pong_winner
 {
     PONG_WINNER_NONE = 0,
@@ -65,6 +56,7 @@ typedef struct pong_state
     int fps_sample_frames;
     Uint64 rendered_frames;
     int signal_game_start;
+    int signal_quit_fade_done;
     int player_score;
     int cpu_score;
     float player_y;
@@ -78,6 +70,18 @@ typedef struct pong_state
     pong_winner winner;
     bool quit_pending;
 } pong_state;
+
+static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
+{
+#if SDL3D_PONG_EMBEDDED_ASSETS
+    return sdl3d_asset_resolver_mount_memory_pack(assets, sdl3d_pong_assets, sdl3d_pong_assets_size, "pong.embedded",
+                                                  error, error_size);
+#elif defined(SDL3D_PONG_PACK_PATH)
+    return sdl3d_asset_resolver_mount_pack_file(assets, SDL3D_PONG_PACK_PATH, error, error_size);
+#else
+    return sdl3d_asset_resolver_mount_directory(assets, SDL3D_PONG_DATA_DIR, error, error_size);
+#endif
+}
 
 static sdl3d_input_manager *ctx_input(const sdl3d_game_context *ctx)
 {
@@ -162,8 +166,17 @@ static void start_quit_fade(sdl3d_game_context *ctx, pong_state *state)
     }
 
     state->quit_pending = true;
-    sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_OUT, (sdl3d_color){0, 0, 0, 255},
-                           0.45f, SIG_PONG_FADE_OUT_DONE);
+    sdl3d_game_data_transition_desc transition;
+    if (!sdl3d_game_data_get_transition(state->data, "quit", &transition))
+    {
+        transition.type = SDL3D_TRANSITION_FADE;
+        transition.direction = SDL3D_TRANSITION_OUT;
+        transition.color = (sdl3d_color){0, 0, 0, 255};
+        transition.duration = 0.45f;
+        transition.done_signal_id = state->signal_quit_fade_done;
+    }
+    sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
+                           transition.duration, transition.done_signal_id);
     (void)ctx;
 }
 
@@ -240,14 +253,6 @@ static float presentation_float(const pong_state *state, const char *key, float 
     return presentation != NULL ? sdl3d_properties_get_float(presentation->props, key, fallback) : fallback;
 }
 
-static const char *presentation_string(const pong_state *state, const char *key, const char *fallback)
-{
-    sdl3d_registered_actor *presentation = presentation_actor(state);
-    const char *value =
-        presentation != NULL ? sdl3d_properties_get_string(presentation->props, key, fallback) : fallback;
-    return value != NULL ? value : fallback;
-}
-
 static bool create_particles(pong_state *state)
 {
     sdl3d_particle_config config;
@@ -271,14 +276,7 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     }
 
     char error[512];
-#if SDL3D_PONG_EMBEDDED_ASSETS
-    bool assets_ready = sdl3d_asset_resolver_mount_memory_pack(assets, sdl3d_pong_assets, sdl3d_pong_assets_size,
-                                                               "pong.embedded", error, (int)sizeof(error));
-#elif defined(SDL3D_PONG_PACK_PATH)
-    bool assets_ready = sdl3d_asset_resolver_mount_pack_file(assets, SDL3D_PONG_PACK_PATH, error, (int)sizeof(error));
-#else
-    bool assets_ready = sdl3d_asset_resolver_mount_directory(assets, SDL3D_PONG_DATA_DIR, error, (int)sizeof(error));
-#endif
+    bool assets_ready = mount_pong_assets(assets, error, (int)sizeof(error));
     if (!assets_ready)
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong asset mount failed: %s", error);
@@ -298,6 +296,7 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     state->actions.pause = sdl3d_game_data_find_action(state->data, "action.pause");
     state->actions.exit = sdl3d_game_data_find_action(state->data, "action.exit");
     state->signal_game_start = sdl3d_game_data_find_signal(state->data, "signal.game.start");
+    state->signal_quit_fade_done = sdl3d_game_data_find_signal(state->data, "signal.app.quit_fade_done");
 
     sync_state_from_data(state);
     sdl3d_signal_emit(ctx_bus(ctx), state->signal_game_start, NULL);
@@ -309,12 +308,12 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     pong_state *state = (pong_state *)userdata;
     SDL_zero(*state);
 
-    if (sdl3d_signal_connect(ctx_bus(ctx), SIG_PONG_FADE_OUT_DONE, on_fade_out_done, ctx) == 0)
+    if (!init_game_data(ctx, state))
     {
         return false;
     }
-
-    if (!init_game_data(ctx, state))
+    if (state->signal_quit_fade_done < 0 ||
+        sdl3d_signal_connect(ctx_bus(ctx), state->signal_quit_fade_done, on_fade_out_done, ctx) == 0)
     {
         return false;
     }
@@ -330,14 +329,19 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong particles disabled: %s", SDL_GetError());
     }
 
-    sdl3d_set_lighting_enabled(ctx->renderer, true);
-    sdl3d_set_ambient_light(ctx->renderer, 0.015f, 0.018f, 0.025f);
-    sdl3d_set_bloom_enabled(ctx->renderer, true);
-    sdl3d_set_ssao_enabled(ctx->renderer, true);
-    sdl3d_set_tonemap_mode(ctx->renderer, SDL3D_TONEMAP_ACES);
+    sdl3d_game_data_render_settings render_settings;
+    sdl3d_game_data_get_render_settings(state->data, &render_settings);
+    sdl3d_set_lighting_enabled(ctx->renderer, render_settings.lighting_enabled);
+    sdl3d_set_bloom_enabled(ctx->renderer, render_settings.bloom_enabled);
+    sdl3d_set_ssao_enabled(ctx->renderer, render_settings.ssao_enabled);
+    sdl3d_set_tonemap_mode(ctx->renderer, render_settings.tonemap);
 
-    sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, (sdl3d_color){0, 0, 0, 255},
-                           0.7f, -1);
+    sdl3d_game_data_transition_desc transition;
+    if (sdl3d_game_data_get_transition(state->data, "startup", &transition))
+    {
+        sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
+                               transition.duration, transition.done_signal_id);
+    }
     return true;
 }
 
@@ -516,14 +520,85 @@ static bool draw_authored_primitive(void *userdata, const sdl3d_game_data_render
     return true;
 }
 
-static void draw_centered_text(sdl3d_render_context *renderer, const sdl3d_font *font, const char *text, float y,
-                               sdl3d_color color)
+static bool ui_visible(const sdl3d_game_context *ctx, const pong_state *state, const char *visible)
 {
-    float text_w = 0.0f;
-    float text_h = 0.0f;
-    sdl3d_measure_text(font, text, &text_w, &text_h);
-    const int width = sdl3d_get_render_context_width(renderer);
-    sdl3d_draw_text_overlay(renderer, font, text, ((float)width - text_w) * 0.5f, y, color);
+    if (visible == NULL || SDL_strcmp(visible, "always") == 0)
+        return true;
+    if (SDL_strcmp(visible, "camera.ball_chase") == 0)
+        return ball_camera_is_active(state);
+    if (SDL_strcmp(visible, "match.player_won") == 0)
+        return state->match_finished && state->winner == PONG_WINNER_PLAYER;
+    if (SDL_strcmp(visible, "match.cpu_won") == 0)
+        return state->match_finished && state->winner == PONG_WINNER_CPU;
+    if (SDL_strcmp(visible, "match.finished") == 0)
+        return state->match_finished;
+    if (SDL_strcmp(visible, "paused") == 0)
+        return ctx->paused && !state->match_finished;
+    if (SDL_strcmp(visible, "round.waiting_to_serve") == 0)
+        return !ctx->paused && !state->match_finished && !state->ball_active;
+    return false;
+}
+
+static bool ui_text_content(const pong_state *state, const sdl3d_game_data_ui_text *text, char *buffer,
+                            size_t buffer_size)
+{
+    if (text->source != NULL && SDL_strcmp(text->source, "debug.fps_frame") == 0)
+    {
+        SDL_snprintf(buffer, buffer_size, text->format != NULL ? text->format : "FPS %.0f  Frame %" SDL_PRIu64,
+                     state->displayed_fps, (unsigned long long)state->rendered_frames);
+        return true;
+    }
+    if (text->source != NULL && SDL_strcmp(text->source, "score.player_cpu") == 0)
+    {
+        SDL_snprintf(buffer, buffer_size, text->format != NULL ? text->format : "%02d   %02d", state->player_score,
+                     state->cpu_score);
+        return true;
+    }
+    if (text->text != NULL)
+    {
+        SDL_snprintf(buffer, buffer_size, "%s", text->text);
+        return true;
+    }
+    return false;
+}
+
+typedef struct ui_draw_context
+{
+    sdl3d_game_context *ctx;
+    const pong_state *state;
+} ui_draw_context;
+
+static bool draw_authored_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
+{
+    ui_draw_context *draw = (ui_draw_context *)userdata;
+    if (!ui_visible(draw->ctx, draw->state, text->visible))
+        return true;
+
+    char content[128];
+    if (!ui_text_content(draw->state, text, content, sizeof(content)))
+        return true;
+
+    sdl3d_color color = text->color;
+    if (text->pulse_alpha)
+    {
+        const float pulse = 0.5f + 0.5f * SDL_sinf(draw->state->pause_flash * SDL_PI_F * 2.0f);
+        color.a = (Uint8)(120.0f + pulse * 135.0f);
+    }
+
+    const int width = sdl3d_get_render_context_width(draw->ctx->renderer);
+    const int height = sdl3d_get_render_context_height(draw->ctx->renderer);
+    float x = text->normalized ? text->x * (float)width : text->x;
+    const float y = text->normalized ? text->y * (float)height : text->y;
+    if (text->centered)
+    {
+        float text_w = 0.0f;
+        float text_h = 0.0f;
+        sdl3d_measure_text(&draw->state->font, content, &text_w, &text_h);
+        x -= text_w * 0.5f;
+    }
+
+    sdl3d_draw_text_overlay(draw->ctx->renderer, &draw->state->font, content, x, y, color);
+    return true;
 }
 
 static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
@@ -533,42 +608,8 @@ static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
         return;
     }
 
-    const int width = sdl3d_get_render_context_width(ctx->renderer);
-    const int height = sdl3d_get_render_context_height(ctx->renderer);
-    sdl3d_draw_textf_overlay(ctx->renderer, &state->font, 18.0f, 16.0f, (sdl3d_color){170, 190, 220, 230},
-                             "FPS %.0f  Frame %" SDL_PRIu64, state->displayed_fps, state->rendered_frames);
-    if (ball_camera_is_active(state))
-    {
-        sdl3d_draw_text_overlay(ctx->renderer, &state->font,
-                                presentation_string(state, "ball_camera_label", "BALL CAM"), 18.0f, 56.0f,
-                                (sdl3d_color){255, 222, 140, 235});
-    }
-    sdl3d_draw_textf_overlay(ctx->renderer, &state->font, (float)width * 0.5f - 94.0f, 22.0f,
-                             (sdl3d_color){235, 242, 255, 255}, "%02d   %02d", state->player_score, state->cpu_score);
-
-    if (state->match_finished)
-    {
-        const char *winner = state->winner == PONG_WINNER_PLAYER
-                                 ? presentation_string(state, "player_win_text", "You win!")
-                                 : presentation_string(state, "cpu_win_text", "You lose!");
-        draw_centered_text(ctx->renderer, &state->font, winner, (float)height * 0.40f,
-                           (sdl3d_color){255, 255, 255, 255});
-        draw_centered_text(ctx->renderer, &state->font,
-                           presentation_string(state, "restart_text", "Press enter to play again"),
-                           (float)height * 0.49f, (sdl3d_color){200, 220, 255, 235});
-    }
-    else if (ctx->paused)
-    {
-        const float pulse = 0.5f + 0.5f * SDL_sinf(state->pause_flash * SDL_PI_F * 2.0f);
-        const Uint8 alpha = (Uint8)(120.0f + pulse * 135.0f);
-        draw_centered_text(ctx->renderer, &state->font, presentation_string(state, "pause_text", "PAUSED"),
-                           (float)height * 0.44f, (sdl3d_color){245, 248, 255, alpha});
-    }
-    else if (!state->ball_active)
-    {
-        draw_centered_text(ctx->renderer, &state->font, presentation_string(state, "ready_text", "Get ready"),
-                           (float)height * 0.44f, (sdl3d_color){210, 225, 255, 190});
-    }
+    ui_draw_context draw = {ctx, state};
+    sdl3d_game_data_for_each_ui_text(state->data, draw_authored_ui_text, &draw);
 }
 
 static float camera_float_or(const pong_state *state, const char *camera_name, const char *property_name,
@@ -643,7 +684,9 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     state->last_render_time = ctx->real_time;
     ++state->rendered_frames;
 
-    sdl3d_clear_render_context(ctx->renderer, (sdl3d_color){3, 4, 8, 255});
+    sdl3d_game_data_render_settings render_settings;
+    sdl3d_game_data_get_render_settings(state->data, &render_settings);
+    sdl3d_clear_render_context(ctx->renderer, render_settings.clear_color);
     configure_lights(ctx->renderer, state);
 
     const sdl3d_camera3d camera = make_active_camera(state);
@@ -689,12 +732,18 @@ int main(int argc, char **argv)
     pong_state state;
     sdl3d_game_config config;
     SDL_zero(config);
-    config.title = "SDL3D Pong";
-    config.width = PONG_WINDOW_WIDTH;
-    config.height = PONG_WINDOW_HEIGHT;
-    config.backend = SDL3D_BACKEND_AUTO;
-    config.tick_rate = PONG_TICK_RATE;
-    config.max_ticks_per_frame = 12;
+    char title[128] = "SDL3D";
+    char error[512];
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (assets == NULL || !mount_pong_assets(assets, error, (int)sizeof(error)) ||
+        !sdl3d_game_data_load_app_config_asset(assets, SDL3D_PONG_DATA_ASSET_PATH, &config, title, (int)sizeof(title),
+                                               error, (int)sizeof(error)))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong app config load failed: %s", assets != NULL ? error : "");
+        sdl3d_asset_resolver_destroy(assets);
+        return 1;
+    }
+    sdl3d_asset_resolver_destroy(assets);
 
     sdl3d_game_callbacks callbacks;
     SDL_zero(callbacks);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -25,27 +25,16 @@
 #include "sdl3d_pong_assets.h"
 #endif
 
-typedef enum pong_winner
-{
-    PONG_WINNER_NONE = 0,
-    PONG_WINNER_PLAYER,
-    PONG_WINNER_CPU,
-} pong_winner;
-
-typedef struct pong_actions
-{
-    int pause;
-    int exit;
-} pong_actions;
-
 typedef struct pong_state
 {
     sdl3d_game_data_runtime *data;
-    pong_actions actions;
     sdl3d_font font;
     bool has_font;
     sdl3d_particle_emitter *ambient_particles;
+    const char *ambient_particles_entity;
+    sdl3d_vec3 ambient_particles_emissive;
     sdl3d_transition transition;
+    sdl3d_game_data_app_control app;
     float time;
     float pause_flash;
     float border_flash;
@@ -55,19 +44,8 @@ typedef struct pong_state
     float displayed_fps;
     int fps_sample_frames;
     Uint64 rendered_frames;
-    int signal_game_start;
-    int signal_quit_fade_done;
-    int player_score;
-    int cpu_score;
-    float player_y;
-    float cpu_y;
-    sdl3d_vec2 ball_position;
-    sdl3d_vec2 ball_velocity;
-    float ball_z;
-    float ball_radius;
     bool ball_active;
     bool match_finished;
-    pong_winner winner;
     bool quit_pending;
 } pong_state;
 
@@ -93,69 +71,10 @@ static sdl3d_signal_bus *ctx_bus(const sdl3d_game_context *ctx)
     return sdl3d_game_session_get_signal_bus(ctx->session);
 }
 
-static float clampf(float value, float lo, float hi)
-{
-    if (value < lo)
-    {
-        return lo;
-    }
-    if (value > hi)
-    {
-        return hi;
-    }
-    return value;
-}
-
 static float fade_down(float value, float dt, float speed)
 {
     value -= dt * speed;
     return value > 0.0f ? value : 0.0f;
-}
-
-static sdl3d_color color_lerp(sdl3d_color a, sdl3d_color b, float t)
-{
-    t = clampf(t, 0.0f, 1.0f);
-    return (sdl3d_color){
-        (Uint8)((float)a.r + ((float)b.r - (float)a.r) * t),
-        (Uint8)((float)a.g + ((float)b.g - (float)a.g) * t),
-        (Uint8)((float)a.b + ((float)b.b - (float)a.b) * t),
-        (Uint8)((float)a.a + ((float)b.a - (float)a.a) * t),
-    };
-}
-
-static float vec2_length(sdl3d_vec2 value)
-{
-    return SDL_sqrtf(value.x * value.x + value.y * value.y);
-}
-
-static sdl3d_vec2 make_vec2(float x, float y)
-{
-    sdl3d_vec2 value;
-    value.x = x;
-    value.y = y;
-    return value;
-}
-
-static sdl3d_vec2 ball_camera_forward(const pong_state *state)
-{
-    sdl3d_vec2 forward = state->ball_velocity;
-    float len = vec2_length(forward);
-    if (len < 0.001f)
-    {
-        forward.x = 1.0f;
-        forward.y = 0.0f;
-        return forward;
-    }
-
-    forward.x /= len;
-    forward.y /= len;
-    return forward;
-}
-
-static bool ball_camera_is_active(const pong_state *state)
-{
-    const char *camera = sdl3d_game_data_active_camera(state->data);
-    return camera != NULL && SDL_strcmp(camera, "camera.ball_chase") == 0;
 }
 
 static void start_quit_fade(sdl3d_game_context *ctx, pong_state *state)
@@ -167,20 +86,17 @@ static void start_quit_fade(sdl3d_game_context *ctx, pong_state *state)
 
     state->quit_pending = true;
     sdl3d_game_data_transition_desc transition;
-    if (!sdl3d_game_data_get_transition(state->data, "quit", &transition))
+    if (state->app.quit_transition == NULL ||
+        !sdl3d_game_data_get_transition(state->data, state->app.quit_transition, &transition))
     {
-        transition.type = SDL3D_TRANSITION_FADE;
-        transition.direction = SDL3D_TRANSITION_OUT;
-        transition.color = (sdl3d_color){0, 0, 0, 255};
-        transition.duration = 0.45f;
-        transition.done_signal_id = state->signal_quit_fade_done;
+        ctx->quit_requested = true;
+        return;
     }
     sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
                            transition.duration, transition.done_signal_id);
-    (void)ctx;
 }
 
-static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properties *payload)
+static void on_quit_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
     sdl3d_game_context *ctx = (sdl3d_game_context *)userdata;
     (void)signal_id;
@@ -188,52 +104,26 @@ static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properti
     ctx->quit_requested = true;
 }
 
+static sdl3d_registered_actor *actor_with_tags(const pong_state *state, const char *tag0, const char *tag1)
+{
+    const char *tags[2] = {tag0, tag1};
+    return tag1 != NULL ? sdl3d_game_data_find_actor_with_tags(state->data, tags, 2)
+                        : sdl3d_game_data_find_actor_with_tag(state->data, tag0);
+}
+
 static void sync_state_from_data(pong_state *state)
 {
-    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(state->data, "entity.paddle.player");
-    sdl3d_registered_actor *cpu = sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu");
-    sdl3d_registered_actor *ball = sdl3d_game_data_find_actor(state->data, "entity.ball");
-    sdl3d_registered_actor *player_score = sdl3d_game_data_find_actor(state->data, "entity.score.player");
-    sdl3d_registered_actor *cpu_score = sdl3d_game_data_find_actor(state->data, "entity.score.cpu");
-    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(state->data, "entity.match");
-    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    sdl3d_registered_actor *ball = actor_with_tags(state, "ball", NULL);
+    sdl3d_registered_actor *match = actor_with_tags(state, "state", "match");
+    sdl3d_registered_actor *presentation = actor_with_tags(state, "state", "presentation");
 
-    if (player != NULL)
-    {
-        state->player_y = player->position.y;
-    }
-    if (cpu != NULL)
-    {
-        state->cpu_y = cpu->position.y;
-    }
     if (ball != NULL)
     {
-        const sdl3d_vec3 velocity =
-            sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
-        state->ball_position = make_vec2(ball->position.x, ball->position.y);
-        state->ball_velocity = make_vec2(velocity.x, velocity.y);
-        state->ball_z = ball->position.z;
-        state->ball_radius = sdl3d_properties_get_float(ball->props, "radius", 0.22f);
         state->ball_active = sdl3d_properties_get_bool(ball->props, "active_motion", false);
-    }
-    if (player_score != NULL)
-    {
-        state->player_score = sdl3d_properties_get_int(player_score->props, "value", 0);
-    }
-    if (cpu_score != NULL)
-    {
-        state->cpu_score = sdl3d_properties_get_int(cpu_score->props, "value", 0);
     }
     if (match != NULL)
     {
-        const char *winner = sdl3d_properties_get_string(match->props, "winner", "none");
         state->match_finished = sdl3d_properties_get_bool(match->props, "finished", false);
-        if (winner != NULL && SDL_strcmp(winner, "player") == 0)
-            state->winner = PONG_WINNER_PLAYER;
-        else if (winner != NULL && SDL_strcmp(winner, "cpu") == 0)
-            state->winner = PONG_WINNER_CPU;
-        else
-            state->winner = PONG_WINNER_NONE;
     }
     if (presentation != NULL)
     {
@@ -244,7 +134,7 @@ static void sync_state_from_data(pong_state *state)
 
 static sdl3d_registered_actor *presentation_actor(const pong_state *state)
 {
-    return sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    return actor_with_tags(state, "state", "presentation");
 }
 
 static float presentation_float(const pong_state *state, const char *key, float fallback)
@@ -255,13 +145,23 @@ static float presentation_float(const pong_state *state, const char *key, float 
 
 static bool create_particles(pong_state *state)
 {
-    sdl3d_particle_config config;
-    if (!sdl3d_game_data_get_particle_emitter(state->data, "entity.effect.ambient_particles", &config))
+    sdl3d_registered_actor *particles = actor_with_tags(state, "effect", "particles");
+    if (particles == NULL)
     {
-        SDL_SetError("missing entity.effect.ambient_particles particles.emitter component");
+        SDL_SetError("missing effect particles entity");
         return false;
     }
 
+    state->ambient_particles_entity = particles->name;
+    sdl3d_particle_config config;
+    if (!sdl3d_game_data_get_particle_emitter(state->data, state->ambient_particles_entity, &config))
+    {
+        SDL_SetError("missing particles.emitter component");
+        return false;
+    }
+
+    sdl3d_game_data_get_particle_emitter_draw_emissive(state->data, state->ambient_particles_entity,
+                                                       &state->ambient_particles_emissive);
     state->ambient_particles = sdl3d_create_particle_emitter(&config);
     return state->ambient_particles != NULL;
 }
@@ -293,14 +193,45 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     }
     sdl3d_asset_resolver_destroy(assets);
 
-    state->actions.pause = sdl3d_game_data_find_action(state->data, "action.pause");
-    state->actions.exit = sdl3d_game_data_find_action(state->data, "action.exit");
-    state->signal_game_start = sdl3d_game_data_find_signal(state->data, "signal.game.start");
-    state->signal_quit_fade_done = sdl3d_game_data_find_signal(state->data, "signal.app.quit_fade_done");
+    sdl3d_game_data_get_app_control(state->data, &state->app);
 
     sync_state_from_data(state);
-    sdl3d_signal_emit(ctx_bus(ctx), state->signal_game_start, NULL);
+    if (state->app.start_signal_id >= 0)
+    {
+        sdl3d_signal_emit(ctx_bus(ctx), state->app.start_signal_id, NULL);
+    }
     return true;
+}
+
+typedef struct font_capture
+{
+    const char *font_id;
+} font_capture;
+
+static bool capture_first_ui_font(void *userdata, const sdl3d_game_data_ui_text *text)
+{
+    font_capture *capture = (font_capture *)userdata;
+    if (capture->font_id == NULL && text->font != NULL)
+        capture->font_id = text->font;
+    return capture->font_id == NULL;
+}
+
+static bool load_authored_font(pong_state *state)
+{
+    font_capture capture;
+    SDL_zero(capture);
+    sdl3d_game_data_for_each_ui_text(state->data, capture_first_ui_font, &capture);
+    if (capture.font_id == NULL)
+        return false;
+
+    sdl3d_game_data_font_asset font;
+    if (!sdl3d_game_data_get_font_asset(state->data, capture.font_id, &font))
+        return false;
+    if (font.builtin)
+        return sdl3d_load_builtin_font(SDL3D_MEDIA_DIR, font.builtin_id, font.size, &state->font);
+
+    SDL_SetError("Pong demo currently supports built-in authored fonts only");
+    return false;
 }
 
 static bool pong_init(sdl3d_game_context *ctx, void *userdata)
@@ -312,13 +243,13 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     {
         return false;
     }
-    if (state->signal_quit_fade_done < 0 ||
-        sdl3d_signal_connect(ctx_bus(ctx), state->signal_quit_fade_done, on_fade_out_done, ctx) == 0)
+    if (state->app.quit_signal_id < 0 ||
+        sdl3d_signal_connect(ctx_bus(ctx), state->app.quit_signal_id, on_quit_signal, ctx) == 0)
     {
         return false;
     }
 
-    state->has_font = sdl3d_load_builtin_font(SDL3D_MEDIA_DIR, SDL3D_BUILTIN_FONT_INTER, 34.0f, &state->font);
+    state->has_font = load_authored_font(state);
     if (!state->has_font)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong font load failed: %s", SDL_GetError());
@@ -337,7 +268,8 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     sdl3d_set_tonemap_mode(ctx->renderer, render_settings.tonemap);
 
     sdl3d_game_data_transition_desc transition;
-    if (sdl3d_game_data_get_transition(state->data, "startup", &transition))
+    if (state->app.startup_transition != NULL &&
+        sdl3d_game_data_get_transition(state->data, state->app.startup_transition, &transition))
     {
         sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
                                transition.duration, transition.done_signal_id);
@@ -372,7 +304,7 @@ static void update_visual_effects(pong_state *state, float dt)
 
 static void consume_common_actions(sdl3d_game_context *ctx, pong_state *state)
 {
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->actions.exit))
+    if (state->app.quit_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.quit_action_id))
     {
         start_quit_fade(ctx, state);
     }
@@ -383,7 +315,8 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     pong_state *state = (pong_state *)userdata;
 
     consume_common_actions(ctx, state);
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->actions.pause) && !state->match_finished)
+    if (state->app.pause_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.pause_action_id) &&
+        !state->match_finished)
     {
         ctx->paused = true;
         state->pause_flash = 0.0f;
@@ -404,7 +337,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     pong_state *state = (pong_state *)userdata;
 
     consume_common_actions(ctx, state);
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->actions.pause))
+    if (state->app.pause_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.pause_action_id))
     {
         ctx->paused = false;
         return;
@@ -420,11 +353,6 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     {
         sdl3d_transition_update(&state->transition, ctx_bus(ctx), real_dt);
     }
-}
-
-static bool string_starts_with(const char *value, const char *prefix)
-{
-    return value != NULL && prefix != NULL && SDL_strncmp(value, prefix, SDL_strlen(prefix)) == 0;
 }
 
 static void configure_lights(sdl3d_render_context *renderer, const pong_state *state)
@@ -466,100 +394,11 @@ static void draw_emissive_render_primitive(sdl3d_render_context *renderer,
 static bool draw_authored_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
 {
     primitive_draw_context *context = (primitive_draw_context *)userdata;
-    const pong_state *state = context->state;
-    sdl3d_color color = primitive->color;
-    sdl3d_vec3 size = primitive->size;
-    float radius = primitive->radius;
-    float emissive_r = 0.0f;
-    float emissive_g = 0.0f;
-    float emissive_b = 0.0f;
-
-    if (string_starts_with(primitive->entity_name, "entity.field.border."))
-    {
-        const float flash = clampf(state->border_flash, 0.0f, 1.0f);
-        color = color_lerp(color, (sdl3d_color){210, 235, 255, 255}, flash);
-        if (size.x < size.y)
-            size.x += 0.06f * flash;
-        else
-            size.y += 0.06f * flash;
-        emissive_r = flash * 0.55f;
-        emissive_g = flash * 0.70f;
-        emissive_b = flash;
-    }
-    else if (string_starts_with(primitive->entity_name, "entity.field.center_ticks"))
-    {
-        emissive_r = 0.10f;
-        emissive_g = 0.12f;
-        emissive_b = 0.16f;
-    }
-    else if (string_starts_with(primitive->entity_name, "entity.paddle."))
-    {
-        const float flash = clampf(state->paddle_flash, 0.0f, 1.0f);
-        color = color_lerp(color, (sdl3d_color){255, 255, 255, 255}, flash);
-        emissive_r = flash * 0.35f;
-        emissive_g = flash * 0.42f;
-        emissive_b = flash * 0.50f;
-    }
-    else if (SDL_strcmp(primitive->entity_name, "entity.ball") == 0)
-    {
-        const float pulse = 0.5f + 0.5f * SDL_sinf(state->time * 9.0f);
-        color = color_lerp(color, (sdl3d_color){255, 245, 156, 255}, pulse);
-        emissive_r = 0.75f + pulse * 0.65f;
-        emissive_g = 0.48f + pulse * 0.30f;
-        emissive_b = 0.08f;
-    }
-    else if (primitive->emissive)
-    {
-        emissive_r = 0.2f;
-        emissive_g = 0.2f;
-        emissive_b = 0.2f;
-    }
-
-    draw_emissive_render_primitive(context->renderer, primitive, color, size, radius, emissive_r, emissive_g,
-                                   emissive_b);
+    (void)context->state;
+    draw_emissive_render_primitive(context->renderer, primitive, primitive->color, primitive->size, primitive->radius,
+                                   primitive->emissive_color.x, primitive->emissive_color.y,
+                                   primitive->emissive_color.z);
     return true;
-}
-
-static bool ui_visible(const sdl3d_game_context *ctx, const pong_state *state, const char *visible)
-{
-    if (visible == NULL || SDL_strcmp(visible, "always") == 0)
-        return true;
-    if (SDL_strcmp(visible, "camera.ball_chase") == 0)
-        return ball_camera_is_active(state);
-    if (SDL_strcmp(visible, "match.player_won") == 0)
-        return state->match_finished && state->winner == PONG_WINNER_PLAYER;
-    if (SDL_strcmp(visible, "match.cpu_won") == 0)
-        return state->match_finished && state->winner == PONG_WINNER_CPU;
-    if (SDL_strcmp(visible, "match.finished") == 0)
-        return state->match_finished;
-    if (SDL_strcmp(visible, "paused") == 0)
-        return ctx->paused && !state->match_finished;
-    if (SDL_strcmp(visible, "round.waiting_to_serve") == 0)
-        return !ctx->paused && !state->match_finished && !state->ball_active;
-    return false;
-}
-
-static bool ui_text_content(const pong_state *state, const sdl3d_game_data_ui_text *text, char *buffer,
-                            size_t buffer_size)
-{
-    if (text->source != NULL && SDL_strcmp(text->source, "debug.fps_frame") == 0)
-    {
-        SDL_snprintf(buffer, buffer_size, text->format != NULL ? text->format : "FPS %.0f  Frame %" SDL_PRIu64,
-                     state->displayed_fps, (unsigned long long)state->rendered_frames);
-        return true;
-    }
-    if (text->source != NULL && SDL_strcmp(text->source, "score.player_cpu") == 0)
-    {
-        SDL_snprintf(buffer, buffer_size, text->format != NULL ? text->format : "%02d   %02d", state->player_score,
-                     state->cpu_score);
-        return true;
-    }
-    if (text->text != NULL)
-    {
-        SDL_snprintf(buffer, buffer_size, "%s", text->text);
-        return true;
-    }
-    return false;
 }
 
 typedef struct ui_draw_context
@@ -571,11 +410,17 @@ typedef struct ui_draw_context
 static bool draw_authored_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
 {
     ui_draw_context *draw = (ui_draw_context *)userdata;
-    if (!ui_visible(draw->ctx, draw->state, text->visible))
+    sdl3d_game_data_ui_metrics metrics;
+    SDL_zero(metrics);
+    metrics.paused = draw->ctx->paused;
+    metrics.fps = draw->state->displayed_fps;
+    metrics.frame = draw->state->rendered_frames;
+
+    if (!sdl3d_game_data_ui_text_is_visible(draw->state->data, text, &metrics))
         return true;
 
     char content[128];
-    if (!ui_text_content(draw->state, text, content, sizeof(content)))
+    if (!sdl3d_game_data_format_ui_text(draw->state->data, text, &metrics, content, sizeof(content)))
         return true;
 
     sdl3d_color color = text->color;
@@ -612,44 +457,11 @@ static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
     sdl3d_game_data_for_each_ui_text(state->data, draw_authored_ui_text, &draw);
 }
 
-static float camera_float_or(const pong_state *state, const char *camera_name, const char *property_name,
-                             float fallback)
-{
-    float value = 0.0f;
-    return sdl3d_game_data_get_camera_float(state->data, camera_name, property_name, &value) ? value : fallback;
-}
-
-static sdl3d_camera3d make_ball_camera(const pong_state *state)
-{
-    const char *camera_name = "camera.ball_chase";
-    const sdl3d_vec2 forward = ball_camera_forward(state);
-    const float ball_z_offset = camera_float_or(state, camera_name, "ball_z_offset", state->ball_radius);
-    const sdl3d_vec3 ball =
-        sdl3d_vec3_make(state->ball_position.x, state->ball_position.y, state->ball_z + ball_z_offset);
-    const float chase_distance = camera_float_or(state, camera_name, "chase_distance", 2.6f);
-    const float camera_height = camera_float_or(state, camera_name, "height", 1.35f);
-    const float lookahead = camera_float_or(state, camera_name, "lookahead", 4.4f);
-    const float target_z_offset = camera_float_or(state, camera_name, "target_z_offset", -0.05f);
-
-    sdl3d_camera3d camera;
-    SDL_zero(camera);
-    camera.position = sdl3d_vec3_make(ball.x - forward.x * chase_distance, ball.y - forward.y * chase_distance,
-                                      ball.z + camera_height);
-    camera.target =
-        sdl3d_vec3_make(ball.x + forward.x * lookahead, ball.y + forward.y * lookahead, ball.z + target_z_offset);
-    camera.up = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
-    camera.fovy = camera_float_or(state, camera_name, "fovy", 68.0f);
-    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
-    return camera;
-}
-
 static sdl3d_camera3d make_active_camera(const pong_state *state)
 {
-    if (ball_camera_is_active(state))
-        return make_ball_camera(state);
-
     sdl3d_camera3d camera;
-    if (sdl3d_game_data_get_camera(state->data, "camera.overhead", &camera))
+    const char *active_camera = sdl3d_game_data_active_camera(state->data);
+    if (active_camera != NULL && sdl3d_game_data_get_camera(state->data, active_camera, &camera))
         return camera;
 
     SDL_zero(camera);
@@ -695,12 +507,15 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     {
         if (state->ambient_particles != NULL)
         {
-            sdl3d_set_emissive(ctx->renderer, 0.8f, 0.9f, 1.0f);
+            sdl3d_set_emissive(ctx->renderer, state->ambient_particles_emissive.x, state->ambient_particles_emissive.y,
+                               state->ambient_particles_emissive.z);
             sdl3d_draw_particles(ctx->renderer, state->ambient_particles);
             sdl3d_set_emissive(ctx->renderer, 0.0f, 0.0f, 0.0f);
         }
         primitive_draw_context draw_context = {ctx->renderer, state};
-        sdl3d_game_data_for_each_render_primitive(state->data, draw_authored_primitive, &draw_context);
+        const sdl3d_game_data_render_eval render_eval = {.time = state->time};
+        sdl3d_game_data_for_each_render_primitive_evaluated(state->data, &render_eval, draw_authored_primitive,
+                                                            &draw_context);
         sdl3d_end_mode_3d(ctx->renderer);
     }
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -52,11 +52,8 @@ typedef enum pong_winner
 
 typedef struct pong_actions
 {
-    int up;
-    int down;
     int pause;
     int exit;
-    int restart;
 } pong_actions;
 
 typedef struct pong_state
@@ -77,10 +74,6 @@ typedef struct pong_state
     int fps_sample_frames;
     Uint64 rendered_frames;
     int signal_game_start;
-    int signal_round_reset;
-    int signal_match_player_won;
-    int signal_match_cpu_won;
-    int signal_flash_border;
     int player_score;
     int cpu_score;
     float player_y;
@@ -196,6 +189,8 @@ static void sync_state_from_data(pong_state *state)
     sdl3d_registered_actor *ball = sdl3d_game_data_find_actor(state->data, "entity.ball");
     sdl3d_registered_actor *player_score = sdl3d_game_data_find_actor(state->data, "entity.score.player");
     sdl3d_registered_actor *cpu_score = sdl3d_game_data_find_actor(state->data, "entity.score.cpu");
+    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(state->data, "entity.match");
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
 
     if (player != NULL)
     {
@@ -220,6 +215,22 @@ static void sync_state_from_data(pong_state *state)
     if (cpu_score != NULL)
     {
         state->cpu_score = sdl3d_properties_get_int(cpu_score->props, "value", 0);
+    }
+    if (match != NULL)
+    {
+        const char *winner = sdl3d_properties_get_string(match->props, "winner", "none");
+        state->match_finished = sdl3d_properties_get_bool(match->props, "finished", false);
+        if (winner != NULL && SDL_strcmp(winner, "player") == 0)
+            state->winner = PONG_WINNER_PLAYER;
+        else if (winner != NULL && SDL_strcmp(winner, "cpu") == 0)
+            state->winner = PONG_WINNER_CPU;
+        else
+            state->winner = PONG_WINNER_NONE;
+    }
+    if (presentation != NULL)
+    {
+        state->border_flash = sdl3d_properties_get_float(presentation->props, "border_flash", 0.0f);
+        state->paddle_flash = sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f);
     }
 }
 
@@ -250,23 +261,6 @@ static bool create_particles(pong_state *state)
 
     state->ambient_particles = sdl3d_create_particle_emitter(&config);
     return state->ambient_particles != NULL;
-}
-
-static void on_flash_border(void *userdata, int signal_id, const sdl3d_properties *payload)
-{
-    pong_state *state = (pong_state *)userdata;
-    (void)signal_id;
-    (void)payload;
-    state->border_flash = 1.0f;
-    state->paddle_flash = 1.0f;
-}
-
-static void on_match_finished(void *userdata, int signal_id, const sdl3d_properties *payload)
-{
-    pong_state *state = (pong_state *)userdata;
-    (void)payload;
-    state->match_finished = true;
-    state->winner = signal_id == state->signal_match_player_won ? PONG_WINNER_PLAYER : PONG_WINNER_CPU;
 }
 
 static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
@@ -303,20 +297,10 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     }
     sdl3d_asset_resolver_destroy(assets);
 
-    state->actions.up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
-    state->actions.down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
     state->actions.pause = sdl3d_game_data_find_action(state->data, "action.pause");
     state->actions.exit = sdl3d_game_data_find_action(state->data, "action.exit");
-    state->actions.restart = sdl3d_game_data_find_action(state->data, "action.restart");
     state->signal_game_start = sdl3d_game_data_find_signal(state->data, "signal.game.start");
-    state->signal_round_reset = sdl3d_game_data_find_signal(state->data, "signal.round.reset");
-    state->signal_match_player_won = sdl3d_game_data_find_signal(state->data, "signal.match.player_won");
-    state->signal_match_cpu_won = sdl3d_game_data_find_signal(state->data, "signal.match.cpu_won");
-    state->signal_flash_border = sdl3d_game_data_find_signal(state->data, "signal.presentation.flash_border");
 
-    sdl3d_signal_connect(ctx_bus(ctx), state->signal_flash_border, on_flash_border, state);
-    sdl3d_signal_connect(ctx_bus(ctx), state->signal_match_player_won, on_match_finished, state);
-    sdl3d_signal_connect(ctx_bus(ctx), state->signal_match_cpu_won, on_match_finished, state);
     sync_state_from_data(state);
     sdl3d_signal_emit(ctx_bus(ctx), state->signal_game_start, NULL);
     return true;
@@ -367,32 +351,17 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
     return true;
 }
 
-static void reset_match(sdl3d_game_context *ctx, pong_state *state)
-{
-    sdl3d_registered_actor *player_score = sdl3d_game_data_find_actor(state->data, "entity.score.player");
-    sdl3d_registered_actor *cpu_score = sdl3d_game_data_find_actor(state->data, "entity.score.cpu");
-    if (player_score != NULL)
-    {
-        sdl3d_properties_set_int(player_score->props, "value", 0);
-    }
-    if (cpu_score != NULL)
-    {
-        sdl3d_properties_set_int(cpu_score->props, "value", 0);
-    }
-    state->match_finished = false;
-    state->winner = PONG_WINNER_NONE;
-    state->border_flash = 0.0f;
-    state->paddle_flash = 0.0f;
-    sdl3d_signal_emit(ctx_bus(ctx), state->signal_round_reset, NULL);
-    sdl3d_signal_emit(ctx_bus(ctx), state->signal_game_start, NULL);
-    sync_state_from_data(state);
-}
-
 static void update_visual_effects(pong_state *state, float dt)
 {
     state->time += dt;
     state->border_flash = fade_down(state->border_flash, dt, 2.8f);
     state->paddle_flash = fade_down(state->paddle_flash, dt, 4.0f);
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    if (presentation != NULL)
+    {
+        sdl3d_properties_set_float(presentation->props, "border_flash", state->border_flash);
+        sdl3d_properties_set_float(presentation->props, "paddle_flash", state->paddle_flash);
+    }
     if (state->ambient_particles != NULL)
     {
         sdl3d_particle_emitter_update(state->ambient_particles, dt);
@@ -417,15 +386,10 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
         ctx->paused = true;
         state->pause_flash = 0.0f;
     }
-    if (state->match_finished && sdl3d_input_is_pressed(ctx_input(ctx), state->actions.restart))
-    {
-        reset_match(ctx, state);
-    }
-
     update_visual_effects(state, dt);
     sdl3d_transition_update(&state->transition, ctx_bus(ctx), dt);
 
-    if (!state->match_finished && !state->quit_pending)
+    if (!state->quit_pending)
     {
         sdl3d_game_data_update(state->data, dt);
     }

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -28,15 +28,6 @@
 #define PONG_WINDOW_WIDTH 1280
 #define PONG_WINDOW_HEIGHT 720
 #define PONG_TICK_RATE (1.0f / 120.0f)
-#define PONG_FIELD_DEPTH -0.45f
-#define PONG_PADDLE_DEPTH 0.28f
-#define PONG_BALL_Z 0.12f
-#define PONG_HALF_WIDTH 9.0f
-#define PONG_HALF_HEIGHT 5.0f
-#define PONG_PADDLE_X 8.0f
-#define PONG_PADDLE_HALF_WIDTH 0.18f
-#define PONG_PADDLE_HALF_HEIGHT 0.95f
-#define PONG_BALL_RADIUS 0.22f
 
 enum
 {
@@ -80,6 +71,8 @@ typedef struct pong_state
     float cpu_y;
     sdl3d_vec2 ball_position;
     sdl3d_vec2 ball_velocity;
+    float ball_z;
+    float ball_radius;
     bool ball_active;
     bool match_finished;
     pong_winner winner;
@@ -206,6 +199,8 @@ static void sync_state_from_data(pong_state *state)
             sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
         state->ball_position = make_vec2(ball->position.x, ball->position.y);
         state->ball_velocity = make_vec2(velocity.x, velocity.y);
+        state->ball_z = ball->position.z;
+        state->ball_radius = sdl3d_properties_get_float(ball->props, "radius", 0.22f);
         state->ball_active = sdl3d_properties_get_bool(ball->props, "active_motion", false);
     }
     if (player_score != NULL)
@@ -234,30 +229,33 @@ static void sync_state_from_data(pong_state *state)
     }
 }
 
+static sdl3d_registered_actor *presentation_actor(const pong_state *state)
+{
+    return sdl3d_game_data_find_actor(state->data, "entity.presentation");
+}
+
+static float presentation_float(const pong_state *state, const char *key, float fallback)
+{
+    sdl3d_registered_actor *presentation = presentation_actor(state);
+    return presentation != NULL ? sdl3d_properties_get_float(presentation->props, key, fallback) : fallback;
+}
+
+static const char *presentation_string(const pong_state *state, const char *key, const char *fallback)
+{
+    sdl3d_registered_actor *presentation = presentation_actor(state);
+    const char *value =
+        presentation != NULL ? sdl3d_properties_get_string(presentation->props, key, fallback) : fallback;
+    return value != NULL ? value : fallback;
+}
+
 static bool create_particles(pong_state *state)
 {
     sdl3d_particle_config config;
-    SDL_zero(config);
-    config.position = sdl3d_vec3_make(0.0f, 0.0f, 0.35f);
-    config.direction = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
-    config.spread = 1.1f;
-    config.speed_min = 0.08f;
-    config.speed_max = 0.45f;
-    config.lifetime_min = 2.5f;
-    config.lifetime_max = 5.0f;
-    config.size_start = 0.035f;
-    config.size_end = 0.012f;
-    config.color_start = (sdl3d_color){220, 235, 255, 105};
-    config.color_end = (sdl3d_color){255, 255, 255, 0};
-    config.gravity = 0.0f;
-    config.max_particles = 360;
-    config.emit_rate = 95.0f;
-    config.shape = SDL3D_PARTICLE_EMITTER_BOX;
-    config.extents = sdl3d_vec3_make(8.8f, 4.8f, 0.18f);
-    config.emissive_intensity = 1.35f;
-    config.camera_facing = true;
-    config.depth_test = true;
-    config.random_seed = 0x1234567u;
+    if (!sdl3d_game_data_get_particle_emitter(state->data, "entity.effect.ambient_particles", &config))
+    {
+        SDL_SetError("missing entity.effect.ambient_particles particles.emitter component");
+        return false;
+    }
 
     state->ambient_particles = sdl3d_create_particle_emitter(&config);
     return state->ambient_particles != NULL;
@@ -354,9 +352,9 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
 static void update_visual_effects(pong_state *state, float dt)
 {
     state->time += dt;
-    state->border_flash = fade_down(state->border_flash, dt, 2.8f);
-    state->paddle_flash = fade_down(state->paddle_flash, dt, 4.0f);
-    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    state->border_flash = fade_down(state->border_flash, dt, presentation_float(state, "border_flash_decay", 2.8f));
+    state->paddle_flash = fade_down(state->paddle_flash, dt, presentation_float(state, "paddle_flash_decay", 4.0f));
+    sdl3d_registered_actor *presentation = presentation_actor(state);
     if (presentation != NULL)
     {
         sdl3d_properties_set_float(presentation->props, "border_flash", state->border_flash);
@@ -408,7 +406,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
         return;
     }
 
-    state->pause_flash += real_dt * 3.0f;
+    state->pause_flash += real_dt * presentation_float(state, "pause_flash_speed", 3.0f);
     while (state->pause_flash >= 1.0f)
     {
         state->pause_flash -= 1.0f;
@@ -420,86 +418,102 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     }
 }
 
-static void add_point_light(sdl3d_render_context *renderer, sdl3d_vec3 position, float r, float g, float b,
-                            float intensity, float range)
+static bool string_starts_with(const char *value, const char *prefix)
 {
-    sdl3d_light light;
-    SDL_zero(light);
-    light.type = SDL3D_LIGHT_POINT;
-    light.position = position;
-    light.color[0] = r;
-    light.color[1] = g;
-    light.color[2] = b;
-    light.intensity = intensity;
-    light.range = range;
-    sdl3d_add_light(renderer, &light);
+    return value != NULL && prefix != NULL && SDL_strncmp(value, prefix, SDL_strlen(prefix)) == 0;
 }
 
 static void configure_lights(sdl3d_render_context *renderer, const pong_state *state)
 {
-    const float pulse = 0.5f + 0.5f * SDL_sinf(state->time * 7.0f);
+    float ambient[3] = {0.015f, 0.018f, 0.026f};
+    sdl3d_game_data_get_world_ambient_light(state->data, ambient);
+
     sdl3d_clear_lights(renderer);
-    sdl3d_set_ambient_light(renderer, 0.015f, 0.018f, 0.026f);
-    add_point_light(renderer, sdl3d_vec3_make(-7.0f, 4.4f, 3.2f), 1.0f, 0.10f, 0.08f, 2.8f, 12.0f);
-    add_point_light(renderer, sdl3d_vec3_make(7.0f, 4.4f, 3.2f), 0.08f, 1.0f, 0.18f, 2.7f, 12.0f);
-    add_point_light(renderer, sdl3d_vec3_make(0.0f, -4.2f, 3.5f), 0.14f, 0.34f, 1.0f, 2.9f, 12.0f);
-    add_point_light(renderer, sdl3d_vec3_make(state->ball_position.x, state->ball_position.y, PONG_BALL_Z + 1.2f), 1.0f,
-                    0.72f + 0.28f * pulse, 0.22f, 2.1f + pulse * 2.0f, 5.0f);
-}
+    sdl3d_set_ambient_light(renderer, ambient[0], ambient[1], ambient[2]);
 
-static void draw_playfield(sdl3d_render_context *renderer, const pong_state *state)
-{
-    const float flash = clampf(state->border_flash, 0.0f, 1.0f);
-    const sdl3d_color base = (sdl3d_color){42, 48, 62, 255};
-    const sdl3d_color pulse = (sdl3d_color){210, 235, 255, 255};
-    const sdl3d_color border = color_lerp((sdl3d_color){62, 72, 92, 255}, pulse, flash);
-    const float border_size = 0.12f + 0.06f * flash;
-
-    sdl3d_set_emissive(renderer, 0.0f, 0.0f, 0.0f);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(0.0f, 0.0f, PONG_FIELD_DEPTH),
-                    sdl3d_vec3_make(PONG_HALF_WIDTH * 2.0f + 0.8f, PONG_HALF_HEIGHT * 2.0f + 0.8f, 0.10f), base);
-    sdl3d_set_emissive(renderer, flash * 0.55f, flash * 0.7f, flash);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(0.0f, PONG_HALF_HEIGHT + border_size, 0.0f),
-                    sdl3d_vec3_make(PONG_HALF_WIDTH * 2.0f + 0.35f, border_size, 0.18f), border);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(0.0f, -PONG_HALF_HEIGHT - border_size, 0.0f),
-                    sdl3d_vec3_make(PONG_HALF_WIDTH * 2.0f + 0.35f, border_size, 0.18f), border);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(-PONG_HALF_WIDTH - border_size, 0.0f, 0.0f),
-                    sdl3d_vec3_make(border_size, PONG_HALF_HEIGHT * 2.0f + 0.35f, 0.18f), border);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(PONG_HALF_WIDTH + border_size, 0.0f, 0.0f),
-                    sdl3d_vec3_make(border_size, PONG_HALF_HEIGHT * 2.0f + 0.35f, 0.18f), border);
-
-    sdl3d_set_emissive(renderer, 0.10f, 0.12f, 0.16f);
-    for (int i = -4; i <= 4; ++i)
+    const int light_count = sdl3d_game_data_world_light_count(state->data);
+    for (int i = 0; i < light_count; ++i)
     {
-        sdl3d_draw_cube(renderer, sdl3d_vec3_make(0.0f, (float)i, 0.02f), sdl3d_vec3_make(0.055f, 0.42f, 0.08f),
-                        (sdl3d_color){115, 132, 162, 180});
+        sdl3d_light light;
+        if (sdl3d_game_data_get_world_light(state->data, i, &light))
+            sdl3d_add_light(renderer, &light);
     }
+}
+
+typedef struct primitive_draw_context
+{
+    sdl3d_render_context *renderer;
+    const pong_state *state;
+} primitive_draw_context;
+
+static void draw_emissive_render_primitive(sdl3d_render_context *renderer,
+                                           const sdl3d_game_data_render_primitive *primitive, sdl3d_color color,
+                                           sdl3d_vec3 size, float radius, float emissive_r, float emissive_g,
+                                           float emissive_b)
+{
+    sdl3d_set_emissive(renderer, emissive_r, emissive_g, emissive_b);
+    if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+        sdl3d_draw_cube(renderer, primitive->position, size, color);
+    else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
+        sdl3d_draw_sphere(renderer, primitive->position, radius, primitive->slices, primitive->rings, color);
     sdl3d_set_emissive(renderer, 0.0f, 0.0f, 0.0f);
 }
 
-static void draw_game_objects(sdl3d_render_context *renderer, const pong_state *state)
+static bool draw_authored_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
 {
-    const float paddle_flash = clampf(state->paddle_flash, 0.0f, 1.0f);
-    const sdl3d_color player_color =
-        color_lerp((sdl3d_color){205, 230, 255, 255}, (sdl3d_color){255, 255, 255, 255}, paddle_flash);
-    const sdl3d_color cpu_color =
-        color_lerp((sdl3d_color){195, 255, 212, 255}, (sdl3d_color){255, 255, 255, 255}, paddle_flash);
-    const float ball_pulse = 0.5f + 0.5f * SDL_sinf(state->time * 9.0f);
-    const sdl3d_color ball_color =
-        color_lerp((sdl3d_color){255, 184, 82, 255}, (sdl3d_color){255, 245, 156, 255}, ball_pulse);
+    primitive_draw_context *context = (primitive_draw_context *)userdata;
+    const pong_state *state = context->state;
+    sdl3d_color color = primitive->color;
+    sdl3d_vec3 size = primitive->size;
+    float radius = primitive->radius;
+    float emissive_r = 0.0f;
+    float emissive_g = 0.0f;
+    float emissive_b = 0.0f;
 
-    sdl3d_set_emissive(renderer, paddle_flash * 0.35f, paddle_flash * 0.42f, paddle_flash * 0.50f);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(-PONG_PADDLE_X, state->player_y, 0.0f),
-                    sdl3d_vec3_make(PONG_PADDLE_HALF_WIDTH * 2.0f, PONG_PADDLE_HALF_HEIGHT * 2.0f, PONG_PADDLE_DEPTH),
-                    player_color);
-    sdl3d_draw_cube(renderer, sdl3d_vec3_make(PONG_PADDLE_X, state->cpu_y, 0.0f),
-                    sdl3d_vec3_make(PONG_PADDLE_HALF_WIDTH * 2.0f, PONG_PADDLE_HALF_HEIGHT * 2.0f, PONG_PADDLE_DEPTH),
-                    cpu_color);
+    if (string_starts_with(primitive->entity_name, "entity.field.border."))
+    {
+        const float flash = clampf(state->border_flash, 0.0f, 1.0f);
+        color = color_lerp(color, (sdl3d_color){210, 235, 255, 255}, flash);
+        if (size.x < size.y)
+            size.x += 0.06f * flash;
+        else
+            size.y += 0.06f * flash;
+        emissive_r = flash * 0.55f;
+        emissive_g = flash * 0.70f;
+        emissive_b = flash;
+    }
+    else if (string_starts_with(primitive->entity_name, "entity.field.center_ticks"))
+    {
+        emissive_r = 0.10f;
+        emissive_g = 0.12f;
+        emissive_b = 0.16f;
+    }
+    else if (string_starts_with(primitive->entity_name, "entity.paddle."))
+    {
+        const float flash = clampf(state->paddle_flash, 0.0f, 1.0f);
+        color = color_lerp(color, (sdl3d_color){255, 255, 255, 255}, flash);
+        emissive_r = flash * 0.35f;
+        emissive_g = flash * 0.42f;
+        emissive_b = flash * 0.50f;
+    }
+    else if (SDL_strcmp(primitive->entity_name, "entity.ball") == 0)
+    {
+        const float pulse = 0.5f + 0.5f * SDL_sinf(state->time * 9.0f);
+        color = color_lerp(color, (sdl3d_color){255, 245, 156, 255}, pulse);
+        emissive_r = 0.75f + pulse * 0.65f;
+        emissive_g = 0.48f + pulse * 0.30f;
+        emissive_b = 0.08f;
+    }
+    else if (primitive->emissive)
+    {
+        emissive_r = 0.2f;
+        emissive_g = 0.2f;
+        emissive_b = 0.2f;
+    }
 
-    sdl3d_set_emissive(renderer, 0.75f + ball_pulse * 0.65f, 0.48f + ball_pulse * 0.30f, 0.08f);
-    sdl3d_draw_sphere(renderer, sdl3d_vec3_make(state->ball_position.x, state->ball_position.y, PONG_BALL_Z),
-                      PONG_BALL_RADIUS, 12, 18, ball_color);
-    sdl3d_set_emissive(renderer, 0.0f, 0.0f, 0.0f);
+    draw_emissive_render_primitive(context->renderer, primitive, color, size, radius, emissive_r, emissive_g,
+                                   emissive_b);
+    return true;
 }
 
 static void draw_centered_text(sdl3d_render_context *renderer, const sdl3d_font *font, const char *text, float y,
@@ -525,7 +539,8 @@ static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
                              "FPS %.0f  Frame %" SDL_PRIu64, state->displayed_fps, state->rendered_frames);
     if (ball_camera_is_active(state))
     {
-        sdl3d_draw_text_overlay(ctx->renderer, &state->font, "BALL CAM", 18.0f, 56.0f,
+        sdl3d_draw_text_overlay(ctx->renderer, &state->font,
+                                presentation_string(state, "ball_camera_label", "BALL CAM"), 18.0f, 56.0f,
                                 (sdl3d_color){255, 222, 140, 235});
     }
     sdl3d_draw_textf_overlay(ctx->renderer, &state->font, (float)width * 0.5f - 94.0f, 22.0f,
@@ -533,54 +548,75 @@ static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
 
     if (state->match_finished)
     {
-        const char *winner = state->winner == PONG_WINNER_PLAYER ? "You win!" : "You lose!";
+        const char *winner = state->winner == PONG_WINNER_PLAYER
+                                 ? presentation_string(state, "player_win_text", "You win!")
+                                 : presentation_string(state, "cpu_win_text", "You lose!");
         draw_centered_text(ctx->renderer, &state->font, winner, (float)height * 0.40f,
                            (sdl3d_color){255, 255, 255, 255});
-        draw_centered_text(ctx->renderer, &state->font, "Press enter to play again", (float)height * 0.49f,
-                           (sdl3d_color){200, 220, 255, 235});
+        draw_centered_text(ctx->renderer, &state->font,
+                           presentation_string(state, "restart_text", "Press enter to play again"),
+                           (float)height * 0.49f, (sdl3d_color){200, 220, 255, 235});
     }
     else if (ctx->paused)
     {
         const float pulse = 0.5f + 0.5f * SDL_sinf(state->pause_flash * SDL_PI_F * 2.0f);
         const Uint8 alpha = (Uint8)(120.0f + pulse * 135.0f);
-        draw_centered_text(ctx->renderer, &state->font, "PAUSED", (float)height * 0.44f,
-                           (sdl3d_color){245, 248, 255, alpha});
+        draw_centered_text(ctx->renderer, &state->font, presentation_string(state, "pause_text", "PAUSED"),
+                           (float)height * 0.44f, (sdl3d_color){245, 248, 255, alpha});
     }
     else if (!state->ball_active)
     {
-        draw_centered_text(ctx->renderer, &state->font, "Get ready", (float)height * 0.44f,
-                           (sdl3d_color){210, 225, 255, 190});
+        draw_centered_text(ctx->renderer, &state->font, presentation_string(state, "ready_text", "Get ready"),
+                           (float)height * 0.44f, (sdl3d_color){210, 225, 255, 190});
     }
 }
 
-static sdl3d_camera3d make_overhead_camera(void)
+static float camera_float_or(const pong_state *state, const char *camera_name, const char *property_name,
+                             float fallback)
 {
+    float value = 0.0f;
+    return sdl3d_game_data_get_camera_float(state->data, camera_name, property_name, &value) ? value : fallback;
+}
+
+static sdl3d_camera3d make_ball_camera(const pong_state *state)
+{
+    const char *camera_name = "camera.ball_chase";
+    const sdl3d_vec2 forward = ball_camera_forward(state);
+    const float ball_z_offset = camera_float_or(state, camera_name, "ball_z_offset", state->ball_radius);
+    const sdl3d_vec3 ball =
+        sdl3d_vec3_make(state->ball_position.x, state->ball_position.y, state->ball_z + ball_z_offset);
+    const float chase_distance = camera_float_or(state, camera_name, "chase_distance", 2.6f);
+    const float camera_height = camera_float_or(state, camera_name, "height", 1.35f);
+    const float lookahead = camera_float_or(state, camera_name, "lookahead", 4.4f);
+    const float target_z_offset = camera_float_or(state, camera_name, "target_z_offset", -0.05f);
+
     sdl3d_camera3d camera;
+    SDL_zero(camera);
+    camera.position = sdl3d_vec3_make(ball.x - forward.x * chase_distance, ball.y - forward.y * chase_distance,
+                                      ball.z + camera_height);
+    camera.target =
+        sdl3d_vec3_make(ball.x + forward.x * lookahead, ball.y + forward.y * lookahead, ball.z + target_z_offset);
+    camera.up = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
+    camera.fovy = camera_float_or(state, camera_name, "fovy", 68.0f);
+    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
+    return camera;
+}
+
+static sdl3d_camera3d make_active_camera(const pong_state *state)
+{
+    if (ball_camera_is_active(state))
+        return make_ball_camera(state);
+
+    sdl3d_camera3d camera;
+    if (sdl3d_game_data_get_camera(state->data, "camera.overhead", &camera))
+        return camera;
+
     SDL_zero(camera);
     camera.position = sdl3d_vec3_make(0.0f, 0.0f, 16.0f);
     camera.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
     camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
     camera.fovy = 11.4f;
     camera.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
-    return camera;
-}
-
-static sdl3d_camera3d make_ball_camera(const pong_state *state)
-{
-    const sdl3d_vec2 forward = ball_camera_forward(state);
-    const sdl3d_vec3 ball = sdl3d_vec3_make(state->ball_position.x, state->ball_position.y, PONG_BALL_Z + 0.22f);
-    const float chase_distance = 2.6f;
-    const float camera_height = 1.35f;
-    const float lookahead = 4.4f;
-
-    sdl3d_camera3d camera;
-    SDL_zero(camera);
-    camera.position = sdl3d_vec3_make(ball.x - forward.x * chase_distance, ball.y - forward.y * chase_distance,
-                                      ball.z + camera_height);
-    camera.target = sdl3d_vec3_make(ball.x + forward.x * lookahead, ball.y + forward.y * lookahead, ball.z - 0.05f);
-    camera.up = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
-    camera.fovy = 68.0f;
-    camera.projection = SDL3D_CAMERA_PERSPECTIVE;
     return camera;
 }
 
@@ -610,19 +646,18 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     sdl3d_clear_render_context(ctx->renderer, (sdl3d_color){3, 4, 8, 255});
     configure_lights(ctx->renderer, state);
 
-    const bool ball_camera_enabled = ball_camera_is_active(state);
-    const sdl3d_camera3d camera = ball_camera_enabled ? make_ball_camera(state) : make_overhead_camera();
+    const sdl3d_camera3d camera = make_active_camera(state);
 
     if (sdl3d_begin_mode_3d(ctx->renderer, camera))
     {
-        draw_playfield(ctx->renderer, state);
         if (state->ambient_particles != NULL)
         {
             sdl3d_set_emissive(ctx->renderer, 0.8f, 0.9f, 1.0f);
             sdl3d_draw_particles(ctx->renderer, state->ambient_particles);
             sdl3d_set_emissive(ctx->renderer, 0.0f, 0.0f, 0.0f);
         }
-        draw_game_objects(ctx->renderer, state);
+        primitive_draw_context draw_context = {ctx->renderer, state};
+        sdl3d_game_data_for_each_render_primitive(state->data, draw_authored_primitive, &draw_context);
         sdl3d_end_mode_3d(ctx->renderer);
     }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -21,11 +21,15 @@ Every file is a JSON object with these fields:
 | --- | --- | --- |
 | `schema` | yes | Schema id. First value: `sdl3d.game.v0`. |
 | `metadata` | yes | Human-readable identity and versioning. |
+| `app` | no | Managed-loop startup config such as title, window size, backend, tick rate, and tick cap. |
 | `profiles` | no | Genre/profile hints and required modules. |
 | `assets` | no | Stable asset ids mapped to paths or future archive refs. |
 | `scripts` | no | Lua scripts that provide game-specific behavior used by adapters. |
 | `input` | no | Named actions and bindings. |
 | `world` | yes | World identity, coordinate policy, bounds, cameras, lights. |
+| `render` | no | Renderer setup such as clear color, lighting, bloom, SSAO, and tonemapping. |
+| `transitions` | no | Named screen transition descriptors such as startup and quit fades. |
+| `ui` | no | Authored UI descriptors. |
 | `entities` | yes | Stable named actors with tags, transforms, properties, and components. |
 | `signals` | no | Authored signal names. |
 | `logic` | no | Sensors, timers, bindings, conditions, and actions. |
@@ -61,6 +65,26 @@ The world object declares one spatial context. It does not imply a sector map.
 ```
 
 Future world kinds can include `tile_grid`, `room_graph`, `sector_map`, and `scene_3d`.
+
+## App And Presentation
+
+The optional `app` object lets a managed-loop game declare startup settings before a window exists:
+
+```json
+{
+  "app": {
+    "title": "SDL3D Pong",
+    "width": 1280,
+    "height": 720,
+    "backend": "auto",
+    "tick_rate": 0.008333333,
+    "max_ticks_per_frame": 12
+  }
+}
+```
+
+The optional `render`, `transitions`, and `ui` sections describe presentation without giving the data
+runtime ownership of the renderer. Games read these descriptors and decide how to apply them.
 
 ## Entities
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -78,13 +78,60 @@ The optional `app` object lets a managed-loop game declare startup settings befo
     "height": 720,
     "backend": "auto",
     "tick_rate": 0.008333333,
-    "max_ticks_per_frame": 12
+    "max_ticks_per_frame": 12,
+    "start_signal": "signal.game.start",
+    "pause_action": "action.pause",
+    "startup_transition": "startup",
+    "quit": {
+      "action": "action.exit",
+      "transition": "quit",
+      "quit_signal": "signal.app.quit_fade_done"
+    }
   }
 }
 ```
 
 The optional `render`, `transitions`, and `ui` sections describe presentation without giving the data
 runtime ownership of the renderer. Games read these descriptors and decide how to apply them.
+
+`start_signal` lets data kick off initial timers or scripted startup logic after the host has loaded the runtime.
+`pause_action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
+`app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes
+the quit. The host still owns pause state and process shutdown.
+
+Font assets can be authored under `assets.fonts`:
+
+```json
+{
+  "assets": {
+    "fonts": [
+      { "id": "font.hud", "builtin": "Inter", "size": 34 }
+    ]
+  }
+}
+```
+
+UI descriptors can bind text to engine metrics or actor properties and can use generic visibility conditions:
+
+```json
+{
+  "name": "ui.score",
+  "font": "font.hud",
+  "format": "%02d   %02d",
+  "bindings": [
+    { "type": "property", "entity": "entity.score.player", "key": "value" },
+    { "type": "property", "entity": "entity.score.cpu", "key": "value" }
+  ],
+  "visible_if": {
+    "type": "not",
+    "condition": { "type": "app.paused", "equals": true }
+  }
+}
+```
+
+Supported UI binding sources are `metric` (`fps`, `frame`, `paused`) and `property`.
+Supported UI conditions include `always`, `app.paused`, `camera.active`, `property.compare`,
+`property.bool`, `all`, `any`, and `not`.
 
 ## Entities
 
@@ -118,6 +165,52 @@ The first generic presentation components are deliberately simple descriptors:
 
 The game data runtime exposes these as read-only descriptors. It does not issue draw calls; each game or
 renderer decides how to render, sort, tint, or override them.
+
+Render primitives may also author generic visual effects:
+
+```json
+{
+  "type": "render.sphere",
+  "radius": 0.22,
+  "color": [255, 184, 82, 255],
+  "effects": [
+    {
+      "type": "pulse",
+      "rate": 9.0,
+      "color": [255, 245, 156, 255],
+      "emissive_base": [0.75, 0.48, 0.08],
+      "emissive_add": [0.65, 0.30, 0.0]
+    }
+  ]
+}
+```
+
+Supported primitive effects are:
+
+- `flash`: reads a float property from a source entity and uses it to blend color, add size, and add emissive color.
+- `pulse`: uses presentation time to animate color and emissive color.
+- `emissive`: adds a constant emissive color.
+
+Particle emitters may include `draw_emissive` for host renderers that draw particles through emissive lighting.
+
+### Cameras
+
+Cameras can be static perspective/orthographic descriptors or generic behavior descriptors. `type: "chase"`
+follows an entity using its velocity property, authored distance, height, lookahead, and offsets:
+
+```json
+{
+  "name": "camera.ball_chase",
+  "type": "chase",
+  "target_entity": "entity.ball",
+  "velocity_property": "velocity",
+  "chase_distance": 2.6,
+  "height": 1.57,
+  "lookahead": 4.4,
+  "target_offset": [0.0, 0.0, 0.22],
+  "fovy": 68.0
+}
+```
 
 ## Logic
 
@@ -241,7 +334,8 @@ Lua adapters receive `(target, payload, ctx)`:
 
 - `target` is an actor wrapper for the authored action/component target, or `nil`.
 - `payload` is a table copied from the signal payload or component payload.
-- `ctx` provides adapter context: `ctx.adapter`, `ctx.dt`, `ctx:actor(name)`, `ctx:random()`, and `ctx:log(message)`.
+- `ctx` provides adapter context: `ctx.adapter`, `ctx.dt`, `ctx:actor(name)`,
+  `ctx:actor_with_tags(...)`, `ctx:random()`, and `ctx:log(message)`.
 
 The preferred Lua API is intentionally game-script oriented. Scripts can check `sdl3d.api`, currently `sdl3d.lua.v1`, when they need to guard version-specific behavior:
 
@@ -282,6 +376,9 @@ Good Pong adapters:
 - `adapter.pong.reflect_from_paddle`: apply Pong-specific deflection based on hit offset.
 - `adapter.pong.cpu_track_ball`: move the CPU paddle toward the ball.
 
+Lua scripts should prefer `ctx:actor_with_tags("role", "qualifier")` for role lookups when exact entity names
+are not part of the rule. This keeps data free to rename actors while preserving their authored tags.
+
 Bad Pong adapters:
 
 - increment score
@@ -299,10 +396,10 @@ Game data is validated before runtime state is instantiated. Host tools can call
 Diagnostics are designed for authored content. Errors include the source file, a best-effort JSON path, and the referenced name when a reference cannot be resolved. For example, a binding action that targets a missing entity reports the action path and the missing entity name. Validation currently checks:
 
 - schema support
-- duplicate names within entity, signal, script, adapter, input action, timer, camera, and sensor namespaces
+- duplicate names within entity, signal, script, adapter, input action, timer, camera, font, and sensor namespaces
 - script ids, modules, dependencies, dependency cycles, and script file existence
 - input binding structure
-- sensor, timer, binding, action, component, adapter, and camera references
+- app lifecycle, UI, render effect, sensor, timer, binding, action, component, adapter, light, and camera references
 - supported generic logic action types and required action payloads
 - warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -84,6 +84,17 @@ Entities are the data form of actor registry entries plus optional component own
 
 Core fields are generic. Components are module-owned and may be ignored by runtimes that do not load that module.
 
+### Presentation Components
+
+The first generic presentation components are deliberately simple descriptors:
+
+- `render.cube` describes an axis-aligned box with `size`, optional `offset`, `color`, and `emissive`.
+- `render.sphere` describes a sphere with `radius`, `rings`, `slices`, `color`, and `emissive`.
+- `particles.emitter` describes an emitter config that can be passed to the particle system.
+
+The game data runtime exposes these as read-only descriptors. It does not issue draw calls; each game or
+renderer decides how to render, sort, tint, or override them.
+
 ## Logic
 
 Logic is event composition:

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -24,6 +24,7 @@
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/properties.h"
+#include "sdl3d/transition.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -78,6 +79,72 @@ extern "C"
      */
     typedef bool (*sdl3d_game_data_render_primitive_fn)(void *userdata,
                                                         const sdl3d_game_data_render_primitive *primitive);
+
+    /** @brief Authored render setup that can be applied to a render context. */
+    typedef struct sdl3d_game_data_render_settings
+    {
+        /** @brief Clear color for the frame. */
+        sdl3d_color clear_color;
+        /** @brief Whether 3D lighting should be enabled. */
+        bool lighting_enabled;
+        /** @brief Whether bloom post-processing should be enabled. */
+        bool bloom_enabled;
+        /** @brief Whether SSAO post-processing should be enabled. */
+        bool ssao_enabled;
+        /** @brief Tonemap operator for lit rendering. */
+        sdl3d_tonemap_mode tonemap;
+    } sdl3d_game_data_render_settings;
+
+    /** @brief Authored transition effect descriptor. */
+    typedef struct sdl3d_game_data_transition_desc
+    {
+        /** @brief Transition effect type. */
+        sdl3d_transition_type type;
+        /** @brief Transition direction. */
+        sdl3d_transition_direction direction;
+        /** @brief Transition color. */
+        sdl3d_color color;
+        /** @brief Duration in seconds. */
+        float duration;
+        /** @brief Signal emitted on completion, or -1. */
+        int done_signal_id;
+    } sdl3d_game_data_transition_desc;
+
+    /** @brief Authored UI text descriptor. */
+    typedef struct sdl3d_game_data_ui_text
+    {
+        /** @brief Stable UI item name. */
+        const char *name;
+        /** @brief Font asset id. */
+        const char *font;
+        /** @brief Literal text, or NULL when @p format is used. */
+        const char *text;
+        /** @brief Format string interpreted by the caller. */
+        const char *format;
+        /** @brief Caller-defined source key for dynamic text. */
+        const char *source;
+        /** @brief Caller-defined visibility key. */
+        const char *visible;
+        /** @brief Horizontal position. For centered text, this is a normalized y-independent coordinate. */
+        float x;
+        /** @brief Vertical position. */
+        float y;
+        /** @brief Whether x/y are normalized to the current render size. */
+        bool normalized;
+        /** @brief Whether the text should be horizontally centered by the caller. */
+        bool centered;
+        /** @brief Whether alpha should pulse while visible. */
+        bool pulse_alpha;
+        /** @brief Text color. */
+        sdl3d_color color;
+    } sdl3d_game_data_ui_text;
+
+    /**
+     * @brief Callback for iterating authored UI text descriptors.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*sdl3d_game_data_ui_text_fn)(void *userdata, const sdl3d_game_data_ui_text *text);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum sdl3d_game_data_diagnostic_severity
@@ -161,6 +228,30 @@ extern "C"
      */
     bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,
                                     sdl3d_game_data_runtime **out_runtime, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Read the managed-loop config authored in a JSON game data asset.
+     *
+     * This lightweight reader is intended for startup, before a managed loop
+     * creates a window or game session. Missing fields keep the values already
+     * present in @p out_config, so callers can initialize defaults first. When
+     * an authored title is present, it is copied into @p title_buffer and
+     * out_config->title points at that buffer.
+     */
+    bool sdl3d_game_data_load_app_config_asset(sdl3d_asset_resolver *assets, const char *asset_path,
+                                               sdl3d_game_config *out_config, char *title_buffer, int title_buffer_size,
+                                               char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Read the managed-loop config authored in a JSON game data file.
+     *
+     * Missing fields keep the values already present in @p out_config, so
+     * callers can initialize defaults first. When an authored title is present,
+     * it is copied into @p title_buffer and out_config->title points at that
+     * buffer.
+     */
+    bool sdl3d_game_data_load_app_config_file(const char *path, sdl3d_game_config *out_config, char *title_buffer,
+                                              int title_buffer_size, char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Validate a JSON game data file without instantiating runtime state.
@@ -319,6 +410,27 @@ extern "C"
      */
     bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime, const char *entity_name,
                                               sdl3d_particle_config *out_config);
+
+    /**
+     * @brief Read authored render setup.
+     *
+     * Missing fields produce conservative defaults: black clear color, lighting
+     * enabled, bloom/SSAO enabled, and ACES tonemapping.
+     */
+    bool sdl3d_game_data_get_render_settings(const sdl3d_game_data_runtime *runtime,
+                                             sdl3d_game_data_render_settings *out_settings);
+
+    /**
+     * @brief Read a named authored transition descriptor.
+     *
+     * @p name is looked up under the top-level `transitions` object.
+     */
+    bool sdl3d_game_data_get_transition(const sdl3d_game_data_runtime *runtime, const char *name,
+                                        sdl3d_game_data_transition_desc *out_transition);
+
+    /** @brief Iterate authored UI text descriptors. */
+    bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
+                                          void *userdata);
 
     /**
      * @brief Return the dt currently being processed by sdl3d_game_data_update().

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -21,6 +21,7 @@
 #include "sdl3d/asset.h"
 #include "sdl3d/camera.h"
 #include "sdl3d/effects.h"
+#include "sdl3d/font.h"
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/properties.h"
@@ -33,6 +34,62 @@ extern "C"
 
     /** @brief Opaque runtime created from one game JSON document. */
     typedef struct sdl3d_game_data_runtime sdl3d_game_data_runtime;
+
+    /** @brief Authored application lifecycle hooks. */
+    typedef struct sdl3d_game_data_app_control
+    {
+        /** @brief Signal emitted by the host after game data has loaded, or -1. */
+        int start_signal_id;
+        /** @brief Input action that requests app quit, or -1. */
+        int quit_action_id;
+        /** @brief Input action that requests pause/unpause, or -1. */
+        int pause_action_id;
+        /** @brief Transition name to play at startup, or NULL. */
+        const char *startup_transition;
+        /** @brief Transition name to play before quit, or NULL. */
+        const char *quit_transition;
+        /** @brief Signal that means the app should quit immediately, or -1. */
+        int quit_signal_id;
+    } sdl3d_game_data_app_control;
+
+    /** @brief Authored font asset descriptor. */
+    typedef struct sdl3d_game_data_font_asset
+    {
+        /** @brief Stable asset id, such as `font.hud`. */
+        const char *id;
+        /** @brief Built-in font id when @p builtin is true. */
+        sdl3d_builtin_font builtin_id;
+        /** @brief True when this asset refers to an SDL3D built-in font. */
+        bool builtin;
+        /** @brief External font path when @p builtin is false, or NULL. */
+        const char *path;
+        /** @brief Requested font pixel size. */
+        float size;
+    } sdl3d_game_data_font_asset;
+
+    /**
+     * @brief Runtime metrics used when evaluating data-authored UI bindings.
+     *
+     * Games provide this small host-state snapshot each frame. The game data
+     * runtime combines it with actor properties and active camera state to
+     * resolve UI visibility and text content without game-specific string maps.
+     */
+    typedef struct sdl3d_game_data_ui_metrics
+    {
+        /** @brief Whether the managed loop is currently paused. */
+        bool paused;
+        /** @brief Most recently sampled frames per second. */
+        float fps;
+        /** @brief Number of rendered frames. */
+        Uint64 frame;
+    } sdl3d_game_data_ui_metrics;
+
+    /** @brief Optional render evaluation inputs for dynamic visual effects. */
+    typedef struct sdl3d_game_data_render_eval
+    {
+        /** @brief Elapsed presentation time in seconds, used by pulse effects. */
+        float time;
+    } sdl3d_game_data_render_eval;
 
     /** @brief Authored render primitive kind. */
     typedef enum sdl3d_game_data_render_primitive_type
@@ -70,6 +127,8 @@ extern "C"
         sdl3d_color color;
         /** @brief Whether the primitive should be treated as emissive by the caller. */
         bool emissive;
+        /** @brief Evaluated emissive RGB contribution. */
+        sdl3d_vec3 emissive_color;
     } sdl3d_game_data_render_primitive;
 
     /**
@@ -347,6 +406,33 @@ extern "C"
     /** @brief Find an authored actor by name in the runtime's session registry. */
     sdl3d_registered_actor *sdl3d_game_data_find_actor(const sdl3d_game_data_runtime *runtime, const char *name);
 
+    /** @brief Find the first authored actor whose entity data contains @p tag. */
+    sdl3d_registered_actor *sdl3d_game_data_find_actor_with_tag(const sdl3d_game_data_runtime *runtime,
+                                                                const char *tag);
+
+    /**
+     * @brief Find the first authored actor whose entity data contains every tag.
+     *
+     * Tags are matched against the entity's `tags` array in the loaded JSON
+     * document. This lets game code request roles like `{"paddle", "player"}`
+     * without depending on exact entity names.
+     */
+    sdl3d_registered_actor *sdl3d_game_data_find_actor_with_tags(const sdl3d_game_data_runtime *runtime,
+                                                                 const char *const *tags, int tag_count);
+
+    /**
+     * @brief Read data-authored application lifecycle hooks.
+     *
+     * Missing fields return neutral values: signal/action ids are -1 and
+     * transition names are NULL.
+     */
+    bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime,
+                                         sdl3d_game_data_app_control *out_control);
+
+    /** @brief Read a font asset descriptor by id from `assets.fonts`. */
+    bool sdl3d_game_data_get_font_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                        sdl3d_game_data_font_asset *out_font);
+
     /**
      * @brief Return the currently active authored camera name.
      *
@@ -402,6 +488,18 @@ extern "C"
                                                    sdl3d_game_data_render_primitive_fn callback, void *userdata);
 
     /**
+     * @brief Iterate active authored render primitives with dynamic effects evaluated.
+     *
+     * This applies generic `effects` authored on render primitive components,
+     * such as property-driven flash colors, size offsets, and time-driven
+     * pulses. Passing NULL for @p eval uses a zeroed evaluation context.
+     */
+    bool sdl3d_game_data_for_each_render_primitive_evaluated(const sdl3d_game_data_runtime *runtime,
+                                                             const sdl3d_game_data_render_eval *eval,
+                                                             sdl3d_game_data_render_primitive_fn callback,
+                                                             void *userdata);
+
+    /**
      * @brief Read an authored particle emitter component from an entity.
      *
      * The returned config is ready for sdl3d_create_particle_emitter(). Texture
@@ -410,6 +508,15 @@ extern "C"
      */
     bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime, const char *entity_name,
                                               sdl3d_particle_config *out_config);
+
+    /**
+     * @brief Read optional draw-time emissive color for a particle emitter entity.
+     *
+     * The color is read from the emitter component's `draw_emissive` field and
+     * defaults to zero when not authored.
+     */
+    bool sdl3d_game_data_get_particle_emitter_draw_emissive(const sdl3d_game_data_runtime *runtime,
+                                                            const char *entity_name, sdl3d_vec3 *out_rgb);
 
     /**
      * @brief Read authored render setup.
@@ -431,6 +538,26 @@ extern "C"
     /** @brief Iterate authored UI text descriptors. */
     bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
                                           void *userdata);
+
+    /**
+     * @brief Evaluate a UI text descriptor's authored visibility condition.
+     *
+     * Supports camera-active checks, app pause checks, actor property
+     * comparisons, and boolean all/any/not composition. Descriptors without a
+     * condition are visible.
+     */
+    bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                            const sdl3d_game_data_ui_metrics *metrics);
+
+    /**
+     * @brief Resolve UI text content from data-authored bindings.
+     *
+     * Literal `text` entries are copied directly. Entries with `bindings`
+     * resolve engine metrics and actor properties, then format them using the
+     * descriptor's `format` string.
+     */
+    bool sdl3d_game_data_format_ui_text(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                        const sdl3d_game_data_ui_metrics *metrics, char *buffer, size_t buffer_size);
 
     /**
      * @brief Return the dt currently being processed by sdl3d_game_data_update().

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -19,7 +19,10 @@
 
 #include "sdl3d/actor_registry.h"
 #include "sdl3d/asset.h"
+#include "sdl3d/camera.h"
+#include "sdl3d/effects.h"
 #include "sdl3d/game.h"
+#include "sdl3d/lighting.h"
 #include "sdl3d/properties.h"
 
 #ifdef __cplusplus
@@ -29,6 +32,52 @@ extern "C"
 
     /** @brief Opaque runtime created from one game JSON document. */
     typedef struct sdl3d_game_data_runtime sdl3d_game_data_runtime;
+
+    /** @brief Authored render primitive kind. */
+    typedef enum sdl3d_game_data_render_primitive_type
+    {
+        /** @brief Axis-aligned cube/box primitive. */
+        SDL3D_GAME_DATA_RENDER_CUBE = 1,
+        /** @brief Sphere primitive. */
+        SDL3D_GAME_DATA_RENDER_SPHERE = 2,
+    } sdl3d_game_data_render_primitive_type;
+
+    /**
+     * @brief Read-only descriptor for an authored render primitive component.
+     *
+     * This is an engine-data description, not a draw call. Renderers or demos
+     * may interpret these descriptors to draw simple generic primitives while
+     * preserving renderer ownership outside the game data runtime.
+     */
+    typedef struct sdl3d_game_data_render_primitive
+    {
+        /** @brief Name of the entity that owns the component. */
+        const char *entity_name;
+        /** @brief Primitive type declared by the component. */
+        sdl3d_game_data_render_primitive_type type;
+        /** @brief Current world-space position from the owning actor plus optional component offset. */
+        sdl3d_vec3 position;
+        /** @brief Cube size for SDL3D_GAME_DATA_RENDER_CUBE. */
+        sdl3d_vec3 size;
+        /** @brief Sphere radius for SDL3D_GAME_DATA_RENDER_SPHERE. */
+        float radius;
+        /** @brief Sphere longitudinal slices for SDL3D_GAME_DATA_RENDER_SPHERE. */
+        int slices;
+        /** @brief Sphere latitudinal rings for SDL3D_GAME_DATA_RENDER_SPHERE. */
+        int rings;
+        /** @brief Authored tint color. */
+        sdl3d_color color;
+        /** @brief Whether the primitive should be treated as emissive by the caller. */
+        bool emissive;
+    } sdl3d_game_data_render_primitive;
+
+    /**
+     * @brief Callback for iterating authored render primitives.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*sdl3d_game_data_render_primitive_fn)(void *userdata,
+                                                        const sdl3d_game_data_render_primitive *primitive);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum sdl3d_game_data_diagnostic_severity
@@ -214,6 +263,62 @@ extern "C"
      * valid until the runtime is destroyed.
      */
     const char *sdl3d_game_data_active_camera(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Read an authored non-adapter camera by name.
+     *
+     * Adapter cameras are game-specific and return false here because their
+     * final pose is computed by game code or script. Orthographic cameras use
+     * `size` as sdl3d_camera3d::fovy; perspective cameras use `fovy`.
+     */
+    bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const char *name,
+                                    sdl3d_camera3d *out_camera);
+
+    /**
+     * @brief Read a numeric custom property from an authored camera.
+     *
+     * This lets games keep camera tuning data in JSON even when the camera pose
+     * itself is adapter-driven.
+     */
+    bool sdl3d_game_data_get_camera_float(const sdl3d_game_data_runtime *runtime, const char *camera_name,
+                                          const char *property_name, float *out_value);
+
+    /** @brief Return the number of authored world lights. */
+    int sdl3d_game_data_world_light_count(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Read the authored world ambient light color.
+     *
+     * Values are linear RGB in the same range expected by
+     * sdl3d_set_ambient_light().
+     */
+    bool sdl3d_game_data_get_world_ambient_light(const sdl3d_game_data_runtime *runtime, float out_rgb[3]);
+
+    /**
+     * @brief Read an authored world light by zero-based index.
+     *
+     * The returned light is suitable for passing to sdl3d_add_light().
+     */
+    bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int index, sdl3d_light *out_light);
+
+    /**
+     * @brief Iterate active authored render primitive components.
+     *
+     * Components currently supported by this iterator are `render.cube` and
+     * `render.sphere`. Iteration skips inactive actors.
+     */
+    bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *runtime,
+                                                   sdl3d_game_data_render_primitive_fn callback, void *userdata);
+
+    /**
+     * @brief Read an authored particle emitter component from an entity.
+     *
+     * The returned config is ready for sdl3d_create_particle_emitter(). Texture
+     * references are intentionally not resolved here yet, so config.texture is
+     * always NULL.
+     */
+    bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime, const char *entity_name,
+                                              sdl3d_particle_config *out_config);
 
     /**
      * @brief Return the dt currently being processed by sdl3d_game_data_update().

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -655,6 +655,58 @@ static yyjson_val *find_camera_json(const sdl3d_game_data_runtime *runtime, cons
     return NULL;
 }
 
+static sdl3d_backend parse_backend(const char *value, sdl3d_backend fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "auto") == 0)
+        return SDL3D_BACKEND_AUTO;
+    if (SDL_strcasecmp(value, "software") == 0)
+        return SDL3D_BACKEND_SOFTWARE;
+    if (SDL_strcasecmp(value, "sdlgpu") == 0 || SDL_strcasecmp(value, "gpu") == 0)
+        return SDL3D_BACKEND_SDLGPU;
+    return fallback;
+}
+
+static sdl3d_tonemap_mode parse_tonemap(const char *value, sdl3d_tonemap_mode fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "none") == 0)
+        return SDL3D_TONEMAP_NONE;
+    if (SDL_strcasecmp(value, "reinhard") == 0)
+        return SDL3D_TONEMAP_REINHARD;
+    if (SDL_strcasecmp(value, "aces") == 0)
+        return SDL3D_TONEMAP_ACES;
+    return fallback;
+}
+
+static sdl3d_transition_type parse_transition_type(const char *value, sdl3d_transition_type fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "fade") == 0)
+        return SDL3D_TRANSITION_FADE;
+    if (SDL_strcasecmp(value, "circle") == 0)
+        return SDL3D_TRANSITION_CIRCLE;
+    if (SDL_strcasecmp(value, "melt") == 0)
+        return SDL3D_TRANSITION_MELT;
+    if (SDL_strcasecmp(value, "pixelate") == 0)
+        return SDL3D_TRANSITION_PIXELATE;
+    return fallback;
+}
+
+static sdl3d_transition_direction parse_transition_direction(const char *value, sdl3d_transition_direction fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "in") == 0)
+        return SDL3D_TRANSITION_IN;
+    if (SDL_strcasecmp(value, "out") == 0)
+        return SDL3D_TRANSITION_OUT;
+    return fallback;
+}
+
 static int axis_index(const char *axis)
 {
     if (axis == NULL)
@@ -1273,6 +1325,93 @@ bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime
     out_config->additive_blend = json_bool(component, "additive_blend", false);
     out_config->texture = NULL;
     out_config->random_seed = (Uint32)json_int(component, "random_seed", 0);
+    return true;
+}
+
+bool sdl3d_game_data_get_render_settings(const sdl3d_game_data_runtime *runtime,
+                                         sdl3d_game_data_render_settings *out_settings)
+{
+    if (out_settings != NULL)
+    {
+        SDL_zero(*out_settings);
+        out_settings->clear_color = (sdl3d_color){0, 0, 0, 255};
+        out_settings->lighting_enabled = true;
+        out_settings->bloom_enabled = true;
+        out_settings->ssao_enabled = true;
+        out_settings->tonemap = SDL3D_TONEMAP_ACES;
+    }
+    if (runtime == NULL || out_settings == NULL)
+        return false;
+
+    yyjson_val *render = obj_get(runtime_root(runtime), "render");
+    if (!yyjson_is_obj(render))
+        return true;
+
+    out_settings->clear_color = json_color(render, "clear_color", out_settings->clear_color);
+    out_settings->lighting_enabled = json_bool(render, "lighting", out_settings->lighting_enabled);
+    out_settings->bloom_enabled = json_bool(render, "bloom", out_settings->bloom_enabled);
+    out_settings->ssao_enabled = json_bool(render, "ssao", out_settings->ssao_enabled);
+    out_settings->tonemap = parse_tonemap(json_string(render, "tonemap", NULL), out_settings->tonemap);
+    return true;
+}
+
+bool sdl3d_game_data_get_transition(const sdl3d_game_data_runtime *runtime, const char *name,
+                                    sdl3d_game_data_transition_desc *out_transition)
+{
+    if (out_transition != NULL)
+    {
+        SDL_zero(*out_transition);
+        out_transition->type = SDL3D_TRANSITION_FADE;
+        out_transition->direction = SDL3D_TRANSITION_IN;
+        out_transition->color = (sdl3d_color){0, 0, 0, 255};
+        out_transition->duration = 0.5f;
+        out_transition->done_signal_id = -1;
+    }
+    if (runtime == NULL || name == NULL || out_transition == NULL)
+        return false;
+
+    yyjson_val *transition = obj_get(obj_get(runtime_root(runtime), "transitions"), name);
+    if (!yyjson_is_obj(transition))
+        return false;
+
+    out_transition->type = parse_transition_type(json_string(transition, "type", NULL), out_transition->type);
+    out_transition->direction =
+        parse_transition_direction(json_string(transition, "direction", NULL), out_transition->direction);
+    out_transition->color = json_color(transition, "color", out_transition->color);
+    out_transition->duration = json_float(transition, "duration", out_transition->duration);
+    const char *done_signal = json_string(transition, "done_signal", NULL);
+    out_transition->done_signal_id =
+        done_signal != NULL ? sdl3d_game_data_find_signal(runtime, done_signal) : out_transition->done_signal_id;
+    return true;
+}
+
+bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
+                                      void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    yyjson_val *texts = obj_get(obj_get(runtime_root(runtime), "ui"), "text");
+    for (size_t i = 0; yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(texts, i);
+        sdl3d_game_data_ui_text text;
+        SDL_zero(text);
+        text.name = json_string(item, "name", NULL);
+        text.font = json_string(item, "font", NULL);
+        text.text = json_string(item, "text", NULL);
+        text.format = json_string(item, "format", NULL);
+        text.source = json_string(item, "source", NULL);
+        text.visible = json_string(item, "visible", "always");
+        text.x = json_float(item, "x", 0.0f);
+        text.y = json_float(item, "y", 0.0f);
+        text.normalized = json_bool(item, "normalized", false);
+        text.centered = json_bool(item, "centered", false);
+        text.pulse_alpha = json_bool(item, "pulse_alpha", false);
+        text.color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
+        if (!callback(userdata, &text))
+            return true;
+    }
     return true;
 }
 
@@ -2392,6 +2531,114 @@ bool sdl3d_game_data_reload_scripts(sdl3d_game_data_runtime *runtime, sdl3d_asse
     SDL_free(loading);
     SDL_free(loaded);
     return true;
+}
+
+static bool apply_app_config_from_root(yyjson_val *root, sdl3d_game_config *out_config, char *title_buffer,
+                                       int title_buffer_size, char *error_buffer, int error_buffer_size)
+{
+    if (!yyjson_is_obj(root) || SDL_strcmp(json_string(root, "schema", ""), "sdl3d.game.v0") != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "unsupported or missing game data schema");
+        return false;
+    }
+
+    yyjson_val *app = obj_get(root, "app");
+    if (!yyjson_is_obj(app))
+        return true;
+
+    const char *title = json_string(app, "title", NULL);
+    if (title != NULL && title_buffer != NULL && title_buffer_size > 0)
+    {
+        SDL_snprintf(title_buffer, (size_t)title_buffer_size, "%s", title);
+        out_config->title = title_buffer;
+    }
+    out_config->width = json_int(app, "width", out_config->width);
+    out_config->height = json_int(app, "height", out_config->height);
+    out_config->backend = parse_backend(json_string(app, "backend", NULL), out_config->backend);
+    out_config->tick_rate = json_float(app, "tick_rate", out_config->tick_rate);
+    out_config->max_ticks_per_frame = json_int(app, "max_ticks_per_frame", out_config->max_ticks_per_frame);
+    out_config->enable_audio = json_bool(app, "enable_audio", out_config->enable_audio);
+    return true;
+}
+
+bool sdl3d_game_data_load_app_config_asset(sdl3d_asset_resolver *assets, const char *asset_path,
+                                           sdl3d_game_config *out_config, char *title_buffer, int title_buffer_size,
+                                           char *error_buffer, int error_buffer_size)
+{
+    if (assets == NULL || asset_path == NULL || asset_path[0] == '\0' || out_config == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "invalid app config load arguments");
+        return false;
+    }
+
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+    char asset_error[256];
+    if (!sdl3d_asset_resolver_read_file(assets, asset_path, &buffer, asset_error, (int)sizeof(asset_error)))
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to read game data asset %s: %s", asset_path,
+                         asset_error);
+        return false;
+    }
+
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, &err);
+    sdl3d_asset_buffer_free(&buffer);
+    if (doc == NULL)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "yyjson error %u at byte %llu: %s", err.code,
+                         (unsigned long long)err.pos, err.msg != NULL ? err.msg : "");
+        return false;
+    }
+
+    const bool ok = apply_app_config_from_root(yyjson_doc_get_root(doc), out_config, title_buffer, title_buffer_size,
+                                               error_buffer, error_buffer_size);
+    yyjson_doc_free(doc);
+    return ok;
+}
+
+bool sdl3d_game_data_load_app_config_file(const char *path, sdl3d_game_config *out_config, char *title_buffer,
+                                          int title_buffer_size, char *error_buffer, int error_buffer_size)
+{
+    if (path == NULL || path[0] == '\0' || out_config == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "invalid app config load arguments");
+        return false;
+    }
+
+    char *base_dir = path_dirname(path);
+    char *asset_name = path_basename(path);
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (base_dir == NULL || asset_name == NULL || assets == NULL)
+    {
+        SDL_free(base_dir);
+        SDL_free(asset_name);
+        sdl3d_asset_resolver_destroy(assets);
+        set_error(error_buffer, error_buffer_size, "failed to allocate app config loader");
+        return false;
+    }
+
+    char asset_error[256];
+    const bool mounted = sdl3d_asset_resolver_mount_directory(assets, base_dir, asset_error, (int)sizeof(asset_error));
+    bool ok = false;
+    if (!mounted)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "failed to mount game data directory %s: %s",
+                         base_dir, asset_error);
+    }
+    else
+    {
+        ok = sdl3d_game_data_load_app_config_asset(assets, asset_name, out_config, title_buffer, title_buffer_size,
+                                                   error_buffer, error_buffer_size);
+    }
+
+    sdl3d_asset_resolver_destroy(assets);
+    SDL_free(base_dir);
+    SDL_free(asset_name);
+    return ok;
 }
 
 bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -230,6 +230,7 @@ static sdl3d_input_manager *runtime_input(const sdl3d_game_data_runtime *runtime
 }
 
 static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 position);
+static void lua_push_actor_wrapper(lua_State *lua, const sdl3d_registered_actor *actor);
 
 static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
 {
@@ -385,6 +386,38 @@ static int lua_random(lua_State *lua)
     return 1;
 }
 
+static int lua_actor_with_tags(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const int arg_count = lua_gettop(lua);
+    const char *tags[16];
+    int tag_count = 0;
+    if (lua_istable(lua, 1))
+    {
+        const lua_Integer count = luaL_len(lua, 1);
+        for (lua_Integer i = 1; i <= count && tag_count < (int)SDL_arraysize(tags); ++i)
+        {
+            lua_geti(lua, 1, i);
+            const char *tag = lua_tostring(lua, -1);
+            if (tag != NULL && tag[0] != '\0')
+                tags[tag_count++] = tag;
+            lua_pop(lua, 1);
+        }
+    }
+    else
+    {
+        for (int i = 1; i <= arg_count && tag_count < (int)SDL_arraysize(tags); ++i)
+        {
+            const char *tag = lua_tostring(lua, i);
+            if (tag != NULL && tag[0] != '\0')
+                tags[tag_count++] = tag;
+        }
+    }
+
+    lua_push_actor_wrapper(lua, sdl3d_game_data_find_actor_with_tags(runtime, tags, tag_count));
+    return 1;
+}
+
 static int lua_log(lua_State *lua)
 {
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[lua] %s", luaL_checkstring(lua, 1));
@@ -393,7 +426,7 @@ static int lua_log(lua_State *lua)
 
 static void install_lua_helpers(lua_State *lua)
 {
-    static const char *source =
+    static const char *source_parts[] = {
         "local Actor = {}\n"
         "local Vec3 = {}\n"
         "local Vec3_mt = { __index = Vec3 }\n"
@@ -440,7 +473,7 @@ static void install_lua_helpers(lua_State *lua)
         "end\n"
         "function math.lerp(a, b, t)\n"
         "    return a + (b - a) * t\n"
-        "end\n"
+        "end\n",
         "function Actor:get_float(key, fallback) return sdl3d.get_float(self, key, fallback or 0) end\n"
         "function Actor:set_float(key, value) sdl3d.set_float(self, key, value) end\n"
         "function Actor:get_int(key, fallback) return sdl3d.get_int(self, key, fallback or 0) end\n"
@@ -486,6 +519,13 @@ static void install_lua_helpers(lua_State *lua)
         "        name = adapter,\n"
         "        dt = dt or 0,\n"
         "        actor = function(self_or_name, maybe_name) return sdl3d.actor(maybe_name or self_or_name) end,\n"
+        "        actor_with_tags = function(self_or_tag, maybe_tag, ...)\n"
+        "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
+        "                return sdl3d.actor_with_tags(maybe_tag, ...)\n"
+        "            end\n"
+        "            if type(self_or_tag) == 'table' then return sdl3d.actor_with_tags(self_or_tag) end\n"
+        "            return sdl3d.actor_with_tags(self_or_tag, maybe_tag, ...)\n"
+        "        end,\n"
         "        random = function(_) return sdl3d.random() end,\n"
         "        log = function(self_or_message, maybe_message) sdl3d.log(maybe_message or self_or_message) end,\n"
         "    }\n"
@@ -493,13 +533,35 @@ static void install_lua_helpers(lua_State *lua)
         "sdl3d.Actor = Actor\n"
         "sdl3d.Vec3 = Vec3\n"
         "sdl3d.api = 'sdl3d.lua.v1'\n"
-        "_G.Vec3 = Vec3\n";
+        "_G.Vec3 = Vec3\n",
+    };
+
+    size_t source_len = 0;
+    for (size_t i = 0; i < SDL_arraysize(source_parts); ++i)
+        source_len += SDL_strlen(source_parts[i]);
+
+    char *source = (char *)SDL_malloc(source_len + 1u);
+    if (source == NULL)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[lua] failed to allocate gameplay API source");
+        return;
+    }
+
+    size_t offset = 0;
+    for (size_t i = 0; i < SDL_arraysize(source_parts); ++i)
+    {
+        const size_t part_len = SDL_strlen(source_parts[i]);
+        SDL_memcpy(source + offset, source_parts[i], part_len);
+        offset += part_len;
+    }
+    source[offset] = '\0';
 
     if (luaL_dostring(lua, source) != LUA_OK)
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[lua] failed to install gameplay API: %s", lua_tostring(lua, -1));
         lua_pop(lua, 1);
     }
+    SDL_free(source);
 }
 
 static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engine *engine)
@@ -531,6 +593,7 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("set_vec3", lua_set_vec3);
     SDL3D_LUA_BIND("dt", lua_get_dt);
     SDL3D_LUA_BIND("random", lua_random);
+    SDL3D_LUA_BIND("actor_with_tags", lua_actor_with_tags);
     SDL3D_LUA_BIND("log", lua_log);
 #undef SDL3D_LUA_BIND
     lua_setglobal(lua, "sdl3d");
@@ -629,6 +692,30 @@ static yyjson_val *find_entity_json(const sdl3d_game_data_runtime *runtime, cons
     return NULL;
 }
 
+static bool entity_json_has_tag(yyjson_val *entity, const char *tag)
+{
+    yyjson_val *tags = obj_get(entity, "tags");
+    for (size_t i = 0; tag != NULL && yyjson_is_arr(tags) && i < yyjson_arr_size(tags); ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(tags, i);
+        if (yyjson_is_str(item) && SDL_strcmp(yyjson_get_str(item), tag) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count)
+{
+    if (tag_count <= 0)
+        return false;
+    for (int i = 0; i < tag_count; ++i)
+    {
+        if (!entity_json_has_tag(entity, tags[i]))
+            return false;
+    }
+    return true;
+}
+
 static yyjson_val *find_component_json(yyjson_val *entity, const char *type)
 {
     yyjson_val *components = obj_get(entity, "components");
@@ -638,6 +725,19 @@ static yyjson_val *find_component_json(yyjson_val *entity, const char *type)
         const char *component_type = json_string(component, "type", NULL);
         if (component_type != NULL && type != NULL && SDL_strcmp(component_type, type) == 0)
             return component;
+    }
+    return NULL;
+}
+
+static yyjson_val *find_font_json(const sdl3d_game_data_runtime *runtime, const char *id)
+{
+    yyjson_val *fonts = obj_get(obj_get(runtime_root(runtime), "assets"), "fonts");
+    for (size_t i = 0; id != NULL && yyjson_is_arr(fonts) && i < yyjson_arr_size(fonts); ++i)
+    {
+        yyjson_val *font = yyjson_arr_get(fonts, i);
+        const char *font_id = json_string(font, "id", NULL);
+        if (font_id != NULL && SDL_strcmp(font_id, id) == 0)
+            return font;
     }
     return NULL;
 }
@@ -704,6 +804,15 @@ static sdl3d_transition_direction parse_transition_direction(const char *value, 
         return SDL3D_TRANSITION_IN;
     if (SDL_strcasecmp(value, "out") == 0)
         return SDL3D_TRANSITION_OUT;
+    return fallback;
+}
+
+static sdl3d_builtin_font parse_builtin_font(const char *value, sdl3d_builtin_font fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "Inter") == 0 || SDL_strcasecmp(value, "inter") == 0)
+        return SDL3D_BUILTIN_FONT_INTER;
     return fallback;
 }
 
@@ -1098,6 +1207,81 @@ sdl3d_registered_actor *sdl3d_game_data_find_actor(const sdl3d_game_data_runtime
     return sdl3d_actor_registry_find(runtime_registry(runtime), name);
 }
 
+sdl3d_registered_actor *sdl3d_game_data_find_actor_with_tag(const sdl3d_game_data_runtime *runtime, const char *tag)
+{
+    const char *tags[1] = {tag};
+    return sdl3d_game_data_find_actor_with_tags(runtime, tags, 1);
+}
+
+sdl3d_registered_actor *sdl3d_game_data_find_actor_with_tags(const sdl3d_game_data_runtime *runtime,
+                                                             const char *const *tags, int tag_count)
+{
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    if (runtime == NULL || tags == NULL || tag_count <= 0 || !yyjson_is_arr(entities))
+        return NULL;
+
+    for (size_t i = 0; i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        if (!entity_json_has_tags(entity, tags, tag_count))
+            continue;
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(entity, "name", NULL));
+        if (actor != NULL)
+            return actor;
+    }
+    return NULL;
+}
+
+bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_app_control *out_control)
+{
+    if (out_control != NULL)
+    {
+        out_control->start_signal_id = -1;
+        out_control->quit_action_id = -1;
+        out_control->pause_action_id = -1;
+        out_control->startup_transition = NULL;
+        out_control->quit_transition = NULL;
+        out_control->quit_signal_id = -1;
+    }
+    if (runtime == NULL || out_control == NULL)
+        return false;
+
+    yyjson_val *app = obj_get(runtime_root(runtime), "app");
+    yyjson_val *quit = obj_get(app, "quit");
+    out_control->start_signal_id = sdl3d_game_data_find_signal(runtime, json_string(app, "start_signal", NULL));
+    out_control->pause_action_id = sdl3d_game_data_find_action(runtime, json_string(app, "pause_action", NULL));
+    out_control->startup_transition = json_string(app, "startup_transition", NULL);
+    out_control->quit_action_id = sdl3d_game_data_find_action(runtime, json_string(quit, "action", NULL));
+    out_control->quit_transition = json_string(quit, "transition", NULL);
+    out_control->quit_signal_id = sdl3d_game_data_find_signal(runtime, json_string(quit, "quit_signal", NULL));
+    return true;
+}
+
+bool sdl3d_game_data_get_font_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                    sdl3d_game_data_font_asset *out_font)
+{
+    if (out_font != NULL)
+    {
+        SDL_zero(*out_font);
+        out_font->builtin_id = SDL3D_BUILTIN_FONT_INTER;
+        out_font->size = 16.0f;
+    }
+    if (runtime == NULL || id == NULL || out_font == NULL)
+        return false;
+
+    yyjson_val *font = find_font_json(runtime, id);
+    if (!yyjson_is_obj(font))
+        return false;
+
+    out_font->id = json_string(font, "id", NULL);
+    out_font->path = json_string(font, "path", NULL);
+    out_font->size = json_float(font, "size", out_font->size);
+    const char *builtin = json_string(font, "builtin", NULL);
+    out_font->builtin = builtin != NULL;
+    out_font->builtin_id = parse_builtin_font(builtin, out_font->builtin_id);
+    return true;
+}
+
 const char *sdl3d_game_data_active_camera(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? runtime->active_camera : NULL;
@@ -1117,6 +1301,53 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
     const char *type = json_string(camera_json, "type", "perspective");
     if (SDL_strcmp(type, "adapter") == 0)
         return false;
+
+    if (SDL_strcmp(type, "chase") == 0)
+    {
+        sdl3d_registered_actor *target =
+            sdl3d_game_data_find_actor(runtime, json_string(camera_json, "target_entity", NULL));
+        if (target == NULL)
+            return false;
+
+        const char *velocity_property = json_string(camera_json, "velocity_property", "velocity");
+        sdl3d_vec3 velocity =
+            sdl3d_properties_get_vec3(target->props, velocity_property, sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+        velocity.z = 0.0f;
+        float velocity_len = SDL_sqrtf(velocity.x * velocity.x + velocity.y * velocity.y);
+        if (velocity_len < 0.001f)
+        {
+            velocity = json_vec3(camera_json, "fallback_forward", sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+            velocity.z = 0.0f;
+            velocity_len = SDL_sqrtf(velocity.x * velocity.x + velocity.y * velocity.y);
+        }
+        if (velocity_len < 0.001f)
+            velocity = sdl3d_vec3_make(1.0f, 0.0f, 0.0f);
+        else
+        {
+            velocity.x /= velocity_len;
+            velocity.y /= velocity_len;
+        }
+
+        const float target_z_offset = json_float(camera_json, "target_z_offset", 0.0f);
+        const float camera_height = json_float(camera_json, "height", 1.0f);
+        const float chase_distance = json_float(camera_json, "chase_distance", 2.0f);
+        const float lookahead = json_float(camera_json, "lookahead", 1.0f);
+        const sdl3d_vec3 target_offset = json_vec3(camera_json, "target_offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        const sdl3d_vec3 eye_offset = json_vec3(camera_json, "eye_offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        const sdl3d_vec3 anchor =
+            sdl3d_vec3_make(target->position.x + target_offset.x, target->position.y + target_offset.y,
+                            target->position.z + target_offset.z);
+
+        out_camera->position = sdl3d_vec3_make(anchor.x - velocity.x * chase_distance + eye_offset.x,
+                                               anchor.y - velocity.y * chase_distance + eye_offset.y,
+                                               anchor.z + camera_height + eye_offset.z);
+        out_camera->target = sdl3d_vec3_make(anchor.x + velocity.x * lookahead, anchor.y + velocity.y * lookahead,
+                                             anchor.z + target_z_offset);
+        out_camera->up = json_vec3(camera_json, "up", sdl3d_vec3_make(0.0f, 0.0f, 1.0f));
+        out_camera->fovy = json_float(camera_json, "fovy", 60.0f);
+        out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
+        return true;
+    }
 
     out_camera->position = json_vec3(camera_json, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
     out_camera->target = json_vec3(camera_json, "target", sdl3d_vec3_make(0.0f, 0.0f, -1.0f));
@@ -1144,6 +1375,8 @@ bool sdl3d_game_data_get_camera_float(const sdl3d_game_data_runtime *runtime, co
 
     yyjson_val *camera = find_camera_json(runtime, camera_name);
     yyjson_val *value = obj_get(obj_get(camera, "properties"), property_name);
+    if (!yyjson_is_num(value))
+        value = obj_get(camera, property_name);
     if (!yyjson_is_num(value))
         return false;
 
@@ -1227,7 +1460,94 @@ bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int
     return true;
 }
 
-bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *runtime,
+static float game_data_clampf(float value, float lo, float hi)
+{
+    if (value < lo)
+        return lo;
+    if (value > hi)
+        return hi;
+    return value;
+}
+
+static sdl3d_color game_data_color_lerp(sdl3d_color a, sdl3d_color b, float t)
+{
+    t = game_data_clampf(t, 0.0f, 1.0f);
+    return (sdl3d_color){
+        (Uint8)((float)a.r + ((float)b.r - (float)a.r) * t),
+        (Uint8)((float)a.g + ((float)b.g - (float)a.g) * t),
+        (Uint8)((float)a.b + ((float)b.b - (float)a.b) * t),
+        (Uint8)((float)a.a + ((float)b.a - (float)a.a) * t),
+    };
+}
+
+static void apply_render_effects(const sdl3d_game_data_runtime *runtime, yyjson_val *component,
+                                 const sdl3d_game_data_render_eval *eval, sdl3d_game_data_render_primitive *primitive)
+{
+    yyjson_val *effects = obj_get(component, "effects");
+    if (!yyjson_is_arr(effects) || primitive == NULL)
+        return;
+
+    for (size_t i = 0; i < yyjson_arr_size(effects); ++i)
+    {
+        yyjson_val *effect = yyjson_arr_get(effects, i);
+        const char *type = json_string(effect, "type", "");
+        if (SDL_strcmp(type, "flash") == 0)
+        {
+            sdl3d_registered_actor *source = sdl3d_game_data_find_actor(runtime, json_string(effect, "source", NULL));
+            const char *property = json_string(effect, "property", NULL);
+            const float value = game_data_clampf(
+                source != NULL && property != NULL ? sdl3d_properties_get_float(source->props, property, 0.0f) : 0.0f,
+                0.0f, 1.0f);
+            primitive->color =
+                game_data_color_lerp(primitive->color, json_color(effect, "color", primitive->color), value);
+
+            const sdl3d_vec3 size_add = json_vec3(effect, "size_add", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            const char *size_mode = json_string(effect, "size_mode", "vector");
+            if (SDL_strcmp(size_mode, "minor_axis") == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+            {
+                if (primitive->size.x <= primitive->size.y)
+                    primitive->size.x += size_add.x * value;
+                else
+                    primitive->size.y += size_add.y * value;
+            }
+            else
+            {
+                primitive->size.x += size_add.x * value;
+                primitive->size.y += size_add.y * value;
+                primitive->size.z += size_add.z * value;
+            }
+
+            const sdl3d_vec3 emissive = json_vec3(effect, "emissive", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            primitive->emissive_color.x += emissive.x * value;
+            primitive->emissive_color.y += emissive.y * value;
+            primitive->emissive_color.z += emissive.z * value;
+        }
+        else if (SDL_strcmp(type, "pulse") == 0)
+        {
+            const float time = eval != NULL ? eval->time : 0.0f;
+            const float rate = json_float(effect, "rate", 1.0f);
+            const float pulse = 0.5f + 0.5f * SDL_sinf(time * rate);
+            primitive->color =
+                game_data_color_lerp(primitive->color, json_color(effect, "color", primitive->color), pulse);
+
+            const sdl3d_vec3 base = json_vec3(effect, "emissive_base", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            const sdl3d_vec3 add = json_vec3(effect, "emissive_add", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            primitive->emissive_color.x += base.x + add.x * pulse;
+            primitive->emissive_color.y += base.y + add.y * pulse;
+            primitive->emissive_color.z += base.z + add.z * pulse;
+        }
+        else if (SDL_strcmp(type, "emissive") == 0)
+        {
+            const sdl3d_vec3 rgb = json_vec3(effect, "color", sdl3d_vec3_make(0.2f, 0.2f, 0.2f));
+            primitive->emissive_color.x += rgb.x;
+            primitive->emissive_color.y += rgb.y;
+            primitive->emissive_color.z += rgb.z;
+        }
+    }
+}
+
+static bool for_each_render_primitive_internal(const sdl3d_game_data_runtime *runtime,
+                                               const sdl3d_game_data_render_eval *eval,
                                                sdl3d_game_data_render_primitive_fn callback, void *userdata)
 {
     if (runtime == NULL || callback == NULL)
@@ -1257,6 +1577,8 @@ bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *ru
             primitive.position.z += offset.z;
             primitive.color = json_color(component, "color", (sdl3d_color){255, 255, 255, 255});
             primitive.emissive = json_bool(component, "emissive", false);
+            primitive.emissive_color =
+                primitive.emissive ? sdl3d_vec3_make(0.2f, 0.2f, 0.2f) : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
 
             if (SDL_strcmp(type, "render.cube") == 0)
             {
@@ -1275,11 +1597,26 @@ bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *ru
                 continue;
             }
 
+            if (eval != NULL)
+                apply_render_effects(runtime, component, eval, &primitive);
             if (!callback(userdata, &primitive))
                 return true;
         }
     }
     return true;
+}
+
+bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *runtime,
+                                               sdl3d_game_data_render_primitive_fn callback, void *userdata)
+{
+    return for_each_render_primitive_internal(runtime, NULL, callback, userdata);
+}
+
+bool sdl3d_game_data_for_each_render_primitive_evaluated(const sdl3d_game_data_runtime *runtime,
+                                                         const sdl3d_game_data_render_eval *eval,
+                                                         sdl3d_game_data_render_primitive_fn callback, void *userdata)
+{
+    return for_each_render_primitive_internal(runtime, eval, callback, userdata);
 }
 
 bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime, const char *entity_name,
@@ -1325,6 +1662,23 @@ bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime
     out_config->additive_blend = json_bool(component, "additive_blend", false);
     out_config->texture = NULL;
     out_config->random_seed = (Uint32)json_int(component, "random_seed", 0);
+    return true;
+}
+
+bool sdl3d_game_data_get_particle_emitter_draw_emissive(const sdl3d_game_data_runtime *runtime, const char *entity_name,
+                                                        sdl3d_vec3 *out_rgb)
+{
+    if (out_rgb != NULL)
+        *out_rgb = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (runtime == NULL || entity_name == NULL || out_rgb == NULL)
+        return false;
+
+    yyjson_val *entity = find_entity_json(runtime, entity_name);
+    yyjson_val *component = find_component_json(entity, "particles.emitter");
+    if (component == NULL)
+        return false;
+
+    *out_rgb = json_vec3(component, "draw_emissive", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
     return true;
 }
 
@@ -1999,6 +2353,250 @@ static bool compare_value(const sdl3d_value *left, const char *op, yyjson_val *r
         return left->as_bool == yyjson_get_bool(right);
     if (left->type == SDL3D_VALUE_STRING && yyjson_is_str(right) && SDL_strcmp(op, "==") == 0)
         return SDL_strcmp(left->as_string, yyjson_get_str(right)) == 0;
+    return false;
+}
+
+static yyjson_val *find_ui_text_json(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *texts = obj_get(obj_get(runtime_root(runtime), "ui"), "text");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
+    {
+        yyjson_val *text = yyjson_arr_get(texts, i);
+        const char *text_name = json_string(text, "name", NULL);
+        if (text_name != NULL && SDL_strcmp(text_name, name) == 0)
+            return text;
+    }
+    return NULL;
+}
+
+static bool value_equals_json_bool(const sdl3d_value *left, bool right)
+{
+    return left != NULL && left->type == SDL3D_VALUE_BOOL && left->as_bool == right;
+}
+
+static bool eval_ui_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
+                              const sdl3d_game_data_ui_metrics *metrics)
+{
+    if (condition == NULL)
+        return true;
+    if (!yyjson_is_obj(condition))
+        return false;
+
+    const char *type = json_string(condition, "type", "");
+    if (SDL_strcmp(type, "always") == 0)
+        return true;
+    if (SDL_strcmp(type, "camera.active") == 0)
+    {
+        const char *camera = json_string(condition, "camera", NULL);
+        const char *active = sdl3d_game_data_active_camera(runtime);
+        return camera != NULL && active != NULL && SDL_strcmp(camera, active) == 0;
+    }
+    if (SDL_strcmp(type, "app.paused") == 0)
+    {
+        const bool expected = json_bool(condition, "equals", true);
+        return (metrics != NULL && metrics->paused) == expected;
+    }
+    if (SDL_strcmp(type, "property.compare") == 0)
+    {
+        sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, json_string(condition, "target", NULL));
+        const char *key = json_string(condition, "key", NULL);
+        const char *op = json_string(condition, "op", NULL);
+        return target != NULL && key != NULL &&
+               compare_value(sdl3d_properties_get_value(target->props, key), op, obj_get(condition, "value"));
+    }
+    if (SDL_strcmp(type, "property.bool") == 0)
+    {
+        sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, json_string(condition, "target", NULL));
+        const char *key = json_string(condition, "key", NULL);
+        return target != NULL && key != NULL &&
+               value_equals_json_bool(sdl3d_properties_get_value(target->props, key),
+                                      json_bool(condition, "equals", true));
+    }
+    if (SDL_strcmp(type, "all") == 0 || SDL_strcmp(type, "any") == 0)
+    {
+        yyjson_val *conditions = obj_get(condition, "conditions");
+        if (!yyjson_is_arr(conditions))
+            return false;
+        const bool require_all = SDL_strcmp(type, "all") == 0;
+        bool saw_any = false;
+        for (size_t i = 0; i < yyjson_arr_size(conditions); ++i)
+        {
+            saw_any = true;
+            const bool passed = eval_ui_condition(runtime, yyjson_arr_get(conditions, i), metrics);
+            if (require_all && !passed)
+                return false;
+            if (!require_all && passed)
+                return true;
+        }
+        return require_all && saw_any;
+    }
+    if (SDL_strcmp(type, "not") == 0)
+        return !eval_ui_condition(runtime, obj_get(condition, "condition"), metrics);
+    return false;
+}
+
+bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                        const sdl3d_game_data_ui_metrics *metrics)
+{
+    if (runtime == NULL || text == NULL)
+        return false;
+    yyjson_val *text_json = find_ui_text_json(runtime, text->name);
+    yyjson_val *condition = obj_get(text_json, "visible_if");
+    if (condition != NULL)
+        return eval_ui_condition(runtime, condition, metrics);
+    return text->visible == NULL || SDL_strcmp(text->visible, "always") == 0;
+}
+
+typedef enum ui_value_type
+{
+    UI_VALUE_NONE,
+    UI_VALUE_INT,
+    UI_VALUE_FLOAT,
+    UI_VALUE_UINT64,
+    UI_VALUE_BOOL,
+    UI_VALUE_STRING,
+} ui_value_type;
+
+typedef struct ui_value
+{
+    ui_value_type type;
+    union {
+        int as_int;
+        float as_float;
+        Uint64 as_uint64;
+        bool as_bool;
+        const char *as_string;
+    };
+} ui_value;
+
+static bool read_ui_binding_value(const sdl3d_game_data_runtime *runtime, yyjson_val *binding,
+                                  const sdl3d_game_data_ui_metrics *metrics, ui_value *out_value)
+{
+    if (out_value != NULL)
+        SDL_zero(*out_value);
+    if (binding == NULL || out_value == NULL)
+        return false;
+
+    const char *type = json_string(binding, "type", "");
+    if (SDL_strcmp(type, "metric") == 0)
+    {
+        const char *metric = json_string(binding, "metric", NULL);
+        if (metric != NULL && SDL_strcmp(metric, "fps") == 0)
+        {
+            out_value->type = UI_VALUE_FLOAT;
+            out_value->as_float = metrics != NULL ? metrics->fps : 0.0f;
+            return true;
+        }
+        if (metric != NULL && SDL_strcmp(metric, "frame") == 0)
+        {
+            out_value->type = UI_VALUE_UINT64;
+            out_value->as_uint64 = metrics != NULL ? metrics->frame : 0u;
+            return true;
+        }
+        if (metric != NULL && SDL_strcmp(metric, "paused") == 0)
+        {
+            out_value->type = UI_VALUE_BOOL;
+            out_value->as_bool = metrics != NULL && metrics->paused;
+            return true;
+        }
+        return false;
+    }
+
+    if (SDL_strcmp(type, "property") == 0)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(binding, "entity", NULL));
+        const char *key = json_string(binding, "key", NULL);
+        const sdl3d_value *value = actor != NULL && key != NULL ? sdl3d_properties_get_value(actor->props, key) : NULL;
+        if (value == NULL)
+            return false;
+        switch (value->type)
+        {
+        case SDL3D_VALUE_INT:
+            out_value->type = UI_VALUE_INT;
+            out_value->as_int = value->as_int;
+            return true;
+        case SDL3D_VALUE_FLOAT:
+            out_value->type = UI_VALUE_FLOAT;
+            out_value->as_float = value->as_float;
+            return true;
+        case SDL3D_VALUE_BOOL:
+            out_value->type = UI_VALUE_BOOL;
+            out_value->as_bool = value->as_bool;
+            return true;
+        case SDL3D_VALUE_STRING:
+            out_value->type = UI_VALUE_STRING;
+            out_value->as_string = value->as_string != NULL ? value->as_string : "";
+            return true;
+        case SDL3D_VALUE_VEC3:
+        case SDL3D_VALUE_COLOR:
+            return false;
+        }
+    }
+    return false;
+}
+
+static bool format_bound_ui_text(const char *format, const ui_value *values, int value_count, char *buffer,
+                                 size_t buffer_size)
+{
+    if (format == NULL || values == NULL || buffer == NULL || buffer_size == 0)
+        return false;
+
+    if (value_count == 1)
+    {
+        if (values[0].type == UI_VALUE_INT)
+            SDL_snprintf(buffer, buffer_size, format, values[0].as_int);
+        else if (values[0].type == UI_VALUE_FLOAT)
+            SDL_snprintf(buffer, buffer_size, format, values[0].as_float);
+        else if (values[0].type == UI_VALUE_UINT64)
+            SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64);
+        else if (values[0].type == UI_VALUE_BOOL)
+            SDL_snprintf(buffer, buffer_size, format, values[0].as_bool ? 1 : 0);
+        else if (values[0].type == UI_VALUE_STRING)
+            SDL_snprintf(buffer, buffer_size, format, values[0].as_string);
+        else
+            return false;
+        return true;
+    }
+    if (value_count == 2 && values[0].type == UI_VALUE_INT && values[1].type == UI_VALUE_INT)
+    {
+        SDL_snprintf(buffer, buffer_size, format, values[0].as_int, values[1].as_int);
+        return true;
+    }
+    if (value_count == 2 && values[0].type == UI_VALUE_FLOAT && values[1].type == UI_VALUE_UINT64)
+    {
+        SDL_snprintf(buffer, buffer_size, format, values[0].as_float, (unsigned long long)values[1].as_uint64);
+        return true;
+    }
+    return false;
+}
+
+bool sdl3d_game_data_format_ui_text(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                    const sdl3d_game_data_ui_metrics *metrics, char *buffer, size_t buffer_size)
+{
+    if (buffer != NULL && buffer_size > 0)
+        buffer[0] = '\0';
+    if (runtime == NULL || text == NULL || buffer == NULL || buffer_size == 0)
+        return false;
+
+    yyjson_val *text_json = find_ui_text_json(runtime, text->name);
+    yyjson_val *bindings = obj_get(text_json, "bindings");
+    if (yyjson_is_arr(bindings) && yyjson_arr_size(bindings) > 0)
+    {
+        ui_value values[4];
+        const int value_count = (int)SDL_min(yyjson_arr_size(bindings), SDL_arraysize(values));
+        for (int i = 0; i < value_count; ++i)
+        {
+            if (!read_ui_binding_value(runtime, yyjson_arr_get(bindings, (size_t)i), metrics, &values[i]))
+                return false;
+        }
+        return format_bound_ui_text(text->format, values, value_count, buffer, buffer_size);
+    }
+
+    if (text->text != NULL)
+    {
+        SDL_snprintf(buffer, buffer_size, "%s", text->text);
+        return true;
+    }
     return false;
 }
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -557,7 +557,13 @@ static bool json_bool(yyjson_val *object, const char *key, bool fallback)
 static float json_float(yyjson_val *object, const char *key, float fallback)
 {
     yyjson_val *value = obj_get(object, key);
-    return yyjson_is_num(value) ? (float)yyjson_get_real(value) : fallback;
+    return yyjson_is_num(value) ? (float)yyjson_get_num(value) : fallback;
+}
+
+static int json_int(yyjson_val *object, const char *key, int fallback)
+{
+    yyjson_val *value = obj_get(object, key);
+    return yyjson_is_int(value) ? (int)yyjson_get_int(value) : fallback;
 }
 
 static sdl3d_vec3 json_vec3_value(yyjson_val *value, sdl3d_vec3 fallback)
@@ -571,13 +577,82 @@ static sdl3d_vec3 json_vec3_value(yyjson_val *value, sdl3d_vec3 fallback)
     if (!yyjson_is_num(x) || !yyjson_is_num(y))
         return fallback;
 
-    return sdl3d_vec3_make((float)yyjson_get_real(x), (float)yyjson_get_real(y),
-                           yyjson_is_num(z) ? (float)yyjson_get_real(z) : fallback.z);
+    return sdl3d_vec3_make((float)yyjson_get_num(x), (float)yyjson_get_num(y),
+                           yyjson_is_num(z) ? (float)yyjson_get_num(z) : fallback.z);
 }
 
 static sdl3d_vec3 json_vec3(yyjson_val *object, const char *key, sdl3d_vec3 fallback)
 {
     return json_vec3_value(obj_get(object, key), fallback);
+}
+
+static sdl3d_color json_color_value(yyjson_val *value, sdl3d_color fallback)
+{
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 3)
+        return fallback;
+
+    yyjson_val *r = yyjson_arr_get(value, 0);
+    yyjson_val *g = yyjson_arr_get(value, 1);
+    yyjson_val *b = yyjson_arr_get(value, 2);
+    yyjson_val *a = yyjson_arr_get(value, 3);
+    if (!yyjson_is_num(r) || !yyjson_is_num(g) || !yyjson_is_num(b))
+        return fallback;
+
+    return (sdl3d_color){
+        (Uint8)SDL_clamp((int)yyjson_get_num(r), 0, 255),
+        (Uint8)SDL_clamp((int)yyjson_get_num(g), 0, 255),
+        (Uint8)SDL_clamp((int)yyjson_get_num(b), 0, 255),
+        yyjson_is_num(a) ? (Uint8)SDL_clamp((int)yyjson_get_num(a), 0, 255) : fallback.a,
+    };
+}
+
+static sdl3d_color json_color(yyjson_val *object, const char *key, sdl3d_color fallback)
+{
+    return json_color_value(obj_get(object, key), fallback);
+}
+
+static yyjson_val *runtime_root(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->doc != NULL ? yyjson_doc_get_root(runtime->doc) : NULL;
+}
+
+static yyjson_val *find_entity_json(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (entity_name != NULL && name != NULL && SDL_strcmp(entity_name, name) == 0)
+            return entity;
+    }
+    return NULL;
+}
+
+static yyjson_val *find_component_json(yyjson_val *entity, const char *type)
+{
+    yyjson_val *components = obj_get(entity, "components");
+    for (size_t i = 0; yyjson_is_arr(components) && i < yyjson_arr_size(components); ++i)
+    {
+        yyjson_val *component = yyjson_arr_get(components, i);
+        const char *component_type = json_string(component, "type", NULL);
+        if (component_type != NULL && type != NULL && SDL_strcmp(component_type, type) == 0)
+            return component;
+    }
+    return NULL;
+}
+
+static yyjson_val *find_camera_json(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *cameras = obj_get(obj_get(runtime_root(runtime), "world"), "cameras");
+    for (size_t i = 0; yyjson_is_arr(cameras) && i < yyjson_arr_size(cameras); ++i)
+    {
+        yyjson_val *camera = yyjson_arr_get(cameras, i);
+        const char *camera_name = json_string(camera, "name", NULL);
+        if (camera_name != NULL && name != NULL && SDL_strcmp(camera_name, name) == 0)
+            return camera;
+    }
+    return NULL;
 }
 
 static int axis_index(const char *axis)
@@ -974,6 +1049,231 @@ sdl3d_registered_actor *sdl3d_game_data_find_actor(const sdl3d_game_data_runtime
 const char *sdl3d_game_data_active_camera(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? runtime->active_camera : NULL;
+}
+
+bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const char *name, sdl3d_camera3d *out_camera)
+{
+    if (out_camera != NULL)
+        SDL_zero(*out_camera);
+    if (runtime == NULL || name == NULL || out_camera == NULL)
+        return false;
+
+    yyjson_val *camera_json = find_camera_json(runtime, name);
+    if (camera_json == NULL)
+        return false;
+
+    const char *type = json_string(camera_json, "type", "perspective");
+    if (SDL_strcmp(type, "adapter") == 0)
+        return false;
+
+    out_camera->position = json_vec3(camera_json, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    out_camera->target = json_vec3(camera_json, "target", sdl3d_vec3_make(0.0f, 0.0f, -1.0f));
+    out_camera->up = json_vec3(camera_json, "up", sdl3d_vec3_make(0.0f, 1.0f, 0.0f));
+    if (SDL_strcmp(type, "orthographic") == 0)
+    {
+        out_camera->projection = SDL3D_CAMERA_ORTHOGRAPHIC;
+        out_camera->fovy = json_float(camera_json, "size", 10.0f);
+    }
+    else
+    {
+        out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
+        out_camera->fovy = json_float(camera_json, "fovy", 60.0f);
+    }
+    return true;
+}
+
+bool sdl3d_game_data_get_camera_float(const sdl3d_game_data_runtime *runtime, const char *camera_name,
+                                      const char *property_name, float *out_value)
+{
+    if (out_value != NULL)
+        *out_value = 0.0f;
+    if (runtime == NULL || camera_name == NULL || property_name == NULL || out_value == NULL)
+        return false;
+
+    yyjson_val *camera = find_camera_json(runtime, camera_name);
+    yyjson_val *value = obj_get(obj_get(camera, "properties"), property_name);
+    if (!yyjson_is_num(value))
+        return false;
+
+    *out_value = (float)yyjson_get_num(value);
+    return true;
+}
+
+int sdl3d_game_data_world_light_count(const sdl3d_game_data_runtime *runtime)
+{
+    yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
+    return yyjson_is_arr(lights) ? (int)yyjson_arr_size(lights) : 0;
+}
+
+bool sdl3d_game_data_get_world_ambient_light(const sdl3d_game_data_runtime *runtime, float out_rgb[3])
+{
+    if (out_rgb != NULL)
+    {
+        out_rgb[0] = 0.0f;
+        out_rgb[1] = 0.0f;
+        out_rgb[2] = 0.0f;
+    }
+    if (runtime == NULL || out_rgb == NULL)
+        return false;
+
+    yyjson_val *ambient = obj_get(obj_get(runtime_root(runtime), "world"), "ambient_light");
+    if (!yyjson_is_arr(ambient) || yyjson_arr_size(ambient) < 3)
+        return false;
+
+    for (int i = 0; i < 3; ++i)
+    {
+        yyjson_val *channel = yyjson_arr_get(ambient, (size_t)i);
+        if (!yyjson_is_num(channel))
+            return false;
+        out_rgb[i] = (float)yyjson_get_num(channel);
+    }
+    return true;
+}
+
+bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int index, sdl3d_light *out_light)
+{
+    if (out_light != NULL)
+        SDL_zero(*out_light);
+    yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
+    if (runtime == NULL || index < 0 || out_light == NULL || !yyjson_is_arr(lights) ||
+        (size_t)index >= yyjson_arr_size(lights))
+        return false;
+
+    yyjson_val *light_json = yyjson_arr_get(lights, (size_t)index);
+    const char *type = json_string(light_json, "type", "point");
+    if (SDL_strcmp(type, "directional") == 0)
+        out_light->type = SDL3D_LIGHT_DIRECTIONAL;
+    else if (SDL_strcmp(type, "spot") == 0)
+        out_light->type = SDL3D_LIGHT_SPOT;
+    else
+        out_light->type = SDL3D_LIGHT_POINT;
+
+    out_light->position = json_vec3(light_json, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const char *target_entity = json_string(light_json, "target_entity", NULL);
+    sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, target_entity);
+    if (target != NULL)
+    {
+        const sdl3d_vec3 offset = json_vec3(light_json, "offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        out_light->position = sdl3d_vec3_make(target->position.x + offset.x, target->position.y + offset.y,
+                                              target->position.z + offset.z);
+    }
+    out_light->direction = json_vec3(light_json, "direction", sdl3d_vec3_make(0.0f, -1.0f, 0.0f));
+    yyjson_val *color = obj_get(light_json, "color");
+    out_light->color[0] = 1.0f;
+    out_light->color[1] = 1.0f;
+    out_light->color[2] = 1.0f;
+    for (int i = 0; yyjson_is_arr(color) && i < 3; ++i)
+    {
+        yyjson_val *channel = yyjson_arr_get(color, (size_t)i);
+        if (yyjson_is_num(channel))
+            out_light->color[i] = (float)yyjson_get_num(channel);
+    }
+    out_light->intensity = json_float(light_json, "intensity", 1.0f);
+    out_light->range = json_float(light_json, "range", 10.0f);
+    out_light->inner_cutoff = json_float(light_json, "inner_cutoff", 0.0f);
+    out_light->outer_cutoff = json_float(light_json, "outer_cutoff", 0.0f);
+    return true;
+}
+
+bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *runtime,
+                                               sdl3d_game_data_render_primitive_fn callback, void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        const char *entity_name = json_string(entity, "name", NULL);
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        yyjson_val *components = obj_get(entity, "components");
+        if (actor == NULL || !actor->active || !yyjson_is_arr(components))
+            continue;
+
+        for (size_t c = 0; c < yyjson_arr_size(components); ++c)
+        {
+            yyjson_val *component = yyjson_arr_get(components, c);
+            const char *type = json_string(component, "type", "");
+            sdl3d_game_data_render_primitive primitive;
+            SDL_zero(primitive);
+            primitive.entity_name = entity_name;
+            primitive.position = actor->position;
+            const sdl3d_vec3 offset = json_vec3(component, "offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            primitive.position.x += offset.x;
+            primitive.position.y += offset.y;
+            primitive.position.z += offset.z;
+            primitive.color = json_color(component, "color", (sdl3d_color){255, 255, 255, 255});
+            primitive.emissive = json_bool(component, "emissive", false);
+
+            if (SDL_strcmp(type, "render.cube") == 0)
+            {
+                primitive.type = SDL3D_GAME_DATA_RENDER_CUBE;
+                primitive.size = json_vec3(component, "size", sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+            }
+            else if (SDL_strcmp(type, "render.sphere") == 0)
+            {
+                primitive.type = SDL3D_GAME_DATA_RENDER_SPHERE;
+                primitive.radius = json_float(component, "radius", 0.5f);
+                primitive.slices = json_int(component, "slices", 16);
+                primitive.rings = json_int(component, "rings", 8);
+            }
+            else
+            {
+                continue;
+            }
+
+            if (!callback(userdata, &primitive))
+                return true;
+        }
+    }
+    return true;
+}
+
+bool sdl3d_game_data_get_particle_emitter(const sdl3d_game_data_runtime *runtime, const char *entity_name,
+                                          sdl3d_particle_config *out_config)
+{
+    if (out_config != NULL)
+        SDL_zero(*out_config);
+    if (runtime == NULL || entity_name == NULL || out_config == NULL)
+        return false;
+
+    yyjson_val *entity = find_entity_json(runtime, entity_name);
+    yyjson_val *component = find_component_json(entity, "particles.emitter");
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+    if (component == NULL || actor == NULL)
+        return false;
+
+    out_config->position = actor->position;
+    out_config->direction = json_vec3(component, "direction", sdl3d_vec3_make(0.0f, 1.0f, 0.0f));
+    out_config->spread = json_float(component, "spread", 0.0f);
+    out_config->speed_min = json_float(component, "speed_min", 0.0f);
+    out_config->speed_max = json_float(component, "speed_max", 0.0f);
+    out_config->lifetime_min = json_float(component, "lifetime_min", 1.0f);
+    out_config->lifetime_max = json_float(component, "lifetime_max", 1.0f);
+    out_config->size_start = json_float(component, "size_start", 0.05f);
+    out_config->size_end = json_float(component, "size_end", 0.01f);
+    out_config->color_start = json_color(component, "color_start", (sdl3d_color){255, 255, 255, 255});
+    out_config->color_end = json_color(component, "color_end", (sdl3d_color){255, 255, 255, 0});
+    out_config->gravity = json_float(component, "gravity", 0.0f);
+    out_config->max_particles = json_int(component, "max_particles", 128);
+    out_config->emit_rate = json_float(component, "emit_rate", 0.0f);
+    const char *shape = json_string(component, "shape", "point");
+    if (SDL_strcmp(shape, "box") == 0)
+        out_config->shape = SDL3D_PARTICLE_EMITTER_BOX;
+    else if (SDL_strcmp(shape, "circle") == 0)
+        out_config->shape = SDL3D_PARTICLE_EMITTER_CIRCLE;
+    else
+        out_config->shape = SDL3D_PARTICLE_EMITTER_POINT;
+    out_config->extents = json_vec3(component, "extents", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    out_config->radius = json_float(component, "radius", 0.0f);
+    out_config->emissive_intensity = json_float(component, "emissive_intensity", 1.0f);
+    out_config->camera_facing = json_bool(component, "camera_facing", true);
+    out_config->depth_test = json_bool(component, "depth_test", true);
+    out_config->additive_blend = json_bool(component, "additive_blend", false);
+    out_config->texture = NULL;
+    out_config->random_seed = (Uint32)json_int(component, "random_seed", 0);
+    return true;
 }
 
 float sdl3d_game_data_delta_time(const sdl3d_game_data_runtime *runtime)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -52,6 +52,7 @@ typedef struct validation_names
     name_table actions;
     name_table timers;
     name_table cameras;
+    name_table fonts;
     name_table sensors;
     name_table used_adapters;
     name_table used_scripts;
@@ -495,6 +496,29 @@ static bool collect_cameras(validation_context *ctx, yyjson_val *root, validatio
     return true;
 }
 
+static bool collect_fonts(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *fonts = obj_get(obj_get(root, "assets"), "fonts");
+    if (fonts == NULL)
+        return true;
+    if (!yyjson_is_arr(fonts))
+        return validation_error(ctx, "$.assets.fonts", "font assets must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(fonts); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.assets.fonts[%zu]", i);
+        yyjson_val *font = yyjson_arr_get(fonts, i);
+        if (!yyjson_is_obj(font))
+            return validation_error(ctx, path, "font asset entries must be objects");
+        if (!require_unique_name(ctx, &names->fonts, "font asset", json_string(font, "id"), path))
+            return false;
+        if (!is_non_empty_string(font, "builtin") && !is_non_empty_string(font, "path"))
+            return validation_error(ctx, path, "font asset requires builtin or path");
+    }
+    return true;
+}
+
 static bool collect_input_actions(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *contexts = obj_get(obj_get(root, "input"), "contexts");
@@ -665,7 +689,7 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
            collect_input_actions(ctx, root, names) && collect_cameras(ctx, root, names) &&
-           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
+           collect_fonts(ctx, root, names) && collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -979,6 +1003,37 @@ static bool validate_adapters(validation_context *ctx, yyjson_val *root, validat
     return true;
 }
 
+static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *app = obj_get(root, "app");
+    if (!yyjson_is_obj(app))
+        return true;
+    const char *start_signal = json_string(app, "start_signal");
+    if (start_signal != NULL && !require_ref(ctx, &names->signals, "signal", start_signal, "$.app.start_signal"))
+        return false;
+    const char *pause_action = json_string(app, "pause_action");
+    if (pause_action != NULL && !require_ref(ctx, &names->actions, "input action", pause_action, "$.app.pause_action"))
+        return false;
+    const char *startup_transition = json_string(app, "startup_transition");
+    if (startup_transition != NULL && !yyjson_is_obj(obj_get(obj_get(root, "transitions"), startup_transition)))
+        return validation_error(ctx, "$.app.startup_transition", "unknown transition reference '%s'",
+                                startup_transition);
+
+    yyjson_val *quit = obj_get(app, "quit");
+    if (!yyjson_is_obj(quit))
+        return true;
+    const char *action = json_string(quit, "action");
+    if (action != NULL && !require_ref(ctx, &names->actions, "input action", action, "$.app.quit.action"))
+        return false;
+    const char *quit_signal = json_string(quit, "quit_signal");
+    if (quit_signal != NULL && !require_ref(ctx, &names->signals, "signal", quit_signal, "$.app.quit.quit_signal"))
+        return false;
+    const char *transition = json_string(quit, "transition");
+    if (transition != NULL && !yyjson_is_obj(obj_get(obj_get(root, "transitions"), transition)))
+        return validation_error(ctx, "$.app.quit.transition", "unknown transition reference '%s'", transition);
+    return true;
+}
+
 static bool validate_cameras(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *cameras = obj_get(obj_get(root, "world"), "cameras");
@@ -998,6 +1053,139 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
             if (json_string(camera, "target_entity") != NULL &&
                 !require_ref(ctx, &names->entities, "entity", json_string(camera, "target_entity"), path))
                 return false;
+        }
+        else if (SDL_strcmp(type != NULL ? type : "", "chase") == 0)
+        {
+            if (!require_ref(ctx, &names->entities, "entity", json_string(camera, "target_entity"), path))
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool validate_ui_condition(validation_context *ctx, yyjson_val *condition, const char *path,
+                                  validation_names *names)
+{
+    if (condition == NULL)
+        return true;
+    if (!yyjson_is_obj(condition))
+        return validation_error(ctx, path, "UI condition must be an object");
+
+    const char *type = json_string(condition, "type");
+    if (SDL_strcmp(type != NULL ? type : "", "always") == 0 || SDL_strcmp(type != NULL ? type : "", "app.paused") == 0)
+        return true;
+    if (SDL_strcmp(type != NULL ? type : "", "camera.active") == 0)
+        return require_ref(ctx, &names->cameras, "camera", json_string(condition, "camera"), path);
+    if (SDL_strcmp(type != NULL ? type : "", "property.compare") == 0 ||
+        SDL_strcmp(type != NULL ? type : "", "property.bool") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(condition, "target"), path))
+            return false;
+        if (!is_non_empty_string(condition, "key"))
+            return validation_error(ctx, path, "UI property condition requires a non-empty key");
+        if (SDL_strcmp(type, "property.compare") == 0 && !is_compare_op(json_string(condition, "op")))
+            return validation_error(ctx, path, "UI property.compare requires a supported comparison operator");
+        return true;
+    }
+    if (SDL_strcmp(type != NULL ? type : "", "not") == 0)
+    {
+        char child_path[PATH_BUFFER_SIZE];
+        format_path(child_path, sizeof(child_path), "%s.condition", path);
+        return validate_ui_condition(ctx, obj_get(condition, "condition"), child_path, names);
+    }
+    if (SDL_strcmp(type != NULL ? type : "", "all") == 0 || SDL_strcmp(type != NULL ? type : "", "any") == 0)
+    {
+        yyjson_val *conditions = obj_get(condition, "conditions");
+        if (!yyjson_is_arr(conditions))
+            return validation_error(ctx, path, "UI %s condition requires a conditions array", type);
+        for (size_t i = 0; i < yyjson_arr_size(conditions); ++i)
+        {
+            char child_path[PATH_BUFFER_SIZE];
+            format_path(child_path, sizeof(child_path), "%s.conditions[%zu]", path, i);
+            if (!validate_ui_condition(ctx, yyjson_arr_get(conditions, i), child_path, names))
+                return false;
+        }
+        return true;
+    }
+    return validation_error(ctx, path, "unsupported UI condition type '%s'", type != NULL ? type : "<missing>");
+}
+
+static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *texts = obj_get(obj_get(root, "ui"), "text");
+    if (texts == NULL)
+        return true;
+    if (!yyjson_is_arr(texts))
+        return validation_error(ctx, "$.ui.text", "UI text must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(texts); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.ui.text[%zu]", i);
+        yyjson_val *text = yyjson_arr_get(texts, i);
+        if (!yyjson_is_obj(text))
+            return validation_error(ctx, path, "UI text entries must be objects");
+        if (json_string(text, "font") != NULL &&
+            !require_ref(ctx, &names->fonts, "font asset", json_string(text, "font"), path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
+        if (!validate_ui_condition(ctx, obj_get(text, "visible_if"), condition_path, names))
+            return false;
+
+        yyjson_val *bindings = obj_get(text, "bindings");
+        for (size_t b = 0; yyjson_is_arr(bindings) && b < yyjson_arr_size(bindings); ++b)
+        {
+            char binding_path[PATH_BUFFER_SIZE];
+            format_path(binding_path, sizeof(binding_path), "%s.bindings[%zu]", path, b);
+            yyjson_val *binding = yyjson_arr_get(bindings, b);
+            const char *type = json_string(binding, "type");
+            if (SDL_strcmp(type != NULL ? type : "", "property") == 0)
+            {
+                if (!require_ref(ctx, &names->entities, "entity", json_string(binding, "entity"), binding_path))
+                    return false;
+                if (!is_non_empty_string(binding, "key"))
+                    return validation_error(ctx, binding_path, "UI property binding requires a non-empty key");
+            }
+            else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
+            {
+                return validation_error(ctx, binding_path, "unsupported UI binding type '%s'",
+                                        type != NULL ? type : "<missing>");
+            }
+        }
+    }
+    return true;
+}
+
+static bool validate_render_effects(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *entities = obj_get(root, "entities");
+    for (size_t e = 0; yyjson_is_arr(entities) && e < yyjson_arr_size(entities); ++e)
+    {
+        yyjson_val *components = obj_get(yyjson_arr_get(entities, e), "components");
+        for (size_t c = 0; yyjson_is_arr(components) && c < yyjson_arr_size(components); ++c)
+        {
+            yyjson_val *effects = obj_get(yyjson_arr_get(components, c), "effects");
+            for (size_t i = 0; yyjson_is_arr(effects) && i < yyjson_arr_size(effects); ++i)
+            {
+                char path[PATH_BUFFER_SIZE];
+                format_path(path, sizeof(path), "$.entities[%zu].components[%zu].effects[%zu]", e, c, i);
+                yyjson_val *effect = yyjson_arr_get(effects, i);
+                const char *type = json_string(effect, "type");
+                if (SDL_strcmp(type != NULL ? type : "", "flash") == 0)
+                {
+                    if (!require_ref(ctx, &names->entities, "entity", json_string(effect, "source"), path))
+                        return false;
+                    if (!is_non_empty_string(effect, "property"))
+                        return validation_error(ctx, path, "flash effect requires a non-empty property");
+                }
+                else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0 &&
+                         SDL_strcmp(type != NULL ? type : "", "emissive") != 0)
+                {
+                    return validation_error(ctx, path, "unsupported render effect type '%s'",
+                                            type != NULL ? type : "<missing>");
+                }
+            }
         }
     }
     return true;
@@ -1065,7 +1253,8 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
-           validate_cameras(ctx, root, names) && validate_lights(ctx, root, names) &&
+           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
            validate_transitions(ctx, root, names) && validate_logic(ctx, root, names) &&
            validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
@@ -1087,6 +1276,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->actions);
     name_table_destroy(&names->timers);
     name_table_destroy(&names->cameras);
+    name_table_destroy(&names->fonts);
     name_table_destroy(&names->sensors);
     name_table_destroy(&names->used_adapters);
     name_table_destroy(&names->used_scripts);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1023,6 +1023,32 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
     return true;
 }
 
+static bool validate_transitions(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *transitions = obj_get(root, "transitions");
+    if (transitions == NULL)
+        return true;
+    if (!yyjson_is_obj(transitions))
+        return validation_error(ctx, "$.transitions", "transitions must be an object");
+
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(transitions, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        yyjson_val *transition = yyjson_obj_iter_get_val(key);
+        const char *name = yyjson_get_str(key);
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.transitions.%s", name != NULL ? name : "<unknown>");
+        if (!yyjson_is_obj(transition))
+            return validation_error(ctx, path, "transition entries must be objects");
+        const char *done_signal = json_string(transition, "done_signal");
+        if (done_signal != NULL && !require_ref(ctx, &names->signals, "signal", done_signal, path))
+            return false;
+    }
+    return true;
+}
+
 static bool warn_unused(validation_context *ctx, const name_table *declared, const name_table *used, const char *kind)
 {
     for (int i = 0; i < declared->count; ++i)
@@ -1040,7 +1066,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
 {
     return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
            validate_cameras(ctx, root, names) && validate_lights(ctx, root, names) &&
-           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
+           validate_transitions(ctx, root, names) && validate_logic(ctx, root, names) &&
+           validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1003,6 +1003,26 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
     return true;
 }
 
+static bool validate_lights(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *lights = obj_get(obj_get(root, "world"), "lights");
+    if (lights == NULL)
+        return true;
+    if (!yyjson_is_arr(lights))
+        return validation_error(ctx, "$.world.lights", "world lights must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(lights); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.world.lights[%zu]", i);
+        yyjson_val *light = yyjson_arr_get(lights, i);
+        const char *target_entity = json_string(light, "target_entity");
+        if (target_entity != NULL && !require_ref(ctx, &names->entities, "entity", target_entity, path))
+            return false;
+    }
+    return true;
+}
+
 static bool warn_unused(validation_context *ctx, const name_table *declared, const name_table *used, const char *kind)
 {
     for (int i = 0; i < declared->count; ++i)
@@ -1019,8 +1039,8 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
-           validate_cameras(ctx, root, names) && validate_logic(ctx, root, names) &&
-           validate_adapters(ctx, root, names) &&
+           validate_cameras(ctx, root, names) && validate_lights(ctx, root, names) &&
+           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -50,6 +50,13 @@ struct RenderPrimitiveCapture
     bool saw_ball = false;
 };
 
+struct UiTextCapture
+{
+    int count = 0;
+    bool saw_score = false;
+    bool saw_pause = false;
+};
+
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                    sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -207,6 +214,28 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
     return true;
 }
 
+bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
+{
+    auto *capture = static_cast<UiTextCapture *>(userdata);
+    capture->count++;
+    if (std::string(text->name) == "ui.score")
+    {
+        capture->saw_score = true;
+        EXPECT_STREQ(text->source, "score.player_cpu");
+        EXPECT_TRUE(text->centered);
+        EXPECT_TRUE(text->normalized);
+        EXPECT_NEAR(text->x, 0.5f, 0.0001f);
+    }
+    if (std::string(text->name) == "ui.pause")
+    {
+        capture->saw_pause = true;
+        EXPECT_STREQ(text->visible, "paused");
+        EXPECT_STREQ(text->text, "PAUSED");
+        EXPECT_TRUE(text->pulse_alpha);
+    }
+    return true;
+}
+
 void append_u16(std::vector<std::uint8_t> &bytes, std::uint16_t value)
 {
     bytes.push_back(static_cast<std::uint8_t>(value & 0xFFu));
@@ -274,6 +303,19 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
 
 TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 {
+    sdl3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(SDL3D_PONG_DATA_PATH, &config, title, sizeof(title), app_error,
+                                                     sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "SDL3D Pong");
+    EXPECT_EQ(config.width, 1280);
+    EXPECT_EQ(config.height, 720);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_AUTO);
+    EXPECT_NEAR(config.tick_rate, 1.0f / 120.0f, 0.00001f);
+    EXPECT_EQ(config.max_ticks_per_frame, 12);
+
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
 
@@ -313,6 +355,23 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(particles.emit_rate, 95.0f, 0.0001f);
     EXPECT_EQ(particles.color_start.a, 105);
 
+    sdl3d_game_data_render_settings render{};
+    ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render));
+    EXPECT_EQ(render.clear_color.r, 3);
+    EXPECT_EQ(render.clear_color.g, 4);
+    EXPECT_EQ(render.clear_color.b, 8);
+    EXPECT_TRUE(render.lighting_enabled);
+    EXPECT_TRUE(render.bloom_enabled);
+    EXPECT_TRUE(render.ssao_enabled);
+    EXPECT_EQ(render.tonemap, SDL3D_TONEMAP_ACES);
+
+    sdl3d_game_data_transition_desc transition{};
+    ASSERT_TRUE(sdl3d_game_data_get_transition(runtime, "quit", &transition));
+    EXPECT_EQ(transition.type, SDL3D_TRANSITION_FADE);
+    EXPECT_EQ(transition.direction, SDL3D_TRANSITION_OUT);
+    EXPECT_NEAR(transition.duration, 0.45f, 0.0001f);
+    EXPECT_GE(transition.done_signal_id, 0);
+
     RenderPrimitiveCapture capture{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &capture));
     EXPECT_EQ(capture.cubes, 16);
@@ -323,8 +382,12 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
     ASSERT_NE(presentation, nullptr);
     EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "border_flash_decay", 0.0f), 2.8f, 0.0001f);
-    EXPECT_STREQ(sdl3d_properties_get_string(presentation->props, "pause_text", ""), "PAUSED");
-    EXPECT_STREQ(sdl3d_properties_get_string(presentation->props, "ball_camera_label", ""), "BALL CAM");
+
+    UiTextCapture ui{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui));
+    EXPECT_EQ(ui.count, 8);
+    EXPECT_TRUE(ui.saw_score);
+    EXPECT_TRUE(ui.saw_pause);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -321,6 +321,53 @@ TEST(GameDataRuntime, LuaControllerMovesCpuPaddleTowardBall)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, PongMatchStateAndRestartAreAuthoredLogic)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_registered_actor *player_score = sdl3d_game_data_find_actor(runtime, "entity.score.player");
+    sdl3d_registered_actor *cpu_score = sdl3d_game_data_find_actor(runtime, "entity.score.cpu");
+    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
+    sdl3d_registered_actor *ball = sdl3d_game_data_find_actor(runtime, "entity.ball");
+    ASSERT_NE(player_score, nullptr);
+    ASSERT_NE(cpu_score, nullptr);
+    ASSERT_NE(match, nullptr);
+    ASSERT_NE(presentation, nullptr);
+    ASSERT_NE(ball, nullptr);
+
+    sdl3d_properties_set_int(player_score->props, "value", 9);
+    const int player_score_signal = sdl3d_game_data_find_signal(runtime, "signal.score.player");
+    ASSERT_GE(player_score_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), player_score_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_properties_get_int(player_score->props, "value", 0), 10);
+    EXPECT_TRUE(sdl3d_properties_get_bool(match->props, "finished", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(match->props, "winner", ""), "player");
+    EXPECT_FALSE(sdl3d_properties_get_bool(ball->props, "active_motion", true));
+
+    sdl3d_properties_set_float(presentation->props, "border_flash", 1.0f);
+    sdl3d_properties_set_float(presentation->props, "paddle_flash", 1.0f);
+    const int restart_signal = sdl3d_game_data_find_signal(runtime, "signal.match.restart");
+    ASSERT_GE(restart_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), restart_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_properties_get_int(player_score->props, "value", -1), 0);
+    EXPECT_EQ(sdl3d_properties_get_int(cpu_score->props, "value", -1), 0);
+    EXPECT_FALSE(sdl3d_properties_get_bool(match->props, "finished", true));
+    EXPECT_STREQ(sdl3d_properties_get_string(match->props, "winner", ""), "none");
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(presentation->props, "border_flash", -1.0f), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(presentation->props, "paddle_flash", -1.0f), 0.0f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, RegisteredCAdaptersOverrideLuaAdapters)
 {
     sdl3d_game_session *session = nullptr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -55,6 +56,12 @@ struct UiTextCapture
     int count = 0;
     bool saw_score = false;
     bool saw_pause = false;
+};
+
+struct EvaluatedPrimitiveCapture
+{
+    bool saw_border = false;
+    bool saw_ball = false;
 };
 
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
@@ -221,7 +228,6 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
     if (std::string(text->name) == "ui.score")
     {
         capture->saw_score = true;
-        EXPECT_STREQ(text->source, "score.player_cpu");
         EXPECT_TRUE(text->centered);
         EXPECT_TRUE(text->normalized);
         EXPECT_NEAR(text->x, 0.5f, 0.0001f);
@@ -229,9 +235,26 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
     if (std::string(text->name) == "ui.pause")
     {
         capture->saw_pause = true;
-        EXPECT_STREQ(text->visible, "paused");
         EXPECT_STREQ(text->text, "PAUSED");
         EXPECT_TRUE(text->pulse_alpha);
+    }
+    return true;
+}
+
+bool capture_evaluated_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
+{
+    auto *capture = static_cast<EvaluatedPrimitiveCapture *>(userdata);
+    if (std::string(primitive->entity_name) == "entity.field.border.top")
+    {
+        capture->saw_border = true;
+        EXPECT_GT(primitive->color.r, 62);
+        EXPECT_GT(primitive->size.y, 0.12f);
+        EXPECT_GT(primitive->emissive_color.z, 0.9f);
+    }
+    if (std::string(primitive->entity_name) == "entity.ball")
+    {
+        capture->saw_ball = true;
+        EXPECT_GT(primitive->emissive_color.x, 0.7f);
     }
     return true;
 }
@@ -293,6 +316,9 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
 
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.ball"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor_with_tag(runtime, "ball"), nullptr);
+    const char *paddle_tags[] = {"paddle", "player"};
+    EXPECT_NE(sdl3d_game_data_find_actor_with_tags(runtime, paddle_tags, 2), nullptr);
     EXPECT_GE(sdl3d_game_data_find_signal(runtime, "signal.ball.serve"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.up"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
@@ -328,11 +354,30 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_EQ(camera.projection, SDL3D_CAMERA_ORTHOGRAPHIC);
     EXPECT_NEAR(camera.position.z, 16.0f, 0.0001f);
     EXPECT_NEAR(camera.fovy, 11.4f, 0.0001f);
-    EXPECT_FALSE(sdl3d_game_data_get_camera(runtime, "camera.ball_chase", &camera));
 
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.ball_chase", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_NEAR(camera.fovy, 68.0f, 0.0001f);
+    EXPECT_NEAR(camera.position.x, -2.6f, 0.0001f);
+    EXPECT_NEAR(camera.position.z, 1.91f, 0.0001f);
     float chase_fovy = 0.0f;
     ASSERT_TRUE(sdl3d_game_data_get_camera_float(runtime, "camera.ball_chase", "fovy", &chase_fovy));
     EXPECT_NEAR(chase_fovy, 68.0f, 0.0001f);
+
+    sdl3d_game_data_app_control app{};
+    ASSERT_TRUE(sdl3d_game_data_get_app_control(runtime, &app));
+    EXPECT_GE(app.start_signal_id, 0);
+    EXPECT_GE(app.quit_action_id, 0);
+    EXPECT_GE(app.pause_action_id, 0);
+    EXPECT_STREQ(app.startup_transition, "startup");
+    EXPECT_STREQ(app.quit_transition, "quit");
+    EXPECT_GE(app.quit_signal_id, 0);
+
+    sdl3d_game_data_font_asset font{};
+    ASSERT_TRUE(sdl3d_game_data_get_font_asset(runtime, "font.hud", &font));
+    EXPECT_TRUE(font.builtin);
+    EXPECT_EQ(font.builtin_id, SDL3D_BUILTIN_FONT_INTER);
+    EXPECT_NEAR(font.size, 34.0f, 0.0001f);
 
     float ambient[3]{};
     ASSERT_TRUE(sdl3d_game_data_get_world_ambient_light(runtime, ambient));
@@ -354,6 +399,10 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_EQ(particles.max_particles, 360);
     EXPECT_NEAR(particles.emit_rate, 95.0f, 0.0001f);
     EXPECT_EQ(particles.color_start.a, 105);
+    sdl3d_vec3 particle_emissive{};
+    ASSERT_TRUE(sdl3d_game_data_get_particle_emitter_draw_emissive(runtime, "entity.effect.ambient_particles",
+                                                                   &particle_emissive));
+    EXPECT_NEAR(particle_emissive.x, 0.8f, 0.0001f);
 
     sdl3d_game_data_render_settings render{};
     ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render));
@@ -382,12 +431,50 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
     ASSERT_NE(presentation, nullptr);
     EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "border_flash_decay", 0.0f), 2.8f, 0.0001f);
+    sdl3d_properties_set_float(presentation->props, "border_flash", 1.0f);
+    sdl3d_game_data_render_eval render_eval{};
+    render_eval.time = 0.25f;
+    EvaluatedPrimitiveCapture evaluated{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive_evaluated(runtime, &render_eval, capture_evaluated_primitive,
+                                                                    &evaluated));
+    EXPECT_TRUE(evaluated.saw_border);
+    EXPECT_TRUE(evaluated.saw_ball);
 
     UiTextCapture ui{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui));
     EXPECT_EQ(ui.count, 8);
     EXPECT_TRUE(ui.saw_score);
     EXPECT_TRUE(ui.saw_pause);
+
+    sdl3d_game_data_ui_metrics metrics{};
+    metrics.fps = 119.5f;
+    metrics.frame = 42;
+    char ui_buffer[128]{};
+    auto format_score = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        if (std::string(text->name) != "ui.score")
+            return true;
+        auto *args = static_cast<std::pair<sdl3d_game_data_runtime *, char *> *>(userdata);
+        sdl3d_game_data_ui_metrics local_metrics{};
+        EXPECT_TRUE(sdl3d_game_data_format_ui_text(args->first, text, &local_metrics, args->second, 128));
+        return false;
+    };
+    std::pair<sdl3d_game_data_runtime *, char *> score_args{runtime, ui_buffer};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, format_score, &score_args));
+    EXPECT_STREQ(ui_buffer, "00   00");
+    auto find_pause_visible = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        if (std::string(text->name) != "ui.pause")
+            return true;
+        auto *args =
+            static_cast<std::tuple<sdl3d_game_data_runtime *, sdl3d_game_data_ui_metrics *, bool *> *>(userdata);
+        *std::get<2>(*args) = sdl3d_game_data_ui_text_is_visible(std::get<0>(*args), text, std::get<1>(*args));
+        return false;
+    };
+    bool pause_visible = false;
+    metrics.paused = true;
+    std::tuple<sdl3d_game_data_runtime *, sdl3d_game_data_ui_metrics *, bool *> pause_args{runtime, &metrics,
+                                                                                           &pause_visible};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_pause_visible, &pause_args));
+    EXPECT_TRUE(pause_visible);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -42,6 +42,14 @@ struct DiagnosticCapture
     std::vector<CapturedDiagnostic> diagnostics;
 };
 
+struct RenderPrimitiveCapture
+{
+    int cubes = 0;
+    int spheres = 0;
+    bool saw_player_paddle = false;
+    bool saw_ball = false;
+};
+
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                    sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -170,6 +178,35 @@ void emit_reload_signal(sdl3d_game_session *session, sdl3d_game_data_runtime *ru
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), signal, nullptr);
 }
 
+bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
+{
+    auto *capture = static_cast<RenderPrimitiveCapture *>(userdata);
+    if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+        capture->cubes++;
+    else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
+        capture->spheres++;
+
+    if (std::string(primitive->entity_name) == "entity.paddle.player")
+    {
+        capture->saw_player_paddle = true;
+        EXPECT_NEAR(primitive->position.x, -8.0f, 0.0001f);
+        EXPECT_NEAR(primitive->size.x, 0.36f, 0.0001f);
+        EXPECT_EQ(primitive->color.r, 205);
+        EXPECT_EQ(primitive->color.g, 230);
+        EXPECT_EQ(primitive->color.b, 255);
+    }
+    if (std::string(primitive->entity_name) == "entity.ball")
+    {
+        capture->saw_ball = true;
+        EXPECT_NEAR(primitive->position.z, 0.12f, 0.0001f);
+        EXPECT_NEAR(primitive->radius, 0.22f, 0.0001f);
+        EXPECT_EQ(primitive->rings, 12);
+        EXPECT_EQ(primitive->slices, 18);
+        EXPECT_TRUE(primitive->emissive);
+    }
+    return true;
+}
+
 void append_u16(std::vector<std::uint8_t> &bytes, std::uint16_t value)
 {
     bytes.push_back(static_cast<std::uint8_t>(value & 0xFFu));
@@ -230,6 +267,64 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_GE(sdl3d_game_data_find_signal(runtime, "signal.ball.serve"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.up"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_camera3d camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.overhead", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_ORTHOGRAPHIC);
+    EXPECT_NEAR(camera.position.z, 16.0f, 0.0001f);
+    EXPECT_NEAR(camera.fovy, 11.4f, 0.0001f);
+    EXPECT_FALSE(sdl3d_game_data_get_camera(runtime, "camera.ball_chase", &camera));
+
+    float chase_fovy = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_camera_float(runtime, "camera.ball_chase", "fovy", &chase_fovy));
+    EXPECT_NEAR(chase_fovy, 68.0f, 0.0001f);
+
+    float ambient[3]{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_ambient_light(runtime, ambient));
+    EXPECT_NEAR(ambient[0], 0.015f, 0.0001f);
+    EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
+    EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
+
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 4);
+    sdl3d_light ball_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 3, &ball_light));
+    EXPECT_EQ(ball_light.type, SDL3D_LIGHT_POINT);
+    EXPECT_NEAR(ball_light.position.x, 0.0f, 0.0001f);
+    EXPECT_NEAR(ball_light.position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(ball_light.position.z, 1.32f, 0.0001f);
+
+    sdl3d_particle_config particles{};
+    ASSERT_TRUE(sdl3d_game_data_get_particle_emitter(runtime, "entity.effect.ambient_particles", &particles));
+    EXPECT_EQ(particles.shape, SDL3D_PARTICLE_EMITTER_BOX);
+    EXPECT_EQ(particles.max_particles, 360);
+    EXPECT_NEAR(particles.emit_rate, 95.0f, 0.0001f);
+    EXPECT_EQ(particles.color_start.a, 105);
+
+    RenderPrimitiveCapture capture{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &capture));
+    EXPECT_EQ(capture.cubes, 16);
+    EXPECT_EQ(capture.spheres, 1);
+    EXPECT_TRUE(capture.saw_player_paddle);
+    EXPECT_TRUE(capture.saw_ball);
+
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
+    ASSERT_NE(presentation, nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "border_flash_decay", 0.0f), 2.8f, 0.0001f);
+    EXPECT_STREQ(sdl3d_properties_get_string(presentation->props, "pause_text", ""), "PAUSED");
+    EXPECT_STREQ(sdl3d_properties_get_string(presentation->props, "ball_camera_label", ""), "BALL CAM");
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- move Pong match state, winner state, restart flow, and hit-flash state into authored JSON entities and signal/action bindings
- let restart input flow through the generic input sensor and branch action instead of C-side match reset code
- move Pong script tuning constants for serve/reflect angles and CPU field bounds into JSON properties
- add runtime coverage proving Pong score, match win, presentation reset, and restart are authored logic

## Tests
- make format
- cmake --build build/default --target pong_demo sdl3d_game_data_test game_data_json_test
- ctest --test-dir build/default --output-on-failure -R 'GameDataRuntime|GameDataJson'
- ctest --test-dir build/default --output-on-failure