### PR TITLE
Add data-driven Pong playfield menus

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -986,19 +986,22 @@
         "signal": "signal.match.player_won",
         "actions": [
           { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
-          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "player" }
+          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "player" },
+          { "type": "entity.set_active", "target": "entity.ball", "active": false }
         ]
       },
       {
         "signal": "signal.match.cpu_won",
         "actions": [
           { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
-          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "cpu" }
+          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "cpu" },
+          { "type": "entity.set_active", "target": "entity.ball", "active": false }
         ]
       },
       {
         "signal": "signal.round.reset",
         "actions": [
+          { "type": "entity.set_active", "target": "entity.ball", "active": true },
           { "type": "property.set", "target": "entity.ball", "key": "active_motion", "value": false },
           { "type": "property.set", "target": "entity.ball", "key": "velocity", "value": [0.0, 0.0] },
           { "type": "property.set", "target": "entity.ball", "key": "has_last_reflect_y", "value": false },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -760,6 +760,7 @@
     "signal.round.reset",
     "signal.match.player_won",
     "signal.match.cpu_won",
+    "signal.match.reset",
     "signal.match.restart",
     "signal.camera.ball.toggle",
     "signal.attract.round_reset",
@@ -1022,6 +1023,18 @@
         ]
       },
       {
+        "signal": "signal.match.reset",
+        "actions": [
+          { "type": "property.set", "target": "entity.score.player", "key": "value", "value": 0 },
+          { "type": "property.set", "target": "entity.score.cpu", "key": "value", "value": 0 },
+          { "type": "property.set", "target": "entity.match", "key": "finished", "value": false },
+          { "type": "property.set", "target": "entity.match", "key": "winner", "value": "none" },
+          { "type": "property.set", "target": "entity.presentation", "key": "border_flash", "value": 0.0 },
+          { "type": "property.set", "target": "entity.presentation", "key": "paddle_flash", "value": 0.0 },
+          { "type": "signal.emit", "signal": "signal.round.reset" }
+        ]
+      },
+      {
         "signal": "signal.match.restart",
         "actions": [
           {
@@ -1034,13 +1047,7 @@
               "value": true
             },
             "then": [
-              { "type": "property.set", "target": "entity.score.player", "key": "value", "value": 0 },
-              { "type": "property.set", "target": "entity.score.cpu", "key": "value", "value": 0 },
-              { "type": "property.set", "target": "entity.match", "key": "finished", "value": false },
-              { "type": "property.set", "target": "entity.match", "key": "winner", "value": "none" },
-              { "type": "property.set", "target": "entity.presentation", "key": "border_flash", "value": 0.0 },
-              { "type": "property.set", "target": "entity.presentation", "key": "paddle_flash", "value": 0.0 },
-              { "type": "signal.emit", "signal": "signal.round.reset" },
+              { "type": "signal.emit", "signal": "signal.match.reset" },
               { "type": "signal.emit", "signal": "signal.game.start" }
             ],
             "else": []

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -71,7 +71,7 @@
             ]
           }
         },
-        { "label": "Back", "scene": "scene.title" }
+        { "label": "Back", "return_scene": true, "scene": "scene.title" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -107,7 +107,7 @@
           { "type": "property", "entity": "entity.score.cpu", "key": "value" }
         ],
         "x": 0.5,
-        "y": 22.0,
+        "y": 0.06,
         "normalized": true,
         "centered": true,
         "color": [235, 242, 255, 255]

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -28,13 +28,53 @@
       "action.paddle.down",
       "action.pause",
       "action.restart",
