### PR TITLE
Add generic scene skip policy

### DIFF
--- a/demos/pong/data/scenes/splash.scene.json
+++ b/demos/pong/data/scenes/splash.scene.json
@@ -7,10 +7,21 @@
   "input": {
     "actions": []
   },
-  "splash": {
-    "next_scene": "scene.title",
-    "hold_seconds": 1.0,
-    "skip_on_input": true
+  "timeline": {
+    "autoplay": true,
+    "skip_policy": {
+      "enabled": true,
+      "input": "any",
+      "scene": "scene.title",
+      "preserve_exit_transition": true,
+      "consume_input": true
+    },
+    "events": [
+      {
+        "time": 1.7,
+        "action": { "type": "scene.request", "scene": "scene.title" }
+      }
+    ]
   },
   "transitions": {
     "enter": "scene_in",

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -285,6 +285,43 @@ extern "C"
         bool skip_on_input;
     } sdl3d_game_data_splash;
 
+    /** @brief Input mode used by a data-authored scene skip policy. */
+    typedef enum sdl3d_game_data_skip_input
+    {
+        /** @brief The active scene cannot be skipped by input. */
+        SDL3D_GAME_DATA_SKIP_INPUT_DISABLED = 0,
+        /** @brief Any key, pointer, or gamepad press skips the scene. */
+        SDL3D_GAME_DATA_SKIP_INPUT_ANY = 1,
+        /** @brief A specific authored input action skips the scene. */
+        SDL3D_GAME_DATA_SKIP_INPUT_ACTION = 2,
+    } sdl3d_game_data_skip_input;
+
+    /**
+     * @brief Data-authored input policy for skipping the active scene.
+     *
+     * Skip policies are generic scene-flow primitives. They are appropriate
+     * for splash screens, cutscenes, attract modes, and any scene whose author
+     * wants controlled early advancement without hard-coding scene-specific
+     * input handling.
+     */
+    typedef struct sdl3d_game_data_skip_policy
+    {
+        /** @brief True when this policy should be evaluated. */
+        bool enabled;
+        /** @brief Input source that can trigger the skip. */
+        sdl3d_game_data_skip_input input;
+        /** @brief Authored input action name when @p input is SDL3D_GAME_DATA_SKIP_INPUT_ACTION. */
+        const char *action;
+        /** @brief Resolved action id for @p action, or -1. */
+        int action_id;
+        /** @brief Target scene requested when the policy triggers. */
+        const char *scene;
+        /** @brief True to route the request through the active scene's exit transition. */
+        bool preserve_exit_transition;
+        /** @brief True to suppress other app/menu controls for the triggering frame. */
+        bool consume_input;
+    } sdl3d_game_data_skip_policy;
+
     /**
      * @brief Runtime state for a data-authored active-scene timeline.
      *
@@ -1045,6 +1082,17 @@ extern "C"
      * scene and how to apply transitions.
      */
     bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash);
+
+    /**
+     * @brief Read the active scene's authored skip policy.
+     *
+     * The runtime first checks `scene.skip_policy`, then
+     * `scene.timeline.skip_policy`. Returns false when no enabled policy is
+     * authored for the active scene. Missing fields use conservative defaults:
+     * any input, transition preservation enabled, and input consumption enabled.
+     */
+    bool sdl3d_game_data_get_active_skip_policy(const sdl3d_game_data_runtime *runtime,
+                                                sdl3d_game_data_skip_policy *out_policy);
 
     /**
      * @brief Initialize reusable timeline state.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -140,9 +140,8 @@ extern "C"
         sdl3d_game_data_app_control app;         /**< Resolved app controls from game data. */
         bool quit_pending;                       /**< True after quit has been requested. */
         bool scene_input_armed;                  /**< True once menu input is idle after scene entry. */
-        const char *splash_scene;                /**< Active splash scene tracked for hold timing. */
-        float splash_elapsed;                    /**< Seconds held after splash transitions finish. */
-        bool splash_skip_requested;              /**< True once input asks the splash to advance. */
+        const char *skip_scene;                  /**< Active scene tracked for pending skip input. */
+        bool skip_requested;                     /**< True once input asks the active scene to skip. */
         sdl3d_game_data_timeline_state timeline; /**< Runtime state for the active scene's authored timeline. */
     } sdl3d_game_data_app_flow;
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2250,6 +2250,61 @@ bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, s
     return out_splash->next_scene != NULL;
 }
 
