### PR TITLE
Add data-authored tween actions

### DIFF
--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1217,6 +1217,21 @@ extern "C"
                                          float dt, sdl3d_game_data_timeline_update_result *out_result);
 
     /**
+     * @brief Advance data-authored runtime animations.
+     *
+     * Animations are started by generic actions such as `ui.animate` and
+     * `property.animate`. This function advances active tweens, applies eased
+     * values to UI runtime state or actor properties, emits completion signals
+     * for one-shot animations, and clears scene-scoped animation state when the
+     * active scene changes.
+     *
+     * @param runtime Runtime created by sdl3d_game_data_load_file().
+     * @param dt Delta time in seconds.
+     * @return true when active animations were advanced successfully.
+     */
+    bool sdl3d_game_data_update_animations(sdl3d_game_data_runtime *runtime, float dt);
+
+    /**
      * @brief Resolve UI text content from data-authored bindings.
      *
      * Literal `text` entries are copied directly. Entries with `bindings`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -108,7 +108,63 @@ typedef struct ui_state_entry
 {
     char *name;
     sdl3d_game_data_ui_state state;
+    bool animated;
 } ui_state_entry;
+
+typedef enum game_data_tween_target
+{
+    GAME_DATA_TWEEN_UI,
+    GAME_DATA_TWEEN_PROPERTY,
+} game_data_tween_target;
+
+typedef enum game_data_tween_value_type
+{
+    GAME_DATA_TWEEN_FLOAT,
+    GAME_DATA_TWEEN_VEC3,
+    GAME_DATA_TWEEN_COLOR,
+} game_data_tween_value_type;
+
+typedef enum game_data_tween_easing
+{
+    GAME_DATA_TWEEN_LINEAR,
+    GAME_DATA_TWEEN_IN_QUAD,
+    GAME_DATA_TWEEN_OUT_QUAD,
+    GAME_DATA_TWEEN_IN_OUT_QUAD,
+} game_data_tween_easing;
+
+typedef enum game_data_tween_repeat
+{
+    GAME_DATA_TWEEN_REPEAT_NONE,
+    GAME_DATA_TWEEN_REPEAT_LOOP,
+    GAME_DATA_TWEEN_REPEAT_PING_PONG,
+} game_data_tween_repeat;
+
+typedef struct game_data_tween_value
+{
+    game_data_tween_value_type type;
+    union {
+        float as_float;
+        sdl3d_vec3 as_vec3;
+        sdl3d_color as_color;
+    };
+} game_data_tween_value;
+
+typedef struct game_data_animation
+{
+    game_data_tween_target target_type;
+    const char *target;
+    const char *property;
+    const char *key;
+    const char *scene;
+    float duration;
+    float elapsed;
+    game_data_tween_easing easing;
+    game_data_tween_repeat repeat;
+    game_data_tween_value from;
+    game_data_tween_value to;
+    sdl3d_value_type property_type;
+    int done_signal_id;
+} game_data_animation;
 
 typedef struct scene_entry
 {
@@ -150,6 +206,10 @@ typedef struct sdl3d_game_data_runtime
     ui_state_entry *ui_states;
     int ui_state_count;
     int ui_state_capacity;
+    game_data_animation *animations;
+    int animation_count;
+    int animation_capacity;
+    const char *animation_scene;
     const char *active_camera;
     float current_dt;
     unsigned int rng_state;
@@ -2295,8 +2355,8 @@ static bool ensure_ui_state_capacity(sdl3d_game_data_runtime *runtime, int requi
     return true;
 }
 
-bool sdl3d_game_data_set_ui_state(sdl3d_game_data_runtime *runtime, const char *name,
-                                  const sdl3d_game_data_ui_state *state)
+static bool set_ui_state_internal(sdl3d_game_data_runtime *runtime, const char *name,
+                                  const sdl3d_game_data_ui_state *state, bool animated)
 {
     if (runtime == NULL || name == NULL || name[0] == '\0' || state == NULL)
         return false;
@@ -2314,7 +2374,14 @@ bool sdl3d_game_data_set_ui_state(sdl3d_game_data_runtime *runtime, const char *
     }
 
     entry->state = *state;
+    entry->animated = animated;
     return true;
+}
+
+bool sdl3d_game_data_set_ui_state(sdl3d_game_data_runtime *runtime, const char *name,
+                                  const sdl3d_game_data_ui_state *state)
+{
+    return set_ui_state_internal(runtime, name, state, false);
 }
 
 bool sdl3d_game_data_get_ui_state(const sdl3d_game_data_runtime *runtime, const char *name,
@@ -2359,6 +2426,360 @@ void sdl3d_game_data_clear_ui_states(sdl3d_game_data_runtime *runtime)
     for (int i = 0; i < runtime->ui_state_count; ++i)
         SDL_free(runtime->ui_states[i].name);
     runtime->ui_state_count = 0;
+}
+
+static void clear_animated_ui_states(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    for (int i = 0; i < runtime->ui_state_count;)
+    {
+        if (!runtime->ui_states[i].animated)
+        {
+            ++i;
+            continue;
+        }
+
+        SDL_free(runtime->ui_states[i].name);
+        if (i + 1 < runtime->ui_state_count)
+            runtime->ui_states[i] = runtime->ui_states[runtime->ui_state_count - 1];
+        --runtime->ui_state_count;
+    }
+}
+
+static void reset_animation_scope_if_needed(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+
+    const char *active_scene = sdl3d_game_data_active_scene(runtime);
+    if (runtime->animation_scene == active_scene)
+        return;
+
+    if (runtime->animation_scene != NULL)
+    {
+        runtime->animation_count = 0;
+        clear_animated_ui_states(runtime);
+    }
+    runtime->animation_scene = active_scene;
+}
+
+static bool ensure_animation_capacity(sdl3d_game_data_runtime *runtime, int required)
+{
+    if (runtime == NULL)
+        return false;
+    if (required <= runtime->animation_capacity)
+        return true;
+
+    int next_capacity = runtime->animation_capacity < 8 ? 8 : runtime->animation_capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    game_data_animation *entries =
+        (game_data_animation *)SDL_realloc(runtime->animations, (size_t)next_capacity * sizeof(*entries));
+    if (entries == NULL)
+        return false;
+
+    SDL_memset(entries + runtime->animation_capacity, 0,
+               (size_t)(next_capacity - runtime->animation_capacity) * sizeof(*entries));
+    runtime->animations = entries;
+    runtime->animation_capacity = next_capacity;
+    return true;
+}
+
+static game_data_tween_easing parse_tween_easing(const char *name)
+{
+    if (name == NULL || SDL_strcmp(name, "linear") == 0)
+        return GAME_DATA_TWEEN_LINEAR;
+    if (SDL_strcmp(name, "in_quad") == 0)
+        return GAME_DATA_TWEEN_IN_QUAD;
+    if (SDL_strcmp(name, "out_quad") == 0)
+        return GAME_DATA_TWEEN_OUT_QUAD;
+    if (SDL_strcmp(name, "in_out_quad") == 0)
+        return GAME_DATA_TWEEN_IN_OUT_QUAD;
+    return GAME_DATA_TWEEN_LINEAR;
+}
+
+static game_data_tween_repeat parse_tween_repeat(const char *name)
+{
+    if (name == NULL || SDL_strcmp(name, "none") == 0)
+        return GAME_DATA_TWEEN_REPEAT_NONE;
+    if (SDL_strcmp(name, "loop") == 0)
+        return GAME_DATA_TWEEN_REPEAT_LOOP;
+    if (SDL_strcmp(name, "ping_pong") == 0)
+        return GAME_DATA_TWEEN_REPEAT_PING_PONG;
+    return GAME_DATA_TWEEN_REPEAT_NONE;
+}
+
+static float apply_tween_easing(game_data_tween_easing easing, float t)
+{
+    t = SDL_clamp(t, 0.0f, 1.0f);
+    switch (easing)
+    {
+    case GAME_DATA_TWEEN_IN_QUAD:
+        return t * t;
+    case GAME_DATA_TWEEN_OUT_QUAD:
+        return 1.0f - (1.0f - t) * (1.0f - t);
+    case GAME_DATA_TWEEN_IN_OUT_QUAD:
+        return t < 0.5f ? 2.0f * t * t : 1.0f - SDL_powf(-2.0f * t + 2.0f, 2.0f) * 0.5f;
+    case GAME_DATA_TWEEN_LINEAR:
+    default:
+        return t;
+    }
+}
+
+static game_data_tween_value tween_float(float value)
+{
+    game_data_tween_value out;
+    SDL_zero(out);
+    out.type = GAME_DATA_TWEEN_FLOAT;
+    out.as_float = value;
+    return out;
+}
+
+static game_data_tween_value tween_vec3(sdl3d_vec3 value)
+{
+    game_data_tween_value out;
+    SDL_zero(out);
+    out.type = GAME_DATA_TWEEN_VEC3;
+    out.as_vec3 = value;
+    return out;
+}
+
+static game_data_tween_value tween_color(sdl3d_color value)
+{
+    game_data_tween_value out;
+    SDL_zero(out);
+    out.type = GAME_DATA_TWEEN_COLOR;
+    out.as_color = value;
+    return out;
+}
+
+static bool json_tween_value(yyjson_val *value, game_data_tween_value_type preferred, game_data_tween_value *out_value)
+{
+    if (value == NULL || out_value == NULL)
+        return false;
+    if (yyjson_is_num(value))
+    {
+        *out_value = tween_float((float)yyjson_get_num(value));
+        return true;
+    }
+    if (yyjson_is_arr(value))
+    {
+        if (preferred == GAME_DATA_TWEEN_COLOR)
+            *out_value = tween_color(json_color_value(value, (sdl3d_color){255, 255, 255, 255}));
+        else
+            *out_value = tween_vec3(json_vec3_value(value, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+        return true;
+    }
+    return false;
+}
+
+static game_data_tween_value_type tween_preferred_type(const char *value_type, const sdl3d_value *current,
+                                                       const char *ui_property)
+{
+    if (value_type != NULL && SDL_strcmp(value_type, "color") == 0)
+        return GAME_DATA_TWEEN_COLOR;
+    if (value_type != NULL && SDL_strcmp(value_type, "vec3") == 0)
+        return GAME_DATA_TWEEN_VEC3;
+    if (ui_property != NULL && (SDL_strcmp(ui_property, "tint") == 0 || SDL_strcmp(ui_property, "color") == 0))
+        return GAME_DATA_TWEEN_COLOR;
+    if (current != NULL && current->type == SDL3D_VALUE_COLOR)
+        return GAME_DATA_TWEEN_COLOR;
+    if (current != NULL && current->type == SDL3D_VALUE_VEC3)
+        return GAME_DATA_TWEEN_VEC3;
+    return GAME_DATA_TWEEN_FLOAT;
+}
+
+static bool current_property_tween_value(const sdl3d_value *current, game_data_tween_value_type preferred,
+                                         game_data_tween_value *out_value, sdl3d_value_type *out_property_type)
+{
+    if (current == NULL || out_value == NULL || out_property_type == NULL)
+        return false;
+
+    *out_property_type = current->type;
+    switch (current->type)
+    {
+    case SDL3D_VALUE_INT:
+        *out_value = tween_float((float)current->as_int);
+        return true;
+    case SDL3D_VALUE_FLOAT:
+        *out_value = tween_float(current->as_float);
+        return true;
+    case SDL3D_VALUE_VEC3:
+        *out_value = tween_vec3(current->as_vec3);
+        return true;
+    case SDL3D_VALUE_COLOR:
+        *out_value = preferred == GAME_DATA_TWEEN_COLOR
+                         ? tween_color(current->as_color)
+                         : tween_vec3(sdl3d_vec3_make((float)current->as_color.r, (float)current->as_color.g,
+                                                      (float)current->as_color.b));
+        return true;
+    case SDL3D_VALUE_BOOL:
+    case SDL3D_VALUE_STRING:
+        return false;
+    }
+    return false;
+}
+
+static bool current_ui_tween_value(const sdl3d_game_data_ui_state *state, const char *property,
+                                   game_data_tween_value *out_value)
+{
+    if (property == NULL || out_value == NULL)
+        return false;
+    if (SDL_strcmp(property, "alpha") == 0)
+        *out_value = tween_float(state != NULL ? state->alpha : 1.0f);
+    else if (SDL_strcmp(property, "scale") == 0)
+        *out_value = tween_float(state != NULL ? state->scale : 1.0f);
+    else if (SDL_strcmp(property, "offset_x") == 0 || SDL_strcmp(property, "x") == 0)
+        *out_value = tween_float(state != NULL ? state->offset_x : 0.0f);
+    else if (SDL_strcmp(property, "offset_y") == 0 || SDL_strcmp(property, "y") == 0)
+        *out_value = tween_float(state != NULL ? state->offset_y : 0.0f);
+    else if (SDL_strcmp(property, "tint") == 0 || SDL_strcmp(property, "color") == 0)
+        *out_value = tween_color(state != NULL ? state->tint : (sdl3d_color){255, 255, 255, 255});
+    else
+        return false;
+    return true;
+}
+
+static game_data_tween_value interpolate_tween_value(const game_data_tween_value *from, const game_data_tween_value *to,
+                                                     float t)
+{
+    if (from->type == GAME_DATA_TWEEN_VEC3 && to->type == GAME_DATA_TWEEN_VEC3)
+    {
+        return tween_vec3(sdl3d_vec3_make(from->as_vec3.x + (to->as_vec3.x - from->as_vec3.x) * t,
+                                          from->as_vec3.y + (to->as_vec3.y - from->as_vec3.y) * t,
+                                          from->as_vec3.z + (to->as_vec3.z - from->as_vec3.z) * t));
+    }
+    if (from->type == GAME_DATA_TWEEN_COLOR && to->type == GAME_DATA_TWEEN_COLOR)
+    {
+        return tween_color((sdl3d_color){
+            (Uint8)SDL_clamp(
+                (int)((float)from->as_color.r + ((float)to->as_color.r - (float)from->as_color.r) * t + 0.5f), 0, 255),
+            (Uint8)SDL_clamp(
+                (int)((float)from->as_color.g + ((float)to->as_color.g - (float)from->as_color.g) * t + 0.5f), 0, 255),
+            (Uint8)SDL_clamp(
+                (int)((float)from->as_color.b + ((float)to->as_color.b - (float)from->as_color.b) * t + 0.5f), 0, 255),
+            (Uint8)SDL_clamp(
+                (int)((float)from->as_color.a + ((float)to->as_color.a - (float)from->as_color.a) * t + 0.5f), 0, 255),
+        });
+    }
+    return tween_float(from->as_float + (to->as_float - from->as_float) * t);
+}
+
+static void apply_ui_tween_value(sdl3d_game_data_runtime *runtime, const char *target, const char *property,
+                                 const game_data_tween_value *value)
+{
+    sdl3d_game_data_ui_state state;
+    (void)sdl3d_game_data_get_ui_state(runtime, target, &state);
+    if (SDL_strcmp(property, "alpha") == 0 && value->type == GAME_DATA_TWEEN_FLOAT)
+    {
+        state.flags |= SDL3D_GAME_DATA_UI_STATE_ALPHA;
+        state.alpha = value->as_float;
+    }
+    else if (SDL_strcmp(property, "scale") == 0 && value->type == GAME_DATA_TWEEN_FLOAT)
+    {
+        state.flags |= SDL3D_GAME_DATA_UI_STATE_SCALE;
+        state.scale = value->as_float;
+    }
+    else if ((SDL_strcmp(property, "offset_x") == 0 || SDL_strcmp(property, "x") == 0) &&
+             value->type == GAME_DATA_TWEEN_FLOAT)
+    {
+        state.flags |= SDL3D_GAME_DATA_UI_STATE_OFFSET;
+        state.offset_x = value->as_float;
+    }
+    else if ((SDL_strcmp(property, "offset_y") == 0 || SDL_strcmp(property, "y") == 0) &&
+             value->type == GAME_DATA_TWEEN_FLOAT)
+    {
+        state.flags |= SDL3D_GAME_DATA_UI_STATE_OFFSET;
+        state.offset_y = value->as_float;
+    }
+    else if ((SDL_strcmp(property, "tint") == 0 || SDL_strcmp(property, "color") == 0) &&
+             value->type == GAME_DATA_TWEEN_COLOR)
+    {
+        state.flags |= SDL3D_GAME_DATA_UI_STATE_TINT;
+        state.tint = value->as_color;
+    }
+    (void)set_ui_state_internal(runtime, target, &state, true);
+}
+
+static void apply_property_tween_value(sdl3d_game_data_runtime *runtime, const game_data_animation *animation,
+                                       const game_data_tween_value *value)
+{
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, animation->target);
+    if (actor == NULL || animation->key == NULL)
+        return;
+
+    if ((animation->property_type == SDL3D_VALUE_INT || animation->property_type == SDL3D_VALUE_FLOAT) &&
+        value->type == GAME_DATA_TWEEN_FLOAT)
+    {
+        if (animation->property_type == SDL3D_VALUE_INT)
+            sdl3d_properties_set_int(actor->props, animation->key, (int)SDL_floorf(value->as_float + 0.5f));
+        else
+            sdl3d_properties_set_float(actor->props, animation->key, value->as_float);
+    }
+    else if (animation->property_type == SDL3D_VALUE_VEC3 && value->type == GAME_DATA_TWEEN_VEC3)
+    {
+        sdl3d_properties_set_vec3(actor->props, animation->key, value->as_vec3);
+    }
+    else if (animation->property_type == SDL3D_VALUE_COLOR && value->type == GAME_DATA_TWEEN_COLOR)
+    {
+        sdl3d_properties_set_color(actor->props, animation->key, value->as_color);
+    }
+}
+
+static void apply_animation_value(sdl3d_game_data_runtime *runtime, const game_data_animation *animation,
+                                  const game_data_tween_value *value)
+{
+    if (animation->target_type == GAME_DATA_TWEEN_UI)
+        apply_ui_tween_value(runtime, animation->target, animation->property, value);
+    else
+        apply_property_tween_value(runtime, animation, value);
+}
+
+static void remove_conflicting_animation(sdl3d_game_data_runtime *runtime, const game_data_animation *animation)
+{
+    for (int i = 0; runtime != NULL && i < runtime->animation_count;)
+    {
+        game_data_animation *existing = &runtime->animations[i];
+        const char *existing_property =
+            existing->target_type == GAME_DATA_TWEEN_PROPERTY ? existing->key : existing->property;
+        const char *new_property =
+            animation->target_type == GAME_DATA_TWEEN_PROPERTY ? animation->key : animation->property;
+        if (existing->target_type == animation->target_type && existing->target != NULL && animation->target != NULL &&
+            existing_property != NULL && new_property != NULL && SDL_strcmp(existing->target, animation->target) == 0 &&
+            SDL_strcmp(existing_property, new_property) == 0)
+        {
+            runtime->animations[i] = runtime->animations[runtime->animation_count - 1];
+            --runtime->animation_count;
+            continue;
+        }
+        ++i;
+    }
+}
+
+static bool start_animation(sdl3d_game_data_runtime *runtime, const game_data_animation *animation)
+{
+    if (runtime == NULL || animation == NULL || animation->target == NULL || animation->duration < 0.0f)
+        return false;
+
+    reset_animation_scope_if_needed(runtime);
+    apply_animation_value(runtime, animation, &animation->from);
+
+    if (animation->duration <= 0.0f)
+    {
+        apply_animation_value(runtime, animation, &animation->to);
+        if (animation->done_signal_id >= 0)
+            sdl3d_signal_emit(runtime_bus(runtime), animation->done_signal_id, NULL);
+        return true;
+    }
+
+    remove_conflicting_animation(runtime, animation);
+    if (!ensure_animation_capacity(runtime, runtime->animation_count + 1))
+        return false;
+    runtime->animations[runtime->animation_count] = *animation;
+    ++runtime->animation_count;
+    return true;
 }
 
 bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash)
@@ -4277,6 +4698,172 @@ bool sdl3d_game_data_format_ui_text(const sdl3d_game_data_runtime *runtime, cons
     return false;
 }
 
+static sdl3d_value_type property_type_from_name(const char *name, sdl3d_value_type fallback)
+{
+    if (name == NULL)
+        return fallback;
+    if (SDL_strcmp(name, "int") == 0)
+        return SDL3D_VALUE_INT;
+    if (SDL_strcmp(name, "float") == 0 || SDL_strcmp(name, "number") == 0)
+        return SDL3D_VALUE_FLOAT;
+    if (SDL_strcmp(name, "vec3") == 0)
+        return SDL3D_VALUE_VEC3;
+    if (SDL_strcmp(name, "color") == 0)
+        return SDL3D_VALUE_COLOR;
+    return fallback;
+}
+
+static bool start_property_animation_from_json(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+    const char *key = json_string(action, "key", NULL);
+    yyjson_val *to_json = obj_get(action, "to");
+    if (to_json == NULL)
+        to_json = obj_get(action, "value");
+    if (actor == NULL || key == NULL || to_json == NULL)
+        return false;
+
+    const sdl3d_value *current = sdl3d_properties_get_value(actor->props, key);
+    const char *value_type = json_string(action, "value_type", NULL);
+    const game_data_tween_value_type preferred = tween_preferred_type(value_type, current, NULL);
+
+    game_data_animation animation;
+    SDL_zero(animation);
+    animation.target_type = GAME_DATA_TWEEN_PROPERTY;
+    animation.target = actor->name;
+    animation.key = key;
+    animation.scene = sdl3d_game_data_active_scene(runtime);
+    animation.duration = json_float(action, "duration", 0.0f);
+    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
+    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
+    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
+    animation.property_type = current != NULL ? current->type : property_type_from_name(value_type, SDL3D_VALUE_FLOAT);
+
+    yyjson_val *from_json = obj_get(action, "from");
+    if (from_json != NULL)
+    {
+        if (!json_tween_value(from_json, preferred, &animation.from))
+            return false;
+    }
+    else if (!current_property_tween_value(current, preferred, &animation.from, &animation.property_type))
+    {
+        animation.from = preferred == GAME_DATA_TWEEN_COLOR  ? tween_color((sdl3d_color){255, 255, 255, 255})
+                         : preferred == GAME_DATA_TWEEN_VEC3 ? tween_vec3(sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
+                                                             : tween_float(0.0f);
+    }
+
+    if (!json_tween_value(to_json, preferred, &animation.to))
+        return false;
+    if (animation.from.type != animation.to.type)
+        return false;
+    if (animation.to.type == GAME_DATA_TWEEN_VEC3)
+        animation.property_type = SDL3D_VALUE_VEC3;
+    else if (animation.to.type == GAME_DATA_TWEEN_COLOR)
+        animation.property_type = SDL3D_VALUE_COLOR;
+    else
+        animation.property_type = property_type_from_name(value_type, animation.property_type);
+
+    return start_animation(runtime, &animation);
+}
+
+static bool start_ui_animation_from_json(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", json_string(action, "ui", NULL));
+    const char *property = json_string(action, "property", NULL);
+    yyjson_val *to_json = obj_get(action, "to");
+    if (to_json == NULL)
+        to_json = obj_get(action, "value");
+    if (target == NULL || property == NULL || to_json == NULL)
+        return false;
+
+    sdl3d_game_data_ui_state state;
+    sdl3d_game_data_ui_state_init(&state);
+    (void)sdl3d_game_data_get_ui_state(runtime, target, &state);
+    const game_data_tween_value_type preferred =
+        tween_preferred_type(json_string(action, "value_type", NULL), NULL, property);
+
+    game_data_animation animation;
+    SDL_zero(animation);
+    animation.target_type = GAME_DATA_TWEEN_UI;
+    animation.target = target;
+    animation.property = property;
+    animation.scene = sdl3d_game_data_active_scene(runtime);
+    animation.duration = json_float(action, "duration", 0.0f);
+    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
+    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
+    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
+    animation.property_type = SDL3D_VALUE_FLOAT;
+
+    yyjson_val *from_json = obj_get(action, "from");
+    if (from_json != NULL)
+    {
+        if (!json_tween_value(from_json, preferred, &animation.from))
+            return false;
+    }
+    else if (!current_ui_tween_value(&state, property, &animation.from))
+    {
+        return false;
+    }
+
+    if (!json_tween_value(to_json, preferred, &animation.to))
+        return false;
+    if (animation.from.type != animation.to.type)
+        return false;
+    return start_animation(runtime, &animation);
+}
+
+bool sdl3d_game_data_update_animations(sdl3d_game_data_runtime *runtime, float dt)
+{
+    if (runtime == NULL)
+        return false;
+
+    reset_animation_scope_if_needed(runtime);
+    const float step = dt > 0.0f ? dt : 0.0f;
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    for (int i = 0; i < runtime->animation_count;)
+    {
+        game_data_animation *animation = &runtime->animations[i];
+        animation->elapsed += step;
+
+        bool complete = false;
+        float t = 1.0f;
+        if (animation->duration > 0.0f)
+        {
+            if (animation->repeat == GAME_DATA_TWEEN_REPEAT_LOOP)
+            {
+                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
+            }
+            else if (animation->repeat == GAME_DATA_TWEEN_REPEAT_PING_PONG)
+            {
+                const float cycle_float = SDL_floorf(animation->elapsed / animation->duration);
+                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
+                if (((int)cycle_float % 2) != 0)
+                    t = 1.0f - t;
+            }
+            else
+            {
+                complete = animation->elapsed >= animation->duration;
+                t = complete ? 1.0f : animation->elapsed / animation->duration;
+            }
+        }
+
+        const float eased = apply_tween_easing(animation->easing, t);
+        const game_data_tween_value value = interpolate_tween_value(&animation->from, &animation->to, eased);
+        apply_animation_value(runtime, animation, &value);
+
+        if (complete)
+        {
+            if (animation->done_signal_id >= 0 && bus != NULL)
+                sdl3d_signal_emit(bus, animation->done_signal_id, NULL);
+            runtime->animations[i] = runtime->animations[runtime->animation_count - 1];
+            --runtime->animation_count;
+            continue;
+        }
+        ++i;
+    }
+    return true;
+}
+
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
@@ -4325,6 +4912,12 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         }
         return true;
     }
+
+    if (SDL_strcmp(type, "property.animate") == 0)
+        return start_property_animation_from_json(runtime, action);
+
+    if (SDL_strcmp(type, "ui.animate") == 0)
+        return start_ui_animation_from_json(runtime, action);
 
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {
@@ -5364,6 +5957,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->bindings);
     SDL_free(runtime->sensors);
     SDL_free(runtime->ui_states);
+    SDL_free(runtime->animations);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -853,6 +853,69 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
 static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
                                   validation_names *names);
 
+static bool is_tween_easing(const char *easing)
+{
+    return easing == NULL || SDL_strcmp(easing, "linear") == 0 || SDL_strcmp(easing, "in_quad") == 0 ||
+           SDL_strcmp(easing, "out_quad") == 0 || SDL_strcmp(easing, "in_out_quad") == 0;
+}
+
+static bool is_tween_repeat(const char *repeat)
+{
+    return repeat == NULL || SDL_strcmp(repeat, "none") == 0 || SDL_strcmp(repeat, "loop") == 0 ||
+           SDL_strcmp(repeat, "ping_pong") == 0;
+}
+
+static bool is_tween_value_type(const char *value_type)
+{
+    return value_type == NULL || SDL_strcmp(value_type, "int") == 0 || SDL_strcmp(value_type, "float") == 0 ||
+           SDL_strcmp(value_type, "number") == 0 || SDL_strcmp(value_type, "vec3") == 0 ||
+           SDL_strcmp(value_type, "color") == 0;
+}
+
+static bool is_ui_tween_property(const char *property)
+{
+    return property != NULL && (SDL_strcmp(property, "alpha") == 0 || SDL_strcmp(property, "scale") == 0 ||
+                                SDL_strcmp(property, "offset_x") == 0 || SDL_strcmp(property, "offset_y") == 0 ||
+                                SDL_strcmp(property, "x") == 0 || SDL_strcmp(property, "y") == 0 ||
+                                SDL_strcmp(property, "tint") == 0 || SDL_strcmp(property, "color") == 0);
+}
+
+static bool validate_tween_value(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                 const char *field_name)
+{
+    if (yyjson_is_num(value) || is_vec_array(value, 2))
+        return true;
+    return validation_error(ctx, json_path, "%s must be a number or numeric array", field_name);
+}
+
+static bool validate_animation_common(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                      validation_names *names)
+{
+    yyjson_val *to = obj_get(action, "to");
+    if (to == NULL)
+        to = obj_get(action, "value");
+    if (to == NULL)
+        return validation_error(ctx, json_path, "animation action requires to or value");
+    if (!validate_tween_value(ctx, to, json_path, "animation target value"))
+        return false;
+    yyjson_val *from = obj_get(action, "from");
+    if (from != NULL && !validate_tween_value(ctx, from, json_path, "animation start value"))
+        return false;
+    yyjson_val *duration = obj_get(action, "duration");
+    if (duration != NULL && (!yyjson_is_num(duration) || yyjson_get_num(duration) < 0.0))
+        return validation_error(ctx, json_path, "animation duration must be a non-negative number");
+    if (!is_tween_easing(json_string(action, "easing")))
+        return validation_error(ctx, json_path, "animation easing must be linear, in_quad, out_quad, or in_out_quad");
+    if (!is_tween_repeat(json_string(action, "repeat")))
+        return validation_error(ctx, json_path, "animation repeat must be none, loop, or ping_pong");
+    if (!is_tween_value_type(json_string(action, "value_type")))
+        return validation_error(ctx, json_path, "animation value_type must be int, float, number, vec3, or color");
+    const char *done_signal = json_string(action, "done_signal");
+    if (done_signal != NULL && !require_ref(ctx, &names->signals, "signal", done_signal, json_path))
+        return false;
+    return true;
+}
+
 static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                 validation_names *names)
 {
@@ -875,6 +938,25 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (obj_get(action, "value") == NULL)
             return validation_error(ctx, json_path, "%s requires a value", type);
         return true;
+    }
+    if (SDL_strcmp(type, "property.animate") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        if (!is_non_empty_string(action, "key"))
+            return validation_error(ctx, json_path, "property.animate requires a non-empty key");
+        return validate_animation_common(ctx, action, json_path, names);
+    }
+    if (SDL_strcmp(type, "ui.animate") == 0)
+    {
+        if (!is_non_empty_string(action, "target") && !is_non_empty_string(action, "ui"))
+            return validation_error(ctx, json_path, "ui.animate requires a non-empty target");
+        if (!is_non_empty_string(action, "property"))
+            return validation_error(ctx, json_path, "ui.animate requires a non-empty property");
+        if (!is_ui_tween_property(json_string(action, "property")))
+            return validation_error(
+                ctx, json_path, "ui.animate property must be alpha, scale, offset_x, offset_y, x, y, tint, or color");
+        return validate_animation_common(ctx, action, json_path, names);
     }
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -760,6 +760,8 @@ bool sdl3d_game_data_update_frame(sdl3d_game_data_frame_state *state, const sdl3
         state->time += desc->dt;
         if (!sdl3d_game_data_update_presentation_clocks(runtime, desc->dt, ctx->paused, pause_entered))
             return false;
+        if (!sdl3d_game_data_update_animations(runtime, desc->dt))
+            return false;
         state->ui_pulse_phase = sdl3d_game_data_ui_pulse_phase(runtime, state->ui_pulse_phase);
     }
     if (sdl3d_game_data_active_scene_update_phase(runtime, "property_effects", ctx->paused) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -390,6 +390,140 @@ void write_skip_policy_json(const std::filesystem::path &dir)
 })json");
 }
 
+void write_animation_json(const std::filesystem::path &dir)
+{
+    write_text(dir / "animation.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Animation", "id": "test.animation", "version": "0.1.0" },
+  "entities": [
+    {
+      "name": "entity.box",
+      "active": true,
+      "properties": {
+        "x": { "type": "float", "value": 0.0 },
+        "ease": { "type": "float", "value": 0.0 },
+        "loop": { "type": "float", "value": 0.0 },
+        "ping": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "signals": ["signal.property.done", "signal.ui.done"],
+  "scenes": {
+    "initial": "scene.intro",
+    "files": [
+      "scenes/intro.scene.json",
+      "scenes/title.scene.json"
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "intro.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.intro",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": ["entity.box"],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.logo",
+        "text": "LOGO",
+        "x": 0.5,
+        "y": 0.5,
+        "normalized": true,
+        "align": "center",
+        "color": [255, 255, 255, 255]
+      }
+    ]
+  },
+  "timeline": {
+    "autoplay": true,
+    "events": [
+      {
+        "time": 0.0,
+        "action": {
+          "type": "property.animate",
+          "target": "entity.box",
+          "key": "x",
+          "from": 0.0,
+          "to": 10.0,
+          "duration": 1.0,
+          "done_signal": "signal.property.done"
+        }
+      },
+      {
+        "time": 0.0,
+        "action": {
+          "type": "property.animate",
+          "target": "entity.box",
+          "key": "ease",
+          "from": 0.0,
+          "to": 1.0,
+          "duration": 1.0,
+          "easing": "out_quad"
+        }
+      },
+      {
+        "time": 0.0,
+        "action": {
+          "type": "property.animate",
+          "target": "entity.box",
+          "key": "loop",
+          "from": 0.0,
+          "to": 1.0,
+          "duration": 1.0,
+          "repeat": "loop"
+        }
+      },
+      {
+        "time": 0.0,
+        "action": {
+          "type": "property.animate",
+          "target": "entity.box",
+          "key": "ping",
+          "from": 0.0,
+          "to": 1.0,
+          "duration": 1.0,
+          "repeat": "ping_pong"
+        }
+      },
+      {
+        "time": 0.0,
+        "action": {
+          "type": "ui.animate",
+          "target": "ui.logo",
+          "property": "alpha",
+          "from": 0.0,
+          "to": 1.0,
+          "duration": 1.0,
+          "done_signal": "signal.ui.done"
+        }
+      },
+      {
+        "time": 0.0,
+        "action": {
+          "type": "ui.animate",
+          "target": "ui.logo",
+          "property": "scale",
+          "from": 1.0,
+          "to": 2.0,
+          "duration": 1.0
+        }
+      }
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "title.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": []
+})json");
+}
+
 void write_hot_reload_script(const std::filesystem::path &dir, int value)
 {
     const std::string script = std::string("local rules = {}\n"
@@ -1440,6 +1574,100 @@ TEST(GameDataRuntime, AppFlowAppliesAuthoredSkipPolicyWithoutMenuBleedThrough)
 
     ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, AppFlowRunsAuthoredTweenActions)
+{
+    const std::filesystem::path dir = unique_test_dir("animation");
+    write_animation_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "animation.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    const int property_done = sdl3d_game_data_find_signal(runtime, "signal.property.done");
+    const int ui_done = sdl3d_game_data_find_signal(runtime, "signal.ui.done");
+    ASSERT_GE(property_done, 0);
+    ASSERT_GE(ui_done, 0);
+    SignalCapture property_capture{};
+    SignalCapture ui_capture{};
+    ASSERT_NE(sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(session), property_done, count_signal,
+                                   &property_capture),
+              0);
+    ASSERT_NE(sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(session), ui_done, count_signal, &ui_capture), 0);
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+
+    sdl3d_registered_actor *box = sdl3d_game_data_find_actor(runtime, "entity.box");
+    ASSERT_NE(box, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_update_animations(runtime, 0.5f));
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "x", -1.0f), 5.0f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "ease", -1.0f), 0.75f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "loop", -1.0f), 0.5f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "ping", -1.0f), 0.5f, 0.0001f);
+    EXPECT_EQ(property_capture.calls, 0);
+    EXPECT_EQ(ui_capture.calls, 0);
+
+    sdl3d_game_data_ui_text logo{};
+    bool saw_logo = false;
+    auto find_logo = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *args = static_cast<std::pair<sdl3d_game_data_ui_text *, bool *> *>(userdata);
+        if (text->name != nullptr && std::string(text->name) == "ui.logo")
+        {
+            *args->first = *text;
+            *args->second = true;
+            return false;
+        }
+        return true;
+    };
+    std::pair<sdl3d_game_data_ui_text *, bool *> logo_args{&logo, &saw_logo};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_logo, &logo_args));
+    ASSERT_TRUE(saw_logo);
+
+    sdl3d_game_data_ui_text resolved_logo{};
+    bool logo_visible = false;
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_text(runtime, &logo, nullptr, &resolved_logo, &logo_visible));
+    EXPECT_TRUE(logo_visible);
+    EXPECT_EQ(resolved_logo.color.a, 128);
+    EXPECT_NEAR(resolved_logo.scale, 1.5f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update_animations(runtime, 0.5f));
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "x", -1.0f), 10.0f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "ease", -1.0f), 1.0f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "loop", -1.0f), 0.0f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "ping", -1.0f), 1.0f, 0.0001f);
+    EXPECT_EQ(property_capture.calls, 1);
+    EXPECT_EQ(ui_capture.calls, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_text(runtime, &logo, nullptr, &resolved_logo, &logo_visible));
+    EXPECT_TRUE(logo_visible);
+    EXPECT_EQ(resolved_logo.color.a, 255);
+    EXPECT_NEAR(resolved_logo.scale, 2.0f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update_animations(runtime, 0.25f));
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "loop", -1.0f), 0.25f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "ping", -1.0f), 0.75f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.title"));
+    ASSERT_TRUE(sdl3d_game_data_update_animations(runtime, 1.0f));
+    EXPECT_NEAR(sdl3d_properties_get_float(box->props, "loop", -1.0f), 0.25f, 0.0001f);
+    sdl3d_game_data_ui_state logo_state{};
+    EXPECT_FALSE(sdl3d_game_data_get_ui_state(runtime, "ui.logo", &logo_state));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add generic `property.animate` and `ui.animate` actions for data-authored runtime tweens
- support float, vec3, and color interpolation with linear, in_quad, out_quad, and in_out_quad easing
- support one-shot, loop, and ping_pong repeat modes, completion signals, scene-scoped cleanup, and validation
- advance authored animations from the shared presentation frame update so Pong and future demos can use the same path

## Tests
- `git diff --check`
- `cmake --build build/release --target sdl3d_game_data_test -j8`
- `./build/release/tests/sdl3d_game_data_test`
- `cmake --build build/release --target pong_demo -j8`

Part of #133.
