### PR TITLE
Add runtime UI presentation state

### DIFF
--- a/include/sdl3d/font.h
+++ b/include/sdl3d/font.h
@@ -120,6 +120,14 @@ extern "C"
     bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text,
                                  float x, float y, sdl3d_color color);
 
+    /**
+     * @brief Draw text on the UI overlay layer with a pixel-space scale multiplier.
+     *
+     * A scale of 1.0 is equivalent to sdl3d_draw_text_overlay().
+     */
+    bool sdl3d_draw_text_overlay_scaled(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text,
+                                        float x, float y, float scale, sdl3d_color color);
+
     bool sdl3d_draw_textf_overlay(struct sdl3d_render_context *context, const sdl3d_font *font, float x, float y,
                                   sdl3d_color color, SDL_PRINTF_FORMAT_STRING const char *fmt, ...)
         SDL_PRINTF_VARARG_FUNC(6);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -225,6 +225,8 @@ extern "C"
         bool centered;
         /** @brief Horizontal alignment used by richer UI layouts. */
         sdl3d_game_data_ui_align align;
+        /** @brief Runtime or authored scale multiplier applied during presentation. */
+        float scale;
         /** @brief Whether alpha should pulse while visible. */
         bool pulse_alpha;
         /** @brief Text color. */
@@ -256,9 +258,51 @@ extern "C"
         sdl3d_game_data_ui_align align;
         /** @brief Vertical alignment of the image rectangle around y. */
         sdl3d_game_data_ui_valign valign;
+        /** @brief Runtime or authored scale multiplier applied around the image anchor. */
+        float scale;
         /** @brief Image tint color. */
         sdl3d_color color;
     } sdl3d_game_data_ui_image;
+
+    /** @brief Bit flags indicating which runtime UI state fields override authored descriptor values. */
+    typedef enum sdl3d_game_data_ui_state_flags
+    {
+        /** @brief Override UI visibility. */
+        SDL3D_GAME_DATA_UI_STATE_VISIBLE = 1u << 0,
+        /** @brief Add a runtime x/y offset to the authored UI position. */
+        SDL3D_GAME_DATA_UI_STATE_OFFSET = 1u << 1,
+        /** @brief Multiply the authored UI scale. */
+        SDL3D_GAME_DATA_UI_STATE_SCALE = 1u << 2,
+        /** @brief Multiply the authored UI alpha. */
+        SDL3D_GAME_DATA_UI_STATE_ALPHA = 1u << 3,
+        /** @brief Multiply the authored UI tint/color. */
+        SDL3D_GAME_DATA_UI_STATE_TINT = 1u << 4,
+    } sdl3d_game_data_ui_state_flags;
+
+    /**
+     * @brief Runtime presentation state for an authored UI item.
+     *
+     * Runtime state is keyed by the UI item's authored `name`. It is layered on
+     * top of static JSON descriptors during resolution, which lets timelines,
+     * scripts, or host code animate UI elements without mutating game data.
+     */
+    typedef struct sdl3d_game_data_ui_state
+    {
+        /** @brief Combination of sdl3d_game_data_ui_state_flags values. */
+        Uint32 flags;
+        /** @brief Visibility override used when SDL3D_GAME_DATA_UI_STATE_VISIBLE is set. */
+        bool visible;
+        /** @brief Runtime x offset in the descriptor's coordinate space. */
+        float offset_x;
+        /** @brief Runtime y offset in the descriptor's coordinate space. */
+        float offset_y;
+        /** @brief Scale multiplier used when SDL3D_GAME_DATA_UI_STATE_SCALE is set. */
+        float scale;
+        /** @brief Alpha multiplier in [0, 1] used when SDL3D_GAME_DATA_UI_STATE_ALPHA is set. */
+        float alpha;
+        /** @brief Tint multiplier used when SDL3D_GAME_DATA_UI_STATE_TINT is set. */
+        sdl3d_color tint;
+    } sdl3d_game_data_ui_state;
 
     /**
      * @brief Callback for iterating authored UI text descriptors.
@@ -1058,6 +1102,59 @@ extern "C"
      */
     bool sdl3d_game_data_for_each_ui_image(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_image_fn callback,
                                            void *userdata);
