### PR TITLE
Add interactive scene flow policy

### DIFF
--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -383,7 +383,26 @@ extern "C"
         bool preserve_exit_transition;
         /** @brief True to suppress other app/menu controls for the triggering frame. */
         bool consume_input;
+        /** @brief True to suppress active-scene menus when skip input triggers. */
+        bool block_menus;
+        /** @brief True to suppress authored scene shortcuts when skip input triggers. */
+        bool block_scene_shortcuts;
     } sdl3d_game_data_skip_policy;
+
+    /**
+     * @brief Interaction policy for an active scene's autoplay timeline.
+     *
+     * These flags let intro, splash, attract, and cutscene authors decide
+     * whether a still-running timeline owns scene flow or whether normal menus
+     * and scene shortcuts remain interactive while timed events continue.
+     */
+    typedef struct sdl3d_game_data_timeline_policy
+    {
+        /** @brief True while an incomplete autoplay timeline suppresses active-scene menus. */
+        bool block_menus;
+        /** @brief True while an incomplete autoplay timeline suppresses authored scene shortcuts. */
+        bool block_scene_shortcuts;
+    } sdl3d_game_data_timeline_policy;
 
     /**
      * @brief Runtime state for a data-authored active-scene timeline.
@@ -1214,6 +1233,16 @@ extern "C"
      */
     bool sdl3d_game_data_get_active_skip_policy(const sdl3d_game_data_runtime *runtime,
                                                 sdl3d_game_data_skip_policy *out_policy);
