### PR TITLE
Persist Pong options and high scores

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -718,7 +718,19 @@
         "difficulty": { "type": "string", "value": "normal" },
         "lighting_profile": { "type": "string", "value": "cinematic" },
         "fullscreen": { "type": "bool", "value": false },
-        "input_style": { "type": "string", "value": "keyboard" }
+        "input_style": { "type": "string", "value": "keyboard" },
+        "persistence_enabled": { "type": "bool", "value": false }
+      }
+    },
+    {
+      "name": "entity.high_scores",
+      "active": true,
+      "tags": ["state", "scores"],
+      "properties": {
+        "player_wins": { "type": "int", "value": 0 },
+        "cpu_wins": { "type": "int", "value": 0 },
+        "matches_played": { "type": "int", "value": 0 },
+        "latest_winner": { "type": "string", "value": "none" }
       }
     },
     {
@@ -770,6 +782,8 @@
     "signal.camera.ball.toggle",
     "signal.attract.round_reset",
     "signal.presentation.flash_border",
+    "signal.persistence.load",
+    "signal.persistence.save_options",
     "signal.ui.menu.move",
     "signal.ui.menu.select",
     "signal.app.quit_fade_done"
@@ -893,6 +907,18 @@
         ]
       },
       {
+        "signal": "signal.persistence.load",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.pong.load_persistence" }
+        ]
+      },
+      {
+        "signal": "signal.persistence.save_options",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.pong.save_options" }
+        ]
+      },
+      {
         "signal": "signal.game.start",
         "actions": [
           { "type": "timer.start", "timer": "timer.round.serve" }
@@ -992,6 +1018,7 @@
         "actions": [
           { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
           { "type": "property.set", "target": "entity.match", "key": "winner", "value": "player" },
+          { "type": "adapter.invoke", "adapter": "adapter.pong.record_player_win" },
           { "type": "entity.set_active", "target": "entity.ball", "active": false }
         ]
       },
@@ -1000,6 +1027,7 @@
         "actions": [
           { "type": "property.set", "target": "entity.match", "key": "finished", "value": true },
           { "type": "property.set", "target": "entity.match", "key": "winner", "value": "cpu" },
+          { "type": "adapter.invoke", "adapter": "adapter.pong.record_cpu_win" },
           { "type": "entity.set_active", "target": "entity.ball", "active": false }
         ]
       },
@@ -1091,6 +1119,34 @@
       "script": "script.pong",
       "function": "cpu_track_ball",
       "description": "Move the CPU paddle toward the current ball position."
+    },
+    {
+      "name": "adapter.pong.load_persistence",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "load_persistence",
+      "description": "Load persisted Pong options and score records from user storage."
+    },
+    {
+      "name": "adapter.pong.save_options",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "save_options",
+      "description": "Persist current Pong options to user storage."
+    },
+    {
+      "name": "adapter.pong.record_player_win",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "record_player_win",
+      "description": "Record a player match win in persistent score data."
+    },
+    {
+      "name": "adapter.pong.record_cpu_win",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "record_cpu_win",
+      "description": "Record a CPU match win in persistent score data."
     }
   ]
 }

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -27,6 +27,7 @@
       "items": [
         {
           "label": "Difficulty",
+          "signal": "signal.persistence.save_options",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -40,6 +41,7 @@
         },
         {
           "label": "Fullscreen",
+          "signal": "signal.persistence.save_options",
           "control": {
             "type": "toggle",
             "target": "entity.settings",
@@ -48,6 +50,7 @@
         },
         {
           "label": "Lighting",
+          "signal": "signal.persistence.save_options",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -61,6 +64,7 @@
         },
         {
           "label": "Input",
+          "signal": "signal.persistence.save_options",
           "control": {
             "type": "choice",
             "target": "entity.settings",

--- a/demos/pong/data/scenes/splash.scene.json
+++ b/demos/pong/data/scenes/splash.scene.json
@@ -19,6 +19,10 @@
     "events": [
       {
         "time": 0.0,
+        "action": { "type": "signal.emit", "signal": "signal.persistence.load" }
+      },
+      {
+        "time": 0.0,
         "action": { "type": "audio.set_bus_volume", "bus": "music", "volume": 1.0 }
       },
       {

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -1,5 +1,8 @@
 local pong = {}
 
+local options_path = "user://settings/options.json"
+local scores_path = "user://scores/pong_scores.json"
+
 local function random_signed_angle(ctx, min_angle, max_angle)
     if max_angle <= 0.0 then
         return 0.0
@@ -103,6 +106,141 @@ function pong.cpu_track_ball(paddle, payload, ctx)
     local next_y = math.clamp(paddle_position.y + step, -field_half_height + half_height, field_half_height - half_height)
     paddle.position = Vec3(paddle_position.x, next_y, paddle_position.z)
     return true
+end
+
+local function settings_actor(ctx)
+    return ctx:actor("entity.settings")
+end
+
+local function scores_actor(ctx)
+    return ctx:actor("entity.high_scores")
+end
+
+local function read_json(ctx, path)
+    local text = ctx.storage.read(path)
+    if text == nil or text == "" then
+        return nil
+    end
+    return sdl3d.json.decode(text)
+end
+
+local function write_json(ctx, path, value)
+    local text = sdl3d.json.encode(value)
+    if text == nil then
+        return false
+    end
+    return ctx.storage.write(path, text)
+end
+
+local function apply_options(settings, options)
+    if settings == nil or type(options) ~= "table" then
+        return
+    end
+    if type(options.difficulty) == "string" then
+        settings:set_string("difficulty", options.difficulty)
+    end
+    if type(options.lighting_profile) == "string" then
+        settings:set_string("lighting_profile", options.lighting_profile)
+    end
+    if type(options.input_style) == "string" then
+        settings:set_string("input_style", options.input_style)
+    end
+    if type(options.fullscreen) == "boolean" then
+        settings:set_bool("fullscreen", options.fullscreen)
+    end
+end
+
+local function current_options(settings)
+    return {
+        schema = "sdl3d.pong.options.v1",
+        difficulty = settings:get_string("difficulty", "normal"),
+        lighting_profile = settings:get_string("lighting_profile", "cinematic"),
+        input_style = settings:get_string("input_style", "keyboard"),
+        fullscreen = settings:get_bool("fullscreen", false),
+    }
+end
+
+local function apply_scores(scores, data)
+    if scores == nil or type(data) ~= "table" then
+        return
+    end
+    scores:set_int("player_wins", tonumber(data.player_wins) or 0)
+    scores:set_int("cpu_wins", tonumber(data.cpu_wins) or 0)
+    scores:set_int("matches_played", tonumber(data.matches_played) or 0)
+    if type(data.latest_winner) == "string" then
+        scores:set_string("latest_winner", data.latest_winner)
+    end
+end
+
+local function current_scores(scores)
+    return {
+        schema = "sdl3d.pong.scores.v1",
+        player_wins = scores:get_int("player_wins", 0),
+        cpu_wins = scores:get_int("cpu_wins", 0),
+        matches_played = scores:get_int("matches_played", 0),
+        latest_winner = scores:get_string("latest_winner", "none"),
+    }
+end
+
+local function save_scores(ctx, scores)
+    if scores == nil then
+        return false
+    end
+    return write_json(ctx, scores_path, current_scores(scores))
+end
+
+local function persistence_enabled(ctx)
+    local settings = settings_actor(ctx)
+    return settings ~= nil and settings:get_bool("persistence_enabled", false)
+end
+
+function pong.load_persistence(_, _, ctx)
+    local settings = settings_actor(ctx)
+    if settings ~= nil then
+        settings:set_bool("persistence_enabled", true)
+    end
+    apply_options(settings, read_json(ctx, options_path))
+    apply_scores(scores_actor(ctx), read_json(ctx, scores_path))
+    return true
+end
+
+function pong.save_options(_, _, ctx)
+    if not persistence_enabled(ctx) then
+        return true
+    end
+    local settings = settings_actor(ctx)
+    if settings == nil then
+        return false
+    end
+    return write_json(ctx, options_path, current_options(settings))
+end
+
+function pong.record_player_win(_, _, ctx)
+    if not persistence_enabled(ctx) then
+        return true
+    end
+    local scores = scores_actor(ctx)
+    if scores == nil then
+        return false
+    end
+    scores:set_int("player_wins", scores:get_int("player_wins", 0) + 1)
+    scores:set_int("matches_played", scores:get_int("matches_played", 0) + 1)
+    scores:set_string("latest_winner", "player")
+    return save_scores(ctx, scores)
+end
+
+function pong.record_cpu_win(_, _, ctx)
+    if not persistence_enabled(ctx) then
+        return true
+    end
+    local scores = scores_actor(ctx)
+    if scores == nil then
+        return false
+    end
+    scores:set_int("cpu_wins", scores:get_int("cpu_wins", 0) + 1)
+    scores:set_int("matches_played", scores:get_int("matches_played", 0) + 1)
+    scores:set_string("latest_winner", "cpu")
+    return save_scores(ctx, scores)
 end
 
 return pong

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -596,7 +596,8 @@ Lua adapters receive `(target, payload, ctx)`:
 - `payload` is a table copied from the signal payload or component payload.
 - `ctx` provides adapter context: `ctx.adapter`, `ctx.dt`, `ctx:actor(name)`,
   `ctx:actor_with_tags(...)`, `ctx:state_get(key, fallback)`,
-  `ctx:state_set(key, value)`, `ctx:random()`, and `ctx:log(message)`.
+  `ctx:state_set(key, value)`, `ctx:random()`, `ctx:log(message)`, and
+  `ctx.storage` safe access to `user://` and `cache://` paths.
 
 The preferred Lua API is intentionally game-script oriented. Scripts can check `sdl3d.api`, currently `sdl3d.lua.v1`, when they need to guard version-specific behavior:
 
@@ -606,7 +607,18 @@ ball.position = Vec3(0, 0, 0.12)
 ball.velocity = Vec3.normalize(ball.velocity) * speed
 ```
 
-Actor wrappers expose property helpers (`get_float`, `set_float`, `get_int`, `set_int`, `get_bool`, `set_bool`, `get_vec3`, `set_vec3`) plus `position` and `velocity` convenience fields. `Vec3` provides `new`, `length`, `normalize`, `clamp`, and arithmetic operators. `math.clamp` and `math.lerp` are also available. The lower-level `sdl3d.get_*` and `sdl3d.set_*` functions remain available as implementation primitives, but gameplay scripts should prefer the wrapper API.
+Actor wrappers expose property helpers (`get_float`, `set_float`, `get_int`, `set_int`, `get_bool`, `set_bool`, `get_string`, `set_string`, `get_vec3`, `set_vec3`) plus `position` and `velocity` convenience fields. `Vec3` provides `new`, `length`, `normalize`, `clamp`, and arithmetic operators. `math.clamp` and `math.lerp` are also available. The lower-level `sdl3d.get_*` and `sdl3d.set_*` functions remain available as implementation primitives, but gameplay scripts should prefer the wrapper API.
+
+Scripts can persist structured data through `sdl3d.json.decode(text)` and
+`sdl3d.json.encode(value)`. The JSON bridge accepts Lua booleans, numbers,
+strings, nil, array-like tables, and string-keyed object tables. It is intended
+for save files, settings, high scores, and other small gameplay data blobs:
+
+```lua
+local scores = sdl3d.json.decode(ctx.storage.read("user://scores/pong.json") or "{}")
+scores.player_wins = (scores.player_wins or 0) + 1
+ctx.storage.write("user://scores/pong.json", sdl3d.json.encode(scores))
+```
 
 Native C registration remains available for host applications that need engine-facing integrations or highly optimized behavior; re-registering an adapter name overrides the authored Lua binding.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -57,6 +57,15 @@ local text, read_err = sdl3d.storage.read("user://settings/options.json")
 local exists = sdl3d.storage.exists("cache://generated/status.txt")
 ```
 
+Scripts can pair storage with the gameplay JSON helpers when persisting
+structured settings, saves, scores, or generated cache metadata:
+
+```lua
+local options = sdl3d.json.decode(ctx.storage.read("user://settings/options.json") or "{}")
+options.fullscreen = true
+ctx.storage.write("user://settings/options.json", sdl3d.json.encode(options))
+```
+
 The adapter context exposes the same table as `ctx.storage`. These bindings use
 the storage API's normal validation, so scripts cannot escape through absolute
 paths, `..`, empty segments, backslashes, or unknown schemes.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -120,7 +120,7 @@ extern "C"
         const char *scene;     /**< Runtime-owned selected target scene, or NULL. */
         const char *return_to; /**< Runtime-owned scene to store as return target, or NULL. */
         int selected_index;    /**< Selected item index after this update, or -1. */
-        int signal_id;         /**< Selected signal id, or -1. */
+        int signal_id;         /**< Selected item signal id, including data-bound controls, or -1. */
         int move_signal_id;    /**< Menu navigation signal id emitted by the host, or -1. */
         int select_signal_id;  /**< Menu activation signal id emitted by the host, or -1. */
         sdl3d_game_data_menu_pause_command pause_command; /**< Pause command requested by selected item. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -23,6 +23,8 @@
 #include "sdl3d/timer_pool.h"
 #include "yyjson.h"
 
+#include <stdlib.h>
+
 #define SDL3D_GAME_DATA_SIGNAL_BASE 20000
 
 typedef enum game_data_sensor_type
@@ -460,6 +462,25 @@ static int lua_set_bool(lua_State *lua)
     return 0;
 }
 
+static int lua_get_string(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    sdl3d_registered_actor *actor = lua_actor_arg(lua, runtime, 1);
+    const char *key = luaL_checkstring(lua, 2);
+    const char *fallback = luaL_optstring(lua, 3, "");
+    lua_pushstring(lua, actor != NULL ? sdl3d_properties_get_string(actor->props, key, fallback) : fallback);
+    return 1;
+}
+
+static int lua_set_string(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    sdl3d_registered_actor *actor = lua_actor_arg(lua, runtime, 1);
+    if (actor != NULL)
+        sdl3d_properties_set_string(actor->props, luaL_checkstring(lua, 2), luaL_checkstring(lua, 3));
+    return 0;
+}
+
 static int lua_get_vec3(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
@@ -728,6 +749,222 @@ static int lua_storage_delete(lua_State *lua)
     return 1;
 }
 
+static void lua_push_json_value(lua_State *lua, yyjson_val *value, int depth)
+{
+    if (value == NULL || depth > 64)
+    {
+        lua_pushnil(lua);
+        return;
+    }
+    if (yyjson_is_null(value))
+    {
+        lua_pushnil(lua);
+    }
+    else if (yyjson_is_bool(value))
+    {
+        lua_pushboolean(lua, yyjson_get_bool(value));
+    }
+    else if (yyjson_is_int(value))
+    {
+        lua_pushinteger(lua, (lua_Integer)yyjson_get_sint(value));
+    }
+    else if (yyjson_is_num(value))
+    {
+        lua_pushnumber(lua, (lua_Number)yyjson_get_real(value));
+    }
+    else if (yyjson_is_str(value))
+    {
+        lua_pushlstring(lua, yyjson_get_str(value), yyjson_get_len(value));
+    }
+    else if (yyjson_is_arr(value))
+    {
+        lua_newtable(lua);
+        size_t idx, max;
+        yyjson_val *entry;
+        yyjson_arr_foreach(value, idx, max, entry)
+        {
+            lua_push_json_value(lua, entry, depth + 1);
+            lua_seti(lua, -2, (lua_Integer)idx + 1);
+        }
+    }
+    else if (yyjson_is_obj(value))
+    {
+        lua_newtable(lua);
+        size_t idx, max;
+        yyjson_val *key;
+        yyjson_val *val;
+        yyjson_obj_foreach(value, idx, max, key, val)
+        {
+            lua_push_json_value(lua, val, depth + 1);
+            lua_setfield(lua, -2, yyjson_get_str(key));
+        }
+    }
+    else
+    {
+        lua_pushnil(lua);
+    }
+}
+
+static bool lua_table_is_json_array(lua_State *lua, int index, lua_Integer *out_count)
+{
+    lua_Integer max_index = 0;
+    lua_Integer count = 0;
+    bool array = true;
+
+    lua_pushnil(lua);
+    while (lua_next(lua, index) != 0)
+    {
+        if (lua_isinteger(lua, -2))
+        {
+            const lua_Integer key = lua_tointeger(lua, -2);
+            if (key <= 0)
+                array = false;
+            else
+            {
+                ++count;
+                if (key > max_index)
+                    max_index = key;
+            }
+        }
+        else
+        {
+            array = false;
+        }
+        lua_pop(lua, 1);
+    }
+
+    if (out_count != NULL)
+        *out_count = array && max_index == count ? count : 0;
+    return array && max_index == count;
+}
+
+static yyjson_mut_val *lua_value_to_json(lua_State *lua, yyjson_mut_doc *doc, int index, int depth, char *error,
+                                         int error_size)
+{
+    if (depth > 64)
+    {
+        set_error(error, error_size, "JSON value is too deeply nested");
+        return NULL;
+    }
+
+    index = lua_absindex(lua, index);
+    if (lua_isnoneornil(lua, index))
+        return yyjson_mut_null(doc);
+    if (lua_isboolean(lua, index))
+        return yyjson_mut_bool(doc, lua_toboolean(lua, index));
+    if (lua_isinteger(lua, index))
+        return yyjson_mut_sint(doc, (int64_t)lua_tointeger(lua, index));
+    if (lua_isnumber(lua, index))
+        return yyjson_mut_real(doc, (double)lua_tonumber(lua, index));
+    if (lua_isstring(lua, index))
+    {
+        size_t len = 0u;
+        const char *text = lua_tolstring(lua, index, &len);
+        return yyjson_mut_strncpy(doc, text, len);
+    }
+    if (!lua_istable(lua, index))
+    {
+        set_error(error, error_size, "JSON encode supports nil, bool, number, string, and table values");
+        return NULL;
+    }
+
+    lua_Integer count = 0;
+    if (lua_table_is_json_array(lua, index, &count))
+    {
+        yyjson_mut_val *arr = yyjson_mut_arr(doc);
+        if (arr == NULL)
+            return NULL;
+        for (lua_Integer i = 1; i <= count; ++i)
+        {
+            lua_geti(lua, index, i);
+            yyjson_mut_val *item = lua_value_to_json(lua, doc, -1, depth + 1, error, error_size);
+            lua_pop(lua, 1);
+            if (item == NULL || !yyjson_mut_arr_add_val(arr, item))
+                return NULL;
+        }
+        return arr;
+    }
+
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    if (obj == NULL)
+        return NULL;
+
+    lua_pushnil(lua);
+    while (lua_next(lua, index) != 0)
+    {
+        if (!lua_isstring(lua, -2))
+        {
+            lua_pop(lua, 2);
+            set_error(error, error_size, "JSON object keys must be strings");
+            return NULL;
+        }
+        size_t key_len = 0u;
+        const char *key_text = lua_tolstring(lua, -2, &key_len);
+        yyjson_mut_val *key = yyjson_mut_strncpy(doc, key_text, key_len);
+        yyjson_mut_val *val = lua_value_to_json(lua, doc, -1, depth + 1, error, error_size);
+        lua_pop(lua, 1);
+        if (key == NULL || val == NULL || !yyjson_mut_obj_add(obj, key, val))
+            return NULL;
+    }
+    return obj;
+}
+
+static int lua_json_decode(lua_State *lua)
+{
+    size_t len = 0u;
+    const char *text = luaL_checklstring(lua, 1, &len);
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)(void *)(size_t)(const void *)text, len, YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        lua_pushnil(lua);
+        lua_pushfstring(lua, "yyjson error %d at byte %d: %s", (int)err.code, (int)err.pos,
+                        err.msg != NULL ? err.msg : "");
+        return 2;
+    }
+
+    lua_push_json_value(lua, yyjson_doc_get_root(doc), 0);
+    yyjson_doc_free(doc);
+    return 1;
+}
+
+static int lua_json_encode(lua_State *lua)
+{
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    if (doc == NULL)
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, "failed to allocate JSON document");
+        return 2;
+    }
+
+    char error[256];
+    error[0] = '\0';
+    yyjson_mut_val *root = lua_value_to_json(lua, doc, 1, 0, error, (int)sizeof(error));
+    if (root == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        lua_pushnil(lua);
+        lua_pushstring(lua, error[0] != '\0' ? error : "failed to encode JSON value");
+        return 2;
+    }
+
+    yyjson_mut_doc_set_root(doc, root);
+    size_t len = 0u;
+    char *json = yyjson_mut_write(doc, YYJSON_WRITE_NOFLAG, &len);
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, "failed to write JSON");
+        return 2;
+    }
+
+    lua_pushlstring(lua, json, len);
+    free(json);
+    return 1;
+}
+
 static void install_lua_helpers(lua_State *lua)
 {
     static const char *source_parts[] = {
@@ -784,6 +1021,8 @@ static void install_lua_helpers(lua_State *lua)
         "function Actor:set_int(key, value) sdl3d.set_int(self, key, value) end\n"
         "function Actor:get_bool(key, fallback) return sdl3d.get_bool(self, key, fallback or false) end\n"
         "function Actor:set_bool(key, value) sdl3d.set_bool(self, key, value and true or false) end\n"
+        "function Actor:get_string(key, fallback) return sdl3d.get_string(self, key, fallback or '') end\n"
+        "function Actor:set_string(key, value) sdl3d.set_string(self, key, value or '') end\n"
         "function Actor:get_vec3(key, fallback)\n"
         "    local x, y, z = sdl3d.get_vec3(self, key)\n"
         "    if x == nil then return fallback end\n"
@@ -854,6 +1093,10 @@ static void install_lua_helpers(lua_State *lua)
         "    mkdir = sdl3d.storage_mkdir,\n"
         "    delete = sdl3d.storage_delete,\n"
         "}\n"
+        "sdl3d.json = {\n"
+        "    decode = sdl3d.json_decode,\n"
+        "    encode = sdl3d.json_encode,\n"
+        "}\n"
         "sdl3d.Actor = Actor\n"
         "sdl3d.Vec3 = Vec3\n"
         "sdl3d.api = 'sdl3d.lua.v1'\n"
@@ -913,6 +1156,8 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("set_int", lua_set_int);
     SDL3D_LUA_BIND("get_bool", lua_get_bool);
     SDL3D_LUA_BIND("set_bool", lua_set_bool);
+    SDL3D_LUA_BIND("get_string", lua_get_string);
+    SDL3D_LUA_BIND("set_string", lua_set_string);
     SDL3D_LUA_BIND("get_vec3", lua_get_vec3);
     SDL3D_LUA_BIND("set_vec3", lua_set_vec3);
     SDL3D_LUA_BIND("dt", lua_get_dt);
@@ -926,6 +1171,8 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("storage_exists", lua_storage_exists);
     SDL3D_LUA_BIND("storage_mkdir", lua_storage_mkdir);
     SDL3D_LUA_BIND("storage_delete", lua_storage_delete);
+    SDL3D_LUA_BIND("json_decode", lua_json_decode);
+    SDL3D_LUA_BIND("json_encode", lua_json_encode);
 #undef SDL3D_LUA_BIND
     lua_setglobal(lua, "sdl3d");
     install_lua_helpers(lua);

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -737,7 +737,7 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
             out_result->scene = !out_result->control_changed ? item.scene : NULL;
             out_result->return_to = !out_result->control_changed ? item.return_to : NULL;
             out_result->return_scene = !out_result->control_changed && item.return_scene;
-            out_result->signal_id = !out_result->control_changed ? item.signal_id : -1;
+            out_result->signal_id = item.signal_id;
             out_result->pause_command =
                 !out_result->control_changed ? item.pause_command : SDL3D_GAME_DATA_MENU_PAUSE_NONE;
             out_result->has_return_paused = !out_result->control_changed && item.has_return_paused;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -154,6 +154,12 @@ std::string read_fixture_file(const char *filename)
     return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
 }
 
+std::string read_text(const std::filesystem::path &path)
+{
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
 std::filesystem::path unique_test_dir(const char *name)
 {
     const std::filesystem::path root = std::filesystem::temp_directory_path();
@@ -180,6 +186,31 @@ void write_text(const std::filesystem::path &path, const char *text)
     std::filesystem::create_directories(path.parent_path());
     std::ofstream out(path, std::ios::binary);
     out << text;
+}
+
+std::filesystem::path copy_pong_data_with_storage_overrides(const std::filesystem::path &dir,
+                                                            const std::filesystem::path &user_root,
+                                                            const std::filesystem::path &cache_root)
+{
+    const std::filesystem::path source = std::filesystem::path(SDL3D_PONG_DATA_PATH).parent_path();
+    const std::filesystem::path dest = dir / "pong_data";
+    std::filesystem::copy(source, dest,
+                          std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing);
+
+    const std::filesystem::path game_path = dest / "pong.game.json";
+    std::string game_json = read_text(game_path);
+    const std::string marker = R"json("profile": "default")json";
+    const std::string replacement = std::string(R"json("profile": "default",
+    "user_root_override": ")json") + user_root.generic_string() +
+                                    R"json(",
+    "cache_root_override": ")json" + cache_root.generic_string() +
+                                    R"json(")json";
+    const size_t marker_pos = game_json.find(marker);
+    if (marker_pos == std::string::npos)
+        throw std::runtime_error("Pong storage profile marker not found");
+    game_json.replace(marker_pos, marker.size(), replacement);
+    write_text(game_path, game_json.c_str());
+    return game_path;
 }
 
 void write_hot_reload_json(const std::filesystem::path &dir)
@@ -1654,6 +1685,47 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+
+    const int menu_select_signal = sdl3d_game_data_find_signal(runtime, "signal.ui.menu.select");
+    const int save_options_signal = sdl3d_game_data_find_signal(runtime, "signal.persistence.save_options");
+    ASSERT_GE(menu_select_signal, 0);
+    ASSERT_GE(save_options_signal, 0);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.selected);
+    EXPECT_TRUE(result.control_changed);
+    EXPECT_EQ(result.select_signal_id, menu_select_signal);
+    EXPECT_EQ(result.signal_id, save_options_signal);
+    EXPECT_EQ(result.scene, nullptr);
+
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
 {
     sdl3d_game_session *session = nullptr;
@@ -2861,7 +2933,13 @@ function storage.roundtrip(_, _, ctx)
     end
 
     local data = ctx.storage.read("user://settings/options.json")
-    if data ~= "{\"difficulty\":\"hard\"}" then
+    local decoded, decode_error = sdl3d.json.decode(data)
+    if decoded == nil or decode_error ~= nil or decoded.difficulty ~= "hard" then
+        return false
+    end
+    local encoded = sdl3d.json.encode({ difficulty = decoded.difficulty, enabled = true, values = { 1, 2, 3 } })
+    local roundtrip = sdl3d.json.decode(encoded)
+    if roundtrip == nil or roundtrip.enabled ~= true or roundtrip.values[2] ~= 2 then
         return false
     end
 
@@ -2872,7 +2950,7 @@ function storage.roundtrip(_, _, ctx)
         return false
     end
 
-    ctx:state_set("loaded_options", data)
+    ctx:state_set("loaded_options", roundtrip.difficulty .. ":" .. tostring(roundtrip.values[2]) .. ":" .. tostring(roundtrip.enabled))
     return true
 end
 
@@ -2931,13 +3009,104 @@ return storage
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), signal_id, nullptr);
 
     EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "loaded_options", ""),
-                 "{\"difficulty\":\"hard\"}");
+                 "hard:2:true");
     EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
     EXPECT_TRUE(std::filesystem::exists(cache_root / "script" / "status.txt"));
     EXPECT_FALSE(std::filesystem::exists(dir / "escape.txt"));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
+{
+    const std::filesystem::path dir = unique_test_dir("pong_persistence");
+    const std::filesystem::path user_root = dir / "user";
+    const std::filesystem::path cache_root = dir / "cache";
+    const std::filesystem::path game_path = copy_pong_data_with_storage_overrides(dir, user_root, cache_root);
+
+    auto emit = [](sdl3d_game_session *session, sdl3d_game_data_runtime *runtime, const char *signal) {
+        const int signal_id = sdl3d_game_data_find_signal(runtime, signal);
+        EXPECT_GE(signal_id, 0) << signal;
+        if (signal_id >= 0)
+            sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), signal_id, nullptr);
+    };
+
+    {
+        sdl3d_game_session *session = nullptr;
+        ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+        char error[512]{};
+        sdl3d_game_data_runtime *runtime = nullptr;
+        ASSERT_TRUE(sdl3d_game_data_load_file(game_path.string().c_str(), session, &runtime, error, sizeof(error)))
+            << error;
+
+        sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+        ASSERT_NE(settings, nullptr);
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "persistence_enabled", true));
+
+        sdl3d_properties_set_string(settings->props, "difficulty", "hard");
+        emit(session, runtime, "signal.persistence.save_options");
+        EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
+
+        emit(session, runtime, "signal.persistence.load");
+        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "persistence_enabled", false));
+
+        sdl3d_properties_set_string(settings->props, "difficulty", "hard");
+        sdl3d_properties_set_string(settings->props, "lighting_profile", "arcade");
+        sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
+        sdl3d_properties_set_bool(settings->props, "fullscreen", true);
+        emit(session, runtime, "signal.persistence.save_options");
+
+        emit(session, runtime, "signal.match.player_won");
+        sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");
+        ASSERT_NE(scores, nullptr);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "player_wins", 0), 1);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "matches_played", 0), 1);
+        EXPECT_STREQ(sdl3d_properties_get_string(scores->props, "latest_winner", ""), "player");
+
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+    }
+
+    EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
+    EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
+
+    {
+        sdl3d_game_session *session = nullptr;
+        ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+        char error[512]{};
+        sdl3d_game_data_runtime *runtime = nullptr;
+        ASSERT_TRUE(sdl3d_game_data_load_file(game_path.string().c_str(), session, &runtime, error, sizeof(error)))
+            << error;
+
+        emit(session, runtime, "signal.persistence.load");
+
+        sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+        ASSERT_NE(settings, nullptr);
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "arcade");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
+        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "fullscreen", false));
+
+        sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");
+        ASSERT_NE(scores, nullptr);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "player_wins", 0), 1);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "cpu_wins", -1), 0);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "matches_played", 0), 1);
+        EXPECT_STREQ(sdl3d_properties_get_string(scores->props, "latest_winner", ""), "player");
+
+        emit(session, runtime, "signal.match.cpu_won");
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "cpu_wins", 0), 1);
+        EXPECT_EQ(sdl3d_properties_get_int(scores->props, "matches_played", 0), 2);
+        EXPECT_STREQ(sdl3d_properties_get_string(scores->props, "latest_winner", ""), "cpu");
+
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+    }
+
     remove_test_dir(dir);
 }
 


### PR DESCRIPTION
## Summary
- add Lua JSON encode/decode helpers plus string actor property helpers for structured script persistence
- persist Pong options and high-score records through data-authored signals and Lua storage writes
- allow data-bound menu controls to emit item signals so options can save without host glue
- document the Lua storage/JSON scripting surface

## Tests
- cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j8
- ./build/release/tests/sdl3d_game_data_test
- ./build/release/tests/game_data_json_test
- git diff --check
- ctest --test-dir build/release --output-on-failure

Related to #143