### PR TITLE
Add data-driven Pong scenes and reusable presentation flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources(
         src/fbx_loader.c
         src/game.c
         src/game_data.c
+        src/game_presentation.c
         src/game_data_validation.c
         src/gltf_loader.c
         src/gl_renderer.c

--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SDL3D_PONG_ASSET_FILES
     pong.game.json
+    scenes/options.scene.json
+    scenes/play.scene.json
+    scenes/title.scene.json
     scripts/pong.lua)
 
 sdl3d_add_embedded_asset_pack(pong_assets

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -14,7 +14,16 @@
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
     "enable_audio": false,
-    "pause_action": "action.pause",
+    "pause": {
+      "action": "action.pause",
+      "allowed_if": {
+        "type": "property.compare",
+        "target": "entity.match",
+        "key": "finished",
+        "op": "==",
+        "value": false
+      }
+    },
     "startup_transition": "startup",
     "quit": {
       "action": "action.exit",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -14,14 +14,26 @@
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
     "enable_audio": false,
-    "start_signal": "signal.game.start",
     "pause_action": "action.pause",
     "startup_transition": "startup",
     "quit": {
       "action": "action.exit",
       "transition": "quit",
       "quit_signal": "signal.app.quit_fade_done"
-    }
+    },
+    "scene_shortcuts": [
+      { "action": "action.scene.title", "scene": "scene.title" },
+      { "action": "action.scene.options", "scene": "scene.options" },
+      { "action": "action.scene.play", "scene": "scene.play" }
+    ]
+  },
+  "scenes": {
+    "initial": "scene.title",
+    "files": [
+      "scenes/title.scene.json",
+      "scenes/options.scene.json",
+      "scenes/play.scene.json"
+    ]
   },
   "render": {
     "clear_color": [3, 4, 8, 255],
@@ -43,6 +55,18 @@
       "color": [0, 0, 0, 255],
       "duration": 0.45,
       "done_signal": "signal.app.quit_fade_done"
+    },
+    "scene_out": {
+      "type": "fade",
+      "direction": "out",
+      "color": [0, 0, 0, 255],
+      "duration": 0.28
+    },
+    "scene_in": {
+      "type": "fade",
+      "direction": "in",
+      "color": [0, 0, 0, 255],
+      "duration": 0.28
     }
   },
   "profiles": [
@@ -70,129 +94,15 @@
         "id": "font.hud",
         "builtin": "Inter",
         "size": 34
+      },
+      {
+        "id": "font.title",
+        "builtin": "Inter",
+        "size": 96
       }
     ]
   },
-  "ui": {
-    "text": [
-      {
-        "name": "ui.debug.frame_counter",
-        "font": "font.hud",
-        "format": "FPS %.0f  Frame %llu",
-        "bindings": [
-          { "type": "metric", "metric": "fps" },
-          { "type": "metric", "metric": "frame" }
-        ],
-        "x": 18.0,
-        "y": 16.0,
-        "color": [170, 190, 220, 230]
-      },
-      {
-        "name": "ui.camera.ball_label",
-        "font": "font.hud",
-        "visible_if": { "type": "camera.active", "camera": "camera.ball_chase" },
-        "text": "BALL CAM",
-        "x": 18.0,
-        "y": 56.0,
-        "color": [255, 222, 140, 235]
-      },
-      {
-        "name": "ui.score",
-        "font": "font.hud",
-        "format": "%02d   %02d",
-        "bindings": [
-          { "type": "property", "entity": "entity.score.player", "key": "value" },
-          { "type": "property", "entity": "entity.score.cpu", "key": "value" }
-        ],
-        "x": 0.5,
-        "y": 22.0,
-        "normalized": true,
-        "centered": true,
-        "color": [235, 242, 255, 255]
-      },
-      {
-        "name": "ui.match.player_won",
-        "font": "font.hud",
-        "visible_if": {
-          "type": "all",
-          "conditions": [
-            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
-            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "player" }
-          ]
-        },
-        "text": "You win!",
-        "x": 0.5,
-        "y": 0.40,
-        "normalized": true,
-        "centered": true,
-        "color": [255, 255, 255, 255]
-      },
-      {
-        "name": "ui.match.cpu_won",
-        "font": "font.hud",
-        "visible_if": {
-          "type": "all",
-          "conditions": [
-            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
-            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "cpu" }
-          ]
-        },
-        "text": "You lose!",
-        "x": 0.5,
-        "y": 0.40,
-        "normalized": true,
-        "centered": true,
-        "color": [255, 255, 255, 255]
-      },
-      {
-        "name": "ui.match.restart",
-        "font": "font.hud",
-        "visible_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
-        "text": "Press enter to play again",
-        "x": 0.5,
-        "y": 0.49,
-        "normalized": true,
-        "centered": true,
-        "color": [200, 220, 255, 235]
-      },
-      {
-        "name": "ui.pause",
-        "font": "font.hud",
-        "visible_if": {
-          "type": "all",
-          "conditions": [
-            { "type": "app.paused", "equals": true },
-            { "type": "not", "condition": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true } }
-          ]
-        },
-        "text": "PAUSED",
-        "x": 0.5,
-        "y": 0.44,
-        "normalized": true,
-        "centered": true,
-        "pulse_alpha": true,
-        "color": [245, 248, 255, 255]
-      },
-      {
-        "name": "ui.ready",
-        "font": "font.hud",
-        "visible_if": {
-          "type": "all",
-          "conditions": [
-            { "type": "app.paused", "equals": false },
-            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false },
-            { "type": "property.compare", "target": "entity.ball", "key": "active_motion", "op": "==", "value": false }
-          ]
-        },
-        "text": "Get ready",
-        "x": 0.5,
-        "y": 0.44,
-        "normalized": true,
-        "centered": true,
-        "color": [210, 225, 255, 190]
-      }
-    ]
-  },
+  "ui": { "text": [] },
   "scripts": [
     {
       "id": "script.pong",
@@ -250,6 +160,48 @@
             "bindings": [
               { "device": "keyboard", "key": "B" }
             ]
+          },
+          {
+            "name": "action.menu.up",
+            "bindings": [
+              { "device": "keyboard", "key": "UP" },
+              { "device": "keyboard", "key": "W" },
+              { "device": "gamepad", "button": "DPAD_UP" }
+            ]
+          },
+          {
+            "name": "action.menu.down",
+            "bindings": [
+              { "device": "keyboard", "key": "DOWN" },
+              { "device": "keyboard", "key": "S" },
+              { "device": "gamepad", "button": "DPAD_DOWN" }
+            ]
+          },
+          {
+            "name": "action.menu.select",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" },
+              { "device": "keyboard", "key": "SPACE" },
+              { "device": "gamepad", "button": "SOUTH" }
+            ]
+          },
+          {
+            "name": "action.scene.title",
+            "bindings": [
+              { "device": "keyboard", "key": "1" }
+            ]
+          },
+          {
+            "name": "action.scene.options",
+            "bindings": [
+              { "device": "keyboard", "key": "2" }
+            ]
+          },
+          {
+            "name": "action.scene.play",
+            "bindings": [
+              { "device": "keyboard", "key": "3" }
+            ]
           }
         ]
       }
@@ -301,7 +253,10 @@
         "position": [-7.0, 4.4, 3.2],
         "color": [1.0, 0.1, 0.08],
         "intensity": 2.8,
-        "range": 12.0
+        "range": 12.0,
+        "effects": [
+          { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [0.65, 0.78, 1.0], "color_blend": 0.55, "intensity_add": 1.6, "range_add": 1.8 }
+        ]
       },
       {
         "name": "light.green",
@@ -309,7 +264,10 @@
         "position": [7.0, 4.4, 3.2],
         "color": [0.08, 1.0, 0.18],
         "intensity": 2.7,
-        "range": 12.0
+        "range": 12.0,
+        "effects": [
+          { "type": "pulse", "rate": 3.8, "color": [0.18, 1.0, 0.50], "color_blend": 0.20, "intensity_add": 0.45, "range_add": 0.8 }
+        ]
       },
       {
         "name": "light.blue",
@@ -317,7 +275,10 @@
         "position": [0.0, -4.2, 3.5],
         "color": [0.14, 0.34, 1.0],
         "intensity": 2.9,
-        "range": 12.0
+        "range": 12.0,
+        "effects": [
+          { "type": "pulse", "rate": 2.5, "phase": 1.2, "color": [0.28, 0.48, 1.0], "color_blend": 0.20, "intensity_add": 0.35, "range_add": 0.7 }
+        ]
       },
       {
         "name": "light.ball",
@@ -326,7 +287,11 @@
         "offset": [0.0, 0.0, 1.2],
         "color": [1.0, 0.86, 0.34],
         "intensity": 3.1,
-        "range": 5.0
+        "range": 5.0,
+        "effects": [
+          { "type": "pulse", "rate": 9.0, "color": [1.0, 0.96, 0.54], "color_blend": 0.35, "intensity_add": 0.9, "range_add": 0.6 },
+          { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [1.0, 1.0, 1.0], "color_blend": 0.45, "intensity_add": 1.5, "range_add": 1.1 }
+        ]
       }
     ]
   },
@@ -538,7 +503,11 @@
         "border_flash_decay": { "type": "float", "value": 2.8 },
         "paddle_flash_decay": { "type": "float", "value": 4.0 },
         "pause_flash_speed": { "type": "float", "value": 3.0 }
-      }
+      },
+      "components": [
+        { "type": "property.decay", "property": "border_flash", "rate_property": "border_flash_decay", "target": 0.0, "min": 0.0, "max": 1.0 },
+        { "type": "property.decay", "property": "paddle_flash", "rate_property": "paddle_flash_decay", "target": 0.0, "min": 0.0, "max": 1.0 }
+      ]
     },
     {
       "name": "entity.effect.ambient_particles",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -34,7 +34,20 @@
       { "action": "action.scene.title", "scene": "scene.title" },
       { "action": "action.scene.options", "scene": "scene.options" },
       { "action": "action.scene.play", "scene": "scene.play" }
-    ]
+    ],
+    "input_policy": {
+      "global_actions": [
+        "action.exit",
+        "action.scene.title",
+        "action.scene.options",
+        "action.scene.play"
+      ]
+    },
+    "scene_transition_policy": {
+      "allow_same_scene": false,
+      "allow_interrupt": false,
+      "reset_menu_input_on_request": true
+    }
   },
   "scenes": {
     "initial": "scene.title",
@@ -50,6 +63,31 @@
     "bloom": true,
     "ssao": true,
     "tonemap": "aces"
+  },
+  "update_phases": {
+    "app_flow": { "active": true, "when_paused": true },
+    "presentation": { "active": true, "when_paused": true },
+    "property_effects": { "active": true, "when_paused": true },
+    "particles": { "active": true, "when_paused": true },
+    "simulation": { "active": true, "when_paused": false }
+  },
+  "presentation": {
+    "metrics": {
+      "fps_sample_seconds": 0.25
+    },
+    "ui_pulse_clock": "clock.pause_flash",
+    "clocks": [
+      {
+        "name": "clock.pause_flash",
+        "target": "entity.presentation",
+        "key": "pause_flash",
+        "speed_property": { "target": "entity.presentation", "key": "pause_flash_speed" },
+        "wrap": 1.0,
+        "reset_on_pause_enter": true,
+        "reset_value": 0.0,
+        "active_if": { "type": "app.paused", "equals": true }
+      }
+    ]
   },
   "transitions": {
     "startup": {
@@ -507,6 +545,7 @@
       "active": true,
       "tags": ["state", "presentation"],
       "properties": {
+        "pause_flash": { "type": "float", "value": 0.0 },
         "border_flash": { "type": "float", "value": 0.0 },
         "paddle_flash": { "type": "float", "value": 0.0 },
         "border_flash_decay": { "type": "float", "value": 2.8 },
@@ -517,6 +556,17 @@
         { "type": "property.decay", "property": "border_flash", "rate_property": "border_flash_decay", "target": 0.0, "min": 0.0, "max": 1.0 },
         { "type": "property.decay", "property": "paddle_flash", "rate_property": "paddle_flash_decay", "target": 0.0, "min": 0.0, "max": 1.0 }
       ]
+    },
+    {
+      "name": "entity.settings",
+      "active": true,
+      "tags": ["state", "settings"],
+      "properties": {
+        "difficulty": { "type": "string", "value": "normal" },
+        "lighting_profile": { "type": "string", "value": "cinematic" },
+        "fullscreen": { "type": "bool", "value": false },
+        "input_style": { "type": "string", "value": "keyboard" }
+      }
     },
     {
       "name": "entity.effect.ambient_particles",

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -4,6 +4,13 @@
   "updates_game": false,
   "renders_world": false,
   "entities": [],
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
+    ]
+  },
   "transitions": {
     "enter": "scene_in",
     "exit": "scene_out"
@@ -16,10 +23,52 @@
       "select_action": "action.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Gameplay" },
-        { "label": "Video" },
-        { "label": "Graphics" },
-        { "label": "Input" },
+        {
+          "label": "Difficulty",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "difficulty",
+            "choices": [
+              { "label": "Easy", "value": "easy" },
+              { "label": "Normal", "value": "normal" },
+              { "label": "Hard", "value": "hard" }
+            ]
+          }
+        },
+        {
+          "label": "Fullscreen",
+          "control": {
+            "type": "toggle",
+            "target": "entity.settings",
+            "key": "fullscreen"
+          }
+        },
+        {
+          "label": "Lighting",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "lighting_profile",
+            "choices": [
+              { "label": "Clean", "value": "clean" },
+              { "label": "Cinematic", "value": "cinematic" },
+              { "label": "Arcade", "value": "arcade" }
+            ]
+          }
+        },
+        {
+          "label": "Input",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "input_style",
+            "choices": [
+              { "label": "Keyboard", "value": "keyboard" },
+              { "label": "Gamepad", "value": "gamepad" }
+            ]
+          }
+        },
         { "label": "Back", "scene": "scene.title" }
       ]
     }

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -1,0 +1,61 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.options",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.options",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Gameplay" },
+        { "label": "Video" },
+        { "label": "Graphics" },
+        { "label": "Input" },
+        { "label": "Back", "scene": "scene.title" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.options.title",
+        "font": "font.title",
+        "text": "OPTIONS",
+        "x": 0.5,
+        "y": 0.23,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.options.menu",
+        "menu": "menu.options",
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.40,
+        "gap": 0.075,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.10,
+          "align": "center",
+          "color": [255, 222, 140, 255]
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -19,8 +19,18 @@
     "entity.score.cpu",
     "entity.match",
     "entity.presentation",
+    "entity.settings",
     "entity.effect.ambient_particles"
   ],
+  "input": {
+    "actions": [
+      "action.paddle.up",
+      "action.paddle.down",
+      "action.pause",
+      "action.restart",
+      "action.camera.ball.toggle"
+    ]
+  },
   "transitions": {
     "enter": "scene_in",
     "exit": "scene_out"

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -1,0 +1,148 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "on_enter_signal": "signal.game.start",
+  "entities": [
+    "entity.field.base",
+    "entity.field.border.top",
+    "entity.field.border.bottom",
+    "entity.field.border.left",
+    "entity.field.border.right",
+    "entity.field.center_ticks",
+    "entity.paddle.player",
+    "entity.paddle.cpu",
+    "entity.ball",
+    "entity.score.player",
+    "entity.score.cpu",
+    "entity.match",
+    "entity.presentation",
+    "entity.effect.ambient_particles"
+  ],
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.debug.frame_counter",
+        "font": "font.hud",
+        "format": "FPS %.0f  Frame %llu",
+        "bindings": [
+          { "type": "metric", "metric": "fps" },
+          { "type": "metric", "metric": "frame" }
+        ],
+        "x": 18.0,
+        "y": 16.0,
+        "color": [170, 190, 220, 230]
+      },
+      {
+        "name": "ui.camera.ball_label",
+        "font": "font.hud",
+        "visible_if": { "type": "camera.active", "camera": "camera.ball_chase" },
+        "text": "BALL CAM",
+        "x": 18.0,
+        "y": 56.0,
+        "color": [255, 222, 140, 235]
+      },
+      {
+        "name": "ui.score",
+        "font": "font.hud",
+        "format": "%02d   %02d",
+        "bindings": [
+          { "type": "property", "entity": "entity.score.player", "key": "value" },
+          { "type": "property", "entity": "entity.score.cpu", "key": "value" }
+        ],
+        "x": 0.5,
+        "y": 22.0,
+        "normalized": true,
+        "centered": true,
+        "color": [235, 242, 255, 255]
+      },
+      {
+        "name": "ui.match.player_won",
+        "font": "font.hud",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "player" }
+          ]
+        },
+        "text": "You win!",
+        "x": 0.5,
+        "y": 0.40,
+        "normalized": true,
+        "centered": true,
+        "color": [255, 255, 255, 255]
+      },
+      {
+        "name": "ui.match.cpu_won",
+        "font": "font.hud",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+            { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "cpu" }
+          ]
+        },
+        "text": "You lose!",
+        "x": 0.5,
+        "y": 0.40,
+        "normalized": true,
+        "centered": true,
+        "color": [255, 255, 255, 255]
+      },
+      {
+        "name": "ui.match.restart",
+        "font": "font.hud",
+        "visible_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+        "text": "Press enter to play again",
+        "x": 0.5,
+        "y": 0.49,
+        "normalized": true,
+        "centered": true,
+        "color": [200, 220, 255, 235]
+      },
+      {
+        "name": "ui.pause",
+        "font": "font.hud",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": true },
+            { "type": "not", "condition": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true } }
+          ]
+        },
+        "text": "PAUSED",
+        "x": 0.5,
+        "y": 0.44,
+        "normalized": true,
+        "centered": true,
+        "pulse_alpha": true,
+        "color": [245, 248, 255, 255]
+      },
+      {
+        "name": "ui.ready",
+        "font": "font.hud",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": false },
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false },
+            { "type": "property.compare", "target": "entity.ball", "key": "active_motion", "op": "==", "value": false }
+          ]
+        },
+        "text": "Get ready",
+        "x": 0.5,
+        "y": 0.44,
+        "normalized": true,
+        "centered": true,
+        "color": [210, 225, 255, 190]
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -1,0 +1,61 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.title",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Play", "scene": "scene.play" },
+        { "label": "Options", "scene": "scene.options" },
+        { "label": "Exit", "quit": true }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.title.logo",
+        "font": "font.title",
+        "text": "PONG",
+        "x": 0.5,
+        "y": 0.21,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.title.menu",
+        "menu": "menu.title",
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.48,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.12,
+          "align": "center",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -4,6 +4,13 @@
   "updates_game": false,
   "renders_world": false,
   "entities": [],
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
+    ]
+  },
   "transitions": {
     "enter": "scene_in",
     "exit": "scene_out"

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -6,20 +6,10 @@
 #include <stdbool.h>
 
 #include "sdl3d/asset.h"
-#include "sdl3d/camera.h"
-#include "sdl3d/drawing3d.h"
-#include "sdl3d/effects.h"
-#include "sdl3d/font.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
-#include "sdl3d/input.h"
-#include "sdl3d/lighting.h"
-#include "sdl3d/math.h"
+#include "sdl3d/game_presentation.h"
 #include "sdl3d/properties.h"
-#include "sdl3d/render_context.h"
-#include "sdl3d/shapes.h"
-#include "sdl3d/signal_bus.h"
-#include "sdl3d/transition.h"
 
 #if SDL3D_PONG_EMBEDDED_ASSETS
 #include "sdl3d_pong_assets.h"
@@ -28,25 +18,16 @@
 typedef struct pong_state
 {
     sdl3d_game_data_runtime *data;
-    sdl3d_font font;
-    bool has_font;
-    sdl3d_particle_emitter *ambient_particles;
-    const char *ambient_particles_entity;
-    sdl3d_vec3 ambient_particles_emissive;
-    sdl3d_transition transition;
-    sdl3d_game_data_app_control app;
+    sdl3d_game_data_font_cache font_cache;
+    sdl3d_game_data_particle_cache particle_cache;
+    sdl3d_game_data_app_flow app_flow;
     float time;
     float pause_flash;
-    float border_flash;
-    float paddle_flash;
     float last_render_time;
     float fps_sample_time;
     float displayed_fps;
     int fps_sample_frames;
     Uint64 rendered_frames;
-    bool ball_active;
-    bool match_finished;
-    bool quit_pending;
 } pong_state;
 
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
@@ -61,49 +42,6 @@ static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int err
 #endif
 }
 
-static sdl3d_input_manager *ctx_input(const sdl3d_game_context *ctx)
-{
-    return sdl3d_game_session_get_input(ctx->session);
-}
-
-static sdl3d_signal_bus *ctx_bus(const sdl3d_game_context *ctx)
-{
-    return sdl3d_game_session_get_signal_bus(ctx->session);
-}
-
-static float fade_down(float value, float dt, float speed)
-{
-    value -= dt * speed;
-    return value > 0.0f ? value : 0.0f;
-}
-
-static void start_quit_fade(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (state->quit_pending)
-    {
-        return;
-    }
-
-    state->quit_pending = true;
-    sdl3d_game_data_transition_desc transition;
-    if (state->app.quit_transition == NULL ||
-        !sdl3d_game_data_get_transition(state->data, state->app.quit_transition, &transition))
-    {
-        ctx->quit_requested = true;
-        return;
-    }
-    sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
-                           transition.duration, transition.done_signal_id);
-}
-
-static void on_quit_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
-{
-    sdl3d_game_context *ctx = (sdl3d_game_context *)userdata;
-    (void)signal_id;
-    (void)payload;
-    ctx->quit_requested = true;
-}
-
 static sdl3d_registered_actor *actor_with_tags(const pong_state *state, const char *tag0, const char *tag1)
 {
     const char *tags[2] = {tag0, tag1};
@@ -111,59 +49,16 @@ static sdl3d_registered_actor *actor_with_tags(const pong_state *state, const ch
                         : sdl3d_game_data_find_actor_with_tag(state->data, tag0);
 }
 
-static void sync_state_from_data(pong_state *state)
+static bool match_is_finished(const pong_state *state)
 {
-    sdl3d_registered_actor *ball = actor_with_tags(state, "ball", NULL);
     sdl3d_registered_actor *match = actor_with_tags(state, "state", "match");
-    sdl3d_registered_actor *presentation = actor_with_tags(state, "state", "presentation");
-
-    if (ball != NULL)
-    {
-        state->ball_active = sdl3d_properties_get_bool(ball->props, "active_motion", false);
-    }
-    if (match != NULL)
-    {
-        state->match_finished = sdl3d_properties_get_bool(match->props, "finished", false);
-    }
-    if (presentation != NULL)
-    {
-        state->border_flash = sdl3d_properties_get_float(presentation->props, "border_flash", 0.0f);
-        state->paddle_flash = sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f);
-    }
-}
-
-static sdl3d_registered_actor *presentation_actor(const pong_state *state)
-{
-    return actor_with_tags(state, "state", "presentation");
+    return match != NULL && sdl3d_properties_get_bool(match->props, "finished", false);
 }
 
 static float presentation_float(const pong_state *state, const char *key, float fallback)
 {
-    sdl3d_registered_actor *presentation = presentation_actor(state);
+    sdl3d_registered_actor *presentation = actor_with_tags(state, "state", "presentation");
     return presentation != NULL ? sdl3d_properties_get_float(presentation->props, key, fallback) : fallback;
-}
-
-static bool create_particles(pong_state *state)
-{
-    sdl3d_registered_actor *particles = actor_with_tags(state, "effect", "particles");
-    if (particles == NULL)
-    {
-        SDL_SetError("missing effect particles entity");
-        return false;
-    }
-
-    state->ambient_particles_entity = particles->name;
-    sdl3d_particle_config config;
-    if (!sdl3d_game_data_get_particle_emitter(state->data, state->ambient_particles_entity, &config))
-    {
-        SDL_SetError("missing particles.emitter component");
-        return false;
-    }
-
-    sdl3d_game_data_get_particle_emitter_draw_emissive(state->data, state->ambient_particles_entity,
-                                                       &state->ambient_particles_emissive);
-    state->ambient_particles = sdl3d_create_particle_emitter(&config);
-    return state->ambient_particles != NULL;
 }
 
 static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
@@ -193,86 +88,27 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     }
     sdl3d_asset_resolver_destroy(assets);
 
-    sdl3d_game_data_get_app_control(state->data, &state->app);
-
-    sync_state_from_data(state);
-    if (state->app.start_signal_id >= 0)
-    {
-        sdl3d_signal_emit(ctx_bus(ctx), state->app.start_signal_id, NULL);
-    }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong data loaded: asset=%s active_scene=%s", SDL3D_PONG_DATA_ASSET_PATH,
+                sdl3d_game_data_active_scene(state->data) != NULL ? sdl3d_game_data_active_scene(state->data)
+                                                                  : "<none>");
     return true;
-}
-
-typedef struct font_capture
-{
-    const char *font_id;
-} font_capture;
-
-static bool capture_first_ui_font(void *userdata, const sdl3d_game_data_ui_text *text)
-{
-    font_capture *capture = (font_capture *)userdata;
-    if (capture->font_id == NULL && text->font != NULL)
-        capture->font_id = text->font;
-    return capture->font_id == NULL;
-}
-
-static bool load_authored_font(pong_state *state)
-{
-    font_capture capture;
-    SDL_zero(capture);
-    sdl3d_game_data_for_each_ui_text(state->data, capture_first_ui_font, &capture);
-    if (capture.font_id == NULL)
-        return false;
-
-    sdl3d_game_data_font_asset font;
-    if (!sdl3d_game_data_get_font_asset(state->data, capture.font_id, &font))
-        return false;
-    if (font.builtin)
-        return sdl3d_load_builtin_font(SDL3D_MEDIA_DIR, font.builtin_id, font.size, &state->font);
-
-    SDL_SetError("Pong demo currently supports built-in authored fonts only");
-    return false;
 }
 
 static bool pong_init(sdl3d_game_context *ctx, void *userdata)
 {
     pong_state *state = (pong_state *)userdata;
     SDL_zero(*state);
+    sdl3d_game_data_font_cache_init(&state->font_cache, SDL3D_MEDIA_DIR);
+    sdl3d_game_data_particle_cache_init(&state->particle_cache);
+    sdl3d_game_data_app_flow_init(&state->app_flow);
 
     if (!init_game_data(ctx, state))
     {
         return false;
     }
-    if (state->app.quit_signal_id < 0 ||
-        sdl3d_signal_connect(ctx_bus(ctx), state->app.quit_signal_id, on_quit_signal, ctx) == 0)
+    if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
     {
         return false;
-    }
-
-    state->has_font = load_authored_font(state);
-    if (!state->has_font)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong font load failed: %s", SDL_GetError());
-    }
-
-    if (!create_particles(state))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong particles disabled: %s", SDL_GetError());
-    }
-
-    sdl3d_game_data_render_settings render_settings;
-    sdl3d_game_data_get_render_settings(state->data, &render_settings);
-    sdl3d_set_lighting_enabled(ctx->renderer, render_settings.lighting_enabled);
-    sdl3d_set_bloom_enabled(ctx->renderer, render_settings.bloom_enabled);
-    sdl3d_set_ssao_enabled(ctx->renderer, render_settings.ssao_enabled);
-    sdl3d_set_tonemap_mode(ctx->renderer, render_settings.tonemap);
-
-    sdl3d_game_data_transition_desc transition;
-    if (state->app.startup_transition != NULL &&
-        sdl3d_game_data_get_transition(state->data, state->app.startup_transition, &transition))
-    {
-        sdl3d_transition_start(&state->transition, transition.type, transition.direction, transition.color,
-                               transition.duration, transition.done_signal_id);
     }
     return true;
 }
@@ -288,60 +124,35 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
 static void update_visual_effects(pong_state *state, float dt)
 {
     state->time += dt;
-    state->border_flash = fade_down(state->border_flash, dt, presentation_float(state, "border_flash_decay", 2.8f));
-    state->paddle_flash = fade_down(state->paddle_flash, dt, presentation_float(state, "paddle_flash_decay", 4.0f));
-    sdl3d_registered_actor *presentation = presentation_actor(state);
-    if (presentation != NULL)
-    {
-        sdl3d_properties_set_float(presentation->props, "border_flash", state->border_flash);
-        sdl3d_properties_set_float(presentation->props, "paddle_flash", state->paddle_flash);
-    }
-    if (state->ambient_particles != NULL)
-    {
-        sdl3d_particle_emitter_update(state->ambient_particles, dt);
-    }
-}
-
-static void consume_common_actions(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (state->app.quit_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.quit_action_id))
-    {
-        start_quit_fade(ctx, state);
-    }
+    sdl3d_game_data_update_property_effects(state->data, dt);
+    sdl3d_game_data_update_particles(state->data, &state->particle_cache, dt);
 }
 
 static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
 
-    consume_common_actions(ctx, state);
-    if (state->app.pause_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.pause_action_id) &&
-        !state->match_finished)
-    {
-        ctx->paused = true;
+    const bool was_paused = ctx->paused;
+    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, !match_is_finished(state), dt);
+    if (!was_paused && ctx->paused)
         state->pause_flash = 0.0f;
-    }
-    update_visual_effects(state, dt);
-    sdl3d_transition_update(&state->transition, ctx_bus(ctx), dt);
 
-    if (!state->quit_pending)
+    update_visual_effects(state, dt);
+
+    if (!sdl3d_game_data_app_flow_quit_pending(&state->app_flow) && !ctx->paused &&
+        sdl3d_game_data_active_scene_updates_game(state->data))
     {
         sdl3d_game_data_update(state->data, dt);
     }
-
-    sync_state_from_data(state);
 }
 
 static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     pong_state *state = (pong_state *)userdata;
 
-    consume_common_actions(ctx, state);
-    if (state->app.pause_action_id >= 0 && sdl3d_input_is_pressed(ctx_input(ctx), state->app.pause_action_id))
-    {
-        ctx->paused = false;
+    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, true, real_dt);
+    if (!ctx->paused)
         return;
-    }
 
     state->pause_flash += real_dt * presentation_float(state, "pause_flash_speed", 3.0f);
     while (state->pause_flash >= 1.0f)
@@ -349,128 +160,6 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
         state->pause_flash -= 1.0f;
     }
     update_visual_effects(state, real_dt);
-    if (state->quit_pending)
-    {
-        sdl3d_transition_update(&state->transition, ctx_bus(ctx), real_dt);
-    }
-}
-
-static void configure_lights(sdl3d_render_context *renderer, const pong_state *state)
-{
-    float ambient[3] = {0.015f, 0.018f, 0.026f};
-    sdl3d_game_data_get_world_ambient_light(state->data, ambient);
-
-    sdl3d_clear_lights(renderer);
-    sdl3d_set_ambient_light(renderer, ambient[0], ambient[1], ambient[2]);
-
-    const int light_count = sdl3d_game_data_world_light_count(state->data);
-    for (int i = 0; i < light_count; ++i)
-    {
-        sdl3d_light light;
-        if (sdl3d_game_data_get_world_light(state->data, i, &light))
-            sdl3d_add_light(renderer, &light);
-    }
-}
-
-typedef struct primitive_draw_context
-{
-    sdl3d_render_context *renderer;
-    const pong_state *state;
-} primitive_draw_context;
-
-static void draw_emissive_render_primitive(sdl3d_render_context *renderer,
-                                           const sdl3d_game_data_render_primitive *primitive, sdl3d_color color,
-                                           sdl3d_vec3 size, float radius, float emissive_r, float emissive_g,
-                                           float emissive_b)
-{
-    sdl3d_set_emissive(renderer, emissive_r, emissive_g, emissive_b);
-    if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
-        sdl3d_draw_cube(renderer, primitive->position, size, color);
-    else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
-        sdl3d_draw_sphere(renderer, primitive->position, radius, primitive->slices, primitive->rings, color);
-    sdl3d_set_emissive(renderer, 0.0f, 0.0f, 0.0f);
-}
-
-static bool draw_authored_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
-{
-    primitive_draw_context *context = (primitive_draw_context *)userdata;
-    (void)context->state;
-    draw_emissive_render_primitive(context->renderer, primitive, primitive->color, primitive->size, primitive->radius,
-                                   primitive->emissive_color.x, primitive->emissive_color.y,
-                                   primitive->emissive_color.z);
-    return true;
-}
-
-typedef struct ui_draw_context
-{
-    sdl3d_game_context *ctx;
-    const pong_state *state;
-} ui_draw_context;
-
-static bool draw_authored_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
-{
-    ui_draw_context *draw = (ui_draw_context *)userdata;
-    sdl3d_game_data_ui_metrics metrics;
-    SDL_zero(metrics);
-    metrics.paused = draw->ctx->paused;
-    metrics.fps = draw->state->displayed_fps;
-    metrics.frame = draw->state->rendered_frames;
-
-    if (!sdl3d_game_data_ui_text_is_visible(draw->state->data, text, &metrics))
-        return true;
-
-    char content[128];
-    if (!sdl3d_game_data_format_ui_text(draw->state->data, text, &metrics, content, sizeof(content)))
-        return true;
-
-    sdl3d_color color = text->color;
-    if (text->pulse_alpha)
-    {
-        const float pulse = 0.5f + 0.5f * SDL_sinf(draw->state->pause_flash * SDL_PI_F * 2.0f);
-        color.a = (Uint8)(120.0f + pulse * 135.0f);
-    }
-
-    const int width = sdl3d_get_render_context_width(draw->ctx->renderer);
-    const int height = sdl3d_get_render_context_height(draw->ctx->renderer);
-    float x = text->normalized ? text->x * (float)width : text->x;
-    const float y = text->normalized ? text->y * (float)height : text->y;
-    if (text->centered)
-    {
-        float text_w = 0.0f;
-        float text_h = 0.0f;
-        sdl3d_measure_text(&draw->state->font, content, &text_w, &text_h);
-        x -= text_w * 0.5f;
-    }
-
-    sdl3d_draw_text_overlay(draw->ctx->renderer, &draw->state->font, content, x, y, color);
-    return true;
-}
-
-static void draw_hud(sdl3d_game_context *ctx, const pong_state *state)
-{
-    if (!state->has_font)
-    {
-        return;
-    }
-
-    ui_draw_context draw = {ctx, state};
-    sdl3d_game_data_for_each_ui_text(state->data, draw_authored_ui_text, &draw);
-}
-
-static sdl3d_camera3d make_active_camera(const pong_state *state)
-{
-    sdl3d_camera3d camera;
-    const char *active_camera = sdl3d_game_data_active_camera(state->data);
-    if (active_camera != NULL && sdl3d_game_data_get_camera(state->data, active_camera, &camera))
-        return camera;
-
-    SDL_zero(camera);
-    camera.position = sdl3d_vec3_make(0.0f, 0.0f, 16.0f);
-    camera.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
-    camera.fovy = 11.4f;
-    camera.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
-    return camera;
 }
 
 static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -496,31 +185,24 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     state->last_render_time = ctx->real_time;
     ++state->rendered_frames;
 