+
+    /**
+     * @brief Initialize runtime UI state to identity values.
+     *
+     * The initialized state has no override flags, zero offset, scale 1, alpha
+     * 1, and white tint.
+     */
+    void sdl3d_game_data_ui_state_init(sdl3d_game_data_ui_state *state);
+
+    /**
+     * @brief Store runtime state for a named authored UI item.
+     *
+     * The runtime copies @p state and owns the name key internally. State
+     * remains active until replaced, cleared by name, or all UI state is
+     * cleared.
+     */
+    bool sdl3d_game_data_set_ui_state(sdl3d_game_data_runtime *runtime, const char *name,
+                                      const sdl3d_game_data_ui_state *state);
+
+    /**
+     * @brief Read runtime state for a named authored UI item.
+     *
+     * Returns false when no state exists for @p name. @p out_state is
+     * initialized to identity values before lookup.
+     */
+    bool sdl3d_game_data_get_ui_state(const sdl3d_game_data_runtime *runtime, const char *name,
+                                      sdl3d_game_data_ui_state *out_state);
+
+    /** @brief Clear runtime state for one named UI item. */
+    bool sdl3d_game_data_clear_ui_state(sdl3d_game_data_runtime *runtime, const char *name);
+
+    /** @brief Clear all runtime UI item state. */
+    void sdl3d_game_data_clear_ui_states(sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Resolve authored text plus runtime UI state for presentation.
+     *
+     * @p out_visible receives the final visibility after authored conditions
+     * and runtime overrides. @p out_text may alias @p text.
+     */
+    bool sdl3d_game_data_resolve_ui_text(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                         const sdl3d_game_data_ui_metrics *metrics, sdl3d_game_data_ui_text *out_text,
+                                         bool *out_visible);
+
+    /**
+     * @brief Resolve authored image plus runtime UI state for presentation.
+     *
+     * @p out_visible receives the final visibility after authored conditions
+     * and runtime overrides. @p out_image may alias @p image.
+     */
+    bool sdl3d_game_data_resolve_ui_image(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_image *image,
+                                          const sdl3d_game_data_ui_metrics *metrics,
+                                          sdl3d_game_data_ui_image *out_image, bool *out_visible);
 
     /**
      * @brief Evaluate a UI text descriptor's authored visibility condition.

--- a/src/font.c
+++ b/src/font.c
@@ -237,7 +237,7 @@ void sdl3d_measure_text(const sdl3d_font *font, const char *text, float *out_wid
  * characters use their native advance.
  */
 static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text, float x,
-                               float y, sdl3d_color color, float digit_cell_width)
+                               float y, sdl3d_color color, float digit_cell_width, float scale)
 {
     int ctx_w, ctx_h;
     sdl3d_camera3d ortho;
@@ -264,6 +264,10 @@ static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d
     if (ctx_w <= 0 || ctx_h <= 0)
     {
         return SDL_SetError("Invalid render context dimensions");
+    }
+    if (scale <= 0.0f)
+    {
+        return true;
     }
 
     ortho.position = sdl3d_vec3_make(0.0f, 0.0f, 1.0f);
@@ -293,8 +297,8 @@ static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d
     }
 
     float cursor_x = x;
-    float cursor_y = y + font->ascent;
-    float line_h = font->ascent - font->descent + font->line_gap;
+    float cursor_y = y + font->ascent * scale;
+    float line_h = (font->ascent - font->descent + font->line_gap) * scale;
     float hx = (float)ctx_w * 0.5f;
     float hy = (float)ctx_h * 0.5f;
 
@@ -325,15 +329,15 @@ static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d
         float gh = g->yoff2 - g->yoff;
         if (gw <= 0 || gh <= 0)
         {
-            cursor_x += advance;
+            cursor_x += advance * scale;
             continue;
         }
 
         /* Screen-space pixel rect for this glyph. */
-        float sx0 = cursor_x + glyph_shift + g->xoff;
-        float sy0 = cursor_y + g->yoff;
-        float sx1 = cursor_x + glyph_shift + g->xoff2;
-        float sy1 = cursor_y + g->yoff2;
+        float sx0 = cursor_x + (glyph_shift + g->xoff) * scale;
+        float sy0 = cursor_y + g->yoff * scale;
+        float sx1 = cursor_x + (glyph_shift + g->xoff2) * scale;
+        float sy1 = cursor_y + g->yoff2 * scale;
 
         /* Map screen pixels to ortho world space (Y flipped). */
         float wx0 = sx0 - hx;
@@ -367,7 +371,7 @@ static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d
             break;
         }
 
-        cursor_x += advance;
+        cursor_x += advance * scale;
     }
 
     sdl3d_end_mode_3d(context);
