### PR TITLE
Expose game data storage config

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -6,6 +6,11 @@
     "version": "0.1.0",
     "description": "Fixed-screen arcade proof that SDL3D gameplay rules can be authored through generic entities, sensors, signals, timers, and actions."
   },
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "SDL3D Pong",
+    "profile": "default"
+  },
   "app": {
     "title": "SDL3D Pong",
     "width": 1280,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -21,6 +21,7 @@ Every file is a JSON object with these fields:
 | --- | --- | --- |
 | `schema` | yes | Schema id. First value: `sdl3d.game.v0`. |
 | `metadata` | yes | Human-readable identity and versioning. |
+| `storage` | no | Writable storage identity used to resolve `user://` and `cache://` roots. |
 | `app` | no | Managed-loop startup config such as title, window size, backend, tick rate, and tick cap. |
 | `profiles` | no | Genre/profile hints and required modules. |
 | `assets` | no | Stable asset ids mapped to paths or future archive refs. |
@@ -47,6 +48,27 @@ Names are authored handles and should be stable across reloads. Use role namespa
 - `adapter.pong.reflect_ball`
 
 Loaders should reject duplicate names inside a namespace and should report the JSON pointer of the failure.
+
+## Storage
+
+The optional `storage` block declares the platform-stable identity used by
+`sdl3d_storage_create()`:
+
+```json
+{
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "SDL3D Pong",
+    "profile": "default"
+  }
+}
+```
+
+`organization` and `application` should be stable after release because they
+become part of the writable save/settings/cache paths on every platform.
+`profile` is optional and scopes roots below `profiles/<profile>`. Test tools
+may also author `user_root_override` and `cache_root_override`, but shipped
+games should normally let SDL3D choose platform-idiomatic locations.
 
 ## World
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -13,11 +13,15 @@ The storage root is derived from stable metadata:
 {
   "storage": {
     "organization": "Blue Sentinel Security",
-    "application": "Pong",
+    "application": "SDL3D Pong",
     "profile": "default"
   }
 }
 ```
+
+Game-data runtimes expose this authored block through
+`sdl3d_game_data_get_storage_config()`, so a managed app can create storage from
+the same data file that declares its window, assets, scenes, and gameplay.
 
 The organization and application identifiers are part of the root path on every
 SDL3D platform policy. This intentionally differs from some older PhysicsFS
@@ -31,11 +35,11 @@ storage. The deterministic planner used by tests and tools follows this shape:
 
 | Platform policy | Example user root |
 | --- | --- |
-| Windows | `%APPDATA%/Blue Sentinel Security/Pong` |
-| Apple | `Application Support/Blue Sentinel Security/Pong` |
-| Unix/Linux | `$XDG_DATA_HOME/Blue Sentinel Security/Pong` |
-| Android | app-private root plus `Blue Sentinel Security/Pong` |
-| Emscripten | persistent virtual root plus `Blue Sentinel Security/Pong` |
+| Windows | `%APPDATA%/Blue Sentinel Security/SDL3D Pong` |
+| Apple | `Application Support/Blue Sentinel Security/SDL3D Pong` |
+| Unix/Linux | `$XDG_DATA_HOME/Blue Sentinel Security/SDL3D Pong` |
+| Android | app-private root plus `Blue Sentinel Security/SDL3D Pong` |
+| Emscripten | persistent virtual root plus `Blue Sentinel Security/SDL3D Pong` |
 
 If a profile is configured, SDL3D appends `profiles/<profile>`. The cache root
 then appends `cache`.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -25,6 +25,7 @@
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/properties.h"
+#include "sdl3d/storage.h"
 #include "sdl3d/transition.h"
 
 #ifdef __cplusplus
@@ -695,6 +696,21 @@ extern "C"
      */
     bool sdl3d_game_data_load_app_config_file(const char *path, sdl3d_game_config *out_config, char *title_buffer,
                                               int title_buffer_size, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Get the writable storage identity authored by the game data.
+     *
+     * The returned config is suitable for sdl3d_storage_create(). String
+     * pointers are owned by @p runtime and remain valid until
+     * sdl3d_game_data_destroy(). If the JSON omits the storage block, SDL3D
+     * derives conservative defaults from metadata/app fields and finally falls
+     * back to sdl3d_storage_config_init() defaults.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param out_config Receives the resolved storage configuration.
+     * @return true when @p out_config was filled.
+     */
+    bool sdl3d_game_data_get_storage_config(const sdl3d_game_data_runtime *runtime, sdl3d_storage_config *out_config);
 
     /**
      * @brief Validate a JSON game data file without instantiating runtime state.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -219,6 +219,7 @@ typedef struct sdl3d_game_data_runtime
     sdl3d_asset_resolver *assets;
     bool owns_assets;
     char *base_dir;
+    sdl3d_storage_config storage_config;
     scene_entry *scenes;
     int scene_count;
     int active_scene_index;
@@ -833,6 +834,17 @@ static const char *json_string(yyjson_val *object, const char *key, const char *
     yyjson_val *value = obj_get(object, key);
     return yyjson_is_str(value) ? yyjson_get_str(value) : fallback;
 }
+
+static const char *first_non_empty_string(const char *first, const char *second, const char *fallback)
+{
+    if (first != NULL && first[0] != '\0')
+        return first;
+    if (second != NULL && second[0] != '\0')
+        return second;
+    return fallback;
+}
+
+static void load_storage_config(sdl3d_game_data_runtime *runtime, yyjson_val *root);
 
 static bool json_bool(yyjson_val *object, const char *key, bool fallback)
 {
@@ -6513,6 +6525,7 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
         sdl3d_game_data_destroy(runtime);
         return false;
     }
+    load_storage_config(runtime, root);
 
     yyjson_val *logic = obj_get(root, "logic");
     load_active_camera(runtime, root);
@@ -6579,6 +6592,34 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
     SDL_free(base_dir);
     SDL_free(asset_name);
     return ok;
+}
+
+static void load_storage_config(sdl3d_game_data_runtime *runtime, yyjson_val *root)
+{
+    sdl3d_storage_config_init(&runtime->storage_config);
+
+    yyjson_val *storage = obj_get(root, "storage");
+    yyjson_val *metadata = obj_get(root, "metadata");
+    yyjson_val *app = obj_get(root, "app");
+
+    runtime->storage_config.organization =
+        first_non_empty_string(json_string(storage, "organization", NULL), json_string(metadata, "organization", NULL),
+                               runtime->storage_config.organization);
+    runtime->storage_config.application = first_non_empty_string(
+        json_string(storage, "application", NULL), json_string(app, "title", NULL),
+        first_non_empty_string(json_string(metadata, "name", NULL), NULL, runtime->storage_config.application));
+    runtime->storage_config.profile = json_string(storage, "profile", NULL);
+    runtime->storage_config.user_root_override = json_string(storage, "user_root_override", NULL);
+    runtime->storage_config.cache_root_override = json_string(storage, "cache_root_override", NULL);
+}
+
+bool sdl3d_game_data_get_storage_config(const sdl3d_game_data_runtime *runtime, sdl3d_storage_config *out_config)
+{
+    if (runtime == NULL || out_config == NULL)
+        return false;
+
+    *out_config = runtime->storage_config;
+    return true;
 }
 
 void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -66,6 +66,7 @@ typedef struct validation_names
 
 static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
                                     validation_names *names);
+static bool validate_storage(validation_context *ctx, yyjson_val *root);
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
 {
@@ -82,6 +83,15 @@ static bool is_non_empty_string(yyjson_val *object, const char *key)
 {
     const char *value = json_string(object, key);
     return value != NULL && value[0] != '\0';
+}
+
+static bool is_storage_path_segment(const char *value)
+{
+    if (value == NULL || value[0] == '\0')
+        return false;
+    if (SDL_strcmp(value, ".") == 0 || SDL_strcmp(value, "..") == 0)
+        return false;
+    return SDL_strchr(value, '/') == NULL && SDL_strchr(value, '\\') == NULL && SDL_strchr(value, ':') == NULL;
 }
 
 static void set_first_error(validation_context *ctx, const char *json_path, const char *message)
@@ -139,6 +149,34 @@ static bool validation_warning(validation_context *ctx, const char *json_path, c
     SDL_vsnprintf(message, sizeof(message), format, args);
     va_end(args);
     return emit_diagnostic(ctx, SDL3D_GAME_DATA_DIAGNOSTIC_WARNING, json_path, "%s", message);
+}
+
+static bool validate_storage_string(validation_context *ctx, yyjson_val *storage, const char *key,
+                                    const char *json_path, bool path_segment)
+{
+    yyjson_val *value = obj_get(storage, key);
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0')
+        return validation_error(ctx, json_path, "storage field must be a non-empty string");
+    if (path_segment && !is_storage_path_segment(yyjson_get_str(value)))
+        return validation_error(ctx, json_path, "storage field must be a safe path segment");
+    return true;
+}
+
+static bool validate_storage(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *storage = obj_get(root, "storage");
+    if (storage == NULL)
+        return true;
+    if (!yyjson_is_obj(storage))
+        return validation_error(ctx, "$.storage", "storage must be an object");
+
+    return validate_storage_string(ctx, storage, "organization", "$.storage.organization", true) &&
+           validate_storage_string(ctx, storage, "application", "$.storage.application", true) &&
+           validate_storage_string(ctx, storage, "profile", "$.storage.profile", true) &&
+           validate_storage_string(ctx, storage, "user_root_override", "$.storage.user_root_override", false) &&
+           validate_storage_string(ctx, storage, "cache_root_override", "$.storage.cache_root_override", false);
 }
 
 static void format_path(char *buffer, size_t buffer_size, const char *format, ...)
@@ -2274,7 +2312,7 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
-    return validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+    return validate_storage(ctx, root) && validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases") &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -922,6 +922,18 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     sdl3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
 
+    sdl3d_storage_config storage{};
+    ASSERT_TRUE(sdl3d_game_data_get_storage_config(runtime, &storage));
+    EXPECT_STREQ(storage.organization, "Blue Sentinel Security");
+    EXPECT_STREQ(storage.application, "SDL3D Pong");
+    EXPECT_STREQ(storage.profile, "default");
+    EXPECT_EQ(storage.user_root_override, nullptr);
+    EXPECT_EQ(storage.cache_root_override, nullptr);
+    char storage_root[256]{};
+    ASSERT_TRUE(sdl3d_storage_build_root_path(&storage, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_USER,
+                                              "/home/player/.local/share", storage_root, sizeof(storage_root)));
+    EXPECT_STREQ(storage_root, "/home/player/.local/share/Blue Sentinel Security/SDL3D Pong/profiles/default");
+
     sdl3d_camera3d camera{};
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.overhead", &camera));
     EXPECT_EQ(camera.projection, SDL3D_CAMERA_ORTHOGRAPHIC);
@@ -2734,6 +2746,43 @@ TEST(GameDataRuntime, ValidationReportsJsonPathAndMissingReference)
     EXPECT_NE(capture.diagnostics[0].path.find("$.logic.bindings[0].actions[0]"), std::string::npos);
     EXPECT_NE(capture.diagnostics[0].message.find("entity.missing"), std::string::npos);
     EXPECT_NE(std::string(error).find("$.logic.bindings[0].actions[0]"), std::string::npos);
+}
+
+TEST(GameDataRuntime, ValidatesAuthoredStorageConfig)
+{
+    const std::filesystem::path dir = unique_test_dir("storage_validation");
+    write_text(dir / "bad_storage.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Storage", "id": "test.bad_storage", "version": "0.1.0" },
+  "storage": { "organization": "Bad/Org", "application": "Pong" },
+  "world": { "name": "world.bad_storage", "kind": "fixed_screen" },
+  "entities": []
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "bad_storage.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.storage.organization"), std::string::npos);
+
+    write_text(dir / "good_storage.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Good Storage", "id": "test.good_storage", "version": "0.1.0" },
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "Storage Test",
+    "profile": "dev"
+  },
+  "world": { "name": "world.good_storage", "kind": "fixed_screen" },
+  "entities": []
+})json");
+    error[0] = '\0';
+    EXPECT_TRUE(
+        sdl3d_game_data_validate_file((dir / "good_storage.game.json").string().c_str(), nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(error[0], '\0');
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, ValidationReportsWarningsWithoutFailingByDefault)


### PR DESCRIPTION
## Summary
- add a top-level `storage` block to Pong game data for org/app/profile identity
- expose authored storage identity through `sdl3d_game_data_get_storage_config()`
- validate storage fields and document the JSON/storage integration

Refs #143. Implements the next storage slice after #144; this does not move runtime cache users yet.

## Tests
- `cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j8`
- `./build/release/tests/sdl3d_game_data_test`
- `./build/release/tests/game_data_json_test`
- `git diff --check`
- `ctest --test-dir build/release --output-on-failure`