-    sdl3d_game_data_render_settings render_settings;
-    sdl3d_game_data_get_render_settings(state->data, &render_settings);
-    sdl3d_clear_render_context(ctx->renderer, render_settings.clear_color);
-    configure_lights(ctx->renderer, state);
+    sdl3d_game_data_ui_metrics metrics;
+    SDL_zero(metrics);
+    metrics.paused = ctx->paused;
+    metrics.fps = state->displayed_fps;
+    metrics.frame = state->rendered_frames;
 
-    const sdl3d_camera3d camera = make_active_camera(state);
-
-    if (sdl3d_begin_mode_3d(ctx->renderer, camera))
-    {
-        if (state->ambient_particles != NULL)
-        {
-            sdl3d_set_emissive(ctx->renderer, state->ambient_particles_emissive.x, state->ambient_particles_emissive.y,
-                               state->ambient_particles_emissive.z);
-            sdl3d_draw_particles(ctx->renderer, state->ambient_particles);
-            sdl3d_set_emissive(ctx->renderer, 0.0f, 0.0f, 0.0f);
-        }
-        primitive_draw_context draw_context = {ctx->renderer, state};
-        const sdl3d_game_data_render_eval render_eval = {.time = state->time};
-        sdl3d_game_data_for_each_render_primitive_evaluated(state->data, &render_eval, draw_authored_primitive,
-                                                            &draw_context);
-        sdl3d_end_mode_3d(ctx->renderer);
-    }
-
-    draw_hud(ctx, state);
-    sdl3d_transition_draw(&state->transition, ctx->renderer);
+    const sdl3d_game_data_render_eval render_eval = {.time = state->time};
+    sdl3d_game_data_frame_desc frame;
+    SDL_zero(frame);
+    frame.runtime = state->data;
+    frame.renderer = ctx->renderer;
+    frame.font_cache = &state->font_cache;
+    frame.particle_cache = &state->particle_cache;
+    frame.app_flow = &state->app_flow;
+    frame.metrics = &metrics;
+    frame.render_eval = &render_eval;
+    frame.pulse_phase = state->pause_flash;
+    sdl3d_game_data_draw_frame(&frame);
 }
 
 static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
@@ -528,15 +210,10 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     pong_state *state = (pong_state *)userdata;
     (void)ctx;
 
-    sdl3d_destroy_particle_emitter(state->ambient_particles);
-    state->ambient_particles = NULL;
+    sdl3d_game_data_particle_cache_free(&state->particle_cache);
+    sdl3d_game_data_font_cache_free(&state->font_cache);
     sdl3d_game_data_destroy(state->data);
     state->data = NULL;
-    if (state->has_font)
-    {
-        sdl3d_free_font(&state->font);
-        state->has_font = false;
-    }
 }
 
 int main(int argc, char **argv)

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -42,22 +42,9 @@ static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int err
 #endif
 }
 
-static sdl3d_registered_actor *actor_with_tags(const pong_state *state, const char *tag0, const char *tag1)
-{
-    const char *tags[2] = {tag0, tag1};
-    return tag1 != NULL ? sdl3d_game_data_find_actor_with_tags(state->data, tags, 2)
-                        : sdl3d_game_data_find_actor_with_tag(state->data, tag0);
-}
-
-static bool match_is_finished(const pong_state *state)
-{
-    sdl3d_registered_actor *match = actor_with_tags(state, "state", "match");
-    return match != NULL && sdl3d_properties_get_bool(match->props, "finished", false);
-}
-
 static float presentation_float(const pong_state *state, const char *key, float fallback)
 {
-    sdl3d_registered_actor *presentation = actor_with_tags(state, "state", "presentation");
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor_with_tag(state->data, "presentation");
     return presentation != NULL ? sdl3d_properties_get_float(presentation->props, key, fallback) : fallback;
 }
 
@@ -133,7 +120,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     pong_state *state = (pong_state *)userdata;
 
     const bool was_paused = ctx->paused;
-    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, !match_is_finished(state), dt);
+    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, dt);
     if (!was_paused && ctx->paused)
         state->pause_flash = 0.0f;
 
@@ -150,7 +137,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
 {
     pong_state *state = (pong_state *)userdata;
 
-    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, true, real_dt);
+    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, real_dt);
     if (!ctx->paused)
         return;
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -9,7 +9,6 @@
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
 #include "sdl3d/game_presentation.h"
-#include "sdl3d/properties.h"
 
 #if SDL3D_PONG_EMBEDDED_ASSETS
 #include "sdl3d_pong_assets.h"
@@ -21,13 +20,7 @@ typedef struct pong_state
     sdl3d_game_data_font_cache font_cache;
     sdl3d_game_data_particle_cache particle_cache;
     sdl3d_game_data_app_flow app_flow;
-    float time;
-    float pause_flash;
-    float last_render_time;
-    float fps_sample_time;
-    float displayed_fps;
-    int fps_sample_frames;
-    Uint64 rendered_frames;
+    sdl3d_game_data_frame_state frame_state;
 } pong_state;
 
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
@@ -40,12 +33,6 @@ static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int err
 #else
     return sdl3d_asset_resolver_mount_directory(assets, SDL3D_PONG_DATA_DIR, error, error_size);
 #endif
-}
-
-static float presentation_float(const pong_state *state, const char *key, float fallback)
-{
-    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor_with_tag(state->data, "presentation");
-    return presentation != NULL ? sdl3d_properties_get_float(presentation->props, key, fallback) : fallback;
 }
 
 static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
@@ -88,6 +75,7 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     sdl3d_game_data_font_cache_init(&state->font_cache, SDL3D_MEDIA_DIR);
     sdl3d_game_data_particle_cache_init(&state->particle_cache);
     sdl3d_game_data_app_flow_init(&state->app_flow);
+    sdl3d_game_data_frame_state_init(&state->frame_state);
 
     if (!init_game_data(ctx, state))
     {
@@ -108,45 +96,28 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
     return true;
 }
 
-static void update_visual_effects(pong_state *state, float dt)
-{
-    state->time += dt;
-    sdl3d_game_data_update_property_effects(state->data, dt);
-    sdl3d_game_data_update_particles(state->data, &state->particle_cache, dt);
-}
-
 static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
 
-    const bool was_paused = ctx->paused;
-    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, dt);
-    if (!was_paused && ctx->paused)
-        state->pause_flash = 0.0f;
-
-    update_visual_effects(state, dt);
-
-    if (!sdl3d_game_data_app_flow_quit_pending(&state->app_flow) && !ctx->paused &&
-        sdl3d_game_data_active_scene_updates_game(state->data))
-    {
-        sdl3d_game_data_update(state->data, dt);
-    }
+    const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
+                                                     .runtime = state->data,
+                                                     .app_flow = &state->app_flow,
+                                                     .particle_cache = &state->particle_cache,
+                                                     .dt = dt};
+    (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
 }
 
 static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     pong_state *state = (pong_state *)userdata;
 
-    sdl3d_game_data_app_flow_update(&state->app_flow, ctx, state->data, real_dt);
-    if (!ctx->paused)
-        return;
-
-    state->pause_flash += real_dt * presentation_float(state, "pause_flash_speed", 3.0f);
-    while (state->pause_flash >= 1.0f)
-    {
-        state->pause_flash -= 1.0f;
-    }
-    update_visual_effects(state, real_dt);
+    const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
+                                                     .runtime = state->data,
+                                                     .app_flow = &state->app_flow,
+                                                     .particle_cache = &state->particle_cache,
+                                                     .dt = real_dt};
+    (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
 }
 
 static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
@@ -154,31 +125,8 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     pong_state *state = (pong_state *)userdata;
     (void)alpha;
 
-    if (state->rendered_frames > 0)
-    {
-        const float frame_dt = ctx->real_time - state->last_render_time;
-        if (frame_dt > 0.0f)
-        {
-            state->fps_sample_time += frame_dt;
-            ++state->fps_sample_frames;
-            if (state->fps_sample_time >= 0.25f)
-            {
-                state->displayed_fps = (float)state->fps_sample_frames / state->fps_sample_time;
-                state->fps_sample_time = 0.0f;
-                state->fps_sample_frames = 0;
-            }
-        }
-    }
-    state->last_render_time = ctx->real_time;
-    ++state->rendered_frames;
+    sdl3d_game_data_frame_state_record_render(&state->frame_state, ctx, state->data);
 
-    sdl3d_game_data_ui_metrics metrics;
-    SDL_zero(metrics);
-    metrics.paused = ctx->paused;
-    metrics.fps = state->displayed_fps;
-    metrics.frame = state->rendered_frames;
-
-    const sdl3d_game_data_render_eval render_eval = {.time = state->time};
     sdl3d_game_data_frame_desc frame;
     SDL_zero(frame);
     frame.runtime = state->data;
@@ -186,9 +134,9 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     frame.font_cache = &state->font_cache;
     frame.particle_cache = &state->particle_cache;
     frame.app_flow = &state->app_flow;
-    frame.metrics = &metrics;
-    frame.render_eval = &render_eval;
-    frame.pulse_phase = state->pause_flash;
+    frame.metrics = &state->frame_state.metrics;
+    frame.render_eval = &state->frame_state.render_eval;
+    frame.pulse_phase = state->frame_state.ui_pulse_phase;
     sdl3d_game_data_draw_frame(&frame);
 }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -99,7 +99,15 @@ The optional `app` object lets a managed-loop game declare startup settings befo
     "scene_shortcuts": [
       { "action": "action.scene.title", "scene": "scene.title" },
       { "action": "action.scene.play", "scene": "scene.play" }
-    ]
+    ],
+    "input_policy": {
+      "global_actions": ["action.exit", "action.scene.title", "action.scene.play"]
+    },
+    "scene_transition_policy": {
+      "allow_same_scene": false,
+      "allow_interrupt": false,
+      "reset_menu_input_on_request": true
+    }
   }
 }
 ```
@@ -112,7 +120,46 @@ runtime ownership of the renderer. Games read these descriptors and decide how t
 `app.pause.allowed_if` is optional; when present, the app-flow helper evaluates it before entering pause.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes
 the quit. `app.scene_shortcuts` maps authored input actions to scene names, which is useful for development
-hotkeys, debug level jumps, and simple game flows. The host still owns process shutdown.
+hotkeys, debug level jumps, and simple game flows. `app.input_policy.global_actions`
+lists actions that remain valid in every scene, while each scene can further
+limit its own actions. `app.scene_transition_policy` controls whether scene
+requests can re-enter the current scene, interrupt an active transition, and
+reset menu input arming after accepted requests. The host still owns process shutdown.
+
+The optional `update_phases` and `presentation` sections let thin managed-loop
+hosts use generic frame orchestration:
+
+```json
+{
+  "update_phases": {
+    "app_flow": { "active": true, "when_paused": true },
+    "presentation": { "active": true, "when_paused": true },
+    "property_effects": { "active": true, "when_paused": true },
+    "particles": { "active": true, "when_paused": true },
+    "simulation": { "active": true, "when_paused": false }
+  },
+  "presentation": {
+    "metrics": { "fps_sample_seconds": 0.25 },
+    "ui_pulse_clock": "clock.pause_flash",
+    "clocks": [
+      {
+        "name": "clock.pause_flash",
+        "target": "entity.presentation",
+        "key": "pause_flash",
+        "speed_property": { "target": "entity.presentation", "key": "pause_flash_speed" },
+        "wrap": 1.0,
+        "reset_on_pause_enter": true,
+        "active_if": { "type": "app.paused", "equals": true }
+      }
+    ]
+  }
+}
+```
+
+`sdl3d_game_data_update_frame()` uses these phases to advance app flow,
+presentation clocks, property effects, particles, and simulation. Presentation
+clocks are reusable oscillators/counters that can write into actor properties;
+UI, lights, scripts, and render helpers can all read the resulting value.
 
 Font assets can be authored under `assets.fonts`:
 
@@ -176,6 +223,27 @@ selected styling, and cursor styling:
 
 This keeps title/options/menu screens data-authored: the input menu defines
 choices and actions, while the UI presenter defines how the choices are laid out.
+Menu items can also author generic settings controls:
+
+```json
+{
+  "label": "Difficulty",
+  "control": {
+    "type": "choice",
+    "target": "entity.settings",
+    "key": "difficulty",
+    "choices": [
+      { "label": "Easy", "value": "easy" },
+      { "label": "Normal", "value": "normal" },
+      { "label": "Hard", "value": "hard" }
+    ]
+  }
+}
+```
+
+Supported control types are `toggle`, `choice`, and `range`. The generic menu
+controller applies these controls directly to actor properties and the menu UI
+presenter displays the current value.
 
 ## Scenes
 
@@ -208,6 +276,9 @@ enter/exit transitions, menus, and scene-local UI:
   "camera": "camera.main",
   "on_enter_signal": "signal.level.enter",
   "entities": ["entity.player", "entity.goal"],
+  "input": {
+    "actions": ["action.move.left", "action.move.right", "action.pause"]
+  },
   "transitions": { "enter": "scene_in", "exit": "scene_out" }
 }
 ```
@@ -215,6 +286,9 @@ enter/exit transitions, menus, and scene-local UI:
 Scenes that omit `entities` include all top-level entities; scenes with an empty
 `entities` array include none. This keeps small demos terse while letting large
 games isolate title screens, menus, levels, dungeons, and cutscenes.
+Scenes that omit `input.actions` accept every action except where app-level
+policy says otherwise. Scenes that author `input.actions` accept only those
+actions plus app-level `global_actions`.
 
 When a scene is activated, the runtime emits the scene's `on_enter_signal` if
 one is authored. The enter payload always includes `from_scene` and `to_scene`.
@@ -233,6 +307,11 @@ starts the active scene's authored `exit` transition, switches scenes when the
 transition finishes, then starts the target scene's authored `enter` transition.
 Hosts that need custom loading screens or streaming can still orchestrate scene
 changes themselves.
+
+`sdl3d_game_data_update_frame()` is the higher-level update companion for thin
+managed-loop games. It evaluates authored update phases, advances app flow,
+presentation clocks, property effects, particle emitters, and simulation using
+the same scene/input policies as the lower-level helpers.
 
 The same helper module can draw authored `render.cube`, `render.sphere`, UI
 text descriptors, and active `particles.emitter` components for the active

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -86,7 +86,11 @@ The optional `app` object lets a managed-loop game declare startup settings befo
       "action": "action.exit",
       "transition": "quit",
       "quit_signal": "signal.app.quit_fade_done"
-    }
+    },
+    "scene_shortcuts": [
+      { "action": "action.scene.title", "scene": "scene.title" },
+      { "action": "action.scene.play", "scene": "scene.play" }
+    ]
   }
 }
 ```
@@ -97,7 +101,8 @@ runtime ownership of the renderer. Games read these descriptors and decide how t
 `start_signal` lets data kick off initial timers or scripted startup logic after the host has loaded the runtime.
 `pause_action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes
-the quit. The host still owns pause state and process shutdown.
+the quit. `app.scene_shortcuts` maps authored input actions to scene names, which is useful for development
+hotkeys, debug level jumps, and simple game flows. The host still owns process shutdown.
 
 Font assets can be authored under `assets.fonts`:
 
@@ -133,6 +138,105 @@ Supported UI binding sources are `metric` (`fps`, `frame`, `paused`) and `proper
 Supported UI conditions include `always`, `app.paused`, `camera.active`, `property.compare`,
 `property.bool`, `all`, `any`, and `not`.
 
+Scene UI can also declare data-driven menu presenters. A presenter turns a
+scene `menus[]` controller into a visible stack with authored alignment, colors,
+selected styling, and cursor styling:
+
+```json
+{
+  "ui": {
+    "menus": [
+      {
+        "name": "ui.title.menu",
+        "menu": "menu.title",
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.48,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": { "text": ">", "offset_x": -0.12, "color": [255, 222, 140, 255] }
+      }
+    ]
+  }
+}
+```
+
+This keeps title/options/menu screens data-authored: the input menu defines
+choices and actions, while the UI presenter defines how the choices are laid out.
+
+## Scenes
+
+Games can split authored content across many scene files. The top-level game
+file declares the initial scene and the scene files to load:
+
+```json
+{
+  "scenes": {
+    "initial": "scene.title",
+    "files": [
+      "scenes/title.scene.json",
+      "scenes/level_001.scene.json"
+    ]
+  }
+}
+```
+
+Each scene file is a JSON object with schema `sdl3d.scene.v0`. Scene files may
+declare whether gameplay updates, whether the authored world renders, which
+entities belong to the scene, which camera becomes active on entry, scene
+enter/exit transitions, menus, and scene-local UI:
+
+```json
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.level_001",
+  "updates_game": true,
+  "renders_world": true,
+  "camera": "camera.main",
+  "on_enter_signal": "signal.level.enter",
+  "entities": ["entity.player", "entity.goal"],
+  "transitions": { "enter": "scene_in", "exit": "scene_out" }
+}
+```
+
+Scenes that omit `entities` include all top-level entities; scenes with an empty
+`entities` array include none. This keeps small demos terse while letting large
+games isolate title screens, menus, levels, dungeons, and cutscenes.
+
+When a scene is activated, the runtime emits the scene's `on_enter_signal` if
+one is authored. The enter payload always includes `from_scene` and `to_scene`.
+Callers may pass additional transient payload properties with
+`sdl3d_game_data_set_active_scene_with_payload()`.
+
+For state that must survive after a transition, use the runtime scene-state
+property bag exposed by `sdl3d_game_data_mutable_scene_state()`. Lua adapters
+can access the same persistent bag through `ctx:state_get(key, fallback)` and
+`ctx:state_set(key, value)`.
+
+The optional `game_presentation` helper API can run common app and scene flow
+directly from data. `sdl3d_game_data_app_flow_update()` consumes authored quit,
+pause, menu, and scene-shortcut actions, while `sdl3d_game_data_scene_flow_request()`
+starts the active scene's authored `exit` transition, switches scenes when the
+transition finishes, then starts the target scene's authored `enter` transition.
+Hosts that need custom loading screens or streaming can still orchestrate scene
+changes themselves.
+
+The same helper module can draw authored `render.cube`, `render.sphere`, UI
+text descriptors, and active `particles.emitter` components for the active
+scene. `sdl3d_game_data_draw_frame()` applies authored render settings, lights,
+camera, world primitives, particles, UI text, and transitions in the usual order,
+with hooks for custom game rendering. Lower-level helpers remain available for
+hosts that need a custom frame graph.
+
+Authored menus can also be updated independently through
+`sdl3d_game_data_update_menus()`. The helper handles input arming, movement, and
+selected-item resolution, then returns a data command for the host or app-flow
+controller to apply. This keeps title screens, options screens, and simple scene
+menus from growing bespoke per-game input code.
+
 ## Entities
 
 Entities are the data form of actor registry entries plus optional component ownership.
@@ -163,8 +267,9 @@ The first generic presentation components are deliberately simple descriptors:
 - `render.sphere` describes a sphere with `radius`, `rings`, `slices`, `color`, and `emissive`.
 - `particles.emitter` describes an emitter config that can be passed to the particle system.
 
-The game data runtime exposes these as read-only descriptors. It does not issue draw calls; each game or
-renderer decides how to render, sort, tint, or override them.
+The game data runtime exposes these as read-only descriptors. It does not issue draw calls itself; each game or
+renderer decides how to render, sort, tint, or override them. The optional `game_presentation` helpers provide
+a default implementation for simple demos and tools.
 
 Render primitives may also author generic visual effects:
 
@@ -192,6 +297,26 @@ Supported primitive effects are:
 - `emissive`: adds a constant emissive color.
 
 Particle emitters may include `draw_emissive` for host renderers that draw particles through emissive lighting.
+
+World lights may also declare `effects`. `pulse` effects can blend color and
+add intensity/range over time; `flash` effects read a float actor property and
+use it as the effect weight. This lets data tune glows, brightness, color shifts,
+and transient flashes without host code.
+
+```json
+{
+  "name": "light.ball",
+  "type": "point",
+  "target_entity": "entity.ball",
+  "color": [1.0, 0.86, 0.34],
+  "intensity": 3.1,
+  "range": 5.0,
+  "effects": [
+    { "type": "pulse", "rate": 9.0, "color": [1.0, 0.96, 0.54], "intensity_add": 0.9 },
+    { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "intensity_add": 1.5 }
+  ]
+}
+```
 
 ### Cameras
 
@@ -272,6 +397,30 @@ Actions run in array order. Conditions may be embedded per action.
 }
 ```
 
+Presentation state that changes continuously can be expressed with components
+instead of host code. `property.decay` moves an integer or float actor property
+toward a target value at an authored rate:
+
+```json
+{
+  "name": "entity.presentation",
+  "properties": {
+    "border_flash": { "type": "float", "value": 0.0 },
+    "border_flash_decay": { "type": "float", "value": 2.8 }
+  },
+  "components": [
+    {
+      "type": "property.decay",
+      "property": "border_flash",
+      "rate_property": "border_flash_decay",
+      "target": 0.0,
+      "min": 0.0,
+      "max": 1.0
+    }
+  ]
+}
+```
+
 ### Conditions
 
 Conditions should be generic comparisons over properties, signal payloads, tags, and entity active state.
@@ -335,7 +484,8 @@ Lua adapters receive `(target, payload, ctx)`:
 - `target` is an actor wrapper for the authored action/component target, or `nil`.
 - `payload` is a table copied from the signal payload or component payload.
 - `ctx` provides adapter context: `ctx.adapter`, `ctx.dt`, `ctx:actor(name)`,
-  `ctx:actor_with_tags(...)`, `ctx:random()`, and `ctx:log(message)`.
+  `ctx:actor_with_tags(...)`, `ctx:state_get(key, fallback)`,
+  `ctx:state_set(key, value)`, `ctx:random()`, and `ctx:log(message)`.
 
 The preferred Lua API is intentionally game-script oriented. Scripts can check `sdl3d.api`, currently `sdl3d.lua.v1`, when they need to guard version-specific behavior:
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -80,7 +80,16 @@ The optional `app` object lets a managed-loop game declare startup settings befo
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
     "start_signal": "signal.game.start",
-    "pause_action": "action.pause",
+    "pause": {
+      "action": "action.pause",
+      "allowed_if": {
+        "type": "property.compare",
+        "target": "entity.match",
+        "key": "finished",
+        "op": "==",
+        "value": false
+      }
+    },
     "startup_transition": "startup",
     "quit": {
       "action": "action.exit",
@@ -99,7 +108,8 @@ The optional `render`, `transitions`, and `ui` sections describe presentation wi
 runtime ownership of the renderer. Games read these descriptors and decide how to apply them.
 
 `start_signal` lets data kick off initial timers or scripted startup logic after the host has loaded the runtime.
-`pause_action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
+`app.pause.action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
+`app.pause.allowed_if` is optional; when present, the app-flow helper evaluates it before entering pause.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes
 the quit. `app.scene_shortcuts` maps authored input actions to scene names, which is useful for development
 hotkeys, debug level jumps, and simple game flows. The host still owns process shutdown.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -240,12 +240,26 @@ extern "C"
         int item_count;
     } sdl3d_game_data_menu;
 
+    /** @brief Generic data-authored control kind for menu items. */
+    typedef enum sdl3d_game_data_menu_control_type
+    {
+        /** @brief Menu item is a command, not a setting control. */
+        SDL3D_GAME_DATA_MENU_CONTROL_NONE = 0,
+        /** @brief Menu item toggles a boolean actor property. */
+        SDL3D_GAME_DATA_MENU_CONTROL_TOGGLE = 1,
+        /** @brief Menu item cycles through authored choices. */
+        SDL3D_GAME_DATA_MENU_CONTROL_CHOICE = 2,
+        /** @brief Menu item increments a numeric property within a range. */
+        SDL3D_GAME_DATA_MENU_CONTROL_RANGE = 3,
+    } sdl3d_game_data_menu_control_type;
+
     /**
      * @brief Runtime descriptor for one authored menu item.
      *
-     * A menu item may request a scene change, request app quit, and/or emit a
-     * signal. Hosts can use these fields directly or translate them into a
-     * higher-level scene transition flow.
+     * A menu item may request a scene change, request app quit, emit a signal,
+     * or mutate an actor property as a generic option control. Hosts can use
+     * these fields directly or translate them into a higher-level scene
+     * transition flow.
      */
     typedef struct sdl3d_game_data_menu_item
     {
@@ -257,7 +271,26 @@ extern "C"
         bool quit;
         /** @brief Signal emitted by this item, or -1 when not authored. */
         int signal_id;
+        /** @brief Authored generic control type. */
+        sdl3d_game_data_menu_control_type control_type;
+        /** @brief Actor that owns the controlled property, or NULL. */
+        const char *control_target;
+        /** @brief Controlled property key, or NULL. */
+        const char *control_key;
+        /** @brief Number of authored choices for choice controls. */
+        int choice_count;
     } sdl3d_game_data_menu_item;
+
+    /** @brief Authored scene transition behavior policy. */
+    typedef struct sdl3d_game_data_scene_transition_policy
+    {
+        /** @brief Permit requesting the currently active scene. */
+        bool allow_same_scene;
+        /** @brief Permit a new scene request to replace an active transition. */
+        bool allow_interrupt;
+        /** @brief Reset menu input arming after an accepted scene request. */
+        bool reset_menu_input_on_request;
+    } sdl3d_game_data_scene_transition_policy;
 
     /** @brief Authored input shortcut that requests a scene change. */
     typedef struct sdl3d_game_data_scene_shortcut
@@ -546,6 +579,30 @@ extern "C"
     bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,
                                            const sdl3d_game_data_ui_metrics *metrics);
 
+    /**
+     * @brief Advance data-authored presentation clocks.
+     *
+     * Presentation clocks are generic data-driven oscillators/counters used by
+     * UI, lights, and other render-facing effects. Authored clocks may write
+     * into actor properties so scripts, UI bindings, and render evaluation can
+     * share the same source of truth.
+     */
+    bool sdl3d_game_data_update_presentation_clocks(sdl3d_game_data_runtime *runtime, float dt, bool paused,
+                                                    bool pause_entered);
+
+    /**
+     * @brief Read the authored UI pulse phase.
+     *
+     * Returns @p fallback when no `presentation.ui_pulse_clock` is authored or
+     * the named clock has no current value.
+     */
+    float sdl3d_game_data_ui_pulse_phase(const sdl3d_game_data_runtime *runtime, float fallback);
+
+    /**
+     * @brief Read authored FPS metric sample duration in seconds.
+     */
+    float sdl3d_game_data_fps_sample_seconds(const sdl3d_game_data_runtime *runtime, float fallback);
+
     /** @brief Read a font asset descriptor by id from `assets.fonts`. */
     bool sdl3d_game_data_get_font_asset(const sdl3d_game_data_runtime *runtime, const char *id,
                                         sdl3d_game_data_font_asset *out_font);
@@ -730,6 +787,19 @@ extern "C"
     bool sdl3d_game_data_active_scene_updates_game(const sdl3d_game_data_runtime *runtime);
 
     /**
+     * @brief Return whether an authored update phase should run for the active scene.
+     *
+     * @p phase is an authored phase name such as `simulation`,
+     * `property_effects`, `particles`, or `presentation`. Scene-level
+     * `update_phases` entries override top-level entries. Missing phases use
+     * conservative defaults: simulation follows `updates_game` and does not run
+     * while paused; presentation/property effects/particles run in both paused
+     * and unpaused frames.
+     */
+    bool sdl3d_game_data_active_scene_update_phase(const sdl3d_game_data_runtime *runtime, const char *phase,
+                                                   bool paused);
+
+    /**
      * @brief Return whether the active scene should render the authored world.
      *
      * Scenes default to rendering the world when they do not specify
@@ -744,6 +814,25 @@ extern "C"
      * backward compatibility. Scenes with an empty list include no entities.
      */
     bool sdl3d_game_data_active_scene_has_entity(const sdl3d_game_data_runtime *runtime, const char *entity_name);
+
+    /**
+     * @brief Return whether the active scene allows an input action.
+     *
+     * If a scene omits `input.actions`, all actions are allowed. When present,
+     * the action must be listed there or in top-level
+     * `app.input_policy.global_actions`.
+     */
+    bool sdl3d_game_data_active_scene_allows_action(const sdl3d_game_data_runtime *runtime, int action_id);
+
+    /**
+     * @brief Read authored scene transition policy.
+     *
+     * Missing fields use stable defaults: same-scene requests and interrupting
+     * active transitions are rejected, and accepted scene requests reset menu
+     * input arming.
+     */
+    bool sdl3d_game_data_get_scene_transition_policy(const sdl3d_game_data_runtime *runtime,
+                                                     sdl3d_game_data_scene_transition_policy *out_policy);
 
     /**
      * @brief Read the transition descriptor attached to a scene phase.
@@ -777,6 +866,17 @@ extern "C"
      */
     bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
                                        sdl3d_game_data_menu_item *out_item);
+
+    /**
+     * @brief Apply the generic control behavior authored on a menu item.
+     *
+     * Toggle controls flip boolean properties, choice controls advance to the
+     * next authored choice, and range controls increment numeric properties with
+     * wrapping. Returns false when @p item is not a control or its target cannot
+     * be resolved.
+     */
+    bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime,
+                                                 const sdl3d_game_data_menu_item *item);
 
     /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -534,6 +534,18 @@ extern "C"
     bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime,
                                          sdl3d_game_data_app_control *out_control);
 
+    /**
+     * @brief Evaluate the data-authored app pause condition.
+     *
+     * Returns true when `app.pause.allowed_if` is absent. When present, the
+     * condition uses the same generic condition language as UI visibility:
+     * actor property comparisons, app pause checks, camera checks, and
+     * all/any/not composition. @p metrics may be NULL when the condition does
+     * not refer to app metrics.
+     */
+    bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,
+                                           const sdl3d_game_data_ui_metrics *metrics);
+
     /** @brief Read a font asset descriptor by id from `assets.fonts`. */
     bool sdl3d_game_data_get_font_asset(const sdl3d_game_data_runtime *runtime, const char *id,
                                         sdl3d_game_data_font_asset *out_font);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -91,6 +91,17 @@ extern "C"
         float time;
     } sdl3d_game_data_render_eval;
 