@@ -383,7 +387,7 @@ static bool draw_text_internal(struct sdl3d_render_context *context, const sdl3d
 bool sdl3d_draw_text(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text, float x, float y,
                      sdl3d_color color)
 {
-    return draw_text_internal(context, font, text, x, y, color, 0.0f);
+    return draw_text_internal(context, font, text, x, y, color, 0.0f, 1.0f);
 }
 
 /* ------------------------------------------------------------------ */
@@ -464,7 +468,7 @@ bool sdl3d_draw_fps(struct sdl3d_render_context *context, const sdl3d_font *font
     float prefix_w, prefix_h;
     sdl3d_measure_text(font, prefix, &prefix_w, &prefix_h);
 
-    if (!draw_text_internal(context, font, prefix, origin_x, origin_y, color, 0.0f))
+    if (!draw_text_internal(context, font, prefix, origin_x, origin_y, color, 0.0f, 1.0f))
     {
         return false;
     }
@@ -484,8 +488,8 @@ bool sdl3d_draw_fps(struct sdl3d_render_context *context, const sdl3d_font *font
     digits[2] = (char)('0' + (ival % 10));
     digits[3] = '\0';
 
-    return draw_text_internal(context, font, digits, origin_x + prefix_w, origin_y, color,
-                              font_max_digit_advance(font));
+    return draw_text_internal(context, font, digits, origin_x + prefix_w, origin_y, color, font_max_digit_advance(font),
+                              1.0f);
 }
 
 /* ------------------------------------------------------------------ */
@@ -560,8 +564,8 @@ bool sdl3d_load_builtin_font(const char *media_dir, sdl3d_builtin_font id, float
 
 #include "gl_renderer.h"
 
-bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text, float x,
-                             float y, sdl3d_color color)
+bool sdl3d_draw_text_overlay_scaled(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text,
+                                    float x, float y, float scale, sdl3d_color color)
 {
     SDL_Rect scissor_rect = {0, 0, 0, 0};
     bool scissor_enabled = false;
@@ -570,12 +574,14 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
         return SDL_InvalidParamError("context");
     if (!font->atlas_texture.pixels)
         return SDL_SetError("sdl3d_draw_text_overlay: font atlas not initialized");
+    if (scale <= 0.0f)
+        return true;
 
     /* Software backend: enable alpha blending for text overlay. */
     if (!context->gl)
     {
         context->color_buffer_blend = true;
-        bool ok = sdl3d_draw_text(context, font, text, x, y, color);
+        bool ok = draw_text_internal(context, font, text, x, y, color, 0.0f, scale);
         context->color_buffer_blend = false;
         return ok;
     }
@@ -627,8 +633,8 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
                      (float)color.a / 255.0f};
 
     float cursor_x = x;
-    float cursor_y = y + font->ascent;
-    float line_h = font->ascent - font->descent + font->line_gap;
+    float cursor_y = y + font->ascent * scale;
+    float line_h = (font->ascent - font->descent + font->line_gap) * scale;
     int vi = 0;
 
     for (const char *p = text; *p; p++)
@@ -648,14 +654,14 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
         float gh = g->yoff2 - g->yoff;
         if (gw <= 0 || gh <= 0)
         {
-            cursor_x += g->xadvance;
+            cursor_x += g->xadvance * scale;
             continue;
         }
 
-        float sx0 = cursor_x + g->xoff;
-        float sy0 = cursor_y + g->yoff;
-        float sx1 = cursor_x + g->xoff2;
-        float sy1 = cursor_y + g->yoff2;
+        float sx0 = cursor_x + g->xoff * scale;
+        float sy0 = cursor_y + g->yoff * scale;
+        float sx1 = cursor_x + g->xoff2 * scale;
+        float sy1 = cursor_y + g->yoff2 * scale;
 
         /* Map to ortho world space (Y flipped). */
         float wx0 = sx0 - hx, wx1 = sx1 - hx;
@@ -696,7 +702,7 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
         uvs[ui + 11] = g->v0;
 
         vi += 6;
-        cursor_x += g->xadvance;
+        cursor_x += g->xadvance * scale;
     }
 
     bool ok = sdl3d_gl_append_overlay(context->gl, positions, uvs, vi, mvp, tint, &font->atlas_texture, scissor_enabled,
@@ -704,6 +710,12 @@ bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_f
     SDL_free(positions);
     SDL_free(uvs);
     return ok;
+}
+
+bool sdl3d_draw_text_overlay(struct sdl3d_render_context *context, const sdl3d_font *font, const char *text, float x,
+                             float y, sdl3d_color color)
+{
+    return sdl3d_draw_text_overlay_scaled(context, font, text, x, y, 1.0f, color);
 }
 
 bool sdl3d_draw_textf_overlay(struct sdl3d_render_context *context, const sdl3d_font *font, float x, float y,

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -104,6 +104,12 @@ typedef struct scene_menu_state
     int item_count;
 } scene_menu_state;
 
+typedef struct ui_state_entry
+{
+    char *name;
+    sdl3d_game_data_ui_state state;
+} ui_state_entry;
+
 typedef struct scene_entry
 {
     yyjson_doc *doc;
@@ -141,6 +147,9 @@ typedef struct sdl3d_game_data_runtime
     int scene_count;
     int active_scene_index;
     sdl3d_properties *scene_state;
+    ui_state_entry *ui_states;
+    int ui_state_count;
+    int ui_state_capacity;
     const char *active_camera;
     float current_dt;
     unsigned int rng_state;
@@ -2228,6 +2237,130 @@ const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtim
     return runtime != NULL ? runtime->scene_state : NULL;
 }
 
+void sdl3d_game_data_ui_state_init(sdl3d_game_data_ui_state *state)
+{
+    if (state == NULL)
+        return;
+    SDL_zero(*state);
+    state->visible = true;
+    state->scale = 1.0f;
+    state->alpha = 1.0f;
+    state->tint = (sdl3d_color){255, 255, 255, 255};
+}
+
+static ui_state_entry *find_ui_state_entry(sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->ui_state_count; ++i)
+    {
+        if (runtime->ui_states[i].name != NULL && SDL_strcmp(runtime->ui_states[i].name, name) == 0)
+            return &runtime->ui_states[i];
+    }
+    return NULL;
+}
+
+static const ui_state_entry *find_ui_state_entry_const(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->ui_state_count; ++i)
+    {
+        if (runtime->ui_states[i].name != NULL && SDL_strcmp(runtime->ui_states[i].name, name) == 0)
+            return &runtime->ui_states[i];
+    }
+    return NULL;
+}
+
+static bool ensure_ui_state_capacity(sdl3d_game_data_runtime *runtime, int required)
+{
+    if (runtime == NULL)
+        return false;
+    if (required <= runtime->ui_state_capacity)
+        return true;
+
+    int next_capacity = runtime->ui_state_capacity < 8 ? 8 : runtime->ui_state_capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    ui_state_entry *entries =
+        (ui_state_entry *)SDL_realloc(runtime->ui_states, (size_t)next_capacity * sizeof(*entries));
+    if (entries == NULL)
+        return false;
+
+    SDL_memset(entries + runtime->ui_state_capacity, 0,
+               (size_t)(next_capacity - runtime->ui_state_capacity) * sizeof(*entries));
+    runtime->ui_states = entries;
+    runtime->ui_state_capacity = next_capacity;
+    return true;
+}
+
+bool sdl3d_game_data_set_ui_state(sdl3d_game_data_runtime *runtime, const char *name,
+                                  const sdl3d_game_data_ui_state *state)
+{
+    if (runtime == NULL || name == NULL || name[0] == '\0' || state == NULL)
+        return false;
+
+    ui_state_entry *entry = find_ui_state_entry(runtime, name);
+    if (entry == NULL)
+    {
+        if (!ensure_ui_state_capacity(runtime, runtime->ui_state_count + 1))
+            return false;
+        entry = &runtime->ui_states[runtime->ui_state_count];
+        entry->name = SDL_strdup(name);
+        if (entry->name == NULL)
+            return false;
+        ++runtime->ui_state_count;
+    }
+
+    entry->state = *state;
+    return true;
+}
+
+bool sdl3d_game_data_get_ui_state(const sdl3d_game_data_runtime *runtime, const char *name,
+                                  sdl3d_game_data_ui_state *out_state)
+{
+    if (out_state != NULL)
+        sdl3d_game_data_ui_state_init(out_state);
+    if (runtime == NULL || name == NULL || out_state == NULL)
+        return false;
+
+    const ui_state_entry *entry = find_ui_state_entry_const(runtime, name);
+    if (entry == NULL)
+        return false;
+
+    *out_state = entry->state;
+    return true;
+}
+
+bool sdl3d_game_data_clear_ui_state(sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return false;
+
+    for (int i = 0; i < runtime->ui_state_count; ++i)
+    {
+        if (runtime->ui_states[i].name != NULL && SDL_strcmp(runtime->ui_states[i].name, name) == 0)
+        {
+            SDL_free(runtime->ui_states[i].name);
+            if (i + 1 < runtime->ui_state_count)
+                runtime->ui_states[i] = runtime->ui_states[runtime->ui_state_count - 1];
+            --runtime->ui_state_count;
+            return true;
+        }
+    }
+    return false;
+}
+
+void sdl3d_game_data_clear_ui_states(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    for (int i = 0; i < runtime->ui_state_count; ++i)
+        SDL_free(runtime->ui_states[i].name);
+    runtime->ui_state_count = 0;
+}
+
 bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash)
 {
     if (out_splash != NULL)
@@ -2802,6 +2935,7 @@ static void ui_text_from_json(yyjson_val *item, sdl3d_game_data_ui_text *text)
                                                                        ? SDL3D_GAME_DATA_UI_ALIGN_CENTER
                                                                        : SDL3D_GAME_DATA_UI_ALIGN_LEFT);
     text->centered = text->align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+    text->scale = json_float(item, "scale", 1.0f);
     text->pulse_alpha = json_bool(item, "pulse_alpha", false);
     text->color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
 }