+static yyjson_val *active_skip_policy_json(const sdl3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *root = scene != NULL ? scene->root : NULL;
+    yyjson_val *policy = obj_get(root, "skip_policy");
+    if (yyjson_is_obj(policy))
+        return policy;
+
+    yyjson_val *timeline = obj_get(root, "timeline");
+    policy = obj_get(timeline, "skip_policy");
+    return yyjson_is_obj(policy) ? policy : NULL;
+}
+
+bool sdl3d_game_data_get_active_skip_policy(const sdl3d_game_data_runtime *runtime,
+                                            sdl3d_game_data_skip_policy *out_policy)
+{
+    if (out_policy != NULL)
+    {
+        SDL_zero(*out_policy);
+        out_policy->enabled = false;
+        out_policy->input = SDL3D_GAME_DATA_SKIP_INPUT_ANY;
+        out_policy->action_id = -1;
+        out_policy->preserve_exit_transition = true;
+        out_policy->consume_input = true;
+    }
+    if (runtime == NULL || out_policy == NULL)
+        return false;
+
+    yyjson_val *policy = active_skip_policy_json(runtime);
+    if (!yyjson_is_obj(policy))
+        return false;
+
+    out_policy->enabled = json_bool(policy, "enabled", true);
+    if (!out_policy->enabled)
+        return false;
+
+    const char *input = json_string(policy, "input", NULL);
+    out_policy->action = json_string(policy, "action", NULL);
+    if (input == NULL)
+        out_policy->input =
+            out_policy->action != NULL ? SDL3D_GAME_DATA_SKIP_INPUT_ACTION : SDL3D_GAME_DATA_SKIP_INPUT_ANY;
+    else if (SDL_strcmp(input, "any") == 0 || SDL_strcmp(input, "any_input") == 0)
+        out_policy->input = SDL3D_GAME_DATA_SKIP_INPUT_ANY;
+    else if (SDL_strcmp(input, "action") == 0)
+        out_policy->input = SDL3D_GAME_DATA_SKIP_INPUT_ACTION;
+    else
+        out_policy->input = SDL3D_GAME_DATA_SKIP_INPUT_DISABLED;
+
+    out_policy->action_id = sdl3d_game_data_find_action(runtime, out_policy->action);
+    out_policy->scene = json_string(policy, "scene", json_string(policy, "target_scene", NULL));
+    out_policy->preserve_exit_transition = json_bool(policy, "preserve_exit_transition", true);
+    out_policy->consume_input = json_bool(policy, "consume_input", true);
+    return out_policy->input != SDL3D_GAME_DATA_SKIP_INPUT_DISABLED;
+}
+
 static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -956,6 +956,51 @@ static bool validate_timeline_action(validation_context *ctx, yyjson_val *action
     return validate_one_action(ctx, action, json_path, names);
 }
 