+    /** @brief Horizontal UI alignment for authored text and generated menu items. */
+    typedef enum sdl3d_game_data_ui_align
+    {
+        /** @brief Anchor text at its left edge. */
+        SDL3D_GAME_DATA_UI_ALIGN_LEFT = 0,
+        /** @brief Anchor text at its center. */
+        SDL3D_GAME_DATA_UI_ALIGN_CENTER = 1,
+        /** @brief Anchor text at its right edge. */
+        SDL3D_GAME_DATA_UI_ALIGN_RIGHT = 2,
+    } sdl3d_game_data_ui_align;
+
     /** @brief Authored render primitive kind. */
     typedef enum sdl3d_game_data_render_primitive_type
     {
@@ -192,6 +203,8 @@ extern "C"
         bool normalized;
         /** @brief Whether the text should be horizontally centered by the caller. */
         bool centered;
+        /** @brief Horizontal alignment used by richer UI layouts. */
+        sdl3d_game_data_ui_align align;
         /** @brief Whether alpha should pulse while visible. */
         bool pulse_alpha;
         /** @brief Text color. */
@@ -204,6 +217,98 @@ extern "C"
      * Return false to stop iteration early.
      */
     typedef bool (*sdl3d_game_data_ui_text_fn)(void *userdata, const sdl3d_game_data_ui_text *text);
+
+    /**
+     * @brief Runtime descriptor for the active scene's primary menu.
+     *
+     * Menus are authored in scene JSON files and map input actions to a
+     * selected item. The runtime owns all string pointers.
+     */
+    typedef struct sdl3d_game_data_menu
+    {
+        /** @brief Stable menu name. */
+        const char *name;
+        /** @brief Input action that moves selection up, or -1. */
+        int up_action_id;
+        /** @brief Input action that moves selection down, or -1. */
+        int down_action_id;
+        /** @brief Input action that activates the selected item, or -1. */
+        int select_action_id;
+        /** @brief Currently selected zero-based item index. */
+        int selected_index;
+        /** @brief Number of selectable menu items. */
+        int item_count;
+    } sdl3d_game_data_menu;
+
+    /**
+     * @brief Runtime descriptor for one authored menu item.
+     *
+     * A menu item may request a scene change, request app quit, and/or emit a
+     * signal. Hosts can use these fields directly or translate them into a
+     * higher-level scene transition flow.
+     */
+    typedef struct sdl3d_game_data_menu_item
+    {
+        /** @brief Display label for the item. */
+        const char *label;
+        /** @brief Target scene name, or NULL when this item does not change scene. */
+        const char *scene;
+        /** @brief True when selecting this item requests application quit. */
+        bool quit;
+        /** @brief Signal emitted by this item, or -1 when not authored. */
+        int signal_id;
+    } sdl3d_game_data_menu_item;
+
+    /** @brief Authored input shortcut that requests a scene change. */
+    typedef struct sdl3d_game_data_scene_shortcut
+    {
+        /** @brief Input action id resolved from the authored action name, or -1. */
+        int action_id;
+        /** @brief Authored input action name. */
+        const char *action;
+        /** @brief Target scene name. */
+        const char *scene;
+    } sdl3d_game_data_scene_shortcut;
+
+    /** @brief Read-only descriptor for an authored particle emitter component. */
+    typedef struct sdl3d_game_data_particle_emitter
+    {
+        /** @brief Name of the entity that owns the emitter. */
+        const char *entity_name;
+        /** @brief Emitter configuration evaluated from authored data and actor position. */
+        sdl3d_particle_config config;
+        /** @brief Draw-time emissive color to apply around particle rendering. */
+        sdl3d_vec3 draw_emissive;
+    } sdl3d_game_data_particle_emitter;
+
+    /**
+     * @brief Callback for iterating active authored particle emitters.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*sdl3d_game_data_particle_emitter_fn)(void *userdata,
+                                                        const sdl3d_game_data_particle_emitter *emitter);
+
+    /**
+     * @brief Persistent state bag shared across authored scene changes.
+     *
+     * Scene-transition payloads are transient and exist only while the target
+     * scene's enter signal is emitted. This runtime-owned bag is the durable
+     * handoff point for data that should survive after the transition, such as
+     * selected character, level index, difficulty, or inventory snapshot ids.
+     *
+     * The returned pointer is owned by @p runtime and remains valid until the
+     * runtime is destroyed. Callers may mutate it with the normal
+     * sdl3d_properties setters.
+     */
+    sdl3d_properties *sdl3d_game_data_mutable_scene_state(sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Read the persistent scene-state bag.
+     *
+     * @see sdl3d_game_data_mutable_scene_state
+     */
+    const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtime *runtime);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum sdl3d_game_data_diagnostic_severity
@@ -479,6 +584,17 @@ extern "C"
     bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int index, sdl3d_light *out_light);
 
     /**
+     * @brief Read an authored world light with generic visual effects evaluated.
+     *
+     * Supported light effects include `pulse` and `flash`, allowing data to
+     * drive color blends, intensity changes, and range changes over time or
+     * from actor properties. Passing NULL for @p eval uses a zeroed evaluation
+     * context.
+     */
+    bool sdl3d_game_data_get_world_light_evaluated(const sdl3d_game_data_runtime *runtime, int index,
+                                                   const sdl3d_game_data_render_eval *eval, sdl3d_light *out_light);
+
+    /**
      * @brief Iterate active authored render primitive components.
      *
      * Components currently supported by this iterator are `render.cube` and
@@ -519,6 +635,15 @@ extern "C"
                                                             const char *entity_name, sdl3d_vec3 *out_rgb);
 
     /**
+     * @brief Iterate active authored particle emitter components.
+     *
+     * Iteration skips inactive actors and entities not included by the active
+     * scene. The descriptor's config is ready for sdl3d_create_particle_emitter().
+     */
+    bool sdl3d_game_data_for_each_particle_emitter(const sdl3d_game_data_runtime *runtime,
+                                                   sdl3d_game_data_particle_emitter_fn callback, void *userdata);
+
+    /**
      * @brief Read authored render setup.
      *
      * Missing fields produce conservative defaults: black clear color, lighting
@@ -534,6 +659,140 @@ extern "C"
      */
     bool sdl3d_game_data_get_transition(const sdl3d_game_data_runtime *runtime, const char *name,
                                         sdl3d_game_data_transition_desc *out_transition);
+
+    /**
+     * @brief Return the active scene name.
+     *
+     * Scene names come from the top-level `scenes.initial` field and referenced
+     * scene files. Returns NULL when the game does not author scenes.
+     */
+    const char *sdl3d_game_data_active_scene(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Return the number of authored scenes loaded by the runtime.
+     *
+     * Games without a `scenes.files` manifest return 0. Scene order matches
+     * the authored manifest order and is stable for the lifetime of the
+     * runtime.
+     */
+    int sdl3d_game_data_scene_count(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Return an authored scene name by manifest index.
+     *
+     * @param index Zero-based scene index in the loaded manifest.
+     * @return Runtime-owned scene name, or NULL when @p index is out of range.
+     */
+    const char *sdl3d_game_data_scene_name_at(const sdl3d_game_data_runtime *runtime, int index);
+
+    /**
+     * @brief Switch to an authored scene by name.
+     *
+     * The new scene's `on_enter_signal`, when present, is emitted after the
+     * active scene changes. The enter payload always includes `from_scene` and
+     * `to_scene` string keys. Returns false when @p scene_name is unknown.
+     */
+    bool sdl3d_game_data_set_active_scene(sdl3d_game_data_runtime *runtime, const char *scene_name);
+
+    /**
+     * @brief Switch to an authored scene and pass state to its enter signal.
+     *
+     * @p payload is copied into a transient enter payload and forwarded to the
+     * target scene's `on_enter_signal`; the caller keeps ownership of @p
+     * payload. The runtime also writes `from_scene` and `to_scene`, overriding
+     * same-named keys in @p payload so every scene-enter observer receives
+     * reliable transition context.
+     *
+     * Use sdl3d_game_data_mutable_scene_state() for data that must persist
+     * after enter-signal processing.
+     */
+    bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runtime, const char *scene_name,
+                                                       const sdl3d_properties *payload);
+
+    /**
+     * @brief Return whether the active scene should advance gameplay systems.
+     *
+     * Scenes default to updating gameplay when they do not specify
+     * `updates_game`. Games without authored scenes return true.
+     */
+    bool sdl3d_game_data_active_scene_updates_game(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Return whether the active scene should render the authored world.
+     *
+     * Scenes default to rendering the world when they do not specify
+     * `renders_world`. Games without authored scenes return true.
+     */
+    bool sdl3d_game_data_active_scene_renders_world(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Return whether an entity belongs to the active scene.
+     *
+     * Scenes that omit an `entities` list include all loaded entities for
+     * backward compatibility. Scenes with an empty list include no entities.
+     */
+    bool sdl3d_game_data_active_scene_has_entity(const sdl3d_game_data_runtime *runtime, const char *entity_name);
+
+    /**
+     * @brief Read the transition descriptor attached to a scene phase.
+     *
+     * @p phase is commonly `enter` or `exit` and is looked up under the scene's
+     * `transitions` object. Returns false when the scene or phase is missing.
+     */
+    bool sdl3d_game_data_get_scene_transition(const sdl3d_game_data_runtime *runtime, const char *scene_name,
+                                              const char *phase, sdl3d_game_data_transition_desc *out_transition);
+
+    /**
+     * @brief Read the active scene's primary menu, if any.
+     *
+     * The first menu in the active scene is considered primary. Returns false
+     * when the scene has no menus.
+     */
+    bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_menu *out_menu);
+
+    /**
+     * @brief Move a menu selection by @p delta with wrap-around.
+     *
+     * Positive values move down, negative values move up. Returns false when
+     * the menu is unknown or contains no items.
+     */
+    bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *menu_name, int delta);
+
+    /**
+     * @brief Read one item from an authored menu.
+     *
+     * @p index is zero based. The returned strings remain owned by the runtime.
+     */
+    bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
+                                       sdl3d_game_data_menu_item *out_item);
+
+    /**
+     * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.
+     */
+    int sdl3d_game_data_scene_shortcut_count(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Read an authored scene shortcut by index.
+     *
+     * Invalid or unresolved shortcut entries still return their authored names,
+     * but use action id -1. This lets validators and hosts report useful
+     * diagnostics without failing at runtime.
+     */
+    bool sdl3d_game_data_scene_shortcut_at(const sdl3d_game_data_runtime *runtime, int index,
+                                           sdl3d_game_data_scene_shortcut *out_shortcut);
+
+    /**
+     * @brief Return whether the active menu has no held navigation actions.
+     *
+     * This lets hosts arm menu input after scene entry. Waiting for idle input
+     * prevents a key or gamepad button held while launching or switching scenes
+     * from immediately activating the new scene's default menu item.
+     *
+     * Scenes without an active menu return true. A NULL input manager returns
+     * false when a menu exists because the runtime cannot prove the menu is idle.
+     */
+    bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime,
+                                                   const sdl3d_input_manager *input);
 
     /** @brief Iterate authored UI text descriptors. */
     bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
@@ -558,6 +817,16 @@ extern "C"
      */
     bool sdl3d_game_data_format_ui_text(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
                                         const sdl3d_game_data_ui_metrics *metrics, char *buffer, size_t buffer_size);
+
+    /**
+     * @brief Advance data-authored property animation components.
+     *
+     * Currently supports `property.decay` components, which move a numeric
+     * actor property toward a target value at an authored rate. This is useful
+     * for reusable presentation state such as flashes, glow weights, and other
+     * transient values without per-game C code.
+     */
+    bool sdl3d_game_data_update_property_effects(sdl3d_game_data_runtime *runtime, float dt);
 
     /**
      * @brief Return the dt currently being processed by sdl3d_game_data_update().

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -296,13 +296,13 @@ extern "C"
     /**
      * @brief Consume authored app/menu/scene input and advance transitions.
      *
-     * @p pause_allowed lets game-specific state, such as a finished match,
-     * suppress pause without duplicating menu, quit, or scene transition logic
-     * in the host. The function updates ctx->paused and ctx->quit_requested
-     * when authored controls request those state changes.
+     * The function updates ctx->paused and ctx->quit_requested when authored
+     * controls request those state changes. If `app.pause.allowed_if` is
+     * authored, it is evaluated before entering pause; unpausing remains
+     * available so games cannot trap the app in a paused state.
      */
     bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
-                                         sdl3d_game_data_runtime *runtime, bool pause_allowed, float dt);
+                                         sdl3d_game_data_runtime *runtime, float dt);
 
     /**
      * @brief Draw active app-level and scene-level transitions.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -91,13 +91,14 @@ extern "C"
      */
     typedef struct sdl3d_game_data_menu_update_result
     {
-        const char *menu;   /**< Runtime-owned active menu name, or NULL. */
-        const char *scene;  /**< Runtime-owned selected target scene, or NULL. */
-        int selected_index; /**< Selected item index after this update, or -1. */
-        int signal_id;      /**< Selected signal id, or -1. */
-        bool handled_input; /**< True when a menu action was consumed. */
-        bool selected;      /**< True when the selected item was activated. */
-        bool quit;          /**< True when the selected item requests quit. */
+        const char *menu;     /**< Runtime-owned active menu name, or NULL. */
+        const char *scene;    /**< Runtime-owned selected target scene, or NULL. */
+        int selected_index;   /**< Selected item index after this update, or -1. */
+        int signal_id;        /**< Selected signal id, or -1. */
+        bool handled_input;   /**< True when a menu action was consumed. */
+        bool selected;        /**< True when the selected item was activated. */
+        bool quit;            /**< True when the selected item requests quit. */
+        bool control_changed; /**< True when selecting the item changed a data-bound control. */
     } sdl3d_game_data_menu_update_result;
 
     /**
@@ -115,6 +116,39 @@ extern "C"
         bool quit_pending;                     /**< True after quit has been requested. */
         bool scene_input_armed;                /**< True once menu input is idle after scene entry. */
     } sdl3d_game_data_app_flow;
+
+    /**
+     * @brief Reusable presentation and update clocks for data-authored games.
+     *
+     * Hosts keep one instance for the lifetime of a game. The state samples FPS
+     * and frame counters, tracks real presentation time, evaluates authored
+     * presentation clocks, and exposes ready-to-pass UI metrics/render inputs.
+     */
+    typedef struct sdl3d_game_data_frame_state
+    {
+        sdl3d_game_data_ui_metrics metrics;      /**< Latest UI metrics. */
+        sdl3d_game_data_render_eval render_eval; /**< Latest render effect inputs. */
+        float time;                              /**< Presentation time in seconds. */
+        float ui_pulse_phase;                    /**< Normalized phase for pulse_alpha UI. */
+        float last_render_time;                  /**< Last sampled real render time. */
+        float fps_sample_time;                   /**< Accumulated FPS sample time. */
+        float displayed_fps;                     /**< Most recently sampled FPS. */
+        int fps_sample_frames;                   /**< Frames accumulated in current FPS sample. */
+        Uint64 rendered_frames;                  /**< Number of rendered frames. */
+        bool was_paused;                         /**< Pause state from the previous update. */
+    } sdl3d_game_data_frame_state;
+
+    /**
+     * @brief Inputs for the generic data-authored update-frame helper.
+     */
+    typedef struct sdl3d_game_data_update_frame_desc
+    {
+        sdl3d_game_context *ctx;                        /**< Managed game context. */
+        sdl3d_game_data_runtime *runtime;               /**< Authored runtime to update. */
+        sdl3d_game_data_app_flow *app_flow;             /**< Optional app flow to update. */
+        sdl3d_game_data_particle_cache *particle_cache; /**< Optional authored particle cache. */
+        float dt;                                       /**< Real or fixed delta time for this update. */
+    } sdl3d_game_data_update_frame_desc;
 
     typedef struct sdl3d_game_data_frame_desc sdl3d_game_data_frame_desc;
 
@@ -234,6 +268,27 @@ extern "C"
      */
     bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
                                       bool *input_armed, sdl3d_game_data_menu_update_result *out_result);
+
+    /**
+     * @brief Initialize reusable frame/update state.
+     */
+    void sdl3d_game_data_frame_state_init(sdl3d_game_data_frame_state *state);
+
+    /**
+     * @brief Advance authored app flow, update phases, presentation clocks, and simulation.
+     *
+     * This helper is intended for thin managed-loop hosts. It uses
+     * data-authored update phase policy to decide whether to update app flow,
+     * property effects, particles, and simulation while paused or unpaused.
+     */
+    bool sdl3d_game_data_update_frame(sdl3d_game_data_frame_state *state,
+                                      const sdl3d_game_data_update_frame_desc *desc);
+
+    /**
+     * @brief Sample render metrics before drawing a frame.
+     */
+    void sdl3d_game_data_frame_state_record_render(sdl3d_game_data_frame_state *state, const sdl3d_game_context *ctx,
+                                                   const sdl3d_game_data_runtime *runtime);
 
     /**
      * @brief Initialize a scene transition flow.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -1,0 +1,325 @@
+/**
+ * @file game_presentation.h
+ * @brief Optional helpers for presenting JSON-authored game data.
+ *
+ * The game-data runtime owns authored state and descriptors. This module is a
+ * thin reusable bridge that applies those descriptors to SDL3D renderer-facing
+ * APIs: simple render primitives, UI text, and scene transition sequencing.
+ *
+ * Applications may use these helpers when the default behavior fits, or ignore
+ * them and provide custom rendering/flow code while still using the same data.
+ */
+
+#ifndef SDL3D_GAME_PRESENTATION_H
+#define SDL3D_GAME_PRESENTATION_H
+
+#include <stdbool.h>
+
+#include "sdl3d/camera.h"
+#include "sdl3d/effects.h"
+#include "sdl3d/font.h"
+#include "sdl3d/game.h"
+#include "sdl3d/game_data.h"
+#include "sdl3d/input.h"
+#include "sdl3d/render_context.h"
+#include "sdl3d/signal_bus.h"
+#include "sdl3d/transition.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief Runtime cache for fonts referenced by authored UI text.
+     *
+     * The cache owns loaded sdl3d_font instances. It does not own the
+     * runtime-provided font id strings.
+     */
+    typedef struct sdl3d_game_data_font_cache
+    {
+        sdl3d_font *fonts;     /**< Loaded font instances. */
+        const char **font_ids; /**< Runtime-owned authored font ids. */
+        int count;             /**< Number of cached fonts. */
+        int capacity;          /**< Allocated cache slots. */
+        const char *media_dir; /**< SDL3D media directory used for built-in fonts. */
+    } sdl3d_game_data_font_cache;
+
+    /**
+     * @brief Scene transition flow driven by authored scene transition data.
+     *
+     * The flow owns only transition state and the pending target scene name.
+     * Scene data remains owned by sdl3d_game_data_runtime.
+     */
+    typedef struct sdl3d_game_data_scene_flow
+    {
+        sdl3d_transition transition; /**< Active enter/exit transition. */
+        const char *pending_scene;   /**< Runtime-owned target scene name, or NULL. */
+        bool fading_out;             /**< True while the current scene is exiting. */
+        bool fading_in;              /**< True while the target scene is entering. */
+    } sdl3d_game_data_scene_flow;
+
+    /**
+     * @brief One cached authored particle emitter.
+     */
+    typedef struct sdl3d_game_data_particle_cache_entry
+    {
+        const char *entity_name;         /**< Runtime-owned entity name. */
+        sdl3d_particle_emitter *emitter; /**< Owned particle emitter instance. */
+        sdl3d_vec3 draw_emissive;        /**< Draw-time emissive color. */
+        bool visible;                    /**< True when active in the current scene/frame. */
+    } sdl3d_game_data_particle_cache_entry;
+
+    /**
+     * @brief Runtime cache for particle emitters referenced by authored data.
+     *
+     * The cache owns emitter instances. It does not own entity name strings.
+     */
+    typedef struct sdl3d_game_data_particle_cache
+    {
+        sdl3d_game_data_particle_cache_entry *entries; /**< Cached emitter entries. */
+        int count;                                     /**< Number of cache entries. */
+        int capacity;                                  /**< Allocated entry slots. */
+    } sdl3d_game_data_particle_cache;
+
+    /**
+     * @brief Result produced by the generic authored menu controller.
+     *
+     * The menu controller owns only navigation and selected-item resolution.
+     * Callers decide how to apply the selected command, such as emitting a
+     * signal, requesting a scene transition, or quitting the app.
+     */
+    typedef struct sdl3d_game_data_menu_update_result
+    {
+        const char *menu;   /**< Runtime-owned active menu name, or NULL. */
+        const char *scene;  /**< Runtime-owned selected target scene, or NULL. */
+        int selected_index; /**< Selected item index after this update, or -1. */
+        int signal_id;      /**< Selected signal id, or -1. */
+        bool handled_input; /**< True when a menu action was consumed. */
+        bool selected;      /**< True when the selected item was activated. */
+        bool quit;          /**< True when the selected item requests quit. */
+    } sdl3d_game_data_menu_update_result;
+
+    /**
+     * @brief Reusable application flow for JSON-authored lifecycle controls.
+     *
+     * The flow owns app-level transition state, scene transition state, menu
+     * input arming, and quit intent. It reads controls from sdl3d_game_data_runtime
+     * and applies them to an sdl3d_game_context.
+     */
+    typedef struct sdl3d_game_data_app_flow
+    {
+        sdl3d_game_data_scene_flow scene_flow; /**< Data-authored scene transition flow. */
+        sdl3d_transition transition;           /**< App-level startup/quit transition. */
+        sdl3d_game_data_app_control app;       /**< Resolved app controls from game data. */
+        bool quit_pending;                     /**< True after quit has been requested. */
+        bool scene_input_armed;                /**< True once menu input is idle after scene entry. */
+    } sdl3d_game_data_app_flow;
+
+    typedef struct sdl3d_game_data_frame_desc sdl3d_game_data_frame_desc;
+
+    /**
+     * @brief Optional callback invoked by sdl3d_game_data_draw_frame().
+     *
+     * Return false to report a draw failure while still allowing the frame
+     * helper to finish restoring renderer state.
+     */
+    typedef bool (*sdl3d_game_data_frame_hook)(void *userdata, const sdl3d_game_data_frame_desc *frame);
+
+    /**
+     * @brief Descriptor for drawing one data-authored presentation frame.
+     *
+     * The helper applies authored render settings, configures lights, clears
+     * the frame, draws active-scene world primitives/particles when enabled,
+     * draws authored UI text, then draws active app/scene transitions. Hooks
+     * are optional extension points for game-specific rendering.
+     */
+    struct sdl3d_game_data_frame_desc
+    {
+        const sdl3d_game_data_runtime *runtime;         /**< Authored runtime to render. */
+        sdl3d_render_context *renderer;                 /**< Render context receiving draw calls. */
+        sdl3d_game_data_font_cache *font_cache;         /**< Font cache used by authored UI text. */
+        sdl3d_game_data_particle_cache *particle_cache; /**< Particle cache used by authored emitters. */
+        const sdl3d_game_data_app_flow *app_flow;       /**< Optional app flow whose transitions are drawn. */
+        const sdl3d_game_data_ui_metrics *metrics;      /**< Optional UI metrics. */
+        const sdl3d_game_data_render_eval *render_eval; /**< Optional primitive effect evaluation inputs. */
+        const sdl3d_camera3d *fallback_camera;          /**< Optional camera used when no active camera resolves. */
+        float pulse_phase;                              /**< Normalized UI pulse phase. */
+        sdl3d_game_data_frame_hook before_world_3d;     /**< Optional hook inside the 3D pass before data draws. */
+        sdl3d_game_data_frame_hook after_world_3d;      /**< Optional hook inside the 3D pass after data draws. */
+        sdl3d_game_data_frame_hook before_ui;           /**< Optional hook before authored UI and transitions. */
+        sdl3d_game_data_frame_hook after_ui;            /**< Optional hook after authored UI and transitions. */
+        void *userdata;                                 /**< User pointer passed to hooks. */
+    };
+
+    /**
+     * @brief Initialize a font cache.
+     *
+     * @param cache     Cache to initialize.
+     * @param media_dir Directory containing SDL3D built-in media, usually SDL3D_MEDIA_DIR.
+     */
+    void sdl3d_game_data_font_cache_init(sdl3d_game_data_font_cache *cache, const char *media_dir);
+
+    /**
+     * @brief Free all fonts owned by a cache.
+     *
+     * Safe to call with NULL or an already-freed cache.
+     */
+    void sdl3d_game_data_font_cache_free(sdl3d_game_data_font_cache *cache);
+
+    /**
+     * @brief Draw authored render primitives for the active scene.
+     *
+     * This renders currently supported primitive components (`render.cube` and
+     * `render.sphere`) using SDL3D's immediate drawing helpers. Call inside an
+     * active 3D pass.
+     */
+    bool sdl3d_game_data_draw_render_primitives(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer);
+
+    /**
+     * @brief Draw authored render primitives with evaluated time-based effects.
+     *
+     * @see sdl3d_game_data_draw_render_primitives
+     */
+    bool sdl3d_game_data_draw_render_primitives_evaluated(const sdl3d_game_data_runtime *runtime,
+                                                          sdl3d_render_context *renderer,
+                                                          const sdl3d_game_data_render_eval *eval);
+
+    /**
+     * @brief Draw authored UI text for the active scene.
+     *
+     * Built-in font assets are loaded on demand through @p font_cache. Text is
+     * drawn on SDL3D's overlay path, after world rendering. @p pulse_phase is a
+     * normalized phase used by UI items with `pulse_alpha`.
+     */
+    bool sdl3d_game_data_draw_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                      sdl3d_game_data_font_cache *font_cache, const sdl3d_game_data_ui_metrics *metrics,
+                                      float pulse_phase);
+
+    /**
+     * @brief Initialize a particle emitter cache.
+     */
+    void sdl3d_game_data_particle_cache_init(sdl3d_game_data_particle_cache *cache);
+
+    /**
+     * @brief Free all particle emitters owned by a cache.
+     */
+    void sdl3d_game_data_particle_cache_free(sdl3d_game_data_particle_cache *cache);
+
+    /**
+     * @brief Advance active authored particle emitters.
+     *
+     * Creates emitters lazily for active scene entities with `particles.emitter`
+     * components, updates their authored positions, and advances particle
+     * simulation by @p dt.
+     */
+    bool sdl3d_game_data_update_particles(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_particle_cache *cache,
+                                          float dt);
+
+    /**
+     * @brief Draw active authored particle emitters.
+     *
+     * Call inside an active 3D pass.
+     */
+    bool sdl3d_game_data_draw_particles(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                        sdl3d_game_data_particle_cache *cache);
+
+    /**
+     * @brief Consume authored active-menu input and resolve selected commands.
+     *
+     * @p input_armed should be persisted by the caller for the active scene.
+     * The controller waits until all menu navigation actions are idle before
+     * accepting new presses, preventing a held key from immediately selecting
+     * the next scene's default menu item.
+     */
+    bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                      bool *input_armed, sdl3d_game_data_menu_update_result *out_result);
+
+    /**
+     * @brief Initialize a scene transition flow.
+     */
+    void sdl3d_game_data_scene_flow_init(sdl3d_game_data_scene_flow *flow);
+
+    /**
+     * @brief Return whether a scene transition is currently active.
+     */
+    bool sdl3d_game_data_scene_flow_is_transitioning(const sdl3d_game_data_scene_flow *flow);
+
+    /**
+     * @brief Request a transition to another authored scene.
+     *
+     * If the target is already active, unknown, or another transition is in
+     * progress, the request is rejected and returns false. Otherwise the flow
+     * starts the active scene's authored `exit` transition when one exists, or
+     * switches scenes on the next update.
+     */
+    bool sdl3d_game_data_scene_flow_request(sdl3d_game_data_scene_flow *flow, sdl3d_game_data_runtime *runtime,
+                                            const char *scene_name);
+
+    /**
+     * @brief Advance a scene transition flow.
+     *
+     * When the exit transition finishes, the flow activates the pending scene
+     * through sdl3d_game_data_set_active_scene(), then starts that scene's
+     * authored `enter` transition when one exists.
+     */
+    void sdl3d_game_data_scene_flow_update(sdl3d_game_data_scene_flow *flow, sdl3d_game_data_runtime *runtime,
+                                           sdl3d_signal_bus *bus, float dt);
+
+    /**
+     * @brief Draw the active transition owned by a scene flow.
+     */
+    void sdl3d_game_data_scene_flow_draw(const sdl3d_game_data_scene_flow *flow, sdl3d_render_context *renderer);
+
+    /**
+     * @brief Initialize reusable app lifecycle flow state.
+     */
+    void sdl3d_game_data_app_flow_init(sdl3d_game_data_app_flow *flow);
+
+    /**
+     * @brief Start app lifecycle flow from authored data.
+     *
+     * Reads app controls and starts the authored startup transition when present.
+     */
+    bool sdl3d_game_data_app_flow_start(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Return true when quit has been requested and is waiting on a transition.
+     */
+    bool sdl3d_game_data_app_flow_quit_pending(const sdl3d_game_data_app_flow *flow);
+
+    /**
+     * @brief Return true while any app or scene transition is active.
+     */
+    bool sdl3d_game_data_app_flow_is_transitioning(const sdl3d_game_data_app_flow *flow);
+
+    /**
+     * @brief Consume authored app/menu/scene input and advance transitions.
+     *
+     * @p pause_allowed lets game-specific state, such as a finished match,
+     * suppress pause without duplicating menu, quit, or scene transition logic
+     * in the host. The function updates ctx->paused and ctx->quit_requested
+     * when authored controls request those state changes.
+     */
+    bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+                                         sdl3d_game_data_runtime *runtime, bool pause_allowed, float dt);
+
+    /**
+     * @brief Draw active app-level and scene-level transitions.
+     */
+    void sdl3d_game_data_app_flow_draw(const sdl3d_game_data_app_flow *flow, sdl3d_render_context *renderer);
+
+    /**
+     * @brief Draw one complete data-authored presentation frame.
+     *
+     * This is the high-level version of the lower-level draw helpers above.
+     * Hosts that only need authored presentation can call this from their
+     * render callback and reserve hooks for custom rendering.
+     */
+    bool sdl3d_game_data_draw_frame(const sdl3d_game_data_frame_desc *frame);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_GAME_PRESENTATION_H */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -17,6 +17,7 @@
 #include "sdl3d/effects.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
+#include "sdl3d/game_presentation.h"
 #include "sdl3d/image.h"
 #include "sdl3d/input.h"
 #include "sdl3d/lighting.h"

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1550,9 +1550,10 @@ bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime, sdl
         return false;
 
     yyjson_val *app = obj_get(runtime_root(runtime), "app");
+    yyjson_val *pause = obj_get(app, "pause");
     yyjson_val *quit = obj_get(app, "quit");
     out_control->start_signal_id = sdl3d_game_data_find_signal(runtime, json_string(app, "start_signal", NULL));
-    out_control->pause_action_id = sdl3d_game_data_find_action(runtime, json_string(app, "pause_action", NULL));
+    out_control->pause_action_id = sdl3d_game_data_find_action(runtime, json_string(pause, "action", NULL));
     out_control->startup_transition = json_string(app, "startup_transition", NULL);
     out_control->quit_action_id = sdl3d_game_data_find_action(runtime, json_string(quit, "action", NULL));
     out_control->quit_transition = json_string(quit, "transition", NULL);
@@ -3083,8 +3084,8 @@ static bool value_equals_json_bool(const sdl3d_value *left, bool right)
     return left != NULL && left->type == SDL3D_VALUE_BOOL && left->as_bool == right;
 }
 
-static bool eval_ui_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
-                              const sdl3d_game_data_ui_metrics *metrics)
+static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
+                                const sdl3d_game_data_ui_metrics *metrics)
 {
     if (condition == NULL)
         return true;
@@ -3137,7 +3138,7 @@ static bool eval_ui_condition(const sdl3d_game_data_runtime *runtime, yyjson_val
         for (size_t i = 0; i < yyjson_arr_size(conditions); ++i)
         {
             saw_any = true;
-            const bool passed = eval_ui_condition(runtime, yyjson_arr_get(conditions, i), metrics);
+            const bool passed = eval_data_condition(runtime, yyjson_arr_get(conditions, i), metrics);
             if (require_all && !passed)
                 return false;
             if (!require_all && passed)
@@ -3146,7 +3147,7 @@ static bool eval_ui_condition(const sdl3d_game_data_runtime *runtime, yyjson_val
         return require_all && saw_any;
     }
     if (SDL_strcmp(type, "not") == 0)
-        return !eval_ui_condition(runtime, obj_get(condition, "condition"), metrics);
+        return !eval_data_condition(runtime, obj_get(condition, "condition"), metrics);
     return false;
 }
 
@@ -3158,8 +3159,21 @@ bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, 
     yyjson_val *text_json = find_ui_text_json(runtime, text->name);
     yyjson_val *condition = obj_get(text_json, "visible_if");
     if (condition != NULL)
-        return eval_ui_condition(runtime, condition, metrics);
+        return eval_data_condition(runtime, condition, metrics);
     return text->visible == NULL || SDL_strcmp(text->visible, "always") == 0;
+}
+
+bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,
+                                       const sdl3d_game_data_ui_metrics *metrics)
+{
+    if (runtime == NULL)
+        return false;
+
+    yyjson_val *pause = obj_get(obj_get(runtime_root(runtime), "app"), "pause");
+    yyjson_val *condition = obj_get(pause, "allowed_if");
+    if (condition == NULL)
+        return true;
+    return eval_data_condition(runtime, condition, metrics);
 }
 
 typedef enum ui_value_type

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1505,6 +1505,18 @@ int sdl3d_game_data_find_action(const sdl3d_game_data_runtime *runtime, const ch
     return -1;
 }
 