@@ -2836,6 +2970,7 @@ static bool emit_ui_menu_cursor(yyjson_val *presenter, float row_y, sdl3d_game_d
     text.normalized = json_bool(presenter, "normalized", false);
     text.align = parse_ui_align(json_string(cursor, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_CENTER);
     text.centered = text.align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+    text.scale = json_float(cursor, "scale", json_float(presenter, "scale", 1.0f));
     text.pulse_alpha = json_bool(cursor, "pulse_alpha", false);
     text.color = json_color(cursor, "color", (sdl3d_color){255, 222, 140, 255});
     return callback(userdata, &text);
@@ -2940,6 +3075,7 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
         text.normalized = normalized;
         text.align = align;
         text.centered = align == SDL3D_GAME_DATA_UI_ALIGN_CENTER;
+        text.scale = json_float(presenter, "scale", 1.0f);
         text.pulse_alpha = selected && json_bool(presenter, "selected_pulse_alpha", false);
         text.color = selected ? json_color(presenter, "selected_color",
                                            json_color(presenter, "color", (sdl3d_color){255, 255, 255, 255}))
@@ -2996,6 +3132,7 @@ static void ui_image_from_json(yyjson_val *item, sdl3d_game_data_ui_image *image
     image->preserve_aspect = json_bool(item, "preserve_aspect", true);
     image->align = parse_ui_align(json_string(item, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_LEFT);
     image->valign = parse_ui_valign(json_string(item, "valign", NULL), SDL3D_GAME_DATA_UI_VALIGN_TOP);
+    image->scale = json_float(item, "scale", 1.0f);
     image->color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
 }
 
@@ -3750,7 +3887,7 @@ static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_v
     return false;
 }
 
-bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+static bool ui_text_authored_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
                                         const sdl3d_game_data_ui_metrics *metrics)
 {
     if (runtime == NULL || text == NULL)
@@ -3762,7 +3899,7 @@ bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, 
     return text->visible == NULL || SDL_strcmp(text->visible, "always") == 0;
 }
 
-bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_image *image,
+static bool ui_image_authored_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_image *image,
                                          const sdl3d_game_data_ui_metrics *metrics)
 {
     if (runtime == NULL || image == NULL)
@@ -3772,6 +3909,117 @@ bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime,
     if (condition != NULL)
         return eval_data_condition(runtime, condition, metrics);
     return image->visible == NULL || SDL_strcmp(image->visible, "always") == 0;
+}
+
+static float clamp_unit(float value)
+{
+    return SDL_clamp(value, 0.0f, 1.0f);
+}
+
+static Uint8 multiply_u8(Uint8 value, float multiplier)
+{
+    return (Uint8)SDL_clamp((int)((float)value * multiplier + 0.5f), 0, 255);
+}
+
+static sdl3d_color apply_ui_state_color(sdl3d_color color, const sdl3d_game_data_ui_state *state)
+{
+    if (state == NULL)
+        return color;
+
+    if ((state->flags & SDL3D_GAME_DATA_UI_STATE_TINT) != 0u)
+    {
+        color.r = multiply_u8(color.r, (float)state->tint.r / 255.0f);
+        color.g = multiply_u8(color.g, (float)state->tint.g / 255.0f);
+        color.b = multiply_u8(color.b, (float)state->tint.b / 255.0f);
+        color.a = multiply_u8(color.a, (float)state->tint.a / 255.0f);
+    }
+    if ((state->flags & SDL3D_GAME_DATA_UI_STATE_ALPHA) != 0u)
+        color.a = multiply_u8(color.a, clamp_unit(state->alpha));
+    return color;
+}
+
+bool sdl3d_game_data_resolve_ui_text(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                     const sdl3d_game_data_ui_metrics *metrics, sdl3d_game_data_ui_text *out_text,
+                                     bool *out_visible)
+{
+    if (out_visible != NULL)
+        *out_visible = false;
+    if (runtime == NULL || text == NULL || out_text == NULL)
+        return false;
+
+    sdl3d_game_data_ui_text resolved = *text;
+    bool visible = ui_text_authored_is_visible(runtime, text, metrics);
+    sdl3d_game_data_ui_state state;
+    if (sdl3d_game_data_get_ui_state(runtime, text->name, &state))
+    {
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_VISIBLE) != 0u)
+            visible = state.visible;
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_OFFSET) != 0u)
+        {
+            resolved.x += state.offset_x;
+            resolved.y += state.offset_y;
+        }
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_SCALE) != 0u)
+            resolved.scale *= state.scale;
+        resolved.color = apply_ui_state_color(resolved.color, &state);
+    }
+
+    if (resolved.scale <= 0.0f || resolved.color.a == 0)
+        visible = false;
+    if (out_visible != NULL)
+        *out_visible = visible;
+    *out_text = resolved;
+    return true;
+}
+
+bool sdl3d_game_data_resolve_ui_image(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_image *image,
+                                      const sdl3d_game_data_ui_metrics *metrics, sdl3d_game_data_ui_image *out_image,
+                                      bool *out_visible)
+{
+    if (out_visible != NULL)
+        *out_visible = false;
+    if (runtime == NULL || image == NULL || out_image == NULL)
+        return false;
+
+    sdl3d_game_data_ui_image resolved = *image;
+    bool visible = ui_image_authored_is_visible(runtime, image, metrics);
+    sdl3d_game_data_ui_state state;
+    if (sdl3d_game_data_get_ui_state(runtime, image->name, &state))
+    {
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_VISIBLE) != 0u)
+            visible = state.visible;
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_OFFSET) != 0u)
+        {
+            resolved.x += state.offset_x;
+            resolved.y += state.offset_y;
+        }
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_SCALE) != 0u)
+            resolved.scale *= state.scale;
+        resolved.color = apply_ui_state_color(resolved.color, &state);
+    }
+
+    if (resolved.scale <= 0.0f || resolved.color.a == 0)
+        visible = false;
+    if (out_visible != NULL)
+        *out_visible = visible;
+    *out_image = resolved;
+    return true;
+}
+
+bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
+                                        const sdl3d_game_data_ui_metrics *metrics)
+{
+    bool visible = false;
+    sdl3d_game_data_ui_text resolved;
+    return sdl3d_game_data_resolve_ui_text(runtime, text, metrics, &resolved, &visible) && visible;
+}
+
+bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_image *image,
+                                         const sdl3d_game_data_ui_metrics *metrics)
+{
+    bool visible = false;
+    sdl3d_game_data_ui_image resolved;
+    return sdl3d_game_data_resolve_ui_image(runtime, image, metrics, &resolved, &visible) && visible;
 }
 
 bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,