+
+    /**
+     * @brief Read the active scene's authored timeline interaction policy.
+     *
+     * Returns false when the active scene has no autoplaying `timeline` object.
+     * Missing policy fields default to false so timelines remain interactive
+     * unless the scene author explicitly blocks menus or scene shortcuts.
+     */
+    bool sdl3d_game_data_get_active_timeline_policy(const sdl3d_game_data_runtime *runtime,
+                                                    sdl3d_game_data_timeline_policy *out_policy);
 
     /**
      * @brief Initialize reusable timeline state.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2909,6 +2909,8 @@ bool sdl3d_game_data_get_active_skip_policy(const sdl3d_game_data_runtime *runti
         out_policy->action_id = -1;
         out_policy->preserve_exit_transition = true;
         out_policy->consume_input = true;
+        out_policy->block_menus = true;
+        out_policy->block_scene_shortcuts = true;
     }
     if (runtime == NULL || out_policy == NULL)
         return false;
@@ -2937,7 +2939,29 @@ bool sdl3d_game_data_get_active_skip_policy(const sdl3d_game_data_runtime *runti
     out_policy->scene = json_string(policy, "scene", json_string(policy, "target_scene", NULL));
     out_policy->preserve_exit_transition = json_bool(policy, "preserve_exit_transition", true);
     out_policy->consume_input = json_bool(policy, "consume_input", true);
+    out_policy->block_menus = json_bool(policy, "block_menus", out_policy->consume_input);
+    out_policy->block_scene_shortcuts =
+        json_bool(policy, "block_scene_shortcuts", json_bool(policy, "block_shortcuts", out_policy->consume_input));
     return out_policy->input != SDL3D_GAME_DATA_SKIP_INPUT_DISABLED;
+}
+
+bool sdl3d_game_data_get_active_timeline_policy(const sdl3d_game_data_runtime *runtime,
+                                                sdl3d_game_data_timeline_policy *out_policy)
+{
+    if (out_policy != NULL)
+        SDL_zero(*out_policy);
+    if (runtime == NULL || out_policy == NULL)
+        return false;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *timeline = obj_get(scene != NULL ? scene->root : NULL, "timeline");
+    if (!yyjson_is_obj(timeline) || !json_bool(timeline, "autoplay", false))
+        return false;
+
+    out_policy->block_menus = json_bool(timeline, "block_menus", false);
+    out_policy->block_scene_shortcuts =
+        json_bool(timeline, "block_scene_shortcuts", json_bool(timeline, "block_shortcuts", false));
+    return true;
 }
 
 static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1195,6 +1195,15 @@ static bool validate_skip_policy(validation_context *ctx, yyjson_val *policy, co
     yyjson_val *consume = obj_get(policy, "consume_input");
     if (consume != NULL && !yyjson_is_bool(consume))
         return validation_error(ctx, json_path, "skip_policy consume_input must be a boolean");
+    yyjson_val *block_menus = obj_get(policy, "block_menus");
+    if (block_menus != NULL && !yyjson_is_bool(block_menus))
+        return validation_error(ctx, json_path, "skip_policy block_menus must be a boolean");
+    yyjson_val *block_shortcuts = obj_get(policy, "block_scene_shortcuts");
+    if (block_shortcuts != NULL && !yyjson_is_bool(block_shortcuts))
+        return validation_error(ctx, json_path, "skip_policy block_scene_shortcuts must be a boolean");
+    block_shortcuts = obj_get(policy, "block_shortcuts");
+    if (block_shortcuts != NULL && !yyjson_is_bool(block_shortcuts))
+        return validation_error(ctx, json_path, "skip_policy block_shortcuts must be a boolean");
 
     if (input_disabled)
         return true;
@@ -1899,6 +1908,15 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     {
         if (!yyjson_is_obj(timeline))
             return validation_error(ctx, json_path, "scene timeline must be an object");
+        yyjson_val *timeline_block_menus = obj_get(timeline, "block_menus");
+        if (timeline_block_menus != NULL && !yyjson_is_bool(timeline_block_menus))
+            return validation_error(ctx, json_path, "scene timeline block_menus must be a boolean");
+        yyjson_val *timeline_block_shortcuts = obj_get(timeline, "block_scene_shortcuts");
+        if (timeline_block_shortcuts != NULL && !yyjson_is_bool(timeline_block_shortcuts))
+            return validation_error(ctx, json_path, "scene timeline block_scene_shortcuts must be a boolean");
+        timeline_block_shortcuts = obj_get(timeline, "block_shortcuts");
+        if (timeline_block_shortcuts != NULL && !yyjson_is_bool(timeline_block_shortcuts))
+            return validation_error(ctx, json_path, "scene timeline block_shortcuts must be a boolean");
         char timeline_skip_path[PATH_BUFFER_SIZE];
         format_path(timeline_skip_path, sizeof(timeline_skip_path), "%s.timeline.skip_policy", json_path);
         if (!validate_skip_policy(ctx, obj_get(timeline, "skip_policy"), timeline_skip_path, names))

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1020,10 +1020,15 @@ static bool app_flow_set_scene_without_transition(sdl3d_game_data_app_flow *flow
 }
 
 static bool app_flow_apply_skip_policy(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
-                                       const sdl3d_input_manager *input, bool capture_input, bool *out_applied)
+                                       const sdl3d_input_manager *input, bool capture_input, bool *out_applied,
+                                       bool *out_block_menus, bool *out_block_scene_shortcuts)
 {
     if (out_applied != NULL)
         *out_applied = false;
+    if (out_block_menus != NULL)
+        *out_block_menus = false;
+    if (out_block_scene_shortcuts != NULL)
+        *out_block_scene_shortcuts = false;
     if (flow == NULL || runtime == NULL)
         return false;
 
@@ -1060,6 +1065,10 @@ static bool app_flow_apply_skip_policy(sdl3d_game_data_app_flow *flow, sdl3d_gam
         {
             flow->skip_requested = true;
             consumed = policy.consume_input;
+            if (out_block_menus != NULL)
+                *out_block_menus = policy.block_menus || policy.consume_input;
+            if (out_block_scene_shortcuts != NULL)
+                *out_block_scene_shortcuts = policy.block_scene_shortcuts || policy.consume_input;
         }
     }
 
@@ -1078,6 +1087,38 @@ static bool app_flow_apply_skip_policy(sdl3d_game_data_app_flow *flow, sdl3d_gam
     }
 
     return consumed;
+}
+
+static bool app_flow_timeline_is_pending(const sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime)
+{
+    sdl3d_game_data_timeline_policy policy;
+    if (flow == NULL || runtime == NULL || flow->timeline.complete ||
+        !sdl3d_game_data_get_active_timeline_policy(runtime, &policy))
+    {
+        return false;
+    }
+    return true;
+}
+
+static void app_flow_timeline_blocks(const sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
+                                     bool *out_block_menus, bool *out_block_scene_shortcuts)
+{
+    if (out_block_menus != NULL)
+        *out_block_menus = false;
+    if (out_block_scene_shortcuts != NULL)
+        *out_block_scene_shortcuts = false;
+
+    if (!app_flow_timeline_is_pending(flow, runtime))
+        return;
+
+    sdl3d_game_data_timeline_policy policy;
+    if (!sdl3d_game_data_get_active_timeline_policy(runtime, &policy))
+        return;
+
+    if (out_block_menus != NULL)
+        *out_block_menus = policy.block_menus;
+    if (out_block_scene_shortcuts != NULL)
+        *out_block_scene_shortcuts = policy.block_scene_shortcuts;
 }
 
 static bool app_flow_update_timeline(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime, float dt)
@@ -1166,7 +1207,13 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     sdl3d_input_manager *input = sdl3d_game_session_get_input(ctx->session);
     sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
     bool skip_applied = false;
-    const bool skip_consumed = app_flow_apply_skip_policy(flow, runtime, input, true, &skip_applied);
+    bool skip_blocks_menus = false;
+    bool skip_blocks_scene_shortcuts = false;
+    const bool skip_consumed = app_flow_apply_skip_policy(flow, runtime, input, true, &skip_applied, &skip_blocks_menus,
+                                                          &skip_blocks_scene_shortcuts);
+    bool timeline_blocks_menus = false;
+    bool timeline_blocks_scene_shortcuts = false;
+    app_flow_timeline_blocks(flow, runtime, &timeline_blocks_menus, &timeline_blocks_scene_shortcuts);
 
     if (!skip_consumed)
     {
@@ -1175,8 +1222,10 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
             sdl3d_input_is_pressed(input, flow->app.quit_action_id))
             app_flow_request_quit(flow, ctx, runtime);
 
-        app_flow_consume_scene_shortcuts(flow, runtime, input);
-        app_flow_consume_menu(flow, ctx, runtime, input, bus);
+        if (!skip_blocks_scene_shortcuts && !timeline_blocks_scene_shortcuts)
+            app_flow_consume_scene_shortcuts(flow, runtime, input);
+        if (!skip_blocks_menus && !timeline_blocks_menus)
+            app_flow_consume_menu(flow, ctx, runtime, input, bus);
 
         if (flow->app.pause_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.pause_action_id) &&
             sdl3d_game_data_active_scene_allows_action(runtime, flow->app.pause_action_id) && !flow->quit_pending &&
@@ -1200,7 +1249,7 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     app_flow_update_transition(flow, ctx, bus, dt);
     sdl3d_game_data_scene_flow_update(&flow->scene_flow, runtime, bus, dt);
     bool deferred_skip_applied = false;
-    (void)app_flow_apply_skip_policy(flow, runtime, input, false, &deferred_skip_applied);
+    (void)app_flow_apply_skip_policy(flow, runtime, input, false, &deferred_skip_applied, NULL, NULL);
     skip_applied = skip_applied || deferred_skip_applied;
     if (!scene_transitioning_before && !skip_applied && !app_flow_update_timeline(flow, runtime, dt))
         return false;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -390,6 +390,118 @@ void write_skip_policy_json(const std::filesystem::path &dir)
 })json");
 }
 
+void write_scene_flow_policy_json(const std::filesystem::path &dir, bool block_menus, bool block_scene_shortcuts)
+{
+    const char *block_menus_text = block_menus ? "true" : "false";
+    const char *block_shortcuts_text = block_scene_shortcuts ? "true" : "false";
+    const std::string game_json = R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Scene Flow Policy", "id": "test.scene_flow_policy", "version": "0.1.0" },
+  "app": {
+    "scene_shortcuts": [
+      { "action": "action.scene.play", "scene": "scene.play" }
+    ],
+    "input_policy": {
+      "global_actions": ["action.scene.play"]
+    }
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.main",
+        "actions": [
+          {
+            "name": "action.menu.select",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" }
+            ]
+          },
+          {
+            "name": "action.menu.up",
+            "bindings": [
+              { "device": "keyboard", "key": "UP" }
+            ]
+          },
+          {
+            "name": "action.menu.down",
+            "bindings": [
+              { "device": "keyboard", "key": "DOWN" }
+            ]
+          },
+          {
+            "name": "action.scene.play",
+            "bindings": [
+              { "device": "keyboard", "key": "3" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": {
+    "initial": "scene.intro",
+    "files": [
+      "scenes/intro.scene.json",
+      "scenes/title.scene.json",
+      "scenes/play.scene.json"
+    ]
+  }
+})json";
+    write_text(dir / "flow_policy.game.json", game_json.c_str());
+
+    std::string intro_json = R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.intro",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "input": { "actions": ["action.menu.select"] },
+  "timeline": {
+    "autoplay": true,
+    "block_menus": )json";
+    intro_json += block_menus_text;
+    intro_json += R"json(,
+    "block_scene_shortcuts": )json";
+    intro_json += block_shortcuts_text;
+    intro_json += R"json(,
+    "events": [
+      {
+        "time": 1.0,
+        "action": { "type": "scene.request", "scene": "scene.title" }
+      }
+    ]
+  },
+  "menus": [
+    {
+      "name": "menu.intro",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        { "label": "Play", "scene": "scene.play" }
+      ]
+    }
+  ]
+})json";
+    write_text(dir / "scenes" / "intro.scene.json", intro_json.c_str());
+    write_text(dir / "scenes" / "title.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": []
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": []
+})json");
+}
+
 void write_animation_json(const std::filesystem::path &dir)
 {
     write_text(dir / "animation.game.json",
@@ -1552,9 +1664,14 @@ TEST(GameDataRuntime, AppFlowAppliesAuthoredSkipPolicyWithoutMenuBleedThrough)
     EXPECT_STREQ(policy.action, "action.skip");
     EXPECT_STREQ(policy.scene, "scene.title");
     EXPECT_TRUE(policy.preserve_exit_transition);
+    EXPECT_TRUE(policy.block_menus);
+    EXPECT_TRUE(policy.block_scene_shortcuts);
 
     sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
+
+    sdl3d_input_update(input, 0);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
 
     SDL_Event key{};
     key.type = SDL_EVENT_KEY_DOWN;
@@ -1593,6 +1710,114 @@ TEST(GameDataRuntime, AppFlowAppliesAuthoredSkipPolicyWithoutMenuBleedThrough)
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
 
     ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.11f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, TimelinePolicyCanBlockMenusAndSceneShortcuts)
+{
+    const std::filesystem::path dir = unique_test_dir("timeline_blocks_input");
+    write_scene_flow_policy_json(dir, true, true);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "flow_policy.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_data_timeline_policy policy{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_timeline_policy(runtime, &policy));
+    EXPECT_TRUE(policy.block_menus);
+    EXPECT_TRUE(policy.block_scene_shortcuts);
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    sdl3d_input_update(input, 0);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    key.key.scancode = SDL_SCANCODE_3;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 1.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.intro");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, TimelinePolicyCanAllowInteractiveIntroMenus)
+{
+    const std::filesystem::path dir = unique_test_dir("timeline_allows_input");
+    write_scene_flow_policy_json(dir, false, false);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "flow_policy.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_data_timeline_policy policy{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_timeline_policy(runtime, &policy));
+    EXPECT_FALSE(policy.block_menus);
+    EXPECT_FALSE(policy.block_scene_shortcuts);
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    sdl3d_input_update(input, 0);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_TRUE(flow.scene_input_armed);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    bool menu_armed = true;
+    sdl3d_game_data_menu_update_result menu_result{};
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &menu_armed, &menu_result));
+    EXPECT_TRUE(menu_result.selected);
+    EXPECT_STREQ(menu_result.scene, "scene.play");
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
 
     sdl3d_game_data_destroy(runtime);


### PR DESCRIPTION
## Summary
- Add data-authored timeline interaction policy so autoplay scenes can block or allow active menus and scene shortcuts while timed events are still pending.
- Add granular skip-policy controls for menu and scene-shortcut blocking while preserving existing consume-input defaults.
- Update generic app flow to honor these policies, enabling conventional noninteractive splashes and interactive intro scenes without scene-specific host code.
- Add focused runtime tests for blocked autoplay timelines and interactive autoplay menus.

## Tests
- `git diff --check`
- `cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j8`
- `./build/release/tests/sdl3d_game_data_test`
- `./build/release/tests/game_data_json_test`
- Pong smoke run: starts on `scene.splash`, plays authored audio, and shuts down cleanly

Part of #133