+static const char *find_action_name(const sdl3d_game_data_runtime *runtime, int action_id)
+{
+    if (runtime == NULL || action_id < 0)
+        return NULL;
+    for (int i = 0; i < runtime->action_count; ++i)
+    {
+        if (runtime->actions[i].id == action_id)
+            return runtime->actions[i].name;
+    }
+    return NULL;
+}
+
 sdl3d_registered_actor *sdl3d_game_data_find_actor(const sdl3d_game_data_runtime *runtime, const char *name)
 {
     return sdl3d_actor_registry_find(runtime_registry(runtime), name);
@@ -2200,6 +2212,46 @@ bool sdl3d_game_data_active_scene_updates_game(const sdl3d_game_data_runtime *ru
     return scene != NULL ? json_bool(scene->root, "updates_game", true) : true;
 }
 
+static bool update_phase_default(const sdl3d_game_data_runtime *runtime, const char *phase, bool paused)
+{
+    if (phase != NULL && SDL_strcmp(phase, "simulation") == 0)
+        return !paused && sdl3d_game_data_active_scene_updates_game(runtime);
+    if (phase != NULL && SDL_strcmp(phase, "app_flow") == 0)
+        return true;
+    if (phase != NULL && (SDL_strcmp(phase, "presentation") == 0 || SDL_strcmp(phase, "property_effects") == 0 ||
+                          SDL_strcmp(phase, "particles") == 0))
+        return true;
+    return !paused;
+}
+
+static bool eval_update_phase_entry(yyjson_val *entry, bool paused, bool fallback)
+{
+    if (yyjson_is_bool(entry))
+        return yyjson_get_bool(entry);
+    if (!yyjson_is_obj(entry))
+        return fallback;
+    if (!json_bool(entry, "active", true))
+        return false;
+    if (paused)
+        return json_bool(entry, "when_paused", fallback);
+    return json_bool(entry, "when_unpaused", true);
+}
+
+bool sdl3d_game_data_active_scene_update_phase(const sdl3d_game_data_runtime *runtime, const char *phase, bool paused)
+{
+    if (runtime == NULL || phase == NULL)
+        return false;
+
+    const bool fallback = update_phase_default(runtime, phase, paused);
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *scene_entry_json = obj_get(obj_get(scene != NULL ? scene->root : NULL, "update_phases"), phase);
+    if (scene_entry_json != NULL)
+        return eval_update_phase_entry(scene_entry_json, paused, fallback);
+
+    yyjson_val *root_entry_json = obj_get(obj_get(runtime_root(runtime), "update_phases"), phase);
+    return eval_update_phase_entry(root_entry_json, paused, fallback);
+}
+
 bool sdl3d_game_data_active_scene_renders_world(const sdl3d_game_data_runtime *runtime)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
@@ -2209,6 +2261,56 @@ bool sdl3d_game_data_active_scene_renders_world(const sdl3d_game_data_runtime *r
 bool sdl3d_game_data_active_scene_has_entity(const sdl3d_game_data_runtime *runtime, const char *entity_name)
 {
     return runtime != NULL && active_scene_has_entity_internal(runtime, entity_name);
+}
+
+static bool string_array_contains(yyjson_val *array, const char *value)
+{
+    for (size_t i = 0; value != NULL && yyjson_is_arr(array) && i < yyjson_arr_size(array); ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(array, i);
+        const char *text = yyjson_is_str(item) ? yyjson_get_str(item) : NULL;
+        if (text != NULL && SDL_strcmp(text, value) == 0)
+            return true;
+    }
+    return false;
+}
+
+bool sdl3d_game_data_active_scene_allows_action(const sdl3d_game_data_runtime *runtime, int action_id)
+{
+    const char *action = find_action_name(runtime, action_id);
+    if (runtime == NULL || action == NULL)
+        return false;
+
+    yyjson_val *global_actions =
+        obj_get(obj_get(obj_get(runtime_root(runtime), "app"), "input_policy"), "global_actions");
+    if (string_array_contains(global_actions, action))
+        return true;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *actions = obj_get(obj_get(scene != NULL ? scene->root : NULL, "input"), "actions");
+    if (actions == NULL)
+        return true;
+    return string_array_contains(actions, action);
+}
+
+bool sdl3d_game_data_get_scene_transition_policy(const sdl3d_game_data_runtime *runtime,
+                                                 sdl3d_game_data_scene_transition_policy *out_policy)
+{
+    if (out_policy != NULL)
+    {
+        out_policy->allow_same_scene = false;
+        out_policy->allow_interrupt = false;
+        out_policy->reset_menu_input_on_request = true;
+    }
+    if (runtime == NULL || out_policy == NULL)
+        return false;
+
+    yyjson_val *policy = obj_get(obj_get(runtime_root(runtime), "app"), "scene_transition_policy");
+    out_policy->allow_same_scene = json_bool(policy, "allow_same_scene", out_policy->allow_same_scene);
+    out_policy->allow_interrupt = json_bool(policy, "allow_interrupt", out_policy->allow_interrupt);
+    out_policy->reset_menu_input_on_request =
+        json_bool(policy, "reset_menu_input_on_request", out_policy->reset_menu_input_on_request);
+    return true;
 }
 
 bool sdl3d_game_data_get_scene_transition(const sdl3d_game_data_runtime *runtime, const char *scene_name,
@@ -2259,6 +2361,21 @@ bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *men
     return true;
 }
 
+static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *type)
+{
+    if (type == NULL)
+        return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
+    if (SDL_strcmp(type, "toggle") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_TOGGLE;
+    if (SDL_strcmp(type, "choice") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_CHOICE;
+    if (SDL_strcmp(type, "range") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_RANGE;
+    return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
+}
+
+static bool json_value_matches_property(yyjson_val *value, const sdl3d_value *property);
+
 bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
                                    sdl3d_game_data_menu_item *out_item)
 {
@@ -2272,11 +2389,147 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
         return false;
 
     yyjson_val *item = yyjson_arr_get(obj_get(menu->menu, "items"), (size_t)index);
+    yyjson_val *control = obj_get(item, "control");
     out_item->label = json_string(item, "label", NULL);
     out_item->scene = json_string(item, "scene", NULL);
     out_item->quit = json_bool(item, "quit", false);
     out_item->signal_id = sdl3d_game_data_find_signal(runtime, json_string(item, "signal", NULL));
+    out_item->control_type = parse_menu_control_type(json_string(control, "type", NULL));
+    out_item->control_target = json_string(control, "target", NULL);
+    out_item->control_key = json_string(control, "key", NULL);
+    out_item->choice_count =
+        yyjson_is_arr(obj_get(control, "choices")) ? (int)yyjson_arr_size(obj_get(control, "choices")) : 0;
     return yyjson_is_obj(item) && out_item->label != NULL;
+}
+
+static yyjson_val *find_menu_item_control_json(const sdl3d_game_data_runtime *runtime,
+                                               const sdl3d_game_data_menu_item *item)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    for (int m = 0; scene != NULL && item != NULL && m < scene->menu_count; ++m)
+    {
+        yyjson_val *items = obj_get(scene->menus[m].menu, "items");
+        for (size_t i = 0; yyjson_is_arr(items) && i < yyjson_arr_size(items); ++i)
+        {
+            yyjson_val *candidate = yyjson_arr_get(items, i);
+            yyjson_val *control = obj_get(candidate, "control");
+            const char *label = json_string(candidate, "label", NULL);
+            const char *target = json_string(control, "target", NULL);
+            const char *key = json_string(control, "key", NULL);
+            if (label != NULL && target != NULL && key != NULL && item->label != NULL && item->control_target != NULL &&
+                item->control_key != NULL && SDL_strcmp(label, item->label) == 0 &&
+                SDL_strcmp(target, item->control_target) == 0 && SDL_strcmp(key, item->control_key) == 0)
+                return control;
+        }
+    }
+    return NULL;
+}
+
+static bool set_property_from_json(sdl3d_properties *props, const char *key, yyjson_val *value)
+{
+    if (props == NULL || key == NULL || value == NULL)
+        return false;
+    if (yyjson_is_bool(value))
+    {
+        sdl3d_properties_set_bool(props, key, yyjson_get_bool(value));
+        return true;
+    }
+    if (yyjson_is_int(value))
+    {
+        sdl3d_properties_set_int(props, key, (int)yyjson_get_sint(value));
+        return true;
+    }
+    if (yyjson_is_num(value))
+    {
+        sdl3d_properties_set_float(props, key, (float)yyjson_get_num(value));
+        return true;
+    }
+    if (yyjson_is_str(value))
+    {
+        sdl3d_properties_set_string(props, key, yyjson_get_str(value));
+        return true;
+    }
+    return false;
+}
+
+static bool json_value_matches_property(yyjson_val *value, const sdl3d_value *property)
+{
+    if (value == NULL || property == NULL)
+        return false;
+    switch (property->type)
+    {
+    case SDL3D_VALUE_BOOL:
+        return yyjson_is_bool(value) && yyjson_get_bool(value) == property->as_bool;
+    case SDL3D_VALUE_INT:
+        return yyjson_is_int(value) && (int)yyjson_get_sint(value) == property->as_int;
+    case SDL3D_VALUE_FLOAT:
+        return yyjson_is_num(value) && SDL_fabsf((float)yyjson_get_num(value) - property->as_float) < 0.0001f;
+    case SDL3D_VALUE_STRING:
+        return yyjson_is_str(value) &&
+               SDL_strcmp(yyjson_get_str(value), property->as_string != NULL ? property->as_string : "") == 0;
+    case SDL3D_VALUE_VEC3:
+    case SDL3D_VALUE_COLOR:
+        return false;
+    }
+    return false;
+}
+
+bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, const sdl3d_game_data_menu_item *item)
+{
+    if (runtime == NULL || item == NULL || item->control_type == SDL3D_GAME_DATA_MENU_CONTROL_NONE ||
+        item->control_target == NULL || item->control_key == NULL)
+        return false;
+
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, item->control_target);
+    if (actor == NULL)
+        return false;
+
+    yyjson_val *control = find_menu_item_control_json(runtime, item);
+    switch (item->control_type)
+    {
+    case SDL3D_GAME_DATA_MENU_CONTROL_TOGGLE: {
+        const bool current =
+            sdl3d_properties_get_bool(actor->props, item->control_key, json_bool(control, "default", false));
+        sdl3d_properties_set_bool(actor->props, item->control_key, !current);
+        return true;
+    }
+    case SDL3D_GAME_DATA_MENU_CONTROL_CHOICE: {
+        yyjson_val *choices = obj_get(control, "choices");
+        if (!yyjson_is_arr(choices) || yyjson_arr_size(choices) == 0)
+            return false;
+        const sdl3d_value *current = sdl3d_properties_get_value(actor->props, item->control_key);
+        int current_index = -1;
+        for (size_t i = 0; i < yyjson_arr_size(choices); ++i)
+        {
+            yyjson_val *choice = yyjson_arr_get(choices, i);
+            yyjson_val *value = yyjson_is_obj(choice) ? obj_get(choice, "value") : choice;
+            if (json_value_matches_property(value, current))
+            {
+                current_index = (int)i;
+                break;
+            }
+        }
+        const int next_index = (current_index + 1) % (int)yyjson_arr_size(choices);
+        yyjson_val *next = yyjson_arr_get(choices, (size_t)next_index);
+        return set_property_from_json(actor->props, item->control_key,
+                                      yyjson_is_obj(next) ? obj_get(next, "value") : next);
+    }
+    case SDL3D_GAME_DATA_MENU_CONTROL_RANGE: {
+        const float min_value = json_float(control, "min", 0.0f);
+        const float max_value = json_float(control, "max", 1.0f);
+        const float step = json_float(control, "step", 1.0f);
+        float value =
+            sdl3d_properties_get_float(actor->props, item->control_key, json_float(control, "default", min_value));
+        value += step;
+        if (value > max_value)
+            value = min_value;
+        sdl3d_properties_set_float(actor->props, item->control_key, SDL_clamp(value, min_value, max_value));
+        return true;
+    }
+    case SDL3D_GAME_DATA_MENU_CONTROL_NONE:
+        return false;
+    }
+    return false;
 }
 
 int sdl3d_game_data_scene_shortcut_count(const sdl3d_game_data_runtime *runtime)
@@ -2313,9 +2566,12 @@ bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *ru
     if (input == NULL)
         return false;
 
-    return (menu.up_action_id < 0 || !sdl3d_input_is_held(input, menu.up_action_id)) &&
-           (menu.down_action_id < 0 || !sdl3d_input_is_held(input, menu.down_action_id)) &&
-           (menu.select_action_id < 0 || !sdl3d_input_is_held(input, menu.select_action_id));
+    return (menu.up_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.up_action_id) ||
+            !sdl3d_input_is_held(input, menu.up_action_id)) &&
+           (menu.down_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.down_action_id) ||
+            !sdl3d_input_is_held(input, menu.down_action_id)) &&
+           (menu.select_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.select_action_id) ||
+            !sdl3d_input_is_held(input, menu.select_action_id));
 }
 
 static void ui_text_from_json(yyjson_val *item, sdl3d_game_data_ui_text *text)
@@ -2375,8 +2631,67 @@ static bool emit_ui_menu_cursor(yyjson_val *presenter, float row_y, sdl3d_game_d
     return callback(userdata, &text);
 }
 
-static bool for_each_ui_menu_presenter(const scene_entry *scene, yyjson_val *presenter,
-                                       sdl3d_game_data_ui_text_fn callback, void *userdata)
+static const char *choice_label_for_property(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(control, "target", NULL));
+    const char *key = json_string(control, "key", NULL);
+    const sdl3d_value *value = actor != NULL && key != NULL ? sdl3d_properties_get_value(actor->props, key) : NULL;
+    yyjson_val *choices = obj_get(control, "choices");
+    for (size_t i = 0; yyjson_is_arr(choices) && i < yyjson_arr_size(choices); ++i)
+    {
+        yyjson_val *choice = yyjson_arr_get(choices, i);
+        yyjson_val *choice_value = yyjson_is_obj(choice) ? obj_get(choice, "value") : choice;
+        if (json_value_matches_property(choice_value, value))
+            return yyjson_is_obj(choice) ? json_string(choice, "label", NULL) : NULL;
+    }
+    return NULL;
+}
+
+static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjson_val *item, char *buffer,
+                                   size_t buffer_size)
+{
+    const char *label = json_string(item, "label", "");
+    yyjson_val *control = obj_get(item, "control");
+    const sdl3d_game_data_menu_control_type type = parse_menu_control_type(json_string(control, "type", NULL));
+    if (buffer == NULL || buffer_size == 0)
+        return;
+
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_NONE)
+    {
+        SDL_strlcpy(buffer, label, buffer_size);
+        return;
+    }
+
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(control, "target", NULL));
+    const char *key = json_string(control, "key", NULL);
+    const sdl3d_value *value = actor != NULL && key != NULL ? sdl3d_properties_get_value(actor->props, key) : NULL;
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_TOGGLE)
+    {
+        const bool enabled =
+            value != NULL && value->type == SDL3D_VALUE_BOOL ? value->as_bool : json_bool(control, "default", false);
+        SDL_snprintf(buffer, buffer_size, "%s: %s", label, enabled ? "On" : "Off");
+        return;
+    }
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_CHOICE)
+    {
+        const char *choice_label = choice_label_for_property(runtime, control);
+        if (choice_label == NULL && value != NULL && value->type == SDL3D_VALUE_STRING)
+            choice_label = value->as_string;
+        SDL_snprintf(buffer, buffer_size, "%s: %s", label, choice_label != NULL ? choice_label : "-");
+        return;
+    }
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_RANGE)
+    {
+        const float current =
+            value != NULL && value->type == SDL3D_VALUE_FLOAT ? value->as_float : json_float(control, "default", 0.0f);
+        SDL_snprintf(buffer, buffer_size, "%s: %.2g", label, current);
+        return;
+    }
+    SDL_strlcpy(buffer, label, buffer_size);
+}
+
+static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, const scene_entry *scene,
+                                       yyjson_val *presenter, sdl3d_game_data_ui_text_fn callback, void *userdata)
 {
     if (scene == NULL || presenter == NULL)
         return true;
@@ -2403,10 +2718,12 @@ static bool for_each_ui_menu_presenter(const scene_entry *scene, yyjson_val *pre
             return false;
 
         sdl3d_game_data_ui_text text;
+        char label[128];
+        format_menu_item_label(runtime, item, label, sizeof(label));
         SDL_zero(text);
         text.name = json_string(presenter, "name", NULL);
         text.font = json_string(presenter, "font", NULL);
-        text.text = json_string(item, "label", "");
+        text.text = label;
         text.visible = "always";
         text.x = x;
         text.y = row_y;
@@ -2423,13 +2740,13 @@ static bool for_each_ui_menu_presenter(const scene_entry *scene, yyjson_val *pre
     return true;
 }
 
-static bool for_each_ui_menu_root(const scene_entry *scene, yyjson_val *root, sdl3d_game_data_ui_text_fn callback,
-                                  void *userdata)
+static bool for_each_ui_menu_root(const sdl3d_game_data_runtime *runtime, const scene_entry *scene, yyjson_val *root,
+                                  sdl3d_game_data_ui_text_fn callback, void *userdata)
 {
     yyjson_val *menus = obj_get(obj_get(root, "ui"), "menus");
     for (size_t i = 0; yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
     {
-        if (!for_each_ui_menu_presenter(scene, yyjson_arr_get(menus, i), callback, userdata))
+        if (!for_each_ui_menu_presenter(runtime, scene, yyjson_arr_get(menus, i), callback, userdata))
             return false;
     }
     return true;
@@ -2448,7 +2765,7 @@ bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sd
 
     for (int root_index = 0; root_index < 2; ++root_index)
         if (!for_each_authored_ui_text_root(roots[root_index], callback, userdata) ||
-            !for_each_ui_menu_root(scene, roots[root_index], callback, userdata))
+            !for_each_ui_menu_root(runtime, scene, roots[root_index], callback, userdata))
             return true;
     return true;
 }
@@ -3174,6 +3491,95 @@ bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,
     if (condition == NULL)
         return true;
     return eval_data_condition(runtime, condition, metrics);
+}
+
+static yyjson_val *find_presentation_clock(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *clocks = obj_get(obj_get(runtime_root(runtime), "presentation"), "clocks");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(clocks) && i < yyjson_arr_size(clocks); ++i)
+    {
+        yyjson_val *clock = yyjson_arr_get(clocks, i);
+        const char *clock_name = json_string(clock, "name", NULL);
+        if (clock_name != NULL && SDL_strcmp(clock_name, name) == 0)
+            return clock;
+    }
+    return NULL;
+}
+
+static sdl3d_registered_actor *clock_actor(const sdl3d_game_data_runtime *runtime, yyjson_val *clock)
+{
+    return sdl3d_game_data_find_actor(runtime, json_string(clock, "target", NULL));
+}
+
+static float clock_property_float(const sdl3d_game_data_runtime *runtime, yyjson_val *ref, float fallback)
+{
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(ref, "target", NULL));
+    const char *key = json_string(ref, "key", NULL);
+    return actor != NULL && key != NULL ? sdl3d_properties_get_float(actor->props, key, fallback) : fallback;
+}
+
+bool sdl3d_game_data_update_presentation_clocks(sdl3d_game_data_runtime *runtime, float dt, bool paused,
+                                                bool pause_entered)
+{
+    if (runtime == NULL)
+        return false;
+    yyjson_val *clocks = obj_get(obj_get(runtime_root(runtime), "presentation"), "clocks");
+    if (!yyjson_is_arr(clocks))
+        return true;
+
+    sdl3d_game_data_ui_metrics metrics;
+    SDL_zero(metrics);
+    metrics.paused = paused;
+    for (size_t i = 0; i < yyjson_arr_size(clocks); ++i)
+    {
+        yyjson_val *clock = yyjson_arr_get(clocks, i);
+        sdl3d_registered_actor *actor = clock_actor(runtime, clock);
+        const char *key = json_string(clock, "key", NULL);
+        if (actor == NULL || key == NULL)
+            continue;
+
+        float value = sdl3d_properties_get_float(actor->props, key, json_float(clock, "initial", 0.0f));
+        if (pause_entered && json_bool(clock, "reset_on_pause_enter", false))
+            value = json_float(clock, "reset_value", 0.0f);
+
+        yyjson_val *condition = obj_get(clock, "active_if");
+        const bool active = condition == NULL || eval_data_condition(runtime, condition, &metrics);
+        if (active)
+        {
+            const float speed =
+                clock_property_float(runtime, obj_get(clock, "speed_property"), json_float(clock, "speed", 1.0f));
+            value += dt * speed;
+            const float wrap = json_float(clock, "wrap", 0.0f);
+            if (wrap > 0.0f)
+            {
+                while (value >= wrap)
+                    value -= wrap;
+                while (value < 0.0f)
+                    value += wrap;
+            }
+        }
+        sdl3d_properties_set_float(actor->props, key, value);
+    }
+    return true;
+}
+
+float sdl3d_game_data_ui_pulse_phase(const sdl3d_game_data_runtime *runtime, float fallback)
+{
+    if (runtime == NULL)
+        return fallback;
+    const char *clock_name = json_string(obj_get(runtime_root(runtime), "presentation"), "ui_pulse_clock", NULL);
+    yyjson_val *clock = find_presentation_clock(runtime, clock_name);
+    sdl3d_registered_actor *actor = clock_actor(runtime, clock);
+    const char *key = json_string(clock, "key", NULL);
+    return actor != NULL && key != NULL ? sdl3d_properties_get_float(actor->props, key, fallback) : fallback;
+}
+
+float sdl3d_game_data_fps_sample_seconds(const sdl3d_game_data_runtime *runtime, float fallback)
+{
+    if (runtime == NULL)
+        return fallback;
+    return json_float(obj_get(obj_get(runtime_root(runtime), "presentation"), "metrics"), "fps_sample_seconds",
+                      fallback);
 }
 
 typedef enum ui_value_type

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -97,6 +97,25 @@ typedef struct sensor_entry
     bool was_active;
 } sensor_entry;
 
+typedef struct scene_menu_state
+{
+    yyjson_val *menu;
+    int selected_index;
+    int item_count;
+} scene_menu_state;
+
+typedef struct scene_entry
+{
+    yyjson_doc *doc;
+    yyjson_val *root;
+    const char *name;
+    const char **entities;
+    int entity_count;
+    bool has_entity_filter;
+    scene_menu_state *menus;
+    int menu_count;
+} scene_entry;
+
 typedef struct sdl3d_game_data_runtime
 {
     yyjson_doc *doc;
@@ -118,6 +137,10 @@ typedef struct sdl3d_game_data_runtime
     int script_count;
     sdl3d_asset_resolver *assets;
     char *base_dir;
+    scene_entry *scenes;
+    int scene_count;
+    int active_scene_index;
+    sdl3d_properties *scene_state;
     const char *active_camera;
     float current_dt;
     unsigned int rng_state;
@@ -231,6 +254,7 @@ static sdl3d_input_manager *runtime_input(const sdl3d_game_data_runtime *runtime
 
 static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 position);
 static void lua_push_actor_wrapper(lua_State *lua, const sdl3d_registered_actor *actor);
+static void copy_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value);
 
 static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
 {
@@ -370,6 +394,97 @@ static int lua_get_dt(lua_State *lua)
 {
     lua_pushnumber(lua, sdl3d_game_data_delta_time(lua_runtime(lua)));
     return 1;
+}
+
+static int lua_state_get(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const sdl3d_value *value =
+        sdl3d_properties_get_value(sdl3d_game_data_scene_state(runtime), luaL_checkstring(lua, 1));
+    if (value == NULL)
+    {
+        lua_pushvalue(lua, 2);
+        return 1;
+    }
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        lua_pushinteger(lua, value->as_int);
+        break;
+    case SDL3D_VALUE_FLOAT:
+        lua_pushnumber(lua, value->as_float);
+        break;
+    case SDL3D_VALUE_BOOL:
+        lua_pushboolean(lua, value->as_bool);
+        break;
+    case SDL3D_VALUE_STRING:
+        lua_pushstring(lua, value->as_string != NULL ? value->as_string : "");
+        break;
+    case SDL3D_VALUE_VEC3:
+        lua_newtable(lua);
+        lua_pushnumber(lua, value->as_vec3.x);
+        lua_setfield(lua, -2, "x");
+        lua_pushnumber(lua, value->as_vec3.y);
+        lua_setfield(lua, -2, "y");
+        lua_pushnumber(lua, value->as_vec3.z);
+        lua_setfield(lua, -2, "z");
+        break;
+    case SDL3D_VALUE_COLOR:
+        lua_newtable(lua);
+        lua_pushinteger(lua, value->as_color.r);
+        lua_setfield(lua, -2, "r");
+        lua_pushinteger(lua, value->as_color.g);
+        lua_setfield(lua, -2, "g");
+        lua_pushinteger(lua, value->as_color.b);
+        lua_setfield(lua, -2, "b");
+        lua_pushinteger(lua, value->as_color.a);
+        lua_setfield(lua, -2, "a");
+        break;
+    }
+    return 1;
+}
+
+static int lua_state_set(lua_State *lua)
+{
+    sdl3d_properties *state = sdl3d_game_data_mutable_scene_state(lua_runtime(lua));
+    const char *key = luaL_checkstring(lua, 1);
+    if (state == NULL)
+        return 0;
+
+    if (lua_isnoneornil(lua, 2))
+    {
+        sdl3d_properties_remove(state, key);
+    }
+    else if (lua_isboolean(lua, 2))
+    {
+        sdl3d_properties_set_bool(state, key, lua_toboolean(lua, 2));
+    }
+    else if (lua_isinteger(lua, 2))
+    {
+        sdl3d_properties_set_int(state, key, (int)lua_tointeger(lua, 2));
+    }
+    else if (lua_isnumber(lua, 2))
+    {
+        sdl3d_properties_set_float(state, key, (float)lua_tonumber(lua, 2));
+    }
+    else if (lua_isstring(lua, 2))
+    {
+        sdl3d_properties_set_string(state, key, lua_tostring(lua, 2));
+    }
+    else if (lua_istable(lua, 2))
+    {
+        lua_getfield(lua, 2, "x");
+        lua_getfield(lua, 2, "y");
+        lua_getfield(lua, 2, "z");
+        const bool has_xy = lua_isnumber(lua, -3) && lua_isnumber(lua, -2);
+        const sdl3d_vec3 value = sdl3d_vec3_make((float)lua_tonumber(lua, -3), (float)lua_tonumber(lua, -2),
+                                                 lua_isnumber(lua, -1) ? (float)lua_tonumber(lua, -1) : 0.0f);
+        lua_pop(lua, 3);
+        if (has_xy)
+            sdl3d_properties_set_vec3(state, key, value);
+    }
+    return 0;
 }
 
 static int lua_random(lua_State *lua)
@@ -526,6 +641,18 @@ static void install_lua_helpers(lua_State *lua)
         "            if type(self_or_tag) == 'table' then return sdl3d.actor_with_tags(self_or_tag) end\n"
         "            return sdl3d.actor_with_tags(self_or_tag, maybe_tag, ...)\n"
         "        end,\n"
+        "        state_get = function(self_or_key, maybe_key, fallback)\n"
+        "            if type(self_or_key) == 'table' and self_or_key.adapter ~= nil then\n"
+        "                return sdl3d.state_get(maybe_key, fallback)\n"
+        "            end\n"
+        "            return sdl3d.state_get(self_or_key, maybe_key)\n"
+        "        end,\n"
+        "        state_set = function(self_or_key, maybe_key, maybe_value)\n"
+        "            if type(self_or_key) == 'table' and self_or_key.adapter ~= nil then\n"
+        "                sdl3d.state_set(maybe_key, maybe_value); return\n"
+        "            end\n"
+        "            sdl3d.state_set(self_or_key, maybe_key)\n"
+        "        end,\n"
         "        random = function(_) return sdl3d.random() end,\n"
         "        log = function(self_or_message, maybe_message) sdl3d.log(maybe_message or self_or_message) end,\n"
         "    }\n"
@@ -592,6 +719,8 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("get_vec3", lua_get_vec3);
     SDL3D_LUA_BIND("set_vec3", lua_set_vec3);
     SDL3D_LUA_BIND("dt", lua_get_dt);
+    SDL3D_LUA_BIND("state_get", lua_state_get);
+    SDL3D_LUA_BIND("state_set", lua_state_set);
     SDL3D_LUA_BIND("random", lua_random);
     SDL3D_LUA_BIND("actor_with_tags", lua_actor_with_tags);
     SDL3D_LUA_BIND("log", lua_log);
@@ -677,6 +806,131 @@ static sdl3d_color json_color(yyjson_val *object, const char *key, sdl3d_color f
 static yyjson_val *runtime_root(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL && runtime->doc != NULL ? yyjson_doc_get_root(runtime->doc) : NULL;
+}
+
+static scene_entry *active_scene_entry(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->active_scene_index < 0 || runtime->active_scene_index >= runtime->scene_count)
+        return NULL;
+    return &runtime->scenes[runtime->active_scene_index];
+}
+
+static const scene_entry *active_scene_entry_const(const sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->active_scene_index < 0 || runtime->active_scene_index >= runtime->scene_count)
+        return NULL;
+    return &runtime->scenes[runtime->active_scene_index];
+}
+
+static scene_entry *find_scene(sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->scene_count; ++i)
+    {
+        if (runtime->scenes[i].name != NULL && SDL_strcmp(runtime->scenes[i].name, name) == 0)
+            return &runtime->scenes[i];
+    }
+    return NULL;
+}
+
+static const scene_entry *find_scene_const(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->scene_count; ++i)
+    {
+        if (runtime->scenes[i].name != NULL && SDL_strcmp(runtime->scenes[i].name, name) == 0)
+            return &runtime->scenes[i];
+    }
+    return NULL;
+}
+
+static scene_menu_state *find_scene_menu(scene_entry *scene, const char *name)
+{
+    if (scene == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < scene->menu_count; ++i)
+    {
+        const char *menu_name = json_string(scene->menus[i].menu, "name", NULL);
+        if (menu_name != NULL && SDL_strcmp(menu_name, name) == 0)
+            return &scene->menus[i];
+    }
+    return NULL;
+}
+
+static const scene_menu_state *find_scene_menu_const(const scene_entry *scene, const char *name)
+{
+    if (scene == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < scene->menu_count; ++i)
+    {
+        const char *menu_name = json_string(scene->menus[i].menu, "name", NULL);
+        if (menu_name != NULL && SDL_strcmp(menu_name, name) == 0)
+            return &scene->menus[i];
+    }
+    return NULL;
+}
+
+static bool scene_has_entity(const scene_entry *scene, const char *entity_name)
+{
+    if (scene == NULL || !scene->has_entity_filter)
+        return true;
+    if (entity_name == NULL)
+        return false;
+    for (int i = 0; i < scene->entity_count; ++i)
+    {
+        if (scene->entities[i] != NULL && SDL_strcmp(scene->entities[i], entity_name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool active_scene_has_entity_internal(const sdl3d_game_data_runtime *runtime, const char *entity_name)
+{
+    return scene_has_entity(active_scene_entry_const(runtime), entity_name);
+}
+
+static void apply_scene_camera(sdl3d_game_data_runtime *runtime, const scene_entry *scene)
+{
+    const char *camera = scene != NULL ? json_string(scene->root, "camera", NULL) : NULL;
+    if (runtime != NULL && camera != NULL)
+        runtime->active_camera = camera;
+}
+
+static sdl3d_properties *create_scene_enter_payload(const char *from_scene, const char *to_scene,
+                                                    const sdl3d_properties *payload)
+{
+    sdl3d_properties *enter_payload = sdl3d_properties_create();
+    if (enter_payload == NULL)
+        return NULL;
+
+    const int count = sdl3d_properties_count(payload);
+    for (int i = 0; i < count; ++i)
+    {
+        const char *key = NULL;
+        if (sdl3d_properties_get_key_at(payload, i, &key, NULL))
+            copy_property_value(enter_payload, key, sdl3d_properties_get_value(payload, key));
+    }
+
+    sdl3d_properties_set_string(enter_payload, "from_scene", from_scene != NULL ? from_scene : "");
+    sdl3d_properties_set_string(enter_payload, "to_scene", to_scene != NULL ? to_scene : "");
+    return enter_payload;
+}
+
+static void emit_scene_enter_signal(sdl3d_game_data_runtime *runtime, const scene_entry *scene, const char *from_scene,
+                                    const sdl3d_properties *payload)
+{
+    if (runtime == NULL || scene == NULL)
+        return;
+
+    const int signal_id = sdl3d_game_data_find_signal(runtime, json_string(scene->root, "on_enter_signal", NULL));
+    if (signal_id >= 0 && runtime_bus(runtime) != NULL)
+    {
+        sdl3d_properties *enter_payload = create_scene_enter_payload(from_scene, scene->name, payload);
+        sdl3d_signal_emit(runtime_bus(runtime), signal_id, enter_payload);
+        sdl3d_properties_destroy(enter_payload);
+    }
 }
 
 static yyjson_val *find_entity_json(const sdl3d_game_data_runtime *runtime, const char *name)
@@ -816,6 +1070,19 @@ static sdl3d_builtin_font parse_builtin_font(const char *value, sdl3d_builtin_fo
     return fallback;
 }
 
+static sdl3d_game_data_ui_align parse_ui_align(const char *value, sdl3d_game_data_ui_align fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "left") == 0)
+        return SDL3D_GAME_DATA_UI_ALIGN_LEFT;
+    if (SDL_strcasecmp(value, "center") == 0 || SDL_strcasecmp(value, "middle") == 0)
+        return SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+    if (SDL_strcasecmp(value, "right") == 0)
+        return SDL3D_GAME_DATA_UI_ALIGN_RIGHT;
+    return fallback;
+}
+
 static int axis_index(const char *axis)
 {
     if (axis == NULL)
@@ -864,6 +1131,34 @@ static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 positio
         return;
     actor->position = position;
     sdl3d_properties_set_vec3(actor->props, "origin", position);
+}
+
+static void copy_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
+{
+    if (target == NULL || key == NULL || value == NULL)
+        return;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        sdl3d_properties_set_int(target, key, value->as_int);
+        break;
+    case SDL3D_VALUE_FLOAT:
+        sdl3d_properties_set_float(target, key, value->as_float);
+        break;
+    case SDL3D_VALUE_BOOL:
+        sdl3d_properties_set_bool(target, key, value->as_bool);
+        break;
+    case SDL3D_VALUE_VEC3:
+        sdl3d_properties_set_vec3(target, key, value->as_vec3);
+        break;
+    case SDL3D_VALUE_STRING:
+        sdl3d_properties_set_string(target, key, value->as_string);
+        break;
+    case SDL3D_VALUE_COLOR:
+        sdl3d_properties_set_color(target, key, value->as_color);
+        break;
+    }
 }
 
 static SDL_Scancode scancode_from_json(const char *name)
@@ -922,6 +1217,14 @@ static SDL_GamepadButton gamepad_button_from_json(const char *name)
         return SDL_GAMEPAD_BUTTON_EAST;
     if (SDL_strcmp(name, "WEST") == 0)
         return SDL_GAMEPAD_BUTTON_WEST;
+    if (SDL_strcmp(name, "DPAD_UP") == 0)
+        return SDL_GAMEPAD_BUTTON_DPAD_UP;
+    if (SDL_strcmp(name, "DPAD_DOWN") == 0)
+        return SDL_GAMEPAD_BUTTON_DPAD_DOWN;
+    if (SDL_strcmp(name, "DPAD_LEFT") == 0)
+        return SDL_GAMEPAD_BUTTON_DPAD_LEFT;
+    if (SDL_strcmp(name, "DPAD_RIGHT") == 0)
+        return SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
     return SDL_GAMEPAD_BUTTON_INVALID;
 }
 