+static bool validate_skip_policy(validation_context *ctx, yyjson_val *policy, const char *json_path,
+                                 validation_names *names)
+{
+    if (policy == NULL)
+        return true;
+    if (!yyjson_is_obj(policy))
+        return validation_error(ctx, json_path, "scene skip_policy must be an object");
+
+    yyjson_val *enabled = obj_get(policy, "enabled");
+    if (enabled != NULL && !yyjson_is_bool(enabled))
+        return validation_error(ctx, json_path, "skip_policy enabled must be a boolean");
+    if (yyjson_is_bool(enabled) && !yyjson_get_bool(enabled))
+        return true;
+
+    const char *input = json_string(policy, "input");
+    const bool input_missing = input == NULL || input[0] == '\0';
+    const bool has_action = json_string(policy, "action") != NULL;
+    const bool input_any = (input_missing && !has_action) || SDL_strcmp(input != NULL ? input : "", "any") == 0 ||
+                           SDL_strcmp(input != NULL ? input : "", "any_input") == 0;
+    const bool input_action = SDL_strcmp(input != NULL ? input : "", "action") == 0 || (input_missing && has_action);
+    const bool input_disabled =
+        SDL_strcmp(input != NULL ? input : "", "none") == 0 || SDL_strcmp(input != NULL ? input : "", "disabled") == 0;
+    if (!input_any && !input_action && !input_disabled)
+        return validation_error(ctx, json_path, "skip_policy input must be any, any_input, action, none, or disabled");
+
+    yyjson_val *preserve = obj_get(policy, "preserve_exit_transition");
+    if (preserve != NULL && !yyjson_is_bool(preserve))
+        return validation_error(ctx, json_path, "skip_policy preserve_exit_transition must be a boolean");
+    yyjson_val *consume = obj_get(policy, "consume_input");
+    if (consume != NULL && !yyjson_is_bool(consume))
+        return validation_error(ctx, json_path, "skip_policy consume_input must be a boolean");
+
+    if (input_disabled)
+        return true;
+
+    const char *scene = json_string(policy, "scene");
+    if (scene == NULL)
+        scene = json_string(policy, "target_scene");
+    if (!require_ref(ctx, &names->scenes, "scene", scene, json_path))
+        return false;
+    if (input_action && !require_ref(ctx, &names->actions, "input action", json_string(policy, "action"), json_path))
+        return false;
+    return true;
+}
+
 static bool validate_logic(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *logic = obj_get(root, "logic");
@@ -1646,6 +1691,10 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     {
         if (!yyjson_is_obj(timeline))
             return validation_error(ctx, json_path, "scene timeline must be an object");
+        char timeline_skip_path[PATH_BUFFER_SIZE];
+        format_path(timeline_skip_path, sizeof(timeline_skip_path), "%s.timeline.skip_policy", json_path);
+        if (!validate_skip_policy(ctx, obj_get(timeline, "skip_policy"), timeline_skip_path, names))
+            return false;
         yyjson_val *events = obj_get(timeline, "events");
         if (events == NULL)
             events = obj_get(timeline, "tracks");
@@ -1673,6 +1722,11 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
                 return false;
         }
     }
+
+    char skip_path[PATH_BUFFER_SIZE];
+    format_path(skip_path, sizeof(skip_path), "%s.skip_policy", json_path);
+    if (!validate_skip_policy(ctx, obj_get(root, "skip_policy"), skip_path, names))
+        return false;
 
     yyjson_val *splash = obj_get(root, "splash");
     if (splash != NULL)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -966,48 +966,80 @@ static void app_flow_consume_scene_shortcuts(sdl3d_game_data_app_flow *flow, sdl
     }
 }
 