-      "action.camera.ball.toggle"
+      "action.camera.ball.toggle",
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
     ]
   },
   "transitions": {
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "menus": [
+    {
+      "name": "menu.match_over",
+      "active_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Yes", "signal": "signal.match.restart" },
+        { "label": "No", "signal": "signal.match.reset", "scene": "scene.title" }
+      ]
+    },
+    {
+      "name": "menu.pause",
+      "active_if": {
+        "type": "all",
+        "conditions": [
+          { "type": "app.paused", "equals": true },
+          { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
+        ]
+      },
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Resume", "pause": "resume" },
+        { "label": "Options", "pause": "resume", "scene": "scene.options", "return_to": "scene.play", "return_paused": true },
+        { "label": "Title", "pause": "resume", "signal": "signal.match.reset", "scene": "scene.title" }
+      ]
+    }
+  ],
   "ui": {
     "text": [
       {
@@ -82,9 +122,9 @@
             { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "player" }
           ]
         },
-        "text": "You win!",
+        "text": "You win! Play again?",
         "x": 0.5,
-        "y": 0.40,
+        "y": 0.37,
         "normalized": true,
         "centered": true,
         "color": [255, 255, 255, 255]
@@ -99,23 +139,12 @@
             { "type": "property.compare", "target": "entity.match", "key": "winner", "op": "==", "value": "cpu" }
           ]
         },
-        "text": "You lose!",
+        "text": "You lose! Play again?",
         "x": 0.5,
-        "y": 0.40,
+        "y": 0.37,
         "normalized": true,
         "centered": true,
         "color": [255, 255, 255, 255]
-      },
-      {
-        "name": "ui.match.restart",
-        "font": "font.hud",
-        "visible_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
-        "text": "Press enter to play again",
-        "x": 0.5,
-        "y": 0.49,
-        "normalized": true,
-        "centered": true,
-        "color": [200, 220, 255, 235]
       },
       {
         "name": "ui.pause",
@@ -129,7 +158,7 @@
         },
         "text": "PAUSED",
         "x": 0.5,
-        "y": 0.44,
+        "y": 0.35,
         "normalized": true,
         "centered": true,
         "pulse_alpha": true,
@@ -152,6 +181,56 @@
         "normalized": true,
         "centered": true,
         "color": [210, 225, 255, 190]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.match.menu",
+        "menu": "menu.match_over",
+        "visible_if": { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": true },
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.48,
+        "gap": 0.08,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.08,
+          "align": "center",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      },
+      {
+        "name": "ui.pause.menu",
+        "menu": "menu.pause",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": true },
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
+          ]
+        },
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.45,
+        "gap": 0.075,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.12,
+          "align": "center",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
       }
     ]
   }

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -74,7 +74,7 @@
       "selected": 0,
       "items": [
         { "label": "Play", "scene": "scene.play" },
-        { "label": "Options", "scene": "scene.options" },
+        { "label": "Options", "scene": "scene.options", "return_to": "scene.title", "return_paused": false },
         { "label": "Exit", "quit": true }
       ]
     }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -461,7 +461,7 @@ Generic action types should cover common wiring:
 - `property.set`
 - `property.add`
 - `property.toggle`
-- `entity.set_active`
+- `entity.set_active` with `target` and boolean `active`, used to include or exclude an entity from generic updates and rendering
 - `transform.set_position`
 - `motion.set_velocity`
 - `signal.emit`

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -474,13 +474,26 @@ extern "C"
         SDL3D_GAME_DATA_MENU_CONTROL_RANGE = 3,
     } sdl3d_game_data_menu_control_type;
 