@@ -1460,6 +1763,74 @@ bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int
     return true;
 }
 
+static float game_data_clampf(float value, float lo, float hi);
+
+static void light_color_lerp(float color[3], const sdl3d_vec3 target, float t)
+{
+    if (color == NULL)
+        return;
+    t = game_data_clampf(t, 0.0f, 1.0f);
+    color[0] = color[0] + (target.x - color[0]) * t;
+    color[1] = color[1] + (target.y - color[1]) * t;
+    color[2] = color[2] + (target.z - color[2]) * t;
+}
+
+static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_val *light_json,
+                                const sdl3d_game_data_render_eval *eval, sdl3d_light *light)
+{
+    yyjson_val *effects = obj_get(light_json, "effects");
+    if (runtime == NULL || light == NULL || !yyjson_is_arr(effects))
+        return;
+
+    for (size_t i = 0; i < yyjson_arr_size(effects); ++i)
+    {
+        yyjson_val *effect = yyjson_arr_get(effects, i);
+        const char *type = json_string(effect, "type", "");
+        float value = 0.0f;
+        if (SDL_strcmp(type, "pulse") == 0)
+        {
+            const float time = eval != NULL ? eval->time : 0.0f;
+            const float rate = json_float(effect, "rate", 1.0f);
+            const float phase = json_float(effect, "phase", 0.0f);
+            value = 0.5f + 0.5f * SDL_sinf(time * rate + phase);
+        }
+        else if (SDL_strcmp(type, "flash") == 0)
+        {
+            sdl3d_registered_actor *source = sdl3d_game_data_find_actor(runtime, json_string(effect, "source", NULL));
+            const char *property = json_string(effect, "property", NULL);
+            value =
+                source != NULL && property != NULL ? sdl3d_properties_get_float(source->props, property, 0.0f) : 0.0f;
+            value = game_data_clampf(value, 0.0f, 1.0f);
+        }
+        else
+        {
+            continue;
+        }
+
+        yyjson_val *color = obj_get(effect, "color");
+        if (yyjson_is_arr(color))
+        {
+            const sdl3d_vec3 target =
+                json_vec3_value(color, sdl3d_vec3_make(light->color[0], light->color[1], light->color[2]));
+            light_color_lerp(light->color, target, value * json_float(effect, "color_blend", 1.0f));
+        }
+        light->intensity += json_float(effect, "intensity_add", 0.0f) * value;
+        light->range += json_float(effect, "range_add", 0.0f) * value;
+    }
+}
+
+bool sdl3d_game_data_get_world_light_evaluated(const sdl3d_game_data_runtime *runtime, int index,
+                                               const sdl3d_game_data_render_eval *eval, sdl3d_light *out_light)
+{
+    if (!sdl3d_game_data_get_world_light(runtime, index, out_light))
+        return false;
+
+    yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
+    yyjson_val *light_json = yyjson_is_arr(lights) ? yyjson_arr_get(lights, (size_t)index) : NULL;
+    apply_light_effects(runtime, light_json, eval, out_light);
+    return true;
+}
+
 static float game_data_clampf(float value, float lo, float hi)
 {
     if (value < lo)
@@ -1558,6 +1929,8 @@ static bool for_each_render_primitive_internal(const sdl3d_game_data_runtime *ru
     {
         yyjson_val *entity = yyjson_arr_get(entities, i);
         const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
         yyjson_val *components = obj_get(entity, "components");
         if (actor == NULL || !actor->active || !yyjson_is_arr(components))
@@ -1682,6 +2055,38 @@ bool sdl3d_game_data_get_particle_emitter_draw_emissive(const sdl3d_game_data_ru
     return true;
 }
 
+bool sdl3d_game_data_for_each_particle_emitter(const sdl3d_game_data_runtime *runtime,
+                                               sdl3d_game_data_particle_emitter_fn callback, void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
+
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        yyjson_val *component = find_component_json(entity, "particles.emitter");
+        if (actor == NULL || !actor->active || component == NULL)
+            continue;
+
+        sdl3d_game_data_particle_emitter emitter;
+        SDL_zero(emitter);
+        emitter.entity_name = entity_name;
+        if (!sdl3d_game_data_get_particle_emitter(runtime, entity_name, &emitter.config))
+            continue;
+        (void)sdl3d_game_data_get_particle_emitter_draw_emissive(runtime, entity_name, &emitter.draw_emissive);
+
+        if (!callback(userdata, &emitter))
+            return true;
+    }
+    return true;
+}
+
 bool sdl3d_game_data_get_render_settings(const sdl3d_game_data_runtime *runtime,
                                          sdl3d_game_data_render_settings *out_settings)
 {
@@ -1739,33 +2144,311 @@ bool sdl3d_game_data_get_transition(const sdl3d_game_data_runtime *runtime, cons
     return true;
 }
 
+const char *sdl3d_game_data_active_scene(const sdl3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    return scene != NULL ? scene->name : NULL;
+}
+
+int sdl3d_game_data_scene_count(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL ? runtime->scene_count : 0;
+}
+
+const char *sdl3d_game_data_scene_name_at(const sdl3d_game_data_runtime *runtime, int index)
+{
+    if (runtime == NULL || index < 0 || index >= runtime->scene_count)
+        return NULL;
+    return runtime->scenes[index].name;
+}
+
+sdl3d_properties *sdl3d_game_data_mutable_scene_state(sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL ? runtime->scene_state : NULL;
+}
+
+const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL ? runtime->scene_state : NULL;
+}
+
+bool sdl3d_game_data_set_active_scene(sdl3d_game_data_runtime *runtime, const char *scene_name)
+{
+    return sdl3d_game_data_set_active_scene_with_payload(runtime, scene_name, NULL);
+}
+
+bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runtime, const char *scene_name,
+                                                   const sdl3d_properties *payload)
+{
+    scene_entry *scene = find_scene(runtime, scene_name);
+    if (runtime == NULL || scene == NULL)
+        return false;
+
+    const char *previous = sdl3d_game_data_active_scene(runtime);
+    runtime->active_scene_index = (int)(scene - runtime->scenes);
+    apply_scene_camera(runtime, scene);
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data scene set: %s -> %s",
+                 previous != NULL ? previous : "<none>", scene->name != NULL ? scene->name : "<none>");
+    emit_scene_enter_signal(runtime, scene, previous, payload);
+    return true;
+}
+
+bool sdl3d_game_data_active_scene_updates_game(const sdl3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    return scene != NULL ? json_bool(scene->root, "updates_game", true) : true;
+}
+
+bool sdl3d_game_data_active_scene_renders_world(const sdl3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    return scene != NULL ? json_bool(scene->root, "renders_world", true) : true;
+}
+
+bool sdl3d_game_data_active_scene_has_entity(const sdl3d_game_data_runtime *runtime, const char *entity_name)
+{
+    return runtime != NULL && active_scene_has_entity_internal(runtime, entity_name);
+}
+
+bool sdl3d_game_data_get_scene_transition(const sdl3d_game_data_runtime *runtime, const char *scene_name,
+                                          const char *phase, sdl3d_game_data_transition_desc *out_transition)
+{
+    const scene_entry *scene = find_scene_const(runtime, scene_name);
+    if (scene == NULL || phase == NULL)
+        return false;
+
+    const char *transition_name = json_string(obj_get(scene->root, "transitions"), phase, NULL);
+    return transition_name != NULL && sdl3d_game_data_get_transition(runtime, transition_name, out_transition);
+}
+
+bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_menu *out_menu)
+{
+    if (out_menu != NULL)
+    {
+        SDL_zero(*out_menu);
+        out_menu->up_action_id = -1;
+        out_menu->down_action_id = -1;
+        out_menu->select_action_id = -1;
+    }
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    if (runtime == NULL || out_menu == NULL || scene == NULL || scene->menu_count <= 0)
+        return false;
+
+    const scene_menu_state *state = &scene->menus[0];
+    yyjson_val *menu = state->menu;
+    out_menu->name = json_string(menu, "name", NULL);
+    out_menu->up_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "up_action", NULL));
+    out_menu->down_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "down_action", NULL));
+    out_menu->select_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "select_action", NULL));
+    out_menu->selected_index = state->selected_index;
+    out_menu->item_count = state->item_count;
+    return out_menu->name != NULL && out_menu->item_count > 0;
+}
+
+bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *menu_name, int delta)
+{
+    scene_menu_state *menu = find_scene_menu(active_scene_entry(runtime), menu_name);
+    if (menu == NULL || menu->item_count <= 0)
+        return false;
+
+    int next = (menu->selected_index + delta) % menu->item_count;
+    if (next < 0)
+        next += menu->item_count;
+    menu->selected_index = next;
+    return true;
+}
+
+bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
+                                   sdl3d_game_data_menu_item *out_item)
+{
+    if (out_item != NULL)
+    {
+        SDL_zero(*out_item);
+        out_item->signal_id = -1;
+    }
+    const scene_menu_state *menu = find_scene_menu_const(active_scene_entry_const(runtime), menu_name);
+    if (runtime == NULL || menu == NULL || out_item == NULL || index < 0 || index >= menu->item_count)
+        return false;
+
+    yyjson_val *item = yyjson_arr_get(obj_get(menu->menu, "items"), (size_t)index);
+    out_item->label = json_string(item, "label", NULL);
+    out_item->scene = json_string(item, "scene", NULL);
+    out_item->quit = json_bool(item, "quit", false);
+    out_item->signal_id = sdl3d_game_data_find_signal(runtime, json_string(item, "signal", NULL));
+    return yyjson_is_obj(item) && out_item->label != NULL;
+}
+
+int sdl3d_game_data_scene_shortcut_count(const sdl3d_game_data_runtime *runtime)
+{
+    yyjson_val *shortcuts = obj_get(obj_get(runtime_root(runtime), "app"), "scene_shortcuts");
+    return yyjson_is_arr(shortcuts) ? (int)yyjson_arr_size(shortcuts) : 0;
+}
+
+bool sdl3d_game_data_scene_shortcut_at(const sdl3d_game_data_runtime *runtime, int index,
+                                       sdl3d_game_data_scene_shortcut *out_shortcut)
+{
+    if (out_shortcut != NULL)
+    {
+        SDL_zero(*out_shortcut);
+        out_shortcut->action_id = -1;
+    }
+    yyjson_val *shortcuts = obj_get(obj_get(runtime_root(runtime), "app"), "scene_shortcuts");
+    if (runtime == NULL || out_shortcut == NULL || !yyjson_is_arr(shortcuts) || index < 0 ||
+        index >= (int)yyjson_arr_size(shortcuts))
+        return false;
+
+    yyjson_val *shortcut = yyjson_arr_get(shortcuts, (size_t)index);
+    out_shortcut->action = json_string(shortcut, "action", NULL);
+    out_shortcut->scene = json_string(shortcut, "scene", NULL);
+    out_shortcut->action_id = sdl3d_game_data_find_action(runtime, out_shortcut->action);
+    return yyjson_is_obj(shortcut) && out_shortcut->action != NULL && out_shortcut->scene != NULL;
+}
+
+bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
+{
+    sdl3d_game_data_menu menu;
+    if (!sdl3d_game_data_get_active_menu(runtime, &menu))
+        return true;
+    if (input == NULL)
+        return false;
+
+    return (menu.up_action_id < 0 || !sdl3d_input_is_held(input, menu.up_action_id)) &&
+           (menu.down_action_id < 0 || !sdl3d_input_is_held(input, menu.down_action_id)) &&
+           (menu.select_action_id < 0 || !sdl3d_input_is_held(input, menu.select_action_id));
+}
+
+static void ui_text_from_json(yyjson_val *item, sdl3d_game_data_ui_text *text)
+{
+    if (text == NULL)
+        return;
+    SDL_zero(*text);
+    text->name = json_string(item, "name", NULL);
+    text->font = json_string(item, "font", NULL);
+    text->text = json_string(item, "text", NULL);
+    text->format = json_string(item, "format", NULL);
+    text->source = json_string(item, "source", NULL);
+    text->visible = json_string(item, "visible", "always");
+    text->x = json_float(item, "x", 0.0f);
+    text->y = json_float(item, "y", 0.0f);
+    text->normalized = json_bool(item, "normalized", false);
+    text->align = parse_ui_align(json_string(item, "align", NULL), json_bool(item, "centered", false)
+                                                                       ? SDL3D_GAME_DATA_UI_ALIGN_CENTER
+                                                                       : SDL3D_GAME_DATA_UI_ALIGN_LEFT);
+    text->centered = text->align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+    text->pulse_alpha = json_bool(item, "pulse_alpha", false);
+    text->color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
+}
+
+static bool for_each_authored_ui_text_root(yyjson_val *root, sdl3d_game_data_ui_text_fn callback, void *userdata)
+{
+    yyjson_val *texts = obj_get(obj_get(root, "ui"), "text");
+    for (size_t i = 0; yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
+    {
+        sdl3d_game_data_ui_text text;
+        ui_text_from_json(yyjson_arr_get(texts, i), &text);
+        if (!callback(userdata, &text))
+            return false;
+    }
+    return true;
+}
+
+static bool emit_ui_menu_cursor(yyjson_val *presenter, float row_y, sdl3d_game_data_ui_text_fn callback, void *userdata)
+{
+    yyjson_val *cursor = obj_get(presenter, "cursor");
+    if (!yyjson_is_obj(cursor) || !json_bool(cursor, "visible", true))
+        return true;
+
+    sdl3d_game_data_ui_text text;
+    SDL_zero(text);
+    text.name = json_string(presenter, "name", NULL);
+    text.font = json_string(cursor, "font", json_string(presenter, "font", NULL));
+    text.text = json_string(cursor, "text", ">");
+    text.visible = "always";
+    text.x = json_float(presenter, "x", 0.0f) + json_float(cursor, "offset_x", -0.05f);
+    text.y = row_y + json_float(cursor, "offset_y", 0.0f);
+    text.normalized = json_bool(presenter, "normalized", false);
+    text.align = parse_ui_align(json_string(cursor, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_CENTER);
+    text.centered = text.align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+    text.pulse_alpha = json_bool(cursor, "pulse_alpha", false);
+    text.color = json_color(cursor, "color", (sdl3d_color){255, 222, 140, 255});
+    return callback(userdata, &text);
+}
+
+static bool for_each_ui_menu_presenter(const scene_entry *scene, yyjson_val *presenter,
+                                       sdl3d_game_data_ui_text_fn callback, void *userdata)
+{
+    if (scene == NULL || presenter == NULL)
+        return true;
+
+    const scene_menu_state *menu_state = find_scene_menu_const(scene, json_string(presenter, "menu", NULL));
+    yyjson_val *items = menu_state != NULL ? obj_get(menu_state->menu, "items") : NULL;
+    if (menu_state == NULL || !yyjson_is_arr(items))
+        return true;
+
+    const float x = json_float(presenter, "x", 0.0f);
+    const float y = json_float(presenter, "y", 0.0f);
+    const float gap = json_float(presenter, "gap", json_bool(presenter, "normalized", false) ? 0.08f : 42.0f);
+    const bool normalized = json_bool(presenter, "normalized", false);
+    const sdl3d_game_data_ui_align align =
+        parse_ui_align(json_string(presenter, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_CENTER);
+
+    for (int i = 0; i < menu_state->item_count; ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
+        const bool selected = i == menu_state->selected_index;
+        const float row_y = y + gap * (float)i;
+
+        if (selected && !emit_ui_menu_cursor(presenter, row_y, callback, userdata))
+            return false;
+
+        sdl3d_game_data_ui_text text;
+        SDL_zero(text);
+        text.name = json_string(presenter, "name", NULL);
+        text.font = json_string(presenter, "font", NULL);
+        text.text = json_string(item, "label", "");
+        text.visible = "always";
+        text.x = x;
+        text.y = row_y;
+        text.normalized = normalized;
+        text.align = align;
+        text.centered = align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+        text.pulse_alpha = selected && json_bool(presenter, "selected_pulse_alpha", false);
+        text.color = selected ? json_color(presenter, "selected_color",
+                                           json_color(presenter, "color", (sdl3d_color){255, 255, 255, 255}))
+                              : json_color(presenter, "color", (sdl3d_color){255, 255, 255, 255});
+        if (!callback(userdata, &text))
+            return false;
+    }
+    return true;
+}
+
+static bool for_each_ui_menu_root(const scene_entry *scene, yyjson_val *root, sdl3d_game_data_ui_text_fn callback,
+                                  void *userdata)
+{
+    yyjson_val *menus = obj_get(obj_get(root, "ui"), "menus");
+    for (size_t i = 0; yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
+    {
+        if (!for_each_ui_menu_presenter(scene, yyjson_arr_get(menus, i), callback, userdata))
+            return false;
+    }
+    return true;
+}
+
 bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
                                       void *userdata)
 {
     if (runtime == NULL || callback == NULL)
         return false;
 
-    yyjson_val *texts = obj_get(obj_get(runtime_root(runtime), "ui"), "text");
-    for (size_t i = 0; yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
-    {
-        yyjson_val *item = yyjson_arr_get(texts, i);
-        sdl3d_game_data_ui_text text;
-        SDL_zero(text);
-        text.name = json_string(item, "name", NULL);
-        text.font = json_string(item, "font", NULL);
-        text.text = json_string(item, "text", NULL);
-        text.format = json_string(item, "format", NULL);
-        text.source = json_string(item, "source", NULL);
-        text.visible = json_string(item, "visible", "always");
-        text.x = json_float(item, "x", 0.0f);
-        text.y = json_float(item, "y", 0.0f);
-        text.normalized = json_bool(item, "normalized", false);
-        text.centered = json_bool(item, "centered", false);
-        text.pulse_alpha = json_bool(item, "pulse_alpha", false);
-        text.color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
-        if (!callback(userdata, &text))
+    yyjson_val *roots[2];
+    roots[0] = runtime_root(runtime);
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    roots[1] = scene != NULL ? scene->root : NULL;
+
+    for (int root_index = 0; root_index < 2; ++root_index)
+        if (!for_each_authored_ui_text_root(roots[root_index], callback, userdata) ||
+            !for_each_ui_menu_root(scene, roots[root_index], callback, userdata))
             return true;
-    }
     return true;
 }
 
@@ -2358,6 +3041,24 @@ static bool compare_value(const sdl3d_value *left, const char *op, yyjson_val *r
 
 static yyjson_val *find_ui_text_json(const sdl3d_game_data_runtime *runtime, const char *name)
 {
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *scene_texts = obj_get(obj_get(scene != NULL ? scene->root : NULL, "ui"), "text");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(scene_texts) && i < yyjson_arr_size(scene_texts); ++i)
+    {
+        yyjson_val *text = yyjson_arr_get(scene_texts, i);
+        const char *text_name = json_string(text, "name", NULL);
+        if (text_name != NULL && SDL_strcmp(text_name, name) == 0)
+            return text;
+    }
+    yyjson_val *scene_menus = obj_get(obj_get(scene != NULL ? scene->root : NULL, "ui"), "menus");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(scene_menus) && i < yyjson_arr_size(scene_menus); ++i)
+    {
+        yyjson_val *menu = yyjson_arr_get(scene_menus, i);
+        const char *menu_name = json_string(menu, "name", NULL);
+        if (menu_name != NULL && SDL_strcmp(menu_name, name) == 0)
+            return menu;
+    }
+
     yyjson_val *texts = obj_get(obj_get(runtime_root(runtime), "ui"), "text");
     for (size_t i = 0; name != NULL && yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
     {
@@ -2365,6 +3066,14 @@ static yyjson_val *find_ui_text_json(const sdl3d_game_data_runtime *runtime, con
         const char *text_name = json_string(text, "name", NULL);
         if (text_name != NULL && SDL_strcmp(text_name, name) == 0)
             return text;
+    }
+    yyjson_val *menus = obj_get(obj_get(runtime_root(runtime), "ui"), "menus");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
+    {
+        yyjson_val *menu = yyjson_arr_get(menus, i);
+        const char *menu_name = json_string(menu, "name", NULL);
+        if (menu_name != NULL && SDL_strcmp(menu_name, name) == 0)
+            return menu;
     }
     return NULL;
 }
@@ -2395,6 +3104,12 @@ static bool eval_ui_condition(const sdl3d_game_data_runtime *runtime, yyjson_val
     {
         const bool expected = json_bool(condition, "equals", true);
         return (metrics != NULL && metrics->paused) == expected;
+    }
+    if (SDL_strcmp(type, "menu.selected") == 0)
+    {
+        const scene_entry *scene = active_scene_entry_const(runtime);
+        const scene_menu_state *menu = find_scene_menu_const(scene, json_string(condition, "menu", NULL));
+        return menu != NULL && menu->selected_index == json_int(condition, "index", -1);
     }
     if (SDL_strcmp(type, "property.compare") == 0)
     {
@@ -2669,6 +3384,9 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return runtime->active_camera != NULL;
     }
 
+    if (SDL_strcmp(type, "scene.set") == 0)
+        return sdl3d_game_data_set_active_scene_with_payload(runtime, json_string(action, "scene", NULL), payload);
+
     if (SDL_strcmp(type, "adapter.invoke") == 0)
     {
         const char *adapter_name = json_string(action, "adapter", NULL);
@@ -2808,6 +3526,195 @@ static void load_active_camera(sdl3d_game_data_runtime *runtime, yyjson_val *roo
     }
 }
 
+static bool load_scene_menus(scene_entry *scene, char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *menus = obj_get(scene->root, "menus");
+    if (!yyjson_is_arr(menus))
+        return true;
+
+    scene->menu_count = (int)yyjson_arr_size(menus);
+    scene->menus = (scene_menu_state *)SDL_calloc((size_t)scene->menu_count, sizeof(*scene->menus));
+    if (scene->menus == NULL && scene->menu_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate scene menus");
+        return false;
+    }
+
+    for (int i = 0; i < scene->menu_count; ++i)
+    {
+        yyjson_val *menu = yyjson_arr_get(menus, (size_t)i);
+        if (!yyjson_is_obj(menu) || json_string(menu, "name", NULL) == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "scene menu requires a non-empty name");
+            return false;
+        }
+
+        yyjson_val *items = obj_get(menu, "items");
+        if (!yyjson_is_arr(items) || yyjson_arr_size(items) <= 0)
+        {
+            set_error(error_buffer, error_buffer_size, "scene menu requires at least one item");
+            return false;
+        }
+
+        scene->menus[i].menu = menu;
+        scene->menus[i].item_count = (int)yyjson_arr_size(items);
+        scene->menus[i].selected_index = SDL_clamp(json_int(menu, "selected", 0), 0, scene->menus[i].item_count - 1);
+    }
+    return true;
+}
+
+static bool load_scene_entities(scene_entry *scene, char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *entities = obj_get(scene->root, "entities");
+    if (entities == NULL)
+        return true;
+    if (!yyjson_is_arr(entities))
+    {
+        set_error(error_buffer, error_buffer_size, "scene entities must be an array");
+        return false;
+    }
+
+    scene->has_entity_filter = true;
+    scene->entity_count = (int)yyjson_arr_size(entities);
+    if (scene->entity_count <= 0)
+        return true;
+
+    scene->entities = (const char **)SDL_calloc((size_t)scene->entity_count, sizeof(*scene->entities));
+    if (scene->entities == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate scene entity list");
+        return false;
+    }
+
+    for (int i = 0; i < scene->entity_count; ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, (size_t)i);
+        if (!yyjson_is_str(entity) || yyjson_get_str(entity)[0] == '\0')
+        {
+            set_error(error_buffer, error_buffer_size, "scene entity entries must be non-empty strings");
+            return false;
+        }
+        scene->entities[i] = yyjson_get_str(entity);
+    }
+    return true;
+}
+
+static bool load_scenes(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *scenes = obj_get(root, "scenes");
+    yyjson_val *files = obj_get(scenes, "files");
+    if (!yyjson_is_arr(files))
+    {
+        runtime->active_scene_index = -1;
+        return true;
+    }
+
+    runtime->scene_count = (int)yyjson_arr_size(files);
+    runtime->scenes = (scene_entry *)SDL_calloc((size_t)runtime->scene_count, sizeof(*runtime->scenes));
+    if (runtime->scenes == NULL && runtime->scene_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate scene table");
+        return false;
+    }
+
+    for (int i = 0; i < runtime->scene_count; ++i)
+    {
+        yyjson_val *file = yyjson_arr_get(files, (size_t)i);
+        if (!yyjson_is_str(file) || yyjson_get_str(file)[0] == '\0')
+        {
+            set_error(error_buffer, error_buffer_size, "scene files must be non-empty strings");
+            return false;
+        }
+
+        char *resolved_path = path_join(runtime->base_dir, yyjson_get_str(file));
+        if (resolved_path == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to resolve scene path");
+            return false;
+        }
+
+        sdl3d_asset_buffer scene_buffer;
+        SDL_zero(scene_buffer);
+        char asset_error[256];
+        if (!sdl3d_asset_resolver_read_file(runtime->assets, resolved_path, &scene_buffer, asset_error,
+                                            (int)sizeof(asset_error)))
+        {
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size, "scene asset %s could not be read: %s",
+                             yyjson_get_str(file), asset_error);
+            }
+            SDL_free(resolved_path);
+            return false;
+        }
+
+        yyjson_read_err err;
+        yyjson_doc *doc =
+            yyjson_read_opts((char *)scene_buffer.data, scene_buffer.size, YYJSON_READ_NOFLAG, NULL, &err);
+        sdl3d_asset_buffer_free(&scene_buffer);
+        SDL_free(resolved_path);
+        if (doc == NULL)
+        {
+            if (error_buffer != NULL && error_buffer_size > 0)
+            {
+                SDL_snprintf(error_buffer, (size_t)error_buffer_size, "scene yyjson error %u at byte %llu: %s",
+                             err.code, (unsigned long long)err.pos, err.msg != NULL ? err.msg : "");
+            }
+            return false;
+        }
+
+        yyjson_val *scene_root = yyjson_doc_get_root(doc);
+        const char *schema = json_string(scene_root, "schema", NULL);
+        const char *name = json_string(scene_root, "name", NULL);
+        if (!yyjson_is_obj(scene_root) || schema == NULL || SDL_strcmp(schema, "sdl3d.scene.v0") != 0 || name == NULL ||
+            name[0] == '\0')
+        {
+            yyjson_doc_free(doc);
+            set_error(error_buffer, error_buffer_size, "scene file has unsupported schema or missing name");
+            return false;
+        }
+        for (int prior = 0; prior < i; ++prior)
+        {
+            if (SDL_strcmp(runtime->scenes[prior].name, name) == 0)
+            {
+                yyjson_doc_free(doc);
+                set_error(error_buffer, error_buffer_size, "duplicate scene name");
+                return false;
+            }
+        }
+
+        runtime->scenes[i].doc = doc;
+        runtime->scenes[i].root = scene_root;
+        runtime->scenes[i].name = name;
+        if (!load_scene_entities(&runtime->scenes[i], error_buffer, error_buffer_size) ||
+            !load_scene_menus(&runtime->scenes[i], error_buffer, error_buffer_size))
+            return false;
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "SDL3D game data scene loaded: name=%s updates_game=%d renders_world=%d entities=%d menus=%d",
+                     name, json_bool(scene_root, "updates_game", true) ? 1 : 0,
+                     json_bool(scene_root, "renders_world", true) ? 1 : 0, runtime->scenes[i].entity_count,
+                     runtime->scenes[i].menu_count);
+    }
+
+    runtime->active_scene_index = runtime->scene_count > 0 ? 0 : -1;
+    const char *initial = json_string(scenes, "initial", NULL);
+    if (initial != NULL)
+    {
+        scene_entry *scene = find_scene(runtime, initial);
+        if (scene == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "initial scene does not reference a loaded scene");
+            return false;
+        }
+        runtime->active_scene_index = (int)(scene - runtime->scenes);
+    }
+    apply_scene_camera(runtime, active_scene_entry(runtime));
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data initial scene: %s",
+                 sdl3d_game_data_active_scene(runtime) != NULL ? sdl3d_game_data_active_scene(runtime) : "<none>");
+    emit_scene_enter_signal(runtime, active_scene_entry(runtime), NULL, NULL);
+    return true;
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -2819,7 +3726,10 @@ static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_v
     for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
         yyjson_val *entity = yyjson_arr_get(entities, i);
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(entity, "name", NULL));
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
         yyjson_val *components = obj_get(entity, "components");
         if (actor == NULL || !actor->active || !yyjson_is_arr(components))
             continue;
@@ -2866,7 +3776,10 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
     for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
         yyjson_val *entity = yyjson_arr_get(entities, i);
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(entity, "name", NULL));
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
         yyjson_val *components = obj_get(entity, "components");
         if (actor == NULL || !actor->active || !yyjson_is_arr(components))
             continue;
@@ -2886,6 +3799,73 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
                                                       actor->position.y + velocity.y * dt, actor->position.z));
         }
     }