-static bool app_flow_capture_splash_input(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
-                                          const sdl3d_input_manager *input)
+static bool app_flow_set_scene_without_transition(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
+                                                  const char *scene_name)
 {
-    sdl3d_game_data_splash splash;
-    if (flow == NULL || runtime == NULL || !sdl3d_game_data_get_active_splash(runtime, &splash))
+    if (flow == NULL || runtime == NULL || scene_name == NULL)
+        return false;
+
+    if (!sdl3d_game_data_set_active_scene(runtime, scene_name))
+        return false;
+
+    sdl3d_game_data_scene_flow_init(&flow->scene_flow);
+    flow->scene_input_armed = false;
+    sdl3d_game_data_timeline_state_init(&flow->timeline);
+    return true;
+}
+
+static bool app_flow_apply_skip_policy(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
+                                       const sdl3d_input_manager *input, bool capture_input, bool *out_applied)
+{
+    if (out_applied != NULL)
+        *out_applied = false;
+    if (flow == NULL || runtime == NULL)
+        return false;
+
+    sdl3d_game_data_skip_policy policy;
+    if (!sdl3d_game_data_get_active_skip_policy(runtime, &policy))
     {
-        if (flow != NULL)
-        {
-            flow->splash_scene = NULL;
-            flow->splash_elapsed = 0.0f;
-            flow->splash_skip_requested = false;
-        }
+        flow->skip_scene = NULL;
+        flow->skip_requested = false;
         return false;
     }
 
     const char *active_scene = sdl3d_game_data_active_scene(runtime);
-    if (flow->splash_scene != active_scene)
+    if (flow->skip_scene != active_scene)
     {
-        flow->splash_scene = active_scene;
-        flow->splash_elapsed = 0.0f;
-        flow->splash_skip_requested = false;
-    }
-    if (splash.skip_on_input && sdl3d_input_any_pressed(input))
-        flow->splash_skip_requested = true;
-    return true;
-}
-
-static void app_flow_advance_splash(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime, float dt)
-{
-    if (flow == NULL || runtime == NULL || flow->quit_pending || flow->transition.active ||
-        sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
-    {
-        return;
+        flow->skip_scene = active_scene;
+        flow->skip_requested = false;
     }
 
-    sdl3d_game_data_splash splash;
-    if (!sdl3d_game_data_get_active_splash(runtime, &splash))
-        return;
+    bool consumed = false;
+    if (capture_input && input != NULL)
+    {
+        bool matched = false;
+        if (policy.input == SDL3D_GAME_DATA_SKIP_INPUT_ANY)
+        {
+            matched = sdl3d_input_any_pressed(input);
+        }
+        else if (policy.input == SDL3D_GAME_DATA_SKIP_INPUT_ACTION)
+        {
+            matched = policy.action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, policy.action_id) &&
+                      sdl3d_input_is_pressed(input, policy.action_id);
+        }
 
-    flow->splash_elapsed += dt > 0.0f ? dt : 0.0f;
-    if (flow->splash_skip_requested || flow->splash_elapsed >= splash.hold_seconds)
-        (void)app_flow_request_scene(flow, runtime, splash.next_scene);
+        if (matched)
+        {
+            flow->skip_requested = true;
+            consumed = policy.consume_input;
+        }
+    }
+
+    if (flow->skip_requested && !flow->quit_pending && !flow->transition.active &&
+        !sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
+    {
+        const bool requested = policy.preserve_exit_transition
+                                   ? app_flow_request_scene(flow, runtime, policy.scene)
+                                   : app_flow_set_scene_without_transition(flow, runtime, policy.scene);
+        if (requested)
+        {
+            flow->skip_requested = false;
+            if (out_applied != NULL)
+                *out_applied = true;
+        }
+    }
+
+    return consumed;
 }
 
 static bool app_flow_update_timeline(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime, float dt)
@@ -1058,9 +1090,8 @@ bool sdl3d_game_data_app_flow_start(sdl3d_game_data_app_flow *flow, sdl3d_game_d
     sdl3d_transition_reset(&flow->transition);
     flow->quit_pending = false;
     flow->scene_input_armed = false;
-    flow->splash_scene = NULL;
-    flow->splash_elapsed = 0.0f;
-    flow->splash_skip_requested = false;
+    flow->skip_scene = NULL;
+    flow->skip_requested = false;
     sdl3d_game_data_timeline_state_init(&flow->timeline);
     if (!sdl3d_game_data_get_app_control(runtime, &flow->app))
         return false;
@@ -1093,9 +1124,10 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
 
     sdl3d_input_manager *input = sdl3d_game_session_get_input(ctx->session);
     sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
-    const bool splash_active = app_flow_capture_splash_input(flow, runtime, input);
+    bool skip_applied = false;
+    const bool skip_consumed = app_flow_apply_skip_policy(flow, runtime, input, true, &skip_applied);
 
-    if (!splash_active)
+    if (!skip_consumed)
     {
         if (flow->app.quit_action_id >= 0 &&
             sdl3d_game_data_active_scene_allows_action(runtime, flow->app.quit_action_id) &&
@@ -1126,9 +1158,11 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     const bool scene_transitioning_before = sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow);
     app_flow_update_transition(flow, ctx, bus, dt);
     sdl3d_game_data_scene_flow_update(&flow->scene_flow, runtime, bus, dt);
-    if (!scene_transitioning_before && !app_flow_update_timeline(flow, runtime, dt))
+    bool deferred_skip_applied = false;
+    (void)app_flow_apply_skip_policy(flow, runtime, input, false, &deferred_skip_applied);
+    skip_applied = skip_applied || deferred_skip_applied;
+    if (!scene_transitioning_before && !skip_applied && !app_flow_update_timeline(flow, runtime, dt))
         return false;
-    app_flow_advance_splash(flow, runtime, dt);
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -282,6 +282,114 @@ void write_timeline_json(const std::filesystem::path &dir)
 })json");
 }
 
