### PR TITLE
Add generic data-authored scene timelines

### DIFF
--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -286,6 +286,37 @@ extern "C"
     } sdl3d_game_data_splash;
 
     /**
+     * @brief Runtime state for a data-authored active-scene timeline.
+     *
+     * Hosts keep this state across frames. The game data runtime resets it
+     * automatically when the active scene changes.
+     */
+    typedef struct sdl3d_game_data_timeline_state
+    {
+        /** @brief Runtime-owned active scene pointer currently tracked by this state. */
+        const char *scene;
+        /** @brief Elapsed timeline time in seconds for @p scene. */
+        float time;
+        /** @brief Next authored event index to evaluate. */
+        int next_event_index;
+        /** @brief True once all authored events have fired. */
+        bool complete;
+    } sdl3d_game_data_timeline_state;
+
+    /**
+     * @brief Result produced after advancing an active-scene timeline.
+     */
+    typedef struct sdl3d_game_data_timeline_update_result
+    {
+        /** @brief Scene requested by a `scene.request` timeline action, or NULL. */
+        const char *scene_request;
+        /** @brief Number of timeline actions executed during this update. */
+        int actions_executed;
+        /** @brief True when the active timeline has no more events to fire. */
+        bool complete;
+    } sdl3d_game_data_timeline_update_result;
+
+    /**
      * @brief Runtime descriptor for the active scene's primary menu.
      *
      * Menus are authored in scene JSON files and map input actions to a
@@ -1014,6 +1045,31 @@ extern "C"
      * scene and how to apply transitions.
      */
     bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash);