+}
+
+static float move_float_toward(float value, float target, float max_delta)
+{
+    if (max_delta < 0.0f)
+        max_delta = -max_delta;
+    if (value < target)
+        return SDL_min(value + max_delta, target);
+    if (value > target)
+        return SDL_max(value - max_delta, target);
+    return target;
+}
+
+bool sdl3d_game_data_update_property_effects(sdl3d_game_data_runtime *runtime, float dt)
+{
+    if (runtime == NULL || runtime->doc == NULL)
+        return false;
+    if (dt < 0.0f)
+        dt = 0.0f;
+
+    bool ok = true;
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
+
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        yyjson_val *components = obj_get(entity, "components");
+        if (actor == NULL || !actor->active || !yyjson_is_arr(components))
+            continue;
+
+        for (size_t c = 0; c < yyjson_arr_size(components); ++c)
+        {
+            yyjson_val *component = yyjson_arr_get(components, c);
+            if (SDL_strcmp(json_string(component, "type", ""), "property.decay") != 0)
+                continue;
+
+            const char *property = json_string(component, "property", NULL);
+            const sdl3d_value *existing = property != NULL ? sdl3d_properties_get_value(actor->props, property) : NULL;
+            if (property == NULL || existing == NULL ||
+                (existing->type != SDL3D_VALUE_FLOAT && existing->type != SDL3D_VALUE_INT))
+            {
+                ok = false;
+                continue;
+            }
+
+            const char *rate_property = json_string(component, "rate_property", NULL);
+            const float rate = rate_property != NULL ? sdl3d_properties_get_float(actor->props, rate_property, 0.0f)
+                                                     : json_float(component, "rate", 1.0f);
+            const float target = json_float(component, "target", 0.0f);
+            float value = existing->type == SDL3D_VALUE_FLOAT ? existing->as_float : (float)existing->as_int;
+            value = move_float_toward(value, target, rate * dt);
+            if (obj_get(component, "min") != NULL)
+                value = SDL_max(value, json_float(component, "min", value));
+            if (obj_get(component, "max") != NULL)
+                value = SDL_min(value, json_float(component, "max", value));
+
+            if (existing->type == SDL3D_VALUE_INT)
+                sdl3d_properties_set_int(actor->props, property, (int)SDL_lroundf(value));
+            else
+                sdl3d_properties_set_float(actor->props, property, value);
+        }
+    }
+    return ok;
 }
 
 static void emit_sensor_signal(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor, sdl3d_registered_actor *a,
@@ -2912,6 +3892,13 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
     for (int i = 0; i < runtime->sensor_count; ++i)
     {
         sensor_entry *sensor = &runtime->sensors[i];
+        if ((sensor->entity != NULL && !active_scene_has_entity_internal(runtime, sensor->entity)) ||
+            (sensor->other != NULL && !active_scene_has_entity_internal(runtime, sensor->other)))
+        {
+            sensor->was_active = false;
+            continue;
+        }
+
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, sensor->entity);
         if (sensor->type == GAME_DATA_SENSOR_INPUT_PRESSED)
         {
@@ -3291,11 +4278,12 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
     runtime->session = session;
     runtime->assets = assets;
     runtime->base_dir = path_dirname(asset_path_without_scheme(asset_path));
+    runtime->scene_state = sdl3d_properties_create();
     runtime->rng_state = 0xC0FFEEu;
-    if (runtime->base_dir == NULL)
+    if (runtime->base_dir == NULL || runtime->scene_state == NULL)
     {
         sdl3d_game_data_destroy(runtime);
-        set_error(error_buffer, error_buffer_size, "failed to resolve game data base directory");
+        set_error(error_buffer, error_buffer_size, "failed to allocate game data runtime state");
         return false;
     }
     if (!sdl3d_game_data_validate_document(root, asset_path, runtime->base_dir, assets, NULL, error_buffer,
@@ -3306,20 +4294,21 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
     }
 
     yyjson_val *logic = obj_get(root, "logic");
+    load_active_camera(runtime, root);
     bool ok = load_signals(runtime, root, error_buffer, error_buffer_size) &&
               load_entities(runtime, root, error_buffer, error_buffer_size) &&
               load_input(runtime, root, error_buffer, error_buffer_size) &&
               load_timers(runtime, logic, error_buffer, error_buffer_size) && load_sensors(runtime, logic) &&
               load_scripts(runtime, root, error_buffer, error_buffer_size) &&
               load_lua_adapters(runtime, root, error_buffer, error_buffer_size) &&
-              load_bindings(runtime, logic, error_buffer, error_buffer_size);
+              load_bindings(runtime, logic, error_buffer, error_buffer_size) &&
+              load_scenes(runtime, root, error_buffer, error_buffer_size);
     if (!ok)
     {
         sdl3d_game_data_destroy(runtime);
         return false;
     }
 
-    load_active_camera(runtime, root);
     runtime->assets = NULL;
     *out_runtime = runtime;
     return true;
@@ -3392,9 +4381,17 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         sdl3d_script_engine_unref(runtime->scripts, runtime->script_entries[i].module_ref);
         SDL_free(runtime->script_entries[i].dependencies);
     }
+    for (int i = 0; i < runtime->scene_count; ++i)
+    {
+        SDL_free(runtime->scenes[i].entities);
+        SDL_free(runtime->scenes[i].menus);
+        yyjson_doc_free(runtime->scenes[i].doc);
+    }
 
     sdl3d_script_engine_destroy(runtime->scripts);
+    sdl3d_properties_destroy(runtime->scene_state);
     SDL_free(runtime->base_dir);
+    SDL_free(runtime->scenes);
     SDL_free(runtime->script_entries);
     SDL_free(runtime->signals);
     SDL_free(runtime->timers);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1074,6 +1074,89 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
         if (!require_ref(ctx, &names->scenes, "scene", json_string(shortcut, "scene"), path))
             return false;
     }
+
+    yyjson_val *input_policy = obj_get(app, "input_policy");
+    if (input_policy != NULL && !yyjson_is_obj(input_policy))
+        return validation_error(ctx, "$.app.input_policy", "input_policy must be an object");
+    yyjson_val *global_actions = obj_get(input_policy, "global_actions");
+    if (global_actions != NULL && !yyjson_is_arr(global_actions))
+        return validation_error(ctx, "$.app.input_policy.global_actions", "global_actions must be an array");
+    for (size_t i = 0; yyjson_is_arr(global_actions) && i < yyjson_arr_size(global_actions); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.app.input_policy.global_actions[%zu]", i);
+        yyjson_val *global_action = yyjson_arr_get(global_actions, i);
+        if (!yyjson_is_str(global_action) ||
+            !require_ref(ctx, &names->actions, "input action", yyjson_get_str(global_action), path))
+            return false;
+    }
+
+    yyjson_val *transition_policy = obj_get(app, "scene_transition_policy");
+    if (transition_policy != NULL && !yyjson_is_obj(transition_policy))
+        return validation_error(ctx, "$.app.scene_transition_policy", "scene_transition_policy must be an object");
+    return true;
+}
+
+static bool validate_update_phases(validation_context *ctx, yyjson_val *phases, const char *json_path)
+{
+    if (phases == NULL)
+        return true;
+    if (!yyjson_is_obj(phases))
+        return validation_error(ctx, json_path, "update_phases must be an object");
+
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(phases, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        yyjson_val *entry = yyjson_obj_iter_get_val(key);
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s.%s", json_path, yyjson_get_str(key));
+        if (!yyjson_is_bool(entry) && !yyjson_is_obj(entry))
+            return validation_error(ctx, path, "update phase must be a bool or object");
+    }
+    return true;
+}
+
+static bool validate_presentation(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *presentation = obj_get(root, "presentation");
+    if (presentation == NULL)
+        return true;
+    if (!yyjson_is_obj(presentation))
+        return validation_error(ctx, "$.presentation", "presentation must be an object");
+
+    yyjson_val *clocks = obj_get(presentation, "clocks");
+    if (clocks != NULL && !yyjson_is_arr(clocks))
+        return validation_error(ctx, "$.presentation.clocks", "clocks must be an array");
+    for (size_t i = 0; yyjson_is_arr(clocks) && i < yyjson_arr_size(clocks); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.presentation.clocks[%zu]", i);
+        yyjson_val *clock = yyjson_arr_get(clocks, i);
+        if (!yyjson_is_obj(clock))
+            return validation_error(ctx, path, "presentation clock must be an object");
+        if (!is_non_empty_string(clock, "name"))
+            return validation_error(ctx, path, "presentation clock requires a non-empty name");
+        if (!require_ref(ctx, &names->entities, "entity", json_string(clock, "target"), path))
+            return false;
+        if (!is_non_empty_string(clock, "key"))
+            return validation_error(ctx, path, "presentation clock requires a non-empty key");
+        yyjson_val *speed_property = obj_get(clock, "speed_property");
+        if (speed_property != NULL)
+        {
+            if (!yyjson_is_obj(speed_property))
+                return validation_error(ctx, path, "speed_property must be an object");
+            if (!require_ref(ctx, &names->entities, "entity", json_string(speed_property, "target"), path))
+                return false;
+            if (!is_non_empty_string(speed_property, "key"))
+                return validation_error(ctx, path, "speed_property requires a non-empty key");
+        }
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.active_if", path);
+        if (!validate_data_condition(ctx, obj_get(clock, "active_if"), condition_path, names))
+            return false;
+    }
     return true;
 }
 
@@ -1413,6 +1496,38 @@ static bool validate_scene_ui_condition(validation_context *ctx, yyjson_val *con
     return validate_data_condition(ctx, condition, path, names);
 }
 
+static bool validate_menu_item_control(validation_context *ctx, yyjson_val *control, const char *path,
+                                       validation_names *names)
+{
+    if (control == NULL)
+        return true;
+    if (!yyjson_is_obj(control))
+        return validation_error(ctx, path, "menu item control must be an object");
+
+    const char *type = json_string(control, "type");
+    if (type == NULL ||
+        (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 && SDL_strcmp(type, "range") != 0))
+        return validation_error(ctx, path, "menu item control requires type toggle, choice, or range");
+    if (!require_ref(ctx, &names->entities, "entity", json_string(control, "target"), path))
+        return false;
+    if (!is_non_empty_string(control, "key"))
+        return validation_error(ctx, path, "menu item control requires a non-empty key");
+
+    if (SDL_strcmp(type, "choice") == 0)
+    {
+        yyjson_val *choices = obj_get(control, "choices");
+        if (!yyjson_is_arr(choices) || yyjson_arr_size(choices) == 0)
+            return validation_error(ctx, path, "choice control requires at least one choice");
+    }
+    if (SDL_strcmp(type, "range") == 0)
+    {
+        if (!yyjson_is_num(obj_get(control, "min")) || !yyjson_is_num(obj_get(control, "max")) ||
+            !yyjson_is_num(obj_get(control, "step")))
+            return validation_error(ctx, path, "range control requires numeric min, max, and step");
+    }
+    return true;
+}
+
 static bool scene_has_menu_name(yyjson_val *scene_root, const char *name)
 {
     yyjson_val *menus = obj_get(scene_root, "menus");
@@ -1450,6 +1565,27 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     const char *camera = json_string(root, "camera");
     if (camera != NULL && !require_ref(ctx, &names->cameras, "camera", camera, json_path))
         return false;
+
+    char phases_path[PATH_BUFFER_SIZE];
+    format_path(phases_path, sizeof(phases_path), "%s.update_phases", json_path);
+    if (!validate_update_phases(ctx, obj_get(root, "update_phases"), phases_path))
+        return false;
+
+    yyjson_val *scene_input = obj_get(root, "input");
+    if (scene_input != NULL && !yyjson_is_obj(scene_input))
+        return validation_error(ctx, json_path, "scene input must be an object");
+    yyjson_val *scene_actions = obj_get(scene_input, "actions");
+    if (scene_actions != NULL && !yyjson_is_arr(scene_actions))
+        return validation_error(ctx, json_path, "scene input.actions must be an array");
+    for (size_t i = 0; yyjson_is_arr(scene_actions) && i < yyjson_arr_size(scene_actions); ++i)
+    {
+        char action_path[PATH_BUFFER_SIZE];
+        format_path(action_path, sizeof(action_path), "%s.input.actions[%zu]", json_path, i);
+        yyjson_val *action = yyjson_arr_get(scene_actions, i);
+        if (!yyjson_is_str(action) ||
+            !require_ref(ctx, &names->actions, "input action", yyjson_get_str(action), action_path))
+            return false;
+    }
 
     yyjson_val *entities = obj_get(root, "entities");
     if (entities != NULL && !yyjson_is_arr(entities))
@@ -1495,6 +1631,10 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
                 return false;
             const char *signal = json_string(item, "signal");
             if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, item_path))
+                return false;
+            char control_path[PATH_BUFFER_SIZE];
+            format_path(control_path, sizeof(control_path), "%s.control", item_path);
+            if (!validate_menu_item_control(ctx, obj_get(item, "control"), control_path, names))
                 return false;
         }
     }
@@ -1623,10 +1763,12 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+           validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases") &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
-           validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
-           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
+           validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
+           validate_lights(ctx, root, names) && validate_logic(ctx, root, names) &&
+           validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -61,6 +61,9 @@ typedef struct validation_names
     int script_count;
 } validation_names;
 
+static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
+                                    validation_names *names);
+
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
 {
     return yyjson_is_obj(object) ? yyjson_obj_get(object, key) : NULL;
@@ -1030,8 +1033,13 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     const char *start_signal = json_string(app, "start_signal");
     if (start_signal != NULL && !require_ref(ctx, &names->signals, "signal", start_signal, "$.app.start_signal"))
         return false;
-    const char *pause_action = json_string(app, "pause_action");
-    if (pause_action != NULL && !require_ref(ctx, &names->actions, "input action", pause_action, "$.app.pause_action"))
+    yyjson_val *pause = obj_get(app, "pause");
+    if (pause != NULL && !yyjson_is_obj(pause))
+        return validation_error(ctx, "$.app.pause", "pause must be an object");
+    const char *pause_action = json_string(pause, "action");
+    if (pause_action != NULL && !require_ref(ctx, &names->actions, "input action", pause_action, "$.app.pause.action"))
+        return false;
+    if (!validate_data_condition(ctx, obj_get(pause, "allowed_if"), "$.app.pause.allowed_if", names))
         return false;
     const char *startup_transition = json_string(app, "startup_transition");
     if (startup_transition != NULL && !yyjson_is_obj(obj_get(obj_get(root, "transitions"), startup_transition)))
@@ -1098,8 +1106,8 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
     return true;
 }
 
-static bool validate_ui_condition(validation_context *ctx, yyjson_val *condition, const char *path,
-                                  validation_names *names)
+static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
+                                    validation_names *names)
 {
     if (condition == NULL)
         return true;
@@ -1117,32 +1125,34 @@ static bool validate_ui_condition(validation_context *ctx, yyjson_val *condition
         if (!require_ref(ctx, &names->entities, "entity", json_string(condition, "target"), path))
             return false;
         if (!is_non_empty_string(condition, "key"))
-            return validation_error(ctx, path, "UI property condition requires a non-empty key");
+            return validation_error(ctx, path, "property condition requires a non-empty key");
         if (SDL_strcmp(type, "property.compare") == 0 && !is_compare_op(json_string(condition, "op")))
-            return validation_error(ctx, path, "UI property.compare requires a supported comparison operator");
+            return validation_error(ctx, path, "property.compare condition requires a supported comparison operator");
+        if (SDL_strcmp(type, "property.compare") == 0 && obj_get(condition, "value") == NULL)
+            return validation_error(ctx, path, "property.compare condition requires a value");
         return true;
     }
     if (SDL_strcmp(type != NULL ? type : "", "not") == 0)
     {
         char child_path[PATH_BUFFER_SIZE];
         format_path(child_path, sizeof(child_path), "%s.condition", path);
-        return validate_ui_condition(ctx, obj_get(condition, "condition"), child_path, names);
+        return validate_data_condition(ctx, obj_get(condition, "condition"), child_path, names);
     }
     if (SDL_strcmp(type != NULL ? type : "", "all") == 0 || SDL_strcmp(type != NULL ? type : "", "any") == 0)
     {
         yyjson_val *conditions = obj_get(condition, "conditions");
         if (!yyjson_is_arr(conditions))
-            return validation_error(ctx, path, "UI %s condition requires a conditions array", type);
+            return validation_error(ctx, path, "%s condition requires a conditions array", type);
         for (size_t i = 0; i < yyjson_arr_size(conditions); ++i)
         {
             char child_path[PATH_BUFFER_SIZE];
             format_path(child_path, sizeof(child_path), "%s.conditions[%zu]", path, i);
-            if (!validate_ui_condition(ctx, yyjson_arr_get(conditions, i), child_path, names))
+            if (!validate_data_condition(ctx, yyjson_arr_get(conditions, i), child_path, names))
                 return false;
         }
         return true;
     }
-    return validation_error(ctx, path, "unsupported UI condition type '%s'", type != NULL ? type : "<missing>");
+    return validation_error(ctx, path, "unsupported condition type '%s'", type != NULL ? type : "<missing>");
 }
 
 static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_names *names)
@@ -1169,7 +1179,7 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
             return false;
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
-        if (!validate_ui_condition(ctx, obj_get(text, "visible_if"), condition_path, names))
+        if (!validate_data_condition(ctx, obj_get(text, "visible_if"), condition_path, names))
             return false;
 
         yyjson_val *bindings = obj_get(text, "bindings");
@@ -1213,7 +1223,7 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
             return false;
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
-        if (!validate_ui_condition(ctx, obj_get(menu, "visible_if"), condition_path, names))
+        if (!validate_data_condition(ctx, obj_get(menu, "visible_if"), condition_path, names))
             return false;
     }
     return true;
@@ -1400,7 +1410,7 @@ static bool validate_scene_ui_condition(validation_context *ctx, yyjson_val *con
             return validation_error(ctx, path, "menu.selected condition requires an integer index");
         return true;
     }
-    return validate_ui_condition(ctx, condition, path, names);
+    return validate_data_condition(ctx, condition, path, names);
 }
 
 static bool scene_has_menu_name(yyjson_val *scene_root, const char *name)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -53,6 +53,7 @@ typedef struct validation_names
     name_table timers;
     name_table cameras;
     name_table fonts;
+    name_table scenes;
     name_table sensors;
     name_table used_adapters;
     name_table used_scripts;
@@ -147,6 +148,8 @@ static void name_table_destroy(name_table *table)
     if (table == NULL)
         return;
     for (int i = 0; i < table->count; ++i)
+        SDL_free((void *)table->names[i]);
+    for (int i = 0; i < table->count; ++i)
         SDL_free((void *)table->paths[i]);
     SDL_free(table->names);
     SDL_free(table->paths);
@@ -181,14 +184,20 @@ static const char *name_table_path(const name_table *table, const char *name)
 
 static bool name_table_add(name_table *table, const char *name, const char *json_path)
 {
+    char *name_copy = SDL_strdup(name != NULL ? name : "");
     char *path_copy = SDL_strdup(json_path != NULL ? json_path : "$");
-    if (path_copy == NULL)
+    if (name_copy == NULL || path_copy == NULL)
+    {
+        SDL_free(name_copy);
+        SDL_free(path_copy);
         return false;
+    }
 
     const int next_count = table->count + 1;
     const char **names = (const char **)SDL_realloc(table->names, (size_t)next_count * sizeof(*names));
     if (names == NULL)
     {
+        SDL_free(name_copy);
         SDL_free(path_copy);
         return false;
     }
@@ -197,12 +206,13 @@ static bool name_table_add(name_table *table, const char *name, const char *json
     const char **paths = (const char **)SDL_realloc(table->paths, (size_t)next_count * sizeof(*paths));
     if (paths == NULL)
     {
+        SDL_free(name_copy);
         SDL_free(path_copy);
         return false;
     }
     table->paths = paths;
 
-    table->names[table->count] = name;
+    table->names[table->count] = name_copy;
     table->paths[table->count] = path_copy;
     table->count = next_count;
     return true;
@@ -373,8 +383,8 @@ static bool is_vec_array(yyjson_val *value, size_t min_count)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb",    "collision.circle", "control.axis_1d",
-        "motion.velocity_2d", "particles.emitter", "render.cube",      "render.sphere",
+        "adapter.controller", "collision.aabb", "collision.circle", "control.axis_1d", "motion.velocity_2d",
+        "particles.emitter",  "property.decay", "render.cube",      "render.sphere",
     };
 
     if (type == NULL)
@@ -786,6 +796,13 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                     !require_ref(ctx, &names->entities, "entity", json_string(component, "target"), path))
                     return false;
             }
+            else if (SDL_strcmp(type, "property.decay") == 0)
+            {
+                if (!is_non_empty_string(component, "property"))
+                    return validation_error(ctx, path, "property.decay requires a non-empty property");
+                if (json_string(component, "rate_property") == NULL && !yyjson_is_num(obj_get(component, "rate")))
+                    return validation_error(ctx, path, "property.decay requires rate or rate_property");
+            }
         }
     }
     return true;
@@ -830,6 +847,8 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return require_ref(ctx, &names->cameras, "camera", json_string(action, "camera"), json_path) &&
                require_ref(ctx, &names->cameras, "camera", json_string(action, "fallback"), json_path);
     }
+    if (SDL_strcmp(type, "scene.set") == 0)
+        return require_ref(ctx, &names->scenes, "scene", json_string(action, "scene"), json_path);
     if (SDL_strcmp(type, "adapter.invoke") == 0)
     {
         const char *adapter = json_string(action, "adapter");
@@ -1031,6 +1050,22 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     const char *transition = json_string(quit, "transition");
     if (transition != NULL && !yyjson_is_obj(obj_get(obj_get(root, "transitions"), transition)))
         return validation_error(ctx, "$.app.quit.transition", "unknown transition reference '%s'", transition);
+
+    yyjson_val *shortcuts = obj_get(app, "scene_shortcuts");
+    if (shortcuts != NULL && !yyjson_is_arr(shortcuts))
+        return validation_error(ctx, "$.app.scene_shortcuts", "scene_shortcuts must be an array");
+    for (size_t i = 0; yyjson_is_arr(shortcuts) && i < yyjson_arr_size(shortcuts); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.app.scene_shortcuts[%zu]", i);
+        yyjson_val *shortcut = yyjson_arr_get(shortcuts, i);
+        if (!yyjson_is_obj(shortcut))
+            return validation_error(ctx, path, "scene shortcut must be an object");
+        if (!require_ref(ctx, &names->actions, "input action", json_string(shortcut, "action"), path))
+            return false;
+        if (!require_ref(ctx, &names->scenes, "scene", json_string(shortcut, "scene"), path))
+            return false;
+    }
     return true;
 }
 
@@ -1112,11 +1147,15 @@ static bool validate_ui_condition(validation_context *ctx, yyjson_val *condition
 
 static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
-    yyjson_val *texts = obj_get(obj_get(root, "ui"), "text");
-    if (texts == NULL)
+    yyjson_val *ui = obj_get(root, "ui");
+    yyjson_val *texts = obj_get(ui, "text");
+    yyjson_val *menus = obj_get(ui, "menus");
+    if (texts == NULL && menus == NULL)
         return true;
-    if (!yyjson_is_arr(texts))
+    if (texts != NULL && !yyjson_is_arr(texts))
         return validation_error(ctx, "$.ui.text", "UI text must be an array");
+    if (menus != NULL && !yyjson_is_arr(menus))
+        return validation_error(ctx, "$.ui.menus", "UI menus must be an array");
 
     for (size_t i = 0; i < yyjson_arr_size(texts); ++i)
     {
@@ -1153,6 +1192,29 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
                                         type != NULL ? type : "<missing>");
             }
         }
+    }
+
+    for (size_t i = 0; yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.ui.menus[%zu]", i);
+        yyjson_val *menu = yyjson_arr_get(menus, i);
+        if (!yyjson_is_obj(menu))
+            return validation_error(ctx, path, "UI menu presenters must be objects");
+        if (!is_non_empty_string(menu, "name"))
+            return validation_error(ctx, path, "UI menu presenter requires a non-empty name");
+        if (!is_non_empty_string(menu, "menu"))
+            return validation_error(ctx, path, "UI menu presenter requires a menu reference");
+        if (!require_ref(ctx, &names->fonts, "font asset", json_string(menu, "font"), path))
+            return false;
+        yyjson_val *cursor = obj_get(menu, "cursor");
+        if (yyjson_is_obj(cursor) && json_string(cursor, "font") != NULL &&
+            !require_ref(ctx, &names->fonts, "font asset", json_string(cursor, "font"), path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
+        if (!validate_ui_condition(ctx, obj_get(menu, "visible_if"), condition_path, names))
+            return false;
     }
     return true;
 }
@@ -1207,6 +1269,27 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
         const char *target_entity = json_string(light, "target_entity");
         if (target_entity != NULL && !require_ref(ctx, &names->entities, "entity", target_entity, path))
             return false;
+
+        yyjson_val *effects = obj_get(light, "effects");
+        for (size_t e = 0; yyjson_is_arr(effects) && e < yyjson_arr_size(effects); ++e)
+        {
+            char effect_path[PATH_BUFFER_SIZE];
+            format_path(effect_path, sizeof(effect_path), "%s.effects[%zu]", path, e);
+            yyjson_val *effect = yyjson_arr_get(effects, e);
+            const char *type = json_string(effect, "type");
+            if (SDL_strcmp(type != NULL ? type : "", "flash") == 0)
+            {
+                if (!require_ref(ctx, &names->entities, "entity", json_string(effect, "source"), effect_path))
+                    return false;
+                if (!is_non_empty_string(effect, "property"))
+                    return validation_error(ctx, effect_path, "light flash effect requires a non-empty property");
+            }
+            else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0)
+            {
+                return validation_error(ctx, effect_path, "unsupported light effect type '%s'",
+                                        type != NULL ? type : "<missing>");
+            }
+        }
     }
     return true;
 }
@@ -1237,6 +1320,283 @@ static bool validate_transitions(validation_context *ctx, yyjson_val *root, vali
     return true;
 }
 
+typedef struct validation_scene_doc
+{
+    yyjson_doc *doc;
+    yyjson_val *root;
+} validation_scene_doc;
+
+static void validation_scene_docs_destroy(validation_scene_doc *docs, int count)
+{
+    if (docs == NULL)
+        return;
+    for (int i = 0; i < count; ++i)
+        yyjson_doc_free(docs[i].doc);
+    SDL_free(docs);
+}
+
+static bool validate_scene_file(validation_context *ctx, validation_names *names, const char *scene_path,
+                                int scene_index, validation_scene_doc *out_doc)
+{
+    char path[PATH_BUFFER_SIZE];
+    format_path(path, sizeof(path), "$.scenes.files[%d]", scene_index);
+    if (scene_path == NULL || scene_path[0] == '\0')
+        return validation_error(ctx, path, "scene file entries must be non-empty strings");
+
+    char *resolved = path_join(ctx->base_dir, scene_path);
+    if (resolved == NULL)
+        return validation_error(ctx, path, "failed to resolve scene file '%s'", scene_path);
+
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+    char asset_error[256];
+    const bool read_ok = ctx->assets != NULL && sdl3d_asset_resolver_read_file(ctx->assets, resolved, &buffer,
+                                                                               asset_error, (int)sizeof(asset_error));
+    SDL_free(resolved);
+    if (!read_ok)
+        return validation_error(ctx, path, "scene asset '%s' does not exist or cannot be read", scene_path);
+
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, &err);
+    sdl3d_asset_buffer_free(&buffer);
+    if (doc == NULL)
+    {
+        return validation_error(ctx, path, "scene yyjson error %u at byte %llu: %s", err.code,
+                                (unsigned long long)err.pos, err.msg != NULL ? err.msg : "");
+    }
+
+    yyjson_val *scene_root = yyjson_doc_get_root(doc);
+    if (!yyjson_is_obj(scene_root) ||
+        SDL_strcmp(json_string(scene_root, "schema") != NULL ? json_string(scene_root, "schema") : "",
+                   "sdl3d.scene.v0") != 0)
+    {
+        yyjson_doc_free(doc);
+        return validation_error(ctx, path, "scene file must use schema sdl3d.scene.v0");
+    }
+
+    const char *name = json_string(scene_root, "name");
+    if (!require_unique_name(ctx, &names->scenes, "scene", name, path))
+    {
+        yyjson_doc_free(doc);
+        return false;
+    }
+
+    out_doc->doc = doc;
+    out_doc->root = scene_root;
+    return true;
+}
+
+static bool validate_scene_ui_condition(validation_context *ctx, yyjson_val *condition, const char *path,
+                                        validation_names *names)
+{
+    if (condition == NULL)
+        return true;
+    const char *type = json_string(condition, "type");
+    if (SDL_strcmp(type != NULL ? type : "", "menu.selected") == 0)
+    {
+        if (!is_non_empty_string(condition, "menu"))
+            return validation_error(ctx, path, "menu.selected condition requires a menu name");
+        if (!yyjson_is_int(obj_get(condition, "index")))
+            return validation_error(ctx, path, "menu.selected condition requires an integer index");
+        return true;
+    }
+    return validate_ui_condition(ctx, condition, path, names);
+}
+
+static bool scene_has_menu_name(yyjson_val *scene_root, const char *name)
+{
+    yyjson_val *menus = obj_get(scene_root, "menus");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
+    {
+        yyjson_val *menu = yyjson_arr_get(menus, i);
+        const char *menu_name = json_string(menu, "name");
+        if (menu_name != NULL && SDL_strcmp(menu_name, name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yyjson_val *game_root,
+                                   validation_names *names, const char *json_path)
+{
+    const char *enter_signal = json_string(root, "on_enter_signal");
+    if (enter_signal != NULL && !require_ref(ctx, &names->signals, "signal", enter_signal, json_path))
+        return false;
+
+    yyjson_val *transitions = obj_get(root, "transitions");
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(transitions, &iter);
+    while (yyjson_is_obj(transitions) && (key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *transition = yyjson_get_str(yyjson_obj_iter_get_val(key));
+        if (transition != NULL && !yyjson_is_obj(obj_get(obj_get(game_root, "transitions"), transition)))
+            return validation_error(ctx, json_path, "scene references unknown transition '%s'", transition);
+    }
+
+    yyjson_val *camera_value = obj_get(root, "camera");
+    if (camera_value != NULL && !yyjson_is_str(camera_value))
+        return validation_error(ctx, json_path, "scene camera must be a string");
+    const char *camera = json_string(root, "camera");
+    if (camera != NULL && !require_ref(ctx, &names->cameras, "camera", camera, json_path))
+        return false;
+
+    yyjson_val *entities = obj_get(root, "entities");
+    if (entities != NULL && !yyjson_is_arr(entities))
+        return validation_error(ctx, json_path, "scene entities must be an array");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        char entity_path[PATH_BUFFER_SIZE];
+        format_path(entity_path, sizeof(entity_path), "%s.entities[%zu]", json_path, i);
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        if (!yyjson_is_str(entity) || yyjson_get_str(entity)[0] == '\0')
+            return validation_error(ctx, entity_path, "scene entity entries must be non-empty strings");
+        if (!require_ref(ctx, &names->entities, "entity", yyjson_get_str(entity), entity_path))
+            return false;
+    }
+
+    yyjson_val *menus = obj_get(root, "menus");
+    for (size_t m = 0; yyjson_is_arr(menus) && m < yyjson_arr_size(menus); ++m)
+    {
+        char menu_path[PATH_BUFFER_SIZE];
+        format_path(menu_path, sizeof(menu_path), "%s.menus[%zu]", json_path, m);
+        yyjson_val *menu = yyjson_arr_get(menus, m);
+        if (!yyjson_is_obj(menu))
+            return validation_error(ctx, menu_path, "scene menu must be an object");
+        if (!is_non_empty_string(menu, "name"))
+            return validation_error(ctx, menu_path, "scene menu requires a non-empty name");
+        if (!require_ref(ctx, &names->actions, "input action", json_string(menu, "up_action"), menu_path) ||
+            !require_ref(ctx, &names->actions, "input action", json_string(menu, "down_action"), menu_path) ||
+            !require_ref(ctx, &names->actions, "input action", json_string(menu, "select_action"), menu_path))
+            return false;
+
+        yyjson_val *items = obj_get(menu, "items");
+        if (!yyjson_is_arr(items) || yyjson_arr_size(items) == 0)
+            return validation_error(ctx, menu_path, "scene menu requires at least one item");
+        for (size_t i = 0; i < yyjson_arr_size(items); ++i)
+        {
+            char item_path[PATH_BUFFER_SIZE];
+            format_path(item_path, sizeof(item_path), "%s.items[%zu]", menu_path, i);
+            yyjson_val *item = yyjson_arr_get(items, i);
+            if (!is_non_empty_string(item, "label"))
+                return validation_error(ctx, item_path, "scene menu item requires a label");
+            const char *scene = json_string(item, "scene");
+            if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, item_path))
+                return false;
+            const char *signal = json_string(item, "signal");
+            if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, item_path))
+                return false;
+        }
+    }
+
+    yyjson_val *texts = obj_get(obj_get(root, "ui"), "text");
+    yyjson_val *ui_menus = obj_get(obj_get(root, "ui"), "menus");
+    if (ui_menus != NULL && !yyjson_is_arr(ui_menus))
+        return validation_error(ctx, json_path, "scene UI menus must be an array");
+    for (size_t i = 0; yyjson_is_arr(ui_menus) && i < yyjson_arr_size(ui_menus); ++i)
+    {
+        char menu_path[PATH_BUFFER_SIZE];
+        format_path(menu_path, sizeof(menu_path), "%s.ui.menus[%zu]", json_path, i);
+        yyjson_val *presenter = yyjson_arr_get(ui_menus, i);
+        if (!yyjson_is_obj(presenter))
+            return validation_error(ctx, menu_path, "scene UI menu presenters must be objects");
+        if (!is_non_empty_string(presenter, "name"))
+            return validation_error(ctx, menu_path, "scene UI menu presenter requires a non-empty name");
+        const char *menu_name = json_string(presenter, "menu");
+        if (!scene_has_menu_name(root, menu_name))
+            return validation_error(ctx, menu_path, "scene UI menu presenter references unknown menu '%s'",
+                                    menu_name != NULL ? menu_name : "<missing>");
+        if (!require_ref(ctx, &names->fonts, "font asset", json_string(presenter, "font"), menu_path))
+            return false;
+        yyjson_val *cursor = obj_get(presenter, "cursor");
+        if (yyjson_is_obj(cursor) && json_string(cursor, "font") != NULL &&
+            !require_ref(ctx, &names->fonts, "font asset", json_string(cursor, "font"), menu_path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", menu_path);
+        if (!validate_scene_ui_condition(ctx, obj_get(presenter, "visible_if"), condition_path, names))
+            return false;
+    }
+
+    for (size_t i = 0; yyjson_is_arr(texts) && i < yyjson_arr_size(texts); ++i)
+    {
+        char text_path[PATH_BUFFER_SIZE];
+        format_path(text_path, sizeof(text_path), "%s.ui.text[%zu]", json_path, i);
+        yyjson_val *text = yyjson_arr_get(texts, i);
+        if (!yyjson_is_obj(text))
+            return validation_error(ctx, text_path, "scene UI text entries must be objects");
+        if (json_string(text, "font") != NULL &&
+            !require_ref(ctx, &names->fonts, "font asset", json_string(text, "font"), text_path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", text_path);
+        if (!validate_scene_ui_condition(ctx, obj_get(text, "visible_if"), condition_path, names))
+            return false;
+
+        yyjson_val *bindings = obj_get(text, "bindings");
+        for (size_t b = 0; yyjson_is_arr(bindings) && b < yyjson_arr_size(bindings); ++b)
+        {
+            char binding_path[PATH_BUFFER_SIZE];
+            format_path(binding_path, sizeof(binding_path), "%s.bindings[%zu]", text_path, b);
+            yyjson_val *binding = yyjson_arr_get(bindings, b);
+            const char *type = json_string(binding, "type");
+            if (SDL_strcmp(type != NULL ? type : "", "property") == 0)
+            {
+                if (!require_ref(ctx, &names->entities, "entity", json_string(binding, "entity"), binding_path))
+                    return false;
+                if (!is_non_empty_string(binding, "key"))
+                    return validation_error(ctx, binding_path, "scene UI property binding requires a non-empty key");
+            }
+            else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
+            {
+                return validation_error(ctx, binding_path, "unsupported scene UI binding type '%s'",
+                                        type != NULL ? type : "<missing>");
+            }
+        }
+    }
+    return true;
+}
+
+static bool validate_scenes(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *scenes = obj_get(root, "scenes");
+    if (scenes == NULL)
+        return true;
+    if (!yyjson_is_obj(scenes))
+        return validation_error(ctx, "$.scenes", "scenes must be an object");
+
+    yyjson_val *files = obj_get(scenes, "files");
+    if (!yyjson_is_arr(files))
+        return validation_error(ctx, "$.scenes.files", "scenes.files must be an array");
+
+    const int count = (int)yyjson_arr_size(files);
+    validation_scene_doc *docs = (validation_scene_doc *)SDL_calloc((size_t)count, sizeof(*docs));
+    if (docs == NULL && count > 0)
+        return validation_error(ctx, "$.scenes.files", "failed to allocate scene validation docs");
+
+    for (int i = 0; i < count; ++i)
+    {
+        yyjson_val *file = yyjson_arr_get(files, (size_t)i);
+        if (!validate_scene_file(ctx, names, yyjson_is_str(file) ? yyjson_get_str(file) : NULL, i, &docs[i]))
+        {
+            validation_scene_docs_destroy(docs, count);
+            return false;
+        }
+    }
+
+    const char *initial = json_string(scenes, "initial");
+    bool ok = initial == NULL || require_ref(ctx, &names->scenes, "scene", initial, "$.scenes.initial");
+    for (int i = 0; ok && i < count; ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.scenes.files[%d]", i);
+        ok = validate_scene_details(ctx, docs[i].root, root, names, path);
+    }
+
+    validation_scene_docs_destroy(docs, count);
+    return ok;
+}
+
 static bool warn_unused(validation_context *ctx, const name_table *declared, const name_table *used, const char *kind)
 {
     for (int i = 0; i < declared->count; ++i)
@@ -1253,10 +1613,10 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+           validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
-           validate_transitions(ctx, root, names) && validate_logic(ctx, root, names) &&
-           validate_adapters(ctx, root, names) &&
+           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }
@@ -1277,6 +1637,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->timers);
     name_table_destroy(&names->cameras);
     name_table_destroy(&names->fonts);
+    name_table_destroy(&names->scenes);
     name_table_destroy(&names->sensors);
     name_table_destroy(&names->used_adapters);
     name_table_destroy(&names->used_scripts);

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -464,15 +464,18 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
     }
 
     bool handled = false;
-    if (menu.up_action_id >= 0 && sdl3d_input_is_pressed(input, menu.up_action_id))
+    if (menu.up_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.up_action_id) &&
+        sdl3d_input_is_pressed(input, menu.up_action_id))
     {
         handled = sdl3d_game_data_menu_move(runtime, menu.name, -1) || handled;
     }
