### PR TITLE
Add Lua storage bindings

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -49,6 +49,18 @@ Game-data audio actions materialize resolver-backed audio assets into
 `sdl3d_game_data_prepare_audio_file()`, which applies the same cache policy as
 `audio.play_sfx` and `audio.play_music`.
 
+Lua game scripts can use the same safe roots through the gameplay API:
+
+```lua
+local ok, err = sdl3d.storage.write("user://settings/options.json", json_text)
+local text, read_err = sdl3d.storage.read("user://settings/options.json")
+local exists = sdl3d.storage.exists("cache://generated/status.txt")
+```
+
+The adapter context exposes the same table as `ctx.storage`. These bindings use
+the storage API's normal validation, so scripts cannot escape through absolute
+paths, `..`, empty segments, backslashes, or unknown schemes.
+
 ## Safety Rules
 
 Storage virtual paths are intentionally strict:

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -372,6 +372,8 @@ static sdl3d_registered_actor *lua_actor_arg(lua_State *lua, sdl3d_game_data_run
     return sdl3d_game_data_find_actor(runtime, actor_name);
 }
 
+static bool ensure_runtime_storage(sdl3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size);
+
 static int lua_get_position(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
@@ -634,6 +636,98 @@ static int lua_log(lua_State *lua)
     return 0;
 }
 