+    /** @brief App pause command authored on a menu item. */
+    typedef enum sdl3d_game_data_menu_pause_command
+    {
+        /** @brief Selecting the item does not change pause state. */
+        SDL3D_GAME_DATA_MENU_PAUSE_NONE = 0,
+        /** @brief Selecting the item pauses the app. */
+        SDL3D_GAME_DATA_MENU_PAUSE_PAUSE = 1,
+        /** @brief Selecting the item resumes the app. */
+        SDL3D_GAME_DATA_MENU_PAUSE_RESUME = 2,
+        /** @brief Selecting the item toggles the app pause state. */
+        SDL3D_GAME_DATA_MENU_PAUSE_TOGGLE = 3,
+    } sdl3d_game_data_menu_pause_command;
+
     /**
      * @brief Runtime descriptor for one authored menu item.
      *
      * A menu item may request a scene change, request app quit, emit a signal,
-     * or mutate an actor property as a generic option control. Hosts can use
-     * these fields directly or translate them into a higher-level scene
-     * transition flow.
+     * change pause state, return to a previously authored scene, or mutate an
+     * actor property as a generic option control. Hosts can use these fields
+     * directly or translate them into a higher-level scene transition flow.
      */
     typedef struct sdl3d_game_data_menu_item
     {
@@ -488,10 +501,20 @@ extern "C"
         const char *label;
         /** @brief Target scene name, or NULL when this item does not change scene. */
         const char *scene;
+        /** @brief Scene stored as the return target when this item changes scene, or NULL. */
+        const char *return_to;
+        /** @brief True when selecting this item requests the stored return scene. */
+        bool return_scene;
         /** @brief True when selecting this item requests application quit. */
         bool quit;
         /** @brief Signal emitted by this item, or -1 when not authored. */
         int signal_id;
+        /** @brief Authored pause command to apply when selecting this item. */
+        sdl3d_game_data_menu_pause_command pause_command;
+        /** @brief True when selecting this item stores a return pause state. */
+        bool has_return_paused;
+        /** @brief Pause state stored for a later return_scene item. */
+        bool return_paused;
         /** @brief Authored generic control type. */
         sdl3d_game_data_menu_control_type control_type;
         /** @brief Actor that owns the controlled property, or NULL. */
@@ -1102,10 +1125,22 @@ extern "C"
     /**
      * @brief Read the active scene's primary menu, if any.
      *
-     * The first menu in the active scene is considered primary. Returns false
-     * when the scene has no menus.
+     * The first menu whose optional `active_if` condition passes is considered
+     * active. Conditions that depend on frame metrics, such as `app.paused`,
+     * evaluate as false through this convenience wrapper.
      */
     bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_menu *out_menu);
+
+    /**
+     * @brief Read the active scene menu using current frame metrics.
+     *
+     * This variant lets authored menu `active_if` conditions depend on app
+     * pause state, camera state, actor properties, or other metrics-backed UI
+     * conditions. It returns false when no active scene menu is eligible.
+     */
+    bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *runtime,
+                                                     const sdl3d_game_data_ui_metrics *metrics,
+                                                     sdl3d_game_data_menu *out_menu);
 
     /**
      * @brief Move a menu selection by @p delta with wrap-around.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -116,16 +116,21 @@ extern "C"
      */
     typedef struct sdl3d_game_data_menu_update_result
     {
-        const char *menu;     /**< Runtime-owned active menu name, or NULL. */
-        const char *scene;    /**< Runtime-owned selected target scene, or NULL. */
-        int selected_index;   /**< Selected item index after this update, or -1. */
-        int signal_id;        /**< Selected signal id, or -1. */
-        int move_signal_id;   /**< Menu navigation signal id emitted by the host, or -1. */
-        int select_signal_id; /**< Menu activation signal id emitted by the host, or -1. */
-        bool handled_input;   /**< True when a menu action was consumed. */
-        bool selected;        /**< True when the selected item was activated. */
-        bool quit;            /**< True when the selected item requests quit. */
-        bool control_changed; /**< True when selecting the item changed a data-bound control. */
+        const char *menu;      /**< Runtime-owned active menu name, or NULL. */
+        const char *scene;     /**< Runtime-owned selected target scene, or NULL. */
+        const char *return_to; /**< Runtime-owned scene to store as return target, or NULL. */
+        int selected_index;    /**< Selected item index after this update, or -1. */
+        int signal_id;         /**< Selected signal id, or -1. */
+        int move_signal_id;    /**< Menu navigation signal id emitted by the host, or -1. */
+        int select_signal_id;  /**< Menu activation signal id emitted by the host, or -1. */
+        sdl3d_game_data_menu_pause_command pause_command; /**< Pause command requested by selected item. */
+        bool handled_input;                               /**< True when a menu action was consumed. */
+        bool selected;                                    /**< True when the selected item was activated. */
+        bool quit;                                        /**< True when the selected item requests quit. */
+        bool return_scene;      /**< True when the selected item requests the stored return scene. */
+        bool has_return_paused; /**< True when selected item stores a return pause state. */
+        bool return_paused;     /**< Pause state to store for a later return_scene item. */
+        bool control_changed;   /**< True when selecting the item changed a data-bound control. */
     } sdl3d_game_data_menu_update_result;
 
     /**
@@ -324,6 +329,17 @@ extern "C"
      */
     bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
                                       bool *input_armed, sdl3d_game_data_menu_update_result *out_result);