+
+    /**
+     * @brief Initialize reusable timeline state.
+     *
+     * Safe to call with NULL.
+     */
+    void sdl3d_game_data_timeline_state_init(sdl3d_game_data_timeline_state *state);
+
+    /**
+     * @brief Advance the active scene's authored autoplay timeline.
+     *
+     * Timeline events are one-shot and must be authored in non-decreasing time
+     * order. This helper executes generic actions that are safe to apply inside
+     * the data runtime (`signal.emit`, `property.set`, etc.). `scene.request`
+     * is reported in @p out_result so hosts can route the request through their
+     * own transition flow instead of forcing an immediate scene switch.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param state Persistent timeline state owned by the host.
+     * @param dt Delta time in seconds.
+     * @param out_result Optional update result.
+     * @return true when the timeline update completed without an execution error.
+     */
+    bool sdl3d_game_data_update_timeline(sdl3d_game_data_runtime *runtime, sdl3d_game_data_timeline_state *state,
+                                         float dt, sdl3d_game_data_timeline_update_result *out_result);
 
     /**
      * @brief Resolve UI text content from data-authored bindings.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -135,14 +135,15 @@ extern "C"
      */
     typedef struct sdl3d_game_data_app_flow
     {
-        sdl3d_game_data_scene_flow scene_flow; /**< Data-authored scene transition flow. */
-        sdl3d_transition transition;           /**< App-level startup/quit transition. */
-        sdl3d_game_data_app_control app;       /**< Resolved app controls from game data. */
-        bool quit_pending;                     /**< True after quit has been requested. */
-        bool scene_input_armed;                /**< True once menu input is idle after scene entry. */
-        const char *splash_scene;              /**< Active splash scene tracked for hold timing. */
-        float splash_elapsed;                  /**< Seconds held after splash transitions finish. */
-        bool splash_skip_requested;            /**< True once input asks the splash to advance. */
+        sdl3d_game_data_scene_flow scene_flow;   /**< Data-authored scene transition flow. */
+        sdl3d_transition transition;             /**< App-level startup/quit transition. */
+        sdl3d_game_data_app_control app;         /**< Resolved app controls from game data. */
+        bool quit_pending;                       /**< True after quit has been requested. */
+        bool scene_input_armed;                  /**< True once menu input is idle after scene entry. */
+        const char *splash_scene;                /**< Active splash scene tracked for hold timing. */
+        float splash_elapsed;                    /**< Seconds held after splash transitions finish. */
+        bool splash_skip_requested;              /**< True once input asks the splash to advance. */
+        sdl3d_game_data_timeline_state timeline; /**< Runtime state for the active scene's authored timeline. */
     } sdl3d_game_data_app_flow;
 
     /**

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2250,6 +2250,96 @@ bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, s
     return out_splash->next_scene != NULL;
 }
 
+static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *timeline = obj_get(scene != NULL ? scene->root : NULL, "timeline");
+    if (!yyjson_is_obj(timeline) || !json_bool(timeline, "autoplay", false))
+        return NULL;
+
+    yyjson_val *events = obj_get(timeline, "events");
+    if (events == NULL)
+        events = obj_get(timeline, "tracks");
+    return yyjson_is_arr(events) ? events : NULL;
+}
+
+static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload);
+
+void sdl3d_game_data_timeline_state_init(sdl3d_game_data_timeline_state *state)
+{
+    if (state != NULL)
+        SDL_zero(*state);
+}
+
+bool sdl3d_game_data_update_timeline(sdl3d_game_data_runtime *runtime, sdl3d_game_data_timeline_state *state, float dt,
+                                     sdl3d_game_data_timeline_update_result *out_result)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    if (runtime == NULL || state == NULL)
+        return false;
+
+    const char *active_scene = sdl3d_game_data_active_scene(runtime);
+    if (state->scene != active_scene)
+    {
+        state->scene = active_scene;
+        state->time = 0.0f;
+        state->next_event_index = 0;
+        state->complete = false;
+    }
+
+    yyjson_val *events = active_timeline_events(runtime);
+    if (!yyjson_is_arr(events))
+    {
+        state->complete = true;
+        if (out_result != NULL)
+            out_result->complete = true;
+        return true;
+    }
+
+    const int event_count = (int)yyjson_arr_size(events);
+    if (state->next_event_index >= event_count)
+    {
+        state->complete = true;
+        if (out_result != NULL)
+            out_result->complete = true;
+        return true;
+    }
+
+    state->time += dt > 0.0f ? dt : 0.0f;
+    bool ok = true;
+    while (state->next_event_index < event_count)
+    {
+        yyjson_val *event = yyjson_arr_get(events, (size_t)state->next_event_index);
+        const float event_time = json_float(event, "time", 0.0f);
+        if (event_time > state->time)
+            break;
+
+        ++state->next_event_index;
+        yyjson_val *action = obj_get(event, "action");
+        const char *type = json_string(action, "type", "");
+        if (SDL_strcmp(type, "scene.request") == 0)
+        {
+            if (out_result != NULL)
+                out_result->scene_request = json_string(action, "scene", NULL);
+        }
+        else if (yyjson_is_obj(action))
+        {
+            ok = execute_one_action(runtime, action, NULL) && ok;
+        }
+
+        if (out_result != NULL)
+            ++out_result->actions_executed;
+        if (out_result != NULL && out_result->scene_request != NULL)
+            break;
+    }
+
+    state->complete = state->next_event_index >= event_count;
+    if (out_result != NULL)
+        out_result->complete = state->complete;
+    return ok;
+}
+
 bool sdl3d_game_data_set_active_scene(sdl3d_game_data_runtime *runtime, const char *scene_name)
 {
     return sdl3d_game_data_set_active_scene_with_payload(runtime, scene_name, NULL);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -945,6 +945,17 @@ static bool validate_action_array(validation_context *ctx, yyjson_val *actions, 
     return true;
 }
 
+static bool validate_timeline_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                     validation_names *names)
+{
+    if (!yyjson_is_obj(action))
+        return validation_error(ctx, json_path, "timeline action must be an object");
+    const char *type = json_string(action, "type");
+    if (SDL_strcmp(type != NULL ? type : "", "scene.request") == 0)
+        return require_ref(ctx, &names->scenes, "scene", json_string(action, "scene"), json_path);
+    return validate_one_action(ctx, action, json_path, names);
+}
+
 static bool validate_logic(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *logic = obj_get(root, "logic");
@@ -1629,6 +1640,39 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     format_path(phases_path, sizeof(phases_path), "%s.update_phases", json_path);
     if (!validate_update_phases(ctx, obj_get(root, "update_phases"), phases_path))
         return false;
+
+    yyjson_val *timeline = obj_get(root, "timeline");
+    if (timeline != NULL)
+    {
+        if (!yyjson_is_obj(timeline))
+            return validation_error(ctx, json_path, "scene timeline must be an object");
+        yyjson_val *events = obj_get(timeline, "events");
+        if (events == NULL)
+            events = obj_get(timeline, "tracks");
+        if (events != NULL && !yyjson_is_arr(events))
+            return validation_error(ctx, json_path, "scene timeline events must be an array");
+
+        double previous_time = 0.0;
+        for (size_t i = 0; yyjson_is_arr(events) && i < yyjson_arr_size(events); ++i)
+        {
+            char event_path[PATH_BUFFER_SIZE];
+            format_path(event_path, sizeof(event_path), "%s.timeline.events[%zu]", json_path, i);
+            yyjson_val *event = yyjson_arr_get(events, i);
+            if (!yyjson_is_obj(event))
+                return validation_error(ctx, event_path, "timeline event must be an object");
+            yyjson_val *time = obj_get(event, "time");
+            if (!yyjson_is_num(time) || yyjson_get_num(time) < 0.0)
+                return validation_error(ctx, event_path, "timeline event requires a non-negative time");
+            if (yyjson_get_num(time) < previous_time)
+                return validation_error(ctx, event_path, "timeline event times must be non-decreasing");
+            previous_time = yyjson_get_num(time);
+
+            char action_path[PATH_BUFFER_SIZE];
+            format_path(action_path, sizeof(action_path), "%s.action", event_path);
+            if (!validate_timeline_action(ctx, obj_get(event, "action"), action_path, names))
+                return false;
+        }
+    }
 
     yyjson_val *splash = obj_get(root, "splash");
     if (splash != NULL)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1010,6 +1010,23 @@ static void app_flow_advance_splash(sdl3d_game_data_app_flow *flow, sdl3d_game_d
         (void)app_flow_request_scene(flow, runtime, splash.next_scene);
 }
 
+static bool app_flow_update_timeline(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime, float dt)
+{
+    if (flow == NULL || runtime == NULL || flow->quit_pending || flow->transition.active ||
+        sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+    {
+        return true;
+    }
+
+    sdl3d_game_data_timeline_update_result result;
+    if (!sdl3d_game_data_update_timeline(runtime, &flow->timeline, dt, &result))
+        return false;
+
+    if (result.scene_request != NULL)
+        (void)app_flow_request_scene(flow, runtime, result.scene_request);
+    return true;
+}
+
 static void app_flow_update_transition(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx, sdl3d_signal_bus *bus,
                                        float dt)
 {
@@ -1044,6 +1061,7 @@ bool sdl3d_game_data_app_flow_start(sdl3d_game_data_app_flow *flow, sdl3d_game_d
     flow->splash_scene = NULL;
     flow->splash_elapsed = 0.0f;
     flow->splash_skip_requested = false;
+    sdl3d_game_data_timeline_state_init(&flow->timeline);
     if (!sdl3d_game_data_get_app_control(runtime, &flow->app))
         return false;
 
@@ -1105,8 +1123,11 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
         }
     }
 
+    const bool scene_transitioning_before = sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow);
     app_flow_update_transition(flow, ctx, bus, dt);
     sdl3d_game_data_scene_flow_update(&flow->scene_flow, runtime, bus, dt);
+    if (!scene_transitioning_before && !app_flow_update_timeline(flow, runtime, dt))
+        return false;
     app_flow_advance_splash(flow, runtime, dt);
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -86,6 +86,11 @@ struct ScenePayloadCapture
     std::string selected_level;
 };
 
+struct SignalCapture
+{
+    int calls = 0;
+};
+
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                    sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -128,6 +133,14 @@ void capture_scene_payload(void *userdata, int signal_id, const sdl3d_properties
     capture->from_scene = sdl3d_properties_get_string(payload, "from_scene", "");
     capture->to_scene = sdl3d_properties_get_string(payload, "to_scene", "");
     capture->selected_level = sdl3d_properties_get_string(payload, "selected_level", "");
+}
+
+void count_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    auto *capture = static_cast<SignalCapture *>(userdata);
+    (void)signal_id;
+    (void)payload;
+    capture->calls++;
 }
 
 std::string fixture_path(const char *filename)
@@ -201,6 +214,71 @@ void write_hot_reload_json(const std::filesystem::path &dir)
       "function": "run"
     }
   ]
+})json");
+}
+
+void write_timeline_json(const std::filesystem::path &dir)
+{
+    write_text(dir / "timeline.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Timeline", "id": "test.timeline", "version": "0.1.0" },
+  "transitions": {
+    "scene_out": { "type": "fade", "direction": "out", "color": [0, 0, 0, 255], "duration": 0.10 },
+    "scene_in": { "type": "fade", "direction": "in", "color": [0, 0, 0, 255], "duration": 0.10 }
+  },
+  "entities": [
+    {
+      "name": "entity.flag",
+      "active": true,
+      "properties": {
+        "ready": { "type": "bool", "value": false }
+      }
+    }
+  ],
+  "signals": ["signal.timeline"],
+  "scenes": {
+    "initial": "scene.intro",
+    "files": [
+      "scenes/intro.scene.json",
+      "scenes/title.scene.json"
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "intro.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.intro",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "transitions": { "exit": "scene_out" },
+  "timeline": {
+    "autoplay": true,
+    "events": [
+      {
+        "time": 0.10,
+        "action": { "type": "property.set", "target": "entity.flag", "key": "ready", "value": true }
+      },
+      {
+        "time": 0.20,
+        "action": { "type": "signal.emit", "signal": "signal.timeline" }
+      },
+      {
+        "time": 0.30,
+        "action": { "type": "scene.request", "scene": "scene.title" }
+      }
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "title.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "transitions": { "enter": "scene_in" }
 })json");
 }
 
@@ -1008,6 +1086,64 @@ TEST(GameDataRuntime, SceneFlowRunsAuthoredExitAndEnterTransitions)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AppFlowRunsAuthoredSceneTimelineActions)
+{
+    const std::filesystem::path dir = unique_test_dir("timeline");
+    write_timeline_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "timeline.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    const int timeline_signal = sdl3d_game_data_find_signal(runtime, "signal.timeline");
+    ASSERT_GE(timeline_signal, 0);
+    SignalCapture signal_capture{};
+    ASSERT_NE(sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(session), timeline_signal, count_signal,
+                                   &signal_capture),
+              0);
+
+    sdl3d_registered_actor *flag = sdl3d_game_data_find_actor(runtime, "entity.flag");
+    ASSERT_NE(flag, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(flag->props, "ready", true));
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.05f));
+    EXPECT_FALSE(sdl3d_properties_get_bool(flag->props, "ready", true));
+    EXPECT_EQ(signal_capture.calls, 0);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.06f));
+    EXPECT_TRUE(sdl3d_properties_get_bool(flag->props, "ready", false));
+    EXPECT_EQ(signal_capture.calls, 0);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.09f));
+    EXPECT_EQ(signal_capture.calls, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.10f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_EQ(signal_capture.calls, 1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, SignalBindingsResolveLuaAdaptersDeclaredInJson)


### PR DESCRIPTION
## Summary
- add Phase 1 of #133: generic active-scene autoplay timelines
- support ordered one-shot timeline events with signal/property actions and transition-preserving scene requests
- wire timelines into the reusable app flow and validate timeline scene data

## Tests
- cmake --build build/release --target sdl3d_game_data_test pong_demo -j8
- ./build/release/tests/sdl3d_game_data_test