-    if (menu.down_action_id >= 0 && sdl3d_input_is_pressed(input, menu.down_action_id))
+    if (menu.down_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.down_action_id) &&
+        sdl3d_input_is_pressed(input, menu.down_action_id))
     {
         handled = sdl3d_game_data_menu_move(runtime, menu.name, 1) || handled;
     }
-    if (menu.select_action_id >= 0 && sdl3d_input_is_pressed(input, menu.select_action_id))
+    if (menu.select_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.select_action_id) &&
+        sdl3d_input_is_pressed(input, menu.select_action_id))
     {
         handled = true;
 
@@ -489,9 +492,14 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
             out_result->menu = refreshed.name;
             out_result->selected_index = refreshed.selected_index;
             out_result->selected = true;
-            out_result->quit = item.quit;
-            out_result->scene = item.scene;
-            out_result->signal_id = item.signal_id;
+            out_result->control_changed = sdl3d_game_data_apply_menu_item_control(runtime, &item);
+            out_result->quit = !out_result->control_changed && item.quit;
+            out_result->scene = !out_result->control_changed ? item.scene : NULL;
+            out_result->signal_id = !out_result->control_changed ? item.signal_id : -1;
+        }
+        else
+        {
+            (void)sdl3d_game_data_apply_menu_item_control(runtime, &item);
         }
     }
     else if (handled && out_result != NULL)
@@ -504,6 +512,89 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
     if (out_result != NULL)
         out_result->handled_input = handled;
     return true;
+}
+
+void sdl3d_game_data_frame_state_init(sdl3d_game_data_frame_state *state)
+{
+    if (state == NULL)
+        return;
+    SDL_zero(*state);
+}
+
+bool sdl3d_game_data_update_frame(sdl3d_game_data_frame_state *state, const sdl3d_game_data_update_frame_desc *desc)
+{
+    if (state == NULL || desc == NULL || desc->ctx == NULL || desc->runtime == NULL)
+        return false;
+
+    sdl3d_game_context *ctx = desc->ctx;
+    sdl3d_game_data_runtime *runtime = desc->runtime;
+    const bool paused_at_start = ctx->paused;
+    if (sdl3d_game_data_active_scene_update_phase(runtime, "app_flow", ctx->paused) && desc->app_flow != NULL)
+    {
+        if (!sdl3d_game_data_app_flow_update(desc->app_flow, ctx, runtime, desc->dt))
+            return false;
+    }
+
+    if (paused_at_start && !ctx->paused)
+    {
+        state->was_paused = false;
+        return true;
+    }
+
+    const bool pause_entered = !state->was_paused && ctx->paused;
+    if (sdl3d_game_data_active_scene_update_phase(runtime, "presentation", ctx->paused))
+    {
+        state->time += desc->dt;
+        if (!sdl3d_game_data_update_presentation_clocks(runtime, desc->dt, ctx->paused, pause_entered))
+            return false;
+        state->ui_pulse_phase = sdl3d_game_data_ui_pulse_phase(runtime, state->ui_pulse_phase);
+    }
+    if (sdl3d_game_data_active_scene_update_phase(runtime, "property_effects", ctx->paused) &&
+        !sdl3d_game_data_update_property_effects(runtime, desc->dt))
+        return false;
+    if (desc->particle_cache != NULL && sdl3d_game_data_active_scene_update_phase(runtime, "particles", ctx->paused) &&
+        !sdl3d_game_data_update_particles(runtime, desc->particle_cache, desc->dt))
+        return false;
+    if (!paused_at_start && sdl3d_game_data_active_scene_update_phase(runtime, "simulation", ctx->paused) &&
+        (desc->app_flow == NULL || !sdl3d_game_data_app_flow_quit_pending(desc->app_flow)))
+    {
+        if (!sdl3d_game_data_update(runtime, desc->dt))
+            return false;
+    }
+
+    state->was_paused = ctx->paused;
+    return true;
+}
+
+void sdl3d_game_data_frame_state_record_render(sdl3d_game_data_frame_state *state, const sdl3d_game_context *ctx,
+                                               const sdl3d_game_data_runtime *runtime)
+{
+    if (state == NULL || ctx == NULL)
+        return;
+
+    if (state->rendered_frames > 0)
+    {
+        const float frame_dt = ctx->real_time - state->last_render_time;
+        if (frame_dt > 0.0f)
+        {
+            state->fps_sample_time += frame_dt;
+            ++state->fps_sample_frames;
+            const float sample_seconds = sdl3d_game_data_fps_sample_seconds(runtime, 0.25f);
+            if (state->fps_sample_time >= sample_seconds)
+            {
+                state->displayed_fps = (float)state->fps_sample_frames / state->fps_sample_time;
+                state->fps_sample_time = 0.0f;
+                state->fps_sample_frames = 0;
+            }
+        }
+    }
+    state->last_render_time = ctx->real_time;
+    ++state->rendered_frames;
+    state->metrics.paused = ctx->paused;
+    state->metrics.fps = state->displayed_fps;
+    state->metrics.frame = state->rendered_frames;
+    state->render_eval.time = state->time;
+    state->ui_pulse_phase = sdl3d_game_data_ui_pulse_phase(runtime, state->ui_pulse_phase);
 }
 
 void sdl3d_game_data_scene_flow_init(sdl3d_game_data_scene_flow *flow)
@@ -524,11 +615,14 @@ bool sdl3d_game_data_scene_flow_request(sdl3d_game_data_scene_flow *flow, sdl3d_
 {
     if (flow == NULL || runtime == NULL || scene_name == NULL)
         return false;
-    if (sdl3d_game_data_scene_flow_is_transitioning(flow))
+
+    sdl3d_game_data_scene_transition_policy policy;
+    (void)sdl3d_game_data_get_scene_transition_policy(runtime, &policy);
+    if (sdl3d_game_data_scene_flow_is_transitioning(flow) && !policy.allow_interrupt)
         return false;
 
     const char *active = sdl3d_game_data_active_scene(runtime);
-    if (active != NULL && SDL_strcmp(active, scene_name) == 0)
+    if (active != NULL && SDL_strcmp(active, scene_name) == 0 && !policy.allow_same_scene)
         return false;
 
     bool known_scene = false;
@@ -545,6 +639,8 @@ bool sdl3d_game_data_scene_flow_request(sdl3d_game_data_scene_flow *flow, sdl3d_
     if (!known_scene)
         return false;
 
+    if (sdl3d_game_data_scene_flow_is_transitioning(flow))
+        sdl3d_transition_reset(&flow->transition);
     flow->pending_scene = scene_name;
     flow->fading_out = true;
     flow->fading_in = false;
@@ -629,7 +725,10 @@ static bool app_flow_request_scene(sdl3d_game_data_app_flow *flow, sdl3d_game_da
 {
     if (sdl3d_game_data_scene_flow_request(&flow->scene_flow, runtime, scene_name))
     {
-        flow->scene_input_armed = false;
+        sdl3d_game_data_scene_transition_policy policy;
+        (void)sdl3d_game_data_get_scene_transition_policy(runtime, &policy);
+        if (policy.reset_menu_input_on_request)
+            flow->scene_input_armed = false;
         return true;
     }
     return false;
@@ -664,6 +763,7 @@ static void app_flow_consume_scene_shortcuts(sdl3d_game_data_app_flow *flow, sdl
     {
         sdl3d_game_data_scene_shortcut shortcut;
         if (sdl3d_game_data_scene_shortcut_at(runtime, i, &shortcut) && shortcut.action_id >= 0 &&
+            sdl3d_game_data_active_scene_allows_action(runtime, shortcut.action_id) &&
             sdl3d_input_is_pressed(input, shortcut.action_id))
         {
             (void)app_flow_request_scene(flow, runtime, shortcut.scene);
@@ -735,14 +835,17 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     sdl3d_input_manager *input = sdl3d_game_session_get_input(ctx->session);
     sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
 
-    if (flow->app.quit_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.quit_action_id))
+    if (flow->app.quit_action_id >= 0 &&
+        sdl3d_game_data_active_scene_allows_action(runtime, flow->app.quit_action_id) &&
+        sdl3d_input_is_pressed(input, flow->app.quit_action_id))
         app_flow_request_quit(flow, ctx, runtime);
 
     app_flow_consume_scene_shortcuts(flow, runtime, input);
     app_flow_consume_menu(flow, ctx, runtime, input, bus);
 
     if (flow->app.pause_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.pause_action_id) &&
-        !flow->quit_pending && !sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+        sdl3d_game_data_active_scene_allows_action(runtime, flow->app.pause_action_id) && !flow->quit_pending &&
+        !sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
     {
         if (ctx->paused)
             ctx->paused = false;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -727,7 +727,7 @@ bool sdl3d_game_data_app_flow_is_transitioning(const sdl3d_game_data_app_flow *f
 }
 
 bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
-                                     sdl3d_game_data_runtime *runtime, bool pause_allowed, float dt)
+                                     sdl3d_game_data_runtime *runtime, float dt)
 {
     if (flow == NULL || ctx == NULL || runtime == NULL || ctx->session == NULL)
         return false;
@@ -746,8 +746,15 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     {
         if (ctx->paused)
             ctx->paused = false;
-        else if (pause_allowed && sdl3d_game_data_active_scene_updates_game(runtime))
-            ctx->paused = true;
+        else
+        {
+            sdl3d_game_data_ui_metrics metrics;
+            SDL_zero(metrics);
+            metrics.paused = ctx->paused;
+            if (sdl3d_game_data_app_pause_allowed(runtime, &metrics) &&
+                sdl3d_game_data_active_scene_updates_game(runtime))
+                ctx->paused = true;
+        }
     }
 
     app_flow_update_transition(flow, ctx, bus, dt);

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1,0 +1,806 @@
+/**
+ * @file game_presentation.c
+ * @brief Renderer-facing helpers for JSON-authored game data.
+ */
+
+#include "sdl3d/game_presentation.h"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/drawing3d.h"
+#include "sdl3d/lighting.h"
+#include "sdl3d/shapes.h"
+
+typedef struct primitive_draw_context
+{
+    sdl3d_render_context *renderer;
+} primitive_draw_context;
+
+typedef struct ui_draw_context
+{
+    const sdl3d_game_data_runtime *runtime;
+    sdl3d_render_context *renderer;
+    sdl3d_game_data_font_cache *font_cache;
+    const sdl3d_game_data_ui_metrics *metrics;
+    float pulse_phase;
+    bool ok;
+} ui_draw_context;
+
+typedef struct particle_update_context
+{
+    sdl3d_game_data_particle_cache *cache;
+    float dt;
+    bool ok;
+} particle_update_context;
+
+static sdl3d_camera3d default_camera(void)
+{
+    sdl3d_camera3d camera;
+    SDL_zero(camera);
+    camera.position = sdl3d_vec3_make(0.0f, 0.0f, 16.0f);
+    camera.target = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    camera.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    camera.fovy = 11.4f;
+    camera.projection = SDL3D_CAMERA_ORTHOGRAPHIC;
+    return camera;
+}
+
+static sdl3d_camera3d active_camera_or_fallback(const sdl3d_game_data_runtime *runtime, const sdl3d_camera3d *fallback)
+{
+    sdl3d_camera3d camera;
+    const char *active_camera = sdl3d_game_data_active_camera(runtime);
+    if (active_camera != NULL && sdl3d_game_data_get_camera(runtime, active_camera, &camera))
+        return camera;
+    if (fallback != NULL)
+        return *fallback;
+    return default_camera();
+}
+
+static bool apply_render_settings(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    sdl3d_game_data_render_settings settings;
+    if (!sdl3d_game_data_get_render_settings(runtime, &settings))
+        return false;
+
+    bool ok = true;
+    ok = sdl3d_clear_render_context(renderer, settings.clear_color) && ok;
+    ok = sdl3d_set_lighting_enabled(renderer, settings.lighting_enabled) && ok;
+    ok = sdl3d_set_bloom_enabled(renderer, settings.bloom_enabled) && ok;
+    ok = sdl3d_set_ssao_enabled(renderer, settings.ssao_enabled) && ok;
+    ok = sdl3d_set_tonemap_mode(renderer, settings.tonemap) && ok;
+    return ok;
+}
+
+static bool apply_world_lights(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                               const sdl3d_game_data_render_eval *eval)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    bool ok = sdl3d_clear_lights(renderer);
+    float ambient[3] = {0.015f, 0.018f, 0.026f};
+    sdl3d_game_data_get_world_ambient_light(runtime, ambient);
+    ok = sdl3d_set_ambient_light(renderer, ambient[0], ambient[1], ambient[2]) && ok;
+
+    const int light_count = sdl3d_game_data_world_light_count(runtime);
+    for (int i = 0; i < light_count; ++i)
+    {
+        sdl3d_light light;
+        if (sdl3d_game_data_get_world_light_evaluated(runtime, i, eval, &light))
+            ok = sdl3d_add_light(renderer, &light) && ok;
+    }
+    return ok;
+}
+
+static bool run_frame_hook(const sdl3d_game_data_frame_desc *frame, sdl3d_game_data_frame_hook hook)
+{
+    return hook == NULL || hook(frame->userdata, frame);
+}
+
+static bool ensure_font_cache_capacity(sdl3d_game_data_font_cache *cache, int required)
+{
+    if (cache == NULL || required <= cache->capacity)
+        return cache != NULL;
+
+    int next_capacity = cache->capacity < 4 ? 4 : cache->capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    sdl3d_font *new_fonts = (sdl3d_font *)SDL_calloc((size_t)next_capacity, sizeof(*new_fonts));
+    if (new_fonts == NULL)
+        return false;
+
+    const char **new_font_ids = (const char **)SDL_calloc((size_t)next_capacity, sizeof(*new_font_ids));
+    if (new_font_ids == NULL)
+    {
+        SDL_free(new_fonts);
+        return false;
+    }
+
+    for (int i = 0; i < cache->count; ++i)
+    {
+        new_fonts[i] = cache->fonts[i];
+        new_font_ids[i] = cache->font_ids[i];
+    }
+
+    SDL_free(cache->fonts);
+    SDL_free(cache->font_ids);
+    cache->fonts = new_fonts;
+    cache->font_ids = new_font_ids;
+    cache->capacity = next_capacity;
+    return true;
+}
+
+static bool ensure_particle_cache_capacity(sdl3d_game_data_particle_cache *cache, int required)
+{
+    if (cache == NULL || required <= cache->capacity)
+        return cache != NULL;
+
+    int next_capacity = cache->capacity < 4 ? 4 : cache->capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    sdl3d_game_data_particle_cache_entry *entries =
+        (sdl3d_game_data_particle_cache_entry *)SDL_realloc(cache->entries, (size_t)next_capacity * sizeof(*entries));
+    if (entries == NULL)
+        return false;
+
+    SDL_memset(entries + cache->capacity, 0, (size_t)(next_capacity - cache->capacity) * sizeof(*entries));
+    cache->entries = entries;
+    cache->capacity = next_capacity;
+    return true;
+}
+
+static sdl3d_game_data_particle_cache_entry *find_particle_entry(sdl3d_game_data_particle_cache *cache,
+                                                                 const char *entity_name)
+{
+    if (cache == NULL || entity_name == NULL)
+        return NULL;
+
+    for (int i = 0; i < cache->count; ++i)
+    {
+        if (cache->entries[i].entity_name != NULL && SDL_strcmp(cache->entries[i].entity_name, entity_name) == 0)
+            return &cache->entries[i];
+    }
+    return NULL;
+}
+
+static sdl3d_game_data_particle_cache_entry *find_or_create_particle_entry(
+    sdl3d_game_data_particle_cache *cache, const sdl3d_game_data_particle_emitter *emitter)
+{
+    if (cache == NULL || emitter == NULL || emitter->entity_name == NULL)
+        return NULL;
+
+    sdl3d_game_data_particle_cache_entry *entry = find_particle_entry(cache, emitter->entity_name);
+    if (entry != NULL)
+        return entry;
+
+    if (!ensure_particle_cache_capacity(cache, cache->count + 1))
+        return NULL;
+
+    entry = &cache->entries[cache->count];
+    SDL_zero(*entry);
+    entry->entity_name = emitter->entity_name;
+    entry->emitter = sdl3d_create_particle_emitter(&emitter->config);
+    if (entry->emitter == NULL)
+        return NULL;
+
+    ++cache->count;
+    return entry;
+}
+
+static sdl3d_font *find_or_load_font(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_font_cache *cache,
+                                     const char *font_id)
+{
+    if (runtime == NULL || cache == NULL || font_id == NULL)
+        return NULL;
+
+    for (int i = 0; i < cache->count; ++i)
+    {
+        if (cache->font_ids[i] != NULL && SDL_strcmp(cache->font_ids[i], font_id) == 0)
+            return &cache->fonts[i];
+    }
+
+    if (!ensure_font_cache_capacity(cache, cache->count + 1))
+        return NULL;
+
+    sdl3d_game_data_font_asset font;
+    if (!sdl3d_game_data_get_font_asset(runtime, font_id, &font))
+        return NULL;
+
+    sdl3d_font *slot = &cache->fonts[cache->count];
+    bool loaded = false;
+    if (font.builtin)
+        loaded = sdl3d_load_builtin_font(cache->media_dir, font.builtin_id, font.size, slot);
+    else if (font.path != NULL)
+        loaded = sdl3d_load_font(font.path, font.size, slot);
+    if (!loaded)
+        return NULL;
+
+    cache->font_ids[cache->count] = font_id;
+    cache->count++;
+    return slot;
+}
+
+static bool draw_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
+{
+    primitive_draw_context *context = (primitive_draw_context *)userdata;
+    if (context == NULL || context->renderer == NULL || primitive == NULL)
+        return false;
+
+    sdl3d_set_emissive(context->renderer, primitive->emissive_color.x, primitive->emissive_color.y,
+                       primitive->emissive_color.z);
+    if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+    {
+        sdl3d_draw_cube(context->renderer, primitive->position, primitive->size, primitive->color);
+    }
+    else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
+    {
+        sdl3d_draw_sphere(context->renderer, primitive->position, primitive->radius, primitive->slices,
+                          primitive->rings, primitive->color);
+    }
+    sdl3d_set_emissive(context->renderer, 0.0f, 0.0f, 0.0f);
+    return true;
+}
+
+static bool draw_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
+{
+    ui_draw_context *draw = (ui_draw_context *)userdata;
+    if (draw == NULL || text == NULL)
+        return false;
+
+    if (!sdl3d_game_data_ui_text_is_visible(draw->runtime, text, draw->metrics))
+        return true;
+
+    char content[128];
+    if (!sdl3d_game_data_format_ui_text(draw->runtime, text, draw->metrics, content, sizeof(content)))
+        return true;
+
+    sdl3d_font *font = find_or_load_font(draw->runtime, draw->font_cache, text->font);
+    if (font == NULL)
+    {
+        draw->ok = false;
+        return true;
+    }
+
+    sdl3d_color color = text->color;
+    if (text->pulse_alpha)
+    {
+        const float pulse = 0.5f + 0.5f * SDL_sinf(draw->pulse_phase * SDL_PI_F * 2.0f);
+        color.a = (Uint8)(120.0f + pulse * 135.0f);
+    }
+
+    const int width = sdl3d_get_render_context_width(draw->renderer);
+    const int height = sdl3d_get_render_context_height(draw->renderer);
+    float x = text->normalized ? text->x * (float)width : text->x;
+    const float y = text->normalized ? text->y * (float)height : text->y;
+    if (text->align == SDL3D_GAME_DATA_UI_ALIGN_CENTER || text->centered)
+    {
+        float text_w = 0.0f;
+        float text_h = 0.0f;
+        sdl3d_measure_text(font, content, &text_w, &text_h);
+        x -= text_w * 0.5f;
+    }
+    else if (text->align == SDL3D_GAME_DATA_UI_ALIGN_RIGHT)
+    {
+        float text_w = 0.0f;
+        float text_h = 0.0f;
+        sdl3d_measure_text(font, content, &text_w, &text_h);
+        x -= text_w;
+    }
+
+    if (!sdl3d_draw_text_overlay(draw->renderer, font, content, x, y, color))
+        draw->ok = false;
+    return true;
+}
+
+static bool update_particle(void *userdata, const sdl3d_game_data_particle_emitter *emitter)
+{
+    particle_update_context *context = (particle_update_context *)userdata;
+    if (context == NULL || context->cache == NULL || emitter == NULL)
+        return false;
+
+    sdl3d_game_data_particle_cache_entry *entry = find_or_create_particle_entry(context->cache, emitter);
+    if (entry == NULL)
+    {
+        context->ok = false;
+        return true;
+    }
+
+    if (!sdl3d_particle_emitter_set_config(entry->emitter, &emitter->config))
+    {
+        context->ok = false;
+        return true;
+    }
+    entry->draw_emissive = emitter->draw_emissive;
+    entry->visible = true;
+    sdl3d_particle_emitter_update(entry->emitter, context->dt);
+    return true;
+}
+
+void sdl3d_game_data_font_cache_init(sdl3d_game_data_font_cache *cache, const char *media_dir)
+{
+    if (cache == NULL)
+        return;
+    SDL_zero(*cache);
+    cache->media_dir = media_dir;
+}
+
+void sdl3d_game_data_font_cache_free(sdl3d_game_data_font_cache *cache)
+{
+    if (cache == NULL)
+        return;
+    for (int i = 0; i < cache->count; ++i)
+        sdl3d_free_font(&cache->fonts[i]);
+    SDL_free(cache->fonts);
+    SDL_free(cache->font_ids);
+    SDL_zero(*cache);
+}
+
+bool sdl3d_game_data_draw_render_primitives(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer)
+{
+    return sdl3d_game_data_draw_render_primitives_evaluated(runtime, renderer, NULL);
+}
+
+bool sdl3d_game_data_draw_render_primitives_evaluated(const sdl3d_game_data_runtime *runtime,
+                                                      sdl3d_render_context *renderer,
+                                                      const sdl3d_game_data_render_eval *eval)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    primitive_draw_context context = {renderer};
+    return sdl3d_game_data_for_each_render_primitive_evaluated(runtime, eval, draw_primitive, &context);
+}
+
+bool sdl3d_game_data_draw_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                  sdl3d_game_data_font_cache *font_cache, const sdl3d_game_data_ui_metrics *metrics,
+                                  float pulse_phase)
+{
+    if (runtime == NULL || renderer == NULL || font_cache == NULL)
+        return false;
+
+    ui_draw_context context;
+    SDL_zero(context);
+    context.runtime = runtime;
+    context.renderer = renderer;
+    context.font_cache = font_cache;
+    context.metrics = metrics;
+    context.pulse_phase = pulse_phase;
+    context.ok = true;
+
+    return sdl3d_game_data_for_each_ui_text(runtime, draw_ui_text, &context) && context.ok;
+}
+
+void sdl3d_game_data_particle_cache_init(sdl3d_game_data_particle_cache *cache)
+{
+    if (cache != NULL)
+        SDL_zero(*cache);
+}
+
+void sdl3d_game_data_particle_cache_free(sdl3d_game_data_particle_cache *cache)
+{
+    if (cache == NULL)
+        return;
+    for (int i = 0; i < cache->count; ++i)
+    {
+        sdl3d_destroy_particle_emitter(cache->entries[i].emitter);
+    }
+    SDL_free(cache->entries);
+    SDL_zero(*cache);
+}
+
+bool sdl3d_game_data_update_particles(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_particle_cache *cache,
+                                      float dt)
+{
+    if (runtime == NULL || cache == NULL)
+        return false;
+
+    for (int i = 0; i < cache->count; ++i)
+    {
+        cache->entries[i].visible = false;
+    }
+
+    particle_update_context context;
+    SDL_zero(context);
+    context.cache = cache;
+    context.dt = dt;
+    context.ok = true;
+
+    return sdl3d_game_data_for_each_particle_emitter(runtime, update_particle, &context) && context.ok;
+}
+
+bool sdl3d_game_data_draw_particles(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                    sdl3d_game_data_particle_cache *cache)
+{
+    if (runtime == NULL || renderer == NULL || cache == NULL)
+        return false;
+
+    for (int i = 0; i < cache->count; ++i)
+    {
+        sdl3d_game_data_particle_cache_entry *entry = &cache->entries[i];
+        if (!entry->visible || entry->emitter == NULL ||
+            !sdl3d_game_data_active_scene_has_entity(runtime, entry->entity_name))
+            continue;
+
+        sdl3d_set_emissive(renderer, entry->draw_emissive.x, entry->draw_emissive.y, entry->draw_emissive.z);
+        sdl3d_draw_particles(renderer, entry->emitter);
+        sdl3d_set_emissive(renderer, 0.0f, 0.0f, 0.0f);
+    }
+    return true;
+}
+
+bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, bool *input_armed,
+                                  sdl3d_game_data_menu_update_result *out_result)
+{
+    if (out_result != NULL)
+    {
+        SDL_zero(*out_result);
+        out_result->selected_index = -1;
+        out_result->signal_id = -1;
+    }
+    if (runtime == NULL || input_armed == NULL)
+        return false;
+
+    sdl3d_game_data_menu menu;
+    if (!sdl3d_game_data_get_active_menu(runtime, &menu))
+        return true;
+
+    if (out_result != NULL)
+    {
+        out_result->menu = menu.name;
+        out_result->selected_index = menu.selected_index;
+    }
+
+    if (!*input_armed)
+    {
+        if (sdl3d_game_data_active_menu_input_is_idle(runtime, input))
+            *input_armed = true;
+        return true;
+    }
+
+    bool handled = false;
+    if (menu.up_action_id >= 0 && sdl3d_input_is_pressed(input, menu.up_action_id))
+    {
+        handled = sdl3d_game_data_menu_move(runtime, menu.name, -1) || handled;
+    }
+    if (menu.down_action_id >= 0 && sdl3d_input_is_pressed(input, menu.down_action_id))
+    {
+        handled = sdl3d_game_data_menu_move(runtime, menu.name, 1) || handled;
+    }
+    if (menu.select_action_id >= 0 && sdl3d_input_is_pressed(input, menu.select_action_id))
+    {
+        handled = true;
+
+        sdl3d_game_data_menu refreshed;
+        if (!sdl3d_game_data_get_active_menu(runtime, &refreshed))
+            return true;
+
+        sdl3d_game_data_menu_item item;
+        if (!sdl3d_game_data_get_menu_item(runtime, refreshed.name, refreshed.selected_index, &item))
+            return true;
+
+        if (out_result != NULL)
+        {
+            out_result->menu = refreshed.name;
+            out_result->selected_index = refreshed.selected_index;
+            out_result->selected = true;
+            out_result->quit = item.quit;
+            out_result->scene = item.scene;
+            out_result->signal_id = item.signal_id;
+        }
+    }
+    else if (handled && out_result != NULL)
+    {
+        sdl3d_game_data_menu refreshed;
+        if (sdl3d_game_data_get_active_menu(runtime, &refreshed))
+            out_result->selected_index = refreshed.selected_index;
+    }
+
+    if (out_result != NULL)
+        out_result->handled_input = handled;
+    return true;
+}
+
+void sdl3d_game_data_scene_flow_init(sdl3d_game_data_scene_flow *flow)
+{
+    if (flow == NULL)
+        return;
+    SDL_zero(*flow);
+    sdl3d_transition_reset(&flow->transition);
+}
+
+bool sdl3d_game_data_scene_flow_is_transitioning(const sdl3d_game_data_scene_flow *flow)
+{
+    return flow != NULL && (flow->fading_out || flow->fading_in || flow->transition.active);
+}
+
+bool sdl3d_game_data_scene_flow_request(sdl3d_game_data_scene_flow *flow, sdl3d_game_data_runtime *runtime,
+                                        const char *scene_name)
+{
+    if (flow == NULL || runtime == NULL || scene_name == NULL)
+        return false;
+    if (sdl3d_game_data_scene_flow_is_transitioning(flow))
+        return false;
+
+    const char *active = sdl3d_game_data_active_scene(runtime);
+    if (active != NULL && SDL_strcmp(active, scene_name) == 0)
+        return false;
+
+    bool known_scene = false;
+    const int scene_count = sdl3d_game_data_scene_count(runtime);
+    for (int i = 0; i < scene_count; ++i)
+    {
+        const char *name = sdl3d_game_data_scene_name_at(runtime, i);
+        if (name != NULL && SDL_strcmp(name, scene_name) == 0)
+        {
+            known_scene = true;
+            break;
+        }
+    }
+    if (!known_scene)
+        return false;
+
+    flow->pending_scene = scene_name;
+    flow->fading_out = true;
+    flow->fading_in = false;
+
+    sdl3d_game_data_transition_desc transition;
+    if (active != NULL && sdl3d_game_data_get_scene_transition(runtime, active, "exit", &transition))
+    {
+        sdl3d_transition_start(&flow->transition, transition.type, transition.direction, transition.color,
+                               transition.duration, transition.done_signal_id);
+    }
+    else
+    {
+        sdl3d_transition_reset(&flow->transition);
+    }
+    return true;
+}
+
+void sdl3d_game_data_scene_flow_update(sdl3d_game_data_scene_flow *flow, sdl3d_game_data_runtime *runtime,
+                                       sdl3d_signal_bus *bus, float dt)
+{
+    if (flow == NULL || runtime == NULL)
+        return;
+
+    sdl3d_transition_update(&flow->transition, bus, dt);
+    if (flow->fading_out && !flow->transition.active)
+    {
+        const char *next_scene = flow->pending_scene;
+        flow->pending_scene = NULL;
+        flow->fading_out = false;
+        if (next_scene != NULL && sdl3d_game_data_set_active_scene(runtime, next_scene))
+        {
+            sdl3d_game_data_transition_desc transition;
+            if (sdl3d_game_data_get_scene_transition(runtime, next_scene, "enter", &transition))
+            {
+                flow->fading_in = true;
+                sdl3d_transition_start(&flow->transition, transition.type, transition.direction, transition.color,
+                                       transition.duration, transition.done_signal_id);
+            }
+            else
+            {
+                sdl3d_transition_reset(&flow->transition);
+            }
+        }
+        else
+        {
+            sdl3d_transition_reset(&flow->transition);
+        }
+    }
+    else if (flow->fading_in && !flow->transition.active)
+    {
+        flow->fading_in = false;
+    }
+}
+
+void sdl3d_game_data_scene_flow_draw(const sdl3d_game_data_scene_flow *flow, sdl3d_render_context *renderer)
+{
+    if (flow != NULL)
+        sdl3d_transition_draw(&flow->transition, renderer);
+}
+
+static void app_flow_request_quit(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+                                  sdl3d_game_data_runtime *runtime)
+{
+    if (flow == NULL || ctx == NULL || runtime == NULL || flow->quit_pending)
+        return;
+
+    flow->quit_pending = true;
+    sdl3d_game_data_transition_desc transition;
+    if (flow->app.quit_transition == NULL ||
+        !sdl3d_game_data_get_transition(runtime, flow->app.quit_transition, &transition))
+    {
+        ctx->quit_requested = true;
+        return;
+    }
+
+    sdl3d_transition_start(&flow->transition, transition.type, transition.direction, transition.color,
+                           transition.duration, transition.done_signal_id);
+}
+
+static bool app_flow_request_scene(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
+                                   const char *scene_name)
+{
+    if (sdl3d_game_data_scene_flow_request(&flow->scene_flow, runtime, scene_name))
+    {
+        flow->scene_input_armed = false;
+        return true;
+    }
+    return false;
+}
+
+static void app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+                                  sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input, sdl3d_signal_bus *bus)
+{
+    if (flow->quit_pending || sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+        return;
+
+    sdl3d_game_data_menu_update_result result;
+    if (!sdl3d_game_data_update_menus(runtime, input, &flow->scene_input_armed, &result) || !result.selected)
+        return;
+
+    if (result.signal_id >= 0)
+        sdl3d_signal_emit(bus, result.signal_id, NULL);
+    if (result.quit)
+        app_flow_request_quit(flow, ctx, runtime);
+    else if (result.scene != NULL)
+        (void)app_flow_request_scene(flow, runtime, result.scene);
+}
+
+static void app_flow_consume_scene_shortcuts(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
+                                             sdl3d_input_manager *input)
+{
+    if (flow->quit_pending || sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+        return;
+
+    const int count = sdl3d_game_data_scene_shortcut_count(runtime);
+    for (int i = 0; i < count; ++i)
+    {
+        sdl3d_game_data_scene_shortcut shortcut;
+        if (sdl3d_game_data_scene_shortcut_at(runtime, i, &shortcut) && shortcut.action_id >= 0 &&
+            sdl3d_input_is_pressed(input, shortcut.action_id))
+        {
+            (void)app_flow_request_scene(flow, runtime, shortcut.scene);
+            return;
+        }
+    }
+}
+
+static void app_flow_update_transition(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx, sdl3d_signal_bus *bus,
+                                       float dt)
+{
+    if (flow->transition.active)
+        sdl3d_transition_update(&flow->transition, bus, dt);
+    if (flow->quit_pending && flow->transition.finished && !flow->transition.active)
+        ctx->quit_requested = true;
+}
+
+void sdl3d_game_data_app_flow_init(sdl3d_game_data_app_flow *flow)
+{
+    if (flow == NULL)
+        return;
+    SDL_zero(*flow);
+    sdl3d_game_data_scene_flow_init(&flow->scene_flow);
+    sdl3d_transition_reset(&flow->transition);
+    flow->app.start_signal_id = -1;
+    flow->app.quit_action_id = -1;
+    flow->app.pause_action_id = -1;
+    flow->app.quit_signal_id = -1;
+}
+
+bool sdl3d_game_data_app_flow_start(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime)
+{
+    if (flow == NULL || runtime == NULL)
+        return false;
+
+    sdl3d_game_data_scene_flow_init(&flow->scene_flow);
+    sdl3d_transition_reset(&flow->transition);
+    flow->quit_pending = false;
+    flow->scene_input_armed = false;
+    if (!sdl3d_game_data_get_app_control(runtime, &flow->app))
+        return false;
+
+    sdl3d_game_data_transition_desc transition;
+    if (flow->app.startup_transition != NULL &&
+        sdl3d_game_data_get_transition(runtime, flow->app.startup_transition, &transition))
+    {
+        sdl3d_transition_start(&flow->transition, transition.type, transition.direction, transition.color,
+                               transition.duration, transition.done_signal_id);
+    }
+    return true;
+}
+
+bool sdl3d_game_data_app_flow_quit_pending(const sdl3d_game_data_app_flow *flow)
+{
+    return flow != NULL && flow->quit_pending;
+}
+
+bool sdl3d_game_data_app_flow_is_transitioning(const sdl3d_game_data_app_flow *flow)
+{
+    return flow != NULL && (flow->transition.active || sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow));
+}
+
+bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+                                     sdl3d_game_data_runtime *runtime, bool pause_allowed, float dt)
+{
+    if (flow == NULL || ctx == NULL || runtime == NULL || ctx->session == NULL)
+        return false;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(ctx->session);
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
+
+    if (flow->app.quit_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.quit_action_id))
+        app_flow_request_quit(flow, ctx, runtime);
+
+    app_flow_consume_scene_shortcuts(flow, runtime, input);
+    app_flow_consume_menu(flow, ctx, runtime, input, bus);
+
+    if (flow->app.pause_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.pause_action_id) &&
+        !flow->quit_pending && !sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+    {
+        if (ctx->paused)
+            ctx->paused = false;
+        else if (pause_allowed && sdl3d_game_data_active_scene_updates_game(runtime))
+            ctx->paused = true;
+    }
+
+    app_flow_update_transition(flow, ctx, bus, dt);
+    sdl3d_game_data_scene_flow_update(&flow->scene_flow, runtime, bus, dt);
+    return true;
+}
+
+void sdl3d_game_data_app_flow_draw(const sdl3d_game_data_app_flow *flow, sdl3d_render_context *renderer)
+{
+    if (flow == NULL)
+        return;
+    sdl3d_game_data_scene_flow_draw(&flow->scene_flow, renderer);
+    sdl3d_transition_draw(&flow->transition, renderer);
+}
+
+bool sdl3d_game_data_draw_frame(const sdl3d_game_data_frame_desc *frame)
+{
+    if (frame == NULL || frame->runtime == NULL || frame->renderer == NULL)
+        return false;
+
+    bool ok = true;
+    ok = apply_render_settings(frame->runtime, frame->renderer) && ok;
+    ok = apply_world_lights(frame->runtime, frame->renderer, frame->render_eval) && ok;
+
+    if (sdl3d_game_data_active_scene_renders_world(frame->runtime))
+    {
+        const sdl3d_camera3d camera = active_camera_or_fallback(frame->runtime, frame->fallback_camera);
+        if (sdl3d_begin_mode_3d(frame->renderer, camera))
+        {
+            ok = run_frame_hook(frame, frame->before_world_3d) && ok;
+            if (frame->particle_cache != NULL)
+                ok = sdl3d_game_data_draw_particles(frame->runtime, frame->renderer, frame->particle_cache) && ok;
+            ok =
+                sdl3d_game_data_draw_render_primitives_evaluated(frame->runtime, frame->renderer, frame->render_eval) &&
+                ok;
+            ok = run_frame_hook(frame, frame->after_world_3d) && ok;
+            sdl3d_end_mode_3d(frame->renderer);
+        }
+        else
+        {
+            ok = false;
+        }
+    }
+
+    ok = run_frame_hook(frame, frame->before_ui) && ok;
+    if (frame->font_cache != NULL)
+    {
+        ok = sdl3d_game_data_draw_ui_text(frame->runtime, frame->renderer, frame->font_cache, frame->metrics,
+                                          frame->pulse_phase) &&
+             ok;
+    }
+    if (frame->app_flow != NULL)
+        sdl3d_game_data_app_flow_draw(frame->app_flow, frame->renderer);
+    ok = run_frame_hook(frame, frame->after_ui) && ok;
+    return ok;
+}

--- a/tests/assets/game_data/scripts/rules.lua
+++ b/tests/assets/game_data/scripts/rules.lua
@@ -5,6 +5,8 @@ function rules.run(target, _, ctx)
     target.velocity = Vec3(test.shared.speed(), 2.0, 0.0)
     target:set_float("speed_length", Vec3.length(target.velocity))
     ctx:actor("entity.target"):set_bool("ctx_ok", ctx.adapter == "adapter.test.run" and ctx.dt >= 0.0)
+    ctx:state_set("last_adapter", ctx.adapter)
+    target:set_bool("state_ok", ctx:state_get("last_adapter", "") == "adapter.test.run")
     target:set_float("random_value", ctx:random())
     return true
 end

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -18,9 +18,11 @@ extern "C"
 #include "sdl3d/asset.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
+#include "sdl3d/game_presentation.h"
 #include "sdl3d/math.h"
 #include "sdl3d/properties.h"
 #include "sdl3d/signal_bus.h"
+#include "sdl3d/timer_pool.h"
 }
 
 namespace