@@ -5101,6 +5349,8 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->scenes[i].menus);
         yyjson_doc_free(runtime->scenes[i].doc);
     }
+    for (int i = 0; i < runtime->ui_state_count; ++i)
+        SDL_free(runtime->ui_states[i].name);
 
     sdl3d_script_engine_destroy(runtime->scripts);
     sdl3d_properties_destroy(runtime->scene_state);
@@ -5113,6 +5363,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->adapters);
     SDL_free(runtime->bindings);
     SDL_free(runtime->sensors);
+    SDL_free(runtime->ui_states);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);
 }

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -336,47 +336,56 @@ static bool draw_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
     if (draw == NULL || text == NULL)
         return false;
 
-    if (!sdl3d_game_data_ui_text_is_visible(draw->runtime, text, draw->metrics))
+    sdl3d_game_data_ui_text resolved;
+    bool visible = false;
+    if (!sdl3d_game_data_resolve_ui_text(draw->runtime, text, draw->metrics, &resolved, &visible))
+    {
+        draw->ok = false;
+        return true;
+    }
+    if (!visible)
         return true;
 
     char content[128];
-    if (!sdl3d_game_data_format_ui_text(draw->runtime, text, draw->metrics, content, sizeof(content)))
+    if (!sdl3d_game_data_format_ui_text(draw->runtime, &resolved, draw->metrics, content, sizeof(content)))
         return true;
 