+
+    /**
+     * @brief Update the active authored menu using current frame metrics.
+     *
+     * Use this when menu `active_if` conditions depend on metric-backed state
+     * such as app pause status. The basic sdl3d_game_data_update_menus()
+     * wrapper evaluates those metric-backed conditions with NULL metrics.
+     */
+    bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                                  bool *input_armed, const sdl3d_game_data_ui_metrics *metrics,
+                                                  sdl3d_game_data_menu_update_result *out_result);
 
     /**
      * @brief Initialize reusable frame/update state.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5401,6 +5401,16 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
     if (SDL_strncmp(type, "audio.", 6) == 0)
         return execute_audio_action(runtime, action, type);
 
+    if (SDL_strcmp(type, "entity.set_active") == 0)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+        yyjson_val *active = obj_get(action, "active");
+        if (actor == NULL || !yyjson_is_bool(active))
+            return false;
+        actor->active = yyjson_get_bool(active);
+        return true;
+    }
+
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3205,7 +3205,28 @@ bool sdl3d_game_data_get_scene_transition(const sdl3d_game_data_runtime *runtime
     return transition_name != NULL && sdl3d_game_data_get_transition(runtime, transition_name, out_transition);
 }
 
-bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_menu *out_menu)
+static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
+                                const sdl3d_game_data_ui_metrics *metrics);
+
+static const scene_menu_state *active_scene_menu_for_metrics(const sdl3d_game_data_runtime *runtime,
+                                                             const sdl3d_game_data_ui_metrics *metrics)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    if (runtime == NULL || scene == NULL || scene->menu_count <= 0)
+        return NULL;
+
+    for (int i = 0; i < scene->menu_count; ++i)
+    {
+        yyjson_val *active_if = obj_get(scene->menus[i].menu, "active_if");
+        if (active_if == NULL || eval_data_condition(runtime, active_if, metrics))
+            return &scene->menus[i];
+    }
+    return NULL;
+}
+
+bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *runtime,
+                                                 const sdl3d_game_data_ui_metrics *metrics,
+                                                 sdl3d_game_data_menu *out_menu)
 {
     if (out_menu != NULL)
     {
@@ -3216,11 +3237,12 @@ bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl
         out_menu->move_signal_id = -1;
         out_menu->select_signal_id = -1;
     }
-    const scene_entry *scene = active_scene_entry_const(runtime);
-    if (runtime == NULL || out_menu == NULL || scene == NULL || scene->menu_count <= 0)
+    if (runtime == NULL || out_menu == NULL)
         return false;
 
-    const scene_menu_state *state = &scene->menus[0];
+    const scene_menu_state *state = active_scene_menu_for_metrics(runtime, metrics);
+    if (state == NULL)
+        return false;
     yyjson_val *menu = state->menu;
     out_menu->name = json_string(menu, "name", NULL);
     out_menu->up_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "up_action", NULL));
@@ -3231,6 +3253,11 @@ bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl
     out_menu->selected_index = state->selected_index;
     out_menu->item_count = state->item_count;
     return out_menu->name != NULL && out_menu->item_count > 0;
+}
+
+bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_menu *out_menu)
+{
+    return sdl3d_game_data_get_active_menu_for_metrics(runtime, NULL, out_menu);
 }
 
 bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *menu_name, int delta)
@@ -3260,6 +3287,18 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
 }
 
 static bool json_value_matches_property(yyjson_val *value, const sdl3d_value *property);
+static sdl3d_game_data_menu_pause_command parse_menu_pause_command(const char *pause)
+{
+    if (pause == NULL)
+        return SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+    if (SDL_strcmp(pause, "pause") == 0)
+        return SDL3D_GAME_DATA_MENU_PAUSE_PAUSE;
+    if (SDL_strcmp(pause, "resume") == 0 || SDL_strcmp(pause, "unpause") == 0)
+        return SDL3D_GAME_DATA_MENU_PAUSE_RESUME;
+    if (SDL_strcmp(pause, "toggle") == 0)
+        return SDL3D_GAME_DATA_MENU_PAUSE_TOGGLE;
+    return SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+}
 
 bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
                                    sdl3d_game_data_menu_item *out_item)
@@ -3277,8 +3316,13 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
     yyjson_val *control = obj_get(item, "control");
     out_item->label = json_string(item, "label", NULL);
     out_item->scene = json_string(item, "scene", NULL);
+    out_item->return_to = json_string(item, "return_to", NULL);
+    out_item->return_scene = json_bool(item, "return_scene", false);
     out_item->quit = json_bool(item, "quit", false);
     out_item->signal_id = sdl3d_game_data_find_signal(runtime, json_string(item, "signal", NULL));
+    out_item->pause_command = parse_menu_pause_command(json_string(item, "pause", NULL));
+    out_item->has_return_paused = obj_get(item, "return_paused") != NULL;
+    out_item->return_paused = json_bool(item, "return_paused", false);
     out_item->control_type = parse_menu_control_type(json_string(control, "type", NULL));
     out_item->control_target = json_string(control, "target", NULL);
     out_item->control_key = json_string(control, "key", NULL);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2075,6 +2075,10 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             !require_ref(ctx, &names->actions, "input action", json_string(menu, "down_action"), menu_path) ||
             !require_ref(ctx, &names->actions, "input action", json_string(menu, "select_action"), menu_path))
             return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.active_if", menu_path);
+        if (!validate_scene_ui_condition(ctx, obj_get(menu, "active_if"), condition_path, names))
+            return false;
         const char *move_signal = json_string(menu, "move_signal");
         if (move_signal != NULL && !require_ref(ctx, &names->signals, "signal", move_signal, menu_path))
             return false;
@@ -2095,9 +2099,23 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             const char *scene = json_string(item, "scene");
             if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, item_path))
                 return false;
+            const char *return_to = json_string(item, "return_to");
+            if (return_to != NULL && !require_ref(ctx, &names->scenes, "scene", return_to, item_path))
+                return false;
             const char *signal = json_string(item, "signal");
             if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, item_path))
                 return false;
+            yyjson_val *return_scene = obj_get(item, "return_scene");
+            if (return_scene != NULL && !yyjson_is_bool(return_scene))
+                return validation_error(ctx, item_path, "scene menu item return_scene must be a boolean");
+            yyjson_val *return_paused = obj_get(item, "return_paused");
+            if (return_paused != NULL && !yyjson_is_bool(return_paused))
+                return validation_error(ctx, item_path, "scene menu item return_paused must be a boolean");
+            const char *pause = json_string(item, "pause");
+            if (pause != NULL && SDL_strcmp(pause, "pause") != 0 && SDL_strcmp(pause, "resume") != 0 &&
+                SDL_strcmp(pause, "unpause") != 0 && SDL_strcmp(pause, "toggle") != 0)
+                return validation_error(ctx, item_path,
+                                        "scene menu item pause must be pause, resume, unpause, or toggle");
             char control_path[PATH_BUFFER_SIZE];
             format_path(control_path, sizeof(control_path), "%s.control", item_path);
             if (!validate_menu_item_control(ctx, obj_get(item, "control"), control_path, names))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1084,6 +1084,14 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     }
     if (SDL_strncmp(type, "audio.", 6) == 0)
         return validate_audio_action(ctx, action, json_path, names, type);
+    if (SDL_strcmp(type, "entity.set_active") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        if (!yyjson_is_bool(obj_get(action, "active")))
+            return validation_error(ctx, json_path, "entity.set_active requires a boolean active value");
+        return true;
+    }
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {
         if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -647,8 +647,26 @@ bool sdl3d_game_data_draw_particles(const sdl3d_game_data_runtime *runtime, sdl3
     return true;
 }
 
-bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, bool *input_armed,
-                                  sdl3d_game_data_menu_update_result *out_result)
+static bool menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                               const sdl3d_game_data_menu *menu)
+{
+    if (menu == NULL)
+        return true;
+    if (input == NULL)
+        return false;
+
+    return (menu->up_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->up_action_id) ||
+            !sdl3d_input_is_held(input, menu->up_action_id)) &&
+           (menu->down_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->down_action_id) ||
+            !sdl3d_input_is_held(input, menu->down_action_id)) &&
+           (menu->select_action_id < 0 ||
+            !sdl3d_game_data_active_scene_allows_action(runtime, menu->select_action_id) ||
+            !sdl3d_input_is_held(input, menu->select_action_id));
+}
+
+bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                              bool *input_armed, const sdl3d_game_data_ui_metrics *metrics,
+                                              sdl3d_game_data_menu_update_result *out_result)
 {
     if (out_result != NULL)
     {
@@ -662,7 +680,7 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
         return false;
 
     sdl3d_game_data_menu menu;
-    if (!sdl3d_game_data_get_active_menu(runtime, &menu))
+    if (!sdl3d_game_data_get_active_menu_for_metrics(runtime, metrics, &menu))
         return true;
 
     if (out_result != NULL)
@@ -673,7 +691,7 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
 
     if (!*input_armed)
     {
-        if (sdl3d_game_data_active_menu_input_is_idle(runtime, input))
+        if (menu_input_is_idle(runtime, input, &menu))
             *input_armed = true;
         return true;
     }
@@ -701,7 +719,7 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
         handled = true;
 
         sdl3d_game_data_menu refreshed;
-        if (!sdl3d_game_data_get_active_menu(runtime, &refreshed))
+        if (!sdl3d_game_data_get_active_menu_for_metrics(runtime, metrics, &refreshed))
             return true;
 
         sdl3d_game_data_menu_item item;
@@ -717,7 +735,13 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
             out_result->control_changed = sdl3d_game_data_apply_menu_item_control(runtime, &item);
             out_result->quit = !out_result->control_changed && item.quit;
             out_result->scene = !out_result->control_changed ? item.scene : NULL;
+            out_result->return_to = !out_result->control_changed ? item.return_to : NULL;
+            out_result->return_scene = !out_result->control_changed && item.return_scene;
             out_result->signal_id = !out_result->control_changed ? item.signal_id : -1;
+            out_result->pause_command =
+                !out_result->control_changed ? item.pause_command : SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+            out_result->has_return_paused = !out_result->control_changed && item.has_return_paused;
+            out_result->return_paused = item.return_paused;
         }
         else
         {
@@ -727,13 +751,19 @@ bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_
     else if (handled && out_result != NULL)
     {
         sdl3d_game_data_menu refreshed;
-        if (sdl3d_game_data_get_active_menu(runtime, &refreshed))
+        if (sdl3d_game_data_get_active_menu_for_metrics(runtime, metrics, &refreshed))
             out_result->selected_index = refreshed.selected_index;
     }
 
     if (out_result != NULL)
         out_result->handled_input = handled;
     return true;
+}
+
+bool sdl3d_game_data_update_menus(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, bool *input_armed,
+                                  sdl3d_game_data_menu_update_result *out_result)
+{
+    return sdl3d_game_data_update_menus_for_metrics(runtime, input, input_armed, NULL, out_result);
 }
 
 void sdl3d_game_data_frame_state_init(sdl3d_game_data_frame_state *state)
@@ -963,29 +993,65 @@ static bool app_flow_request_scene(sdl3d_game_data_app_flow *flow, sdl3d_game_da
     return false;
 }
 
-static void app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+static void app_flow_apply_pause_command(sdl3d_game_context *ctx, sdl3d_game_data_menu_pause_command command)
+{
+    if (ctx == NULL)
+        return;
+
+    if (command == SDL3D_GAME_DATA_MENU_PAUSE_PAUSE)
+        ctx->paused = true;
+    else if (command == SDL3D_GAME_DATA_MENU_PAUSE_RESUME)
+        ctx->paused = false;
+    else if (command == SDL3D_GAME_DATA_MENU_PAUSE_TOGGLE)
+        ctx->paused = !ctx->paused;
+}
+
+static bool app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
                                   sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input, sdl3d_signal_bus *bus)
 {
     if (flow->quit_pending || sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
-        return;
+        return false;
+
+    sdl3d_game_data_ui_metrics metrics;
+    SDL_zero(metrics);
+    metrics.paused = ctx != NULL && ctx->paused;
 
     sdl3d_game_data_menu_update_result result;
-    if (!sdl3d_game_data_update_menus(runtime, input, &flow->scene_input_armed, &result) || !result.handled_input)
-        return;
+    if (!sdl3d_game_data_update_menus_for_metrics(runtime, input, &flow->scene_input_armed, &metrics, &result) ||
+        !result.handled_input)
+        return false;
 
     if (result.move_signal_id >= 0)
         sdl3d_signal_emit(bus, result.move_signal_id, NULL);
     if (result.select_signal_id >= 0)
         sdl3d_signal_emit(bus, result.select_signal_id, NULL);
     if (!result.selected)
-        return;
+        return true;
 
     if (result.signal_id >= 0)
         sdl3d_signal_emit(bus, result.signal_id, NULL);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    if (result.return_to != NULL && scene_state != NULL)
+        sdl3d_properties_set_string(scene_state, "return_scene", result.return_to);
+    if (result.has_return_paused && scene_state != NULL)
+        sdl3d_properties_set_bool(scene_state, "return_paused", result.return_paused);
+
+    const char *scene = result.scene;
+    if (result.return_scene && scene_state != NULL)
+    {
+        scene = sdl3d_properties_get_string(scene_state, "return_scene", scene);
+        if (ctx != NULL)
+            ctx->paused = sdl3d_properties_get_bool(scene_state, "return_paused", ctx->paused);
+    }
+    app_flow_apply_pause_command(ctx, result.pause_command);
+
     if (result.quit)
         app_flow_request_quit(flow, ctx, runtime);
-    else if (result.scene != NULL)
-        (void)app_flow_request_scene(flow, runtime, result.scene);
+    else if (scene != NULL)
+        (void)app_flow_request_scene(flow, runtime, scene);
+
+    return true;
 }
 
 static void app_flow_consume_scene_shortcuts(sdl3d_game_data_app_flow *flow, sdl3d_game_data_runtime *runtime,
@@ -1228,10 +1294,12 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
 
         if (!skip_blocks_scene_shortcuts && !timeline_blocks_scene_shortcuts)
             app_flow_consume_scene_shortcuts(flow, runtime, input);
+        bool menu_consumed = false;
         if (!skip_blocks_menus && !timeline_blocks_menus)
-            app_flow_consume_menu(flow, ctx, runtime, input, bus);
+            menu_consumed = app_flow_consume_menu(flow, ctx, runtime, input, bus);
 
-        if (flow->app.pause_action_id >= 0 && sdl3d_input_is_pressed(input, flow->app.pause_action_id) &&
+        if (!menu_consumed && flow->app.pause_action_id >= 0 &&
+            sdl3d_input_is_pressed(input, flow->app.pause_action_id) &&
             sdl3d_game_data_active_scene_allows_action(runtime, flow->app.pause_action_id) && !flow->quit_pending &&
             !sdl3d_game_data_scene_flow_is_transitioning(&flow->scene_flow))
         {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1065,7 +1065,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     UiTextCapture ui{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui));
-    EXPECT_EQ(ui.count, 8);
+    EXPECT_EQ(ui.count, 14);
     EXPECT_TRUE(ui.saw_score);
     EXPECT_TRUE(ui.saw_pause);
 
@@ -1386,7 +1386,7 @@ TEST(GameDataRuntime, ResolvesRuntimeUiStateForTextAndImages)
     ASSERT_TRUE(sdl3d_game_data_resolve_ui_text(runtime, &pause, &metrics, &resolved_pause, &pause_visible));
     EXPECT_TRUE(pause_visible);
     EXPECT_NEAR(resolved_pause.x, 0.52f, 0.0001f);
-    EXPECT_NEAR(resolved_pause.y, 0.41f, 0.0001f);
+    EXPECT_NEAR(resolved_pause.y, 0.32f, 0.0001f);
     EXPECT_NEAR(resolved_pause.scale, 2.0f, 0.0001f);
     EXPECT_EQ(resolved_pause.color.r, 123);
     EXPECT_EQ(resolved_pause.color.g, 248);
@@ -1519,6 +1519,123 @@ TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)
     EXPECT_EQ(result.signal_id, -1);
     EXPECT_EQ(result.move_signal_id, -1);
     EXPECT_EQ(result.select_signal_id, menu_select_signal);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, PlaySceneMenusAreSelectedByAuthoredConditions)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+
+    sdl3d_game_data_ui_metrics metrics{};
+    sdl3d_game_data_menu menu{};
+    EXPECT_FALSE(sdl3d_game_data_get_active_menu_for_metrics(runtime, &metrics, &menu));
+
+    metrics.paused = true;
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(runtime, &metrics, &menu));
+    EXPECT_STREQ(menu.name, "menu.pause");
+    EXPECT_EQ(menu.item_count, 3);
+
+    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    ASSERT_NE(match, nullptr);
+    sdl3d_properties_set_bool(match->props, "finished", true);
+    metrics.paused = false;
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(runtime, &metrics, &menu));
+    EXPECT_STREQ(menu.name, "menu.match_over");
+    EXPECT_EQ(menu.item_count, 2);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, PauseMenuResumeConsumesSharedEnterWithoutRepausing)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    ctx.paused = true;
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    flow.scene_input_armed = true;
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_FALSE(ctx.paused);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "return_scene", "scene.play");
+    sdl3d_properties_set_bool(scene_state, "return_paused", true);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
+    EXPECT_TRUE(item.return_scene);
+    EXPECT_STREQ(item.scene, "scene.title");
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    bool armed = true;
+    sdl3d_game_data_ui_metrics metrics{};
+    sdl3d_game_data_menu_update_result result{};
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
+    EXPECT_EQ(result.selected_index, 4);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
+    EXPECT_TRUE(result.selected);
+    EXPECT_TRUE(result.return_scene);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "return_scene", ""), "scene.play");
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "return_paused", false));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -775,6 +775,7 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
         EXPECT_TRUE(text->centered);
         EXPECT_TRUE(text->normalized);
         EXPECT_NEAR(text->x, 0.5f, 0.0001f);
+        EXPECT_NEAR(text->y, 0.06f, 0.0001f);
     }
     if (std::string(text->name) == "ui.pause")
     {
@@ -2416,6 +2417,7 @@ TEST(GameDataRuntime, PongMatchStateAndRestartAreAuthoredLogic)
     EXPECT_EQ(sdl3d_properties_get_int(player_score->props, "value", 0), 10);
     EXPECT_TRUE(sdl3d_properties_get_bool(match->props, "finished", false));
     EXPECT_STREQ(sdl3d_properties_get_string(match->props, "winner", ""), "player");
+    EXPECT_FALSE(ball->active);
     EXPECT_FALSE(sdl3d_properties_get_bool(ball->props, "active_motion", true));
 
     sdl3d_properties_set_float(presentation->props, "border_flash", 1.0f);
@@ -2428,6 +2430,7 @@ TEST(GameDataRuntime, PongMatchStateAndRestartAreAuthoredLogic)
     EXPECT_EQ(sdl3d_properties_get_int(cpu_score->props, "value", -1), 0);
     EXPECT_FALSE(sdl3d_properties_get_bool(match->props, "finished", true));
     EXPECT_STREQ(sdl3d_properties_get_string(match->props, "winner", ""), "none");
+    EXPECT_TRUE(ball->active);
     EXPECT_FLOAT_EQ(sdl3d_properties_get_float(presentation->props, "border_flash", -1.0f), 0.0f);
     EXPECT_FLOAT_EQ(sdl3d_properties_get_float(presentation->props, "paddle_flash", -1.0f), 0.0f);
 


### PR DESCRIPTION
## Summary
- add data-authored active_if conditions for scene menus so multiple menus can share a scene and activate from app/game state
- add menu item app-flow commands for pause/resume, return-scene routing, and return pause state
- update generic menu/app-flow handling so menu input consumes shared Enter before app pause toggling
- replace Pong match-over prompt with Yes/No choices: Yes restarts, No resets and returns to title
- add a pause menu with Resume, Options, and Title; Options returns to the paused play scene through authored return metadata
- route title/options Back through the same return-scene path
- add generic entity.set_active data actions and use them to hide the ball while the match-over menu is visible
- restore the playfield score UI to an on-screen normalized HUD position

## Tests
- git diff --check
- cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j8
- ./build/release/tests/sdl3d_game_data_test
- ./build/release/tests/game_data_json_test
- ctest --test-dir build/release --output-on-failure