@@ -58,10 +60,24 @@ struct UiTextCapture
     bool saw_pause = false;
 };
 
+struct ParticleCapture
+{
+    int count = 0;
+    bool saw_ambient = false;
+};
+
 struct EvaluatedPrimitiveCapture
 {
     bool saw_border = false;
     bool saw_ball = false;
+};
+
+struct ScenePayloadCapture
+{
+    bool called = false;
+    std::string from_scene;
+    std::string to_scene;
+    std::string selected_level;
 };
 
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
@@ -96,6 +112,16 @@ void capture_diagnostic(void *userdata, sdl3d_game_data_diagnostic_severity seve
     auto *capture = static_cast<DiagnosticCapture *>(userdata);
     capture->diagnostics.push_back(
         {severity, json_path != nullptr ? json_path : "", message != nullptr ? message : ""});
+}
+
+void capture_scene_payload(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    auto *capture = static_cast<ScenePayloadCapture *>(userdata);
+    (void)signal_id;
+    capture->called = true;
+    capture->from_scene = sdl3d_properties_get_string(payload, "from_scene", "");
+    capture->to_scene = sdl3d_properties_get_string(payload, "to_scene", "");
+    capture->selected_level = sdl3d_properties_get_string(payload, "selected_level", "");
 }
 
 std::string fixture_path(const char *filename)
@@ -241,6 +267,19 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
     return true;
 }
 
+bool capture_particle(void *userdata, const sdl3d_game_data_particle_emitter *emitter)
+{
+    auto *capture = static_cast<ParticleCapture *>(userdata);
+    ++capture->count;
+    if (std::string(emitter->entity_name) == "entity.effect.ambient_particles")
+    {
+        capture->saw_ambient = true;
+        EXPECT_EQ(emitter->config.max_particles, 360);
+        EXPECT_NEAR(emitter->draw_emissive.x, 0.8f, 0.0001f);
+    }
+    return true;
+}
+
 bool capture_evaluated_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
 {
     auto *capture = static_cast<EvaluatedPrimitiveCapture *>(userdata);
@@ -321,7 +360,21 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_NE(sdl3d_game_data_find_actor_with_tags(runtime, paddle_tags, 2), nullptr);
     EXPECT_GE(sdl3d_game_data_find_signal(runtime, "signal.ball.serve"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.up"), 0);
+    EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.title"), 0);
+    EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.options"), 0);
+    EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 3);
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 0), "scene.title");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 1), "scene.options");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.play");
+    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, -1), nullptr);
+    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 3), nullptr);
+    EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_renders_world(runtime));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
+    EXPECT_EQ(sdl3d_timer_pool_active_count(sdl3d_game_session_get_timer_pool(session)), 0);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -366,7 +419,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     sdl3d_game_data_app_control app{};
     ASSERT_TRUE(sdl3d_game_data_get_app_control(runtime, &app));
-    EXPECT_GE(app.start_signal_id, 0);
+    EXPECT_EQ(app.start_signal_id, -1);
     EXPECT_GE(app.quit_action_id, 0);
     EXPECT_GE(app.pause_action_id, 0);
     EXPECT_STREQ(app.startup_transition, "startup");
@@ -378,6 +431,9 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_TRUE(font.builtin);
     EXPECT_EQ(font.builtin_id, SDL3D_BUILTIN_FONT_INTER);
     EXPECT_NEAR(font.size, 34.0f, 0.0001f);
+    ASSERT_TRUE(sdl3d_game_data_get_font_asset(runtime, "font.title", &font));
+    EXPECT_TRUE(font.builtin);
+    EXPECT_NEAR(font.size, 96.0f, 0.0001f);
 
     float ambient[3]{};
     ASSERT_TRUE(sdl3d_game_data_get_world_ambient_light(runtime, ambient));
@@ -404,6 +460,10 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
                                                                    &particle_emissive));
     EXPECT_NEAR(particle_emissive.x, 0.8f, 0.0001f);
 
+    ParticleCapture title_particles{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_particle_emitter(runtime, capture_particle, &title_particles));
+    EXPECT_EQ(title_particles.count, 0);
+
     sdl3d_game_data_render_settings render{};
     ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render));
     EXPECT_EQ(render.clear_color.r, 3);
@@ -421,6 +481,31 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(transition.duration, 0.45f, 0.0001f);
     EXPECT_GE(transition.done_signal_id, 0);
 
+    RenderPrimitiveCapture title_capture{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &title_capture));
+    EXPECT_EQ(title_capture.cubes, 0);
+    EXPECT_EQ(title_capture.spheres, 0);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
+    EXPECT_TRUE(sdl3d_game_data_active_scene_updates_game(runtime));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_renders_world(runtime));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
+    EXPECT_EQ(sdl3d_timer_pool_active_count(sdl3d_game_session_get_timer_pool(session)), 1);
+
+    ParticleCapture play_particles{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_particle_emitter(runtime, capture_particle, &play_particles));
+    EXPECT_EQ(play_particles.count, 1);
+    EXPECT_TRUE(play_particles.saw_ambient);
+
+    sdl3d_game_data_particle_cache particle_cache{};
+    sdl3d_game_data_particle_cache_init(&particle_cache);
+    ASSERT_TRUE(sdl3d_game_data_update_particles(runtime, &particle_cache, 0.1f));
+    EXPECT_EQ(particle_cache.count, 1);
+    EXPECT_TRUE(particle_cache.entries[0].visible);
+    sdl3d_game_data_particle_cache_free(&particle_cache);
+
     RenderPrimitiveCapture capture{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &capture));
     EXPECT_EQ(capture.cubes, 16);
@@ -432,6 +517,18 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     ASSERT_NE(presentation, nullptr);
     EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "border_flash_decay", 0.0f), 2.8f, 0.0001f);
     sdl3d_properties_set_float(presentation->props, "border_flash", 1.0f);
+    ASSERT_TRUE(sdl3d_game_data_update_property_effects(runtime, 0.25f));
+    EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "border_flash", -1.0f), 0.3f, 0.0001f);
+    sdl3d_properties_set_float(presentation->props, "border_flash", 1.0f);
+
+    sdl3d_light base_light{};
+    sdl3d_light flashed_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &base_light));
+    sdl3d_game_data_render_eval light_eval{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 0, &light_eval, &flashed_light));
+    EXPECT_GT(flashed_light.intensity, base_light.intensity);
+    EXPECT_GT(flashed_light.range, base_light.range);
+
     sdl3d_game_data_render_eval render_eval{};
     render_eval.time = 0.25f;
     EvaluatedPrimitiveCapture evaluated{};
@@ -475,6 +572,284 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
                                                                                            &pause_visible};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_pause_visible, &pause_args));
     EXPECT_TRUE(pause_visible);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.title");
+    EXPECT_EQ(menu.item_count, 3);
+    EXPECT_EQ(menu.selected_index, 0);
+    EXPECT_GE(menu.up_action_id, 0);
+    EXPECT_GE(menu.down_action_id, 0);
+    EXPECT_GE(menu.select_action_id, 0);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    EXPECT_TRUE(sdl3d_game_data_active_menu_input_is_idle(runtime, input));
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    EXPECT_FALSE(sdl3d_game_data_active_menu_input_is_idle(runtime, input));
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    EXPECT_TRUE(sdl3d_game_data_active_menu_input_is_idle(runtime, input));
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Options");
+    EXPECT_STREQ(item.scene, "scene.options");
+    EXPECT_FALSE(item.quit);
+
+    ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, menu.name, -1));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.selected_index, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, menu.selected_index, &item));
+    EXPECT_STREQ(item.label, "Exit");
+    EXPECT_TRUE(item.quit);
+
+    ASSERT_EQ(sdl3d_game_data_scene_shortcut_count(runtime), 3);
+    sdl3d_game_data_scene_shortcut shortcut{};
+    ASSERT_TRUE(sdl3d_game_data_scene_shortcut_at(runtime, 2, &shortcut));
+    EXPECT_STREQ(shortcut.action, "action.scene.play");
+    EXPECT_STREQ(shortcut.scene, "scene.play");
+    EXPECT_GE(shortcut.action_id, 0);
+
+    sdl3d_game_data_transition_desc transition{};
+    ASSERT_TRUE(sdl3d_game_data_get_scene_transition(runtime, "scene.title", "exit", &transition));
+    EXPECT_EQ(transition.type, SDL3D_TRANSITION_FADE);
+    EXPECT_EQ(transition.direction, SDL3D_TRANSITION_OUT);
+
+    bool saw_title_cursor = false;
+    bool saw_title_exit = false;
+    auto find_title_menu_ui = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *flags = static_cast<std::pair<bool *, bool *> *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.title.menu" && value == ">")
+        {
+            *flags->first = true;
+        }
+        if (name == "ui.title.menu" && value == "Exit")
+        {
+            *flags->second = true;
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_CENTER);
+            EXPECT_TRUE(text->pulse_alpha);
+        }
+        if (*flags->first && *flags->second)
+            return false;
+        return true;
+    };
+    std::pair<bool *, bool *> title_menu_flags{&saw_title_cursor, &saw_title_exit};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_title_menu_ui, &title_menu_flags));
+    EXPECT_TRUE(saw_title_cursor);
+    EXPECT_TRUE(saw_title_exit);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options");
+    EXPECT_EQ(menu.item_count, 5);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
+    EXPECT_STREQ(item.scene, "scene.title");
+
+    ScenePayloadCapture payload_capture{};
+    const int start_signal = sdl3d_game_data_find_signal(runtime, "signal.game.start");
+    ASSERT_GE(start_signal, 0);
+    ASSERT_NE(sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(session), start_signal, capture_scene_payload,
+                                   &payload_capture),
+              0);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    ASSERT_NE(payload, nullptr);
+    sdl3d_properties_set_string(payload, "from_scene", "scene.options");
+    sdl3d_properties_set_string(payload, "selected_level", "level.test");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload));
+    EXPECT_TRUE(payload_capture.called);
+    EXPECT_EQ(payload_capture.from_scene, "scene.options");
+    EXPECT_EQ(payload_capture.to_scene, "scene.play");
+    EXPECT_EQ(payload_capture.selected_level, "level.test");
+    sdl3d_properties_destroy(payload);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "selected_level", "level.002");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.title"));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "selected_level", ""), "level.002");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    bool armed = false;
+    sdl3d_game_data_menu_update_result result{};
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(armed);
+    EXPECT_FALSE(result.handled_input);
+    EXPECT_FALSE(result.selected);
+    EXPECT_STREQ(result.menu, "menu.title");
+    EXPECT_EQ(result.selected_index, 0);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_DOWN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_FALSE(result.selected);
+    EXPECT_STREQ(result.menu, "menu.title");
+    EXPECT_EQ(result.selected_index, 1);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.selected);
+    EXPECT_FALSE(result.quit);
+    EXPECT_STREQ(result.menu, "menu.title");
+    EXPECT_EQ(result.selected_index, 1);
+    EXPECT_STREQ(result.scene, "scene.options");
+    EXPECT_EQ(result.signal_id, -1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.8f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_FALSE(ctx.quit_requested);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_3;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.29f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.29f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    EXPECT_TRUE(ctx.paused);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    EXPECT_FALSE(ctx.paused);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 6);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 7);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_quit_pending(&flow));
+    EXPECT_FALSE(ctx.quit_requested);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.5f));
+    EXPECT_TRUE(ctx.quit_requested);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, SceneFlowRunsAuthoredExitAndEnterTransitions)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_game_data_scene_flow flow{};
+    sdl3d_game_data_scene_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_scene_flow_request(&flow, runtime, "scene.play"));
+    EXPECT_TRUE(sdl3d_game_data_scene_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+    EXPECT_FALSE(sdl3d_game_data_scene_flow_request(&flow, runtime, "scene.options"));
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    sdl3d_game_data_scene_flow_update(&flow, runtime, bus, 0.29f);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+    EXPECT_TRUE(sdl3d_game_data_scene_flow_is_transitioning(&flow));
+
+    sdl3d_game_data_scene_flow_update(&flow, runtime, bus, 0.29f);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+    EXPECT_FALSE(sdl3d_game_data_scene_flow_is_transitioning(&flow));
+    EXPECT_FALSE(sdl3d_game_data_scene_flow_request(&flow, runtime, "scene.play"));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -557,6 +932,7 @@ TEST(GameDataRuntime, LuaControllerMovesCpuPaddleTowardBall)
     sdl3d_properties_set_vec3(ball->props, "origin", ball->position);
     sdl3d_properties_set_vec3(cpu->props, "origin", cpu->position);
 
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
 
     EXPECT_GT(cpu->position.y, 0.0f);
@@ -666,6 +1042,9 @@ TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
     EXPECT_FLOAT_EQ(velocity.y, 2.0f);
     EXPECT_NEAR(speed_length, SDL_sqrtf(53.0f), 0.0001f);
     EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "ctx_ok", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "state_ok", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "last_adapter", ""),
+                 "adapter.test.run");
     EXPECT_GE(random_value, 0.0f);
     EXPECT_LT(random_value, 1.0f);
 
@@ -727,6 +1106,7 @@ TEST(GameDataRuntime, LoadsLuaBackedGameDataFromMemoryPack)
     EXPECT_FLOAT_EQ(target->position.x, 1.0f);
     EXPECT_FLOAT_EQ(target->position.y, 2.0f);
     EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "ctx_ok", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(target->props, "state_ok", false));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -966,6 +1346,7 @@ TEST(GameDataRuntime, AuthoredGoalSensorDrivesScoreBinding)
     ASSERT_NE(cpu_score, nullptr);
 
     ball->position.x = -10.0f;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f / 60.0f));
 
     EXPECT_EQ(sdl3d_properties_get_int(cpu_score->props, "value", 0), 1);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -670,8 +670,34 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
     EXPECT_EQ(menu.item_count, 5);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Difficulty");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
+    EXPECT_STREQ(item.control_target, "entity.settings");
+    EXPECT_STREQ(item.control_key, "difficulty");
+    EXPECT_EQ(item.choice_count, 3);
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "normal");
+    ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
     EXPECT_STREQ(item.scene, "scene.title");
+
+    bool saw_options_value = false;
+    auto find_options_value = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *saw = static_cast<bool *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.options.menu" && value == "Difficulty: Hard")
+        {
+            *saw = true;
+            return false;
+        }
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_options_value, &saw_options_value));
+    EXPECT_TRUE(saw_options_value);
 
     ScenePayloadCapture payload_capture{};
     const int start_signal = sdl3d_game_data_find_signal(runtime, "signal.game.start");
@@ -696,6 +722,58 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     sdl3d_properties_set_string(scene_state, "selected_level", "level.002");
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.title"));
     EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "selected_level", ""), "level.002");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    const int pause = sdl3d_game_data_find_action(runtime, "action.pause");
+    const int scene_play = sdl3d_game_data_find_action(runtime, "action.scene.play");
+    ASSERT_GE(pause, 0);
+    ASSERT_GE(scene_play, 0);
+    EXPECT_FALSE(sdl3d_game_data_active_scene_allows_action(runtime, pause));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, scene_play));
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, pause));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(runtime, "presentation", true));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_update_phase(runtime, "simulation", true));
+
+    sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
+    ASSERT_NE(presentation, nullptr);
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+
+    sdl3d_game_data_frame_state frame_state{};
+    sdl3d_game_data_frame_state_init(&frame_state);
+    sdl3d_game_data_update_frame_desc update{};
+    update.ctx = &ctx;
+    update.runtime = runtime;
+    update.dt = 0.25f;
+    ASSERT_TRUE(sdl3d_game_data_update_frame(&frame_state, &update));
+    EXPECT_NEAR(frame_state.time, 0.25f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "pause_flash", -1.0f), 0.0f, 0.0001f);
+
+    ctx.paused = true;
+    update.dt = 0.1f;
+    ASSERT_TRUE(sdl3d_game_data_update_frame(&frame_state, &update));
+    EXPECT_NEAR(sdl3d_properties_get_float(presentation->props, "pause_flash", -1.0f), 0.3f, 0.0001f);
+    EXPECT_NEAR(sdl3d_game_data_ui_pulse_phase(runtime, -1.0f), 0.3f, 0.0001f);
+
+    sdl3d_game_data_scene_transition_policy policy{};
+    ASSERT_TRUE(sdl3d_game_data_get_scene_transition_policy(runtime, &policy));
+    EXPECT_FALSE(policy.allow_same_scene);
+    EXPECT_FALSE(policy.allow_interrupt);
+    EXPECT_TRUE(policy.reset_menu_input_on_request);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -426,6 +426,13 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_STREQ(app.quit_transition, "quit");
     EXPECT_GE(app.quit_signal_id, 0);
 
+    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    ASSERT_NE(match, nullptr);
+    EXPECT_TRUE(sdl3d_game_data_app_pause_allowed(runtime, nullptr));
+    sdl3d_properties_set_bool(match->props, "finished", true);
+    EXPECT_FALSE(sdl3d_game_data_app_pause_allowed(runtime, nullptr));
+    sdl3d_properties_set_bool(match->props, "finished", false);
+
     sdl3d_game_data_font_asset font{};
     ASSERT_TRUE(sdl3d_game_data_get_font_asset(runtime, "font.hud", &font));
     EXPECT_TRUE(font.builtin);
@@ -765,7 +772,7 @@ TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
     ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
     EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
 
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.8f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.8f));
     EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
     EXPECT_FALSE(ctx.quit_requested);
 
@@ -778,13 +785,13 @@ TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
 
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
     EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
 
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.29f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.29f));
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.29f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.29f));
     EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
 
     key.type = SDL_EVENT_KEY_UP;
@@ -794,7 +801,7 @@ TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
     key.key.scancode = SDL_SCANCODE_RETURN;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 3);
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
     EXPECT_TRUE(ctx.paused);
 
     key.type = SDL_EVENT_KEY_UP;
@@ -804,21 +811,35 @@ TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
     key.key.scancode = SDL_SCANCODE_RETURN;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 5);
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
     EXPECT_FALSE(ctx.paused);
+
+    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    ASSERT_NE(match, nullptr);
+    sdl3d_properties_set_bool(match->props, "finished", true);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 6);
     key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    key.key.scancode = SDL_SCANCODE_RETURN;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 7);
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.0f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_FALSE(ctx.paused);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 8);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 9);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
     EXPECT_TRUE(sdl3d_game_data_app_flow_quit_pending(&flow));
     EXPECT_FALSE(ctx.quit_requested);
 
-    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, true, 0.5f));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.5f));
     EXPECT_TRUE(ctx.quit_requested);
 
     sdl3d_game_data_destroy(runtime);

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -268,6 +268,20 @@ TEST(GameDataJson, PongLogicReferencesKnownEntitiesSignalsTimersCamerasAndAdapte
     yyjson_val *logic = required_object(doc.root(), "logic");
     collect_named_objects(required_array(logic, "timers"), "name", &timers);
 
+    std::set<std::string> actions;
+    yyjson_val *input_contexts = required_array(required_object(doc.root(), "input"), "contexts");
+    for (size_t i = 0; i < yyjson_arr_size(input_contexts); ++i)
+    {
+        yyjson_val *context = yyjson_arr_get(input_contexts, i);
+        ASSERT_TRUE(yyjson_is_obj(context));
+        collect_named_objects(required_array(context, "actions"), "name", &actions);
+    }
+    yyjson_val *pause = required_object(required_object(doc.root(), "app"), "pause");
+    expect_ref(actions, pause, "action");
+    yyjson_val *allowed_if = required_object(pause, "allowed_if");
+    expect_ref(entities, allowed_if, "target");
+    EXPECT_EQ(required_string(allowed_if, "type"), "property.compare");
+
     yyjson_val *sensors = required_array(logic, "sensors");
     for (size_t i = 0; i < yyjson_arr_size(sensors); ++i)
     {


### PR DESCRIPTION
## Summary
- adds reusable game-data app flow helpers for authored startup/quit transitions, pause, menu selection, and scene switching
- moves Pong scene shortcuts into JSON via app.scene_shortcuts instead of hardcoded host tables
- moves Pong pause gating into app.pause.allowed_if so match-finished pause suppression is authored data, not host logic
- adds scene input policy through app.input_policy.global_actions and per-scene input.actions so shared bindings can mean different things per scene
- adds authored scene transition policy for same-scene requests, interruption, and menu input reset behavior
- adds a generic frame/update helper with authored update phases for app flow, presentation, property effects, particles, and simulation
- adds presentation clocks and frame metrics so FPS/frame counters, render time, and pause pulse phase are engine-owned and data-authored
- adds generic options menu controls for toggle, choice, and range settings bound to actor properties
- generalizes authored particle emitter presentation through a reusable particle cache and draw/update helpers
- adds a generic authored menu controller that handles input arming, navigation, selected-item command resolution, and data-bound controls
- adds a generic presentation frame helper for authored render settings, evaluated lights, camera, particles, primitives, UI, and transitions with custom draw hooks
- adds data-authored light effects for pulse/flash-driven color, intensity, and range changes
- adds data-authored property.decay components so transient presentation state such as flashes no longer needs Pong C code
- adds scene UI menu presenters for stacked, aligned, data-authored menus with selected colors, cursor styling, and current option values
- trims Pong host glue so the demo delegates menu/scene/quit/pause/particle/frame/effect/update behavior to engine-level primitives
- removes Pong-side mirrors for match/flash/frame state; authored actor properties and reusable frame state are the source of truth
- validates scene shortcut, app pause condition, input policy, update phase, presentation clock, UI menu, menu control, light effect, and property decay references

## Testing
- make format-fix && make format && git diff --check
- cmake --build build/default -j 8 --target sdl3d_game_data_test game_data_json_test && ./build/default/tests/sdl3d_game_data_test && ./build/default/tests/game_data_json_test
- make demos
- cmake --build build/release -j 8 --target pong_demo
- ctest --test-dir build/debug --output-on-failure