-    sdl3d_font *font = find_or_load_font(draw->runtime, draw->font_cache, text->font);
+    sdl3d_font *font = find_or_load_font(draw->runtime, draw->font_cache, resolved.font);
     if (font == NULL)
     {
         draw->ok = false;
         return true;
     }
 
-    sdl3d_color color = text->color;
-    if (text->pulse_alpha)
+    sdl3d_color color = resolved.color;
+    if (resolved.pulse_alpha)
     {
         const float pulse = 0.5f + 0.5f * SDL_sinf(draw->pulse_phase * SDL_PI_F * 2.0f);
-        color.a = (Uint8)(120.0f + pulse * 135.0f);
+        const float alpha = (120.0f + pulse * 135.0f) / 255.0f;
+        color.a = (Uint8)SDL_clamp((int)((float)color.a * alpha + 0.5f), 0, 255);
     }
 
     const int width = sdl3d_get_render_context_width(draw->renderer);
     const int height = sdl3d_get_render_context_height(draw->renderer);
-    float x = text->normalized ? text->x * (float)width : text->x;
-    const float y = text->normalized ? text->y * (float)height : text->y;
-    if (text->align == SDL3D_GAME_DATA_UI_ALIGN_CENTER || text->centered)
+    const float scale = resolved.scale > 0.0f ? resolved.scale : 1.0f;
+    float x = resolved.normalized ? resolved.x * (float)width : resolved.x;
+    const float y = resolved.normalized ? resolved.y * (float)height : resolved.y;
+    if (resolved.align == SDL3D_GAME_DATA_UI_ALIGN_CENTER || resolved.centered)
     {
         float text_w = 0.0f;
         float text_h = 0.0f;
         sdl3d_measure_text(font, content, &text_w, &text_h);
-        x -= text_w * 0.5f;
+        x -= text_w * scale * 0.5f;
     }
