### PR TITLE
Remove legacy splash scene API

### DIFF
--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -348,17 +348,6 @@ extern "C"
      */
     typedef bool (*sdl3d_game_data_ui_image_fn)(void *userdata, const sdl3d_game_data_ui_image *image);
 
-    /** @brief Data-authored splash scene flow descriptor. */
-    typedef struct sdl3d_game_data_splash
-    {
-        /** @brief Target scene requested after the splash completes. */
-        const char *next_scene;
-        /** @brief Seconds to hold after the splash fade-in has finished. */
-        float hold_seconds;
-        /** @brief True when any input press should skip the remaining hold time. */
-        bool skip_on_input;
-    } sdl3d_game_data_splash;
-
     /** @brief Input mode used by a data-authored scene skip policy. */
     typedef enum sdl3d_game_data_skip_input
     {
@@ -1214,15 +1203,6 @@ extern "C"
     bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime,
                                              const sdl3d_game_data_ui_image *image,
                                              const sdl3d_game_data_ui_metrics *metrics);
-
-    /**
-     * @brief Read the active scene's authored splash descriptor.
-     *
-     * Returns false when the active scene has no `splash` block. The descriptor
-     * is data-only; application flow helpers decide when to request the next
-     * scene and how to apply transitions.
-     */
-    bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash);
 
     /**
      * @brief Read the active scene's authored skip policy.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2885,28 +2885,6 @@ static bool start_animation(sdl3d_game_data_runtime *runtime, const game_data_an
     return true;
 }
 
-bool sdl3d_game_data_get_active_splash(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_splash *out_splash)
-{
-    if (out_splash != NULL)
-    {
-        SDL_zero(*out_splash);
-        out_splash->hold_seconds = 1.0f;
-        out_splash->skip_on_input = true;
-    }
-    if (runtime == NULL || out_splash == NULL)
-        return false;
-
-    const scene_entry *scene = active_scene_entry_const(runtime);
-    yyjson_val *splash = obj_get(scene != NULL ? scene->root : NULL, "splash");
-    if (!yyjson_is_obj(splash))
-        return false;
-
-    out_splash->next_scene = json_string(splash, "next_scene", NULL);
-    out_splash->hold_seconds = json_float(splash, "hold_seconds", out_splash->hold_seconds);
-    out_splash->skip_on_input = json_bool(splash, "skip_on_input", out_splash->skip_on_input);
-    return out_splash->next_scene != NULL;
-}
-
 static yyjson_val *active_skip_policy_json(const sdl3d_game_data_runtime *runtime)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1936,17 +1936,10 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     if (!validate_skip_policy(ctx, obj_get(root, "skip_policy"), skip_path, names))
         return false;
 
-    yyjson_val *splash = obj_get(root, "splash");
-    if (splash != NULL)
-    {
-        if (!yyjson_is_obj(splash))
-            return validation_error(ctx, json_path, "scene splash must be an object");
-        if (!require_ref(ctx, &names->scenes, "scene", json_string(splash, "next_scene"), json_path))
-            return false;
-        yyjson_val *hold = obj_get(splash, "hold_seconds");
-        if (hold != NULL && (!yyjson_is_num(hold) || yyjson_get_num(hold) < 0.0))
-            return validation_error(ctx, json_path, "scene splash hold_seconds must be a non-negative number");
-    }
+    if (obj_get(root, "splash") != NULL)
+        return validation_error(ctx, json_path,
+                                "scene splash is no longer supported; use scene.timeline, skip_policy, UI images, "
+                                "and scene transitions");
 
     yyjson_val *scene_input = obj_get(root, "input");
     if (scene_input != NULL && !yyjson_is_obj(scene_input))

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -920,9 +920,6 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     sdl3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
 
-    sdl3d_game_data_splash splash{};
-    EXPECT_FALSE(sdl3d_game_data_get_active_splash(runtime, &splash));
-
     sdl3d_game_data_skip_policy skip{};
     ASSERT_TRUE(sdl3d_game_data_get_active_skip_policy(runtime, &skip));
     EXPECT_TRUE(skip.enabled);
@@ -2171,6 +2168,57 @@ TEST(GameDataRuntime, RejectsLuaScriptManifestErrorsBeforeGameplay)
         sdl3d_game_data_destroy(runtime);
         sdl3d_game_session_destroy(session);
     }
+}
+
+TEST(GameDataRuntime, RejectsLegacySplashSceneBlock)
+{
+    const std::filesystem::path dir = unique_test_dir("legacy_splash");
+    write_text(dir / "legacy_splash.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Legacy Splash", "id": "test.legacy_splash", "version": "0.1.0" },
+  "scenes": {
+    "initial": "scene.splash",
+    "files": [
+      "scenes/splash.scene.json",
+      "scenes/title.scene.json"
+    ]
+  }
+})json");
+    write_text(dir / "scenes" / "splash.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.splash",
+  "updates_game": false,
+  "renders_world": false,
+  "splash": {
+    "next_scene": "scene.title",
+    "hold_seconds": 1.0,
+    "skip_on_input": true
+  }
+})json");
+    write_text(dir / "scenes" / "title.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false
+})json");
+
+    DiagnosticCapture capture;
+    sdl3d_game_data_validation_options options{};
+    options.diagnostic = capture_diagnostic;
+    options.userdata = &capture;
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "legacy_splash.game.json").string().c_str(), &options, error,
+                                               sizeof(error)));
+    ASSERT_FALSE(capture.diagnostics.empty());
+    EXPECT_EQ(capture.diagnostics[0].severity, SDL3D_GAME_DATA_DIAGNOSTIC_ERROR);
+    EXPECT_NE(capture.diagnostics[0].message.find("scene.timeline"), std::string::npos);
+    EXPECT_NE(std::string(error).find("scene splash is no longer supported"), std::string::npos);
+
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, AuthoredGoalSensorDrivesScoreBinding)


### PR DESCRIPTION
## Summary
- remove the legacy public splash descriptor/API so splash screens are no longer a special engine concept
- reject legacy scene `splash` blocks during game-data validation with guidance to use generic scene primitives
- keep Pong splash behavior on initial scene + UI image + timeline + skip policy + transitions + audio
- add a regression test proving legacy splash scene blocks are rejected

## Tests
- `git diff --check`
- `cmake --build build/release --target sdl3d_game_data_test pong_demo -j8`
- `./build/release/tests/sdl3d_game_data_test`
- `cmake --build build/release --target game_data_json_test -j8`
- `./build/release/tests/game_data_json_test`
- short `./build/release/demos/pong/pong_demo` smoke run

Part of #133.