+void write_skip_policy_json(const std::filesystem::path &dir)
+{
+    write_text(dir / "skip.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Skip", "id": "test.skip", "version": "0.1.0" },
+  "transitions": {
+    "scene_out": { "type": "fade", "direction": "out", "color": [0, 0, 0, 255], "duration": 0.10 },
+    "scene_in": { "type": "fade", "direction": "in", "color": [0, 0, 0, 255], "duration": 0.10 }
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.main",
+        "actions": [
+          {
+            "name": "action.skip",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" },
+              { "device": "gamepad", "button": "SOUTH" }
+            ]
+          },
+          {
+            "name": "action.menu.select",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" },
+              { "device": "gamepad", "button": "SOUTH" }
+            ]
+          },
+          {
+            "name": "action.menu.up",
+            "bindings": [
+              { "device": "keyboard", "key": "UP" }
+            ]
+          },
+          {
+            "name": "action.menu.down",
+            "bindings": [
+              { "device": "keyboard", "key": "DOWN" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": {
+    "initial": "scene.intro",
+    "files": [
+      "scenes/intro.scene.json",
+      "scenes/title.scene.json",
+      "scenes/play.scene.json"
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "intro.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.intro",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "input": { "actions": ["action.skip"] },
+  "transitions": { "exit": "scene_out" },
+  "timeline": {
+    "autoplay": true,
+    "skip_policy": {
+      "enabled": true,
+      "input": "action",
+      "action": "action.skip",
+      "scene": "scene.title",
+      "preserve_exit_transition": true,
+      "consume_input": true
+    },
+    "events": []
+  }
+})json");
+    write_text(dir / "scenes" / "title.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "input": { "actions": ["action.menu.up", "action.menu.down", "action.menu.select"] },
+  "transitions": { "enter": "scene_in", "exit": "scene_out" },
+  "menus": [
+    {
+      "name": "menu.title",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        { "label": "Play", "scene": "scene.play" }
+      ]
+    }
+  ]
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [],
+  "transitions": { "enter": "scene_in" }
+})json");
+}
+
 void write_hot_reload_script(const std::filesystem::path &dir, int value)
 {
     const std::string script = std::string("local rules = {}\n"
@@ -679,10 +787,15 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
 
     sdl3d_game_data_splash splash{};
-    ASSERT_TRUE(sdl3d_game_data_get_active_splash(runtime, &splash));
-    EXPECT_STREQ(splash.next_scene, "scene.title");
-    EXPECT_NEAR(splash.hold_seconds, 1.0f, 0.0001f);
-    EXPECT_TRUE(splash.skip_on_input);
+    EXPECT_FALSE(sdl3d_game_data_get_active_splash(runtime, &splash));
+
+    sdl3d_game_data_skip_policy skip{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_skip_policy(runtime, &skip));
+    EXPECT_TRUE(skip.enabled);
+    EXPECT_EQ(skip.input, SDL3D_GAME_DATA_SKIP_INPUT_ANY);
+    EXPECT_STREQ(skip.scene, "scene.title");
+    EXPECT_TRUE(skip.preserve_exit_transition);
+    EXPECT_TRUE(skip.consume_input);
 
     sdl3d_game_data_image_asset image_asset{};
     ASSERT_TRUE(sdl3d_game_data_get_image_asset(runtime, "image.splash.logo", &image_asset));
@@ -1140,6 +1253,81 @@ TEST(GameDataRuntime, AppFlowRunsAuthoredSceneTimelineActions)
     ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
     EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
     EXPECT_EQ(signal_capture.calls, 1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, AppFlowAppliesAuthoredSkipPolicyWithoutMenuBleedThrough)
+{
+    const std::filesystem::path dir = unique_test_dir("skip_policy");
+    write_skip_policy_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(
+        sdl3d_game_data_load_file((dir / "skip.game.json").string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    sdl3d_game_data_skip_policy policy{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_skip_policy(runtime, &policy));
+    EXPECT_EQ(policy.input, SDL3D_GAME_DATA_SKIP_INPUT_ACTION);
+    EXPECT_STREQ(policy.action, "action.skip");
+    EXPECT_STREQ(policy.scene, "scene.title");
+    EXPECT_TRUE(policy.preserve_exit_transition);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add a public data-authored scene skip policy descriptor for any-input or action-specific skips
- route app-flow skip handling through the generic policy, including pending skips during transitions and menu input re-arming
- migrate Pong splash from the splash-specific block to a timeline event plus skip policy

## Tests
- cmake --build build/release --target sdl3d_game_data_test pong_demo -j8
- ./build/release/tests/sdl3d_game_data_test

Refs #133