-    else if (text->align == SDL3D_GAME_DATA_UI_ALIGN_RIGHT)
+    else if (resolved.align == SDL3D_GAME_DATA_UI_ALIGN_RIGHT)
     {
         float text_w = 0.0f;
         float text_h = 0.0f;
         sdl3d_measure_text(font, content, &text_w, &text_h);
-        x -= text_w;
+        x -= text_w * scale;
     }
 
-    if (!sdl3d_draw_text_overlay(draw->renderer, font, content, x, y, color))
+    if (!sdl3d_draw_text_overlay_scaled(draw->renderer, font, content, x, y, scale, color))
         draw->ok = false;
     return true;
 }
@@ -388,6 +397,7 @@ static void resolve_ui_image_rect(const sdl3d_game_data_ui_image *image, const s
     float h = image->normalized ? image->h * (float)height : image->h;
     const float texture_w = (float)texture->width;
     const float texture_h = (float)texture->height;
+    const float scale = image->scale > 0.0f ? image->scale : 1.0f;
 
     if (w <= 0.0f && h <= 0.0f)
     {
@@ -408,6 +418,8 @@ static void resolve_ui_image_rect(const sdl3d_game_data_ui_image *image, const s
         w = texture_w * fit;
         h = texture_h * fit;
     }
+    w *= scale;
+    h *= scale;
 
     float x = image->normalized ? image->x * (float)width : image->x;
     float y = image->normalized ? image->y * (float)height : image->y;
@@ -432,10 +444,17 @@ static bool draw_ui_image(void *userdata, const sdl3d_game_data_ui_image *image)
     if (draw == NULL || image == NULL)
         return false;
 
-    if (!sdl3d_game_data_ui_image_is_visible(draw->runtime, image, draw->metrics))
+    sdl3d_game_data_ui_image resolved;
+    bool visible = false;
+    if (!sdl3d_game_data_resolve_ui_image(draw->runtime, image, draw->metrics, &resolved, &visible))
+    {
+        draw->ok = false;
+        return true;
+    }
+    if (!visible)
         return true;
 
-    sdl3d_texture2d *texture = find_or_load_image(draw->runtime, draw->image_cache, image->image);
+    sdl3d_texture2d *texture = find_or_load_image(draw->runtime, draw->image_cache, resolved.image);
     if (texture == NULL)
     {
         draw->ok = false;
@@ -448,8 +467,8 @@ static bool draw_ui_image(void *userdata, const sdl3d_game_data_ui_image *image)
     float y = 0.0f;
     float w = 0.0f;
     float h = 0.0f;
-    resolve_ui_image_rect(image, texture, width, height, &x, &y, &w, &h);
-    if (!sdl3d_draw_texture_overlay(draw->renderer, texture, x, y, w, h, image->color))
+    resolve_ui_image_rect(&resolved, texture, width, height, &x, &y, &w, &h);
+    if (!sdl3d_draw_texture_overlay(draw->renderer, texture, x, y, w, h, resolved.color))
         draw->ok = false;
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -955,6 +955,118 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, ResolvesRuntimeUiStateForTextAndImages)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_game_data_ui_image logo{};
+    bool saw_logo = false;
+    auto find_logo = [](void *userdata, const sdl3d_game_data_ui_image *image) -> bool {
+        auto *args = static_cast<std::pair<sdl3d_game_data_ui_image *, bool *> *>(userdata);
+        if (image->name != nullptr && std::string(image->name) == "ui.splash.logo")
+        {
+            *args->first = *image;
+            *args->second = true;
+            return false;
+        }
+        return true;
+    };
+    std::pair<sdl3d_game_data_ui_image *, bool *> logo_args{&logo, &saw_logo};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_image(runtime, find_logo, &logo_args));
+    ASSERT_TRUE(saw_logo);
+
+    sdl3d_game_data_ui_state image_state{};
+    sdl3d_game_data_ui_state_init(&image_state);
+    image_state.flags = SDL3D_GAME_DATA_UI_STATE_OFFSET | SDL3D_GAME_DATA_UI_STATE_SCALE |
+                        SDL3D_GAME_DATA_UI_STATE_ALPHA | SDL3D_GAME_DATA_UI_STATE_TINT;
+    image_state.offset_x = 0.10f;
+    image_state.offset_y = -0.05f;
+    image_state.scale = 0.5f;
+    image_state.alpha = 0.25f;
+    image_state.tint = {128, 64, 255, 200};
+    ASSERT_TRUE(sdl3d_game_data_set_ui_state(runtime, "ui.splash.logo", &image_state));
+
+    sdl3d_game_data_ui_state stored_image_state{};
+    ASSERT_TRUE(sdl3d_game_data_get_ui_state(runtime, "ui.splash.logo", &stored_image_state));
+    EXPECT_EQ(stored_image_state.flags, image_state.flags);
+    EXPECT_NEAR(stored_image_state.scale, 0.5f, 0.0001f);
+
+    sdl3d_game_data_ui_image resolved_logo{};
+    bool logo_visible = false;
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_image(runtime, &logo, nullptr, &resolved_logo, &logo_visible));
+    EXPECT_TRUE(logo_visible);
+    EXPECT_NEAR(resolved_logo.x, 0.60f, 0.0001f);
+    EXPECT_NEAR(resolved_logo.y, 0.45f, 0.0001f);
+    EXPECT_NEAR(resolved_logo.scale, 0.5f, 0.0001f);
+    EXPECT_EQ(resolved_logo.color.r, 128);
+    EXPECT_EQ(resolved_logo.color.g, 64);
+    EXPECT_EQ(resolved_logo.color.b, 255);
+    EXPECT_EQ(resolved_logo.color.a, 50);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+
+    sdl3d_game_data_ui_text pause{};
+    bool saw_pause = false;
+    auto find_pause = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *args = static_cast<std::pair<sdl3d_game_data_ui_text *, bool *> *>(userdata);
+        if (text->name != nullptr && std::string(text->name) == "ui.pause")
+        {
+            *args->first = *text;
+            *args->second = true;
+            return false;
+        }
+        return true;
+    };
+    std::pair<sdl3d_game_data_ui_text *, bool *> pause_args{&pause, &saw_pause};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_pause, &pause_args));
+    ASSERT_TRUE(saw_pause);
+
+    sdl3d_game_data_ui_metrics metrics{};
+    metrics.paused = false;
+    EXPECT_FALSE(sdl3d_game_data_ui_text_is_visible(runtime, &pause, &metrics));
+
+    sdl3d_game_data_ui_state text_state{};
+    sdl3d_game_data_ui_state_init(&text_state);
+    text_state.flags = SDL3D_GAME_DATA_UI_STATE_VISIBLE | SDL3D_GAME_DATA_UI_STATE_OFFSET |
+                       SDL3D_GAME_DATA_UI_STATE_SCALE | SDL3D_GAME_DATA_UI_STATE_ALPHA | SDL3D_GAME_DATA_UI_STATE_TINT;
+    text_state.visible = true;
+    text_state.offset_x = 0.02f;
+    text_state.offset_y = -0.03f;
+    text_state.scale = 2.0f;
+    text_state.alpha = 0.5f;
+    text_state.tint = {128, 255, 64, 128};
+    ASSERT_TRUE(sdl3d_game_data_set_ui_state(runtime, "ui.pause", &text_state));
+
+    sdl3d_game_data_ui_text resolved_pause{};
+    bool pause_visible = false;
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_text(runtime, &pause, &metrics, &resolved_pause, &pause_visible));
+    EXPECT_TRUE(pause_visible);
+    EXPECT_NEAR(resolved_pause.x, 0.52f, 0.0001f);
+    EXPECT_NEAR(resolved_pause.y, 0.41f, 0.0001f);
+    EXPECT_NEAR(resolved_pause.scale, 2.0f, 0.0001f);
+    EXPECT_EQ(resolved_pause.color.r, 123);
+    EXPECT_EQ(resolved_pause.color.g, 248);
+    EXPECT_EQ(resolved_pause.color.b, 64);
+    EXPECT_EQ(resolved_pause.color.a, 64);
+
+    text_state.visible = false;
+    ASSERT_TRUE(sdl3d_game_data_set_ui_state(runtime, "ui.pause", &text_state));
+    EXPECT_FALSE(sdl3d_game_data_ui_text_is_visible(runtime, &pause, &metrics));
+
+    EXPECT_TRUE(sdl3d_game_data_clear_ui_state(runtime, "ui.pause"));
+    EXPECT_FALSE(sdl3d_game_data_get_ui_state(runtime, "ui.pause", &text_state));
+    sdl3d_game_data_clear_ui_states(runtime);
+    EXPECT_FALSE(sdl3d_game_data_get_ui_state(runtime, "ui.splash.logo", &image_state));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks)
 {
     sdl3d_game_session *session = nullptr;


### PR DESCRIPTION
## Summary
- add public runtime UI state APIs for visibility, offset, scale, alpha, and tint overrides
- resolve authored UI text/images plus runtime state before presentation drawing
- add scaled overlay text drawing so text scale is honored by the renderer
- cover text/image state resolution, visibility override, tint/alpha composition, and clear/get behavior in tests

## Tests
- cmake --build build/release --target sdl3d_game_data_test -j8
- ./build/release/tests/sdl3d_game_data_test
- cmake --build build/release --target pong_demo -j8

Refs #133