### PR TITLE
Add persistent storage API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ target_sources(
         src/sdl3d.c
         src/shading.c
         src/shapes.c
+        src/storage.c
         src/sw_backend.c
         src/texture.c
         src/teleporter.c

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,54 @@
+# SDL3D Storage
+
+`sdl3d_storage` is the writable companion to the read-only asset resolver.
+Shipped files should continue to use `asset://`; persistent and generated files
+should use storage paths:
+
+- `user://` for player-owned data: settings, saves, high scores, profiles, replays
+- `cache://` for disposable generated data: materialized audio, shader caches, thumbnails
+
+The storage root is derived from stable metadata:
+
+```json
+{
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "Pong",
+    "profile": "default"
+  }
+}
+```
+
+The organization and application identifiers are part of the root path on every
+SDL3D platform policy. This intentionally differs from some older PhysicsFS
+Unix examples that used only the application name; keeping both identifiers
+reduces collisions and matches the Windows/macOS convention.
+
+## Platform Policy
+
+SDL3D uses `SDL_GetPrefPath(organization, application)` for native runtime
+storage. The deterministic planner used by tests and tools follows this shape:
+
+| Platform policy | Example user root |
+| --- | --- |
+| Windows | `%APPDATA%/Blue Sentinel Security/Pong` |
+| Apple | `Application Support/Blue Sentinel Security/Pong` |
+| Unix/Linux | `$XDG_DATA_HOME/Blue Sentinel Security/Pong` |
+| Android | app-private root plus `Blue Sentinel Security/Pong` |
+| Emscripten | persistent virtual root plus `Blue Sentinel Security/Pong` |
+
+If a profile is configured, SDL3D appends `profiles/<profile>`. The cache root
+then appends `cache`.
+
+## Safety Rules
+
+Storage virtual paths are intentionally strict:
+
+- accepted schemes are only `user://` and `cache://`
+- absolute paths are rejected
+- `..`, `.`, empty path segments, backslashes, and additional URI schemes are rejected
+- writes create parent directories automatically
+- writes use a temporary file in the target directory and rename it into place
+
+This keeps user-writable data separate from shipped assets while leaving room for
+future explicit override, patch, cloud sync, or mod systems.

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -28,6 +28,7 @@
 #include "sdl3d/scene.h"
 #include "sdl3d/script.h"
 #include "sdl3d/shapes.h"
+#include "sdl3d/storage.h"
 #include "sdl3d/teleporter.h"
 #include "sdl3d/texture.h"
 #include "sdl3d/time.h"

--- a/include/sdl3d/storage.h
+++ b/include/sdl3d/storage.h
@@ -1,0 +1,204 @@
+/**
+ * @file storage.h
+ * @brief Safe persistent and cache storage roots for game-authored data.
+ *
+ * The storage API is the writable companion to the read-only asset resolver.
+ * Games address writable files through stable virtual paths such as
+ * user://scores/high_scores.json and cache://audio/materialized.wav. SDL3D
+ * resolves those paths to platform-appropriate locations derived from stable
+ * organization and application metadata.
+ */
+
+#ifndef SDL3D_STORAGE_H
+#define SDL3D_STORAGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque persistent storage context. */
+    typedef struct sdl3d_storage sdl3d_storage;
+
+    /** @brief Writable storage roots understood by sdl3d_storage. */
+    typedef enum sdl3d_storage_root
+    {
+        /** @brief User-owned persistent data such as saves, settings, and high scores. */
+        SDL3D_STORAGE_ROOT_USER = 0,
+        /** @brief Disposable generated data such as decoded or materialized caches. */
+        SDL3D_STORAGE_ROOT_CACHE = 1,
+        /** @brief Number of storage roots. */
+        SDL3D_STORAGE_ROOT_COUNT = 2,
+    } sdl3d_storage_root;
+
+    /**
+     * @brief Platform layout selector for deterministic root planning.
+     *
+     * SDL3D_STORAGE_PLATFORM_NATIVE uses SDL_GetPrefPath() at runtime. The
+     * named platform values are pure path planners for tests, tools, and
+     * diagnostics that need to verify SDL3D's path policy without running on
+     * every target OS.
+     */
+    typedef enum sdl3d_storage_platform
+    {
+        /** @brief Use SDL_GetPrefPath() for the current host platform. */
+        SDL3D_STORAGE_PLATFORM_NATIVE = 0,
+        /** @brief Plan a Windows-style app-data layout. */
+        SDL3D_STORAGE_PLATFORM_WINDOWS,
+        /** @brief Plan an Apple Application Support style layout. */
+        SDL3D_STORAGE_PLATFORM_APPLE,
+        /** @brief Plan an XDG-style Unix/Linux layout. */
+        SDL3D_STORAGE_PLATFORM_UNIX,
+        /** @brief Plan an app-private Android-style layout. */
+        SDL3D_STORAGE_PLATFORM_ANDROID,
+        /** @brief Plan an Emscripten virtual filesystem style layout. */
+        SDL3D_STORAGE_PLATFORM_EMSCRIPTEN,
+    } sdl3d_storage_platform;
+
+    /**
+     * @brief Configuration used to create a writable storage context.
+     *
+     * @p organization and @p application are required stable identifiers. Use
+     * the same organization for all games from a publisher and never change an
+     * application's identifier after release unless migration is intentional.
+     *
+     * @p profile is optional and, when present, scopes both user and cache roots
+     * below profiles/<profile>. This is useful for tests, save profiles, or
+     * parallel game instances.
+     *
+     * Root overrides are intended for tests and tools. Normal games should leave
+     * them NULL so SDL3D can choose the platform-idiomatic location.
+     */
+    typedef struct sdl3d_storage_config
+    {
+        /** @brief Stable publisher, studio, company, or domain-style organization. */
+        const char *organization;
+        /** @brief Stable application/game identifier. */
+        const char *application;
+        /** @brief Optional profile subdirectory. */
+        const char *profile;
+        /** @brief Optional exact filesystem root for user://. */
+        const char *user_root_override;
+        /** @brief Optional exact filesystem root for cache://. */
+        const char *cache_root_override;
+    } sdl3d_storage_config;
+
+    /**
+     * @brief Owned bytes returned by sdl3d_storage_read_file().
+     *
+     * The data may be binary and is not guaranteed to be null-terminated. Free
+     * it with sdl3d_storage_buffer_free().
+     */
+    typedef struct sdl3d_storage_buffer
+    {
+        /** @brief Owned byte buffer, or NULL when empty or invalid. */
+        void *data;
+        /** @brief Number of valid bytes in @p data. */
+        size_t size;
+    } sdl3d_storage_buffer;
+
+    /**
+     * @brief Fill a storage config with documented defaults.
+     *
+     * The default organization is "SDL3D" and the default application is
+     * "SDL3D". Games should override both through data or host configuration.
+     */
+    void sdl3d_storage_config_init(sdl3d_storage_config *config);
+
+    /**
+     * @brief Build an org/app-aware root path for a target platform policy.
+     *
+     * @p base_path is the platform-provided parent directory, such as
+     * %APPDATA%, Application Support, XDG_DATA_HOME, or an app-private mobile
+     * root. SDL3D appends organization and application on every named platform
+     * for consistency; @p profile appends profiles/<profile>; cache roots append
+     * cache.
+     *
+     * This function does not touch the filesystem.
+     *
+     * @return true when @p out_path received a valid null-terminated path.
+     */
+    bool sdl3d_storage_build_root_path(const sdl3d_storage_config *config, sdl3d_storage_platform platform,
+                                       sdl3d_storage_root root, const char *base_path, char *out_path,
+                                       int out_path_size);
+
+    /**
+     * @brief Create a storage context and ensure its root directories exist.
+     *
+     * If root overrides are not provided, SDL3D uses SDL_GetPrefPath() with the
+     * configured organization and application, then creates a cache subdirectory
+     * beneath that root.
+     *
+     * @return true when the storage context was created.
+     */
+    bool sdl3d_storage_create(const sdl3d_storage_config *config, sdl3d_storage **out_storage, char *error_buffer,
+                              int error_buffer_size);
+
+    /** @brief Destroy a storage context. Safe to call with NULL. */
+    void sdl3d_storage_destroy(sdl3d_storage *storage);
+
+    /**
+     * @brief Get the resolved filesystem root for user:// or cache://.
+     *
+     * The returned pointer is owned by @p storage and remains valid until
+     * sdl3d_storage_destroy().
+     */
+    const char *sdl3d_storage_get_root(const sdl3d_storage *storage, sdl3d_storage_root root);
+
+    /**
+     * @brief Resolve a virtual user:// or cache:// path to a filesystem path.
+     *
+     * Paths are strict: absolute paths, parent traversal, empty segments,
+     * backslashes, and unknown URI schemes are rejected.
+     */
+    bool sdl3d_storage_resolve_path(const sdl3d_storage *storage, const char *virtual_path, char *out_path,
+                                    int out_path_size);
+
+    /**
+     * @brief Create a directory under user:// or cache://, including parents.
+     */
+    bool sdl3d_storage_create_directory(sdl3d_storage *storage, const char *virtual_path, char *error_buffer,
+                                        int error_buffer_size);
+
+    /**
+     * @brief Return whether a virtual storage path currently exists.
+     */
+    bool sdl3d_storage_exists(const sdl3d_storage *storage, const char *virtual_path);
+
+    /**
+     * @brief Read a file from user:// or cache:// into an owned buffer.
+     */
+    bool sdl3d_storage_read_file(const sdl3d_storage *storage, const char *virtual_path,
+                                 sdl3d_storage_buffer *out_buffer, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Write a complete file under user:// or cache://.
+     *
+     * Parent directories are created automatically. The write uses a temporary
+     * file in the target directory and renames it into place; this is atomic on
+     * platforms that provide same-directory atomic rename and falls back to
+     * replace-then-rename only when the platform refuses to replace an existing
+     * destination.
+     */
+    bool sdl3d_storage_write_file(sdl3d_storage *storage, const char *virtual_path, const void *data, size_t size,
+                                  char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Delete a file or empty directory under user:// or cache://.
+     */
+    bool sdl3d_storage_delete(sdl3d_storage *storage, const char *virtual_path, char *error_buffer,
+                              int error_buffer_size);
+
+    /**
+     * @brief Free bytes returned by sdl3d_storage_read_file().
+     */
+    void sdl3d_storage_buffer_free(sdl3d_storage_buffer *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_STORAGE_H */

--- a/src/storage.c
+++ b/src/storage.c
@@ -1,0 +1,530 @@
+/**
+ * @file storage.c
+ * @brief Persistent storage implementation.
+ */
+
+#include "sdl3d/storage.h"
+
+#include <stdint.h>
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
+
+struct sdl3d_storage
+{
+    char *roots[SDL3D_STORAGE_ROOT_COUNT];
+};
+
+static void set_storage_error(char *buffer, int buffer_size, const char *message)
+{
+    if (buffer != NULL && buffer_size > 0)
+        SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown storage error");
+}
+
+static const char *non_empty_or_default(const char *value, const char *fallback)
+{
+    return value != NULL && value[0] != '\0' ? value : fallback;
+}
+
+static bool append_text(char *out, int out_size, size_t *used, const char *text)
+{
+    if (out == NULL || out_size <= 0 || used == NULL || text == NULL)
+        return false;
+    const size_t len = SDL_strlen(text);
+    if (*used > (size_t)out_size || len >= (size_t)out_size - *used)
+        return false;
+    SDL_memcpy(out + *used, text, len + 1u);
+    *used += len;
+    return true;
+}
+
+static bool append_separator(char *out, int out_size, size_t *used)
+{
+    if (used == NULL)
+        return false;
+    if (*used == 0)
+        return true;
+    if (out[*used - 1u] == '/' || out[*used - 1u] == '\\')
+        return true;
+    return append_text(out, out_size, used, "/");
+}
+
+static bool is_valid_segment(const char *segment)
+{
+    if (segment == NULL || segment[0] == '\0')
+        return false;
+    if (SDL_strcmp(segment, ".") == 0 || SDL_strcmp(segment, "..") == 0)
+        return false;
+    return SDL_strchr(segment, '/') == NULL && SDL_strchr(segment, '\\') == NULL && SDL_strchr(segment, ':') == NULL;
+}
+
+static bool append_segment(char *out, int out_size, size_t *used, const char *segment)
+{
+    return is_valid_segment(segment) && append_separator(out, out_size, used) &&
+           append_text(out, out_size, used, segment);
+}
+
+static bool copy_root(const char *root, char *out, int out_size)
+{
+    if (root == NULL || root[0] == '\0' || out == NULL || out_size <= 0)
+        return false;
+    const size_t len = SDL_strlen(root);
+    if (len >= (size_t)out_size)
+        return false;
+    SDL_memcpy(out, root, len + 1u);
+    return true;
+}
+
+static char *join_alloc(const char *base, const char *leaf)
+{
+    if (base == NULL || leaf == NULL)
+        return NULL;
+    const size_t base_len = SDL_strlen(base);
+    const bool needs_sep = base_len > 0 && base[base_len - 1u] != '/' && base[base_len - 1u] != '\\';
+    const size_t leaf_len = SDL_strlen(leaf);
+    char *result = (char *)SDL_malloc(base_len + (needs_sep ? 1u : 0u) + leaf_len + 1u);
+    if (result == NULL)
+        return NULL;
+    SDL_memcpy(result, base, base_len);
+    size_t used = base_len;
+    if (needs_sep)
+        result[used++] = '/';
+    SDL_memcpy(result + used, leaf, leaf_len + 1u);
+    return result;
+}
+
+static bool has_uri_scheme(const char *path)
+{
+    return path != NULL && SDL_strstr(path, "://") != NULL;
+}
+
+static bool root_from_virtual_path(const char *virtual_path, sdl3d_storage_root *out_root, const char **out_relative)
+{
+    if (virtual_path == NULL)
+        return false;
+    if (SDL_strncmp(virtual_path, "user://", 7) == 0)
+    {
+        if (out_root != NULL)
+            *out_root = SDL3D_STORAGE_ROOT_USER;
+        if (out_relative != NULL)
+            *out_relative = virtual_path + 7;
+        return true;
+    }
+    if (SDL_strncmp(virtual_path, "cache://", 8) == 0)
+    {
+        if (out_root != NULL)
+            *out_root = SDL3D_STORAGE_ROOT_CACHE;
+        if (out_relative != NULL)
+            *out_relative = virtual_path + 8;
+        return true;
+    }
+    return false;
+}
+
+static bool validate_relative_path(const char *path)
+{
+    if (path == NULL || path[0] == '\0' || path[0] == '/' || path[0] == '\\' || has_uri_scheme(path))
+        return false;
+    if (SDL_strchr(path, '\\') != NULL || SDL_strchr(path, ':') != NULL)
+        return false;
+    const size_t path_len = SDL_strlen(path);
+    if (path[path_len - 1u] == '/')
+        return false;
+
+    const char *segment = path;
+    while (*segment != '\0')
+    {
+        const char *end = SDL_strchr(segment, '/');
+        const size_t len = end != NULL ? (size_t)(end - segment) : SDL_strlen(segment);
+        if (len == 0u)
+            return false;
+        if ((len == 1u && segment[0] == '.') || (len == 2u && segment[0] == '.' && segment[1] == '.'))
+            return false;
+        if (end == NULL)
+            break;
+        segment = end + 1;
+    }
+    return true;
+}
+
+static bool make_directory_recursive(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+
+    SDL_PathInfo info;
+    SDL_zero(info);
+    if (SDL_GetPathInfo(path, &info))
+        return info.type == SDL_PATHTYPE_DIRECTORY;
+
+    char *copy = SDL_strdup(path);
+    if (copy == NULL)
+        return false;
+
+    bool ok = true;
+    for (char *p = copy + 1; *p != '\0'; ++p)
+    {
+        if (*p != '/' && *p != '\\')
+            continue;
+        const char saved = *p;
+        *p = '\0';
+        if (copy[0] != '\0')
+        {
+            SDL_zero(info);
+            if (!SDL_GetPathInfo(copy, &info))
+                ok = SDL_CreateDirectory(copy);
+            else
+                ok = info.type == SDL_PATHTYPE_DIRECTORY;
+        }
+        *p = saved;
+        if (!ok)
+            break;
+    }
+
+    if (ok)
+    {
+        SDL_zero(info);
+        if (!SDL_GetPathInfo(copy, &info))
+            ok = SDL_CreateDirectory(copy);
+        else
+            ok = info.type == SDL_PATHTYPE_DIRECTORY;
+    }
+
+    SDL_free(copy);
+    return ok;
+}
+
+static char *parent_directory(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    const char *slash = SDL_strrchr(path, '/');
+    const char *backslash = SDL_strrchr(path, '\\');
+    if (backslash != NULL && (slash == NULL || backslash > slash))
+        slash = backslash;
+    if (slash == NULL)
+        return SDL_strdup(".");
+    const size_t len = (size_t)(slash - path);
+    if (len == 0u)
+        return SDL_strdup("/");
+    char *parent = (char *)SDL_malloc(len + 1u);
+    if (parent == NULL)
+        return NULL;
+    SDL_memcpy(parent, path, len);
+    parent[len] = '\0';
+    return parent;
+}
+
+static bool write_all(SDL_IOStream *stream, const void *data, size_t size)
+{
+    const uint8_t *bytes = (const uint8_t *)data;
+    size_t written = 0;
+    while (written < size)
+    {
+        const size_t chunk = SDL_WriteIO(stream, bytes + written, size - written);
+        if (chunk == 0u)
+            return false;
+        written += chunk;
+    }
+    return true;
+}
+
+void sdl3d_storage_config_init(sdl3d_storage_config *config)
+{
+    if (config == NULL)
+        return;
+    SDL_zero(*config);
+    config->organization = "SDL3D";
+    config->application = "SDL3D";
+}
+
+bool sdl3d_storage_build_root_path(const sdl3d_storage_config *config, sdl3d_storage_platform platform,
+                                   sdl3d_storage_root root, const char *base_path, char *out_path, int out_path_size)
+{
+    (void)platform;
+    if (root < 0 || root >= SDL3D_STORAGE_ROOT_COUNT || !copy_root(base_path, out_path, out_path_size))
+        return false;
+
+    size_t used = SDL_strlen(out_path);
+    const char *organization = non_empty_or_default(config != NULL ? config->organization : NULL, "SDL3D");
+    const char *application = non_empty_or_default(config != NULL ? config->application : NULL, "SDL3D");
+    if (!append_segment(out_path, out_path_size, &used, organization) ||
+        !append_segment(out_path, out_path_size, &used, application))
+    {
+        return false;
+    }
+
+    const char *profile = config != NULL ? config->profile : NULL;
+    if (profile != NULL && profile[0] != '\0')
+    {
+        if (!append_segment(out_path, out_path_size, &used, "profiles") ||
+            !append_segment(out_path, out_path_size, &used, profile))
+        {
+            return false;
+        }
+    }
+
+    if (root == SDL3D_STORAGE_ROOT_CACHE && !append_segment(out_path, out_path_size, &used, "cache"))
+        return false;
+    return true;
+}
+
+bool sdl3d_storage_create(const sdl3d_storage_config *config, sdl3d_storage **out_storage, char *error_buffer,
+                          int error_buffer_size)
+{
+    if (out_storage == NULL)
+    {
+        set_storage_error(error_buffer, error_buffer_size, "storage output pointer is required");
+        return false;
+    }
+    *out_storage = NULL;
+
+    sdl3d_storage_config defaults;
+    sdl3d_storage_config_init(&defaults);
+    if (config != NULL)
+        defaults = *config;
+    defaults.organization = non_empty_or_default(defaults.organization, "SDL3D");
+    defaults.application = non_empty_or_default(defaults.application, "SDL3D");
+
+    if (!is_valid_segment(defaults.organization) || !is_valid_segment(defaults.application) ||
+        (defaults.profile != NULL && defaults.profile[0] != '\0' && !is_valid_segment(defaults.profile)))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "storage metadata contains unsafe path characters");
+        return false;
+    }
+
+    sdl3d_storage *storage = (sdl3d_storage *)SDL_calloc(1u, sizeof(*storage));
+    if (storage == NULL)
+    {
+        set_storage_error(error_buffer, error_buffer_size, "failed to allocate storage context");
+        return false;
+    }
+
+    if (defaults.user_root_override != NULL && defaults.user_root_override[0] != '\0')
+    {
+        storage->roots[SDL3D_STORAGE_ROOT_USER] = SDL_strdup(defaults.user_root_override);
+    }
+    else
+    {
+        char *pref = SDL_GetPrefPath(defaults.organization, defaults.application);
+        if (pref != NULL && defaults.profile != NULL && defaults.profile[0] != '\0')
+        {
+            char *profiles = join_alloc(pref, "profiles");
+            storage->roots[SDL3D_STORAGE_ROOT_USER] = join_alloc(profiles, defaults.profile);
+            SDL_free(profiles);
+        }
+        else
+        {
+            storage->roots[SDL3D_STORAGE_ROOT_USER] = SDL_strdup(pref);
+        }
+        SDL_free(pref);
+    }
+
+    if (defaults.cache_root_override != NULL && defaults.cache_root_override[0] != '\0')
+        storage->roots[SDL3D_STORAGE_ROOT_CACHE] = SDL_strdup(defaults.cache_root_override);
+    else
+        storage->roots[SDL3D_STORAGE_ROOT_CACHE] = join_alloc(storage->roots[SDL3D_STORAGE_ROOT_USER], "cache");
+
+    if (storage->roots[SDL3D_STORAGE_ROOT_USER] == NULL || storage->roots[SDL3D_STORAGE_ROOT_CACHE] == NULL)
+    {
+        sdl3d_storage_destroy(storage);
+        set_storage_error(error_buffer, error_buffer_size, "failed to resolve storage roots");
+        return false;
+    }
+
+    if (!make_directory_recursive(storage->roots[SDL3D_STORAGE_ROOT_USER]) ||
+        !make_directory_recursive(storage->roots[SDL3D_STORAGE_ROOT_CACHE]))
+    {
+        sdl3d_storage_destroy(storage);
+        set_storage_error(error_buffer, error_buffer_size, "failed to create storage roots");
+        return false;
+    }
+
+    *out_storage = storage;
+    return true;
+}
+
+void sdl3d_storage_destroy(sdl3d_storage *storage)
+{
+    if (storage == NULL)
+        return;
+    for (int i = 0; i < SDL3D_STORAGE_ROOT_COUNT; ++i)
+        SDL_free(storage->roots[i]);
+    SDL_free(storage);
+}
+
+const char *sdl3d_storage_get_root(const sdl3d_storage *storage, sdl3d_storage_root root)
+{
+    if (storage == NULL || root < 0 || root >= SDL3D_STORAGE_ROOT_COUNT)
+        return NULL;
+    return storage->roots[root];
+}
+
+bool sdl3d_storage_resolve_path(const sdl3d_storage *storage, const char *virtual_path, char *out_path,
+                                int out_path_size)
+{
+    sdl3d_storage_root root;
+    const char *relative = NULL;
+    if (storage == NULL || out_path == NULL || out_path_size <= 0 ||
+        !root_from_virtual_path(virtual_path, &root, &relative) || !validate_relative_path(relative))
+    {
+        return false;
+    }
+
+    const char *root_path = storage->roots[root];
+    if (root_path == NULL || root_path[0] == '\0')
+        return false;
+
+    const size_t root_len = SDL_strlen(root_path);
+    const bool needs_sep = root_len > 0u && root_path[root_len - 1u] != '/' && root_path[root_len - 1u] != '\\';
+    const size_t relative_len = SDL_strlen(relative);
+    const size_t total = root_len + (needs_sep ? 1u : 0u) + relative_len;
+    if (total >= (size_t)out_path_size)
+        return false;
+    SDL_memcpy(out_path, root_path, root_len);
+    size_t used = root_len;
+    if (needs_sep)
+        out_path[used++] = '/';
+    SDL_memcpy(out_path + used, relative, relative_len + 1u);
+    return true;
+}
+
+bool sdl3d_storage_create_directory(sdl3d_storage *storage, const char *virtual_path, char *error_buffer,
+                                    int error_buffer_size)
+{
+    char path[4096];
+    if (!sdl3d_storage_resolve_path(storage, virtual_path, path, sizeof(path)))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "invalid storage directory path");
+        return false;
+    }
+    if (!make_directory_recursive(path))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "failed to create storage directory");
+        return false;
+    }
+    return true;
+}
+
+bool sdl3d_storage_exists(const sdl3d_storage *storage, const char *virtual_path)
+{
+    char path[4096];
+    SDL_PathInfo info;
+    SDL_zero(info);
+    return sdl3d_storage_resolve_path(storage, virtual_path, path, sizeof(path)) && SDL_GetPathInfo(path, &info);
+}
+
+bool sdl3d_storage_read_file(const sdl3d_storage *storage, const char *virtual_path, sdl3d_storage_buffer *out_buffer,
+                             char *error_buffer, int error_buffer_size)
+{
+    if (out_buffer == NULL)
+    {
+        set_storage_error(error_buffer, error_buffer_size, "storage read output buffer is required");
+        return false;
+    }
+    out_buffer->data = NULL;
+    out_buffer->size = 0u;
+
+    char path[4096];
+    if (!sdl3d_storage_resolve_path(storage, virtual_path, path, sizeof(path)))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "invalid storage read path");
+        return false;
+    }
+
+    size_t size = 0u;
+    void *data = SDL_LoadFile(path, &size);
+    if (data == NULL)
+    {
+        set_storage_error(error_buffer, error_buffer_size, SDL_GetError());
+        return false;
+    }
+    out_buffer->data = data;
+    out_buffer->size = size;
+    return true;
+}
+
+bool sdl3d_storage_write_file(sdl3d_storage *storage, const char *virtual_path, const void *data, size_t size,
+                              char *error_buffer, int error_buffer_size)
+{
+    if (data == NULL && size > 0u)
+    {
+        set_storage_error(error_buffer, error_buffer_size, "storage write data is required");
+        return false;
+    }
+
+    char path[4096];
+    if (!sdl3d_storage_resolve_path(storage, virtual_path, path, sizeof(path)))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "invalid storage write path");
+        return false;
+    }
+
+    char *parent = parent_directory(path);
+    if (parent == NULL || !make_directory_recursive(parent))
+    {
+        SDL_free(parent);
+        set_storage_error(error_buffer, error_buffer_size, "failed to create storage write directory");
+        return false;
+    }
+    SDL_free(parent);
+
+    bool ok = false;
+    char temp_path[4096];
+    for (int attempt = 0; attempt < 16 && !ok; ++attempt)
+    {
+        SDL_snprintf(temp_path, sizeof(temp_path), "%s.tmp.%llu.%d", path, (unsigned long long)SDL_GetTicksNS(),
+                     attempt);
+        SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
+        if (stream == NULL)
+            continue;
+        ok = write_all(stream, data, size) && SDL_FlushIO(stream);
+        ok = SDL_CloseIO(stream) && ok;
+        if (!ok)
+        {
+            SDL_RemovePath(temp_path);
+            continue;
+        }
+        if (!SDL_RenamePath(temp_path, path))
+        {
+            SDL_RemovePath(path);
+            ok = SDL_RenamePath(temp_path, path);
+        }
+        if (!ok)
+            SDL_RemovePath(temp_path);
+    }
+
+    if (!ok)
+    {
+        set_storage_error(error_buffer, error_buffer_size, "failed to write storage file");
+        return false;
+    }
+    return true;
+}
+
+bool sdl3d_storage_delete(sdl3d_storage *storage, const char *virtual_path, char *error_buffer, int error_buffer_size)
+{
+    char path[4096];
+    if (!sdl3d_storage_resolve_path(storage, virtual_path, path, sizeof(path)))
+    {
+        set_storage_error(error_buffer, error_buffer_size, "invalid storage delete path");
+        return false;
+    }
+    if (!SDL_RemovePath(path))
+    {
+        set_storage_error(error_buffer, error_buffer_size, SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+void sdl3d_storage_buffer_free(sdl3d_storage_buffer *buffer)
+{
+    if (buffer == NULL)
+        return;
+    SDL_free(buffer->data);
+    buffer->data = NULL;
+    buffer->size = 0u;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SDL3D_TEST_SOURCES
     test_level.cpp
     test_properties.cpp
     test_signal_bus.cpp
+    test_storage.cpp
     test_trigger.cpp
     test_timer_pool.cpp
     test_fps_mover.cpp
@@ -227,6 +228,7 @@ else()
     target_include_directories(sdl3d_level_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     sdl3d_add_test(sdl3d_properties_test test_properties.cpp unit)
     sdl3d_add_test(sdl3d_signal_bus_test test_signal_bus.cpp unit)
+    sdl3d_add_test(sdl3d_storage_test test_storage.cpp unit)
     sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
     sdl3d_add_test(sdl3d_timer_pool_test test_timer_pool.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)

--- a/tests/test_storage.cpp
+++ b/tests/test_storage.cpp
@@ -1,0 +1,226 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+extern "C"
+{
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/storage.h"
+}
+
+namespace
+{
+
+std::filesystem::path unique_test_dir(const char *name)
+{
+    std::filesystem::path root;
+    char *pref = SDL_GetPrefPath("SDL3DTests", "Storage");
+    if (pref != nullptr)
+    {
+        root = pref;
+        SDL_free(pref);
+    }
+    else
+    {
+        root = std::filesystem::temp_directory_path();
+    }
+
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    for (int attempt = 0; attempt < 100; ++attempt)
+    {
+        const std::filesystem::path dir = root / ("sdl3d_storage_test_" + std::string(name) + "_" +
+                                                  std::to_string(now) + "_" + std::to_string(attempt));
+        std::error_code error;
+        if (std::filesystem::create_directories(dir, error))
+            return dir;
+    }
+    throw std::runtime_error("failed to create unique storage test directory");
+}
+
+void remove_test_dir(const std::filesystem::path &dir)
+{
+    std::error_code error;
+    std::filesystem::remove_all(dir, error);
+}
+
+std::string normalize_slashes(std::string path)
+{
+    for (char &ch : path)
+    {
+        if (ch == '\\')
+            ch = '/';
+    }
+    return path;
+}
+
+sdl3d_storage_config test_config()
+{
+    sdl3d_storage_config config{};
+    sdl3d_storage_config_init(&config);
+    config.organization = "Blue Sentinel";
+    config.application = "Pong";
+    return config;
+}
+
+} // namespace
+
+TEST(StoragePathPolicy, BuildsOrgAppRootsForDesktopAndWebPlatforms)
+{
+    const sdl3d_storage_config config = test_config();
+    char path[256]{};
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_WINDOWS, SDL3D_STORAGE_ROOT_USER,
+                                              "C:/Users/Example/AppData/Roaming", path, sizeof(path)));
+    EXPECT_STREQ(path, "C:/Users/Example/AppData/Roaming/Blue Sentinel/Pong");
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_APPLE, SDL3D_STORAGE_ROOT_USER,
+                                              "/Users/example/Library/Application Support", path, sizeof(path)));
+    EXPECT_STREQ(path, "/Users/example/Library/Application Support/Blue Sentinel/Pong");
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_USER,
+                                              "/home/example/.local/share", path, sizeof(path)));
+    EXPECT_STREQ(path, "/home/example/.local/share/Blue Sentinel/Pong");
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_ANDROID, SDL3D_STORAGE_ROOT_USER,
+                                              "/data/user/0/com.example.pong/files", path, sizeof(path)));
+    EXPECT_STREQ(path, "/data/user/0/com.example.pong/files/Blue Sentinel/Pong");
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_EMSCRIPTEN, SDL3D_STORAGE_ROOT_USER,
+                                              "/persistent", path, sizeof(path)));
+    EXPECT_STREQ(path, "/persistent/Blue Sentinel/Pong");
+}
+
+TEST(StoragePathPolicy, BuildsProfiledCacheRoots)
+{
+    sdl3d_storage_config config = test_config();
+    config.profile = "player1";
+    char path[256]{};
+
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_CACHE,
+                                              "/home/example/.local/share", path, sizeof(path)));
+    EXPECT_STREQ(path, "/home/example/.local/share/Blue Sentinel/Pong/profiles/player1/cache");
+}
+
+TEST(StoragePathPolicy, RejectsUnsafeMetadataAndSmallBuffers)
+{
+    sdl3d_storage_config config = test_config();
+    char path[16]{};
+
+    EXPECT_FALSE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_USER,
+                                               "/home/example/.local/share", path, sizeof(path)));
+
+    config.organization = "Blue/Sentinel";
+    char large_path[256]{};
+    EXPECT_FALSE(sdl3d_storage_build_root_path(&config, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_USER, "/tmp",
+                                               large_path, sizeof(large_path)));
+}
+
+TEST(StorageRuntime, CreatesOverrideRootsAndResolvesVirtualPaths)
+{
+    const std::filesystem::path root = unique_test_dir("resolve");
+    const std::filesystem::path user_root = root / "user";
+    const std::filesystem::path cache_root = root / "cache";
+
+    sdl3d_storage_config config = test_config();
+    const std::string user_root_string = user_root.string();
+    const std::string cache_root_string = cache_root.string();
+    config.user_root_override = user_root_string.c_str();
+    config.cache_root_override = cache_root_string.c_str();
+
+    sdl3d_storage *storage = nullptr;
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_storage_create(&config, &storage, error, sizeof(error))) << error;
+    ASSERT_NE(storage, nullptr);
+
+    EXPECT_EQ(normalize_slashes(sdl3d_storage_get_root(storage, SDL3D_STORAGE_ROOT_USER)),
+              normalize_slashes(user_root_string));
+    EXPECT_EQ(normalize_slashes(sdl3d_storage_get_root(storage, SDL3D_STORAGE_ROOT_CACHE)),
+              normalize_slashes(cache_root_string));
+
+    char resolved[512]{};
+    ASSERT_TRUE(sdl3d_storage_resolve_path(storage, "user://settings/options.json", resolved, sizeof(resolved)));
+    EXPECT_EQ(normalize_slashes(resolved), normalize_slashes((user_root / "settings/options.json").string()));
+    ASSERT_TRUE(sdl3d_storage_resolve_path(storage, "cache://audio/title.ogg", resolved, sizeof(resolved)));
+    EXPECT_EQ(normalize_slashes(resolved), normalize_slashes((cache_root / "audio/title.ogg").string()));
+
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "asset://settings/options.json", resolved, sizeof(resolved)));
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "user://../escape.txt", resolved, sizeof(resolved)));
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "user://settings//options.json", resolved, sizeof(resolved)));
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "user://settings/", resolved, sizeof(resolved)));
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "user://settings\\options.json", resolved, sizeof(resolved)));
+    EXPECT_FALSE(sdl3d_storage_resolve_path(storage, "/absolute/path", resolved, sizeof(resolved)));
+
+    sdl3d_storage_destroy(storage);
+    remove_test_dir(root);
+}
+
+TEST(StorageRuntime, WritesReadsReplacesAndDeletesFiles)
+{
+    const std::filesystem::path root = unique_test_dir("rw");
+    const std::filesystem::path user_root = root / "user";
+
+    sdl3d_storage_config config = test_config();
+    const std::string user_root_string = user_root.string();
+    config.user_root_override = user_root_string.c_str();
+
+    sdl3d_storage *storage = nullptr;
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_storage_create(&config, &storage, error, sizeof(error))) << error;
+
+    const char first[] = "first";
+    ASSERT_TRUE(sdl3d_storage_write_file(storage, "user://scores/high_scores.json", first, sizeof(first) - 1u, error,
+                                         sizeof(error)))
+        << error;
+    EXPECT_TRUE(sdl3d_storage_exists(storage, "user://scores/high_scores.json"));
+
+    sdl3d_storage_buffer buffer{};
+    ASSERT_TRUE(sdl3d_storage_read_file(storage, "user://scores/high_scores.json", &buffer, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(std::string(static_cast<const char *>(buffer.data), buffer.size), "first");
+    sdl3d_storage_buffer_free(&buffer);
+
+    const char second[] = "second";
+    ASSERT_TRUE(sdl3d_storage_write_file(storage, "user://scores/high_scores.json", second, sizeof(second) - 1u, error,
+                                         sizeof(error)))
+        << error;
+    ASSERT_TRUE(sdl3d_storage_read_file(storage, "user://scores/high_scores.json", &buffer, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(std::string(static_cast<const char *>(buffer.data), buffer.size), "second");
+    sdl3d_storage_buffer_free(&buffer);
+
+    ASSERT_TRUE(sdl3d_storage_create_directory(storage, "cache://audio/materialized", error, sizeof(error))) << error;
+    EXPECT_TRUE(sdl3d_storage_exists(storage, "cache://audio/materialized"));
+
+    ASSERT_TRUE(sdl3d_storage_delete(storage, "user://scores/high_scores.json", error, sizeof(error))) << error;
+    EXPECT_FALSE(sdl3d_storage_exists(storage, "user://scores/high_scores.json"));
+
+    sdl3d_storage_destroy(storage);
+    remove_test_dir(root);
+}
+
+TEST(StorageRuntime, RejectsInvalidWrites)
+{
+    const std::filesystem::path root = unique_test_dir("reject");
+    const std::filesystem::path user_root = root / "user";
+
+    sdl3d_storage_config config = test_config();
+    const std::string user_root_string = user_root.string();
+    config.user_root_override = user_root_string.c_str();
+
+    sdl3d_storage *storage = nullptr;
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_storage_create(&config, &storage, error, sizeof(error))) << error;
+
+    const char data[] = "nope";
+    EXPECT_FALSE(sdl3d_storage_write_file(storage, "user://../escape.txt", data, sizeof(data), error, sizeof(error)));
+    EXPECT_FALSE(sdl3d_storage_write_file(storage, "cache://bad\\name.txt", data, sizeof(data), error, sizeof(error)));
+    EXPECT_FALSE(sdl3d_storage_write_file(storage, "asset://readonly.txt", data, sizeof(data), error, sizeof(error)));
+
+    sdl3d_storage_destroy(storage);
+    remove_test_dir(root);
+}


### PR DESCRIPTION
## Summary
- add public sdl3d_storage API for safe user:// and cache:// writes
- add org/app-aware root planning for Windows, Apple, Unix, Android-style, and Emscripten-style policies
- use SDL_GetPrefPath for native roots, with test/tool overrides for deterministic filesystem tests
- enforce strict virtual path validation to reject absolute paths, traversal, empty segments, backslashes, and unknown schemes
- add recursive directory creation, read/write/delete/exists helpers, and best-effort same-directory atomic replacement writes
- document the storage model and add the new header to the public umbrella include

Refs #143; this implements Phase 1.

## Tests
- cmake -S . -B build/release -DCMAKE_BUILD_TYPE=Release
- cmake --build build/release --target sdl3d_storage_test sdl3d_api_test -j8
- ./build/release/tests/sdl3d_storage_test
- ./build/release/tests/sdl3d_api_test
- git diff --check
- ctest --test-dir build/release --output-on-failure