+static int lua_storage_read(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *path = luaL_checkstring(lua, 1);
+
+    char error[256];
+    if (!ensure_runtime_storage(runtime, error, (int)sizeof(error)))
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, error);
+        return 2;
+    }
+
+    sdl3d_storage_buffer buffer;
+    SDL_zero(buffer);
+    if (!sdl3d_storage_read_file(runtime->storage, path, &buffer, error, (int)sizeof(error)))
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, error);
+        return 2;
+    }
+
+    lua_pushlstring(lua, (const char *)buffer.data, buffer.size);
+    sdl3d_storage_buffer_free(&buffer);
+    return 1;
+}
+
+static int lua_storage_write(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *path = luaL_checkstring(lua, 1);
+    size_t size = 0u;
+    const char *data = luaL_checklstring(lua, 2, &size);
+
+    char error[256];
+    const bool ok = ensure_runtime_storage(runtime, error, (int)sizeof(error)) &&
+                    sdl3d_storage_write_file(runtime->storage, path, data, size, error, (int)sizeof(error));
+    lua_pushboolean(lua, ok);
+    if (!ok)
+    {
+        lua_pushstring(lua, error);
+        return 2;
+    }
+    return 1;
+}
+
+static int lua_storage_exists(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *path = luaL_checkstring(lua, 1);
+
+    char error[256];
+    const bool ok =
+        ensure_runtime_storage(runtime, error, (int)sizeof(error)) && sdl3d_storage_exists(runtime->storage, path);
+    lua_pushboolean(lua, ok);
+    return 1;
+}
+
+static int lua_storage_mkdir(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *path = luaL_checkstring(lua, 1);
+
+    char error[256];
+    const bool ok = ensure_runtime_storage(runtime, error, (int)sizeof(error)) &&
+                    sdl3d_storage_create_directory(runtime->storage, path, error, (int)sizeof(error));
+    lua_pushboolean(lua, ok);
+    if (!ok)
+    {
+        lua_pushstring(lua, error);
+        return 2;
+    }
+    return 1;
+}
+
+static int lua_storage_delete(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *path = luaL_checkstring(lua, 1);
+
+    char error[256];
+    const bool ok = ensure_runtime_storage(runtime, error, (int)sizeof(error)) &&
+                    sdl3d_storage_delete(runtime->storage, path, error, (int)sizeof(error));
+    lua_pushboolean(lua, ok);
+    if (!ok)
+    {
+        lua_pushstring(lua, error);
+        return 2;
+    }
+    return 1;
+}
+
 static void install_lua_helpers(lua_State *lua)
 {
     static const char *source_parts[] = {
@@ -750,8 +844,16 @@ static void install_lua_helpers(lua_State *lua)
         "        end,\n"
         "        random = function(_) return sdl3d.random() end,\n"
         "        log = function(self_or_message, maybe_message) sdl3d.log(maybe_message or self_or_message) end,\n"
+        "        storage = sdl3d.storage,\n"
         "    }\n"
         "end\n"
+        "sdl3d.storage = {\n"
+        "    read = sdl3d.storage_read,\n"
+        "    write = sdl3d.storage_write,\n"
+        "    exists = sdl3d.storage_exists,\n"
+        "    mkdir = sdl3d.storage_mkdir,\n"
+        "    delete = sdl3d.storage_delete,\n"
+        "}\n"
         "sdl3d.Actor = Actor\n"
         "sdl3d.Vec3 = Vec3\n"
         "sdl3d.api = 'sdl3d.lua.v1'\n"
@@ -819,6 +921,11 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("random", lua_random);
     SDL3D_LUA_BIND("actor_with_tags", lua_actor_with_tags);
     SDL3D_LUA_BIND("log", lua_log);
+    SDL3D_LUA_BIND("storage_read", lua_storage_read);
+    SDL3D_LUA_BIND("storage_write", lua_storage_write);
+    SDL3D_LUA_BIND("storage_exists", lua_storage_exists);
+    SDL3D_LUA_BIND("storage_mkdir", lua_storage_mkdir);
+    SDL3D_LUA_BIND("storage_delete", lua_storage_delete);
 #undef SDL3D_LUA_BIND
     lua_setglobal(lua, "sdl3d");
     install_lua_helpers(lua);
@@ -5106,14 +5213,23 @@ static char *make_safe_audio_filename(const char *path)
     return filename;
 }
 
-static bool ensure_audio_cache_storage(sdl3d_game_data_runtime *runtime)
+static bool ensure_runtime_storage(sdl3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size)
 {
     if (runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "game data runtime is required");
         return false;
+    }
+    if (runtime->storage != NULL)
+        return true;
 
+    return sdl3d_storage_create(&runtime->storage_config, &runtime->storage, error_buffer, error_buffer_size);
+}
+
+static bool ensure_audio_cache_storage(sdl3d_game_data_runtime *runtime)
+{
     char storage_error[256];
-    if (runtime->storage == NULL &&
-        !sdl3d_storage_create(&runtime->storage_config, &runtime->storage, storage_error, (int)sizeof(storage_error)))
+    if (!ensure_runtime_storage(runtime, storage_error, (int)sizeof(storage_error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D audio cache storage unavailable: %s", storage_error);
         return false;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2840,6 +2840,107 @@ TEST(GameDataRuntime, MaterializesAudioAssetsThroughAuthoredCacheStorage)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, LuaStorageBindingsUseSafeVirtualRoots)
+{
+    const std::filesystem::path dir = unique_test_dir("lua_storage");
+    const std::filesystem::path user_root = dir / "user";
+    const std::filesystem::path cache_root = dir / "cache";
+
+    write_text(dir / "scripts" / "storage.lua",
+               R"lua(local storage = {}
+
+function storage.roundtrip(_, _, ctx)
+    local unsafe_ok = ctx.storage.write("user://../escape.txt", "no")
+    if unsafe_ok then
+        return false
+    end
+
+    local ok = ctx.storage.write("user://settings/options.json", "{\"difficulty\":\"hard\"}")
+    if not ok or not ctx.storage.exists("user://settings/options.json") then
+        return false
+    end
+
+    local data = ctx.storage.read("user://settings/options.json")
+    if data ~= "{\"difficulty\":\"hard\"}" then
+        return false
+    end
+
+    if not ctx.storage.mkdir("cache://script") then
+        return false
+    end
+    if not ctx.storage.write("cache://script/status.txt", "cached") then
+        return false
+    end
+
+    ctx:state_set("loaded_options", data)
+    return true
+end
+
+return storage
+)lua");
+
+    const std::string game_json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Lua Storage", "id": "test.lua_storage", "version": "0.1.0" },
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "Lua Storage Test",
+    "user_root_override": ")json") +
+                                  user_root.generic_string() + R"json(",
+    "cache_root_override": ")json" +
+                                  cache_root.generic_string() + R"json("
+  },
+  "scripts": [
+    { "id": "script.storage", "path": "scripts/storage.lua", "module": "test.storage" }
+  ],
+  "world": { "name": "world.lua_storage", "kind": "fixed_screen" },
+  "entities": [],
+  "signals": [ "signal.storage.roundtrip" ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.storage.roundtrip",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.storage.roundtrip" }
+        ]
+      }
+    ]
+  },
+  "adapters": [
+    {
+      "name": "adapter.storage.roundtrip",
+      "kind": "action",
+      "script": "script.storage",
+      "function": "roundtrip"
+    }
+  ]
+})json";
+    write_text(dir / "lua_storage.game.json", game_json.c_str());
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "lua_storage.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    const int signal_id = sdl3d_game_data_find_signal(runtime, "signal.storage.roundtrip");
+    ASSERT_GE(signal_id, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), signal_id, nullptr);
+
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "loaded_options", ""),
+                 "{\"difficulty\":\"hard\"}");
+    EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
+    EXPECT_TRUE(std::filesystem::exists(cache_root / "script" / "status.txt"));
+    EXPECT_FALSE(std::filesystem::exists(dir / "escape.txt"));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ValidationReportsWarningsWithoutFailingByDefault)
 {
     DiagnosticCapture capture;


### PR DESCRIPTION
## Summary
- expose safe `user://` and `cache://` storage operations to Lua scripts
- add the nicer `sdl3d.storage` / `ctx.storage` table for read, write, exists, mkdir, and delete
- document script storage usage and safety rules
- add an end-to-end Lua adapter test covering user writes, cache writes, reads, exists, mkdir, and traversal rejection

Refs #143. This is the first Phase 4 slice; Pong options/high-score persistence can now build on these script primitives without new engine storage APIs.

## Tests
- `cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j8`
- `./build/release/tests/sdl3d_game_data_test`
- `./build/release/tests/game_data_json_test`
- `git diff --check`
- `ctest --test-dir build/release --output-on-failure`