### PR TITLE
Add data-driven professional options menu

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -697,7 +697,7 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
 static bool switch_demo_backend(sdl3d_game_context *ctx, doom_state *state)
 {
     sdl3d_backend next =
-        (state->current_backend == SDL3D_BACKEND_SDLGPU) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_SDLGPU;
+        (state->current_backend == SDL3D_BACKEND_OPENGL) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_OPENGL;
 
     if (sdl3d_switch_backend(&ctx->window, &ctx->renderer, next))
     {
@@ -1060,7 +1060,7 @@ int main(int argc, char *argv[])
     config.title = "SDL3D - Doom Level";
     config.width = WINDOW_W;
     config.height = WINDOW_H;
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.tick_rate = 1.0f / 60.0f;
     config.enable_audio = true;
 

--- a/demos/gui_demo/main.c
+++ b/demos/gui_demo/main.c
@@ -543,7 +543,7 @@ int main(int argc, char *argv[])
                 if (ev.key.scancode == SDL_SCANCODE_GRAVE)
                 {
                     sdl3d_backend cur = sdl3d_get_render_context_backend(ctx);
-                    sdl3d_backend next = (cur == SDL3D_BACKEND_SDLGPU) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_SDLGPU;
+                    sdl3d_backend next = (cur == SDL3D_BACKEND_OPENGL) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_OPENGL;
                     if (sdl3d_switch_backend(&win, &ctx, next))
                     {
                         SDL_StartTextInput(win);

--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -9,6 +9,10 @@ set(SDL3D_PONG_ASSET_FILES
     images/splash-logo.jpg
     pong.game.json
     scenes/options.scene.json
+    scenes/options_audio.scene.json
+    scenes/options_display.scene.json
+    scenes/options_gamepad.scene.json
+    scenes/options_keyboard.scene.json
     scenes/play.scene.json
     scenes/splash.scene.json
     scenes/title.scene.json

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -815,8 +815,18 @@
     "signal.presentation.flash_border",
     "signal.persistence.load",
     "signal.persistence.save_options",
+    "signal.settings.snapshot_all",
+    "signal.settings.snapshot_display",
+    "signal.settings.snapshot_keyboard",
+    "signal.settings.snapshot_gamepad",
+    "signal.settings.snapshot_audio",
     "signal.settings.apply",
     "signal.settings.apply_audio",
+    "signal.settings.cancel_all",
+    "signal.settings.cancel_display",
+    "signal.settings.cancel_keyboard",
+    "signal.settings.cancel_gamepad",
+    "signal.settings.cancel_audio",
     "signal.settings.reset_all",
     "signal.settings.reset_display",
     "signal.settings.reset_keyboard",
@@ -974,38 +984,95 @@
         ]
       },
       {
+        "signal": "signal.settings.snapshot_all",
+        "actions": [
+          { "type": "property.snapshot", "name": "options.all", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.snapshot_display",
+        "actions": [
+          { "type": "property.snapshot", "name": "options.display", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.snapshot_keyboard",
+        "actions": [
+          { "type": "property.snapshot", "name": "options.keyboard", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.snapshot_gamepad",
+        "actions": [
+          { "type": "property.snapshot", "name": "options.gamepad", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.snapshot_audio",
+        "actions": [
+          { "type": "property.snapshot", "name": "options.audio", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.cancel_all",
+        "actions": [
+          { "type": "property.restore_snapshot", "name": "options.all", "target": "entity.settings" },
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+        ]
+      },
+      {
+        "signal": "signal.settings.cancel_display",
+        "actions": [
+          { "type": "property.restore_snapshot", "name": "options.display", "target": "entity.settings" }
+        ]
+      },
+      {
+        "signal": "signal.settings.cancel_keyboard",
+        "actions": [
+          { "type": "property.restore_snapshot", "name": "options.keyboard", "target": "entity.settings" }
+        ]
+      },
+      {
+        "signal": "signal.settings.cancel_gamepad",
+        "actions": [
+          { "type": "property.restore_snapshot", "name": "options.gamepad", "target": "entity.settings" }
+        ]
+      },
+      {
+        "signal": "signal.settings.cancel_audio",
+        "actions": [
+          { "type": "property.restore_snapshot", "name": "options.audio", "target": "entity.settings" },
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+        ]
+      },
+      {
         "signal": "signal.settings.reset_all",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply" }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
         ]
       },
       {
         "signal": "signal.settings.reset_display",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply" }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
         ]
       },
       {
         "signal": "signal.settings.reset_keyboard",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply" }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] }
         ]
       },
       {
         "signal": "signal.settings.reset_gamepad",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply" }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] }
         ]
       },
       {
         "signal": "signal.settings.reset_audio",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply" }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -16,7 +16,6 @@
     "logical_width": 1280,
     "logical_height": 720,
     "backend": "software",
-    "settings_path": "user://settings/options.json",
     "window": {
       "display_mode": "fullscreen_borderless",
       "development_display_mode": "windowed",
@@ -750,7 +749,8 @@
         "music_volume": { "type": "float", "value": 1.0 },
         "dialogue_volume": { "type": "float", "value": 1.0 },
         "ambience_volume": { "type": "float", "value": 1.0 },
-        "persistence_enabled": { "type": "bool", "value": false }
+        "options_persistence_enabled": { "type": "bool", "value": false },
+        "score_persistence_enabled": { "type": "bool", "value": true }
       }
     },
     {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -248,7 +248,6 @@
           {
             "name": "action.paddle.up",
             "bindings": [
-              { "device": "keyboard", "key": "W" },
               { "device": "keyboard", "key": "UP" },
               { "device": "gamepad", "axis": "left_y", "scale": -1.0 }
             ]
@@ -256,7 +255,6 @@
           {
             "name": "action.paddle.down",
             "bindings": [
-              { "device": "keyboard", "key": "S" },
               { "device": "keyboard", "key": "DOWN" },
               { "device": "gamepad", "axis": "left_y", "scale": 1.0 }
             ]
@@ -272,7 +270,7 @@
           {
             "name": "action.exit",
             "bindings": [
-              { "device": "keyboard", "key": "ESCAPE" },
+              { "device": "keyboard", "key": "BACKSPACE" },
               { "device": "gamepad", "button": "BACK" }
             ]
           },
@@ -293,7 +291,6 @@
             "name": "action.menu.up",
             "bindings": [
               { "device": "keyboard", "key": "UP" },
-              { "device": "keyboard", "key": "W" },
               { "device": "gamepad", "button": "DPAD_UP" }
             ]
           },
@@ -301,7 +298,6 @@
             "name": "action.menu.down",
             "bindings": [
               { "device": "keyboard", "key": "DOWN" },
-              { "device": "keyboard", "key": "S" },
               { "device": "gamepad", "button": "DPAD_DOWN" }
             ]
           },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -25,6 +25,10 @@
       "vsync": true,
       "renderer": "opengl",
       "apply_signal": "signal.settings.apply",
+      "apply_signals": [
+        "signal.settings.apply",
+        "signal.settings.reset_display"
+      ],
       "settings": {
         "target": "entity.settings",
         "display_mode": "display_mode",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -744,8 +744,6 @@
       "active": true,
       "tags": ["state", "settings"],
       "properties": {
-        "difficulty": { "type": "string", "value": "normal" },
-        "lighting_profile": { "type": "string", "value": "cinematic" },
         "display_mode": { "type": "string", "value": "windowed" },
         "vsync": { "type": "bool", "value": true },
         "renderer": { "type": "string", "value": "opengl" },
@@ -826,19 +824,16 @@
     "signal.presentation.flash_border",
     "signal.persistence.load",
     "signal.persistence.save_options",
-    "signal.settings.snapshot_all",
     "signal.settings.snapshot_display",
     "signal.settings.snapshot_keyboard",
     "signal.settings.snapshot_gamepad",
     "signal.settings.snapshot_audio",
     "signal.settings.apply",
     "signal.settings.apply_audio",
-    "signal.settings.cancel_all",
     "signal.settings.cancel_display",
     "signal.settings.cancel_keyboard",
     "signal.settings.cancel_gamepad",
     "signal.settings.cancel_audio",
-    "signal.settings.reset_all",
     "signal.settings.reset_display",
     "signal.settings.reset_keyboard",
     "signal.settings.reset_gamepad",
@@ -995,12 +990,6 @@
         ]
       },
       {
-        "signal": "signal.settings.snapshot_all",
-        "actions": [
-          { "type": "property.snapshot", "name": "options.all", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
-        ]
-      },
-      {
         "signal": "signal.settings.snapshot_display",
         "actions": [
           { "type": "property.snapshot", "name": "options.display", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
@@ -1022,13 +1011,6 @@
         "signal": "signal.settings.snapshot_audio",
         "actions": [
           { "type": "property.snapshot", "name": "options.audio", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
-        ]
-      },
-      {
-        "signal": "signal.settings.cancel_all",
-        "actions": [
-          { "type": "property.restore_snapshot", "name": "options.all", "target": "entity.settings" },
-          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
         ]
       },
       {
@@ -1054,12 +1036,6 @@
         "actions": [
           { "type": "property.restore_snapshot", "name": "options.audio", "target": "entity.settings" },
           { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
-        ]
-      },
-      {
-        "signal": "signal.settings.reset_all",
-        "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -306,6 +306,22 @@
             ]
           },
           {
+            "name": "action.menu.left",
+            "bindings": [
+              { "device": "keyboard", "key": "LEFT" },
+              { "device": "keyboard", "key": "A" },
+              { "device": "gamepad", "button": "DPAD_LEFT" }
+            ]
+          },
+          {
+            "name": "action.menu.right",
+            "bindings": [
+              { "device": "keyboard", "key": "RIGHT" },
+              { "device": "keyboard", "key": "D" },
+              { "device": "gamepad", "button": "DPAD_RIGHT" }
+            ]
+          },
+          {
             "name": "action.menu.select",
             "bindings": [
               { "device": "keyboard", "key": "RETURN" },
@@ -754,10 +770,8 @@
         "keyboard_cancel": { "type": "string", "value": "escape_backspace" },
         "gamepad_icons": { "type": "string", "value": "xbox" },
         "vibration": { "type": "bool", "value": true },
-        "sfx_volume": { "type": "float", "value": 1.0 },
-        "music_volume": { "type": "float", "value": 1.0 },
-        "dialogue_volume": { "type": "float", "value": 1.0 },
-        "ambience_volume": { "type": "float", "value": 1.0 },
+        "sfx_volume": { "type": "int", "value": 8 },
+        "music_volume": { "type": "int", "value": 7 },
         "options_persistence_enabled": { "type": "bool", "value": false },
         "score_persistence_enabled": { "type": "bool", "value": true }
       }
@@ -983,10 +997,8 @@
       {
         "signal": "signal.settings.apply_audio",
         "actions": [
-          { "type": "audio.set_bus_volume", "bus": "sfx", "source": { "target": "entity.settings", "key": "sfx_volume" } },
-          { "type": "audio.set_bus_volume", "bus": "music", "source": { "target": "entity.settings", "key": "music_volume" } },
-          { "type": "audio.set_bus_volume", "bus": "dialogue", "source": { "target": "entity.settings", "key": "dialogue_volume" } },
-          { "type": "audio.set_bus_volume", "bus": "ambience", "source": { "target": "entity.settings", "key": "ambience_volume" } }
+          { "type": "audio.set_bus_volume", "bus": "sfx", "source": { "target": "entity.settings", "key": "sfx_volume", "scale": 0.1 } },
+          { "type": "audio.set_bus_volume", "bus": "music", "source": { "target": "entity.settings", "key": "music_volume", "scale": 0.1 } }
         ]
       },
       {
@@ -1010,7 +1022,7 @@
       {
         "signal": "signal.settings.snapshot_audio",
         "actions": [
-          { "type": "property.snapshot", "name": "options.audio", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
+          { "type": "property.snapshot", "name": "options.audio", "target": "entity.settings", "keys": ["sfx_volume", "music_volume"] }
         ]
       },
       {
@@ -1059,7 +1071,8 @@
       {
         "signal": "signal.settings.reset_audio",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -763,11 +763,6 @@
         "display_mode": { "type": "string", "value": "windowed" },
         "vsync": { "type": "bool", "value": true },
         "renderer": { "type": "string", "value": "opengl" },
-        "input_style": { "type": "string", "value": "keyboard" },
-        "keyboard_preset": { "type": "string", "value": "xbox_parity" },
-        "keyboard_move": { "type": "string", "value": "wasd" },
-        "keyboard_confirm": { "type": "string", "value": "enter_space" },
-        "keyboard_cancel": { "type": "string", "value": "escape_backspace" },
         "gamepad_icons": { "type": "string", "value": "xbox" },
         "vibration": { "type": "bool", "value": true },
         "sfx_volume": { "type": "int", "value": 8 },
@@ -839,13 +834,11 @@
     "signal.persistence.load",
     "signal.persistence.save_options",
     "signal.settings.snapshot_display",
-    "signal.settings.snapshot_keyboard",
     "signal.settings.snapshot_gamepad",
     "signal.settings.snapshot_audio",
     "signal.settings.apply",
     "signal.settings.apply_audio",
     "signal.settings.cancel_display",
-    "signal.settings.cancel_keyboard",
     "signal.settings.cancel_gamepad",
     "signal.settings.cancel_audio",
     "signal.settings.reset_display",
@@ -1008,12 +1001,6 @@
         ]
       },
       {
-        "signal": "signal.settings.snapshot_keyboard",
-        "actions": [
-          { "type": "property.snapshot", "name": "options.keyboard", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] }
-        ]
-      },
-      {
         "signal": "signal.settings.snapshot_gamepad",
         "actions": [
           { "type": "property.snapshot", "name": "options.gamepad", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] }
@@ -1029,12 +1016,6 @@
         "signal": "signal.settings.cancel_display",
         "actions": [
           { "type": "property.restore_snapshot", "name": "options.display", "target": "entity.settings" }
-        ]
-      },
-      {
-        "signal": "signal.settings.cancel_keyboard",
-        "actions": [
-          { "type": "property.restore_snapshot", "name": "options.keyboard", "target": "entity.settings" }
         ]
       },
       {
@@ -1059,7 +1040,7 @@
       {
         "signal": "signal.settings.reset_keyboard",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] }
+          { "type": "input.reset_key_bindings", "menu": "menu.options.keyboard" }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -23,7 +23,14 @@
       "maximized": true,
       "resizable": true,
       "vsync": true,
-      "renderer": "opengl"
+      "renderer": "opengl",
+      "apply_signal": "signal.settings.apply",
+      "settings": {
+        "target": "entity.settings",
+        "display_mode": "display_mode",
+        "vsync": "vsync",
+        "renderer": "renderer"
+      }
     },
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -15,15 +15,15 @@
     "title": "SDL3D Pong",
     "logical_width": 1280,
     "logical_height": 720,
-    "backend": "software",
+    "backend": "opengl",
     "window": {
-      "display_mode": "fullscreen_borderless",
+      "display_mode": "windowed",
       "development_display_mode": "windowed",
-      "production_display_mode": "fullscreen_borderless",
+      "production_display_mode": "windowed",
       "maximized": true,
       "resizable": true,
       "vsync": true,
-      "renderer": "software"
+      "renderer": "opengl"
     },
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
@@ -735,9 +735,9 @@
       "properties": {
         "difficulty": { "type": "string", "value": "normal" },
         "lighting_profile": { "type": "string", "value": "cinematic" },
-        "display_mode": { "type": "string", "value": "fullscreen_borderless" },
+        "display_mode": { "type": "string", "value": "windowed" },
         "vsync": { "type": "bool", "value": true },
-        "renderer": { "type": "string", "value": "software" },
+        "renderer": { "type": "string", "value": "opengl" },
         "input_style": { "type": "string", "value": "keyboard" },
         "keyboard_preset": { "type": "string", "value": "xbox_parity" },
         "keyboard_move": { "type": "string", "value": "wasd" },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -249,6 +249,7 @@
             "name": "action.paddle.up",
             "bindings": [
               { "device": "keyboard", "key": "UP" },
+              { "device": "gamepad", "button": "DPAD_UP" },
               { "device": "gamepad", "axis": "left_y", "scale": -1.0 }
             ]
           },
@@ -256,6 +257,7 @@
             "name": "action.paddle.down",
             "bindings": [
               { "device": "keyboard", "key": "DOWN" },
+              { "device": "gamepad", "button": "DPAD_DOWN" },
               { "device": "gamepad", "axis": "left_y", "scale": 1.0 }
             ]
           },
@@ -284,7 +286,8 @@
           {
             "name": "action.camera.ball.toggle",
             "bindings": [
-              { "device": "keyboard", "key": "B" }
+              { "device": "keyboard", "key": "B" },
+              { "device": "gamepad", "button": "NORTH" }
             ]
           },
           {
@@ -1036,13 +1039,14 @@
       {
         "signal": "signal.settings.reset_keyboard",
         "actions": [
-          { "type": "input.reset_key_bindings", "menu": "menu.options.keyboard" }
+          { "type": "input.reset_bindings", "menu": "menu.options.keyboard" }
         ]
       },
       {
         "signal": "signal.settings.reset_gamepad",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
+          { "type": "input.reset_bindings", "menu": "menu.options.gamepad" }
         ]
       },
       {

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -13,9 +13,19 @@
   },
   "app": {
     "title": "SDL3D Pong",
-    "width": 1280,
-    "height": 720,
-    "backend": "auto",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "software",
+    "settings_path": "user://settings/options.json",
+    "window": {
+      "display_mode": "fullscreen_borderless",
+      "development_display_mode": "windowed",
+      "production_display_mode": "fullscreen_borderless",
+      "maximized": true,
+      "resizable": true,
+      "vsync": true,
+      "renderer": "software"
+    },
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
     "enable_audio": true,
@@ -60,6 +70,10 @@
       "scenes/splash.scene.json",
       "scenes/title.scene.json",
       "scenes/options.scene.json",
+      "scenes/options_display.scene.json",
+      "scenes/options_keyboard.scene.json",
+      "scenes/options_gamepad.scene.json",
+      "scenes/options_audio.scene.json",
       "scenes/play.scene.json"
     ]
   },
@@ -147,6 +161,11 @@
         "id": "font.hud",
         "builtin": "Inter",
         "size": 34
+      },
+      {
+        "id": "font.small",
+        "builtin": "Inter",
+        "size": 22
       },
       {
         "id": "font.title",
@@ -717,8 +736,20 @@
       "properties": {
         "difficulty": { "type": "string", "value": "normal" },
         "lighting_profile": { "type": "string", "value": "cinematic" },
-        "fullscreen": { "type": "bool", "value": false },
+        "display_mode": { "type": "string", "value": "fullscreen_borderless" },
+        "vsync": { "type": "bool", "value": true },
+        "renderer": { "type": "string", "value": "software" },
         "input_style": { "type": "string", "value": "keyboard" },
+        "keyboard_preset": { "type": "string", "value": "xbox_parity" },
+        "keyboard_move": { "type": "string", "value": "wasd" },
+        "keyboard_confirm": { "type": "string", "value": "enter_space" },
+        "keyboard_cancel": { "type": "string", "value": "escape_backspace" },
+        "gamepad_icons": { "type": "string", "value": "xbox" },
+        "vibration": { "type": "bool", "value": true },
+        "sfx_volume": { "type": "float", "value": 1.0 },
+        "music_volume": { "type": "float", "value": 1.0 },
+        "dialogue_volume": { "type": "float", "value": 1.0 },
+        "ambience_volume": { "type": "float", "value": 1.0 },
         "persistence_enabled": { "type": "bool", "value": false }
       }
     },
@@ -784,6 +815,13 @@
     "signal.presentation.flash_border",
     "signal.persistence.load",
     "signal.persistence.save_options",
+    "signal.settings.apply",
+    "signal.settings.apply_audio",
+    "signal.settings.reset_all",
+    "signal.settings.reset_display",
+    "signal.settings.reset_keyboard",
+    "signal.settings.reset_gamepad",
+    "signal.settings.reset_audio",
     "signal.ui.menu.move",
     "signal.ui.menu.select",
     "signal.app.quit_fade_done"
@@ -909,13 +947,65 @@
       {
         "signal": "signal.persistence.load",
         "actions": [
-          { "type": "adapter.invoke", "adapter": "adapter.pong.load_persistence" }
+          { "type": "adapter.invoke", "adapter": "adapter.pong.load_persistence" },
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
         ]
       },
       {
         "signal": "signal.persistence.save_options",
         "actions": [
           { "type": "adapter.invoke", "adapter": "adapter.pong.save_options" }
+        ]
+      },
+      {
+        "signal": "signal.settings.apply",
+        "actions": [
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" },
+          { "type": "signal.emit", "signal": "signal.persistence.save_options" }
+        ]
+      },
+      {
+        "signal": "signal.settings.apply_audio",
+        "actions": [
+          { "type": "audio.set_bus_volume", "bus": "sfx", "source": { "target": "entity.settings", "key": "sfx_volume" } },
+          { "type": "audio.set_bus_volume", "bus": "music", "source": { "target": "entity.settings", "key": "music_volume" } },
+          { "type": "audio.set_bus_volume", "bus": "dialogue", "source": { "target": "entity.settings", "key": "dialogue_volume" } },
+          { "type": "audio.set_bus_volume", "bus": "ambience", "source": { "target": "entity.settings", "key": "ambience_volume" } }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_all",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["difficulty", "lighting_profile", "display_mode", "vsync", "renderer", "input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel", "gamepad_icons", "vibration", "sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_display",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_keyboard",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["input_style", "keyboard_preset", "keyboard_move", "keyboard_confirm", "keyboard_cancel"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_gamepad",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_audio",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume", "dialogue_volume", "ambience_volume"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply" }
         ]
       },
       {

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -1,6 +1,7 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options",
+  "on_enter_signal": "signal.settings.snapshot_all",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -31,7 +32,6 @@
         { "label": "Audio", "scene": "scene.options.audio", "return_to": "scene.options" },
         {
           "label": "Gameplay",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -45,7 +45,6 @@
         },
         {
           "label": "Lighting",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -57,8 +56,10 @@
             ]
           }
         },
+        { "label": "Apply", "signal": "signal.settings.apply", "return_scene": true, "scene": "scene.title" },
+        { "label": "Cancel", "signal": "signal.settings.cancel_all", "return_scene": true, "scene": "scene.title" },
         { "label": "Reset All Defaults", "signal": "signal.settings.reset_all" },
-        { "label": "Back", "return_scene": true, "scene": "scene.title" }
+        { "label": "Back", "signal": "signal.settings.cancel_all", "return_scene": true, "scene": "scene.title" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -26,10 +26,10 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Display", "scene": "scene.options.display", "return_to": "scene.options" },
-        { "label": "Keyboard", "scene": "scene.options.keyboard", "return_to": "scene.options" },
-        { "label": "Gamepad", "scene": "scene.options.gamepad", "return_to": "scene.options" },
-        { "label": "Audio", "scene": "scene.options.audio", "return_to": "scene.options" },
+        { "label": "Display", "scene": "scene.options.display" },
+        { "label": "Keyboard", "scene": "scene.options.keyboard" },
+        { "label": "Gamepad", "scene": "scene.options.gamepad" },
+        { "label": "Audio", "scene": "scene.options.audio" },
         {
           "label": "Gameplay",
           "control": {

--- a/demos/pong/data/scenes/options.scene.json
+++ b/demos/pong/data/scenes/options.scene.json
@@ -1,7 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options",
-  "on_enter_signal": "signal.settings.snapshot_all",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -30,36 +29,7 @@
         { "label": "Keyboard", "scene": "scene.options.keyboard" },
         { "label": "Gamepad", "scene": "scene.options.gamepad" },
         { "label": "Audio", "scene": "scene.options.audio" },
-        {
-          "label": "Gameplay",
-          "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "difficulty",
-            "choices": [
-              { "label": "Easy", "value": "easy" },
-              { "label": "Normal", "value": "normal" },
-              { "label": "Hard", "value": "hard" }
-            ]
-          }
-        },
-        {
-          "label": "Lighting",
-          "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "lighting_profile",
-            "choices": [
-              { "label": "Clean", "value": "clean" },
-              { "label": "Cinematic", "value": "cinematic" },
-              { "label": "Arcade", "value": "arcade" }
-            ]
-          }
-        },
-        { "label": "Apply", "signal": "signal.settings.apply", "return_scene": true, "scene": "scene.title" },
-        { "label": "Cancel", "signal": "signal.settings.cancel_all", "return_scene": true, "scene": "scene.title" },
-        { "label": "Reset All Defaults", "signal": "signal.settings.reset_all" },
-        { "label": "Back", "signal": "signal.settings.cancel_all", "return_scene": true, "scene": "scene.title" }
+        { "label": "Back", "return_scene": true, "scene": "scene.title" }
       ]
     }
   ],
@@ -82,8 +52,8 @@
         "menu": "menu.options",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.31,
-        "gap": 0.064,
+        "y": 0.36,
+        "gap": 0.078,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],

--- a/demos/pong/data/scenes/options_audio.scene.json
+++ b/demos/pong/data/scenes/options_audio.scene.json
@@ -1,6 +1,7 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.audio",
+  "on_enter_signal": "signal.settings.snapshot_audio",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -27,7 +28,6 @@
       "items": [
         {
           "label": "Sound Effects",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "range",
             "target": "entity.settings",
@@ -39,7 +39,6 @@
         },
         {
           "label": "Music",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "range",
             "target": "entity.settings",
@@ -51,7 +50,6 @@
         },
         {
           "label": "Dialogue",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "range",
             "target": "entity.settings",
@@ -63,7 +61,6 @@
         },
         {
           "label": "Ambience",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "range",
             "target": "entity.settings",
@@ -73,8 +70,10 @@
             "step": 0.1
           }
         },
+        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
+        { "label": "Cancel", "signal": "signal.settings.cancel_audio", "scene": "scene.options" },
         { "label": "Reset Audio Defaults", "signal": "signal.settings.reset_audio" },
-        { "label": "Back", "scene": "scene.options" }
+        { "label": "Back", "signal": "signal.settings.cancel_audio", "scene": "scene.options" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/options_audio.scene.json
+++ b/demos/pong/data/scenes/options_audio.scene.json
@@ -9,6 +9,8 @@
     "actions": [
       "action.menu.up",
       "action.menu.down",
+      "action.menu.left",
+      "action.menu.right",
       "action.menu.select"
     ]
   },
@@ -21,6 +23,8 @@
       "name": "menu.options.audio",
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
+      "left_action": "action.menu.left",
+      "right_action": "action.menu.right",
       "select_action": "action.menu.select",
       "move_signal": "signal.ui.menu.move",
       "select_signal": "signal.ui.menu.select",
@@ -28,52 +32,36 @@
       "items": [
         {
           "label": "Sound Effects",
+          "signal": "signal.settings.apply_audio",
           "control": {
             "type": "range",
             "target": "entity.settings",
             "key": "sfx_volume",
-            "min": 0.0,
-            "max": 1.0,
-            "step": 0.1
+            "value_type": "int",
+            "display": "slider",
+            "min": 0,
+            "max": 10,
+            "step": 1,
+            "default": 8
           }
         },
         {
           "label": "Music",
+          "signal": "signal.settings.apply_audio",
           "control": {
             "type": "range",
             "target": "entity.settings",
             "key": "music_volume",
-            "min": 0.0,
-            "max": 1.0,
-            "step": 0.1
+            "value_type": "int",
+            "display": "slider",
+            "min": 0,
+            "max": 10,
+            "step": 1,
+            "default": 7
           }
         },
-        {
-          "label": "Dialogue",
-          "control": {
-            "type": "range",
-            "target": "entity.settings",
-            "key": "dialogue_volume",
-            "min": 0.0,
-            "max": 1.0,
-            "step": 0.1
-          }
-        },
-        {
-          "label": "Ambience",
-          "control": {
-            "type": "range",
-            "target": "entity.settings",
-            "key": "ambience_volume",
-            "min": 0.0,
-            "max": 1.0,
-            "step": 0.1
-          }
-        },
-        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
-        { "label": "Cancel", "signal": "signal.settings.cancel_audio", "scene": "scene.options" },
-        { "label": "Reset Audio Defaults", "signal": "signal.settings.reset_audio" },
-        { "label": "Back", "signal": "signal.settings.cancel_audio", "scene": "scene.options" }
+        { "label": "Reset Settings", "signal": "signal.settings.reset_audio" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
@@ -96,8 +84,8 @@
         "menu": "menu.options.audio",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.34,
-        "gap": 0.068,
+        "y": 0.39,
+        "gap": 0.078,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],

--- a/demos/pong/data/scenes/options_audio.scene.json
+++ b/demos/pong/data/scenes/options_audio.scene.json
@@ -1,6 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
-  "name": "scene.options",
+  "name": "scene.options.audio",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -17,7 +17,7 @@
   },
   "menus": [
     {
-      "name": "menu.options",
+      "name": "menu.options.audio",
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
       "select_action": "action.menu.select",
@@ -25,49 +25,65 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Display", "scene": "scene.options.display", "return_to": "scene.options" },
-        { "label": "Keyboard", "scene": "scene.options.keyboard", "return_to": "scene.options" },
-        { "label": "Gamepad", "scene": "scene.options.gamepad", "return_to": "scene.options" },
-        { "label": "Audio", "scene": "scene.options.audio", "return_to": "scene.options" },
         {
-          "label": "Gameplay",
+          "label": "Sound Effects",
           "signal": "signal.settings.apply",
           "control": {
-            "type": "choice",
+            "type": "range",
             "target": "entity.settings",
-            "key": "difficulty",
-            "choices": [
-              { "label": "Easy", "value": "easy" },
-              { "label": "Normal", "value": "normal" },
-              { "label": "Hard", "value": "hard" }
-            ]
+            "key": "sfx_volume",
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.1
           }
         },
         {
-          "label": "Lighting",
+          "label": "Music",
           "signal": "signal.settings.apply",
           "control": {
-            "type": "choice",
+            "type": "range",
             "target": "entity.settings",
-            "key": "lighting_profile",
-            "choices": [
-              { "label": "Clean", "value": "clean" },
-              { "label": "Cinematic", "value": "cinematic" },
-              { "label": "Arcade", "value": "arcade" }
-            ]
+            "key": "music_volume",
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.1
           }
         },
-        { "label": "Reset All Defaults", "signal": "signal.settings.reset_all" },
-        { "label": "Back", "return_scene": true, "scene": "scene.title" }
+        {
+          "label": "Dialogue",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "range",
+            "target": "entity.settings",
+            "key": "dialogue_volume",
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.1
+          }
+        },
+        {
+          "label": "Ambience",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "range",
+            "target": "entity.settings",
+            "key": "ambience_volume",
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.1
+          }
+        },
+        { "label": "Reset Audio Defaults", "signal": "signal.settings.reset_audio" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
   "ui": {
     "text": [
       {
-        "name": "ui.options.title",
+        "name": "ui.options.audio.title",
         "font": "font.title",
-        "text": "OPTIONS",
+        "text": "AUDIO",
         "x": 0.5,
         "y": 0.18,
         "normalized": true,
@@ -77,12 +93,12 @@
     ],
     "menus": [
       {
-        "name": "ui.options.menu",
-        "menu": "menu.options",
+        "name": "ui.options.audio.menu",
+        "menu": "menu.options.audio",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.31,
-        "gap": 0.064,
+        "y": 0.34,
+        "gap": 0.068,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],
@@ -90,7 +106,7 @@
         "selected_pulse_alpha": true,
         "cursor": {
           "text": ">",
-          "offset_x": -0.14,
+          "offset_x": -0.18,
           "align": "center",
           "color": [255, 222, 140, 255]
         }

--- a/demos/pong/data/scenes/options_display.scene.json
+++ b/demos/pong/data/scenes/options_display.scene.json
@@ -1,6 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
-  "name": "scene.options",
+  "name": "scene.options.display",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -17,7 +17,7 @@
   },
   "menus": [
     {
-      "name": "menu.options",
+      "name": "menu.options.display",
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
       "select_action": "action.menu.select",
@@ -25,64 +25,78 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Display", "scene": "scene.options.display", "return_to": "scene.options" },
-        { "label": "Keyboard", "scene": "scene.options.keyboard", "return_to": "scene.options" },
-        { "label": "Gamepad", "scene": "scene.options.gamepad", "return_to": "scene.options" },
-        { "label": "Audio", "scene": "scene.options.audio", "return_to": "scene.options" },
         {
-          "label": "Gameplay",
+          "label": "Display Mode",
           "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
-            "key": "difficulty",
+            "key": "display_mode",
             "choices": [
-              { "label": "Easy", "value": "easy" },
-              { "label": "Normal", "value": "normal" },
-              { "label": "Hard", "value": "hard" }
+              { "label": "Windowed", "value": "windowed" },
+              { "label": "Fullscreen Exclusive", "value": "fullscreen_exclusive" },
+              { "label": "Fullscreen Borderless", "value": "fullscreen_borderless" }
             ]
           }
         },
         {
-          "label": "Lighting",
+          "label": "Vsync",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "toggle",
+            "target": "entity.settings",
+            "key": "vsync"
+          }
+        },
+        {
+          "label": "Renderer",
           "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
-            "key": "lighting_profile",
+            "key": "renderer",
             "choices": [
-              { "label": "Clean", "value": "clean" },
-              { "label": "Cinematic", "value": "cinematic" },
-              { "label": "Arcade", "value": "arcade" }
+              { "label": "Software", "value": "software" },
+              { "label": "OpenGL", "value": "opengl" }
             ]
           }
         },
-        { "label": "Reset All Defaults", "signal": "signal.settings.reset_all" },
-        { "label": "Back", "return_scene": true, "scene": "scene.title" }
+        { "label": "Reset Display Defaults", "signal": "signal.settings.reset_display" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
   "ui": {
     "text": [
       {
-        "name": "ui.options.title",
+        "name": "ui.options.display.title",
         "font": "font.title",
-        "text": "OPTIONS",
+        "text": "DISPLAY",
         "x": 0.5,
-        "y": 0.18,
+        "y": 0.20,
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.options.display.note",
+        "font": "font.small",
+        "text": "Display changes apply next launch.",
+        "x": 0.5,
+        "y": 0.82,
+        "normalized": true,
+        "centered": true,
+        "color": [160, 182, 220, 210]
       }
     ],
     "menus": [
       {
-        "name": "ui.options.menu",
-        "menu": "menu.options",
+        "name": "ui.options.display.menu",
+        "menu": "menu.options.display",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.31,
-        "gap": 0.064,
+        "y": 0.38,
+        "gap": 0.074,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],
@@ -90,7 +104,7 @@
         "selected_pulse_alpha": true,
         "cursor": {
           "text": ">",
-          "offset_x": -0.14,
+          "offset_x": -0.18,
           "align": "center",
           "color": [255, 222, 140, 255]
         }

--- a/demos/pong/data/scenes/options_display.scene.json
+++ b/demos/pong/data/scenes/options_display.scene.json
@@ -28,6 +28,7 @@
       "items": [
         {
           "label": "Display Mode",
+          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -41,6 +42,7 @@
         },
         {
           "label": "Vsync",
+          "signal": "signal.settings.apply",
           "control": {
             "type": "toggle",
             "target": "entity.settings",
@@ -49,6 +51,7 @@
         },
         {
           "label": "Renderer",
+          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -59,10 +62,8 @@
             ]
           }
         },
-        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
-        { "label": "Cancel", "signal": "signal.settings.cancel_display", "scene": "scene.options" },
-        { "label": "Reset Display Defaults", "signal": "signal.settings.reset_display" },
-        { "label": "Back", "signal": "signal.settings.cancel_display", "scene": "scene.options" }
+        { "label": "Reset Settings", "signal": "signal.settings.reset_display" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/options_display.scene.json
+++ b/demos/pong/data/scenes/options_display.scene.json
@@ -1,6 +1,7 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.display",
+  "on_enter_signal": "signal.settings.snapshot_display",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -27,7 +28,6 @@
       "items": [
         {
           "label": "Display Mode",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -41,7 +41,6 @@
         },
         {
           "label": "Vsync",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "toggle",
             "target": "entity.settings",
@@ -50,7 +49,6 @@
         },
         {
           "label": "Renderer",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -61,8 +59,10 @@
             ]
           }
         },
+        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
+        { "label": "Cancel", "signal": "signal.settings.cancel_display", "scene": "scene.options" },
         { "label": "Reset Display Defaults", "signal": "signal.settings.reset_display" },
-        { "label": "Back", "scene": "scene.options" }
+        { "label": "Back", "signal": "signal.settings.cancel_display", "scene": "scene.options" }
       ]
     }
   ],
@@ -77,16 +77,6 @@
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
-      },
-      {
-        "name": "ui.options.display.note",
-        "font": "font.small",
-        "text": "Display changes apply next launch.",
-        "x": 0.5,
-        "y": 0.82,
-        "normalized": true,
-        "centered": true,
-        "color": [160, 182, 220, 210]
       }
     ],
     "menus": [

--- a/demos/pong/data/scenes/options_gamepad.scene.json
+++ b/demos/pong/data/scenes/options_gamepad.scene.json
@@ -1,7 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.gamepad",
-  "on_enter_signal": "signal.settings.snapshot_gamepad",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -9,6 +8,8 @@
     "actions": [
       "action.menu.up",
       "action.menu.down",
+      "action.menu.left",
+      "action.menu.right",
       "action.menu.select"
     ]
   },
@@ -21,6 +22,8 @@
       "name": "menu.options.gamepad",
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
+      "left_action": "action.menu.left",
+      "right_action": "action.menu.right",
       "select_action": "action.menu.select",
       "move_signal": "signal.ui.menu.move",
       "select_signal": "signal.ui.menu.select",
@@ -47,10 +50,91 @@
             "key": "vibration"
           }
         },
-        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
-        { "label": "Cancel", "signal": "signal.settings.cancel_gamepad", "scene": "scene.options" },
-        { "label": "Reset Gamepad Defaults", "signal": "signal.settings.reset_gamepad" },
-        { "label": "Back", "signal": "signal.settings.cancel_gamepad", "scene": "scene.options" }
+        {
+          "label": "Up",
+          "control": {
+            "type": "key_binding",
+            "default": "DPAD_UP",
+            "bindings": [
+              { "action": "action.paddle.up", "device": "gamepad" },
+              { "action": "action.menu.up", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Down",
+          "control": {
+            "type": "key_binding",
+            "default": "DPAD_DOWN",
+            "bindings": [
+              { "action": "action.paddle.down", "device": "gamepad" },
+              { "action": "action.menu.down", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Left",
+          "control": {
+            "type": "key_binding",
+            "default": "DPAD_LEFT",
+            "bindings": [
+              { "action": "action.menu.left", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Right",
+          "control": {
+            "type": "key_binding",
+            "default": "DPAD_RIGHT",
+            "bindings": [
+              { "action": "action.menu.right", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Accept",
+          "control": {
+            "type": "key_binding",
+            "default": "SOUTH",
+            "bindings": [
+              { "action": "action.menu.select", "device": "gamepad" },
+              { "action": "action.restart", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Cancel",
+          "control": {
+            "type": "key_binding",
+            "default": "BACK",
+            "bindings": [
+              { "action": "action.exit", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Pause",
+          "control": {
+            "type": "key_binding",
+            "default": "START",
+            "bindings": [
+              { "action": "action.pause", "device": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Ball Camera",
+          "control": {
+            "type": "key_binding",
+            "default": "NORTH",
+            "bindings": [
+              { "action": "action.camera.ball.toggle", "device": "gamepad" }
+            ]
+          }
+        },
+        { "label": "Reset Settings", "signal": "signal.settings.reset_gamepad" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
@@ -61,10 +145,23 @@
         "font": "font.title",
         "text": "GAMEPAD",
         "x": 0.5,
-        "y": 0.20,
+        "y": 0.12,
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.options.gamepad.status",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "scene_state", "key": "gamepad_binding_status" }
+        ],
+        "x": 0.5,
+        "y": 0.88,
+        "normalized": true,
+        "centered": true,
+        "color": [172, 206, 255, 220]
       }
     ],
     "menus": [
@@ -73,8 +170,8 @@
         "menu": "menu.options.gamepad",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.38,
-        "gap": 0.078,
+        "y": 0.22,
+        "gap": 0.052,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],

--- a/demos/pong/data/scenes/options_gamepad.scene.json
+++ b/demos/pong/data/scenes/options_gamepad.scene.json
@@ -1,6 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
-  "name": "scene.options",
+  "name": "scene.options.gamepad",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -17,7 +17,7 @@
   },
   "menus": [
     {
-      "name": "menu.options",
+      "name": "menu.options.gamepad",
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
       "select_action": "action.menu.select",
@@ -25,51 +25,42 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Display", "scene": "scene.options.display", "return_to": "scene.options" },
-        { "label": "Keyboard", "scene": "scene.options.keyboard", "return_to": "scene.options" },
-        { "label": "Gamepad", "scene": "scene.options.gamepad", "return_to": "scene.options" },
-        { "label": "Audio", "scene": "scene.options.audio", "return_to": "scene.options" },
         {
-          "label": "Gameplay",
+          "label": "Button Icons",
           "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
-            "key": "difficulty",
+            "key": "gamepad_icons",
             "choices": [
-              { "label": "Easy", "value": "easy" },
-              { "label": "Normal", "value": "normal" },
-              { "label": "Hard", "value": "hard" }
+              { "label": "Xbox", "value": "xbox" },
+              { "label": "Nintendo", "value": "nintendo" },
+              { "label": "PlayStation", "value": "playstation" }
             ]
           }
         },
         {
-          "label": "Lighting",
+          "label": "Vibration",
           "signal": "signal.settings.apply",
           "control": {
-            "type": "choice",
+            "type": "toggle",
             "target": "entity.settings",
-            "key": "lighting_profile",
-            "choices": [
-              { "label": "Clean", "value": "clean" },
-              { "label": "Cinematic", "value": "cinematic" },
-              { "label": "Arcade", "value": "arcade" }
-            ]
+            "key": "vibration"
           }
         },
-        { "label": "Reset All Defaults", "signal": "signal.settings.reset_all" },
-        { "label": "Back", "return_scene": true, "scene": "scene.title" }
+        { "label": "Reset Gamepad Defaults", "signal": "signal.settings.reset_gamepad" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
   "ui": {
     "text": [
       {
-        "name": "ui.options.title",
+        "name": "ui.options.gamepad.title",
         "font": "font.title",
-        "text": "OPTIONS",
+        "text": "GAMEPAD",
         "x": 0.5,
-        "y": 0.18,
+        "y": 0.20,
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
@@ -77,12 +68,12 @@
     ],
     "menus": [
       {
-        "name": "ui.options.menu",
-        "menu": "menu.options",
+        "name": "ui.options.gamepad.menu",
+        "menu": "menu.options.gamepad",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.31,
-        "gap": 0.064,
+        "y": 0.38,
+        "gap": 0.078,
         "normalized": true,
         "align": "center",
         "color": [225, 236, 255, 245],
@@ -90,7 +81,7 @@
         "selected_pulse_alpha": true,
         "cursor": {
           "text": ">",
-          "offset_x": -0.14,
+          "offset_x": -0.18,
           "align": "center",
           "color": [255, 222, 140, 255]
         }

--- a/demos/pong/data/scenes/options_gamepad.scene.json
+++ b/demos/pong/data/scenes/options_gamepad.scene.json
@@ -1,6 +1,7 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.gamepad",
+  "on_enter_signal": "signal.settings.snapshot_gamepad",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -27,7 +28,6 @@
       "items": [
         {
           "label": "Button Icons",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -41,15 +41,16 @@
         },
         {
           "label": "Vibration",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "toggle",
             "target": "entity.settings",
             "key": "vibration"
           }
         },
+        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
+        { "label": "Cancel", "signal": "signal.settings.cancel_gamepad", "scene": "scene.options" },
         { "label": "Reset Gamepad Defaults", "signal": "signal.settings.reset_gamepad" },
-        { "label": "Back", "scene": "scene.options" }
+        { "label": "Back", "signal": "signal.settings.cancel_gamepad", "scene": "scene.options" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/options_keyboard.scene.json
+++ b/demos/pong/data/scenes/options_keyboard.scene.json
@@ -1,6 +1,7 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.keyboard",
+  "on_enter_signal": "signal.settings.snapshot_keyboard",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -27,7 +28,6 @@
       "items": [
         {
           "label": "Input Style",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -40,7 +40,6 @@
         },
         {
           "label": "Preset",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -53,7 +52,6 @@
         },
         {
           "label": "Move",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -66,7 +64,6 @@
         },
         {
           "label": "Confirm",
-          "signal": "signal.settings.apply",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -78,8 +75,7 @@
           }
         },
         {
-          "label": "Cancel",
-          "signal": "signal.settings.apply",
+          "label": "Cancel Button",
           "control": {
             "type": "choice",
             "target": "entity.settings",
@@ -90,8 +86,10 @@
             ]
           }
         },
+        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
+        { "label": "Cancel Changes", "signal": "signal.settings.cancel_keyboard", "scene": "scene.options" },
         { "label": "Reset Keyboard Defaults", "signal": "signal.settings.reset_keyboard" },
-        { "label": "Back", "scene": "scene.options" }
+        { "label": "Back", "signal": "signal.settings.cancel_keyboard", "scene": "scene.options" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/options_keyboard.scene.json
+++ b/demos/pong/data/scenes/options_keyboard.scene.json
@@ -1,7 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.keyboard",
-  "on_enter_signal": "signal.settings.snapshot_keyboard",
   "updates_game": false,
   "renders_world": false,
   "entities": [],
@@ -27,69 +26,82 @@
       "selected": 0,
       "items": [
         {
-          "label": "Input Style",
+          "label": "Up",
           "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "input_style",
-            "choices": [
-              { "label": "Keyboard", "value": "keyboard" },
-              { "label": "Gamepad", "value": "gamepad" }
+            "type": "key_binding",
+            "default": "W",
+            "bindings": [
+              { "action": "action.paddle.up", "device": "keyboard" },
+              { "action": "action.menu.up", "device": "keyboard" }
             ]
           }
         },
         {
-          "label": "Preset",
+          "label": "Down",
           "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "keyboard_preset",
-            "choices": [
-              { "label": "Xbox Parity", "value": "xbox_parity" },
-              { "label": "Classic PC", "value": "classic_pc" }
+            "type": "key_binding",
+            "default": "S",
+            "bindings": [
+              { "action": "action.paddle.down", "device": "keyboard" },
+              { "action": "action.menu.down", "device": "keyboard" }
             ]
           }
         },
         {
-          "label": "Move",
+          "label": "Left",
           "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "keyboard_move",
-            "choices": [
-              { "label": "WASD", "value": "wasd" },
-              { "label": "Arrow Keys", "value": "arrows" }
+            "type": "key_binding",
+            "default": "A",
+            "bindings": [
+              { "action": "action.menu.left", "device": "keyboard" }
             ]
           }
         },
         {
-          "label": "Confirm",
+          "label": "Right",
           "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "keyboard_confirm",
-            "choices": [
-              { "label": "Enter / Space", "value": "enter_space" },
-              { "label": "Z / Enter", "value": "z_enter" }
+            "type": "key_binding",
+            "default": "D",
+            "bindings": [
+              { "action": "action.menu.right", "device": "keyboard" }
             ]
           }
         },
         {
-          "label": "Cancel Button",
+          "label": "Accept",
           "control": {
-            "type": "choice",
-            "target": "entity.settings",
-            "key": "keyboard_cancel",
-            "choices": [
-              { "label": "Escape / Backspace", "value": "escape_backspace" },
-              { "label": "X / Escape", "value": "x_escape" }
+            "type": "key_binding",
+            "default": "RETURN",
+            "bindings": [
+              { "action": "action.menu.select", "device": "keyboard" },
+              { "action": "action.pause", "device": "keyboard" },
+              { "action": "action.restart", "device": "keyboard" }
             ]
           }
         },
-        { "label": "Apply", "signal": "signal.settings.apply", "scene": "scene.options" },
-        { "label": "Cancel Changes", "signal": "signal.settings.cancel_keyboard", "scene": "scene.options" },
-        { "label": "Reset Keyboard Defaults", "signal": "signal.settings.reset_keyboard" },
-        { "label": "Back", "signal": "signal.settings.cancel_keyboard", "scene": "scene.options" }
+        {
+          "label": "Cancel",
+          "control": {
+            "type": "key_binding",
+            "default": "ESCAPE",
+            "allow_escape": true,
+            "bindings": [
+              { "action": "action.exit", "device": "keyboard" }
+            ]
+          }
+        },
+        {
+          "label": "Ball Camera",
+          "control": {
+            "type": "key_binding",
+            "default": "B",
+            "bindings": [
+              { "action": "action.camera.ball.toggle", "device": "keyboard" }
+            ]
+          }
+        },
+        { "label": "Reset Settings", "signal": "signal.settings.reset_keyboard" },
+        { "label": "Back", "scene": "scene.options" }
       ]
     }
   ],
@@ -100,10 +112,23 @@
         "font": "font.title",
         "text": "KEYBOARD",
         "x": 0.5,
-        "y": 0.16,
+        "y": 0.13,
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.options.keyboard.status",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "scene_state", "key": "keyboard_binding_status" }
+        ],
+        "x": 0.5,
+        "y": 0.88,
+        "normalized": true,
+        "centered": true,
+        "color": [255, 222, 140, 230]
       }
     ],
     "menus": [
@@ -112,7 +137,7 @@
         "menu": "menu.options.keyboard",
         "font": "font.hud",
         "x": 0.5,
-        "y": 0.31,
+        "y": 0.25,
         "gap": 0.062,
         "normalized": true,
         "align": "center",

--- a/demos/pong/data/scenes/options_keyboard.scene.json
+++ b/demos/pong/data/scenes/options_keyboard.scene.json
@@ -29,7 +29,7 @@
           "label": "Up",
           "control": {
             "type": "key_binding",
-            "default": "W",
+            "default": "UP",
             "bindings": [
               { "action": "action.paddle.up", "device": "keyboard" },
               { "action": "action.menu.up", "device": "keyboard" }
@@ -40,7 +40,7 @@
           "label": "Down",
           "control": {
             "type": "key_binding",
-            "default": "S",
+            "default": "DOWN",
             "bindings": [
               { "action": "action.paddle.down", "device": "keyboard" },
               { "action": "action.menu.down", "device": "keyboard" }
@@ -83,8 +83,7 @@
           "label": "Cancel",
           "control": {
             "type": "key_binding",
-            "default": "ESCAPE",
-            "allow_escape": true,
+            "default": "BACKSPACE",
             "bindings": [
               { "action": "action.exit", "device": "keyboard" }
             ]

--- a/demos/pong/data/scenes/options_keyboard.scene.json
+++ b/demos/pong/data/scenes/options_keyboard.scene.json
@@ -1,0 +1,133 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.options.keyboard",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.options.keyboard",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        {
+          "label": "Input Style",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "input_style",
+            "choices": [
+              { "label": "Keyboard", "value": "keyboard" },
+              { "label": "Gamepad", "value": "gamepad" }
+            ]
+          }
+        },
+        {
+          "label": "Preset",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "keyboard_preset",
+            "choices": [
+              { "label": "Xbox Parity", "value": "xbox_parity" },
+              { "label": "Classic PC", "value": "classic_pc" }
+            ]
+          }
+        },
+        {
+          "label": "Move",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "keyboard_move",
+            "choices": [
+              { "label": "WASD", "value": "wasd" },
+              { "label": "Arrow Keys", "value": "arrows" }
+            ]
+          }
+        },
+        {
+          "label": "Confirm",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "keyboard_confirm",
+            "choices": [
+              { "label": "Enter / Space", "value": "enter_space" },
+              { "label": "Z / Enter", "value": "z_enter" }
+            ]
+          }
+        },
+        {
+          "label": "Cancel",
+          "signal": "signal.settings.apply",
+          "control": {
+            "type": "choice",
+            "target": "entity.settings",
+            "key": "keyboard_cancel",
+            "choices": [
+              { "label": "Escape / Backspace", "value": "escape_backspace" },
+              { "label": "X / Escape", "value": "x_escape" }
+            ]
+          }
+        },
+        { "label": "Reset Keyboard Defaults", "signal": "signal.settings.reset_keyboard" },
+        { "label": "Back", "scene": "scene.options" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.options.keyboard.title",
+        "font": "font.title",
+        "text": "KEYBOARD",
+        "x": 0.5,
+        "y": 0.16,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.options.keyboard.menu",
+        "menu": "menu.options.keyboard",
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.31,
+        "gap": 0.062,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.18,
+          "align": "center",
+          "color": [255, 222, 140, 255]
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -239,23 +239,29 @@ local function save_scores(ctx, scores)
     return write_json(ctx, scores_path, current_scores(scores))
 end
 
-local function persistence_enabled(ctx)
+local function options_persistence_enabled(ctx)
     local settings = settings_actor(ctx)
-    return settings ~= nil and settings:get_bool("persistence_enabled", false)
+    return settings ~= nil and settings:get_bool("options_persistence_enabled", false)
+end
+
+local function score_persistence_enabled(ctx)
+    local settings = settings_actor(ctx)
+    return settings ~= nil and settings:get_bool("score_persistence_enabled", false)
 end
 
 function pong.load_persistence(_, _, ctx)
     local settings = settings_actor(ctx)
-    if settings ~= nil then
-        settings:set_bool("persistence_enabled", true)
+    if options_persistence_enabled(ctx) then
+        apply_options(settings, read_json(ctx, options_path))
     end
-    apply_options(settings, read_json(ctx, options_path))
-    apply_scores(scores_actor(ctx), read_json(ctx, scores_path))
+    if score_persistence_enabled(ctx) then
+        apply_scores(scores_actor(ctx), read_json(ctx, scores_path))
+    end
     return true
 end
 
 function pong.save_options(_, _, ctx)
-    if not persistence_enabled(ctx) then
+    if not options_persistence_enabled(ctx) then
         return true
     end
     local settings = settings_actor(ctx)
@@ -266,7 +272,7 @@ function pong.save_options(_, _, ctx)
 end
 
 function pong.record_player_win(_, _, ctx)
-    if not persistence_enabled(ctx) then
+    if not score_persistence_enabled(ctx) then
         return true
     end
     local scores = scores_actor(ctx)
@@ -280,7 +286,7 @@ function pong.record_player_win(_, _, ctx)
 end
 
 function pong.record_cpu_win(_, _, ctx)
-    if not persistence_enabled(ctx) then
+    if not score_persistence_enabled(ctx) then
         return true
     end
     local scores = scores_actor(ctx)

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -136,12 +136,6 @@ local function apply_options(settings, options)
     if settings == nil or type(options) ~= "table" then
         return
     end
-    if type(options.difficulty) == "string" then
-        settings:set_string("difficulty", options.difficulty)
-    end
-    if type(options.lighting_profile) == "string" then
-        settings:set_string("lighting_profile", options.lighting_profile)
-    end
     if type(options.display_mode) == "string" then
         settings:set_string("display_mode", options.display_mode)
     elseif type(options.fullscreen) == "boolean" then
@@ -191,8 +185,6 @@ end
 local function current_options(settings)
     return {
         schema = "sdl3d.pong.options.v1",
-        difficulty = settings:get_string("difficulty", "normal"),
-        lighting_profile = settings:get_string("lighting_profile", "cinematic"),
         display_mode = settings:get_string("display_mode", "fullscreen_borderless"),
         vsync = settings:get_bool("vsync", true),
         renderer = settings:get_string("renderer", "software"),

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -142,11 +142,49 @@ local function apply_options(settings, options)
     if type(options.lighting_profile) == "string" then
         settings:set_string("lighting_profile", options.lighting_profile)
     end
+    if type(options.display_mode) == "string" then
+        settings:set_string("display_mode", options.display_mode)
+    elseif type(options.fullscreen) == "boolean" then
+        settings:set_string("display_mode", options.fullscreen and "fullscreen_borderless" or "windowed")
+    end
+    if type(options.vsync) == "boolean" then
+        settings:set_bool("vsync", options.vsync)
+    end
+    if type(options.renderer) == "string" then
+        settings:set_string("renderer", options.renderer)
+    end
     if type(options.input_style) == "string" then
         settings:set_string("input_style", options.input_style)
     end
-    if type(options.fullscreen) == "boolean" then
-        settings:set_bool("fullscreen", options.fullscreen)
+    if type(options.keyboard_preset) == "string" then
+        settings:set_string("keyboard_preset", options.keyboard_preset)
+    end
+    if type(options.keyboard_move) == "string" then
+        settings:set_string("keyboard_move", options.keyboard_move)
+    end
+    if type(options.keyboard_confirm) == "string" then
+        settings:set_string("keyboard_confirm", options.keyboard_confirm)
+    end
+    if type(options.keyboard_cancel) == "string" then
+        settings:set_string("keyboard_cancel", options.keyboard_cancel)
+    end
+    if type(options.gamepad_icons) == "string" then
+        settings:set_string("gamepad_icons", options.gamepad_icons)
+    end
+    if type(options.vibration) == "boolean" then
+        settings:set_bool("vibration", options.vibration)
+    end
+    if type(options.sfx_volume) == "number" then
+        settings:set_float("sfx_volume", math.clamp(options.sfx_volume, 0.0, 1.0))
+    end
+    if type(options.music_volume) == "number" then
+        settings:set_float("music_volume", math.clamp(options.music_volume, 0.0, 1.0))
+    end
+    if type(options.dialogue_volume) == "number" then
+        settings:set_float("dialogue_volume", math.clamp(options.dialogue_volume, 0.0, 1.0))
+    end
+    if type(options.ambience_volume) == "number" then
+        settings:set_float("ambience_volume", math.clamp(options.ambience_volume, 0.0, 1.0))
     end
 end
 
@@ -155,8 +193,20 @@ local function current_options(settings)
         schema = "sdl3d.pong.options.v1",
         difficulty = settings:get_string("difficulty", "normal"),
         lighting_profile = settings:get_string("lighting_profile", "cinematic"),
+        display_mode = settings:get_string("display_mode", "fullscreen_borderless"),
+        vsync = settings:get_bool("vsync", true),
+        renderer = settings:get_string("renderer", "software"),
         input_style = settings:get_string("input_style", "keyboard"),
-        fullscreen = settings:get_bool("fullscreen", false),
+        keyboard_preset = settings:get_string("keyboard_preset", "xbox_parity"),
+        keyboard_move = settings:get_string("keyboard_move", "wasd"),
+        keyboard_confirm = settings:get_string("keyboard_confirm", "enter_space"),
+        keyboard_cancel = settings:get_string("keyboard_cancel", "escape_backspace"),
+        gamepad_icons = settings:get_string("gamepad_icons", "xbox"),
+        vibration = settings:get_bool("vibration", true),
+        sfx_volume = settings:get_float("sfx_volume", 1.0),
+        music_volume = settings:get_float("music_volume", 1.0),
+        dialogue_volume = settings:get_float("dialogue_volume", 1.0),
+        ambience_volume = settings:get_float("ambience_volume", 1.0),
     }
 end
 

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -169,16 +169,10 @@ local function apply_options(settings, options)
         settings:set_bool("vibration", options.vibration)
     end
     if type(options.sfx_volume) == "number" then
-        settings:set_float("sfx_volume", math.clamp(options.sfx_volume, 0.0, 1.0))
+        settings:set_int("sfx_volume", math.floor(math.clamp(options.sfx_volume, 0, 10) + 0.5))
     end
     if type(options.music_volume) == "number" then
-        settings:set_float("music_volume", math.clamp(options.music_volume, 0.0, 1.0))
-    end
-    if type(options.dialogue_volume) == "number" then
-        settings:set_float("dialogue_volume", math.clamp(options.dialogue_volume, 0.0, 1.0))
-    end
-    if type(options.ambience_volume) == "number" then
-        settings:set_float("ambience_volume", math.clamp(options.ambience_volume, 0.0, 1.0))
+        settings:set_int("music_volume", math.floor(math.clamp(options.music_volume, 0, 10) + 0.5))
     end
 end
 
@@ -195,10 +189,8 @@ local function current_options(settings)
         keyboard_cancel = settings:get_string("keyboard_cancel", "escape_backspace"),
         gamepad_icons = settings:get_string("gamepad_icons", "xbox"),
         vibration = settings:get_bool("vibration", true),
-        sfx_volume = settings:get_float("sfx_volume", 1.0),
-        music_volume = settings:get_float("music_volume", 1.0),
-        dialogue_volume = settings:get_float("dialogue_volume", 1.0),
-        ambience_volume = settings:get_float("ambience_volume", 1.0),
+        sfx_volume = settings:get_int("sfx_volume", 8),
+        music_volume = settings:get_int("music_volume", 7),
     }
 end
 

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -147,21 +147,6 @@ local function apply_options(settings, options)
     if type(options.renderer) == "string" then
         settings:set_string("renderer", options.renderer)
     end
-    if type(options.input_style) == "string" then
-        settings:set_string("input_style", options.input_style)
-    end
-    if type(options.keyboard_preset) == "string" then
-        settings:set_string("keyboard_preset", options.keyboard_preset)
-    end
-    if type(options.keyboard_move) == "string" then
-        settings:set_string("keyboard_move", options.keyboard_move)
-    end
-    if type(options.keyboard_confirm) == "string" then
-        settings:set_string("keyboard_confirm", options.keyboard_confirm)
-    end
-    if type(options.keyboard_cancel) == "string" then
-        settings:set_string("keyboard_cancel", options.keyboard_cancel)
-    end
     if type(options.gamepad_icons) == "string" then
         settings:set_string("gamepad_icons", options.gamepad_icons)
     end
@@ -182,11 +167,6 @@ local function current_options(settings)
         display_mode = settings:get_string("display_mode", "fullscreen_borderless"),
         vsync = settings:get_bool("vsync", true),
         renderer = settings:get_string("renderer", "software"),
-        input_style = settings:get_string("input_style", "keyboard"),
-        keyboard_preset = settings:get_string("keyboard_preset", "xbox_parity"),
-        keyboard_move = settings:get_string("keyboard_move", "wasd"),
-        keyboard_confirm = settings:get_string("keyboard_confirm", "enter_space"),
-        keyboard_cancel = settings:get_string("keyboard_cancel", "escape_backspace"),
         gamepad_icons = settings:get_string("gamepad_icons", "xbox"),
         vibration = settings:get_bool("vibration", true),
         sfx_volume = settings:get_int("sfx_volume", 8),

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -108,7 +108,14 @@ The optional `app` object lets a managed-loop game declare startup settings befo
       "maximized": true,
       "resizable": true,
       "vsync": true,
-      "renderer": "software"
+      "renderer": "software",
+      "apply_signal": "signal.settings.apply",
+      "settings": {
+        "target": "entity.settings",
+        "display_mode": "display_mode",
+        "renderer": "renderer",
+        "vsync": "vsync"
+      }
     },
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
@@ -153,6 +160,9 @@ runtime ownership of the renderer. Games read these descriptors and decide how t
 presentation are policy, not game-world scale. `app.window` can author display mode, renderer, vsync, title/icon
 overrides, and development/production display-mode defaults. `settings_path`, when present, lets startup read persisted
 display options such as `display_mode`, `renderer`, and `vsync` before creating the window.
+`app.window.apply_signal`, when present, lets the reusable app-flow helper apply live window settings from the
+configured settings actor after a menu emits that signal. The helper applies display mode and V-sync in place and
+recreates the window/render context when the renderer backend changes.
 `app.pause.action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
 `app.pause.allowed_if` is optional; when present, the app-flow helper evaluates it before entering pause.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -293,10 +293,44 @@ Menu items can also author generic settings controls and emit data-authored sign
 
 Supported control types are `toggle`, `choice`, and `range`. The generic menu
 controller applies these controls directly to actor properties and the menu UI
-presenter displays the current value. Settings menus that need Apply/Cancel
-behavior can snapshot the edited properties when a scene opens, let controls
-stage values in those actor properties, then either persist the staged values or
-restore the snapshot:
+presenter displays the current value. A menu can author `left_action` and
+`right_action` so range and choice controls can be adjusted without activating
+navigation items:
+
+```json
+{
+  "name": "menu.options.audio",
+  "up_action": "action.menu.up",
+  "down_action": "action.menu.down",
+  "left_action": "action.menu.left",
+  "right_action": "action.menu.right",
+  "select_action": "action.menu.select",
+  "items": [
+    {
+      "label": "Music",
+      "signal": "signal.settings.apply_audio",
+      "control": {
+        "type": "range",
+        "target": "entity.settings",
+        "key": "music_volume",
+        "value_type": "int",
+        "display": "slider",
+        "min": 0,
+        "max": 10,
+        "step": 1,
+        "default": 7
+      }
+    }
+  ]
+}
+```
+
+Range controls clamp to their authored min/max. Adding `"value_type": "int"`
+stores the result as an integer property; adding `"display": "slider"` renders
+the menu value as a compact slider label. Settings menus that need Apply/Cancel
+behavior can still snapshot the edited properties when a scene opens, let
+controls stage values in those actor properties, then either persist the staged
+values or restore the snapshot:
 
 ```json
 {
@@ -326,13 +360,14 @@ Settings screens can reset authored defaults without game-specific code:
 ```
 
 Audio bus volume can also be driven from actor properties so options menus can
-share one generic settings actor:
+share one generic settings actor. Use `source.scale` when the authored setting
+uses player-facing integer units rather than normalized engine volume:
 
 ```json
 {
   "type": "audio.set_bus_volume",
   "bus": "music",
-  "source": { "target": "entity.settings", "key": "music_volume" }
+  "source": { "target": "entity.settings", "key": "music_volume", "scale": 0.1 }
 }
 ```
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -22,7 +22,7 @@ Every file is a JSON object with these fields:
 | `schema` | yes | Schema id. First value: `sdl3d.game.v0`. |
 | `metadata` | yes | Human-readable identity and versioning. |
 | `storage` | no | Writable storage identity used to resolve `user://` and `cache://` roots. |
-| `app` | no | Managed-loop startup config such as title, window size, backend, tick rate, and tick cap. |
+| `app` | no | Managed-loop startup config such as title, logical resolution, window mode, backend, tick rate, and tick cap. |
 | `profiles` | no | Genre/profile hints and required modules. |
 | `assets` | no | Stable asset ids mapped to paths or future archive refs. |
 | `scripts` | no | Lua scripts that provide game-specific behavior used by adapters. |
@@ -96,9 +96,20 @@ The optional `app` object lets a managed-loop game declare startup settings befo
 {
   "app": {
     "title": "SDL3D Pong",
-    "width": 1280,
-    "height": 720,
-    "backend": "auto",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "software",
+    "icon_path": "media/icons/game.png",
+    "settings_path": "user://settings/options.json",
+    "window": {
+      "display_mode": "fullscreen_borderless",
+      "development_display_mode": "windowed",
+      "production_display_mode": "fullscreen_borderless",
+      "maximized": true,
+      "resizable": true,
+      "vsync": true,
+      "renderer": "software"
+    },
     "tick_rate": 0.008333333,
     "max_ticks_per_frame": 12,
     "start_signal": "signal.game.start",
@@ -138,6 +149,10 @@ The optional `render`, `transitions`, and `ui` sections describe presentation wi
 runtime ownership of the renderer. Games read these descriptors and decide how to apply them.
 
 `start_signal` lets data kick off initial timers or scripted startup logic after the host has loaded the runtime.
+`app.logical_width` and `app.logical_height` define the game's virtual resolution; desktop window size and fullscreen
+presentation are policy, not game-world scale. `app.window` can author display mode, renderer, vsync, title/icon
+overrides, and development/production display-mode defaults. `settings_path`, when present, lets startup read persisted
+display options such as `display_mode`, `renderer`, and `vsync` before creating the window.
 `app.pause.action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
 `app.pause.allowed_if` is optional; when present, the app-flow helper evaluates it before entering pause.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes
@@ -245,11 +260,12 @@ selected styling, and cursor styling:
 
 This keeps title/options/menu screens data-authored: the input menu defines
 choices and actions, while the UI presenter defines how the choices are laid out.
-Menu items can also author generic settings controls:
+Menu items can also author generic settings controls and emit data-authored signals when a value changes:
 
 ```json
 {
   "label": "Difficulty",
+  "signal": "signal.settings.apply",
   "control": {
     "type": "choice",
     "target": "entity.settings",
@@ -266,6 +282,27 @@ Menu items can also author generic settings controls:
 Supported control types are `toggle`, `choice`, and `range`. The generic menu
 controller applies these controls directly to actor properties and the menu UI
 presenter displays the current value.
+
+Settings screens can reset authored defaults without game-specific code:
+
+```json
+{
+  "type": "property.reset_defaults",
+  "target": "entity.settings",
+  "keys": ["display_mode", "vsync", "renderer"]
+}
+```
+
+Audio bus volume can also be driven from actor properties so options menus can
+share one generic settings actor:
+
+```json
+{
+  "type": "audio.set_bus_volume",
+  "bus": "music",
+  "source": { "target": "entity.settings", "key": "music_volume" }
+}
+```
 
 ## Scenes
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -240,7 +240,8 @@ UI descriptors can bind text to engine metrics or actor properties and can use g
 }
 ```
 
-Supported UI binding sources are `metric` (`fps`, `frame`, `paused`) and `property`.
+Supported UI binding sources are `metric` (`fps`, `frame`, `paused`), `property`,
+and `scene_state`.
 Supported UI conditions include `always`, `app.paused`, `camera.active`, `property.compare`,
 `property.bool`, `all`, `any`, and `not`.
 
@@ -291,11 +292,11 @@ Menu items can also author generic settings controls and emit data-authored sign
 }
 ```
 
-Supported control types are `toggle`, `choice`, and `range`. The generic menu
-controller applies these controls directly to actor properties and the menu UI
-presenter displays the current value. A menu can author `left_action` and
-`right_action` so range and choice controls can be adjusted without activating
-navigation items:
+Supported control types are `toggle`, `choice`, `range`, and `key_binding`.
+The generic menu controller applies property controls directly to actor
+properties and the menu UI presenter displays the current value. A menu can
+author `left_action` and `right_action` so range and choice controls can be
+adjusted without activating navigation items:
 
 ```json
 {
@@ -327,10 +328,38 @@ navigation items:
 
 Range controls clamp to their authored min/max. Adding `"value_type": "int"`
 stores the result as an integer property; adding `"display": "slider"` renders
-the menu value as a compact slider label. Settings menus that need Apply/Cancel
-behavior can still snapshot the edited properties when a scene opens, let
-controls stage values in those actor properties, then either persist the staged
-values or restore the snapshot:
+the menu value as a compact slider label.
+
+`key_binding` controls capture the next keyboard key and immediately rebind all
+authored actions. This is how games can expose one player-facing input such as
+`Up` while updating both gameplay and menu actions:
+
+```json
+{
+  "label": "Up",
+  "control": {
+    "type": "key_binding",
+    "default": "W",
+    "bindings": [
+      { "action": "action.paddle.up", "device": "keyboard" },
+      { "action": "action.menu.up", "device": "keyboard" }
+    ]
+  }
+}
+```
+
+Duplicate keys within the same menu are rejected during capture. Pressing the
+capture cancel key, Escape by default, cancels capture unless the binding opts
+into `"allow_escape": true`. Resetting authored keyboard controls is a logic
+action:
+
+```json
+{ "type": "input.reset_key_bindings", "menu": "menu.options.keyboard" }
+```
+
+Settings menus that need Apply/Cancel behavior can still snapshot the edited
+properties when a scene opens, let controls stage values in those actor
+properties, then either persist the staged values or restore the snapshot:
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -110,6 +110,7 @@ The optional `app` object lets a managed-loop game declare startup settings befo
       "vsync": true,
       "renderer": "software",
       "apply_signal": "signal.settings.apply",
+      "apply_signals": ["signal.settings.apply", "signal.settings.reset_display"],
       "settings": {
         "target": "entity.settings",
         "display_mode": "display_mode",
@@ -161,8 +162,9 @@ presentation are policy, not game-world scale. `app.window` can author display m
 overrides, and development/production display-mode defaults. `settings_path`, when present, lets startup read persisted
 display options such as `display_mode`, `renderer`, and `vsync` before creating the window.
 `app.window.apply_signal`, when present, lets the reusable app-flow helper apply live window settings from the
-configured settings actor after a menu emits that signal. The helper applies display mode and V-sync in place and
-recreates the window/render context when the renderer backend changes.
+configured settings actor after a menu emits that signal. `app.window.apply_signals` can list additional signals,
+such as menu-specific reset signals, that should trigger the same live apply. The helper applies display mode and
+V-sync in place and recreates the window/render context when the renderer backend changes.
 `app.pause.action` and `startup_transition` let the managed-loop host avoid hardcoded action/transition names.
 `app.pause.allowed_if` is optional; when present, the app-flow helper evaluates it before entering pause.
 `app.quit` lets data choose which input action requests quit, which transition plays, and which signal completes

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -330,16 +330,17 @@ Range controls clamp to their authored min/max. Adding `"value_type": "int"`
 stores the result as an integer property; adding `"display": "slider"` renders
 the menu value as a compact slider label.
 
-`key_binding` controls capture the next keyboard key and immediately rebind all
-authored actions. This is how games can expose one player-facing input such as
-`Up` while updating both gameplay and menu actions:
+`key_binding` controls capture the next keyboard key or gamepad button and
+immediately rebind all authored actions for that device. This is how games can
+expose one player-facing input such as `Up` while updating both gameplay and
+menu actions:
 
 ```json
 {
   "label": "Up",
   "control": {
     "type": "key_binding",
-    "default": "W",
+    "default": "UP",
     "bindings": [
       { "action": "action.paddle.up", "device": "keyboard" },
       { "action": "action.menu.up", "device": "keyboard" }
@@ -348,13 +349,13 @@ authored actions. This is how games can expose one player-facing input such as
 }
 ```
 
-Duplicate keys within the same menu are rejected during capture. Pressing the
-capture cancel key, Escape by default, cancels capture unless the binding opts
-into `"allow_escape": true`. Resetting authored keyboard controls is a logic
-action:
+For gamepads, use the same control shape with `"device": "gamepad"` and a
+button name such as `"SOUTH"` or `"DPAD_UP"`. Duplicate inputs within the same
+menu are rejected during capture. Pressing the capture cancel key, Escape by
+default, cancels capture. Resetting authored binding controls is a logic action:
 
 ```json
-{ "type": "input.reset_key_bindings", "menu": "menu.options.keyboard" }
+{ "type": "input.reset_bindings", "menu": "menu.options.keyboard" }
 ```
 
 Settings menus that need Apply/Cancel behavior can still snapshot the edited

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -281,7 +281,27 @@ Menu items can also author generic settings controls and emit data-authored sign
 
 Supported control types are `toggle`, `choice`, and `range`. The generic menu
 controller applies these controls directly to actor properties and the menu UI
-presenter displays the current value.
+presenter displays the current value. Settings menus that need Apply/Cancel
+behavior can snapshot the edited properties when a scene opens, let controls
+stage values in those actor properties, then either persist the staged values or
+restore the snapshot:
+
+```json
+{
+  "type": "property.snapshot",
+  "name": "options.display",
+  "target": "entity.settings",
+  "keys": ["display_mode", "vsync", "renderer"]
+}
+```
+
+```json
+{
+  "type": "property.restore_snapshot",
+  "name": "options.display",
+  "target": "entity.settings"
+}
+```
 
 Settings screens can reset authored defaults without game-specific code:
 
@@ -520,6 +540,8 @@ Generic action types should cover common wiring:
 - `property.set`
 - `property.add`
 - `property.toggle`
+- `property.snapshot`
+- `property.restore_snapshot`
 - `entity.set_active` with `target` and boolean `active`, used to include or exclude an entity from generic updates and rendering
 - `transform.set_position`
 - `motion.set_velocity`

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -328,13 +328,19 @@ extern "C"
      */
     typedef struct sdl3d_game_config
     {
-        const char *title;       /**< Window title, or "SDL3D" when NULL. */
-        int width;               /**< Window width in pixels, or 1280 when <= 0. */
-        int height;              /**< Window height in pixels, or 720 when <= 0. */
-        sdl3d_backend backend;   /**< Requested backend, or SDL3D_BACKEND_AUTO when zero. */
-        float tick_rate;         /**< Fixed timestep in seconds, or 1/60 when <= 0. */
-        int max_ticks_per_frame; /**< Catch-up tick cap per rendered frame, or 8 when <= 0. */
-        bool enable_audio;       /**< When true, create session audio before init when available. */
+        const char *title;              /**< Window title, or "SDL3D" when NULL. */
+        int width;                      /**< Initial window width in pixels, or logical width when <= 0. */
+        int height;                     /**< Initial window height in pixels, or logical height when <= 0. */
+        int logical_width;              /**< Virtual render width, or 1280 when <= 0. */
+        int logical_height;             /**< Virtual render height, or 720 when <= 0. */
+        const char *icon_path;          /**< Optional filesystem path to a window icon image. */
+        sdl3d_backend backend;          /**< Requested backend, or SDL3D_BACKEND_AUTO when zero. */
+        sdl3d_window_mode display_mode; /**< Window presentation mode, or SDL3D default when zero. */
+        int vsync;                      /**< >0 enables vsync, <0 disables vsync, 0 uses the SDL3D default. */
+        int maximized;                  /**< >0 maximizes, <0 keeps window normal, 0 uses the SDL3D default. */
+        float tick_rate;                /**< Fixed timestep in seconds, or 1/60 when <= 0. */
+        int max_ticks_per_frame;        /**< Catch-up tick cap per rendered frame, or 8 when <= 0. */
+        bool enable_audio;              /**< When true, create session audio before init when available. */
     } sdl3d_game_config;
 
     /**

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1261,7 +1261,7 @@ extern "C"
                                                   const sdl3d_game_data_menu_item *item, int direction);
 
     /**
-     * @brief Start keyboard-capture mode for a key-binding menu item.
+     * @brief Start capture mode for a key or gamepad-button binding menu item.
      *
      * The menu item must author a `control` with `type: "key_binding"`.
      * While capture is active, callers should pass input snapshots to
@@ -1271,21 +1271,22 @@ extern "C"
     bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
                                                         int item_index);
 
-    /** @brief Return true while a key-binding menu item is waiting for a key. */
+    /** @brief Return true while a binding menu item is waiting for an input. */
     bool sdl3d_game_data_menu_key_binding_capture_active(const sdl3d_game_data_runtime *runtime);
 
     /**
-     * @brief Advance active key-binding capture from current input.
+     * @brief Advance active binding capture from current input.
      *
-     * The runtime reads the first keyboard scancode captured by
-     * sdl3d_input_update(). Successful captures immediately update the live
-     * input manager for every action authored by the menu item.
+     * The runtime reads the first keyboard scancode or gamepad button captured
+     * by sdl3d_input_update(), depending on the menu item's authored device.
+     * Successful captures immediately update the live input manager for every
+     * action authored by the menu item.
      */
     sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_binding_capture(
         sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input);
 
     /**
-     * @brief Reset all key-binding controls in a menu to their authored defaults.
+     * @brief Reset all binding controls in a menu to their authored defaults.
      */
     bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -51,6 +51,16 @@ extern "C"
         const char *quit_transition;
         /** @brief Signal that means the app should quit immediately, or -1. */
         int quit_signal_id;
+        /** @brief Signal that applies live window settings, or -1. */
+        int window_apply_signal_id;
+        /** @brief Actor containing authored window setting properties, or NULL. */
+        const char *window_settings_target;
+        /** @brief Property key containing display mode, or NULL. */
+        const char *window_display_mode_key;
+        /** @brief Property key containing renderer/backend, or NULL. */
+        const char *window_renderer_key;
+        /** @brief Property key containing V-sync, or NULL. */
+        const char *window_vsync_key;
     } sdl3d_game_data_app_control;
 
     /** @brief Authored font asset descriptor. */

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -460,6 +460,10 @@ extern "C"
         int up_action_id;
         /** @brief Input action that moves selection down, or -1. */
         int down_action_id;
+        /** @brief Input action that decreases the selected control, or -1. */
+        int left_action_id;
+        /** @brief Input action that increases the selected control, or -1. */
+        int right_action_id;
         /** @brief Input action that activates the selected item, or -1. */
         int select_action_id;
         /** @brief Signal emitted after successful navigation, or -1. */
@@ -1215,13 +1219,27 @@ extern "C"
     /**
      * @brief Apply the generic control behavior authored on a menu item.
      *
-     * Toggle controls flip boolean properties, choice controls advance to the
-     * next authored choice, and range controls increment numeric properties with
-     * wrapping. Returns false when @p item is not a control or its target cannot
-     * be resolved.
+     * Toggle controls flip boolean properties, choice controls advance by one
+     * authored choice, and range controls increase by one authored step.
+     * Returns false when @p item is not a control or its target cannot be
+     * resolved.
      */
     bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime,
                                                  const sdl3d_game_data_menu_item *item);
+
+    /**
+     * @brief Adjust the generic control behavior authored on a menu item.
+     *
+     * @p direction should be positive to increase/advance or negative to
+     * decrease/rewind. Choice controls wrap across authored choices; range
+     * controls clamp to their authored min/max and preserve integer properties
+     * when authored with `value_type: "int"`. Toggle controls ignore direction
+     * and flip the current boolean value.
+     *
+     * @return true when a control value changed.
+     */
+    bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime,
+                                                  const sdl3d_game_data_menu_item *item, int direction);
 
     /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -840,6 +840,16 @@ extern "C"
                                          sdl3d_game_data_app_control *out_control);
 
     /**
+     * @brief Return whether an authored signal should apply live window settings.
+     *
+     * Games declare these signals under `app.window.apply_signal` or
+     * `app.window.apply_signals`. This lets reusable menu controls apply display
+     * mode, renderer, and V-sync changes immediately without hard-coding menu
+     * names in the host.
+     */
+    bool sdl3d_game_data_app_signal_applies_window_settings(const sdl3d_game_data_runtime *runtime, int signal_id);
+
+    /**
      * @brief Evaluate the data-authored app pause condition.
      *
      * Returns true when `app.pause.allowed_if` is absent. When present, the

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -487,6 +487,8 @@ extern "C"
         SDL3D_GAME_DATA_MENU_CONTROL_CHOICE = 2,
         /** @brief Menu item increments a numeric property within a range. */
         SDL3D_GAME_DATA_MENU_CONTROL_RANGE = 3,
+        /** @brief Menu item captures a keyboard key and rebinds authored actions. */
+        SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING = 4,
     } sdl3d_game_data_menu_control_type;
 
     /** @brief App pause command authored on a menu item. */
@@ -501,6 +503,21 @@ extern "C"
         /** @brief Selecting the item toggles the app pause state. */
         SDL3D_GAME_DATA_MENU_PAUSE_TOGGLE = 3,
     } sdl3d_game_data_menu_pause_command;
+
+    /** @brief Result of advancing an active key-binding capture. */
+    typedef enum sdl3d_game_data_key_binding_capture_status
+    {
+        /** @brief No key-binding capture is active. */
+        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_NONE = 0,
+        /** @brief Capture is active and still waiting for a key press. */
+        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING = 1,
+        /** @brief Capture was canceled by its cancel key. */
+        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED = 2,
+        /** @brief The captured key was applied to authored action bindings. */
+        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED = 3,
+        /** @brief The captured key was rejected because another binding uses it. */
+        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT = 4,
+    } sdl3d_game_data_key_binding_capture_status;
 
     /**
      * @brief Runtime descriptor for one authored menu item.
@@ -538,6 +555,8 @@ extern "C"
         const char *control_key;
         /** @brief Number of authored choices for choice controls. */
         int choice_count;
+        /** @brief Number of action bindings affected by a key-binding control. */
+        int key_binding_count;
     } sdl3d_game_data_menu_item;
 
     /** @brief Authored scene transition behavior policy. */
@@ -1240,6 +1259,35 @@ extern "C"
      */
     bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime,
                                                   const sdl3d_game_data_menu_item *item, int direction);
+
+    /**
+     * @brief Start keyboard-capture mode for a key-binding menu item.
+     *
+     * The menu item must author a `control` with `type: "key_binding"`.
+     * While capture is active, callers should pass input snapshots to
+     * sdl3d_game_data_update_menu_key_binding_capture() before normal menu
+     * navigation.
+     */
+    bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                        int item_index);
+
+    /** @brief Return true while a key-binding menu item is waiting for a key. */
+    bool sdl3d_game_data_menu_key_binding_capture_active(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Advance active key-binding capture from current input.
+     *
+     * The runtime reads the first keyboard scancode captured by
+     * sdl3d_input_update(). Successful captures immediately update the live
+     * input manager for every action authored by the menu item.
+     */
+    sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_binding_capture(
+        sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input);
+
+    /**
+     * @brief Reset all key-binding controls in a menu to their authored defaults.
+     */
+    bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
 
     /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -127,10 +127,13 @@ extern "C"
         bool handled_input;                               /**< True when a menu action was consumed. */
         bool selected;                                    /**< True when the selected item was activated. */
         bool quit;                                        /**< True when the selected item requests quit. */
-        bool return_scene;      /**< True when the selected item requests the stored return scene. */
-        bool has_return_paused; /**< True when selected item stores a return pause state. */
-        bool return_paused;     /**< Pause state to store for a later return_scene item. */
-        bool control_changed;   /**< True when selecting the item changed a data-bound control. */
+        bool return_scene;                /**< True when the selected item requests the stored return scene. */
+        bool has_return_paused;           /**< True when selected item stores a return pause state. */
+        bool return_paused;               /**< Pause state to store for a later return_scene item. */
+        bool control_changed;             /**< True when selecting the item changed a data-bound control. */
+        bool key_binding_capture_started; /**< True when a key-binding item entered capture mode. */
+        bool key_binding_changed;         /**< True when a captured key changed authored action bindings. */
+        bool key_binding_conflict;        /**< True when a captured key was rejected as a duplicate binding. */
     } sdl3d_game_data_menu_update_result;
 
     /**

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -244,6 +244,16 @@ extern "C"
     SDL_Scancode sdl3d_input_get_pressed_scancode(const sdl3d_input_manager *input);
 
     /**
+     * @brief Return the first gamepad button pressed during the current input tick.
+     *
+     * The value is captured by sdl3d_input_update() before transient button
+     * edges are cleared. Returns SDL_GAMEPAD_BUTTON_INVALID when no gamepad
+     * button was pressed or live gamepad input is unavailable, such as during
+     * demo playback.
+     */
+    SDL_GamepadButton sdl3d_input_get_pressed_gamepad_button(const sdl3d_input_manager *input);
+
+    /**
      * @brief Return true if any button-like input or action was pressed this tick.
      *
      * This supports generic flows such as splash screens where "press anything

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -235,6 +235,15 @@ extern "C"
     float sdl3d_input_get_value(const sdl3d_input_manager *input, int action_id);
 
     /**
+     * @brief Return the first keyboard scancode pressed during the current input tick.
+     *
+     * The value is captured by sdl3d_input_update() before transient key
+     * edges are cleared. Returns SDL_SCANCODE_UNKNOWN when no key was pressed
+     * or live keyboard input is unavailable, such as during demo playback.
+     */
+    SDL_Scancode sdl3d_input_get_pressed_scancode(const sdl3d_input_manager *input);
+
+    /**
      * @brief Return true if any button-like input or action was pressed this tick.
      *
      * This supports generic flows such as splash screens where "press anything

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -16,8 +16,21 @@ extern "C"
     {
         SDL3D_BACKEND_AUTO = 0,
         SDL3D_BACKEND_SOFTWARE = 1,
-        SDL3D_BACKEND_SDLGPU = 2
+        SDL3D_BACKEND_OPENGL = 2
     } sdl3d_backend;
+
+    /** @brief Window presentation mode used by high-level window creation. */
+    typedef enum sdl3d_window_mode
+    {
+        /** @brief Use SDL3D's build/profile default window mode. */
+        SDL3D_WINDOW_MODE_DEFAULT = 0,
+        /** @brief Desktop window. */
+        SDL3D_WINDOW_MODE_WINDOWED = 1,
+        /** @brief Exclusive fullscreen display mode. */
+        SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE = 2,
+        /** @brief Borderless desktop fullscreen. */
+        SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS = 3
+    } sdl3d_window_mode;
 
     typedef struct sdl3d_render_context_config
     {
@@ -28,18 +41,28 @@ extern "C"
         SDL_RendererLogicalPresentation logical_presentation;
     } sdl3d_render_context_config;
 
-    /*
-     * High-level window configuration. Use sdl3d_init_window_config for
-     * sensible defaults, then override what you need.
+    /**
+     * @brief High-level window configuration.
+     *
+     * Use sdl3d_init_window_config() for sensible defaults, then override what
+     * the game needs. Windowed mode is resizable by default. Games should
+     * prefer logical_width/logical_height for authored layout and world scale;
+     * width/height only describe the initial desktop window size.
      */
     typedef struct sdl3d_window_config
     {
-        int width;
-        int height;
-        const char *title;
-        sdl3d_backend backend;       /* AUTO, SOFTWARE, or SDLGPU */
-        bool allow_backend_fallback; /* try next backend if preferred fails */
-        bool resizable;
+        int width;                      /**< Initial window width in pixels. */
+        int height;                     /**< Initial window height in pixels. */
+        int logical_width;              /**< Virtual render width used for layout and presentation. */
+        int logical_height;             /**< Virtual render height used for layout and presentation. */
+        const char *title;              /**< Window title, or "SDL3D" when NULL. */
+        const char *icon_path;          /**< Optional filesystem path to a window icon image. */
+        sdl3d_backend backend;          /**< AUTO, SOFTWARE, or OPENGL. */
+        bool allow_backend_fallback;    /**< Try the next backend if the preferred backend fails. */
+        sdl3d_window_mode display_mode; /**< Windowed, exclusive fullscreen, or borderless fullscreen. */
+        bool vsync;                     /**< Request synchronized presentation where supported. */
+        bool maximized;                 /**< Create the desktop window maximized. */
+        bool resizable;                 /**< Allow the user to resize desktop windowed mode. */
     } sdl3d_window_config;
 
     /*
@@ -68,20 +91,28 @@ extern "C"
 
     /* ---- High-level API (recommended: library manages window setup) ---- */
 
-    /*
-     * Fill a window config with sensible defaults:
-     *   width=1280, height=720, title="SDL3D", backend=AUTO,
-     *   allow_backend_fallback=true, resizable=true.
+    /**
+     * @brief Fill a window config with sensible defaults.
+     *
+     * Defaults are width=1280, height=720, logical_width=1280,
+     * logical_height=720, title="SDL3D", backend=AUTO,
+     * display_mode=WINDOWED, vsync=true, maximized=false,
+     * allow_backend_fallback=true, and resizable=true.
      */
     void sdl3d_init_window_config(sdl3d_window_config *config);
 
-    /*
-     * Create a window and render context in one call. Handles all
-     * backend-specific setup (GL attributes, SDL_Renderer for software,
-     * window flags) internally. The caller receives an SDL_Window* for
-     * event polling and an sdl3d_render_context* for rendering.
+    /**
+     * @brief Create a window and render context in one call.
      *
-     * The logical resolution matches the requested width/height.
+     * Handles backend-specific setup, SDL_Renderer creation for the software
+     * path, window flags, optional title/icon metadata, presentation mode, and
+     * logical resolution. The caller receives an SDL_Window* for event polling
+     * and an sdl3d_render_context* for rendering.
+     *
+     * @param config Optional window configuration. NULL selects defaults.
+     * @param out_window Receives the SDL window on success.
+     * @param out_context Receives the render context on success.
+     * @return true on success, false on failure.
      */
     bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_window,
                              sdl3d_render_context **out_context);

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -118,6 +118,23 @@ extern "C"
                              sdl3d_render_context **out_context);
 
     /**
+     * @brief Apply live window presentation settings to an existing window.
+     *
+     * The function applies display mode and V-sync in place when the backend is
+     * unchanged. If @p config requests a different backend, it creates a new
+     * window/render context using @p config before destroying the old pair, so
+     * failure leaves the existing window usable. On success, @p window and
+     * @p context are updated to the active objects.
+     *
+     * @param window  Pointer to the SDL window pointer to update.
+     * @param context Pointer to the SDL3D render context pointer to update.
+     * @param config  Desired window/backend settings.
+     * @return true on success, false on failure.
+     */
+    bool sdl3d_apply_window_config(SDL_Window **window, sdl3d_render_context **context,
+                                   const sdl3d_window_config *config);
+
+    /**
      * @brief Destroy a window and render context created by sdl3d_create_window.
      *
      * This releases the SDL3D render context, the SDL_Renderer owned by the

--- a/include/sdl3d/render_context.h
+++ b/include/sdl3d/render_context.h
@@ -106,8 +106,10 @@ extern "C"
      *
      * Handles backend-specific setup, SDL_Renderer creation for the software
      * path, window flags, optional title/icon metadata, presentation mode, and
-     * logical resolution. The caller receives an SDL_Window* for event polling
-     * and an sdl3d_render_context* for rendering.
+     * logical resolution. High-level windows present the logical resolution
+     * with letterboxing so resizable windows preserve the authored aspect
+     * ratio. The caller receives an SDL_Window* for event polling and an
+     * sdl3d_render_context* for rendering.
      *
      * @param config Optional window configuration. NULL selects defaults.
      * @param out_window Receives the SDL window on success.

--- a/src/game.c
+++ b/src/game.c
@@ -14,6 +14,12 @@
 #define SDL3D_GAME_DEFAULT_FIXED_DT (1.0f / 60.0f)
 #define SDL3D_GAME_DEFAULT_MAX_TICKS 8
 
+#if defined(SDL3D_PRODUCTION_BUILD)
+#define SDL3D_GAME_DEFAULT_WINDOW_MODE SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS
+#else
+#define SDL3D_GAME_DEFAULT_WINDOW_MODE SDL3D_WINDOW_MODE_WINDOWED
+#endif
+
 struct sdl3d_game_session
 {
     sdl3d_actor_registry *registry;
@@ -374,12 +380,28 @@ static bool sdl3d_game_create_context(const sdl3d_game_config *config, sdl3d_gam
 {
     sdl3d_window_config window_config;
     sdl3d_game_session_desc session_desc;
+    const int logical_width =
+        (config != NULL && config->logical_width > 0) ? config->logical_width : SDL3D_GAME_DEFAULT_WIDTH;
+    const int logical_height =
+        (config != NULL && config->logical_height > 0) ? config->logical_height : SDL3D_GAME_DEFAULT_HEIGHT;
 
     sdl3d_init_window_config(&window_config);
-    window_config.width = (config != NULL && config->width > 0) ? config->width : SDL3D_GAME_DEFAULT_WIDTH;
-    window_config.height = (config != NULL && config->height > 0) ? config->height : SDL3D_GAME_DEFAULT_HEIGHT;
+    window_config.width = (config != NULL && config->width > 0) ? config->width : logical_width;
+    window_config.height = (config != NULL && config->height > 0) ? config->height : logical_height;
+    window_config.logical_width = logical_width;
+    window_config.logical_height = logical_height;
     window_config.title = (config != NULL && config->title != NULL) ? config->title : "SDL3D";
+    window_config.icon_path = config != NULL ? config->icon_path : NULL;
     window_config.backend = (config != NULL) ? config->backend : SDL3D_BACKEND_AUTO;
+    window_config.display_mode = (config != NULL && config->display_mode != SDL3D_WINDOW_MODE_DEFAULT)
+                                     ? config->display_mode
+                                     : SDL3D_GAME_DEFAULT_WINDOW_MODE;
+    if (config != NULL && config->vsync != 0)
+        window_config.vsync = config->vsync > 0;
+    if (config != NULL && config->maximized != 0)
+        window_config.maximized = config->maximized > 0;
+    else
+        window_config.maximized = true;
 
     if (!sdl3d_create_window(&window_config, &ctx->window, &ctx->renderer))
     {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2139,6 +2139,29 @@ bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime, sdl
     return true;
 }
 
+bool sdl3d_game_data_app_signal_applies_window_settings(const sdl3d_game_data_runtime *runtime, int signal_id)
+{
+    if (runtime == NULL || signal_id < 0)
+        return false;
+
+    yyjson_val *window = obj_get(obj_get(runtime_root(runtime), "app"), "window");
+    const char *apply_signal = json_string(window, "apply_signal", NULL);
+    if (apply_signal != NULL && sdl3d_game_data_find_signal(runtime, apply_signal) == signal_id)
+        return true;
+
+    yyjson_val *apply_signals = obj_get(window, "apply_signals");
+    if (!yyjson_is_arr(apply_signals))
+        return false;
+
+    for (size_t i = 0; i < yyjson_arr_size(apply_signals); ++i)
+    {
+        yyjson_val *signal = yyjson_arr_get(apply_signals, i);
+        if (yyjson_is_str(signal) && sdl3d_game_data_find_signal(runtime, yyjson_get_str(signal)) == signal_id)
+            return true;
+    }
+    return false;
+}
+
 bool sdl3d_game_data_get_font_asset(const sdl3d_game_data_runtime *runtime, const char *id,
                                     sdl3d_game_data_font_asset *out_font)
 {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -176,6 +176,13 @@ typedef struct materialized_audio_file
     char *file_path;
 } materialized_audio_file;
 
+typedef struct property_snapshot
+{
+    char *name;
+    char *target;
+    sdl3d_properties *properties;
+} property_snapshot;
+
 typedef struct scene_activity_state
 {
     const char *scene;
@@ -236,6 +243,9 @@ typedef struct sdl3d_game_data_runtime
     materialized_audio_file *audio_files;
     int audio_file_count;
     int audio_file_capacity;
+    property_snapshot *property_snapshots;
+    int property_snapshot_count;
+    int property_snapshot_capacity;
     sdl3d_storage *storage;
     const char *active_camera;
     scene_activity_state activity;
@@ -5791,6 +5801,108 @@ static bool json_string_array_contains(yyjson_val *array, const char *value)
     return false;
 }
 
+static property_snapshot *find_property_snapshot(sdl3d_game_data_runtime *runtime, const char *name, const char *target)
+{
+    if (runtime == NULL || name == NULL || target == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->property_snapshot_count; ++i)
+    {
+        property_snapshot *snapshot = &runtime->property_snapshots[i];
+        if (snapshot->name != NULL && snapshot->target != NULL && SDL_strcmp(snapshot->name, name) == 0 &&
+            SDL_strcmp(snapshot->target, target) == 0)
+            return snapshot;
+    }
+    return NULL;
+}
+
+static property_snapshot *get_or_create_property_snapshot(sdl3d_game_data_runtime *runtime, const char *name,
+                                                          const char *target)
+{
+    property_snapshot *existing = find_property_snapshot(runtime, name, target);
+    if (existing != NULL)
+        return existing;
+    if (runtime == NULL || name == NULL || name[0] == '\0' || target == NULL || target[0] == '\0')
+        return NULL;
+    if (runtime->property_snapshot_count >= runtime->property_snapshot_capacity)
+    {
+        const int next_capacity = runtime->property_snapshot_capacity > 0 ? runtime->property_snapshot_capacity * 2 : 4;
+        property_snapshot *next = (property_snapshot *)SDL_realloc(
+            runtime->property_snapshots, (size_t)next_capacity * sizeof(*runtime->property_snapshots));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + runtime->property_snapshot_capacity, 0,
+                   (size_t)(next_capacity - runtime->property_snapshot_capacity) *
+                       sizeof(*runtime->property_snapshots));
+        runtime->property_snapshots = next;
+        runtime->property_snapshot_capacity = next_capacity;
+    }
+
+    property_snapshot *snapshot = &runtime->property_snapshots[runtime->property_snapshot_count];
+    snapshot->name = SDL_strdup(name);
+    snapshot->target = SDL_strdup(target);
+    snapshot->properties = sdl3d_properties_create();
+    if (snapshot->name == NULL || snapshot->target == NULL || snapshot->properties == NULL)
+    {
+        SDL_free(snapshot->name);
+        SDL_free(snapshot->target);
+        sdl3d_properties_destroy(snapshot->properties);
+        SDL_zero(*snapshot);
+        return NULL;
+    }
+    runtime->property_snapshot_count++;
+    return snapshot;
+}
+
+static void copy_selected_properties(sdl3d_properties *target, const sdl3d_properties *source, yyjson_val *keys)
+{
+    if (target == NULL || source == NULL)
+        return;
+    if (yyjson_is_arr(keys))
+    {
+        for (size_t i = 0; i < yyjson_arr_size(keys); ++i)
+        {
+            const char *key = yyjson_get_str(yyjson_arr_get(keys, i));
+            copy_property_value(target, key, sdl3d_properties_get_value(source, key));
+        }
+        return;
+    }
+
+    const int count = sdl3d_properties_count(source);
+    for (int i = 0; i < count; ++i)
+    {
+        const char *key = NULL;
+        if (sdl3d_properties_get_key_at(source, i, &key, NULL))
+            copy_property_value(target, key, sdl3d_properties_get_value(source, key));
+    }
+}
+
+static bool snapshot_actor_properties(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", NULL);
+    const char *name = json_string(action, "name", NULL);
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    property_snapshot *snapshot = get_or_create_property_snapshot(runtime, name, target);
+    if (actor == NULL || snapshot == NULL)
+        return false;
+
+    sdl3d_properties_clear(snapshot->properties);
+    copy_selected_properties(snapshot->properties, actor->props, obj_get(action, "keys"));
+    return true;
+}
+
+static bool restore_actor_property_snapshot(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", NULL);
+    const char *name = json_string(action, "name", NULL);
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    property_snapshot *snapshot = find_property_snapshot(runtime, name, target);
+    if (actor == NULL || snapshot == NULL)
+        return false;
+
+    copy_selected_properties(actor->props, snapshot->properties, obj_get(action, "keys"));
+    return true;
+}
+
 static bool reset_actor_properties_to_authored_defaults(sdl3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *target = json_string(action, "target", NULL);
@@ -5866,6 +5978,12 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         }
         return true;
     }
+
+    if (SDL_strcmp(type, "property.snapshot") == 0)
+        return snapshot_actor_properties(runtime, action);
+
+    if (SDL_strcmp(type, "property.restore_snapshot") == 0)
+        return restore_actor_property_snapshot(runtime, action);
 
     if (SDL_strcmp(type, "property.animate") == 0)
         return start_property_animation_from_json(runtime, action);
@@ -7206,6 +7324,12 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->audio_files[i].asset_path);
         SDL_free(runtime->audio_files[i].file_path);
     }
+    for (int i = 0; i < runtime->property_snapshot_count; ++i)
+    {
+        SDL_free(runtime->property_snapshots[i].name);
+        SDL_free(runtime->property_snapshots[i].target);
+        sdl3d_properties_destroy(runtime->property_snapshots[i].properties);
+    }
 
     sdl3d_script_engine_destroy(runtime->scripts);
     sdl3d_properties_destroy(runtime->scene_state);
@@ -7224,6 +7348,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->ui_states);
     SDL_free(runtime->animations);
     SDL_free(runtime->audio_files);
+    SDL_free(runtime->property_snapshots);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1760,6 +1760,8 @@ static SDL_Scancode scancode_from_json(const char *name)
         return SDL_SCANCODE_RETURN;
     if (SDL_strcmp(name, "ESCAPE") == 0)
         return SDL_SCANCODE_ESCAPE;
+    if (SDL_strcmp(name, "BACKSPACE") == 0 || SDL_strcmp(name, "DELETE") == 0)
+        return SDL_SCANCODE_BACKSPACE;
     if (SDL_strlen(name) == 1)
         return SDL_GetScancodeFromKey(SDL_GetKeyFromName(name), NULL);
     return SDL_GetScancodeFromName(name);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2110,6 +2110,11 @@ bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime, sdl
         out_control->startup_transition = NULL;
         out_control->quit_transition = NULL;
         out_control->quit_signal_id = -1;
+        out_control->window_apply_signal_id = -1;
+        out_control->window_settings_target = NULL;
+        out_control->window_display_mode_key = NULL;
+        out_control->window_renderer_key = NULL;
+        out_control->window_vsync_key = NULL;
     }
     if (runtime == NULL || out_control == NULL)
         return false;
@@ -2117,12 +2122,20 @@ bool sdl3d_game_data_get_app_control(const sdl3d_game_data_runtime *runtime, sdl
     yyjson_val *app = obj_get(runtime_root(runtime), "app");
     yyjson_val *pause = obj_get(app, "pause");
     yyjson_val *quit = obj_get(app, "quit");
+    yyjson_val *window = obj_get(app, "window");
+    yyjson_val *window_settings = obj_get(window, "settings");
     out_control->start_signal_id = sdl3d_game_data_find_signal(runtime, json_string(app, "start_signal", NULL));
     out_control->pause_action_id = sdl3d_game_data_find_action(runtime, json_string(pause, "action", NULL));
     out_control->startup_transition = json_string(app, "startup_transition", NULL);
     out_control->quit_action_id = sdl3d_game_data_find_action(runtime, json_string(quit, "action", NULL));
     out_control->quit_transition = json_string(quit, "transition", NULL);
     out_control->quit_signal_id = sdl3d_game_data_find_signal(runtime, json_string(quit, "quit_signal", NULL));
+    out_control->window_apply_signal_id =
+        sdl3d_game_data_find_signal(runtime, json_string(window, "apply_signal", NULL));
+    out_control->window_settings_target = json_string(window_settings, "target", "entity.settings");
+    out_control->window_display_mode_key = json_string(window_settings, "display_mode", "display_mode");
+    out_control->window_renderer_key = json_string(window_settings, "renderer", "renderer");
+    out_control->window_vsync_key = json_string(window_settings, "vsync", "vsync");
     return true;
 }
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6993,7 +6993,7 @@ static bool apply_app_config_from_root(yyjson_val *root, sdl3d_game_config *out_
 static void apply_persisted_app_settings(yyjson_val *root, sdl3d_game_config *out_config)
 {
     yyjson_val *app = obj_get(root, "app");
-    const char *settings_path = json_string(app, "settings_path", "user://settings/options.json");
+    const char *settings_path = json_string(app, "settings_path", NULL);
     if (settings_path == NULL || settings_path[0] == '\0')
         return;
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1531,10 +1531,26 @@ static sdl3d_backend parse_backend(const char *value, sdl3d_backend fallback)
         return SDL3D_BACKEND_AUTO;
     if (SDL_strcasecmp(value, "software") == 0)
         return SDL3D_BACKEND_SOFTWARE;
-    if (SDL_strcasecmp(value, "sdlgpu") == 0 || SDL_strcasecmp(value, "gpu") == 0)
-        return SDL3D_BACKEND_SDLGPU;
+    if (SDL_strcasecmp(value, "opengl") == 0 || SDL_strcasecmp(value, "gl") == 0 || SDL_strcasecmp(value, "gpu") == 0)
+        return SDL3D_BACKEND_OPENGL;
     return fallback;
 }
+
+static sdl3d_window_mode parse_window_mode(const char *value, sdl3d_window_mode fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "windowed") == 0 || SDL_strcasecmp(value, "window") == 0)
+        return SDL3D_WINDOW_MODE_WINDOWED;
+    if (SDL_strcasecmp(value, "fullscreen_exclusive") == 0 || SDL_strcasecmp(value, "exclusive") == 0)
+        return SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE;
+    if (SDL_strcasecmp(value, "fullscreen_borderless") == 0 || SDL_strcasecmp(value, "borderless") == 0 ||
+        SDL_strcasecmp(value, "desktop_fullscreen") == 0)
+        return SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS;
+    return fallback;
+}
+
+static void storage_config_from_root(yyjson_val *root, sdl3d_storage_config *out_config);
 
 static sdl3d_tonemap_mode parse_tonemap(const char *value, sdl3d_tonemap_mode fallback)
 {
@@ -5711,6 +5727,20 @@ static bool execute_audio_play_music(sdl3d_game_data_runtime *runtime, yyjson_va
     return ok;
 }
 
+static float action_float_or_property(sdl3d_game_data_runtime *runtime, yyjson_val *action, const char *key,
+                                      float fallback)
+{
+    yyjson_val *source = obj_get(action, "source");
+    if (yyjson_is_obj(source))
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(source, "target", NULL));
+        const char *property = json_string(source, "key", NULL);
+        if (actor != NULL && property != NULL)
+            return sdl3d_properties_get_float(actor->props, property, fallback);
+    }
+    return json_float(action, key, fallback);
+}
+
 static bool execute_audio_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const char *type)
 {
     sdl3d_audio_engine *audio = sdl3d_game_session_get_audio(runtime != NULL ? runtime->session : NULL);
@@ -5742,10 +5772,50 @@ static bool execute_audio_action(sdl3d_game_data_runtime *runtime, yyjson_val *a
     if (SDL_strcmp(type, "audio.set_bus_volume") == 0)
     {
         sdl3d_audio_set_bus_volume(audio, parse_audio_bus(json_string(action, "bus", NULL), SDL3D_AUDIO_BUS_COUNT),
-                                   json_float(action, "volume", 1.0f));
+                                   action_float_or_property(runtime, action, "volume", 1.0f));
         return true;
     }
     return false;
+}
+
+static bool json_string_array_contains(yyjson_val *array, const char *value)
+{
+    if (!yyjson_is_arr(array) || value == NULL)
+        return false;
+    for (size_t i = 0; i < yyjson_arr_size(array); ++i)
+    {
+        const char *entry = yyjson_get_str(yyjson_arr_get(array, i));
+        if (entry != NULL && SDL_strcmp(entry, value) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool reset_actor_properties_to_authored_defaults(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", NULL);
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    yyjson_val *entity = find_entity_json(runtime, target);
+    yyjson_val *properties = obj_get(entity, "properties");
+    yyjson_val *keys = obj_get(action, "keys");
+    if (actor == NULL || !yyjson_is_obj(properties))
+        return false;
+
+    yyjson_val *key;
+    yyjson_val *entry;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(properties, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        if (yyjson_is_arr(keys) && !json_string_array_contains(keys, name))
+            continue;
+        entry = yyjson_obj_iter_get_val(key);
+        yyjson_val *value = obj_get(entry, "value");
+        if (value != NULL)
+            set_actor_property_from_json(actor, name, value);
+    }
+    return true;
 }
 
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload)
@@ -5799,6 +5869,9 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "property.animate") == 0)
         return start_property_animation_from_json(runtime, action);
+
+    if (SDL_strcmp(type, "property.reset_defaults") == 0)
+        return reset_actor_properties_to_authored_defaults(runtime, action);
 
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
@@ -6763,13 +6836,83 @@ static bool apply_app_config_from_root(yyjson_val *root, sdl3d_game_config *out_
         SDL_snprintf(title_buffer, (size_t)title_buffer_size, "%s", title);
         out_config->title = title_buffer;
     }
-    out_config->width = json_int(app, "width", out_config->width);
-    out_config->height = json_int(app, "height", out_config->height);
+    out_config->width = json_int(app, "window_width", json_int(app, "width", out_config->width));
+    out_config->height = json_int(app, "window_height", json_int(app, "height", out_config->height));
+    out_config->logical_width = json_int(app, "logical_width", json_int(app, "width", out_config->logical_width));
+    out_config->logical_height = json_int(app, "logical_height", json_int(app, "height", out_config->logical_height));
+    out_config->icon_path = json_string(app, "icon_path", json_string(app, "icon", out_config->icon_path));
     out_config->backend = parse_backend(json_string(app, "backend", NULL), out_config->backend);
+    yyjson_val *window = obj_get(app, "window");
+    if (yyjson_is_obj(window))
+    {
+        const char *window_title = json_string(window, "title", NULL);
+        if (window_title != NULL && title_buffer != NULL && title_buffer_size > 0)
+        {
+            SDL_snprintf(title_buffer, (size_t)title_buffer_size, "%s", window_title);
+            out_config->title = title_buffer;
+        }
+#if defined(SDL3D_PRODUCTION_BUILD)
+        const char *mode = json_string(window, "production_display_mode", json_string(window, "display_mode", NULL));
+#else
+        const char *mode = json_string(window, "development_display_mode", json_string(window, "display_mode", NULL));
+#endif
+        out_config->display_mode = parse_window_mode(mode, out_config->display_mode);
+        yyjson_val *vsync = obj_get(window, "vsync");
+        if (yyjson_is_bool(vsync))
+            out_config->vsync = yyjson_get_bool(vsync) ? 1 : -1;
+        yyjson_val *maximized = obj_get(window, "maximized");
+        if (yyjson_is_bool(maximized))
+            out_config->maximized = yyjson_get_bool(maximized) ? 1 : -1;
+        out_config->backend = parse_backend(json_string(window, "renderer", NULL), out_config->backend);
+        out_config->icon_path = json_string(window, "icon_path", json_string(window, "icon", out_config->icon_path));
+    }
     out_config->tick_rate = json_float(app, "tick_rate", out_config->tick_rate);
     out_config->max_ticks_per_frame = json_int(app, "max_ticks_per_frame", out_config->max_ticks_per_frame);
     out_config->enable_audio = json_bool(app, "enable_audio", out_config->enable_audio);
     return true;
+}
+
+static void apply_persisted_app_settings(yyjson_val *root, sdl3d_game_config *out_config)
+{
+    yyjson_val *app = obj_get(root, "app");
+    const char *settings_path = json_string(app, "settings_path", "user://settings/options.json");
+    if (settings_path == NULL || settings_path[0] == '\0')
+        return;
+
+    sdl3d_storage_config storage_config;
+    storage_config_from_root(root, &storage_config);
+
+    char storage_error[256];
+    sdl3d_storage *storage = NULL;
+    if (!sdl3d_storage_create(&storage_config, &storage, storage_error, (int)sizeof(storage_error)))
+    {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D app settings storage unavailable: %s", storage_error);
+        return;
+    }
+
+    sdl3d_storage_buffer buffer;
+    SDL_zero(buffer);
+    if (!sdl3d_storage_read_file(storage, settings_path, &buffer, storage_error, (int)sizeof(storage_error)))
+    {
+        sdl3d_storage_destroy(storage);
+        return;
+    }
+
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, NULL);
+    yyjson_val *settings = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    if (yyjson_is_obj(settings))
+    {
+        out_config->display_mode =
+            parse_window_mode(json_string(settings, "display_mode", NULL), out_config->display_mode);
+        out_config->backend = parse_backend(json_string(settings, "renderer", NULL), out_config->backend);
+        yyjson_val *vsync = obj_get(settings, "vsync");
+        if (yyjson_is_bool(vsync))
+            out_config->vsync = yyjson_get_bool(vsync) ? 1 : -1;
+    }
+
+    yyjson_doc_free(doc);
+    sdl3d_storage_buffer_free(&buffer);
+    sdl3d_storage_destroy(storage);
 }
 
 bool sdl3d_game_data_load_app_config_asset(sdl3d_asset_resolver *assets, const char *asset_path,
@@ -6804,8 +6947,11 @@ bool sdl3d_game_data_load_app_config_asset(sdl3d_asset_resolver *assets, const c
         return false;
     }
 
-    const bool ok = apply_app_config_from_root(yyjson_doc_get_root(doc), out_config, title_buffer, title_buffer_size,
-                                               error_buffer, error_buffer_size);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    const bool ok =
+        apply_app_config_from_root(root, out_config, title_buffer, title_buffer_size, error_buffer, error_buffer_size);
+    if (ok)
+        apply_persisted_app_settings(root, out_config);
     yyjson_doc_free(doc);
     return ok;
 }
@@ -6987,23 +7133,32 @@ bool sdl3d_game_data_load_file(const char *path, sdl3d_game_session *session, sd
     return ok;
 }
 
-static void load_storage_config(sdl3d_game_data_runtime *runtime, yyjson_val *root)
+static void storage_config_from_root(yyjson_val *root, sdl3d_storage_config *out_config)
 {
-    sdl3d_storage_config_init(&runtime->storage_config);
+    if (out_config == NULL)
+        return;
+    sdl3d_storage_config_init(out_config);
 
     yyjson_val *storage = obj_get(root, "storage");
     yyjson_val *metadata = obj_get(root, "metadata");
     yyjson_val *app = obj_get(root, "app");
 
-    runtime->storage_config.organization =
+    out_config->organization =
         first_non_empty_string(json_string(storage, "organization", NULL), json_string(metadata, "organization", NULL),
-                               runtime->storage_config.organization);
-    runtime->storage_config.application = first_non_empty_string(
+                               out_config->organization);
+    out_config->application = first_non_empty_string(
         json_string(storage, "application", NULL), json_string(app, "title", NULL),
-        first_non_empty_string(json_string(metadata, "name", NULL), NULL, runtime->storage_config.application));
-    runtime->storage_config.profile = json_string(storage, "profile", NULL);
-    runtime->storage_config.user_root_override = json_string(storage, "user_root_override", NULL);
-    runtime->storage_config.cache_root_override = json_string(storage, "cache_root_override", NULL);
+        first_non_empty_string(json_string(metadata, "name", NULL), NULL, out_config->application));
+    out_config->profile = json_string(storage, "profile", NULL);
+    out_config->user_root_override = json_string(storage, "user_root_override", NULL);
+    out_config->cache_root_override = json_string(storage, "cache_root_override", NULL);
+}
+
+static void load_storage_config(sdl3d_game_data_runtime *runtime, yyjson_val *root)
+{
+    if (runtime == NULL)
+        return;
+    storage_config_from_root(root, &runtime->storage_config);
 }
 
 bool sdl3d_game_data_get_storage_config(const sdl3d_game_data_runtime *runtime, sdl3d_storage_config *out_config)

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3661,6 +3661,8 @@ bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *
         SDL_zero(*out_menu);
         out_menu->up_action_id = -1;
         out_menu->down_action_id = -1;
+        out_menu->left_action_id = -1;
+        out_menu->right_action_id = -1;
         out_menu->select_action_id = -1;
         out_menu->move_signal_id = -1;
         out_menu->select_signal_id = -1;
@@ -3675,6 +3677,8 @@ bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *
     out_menu->name = json_string(menu, "name", NULL);
     out_menu->up_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "up_action", NULL));
     out_menu->down_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "down_action", NULL));
+    out_menu->left_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "left_action", NULL));
+    out_menu->right_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "right_action", NULL));
     out_menu->select_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "select_action", NULL));
     out_menu->move_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "move_signal", NULL));
     out_menu->select_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "select_signal", NULL));
@@ -3831,8 +3835,26 @@ static bool json_value_matches_property(yyjson_val *value, const sdl3d_value *pr
     return false;
 }
 
-bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, const sdl3d_game_data_menu_item *item)
+static bool menu_range_is_integer(yyjson_val *control)
 {
+    return SDL_strcmp(json_string(control, "value_type", ""), "int") == 0 ||
+           SDL_strcmp(json_string(control, "value_type", ""), "integer") == 0;
+}
+
+static float menu_control_numeric_value(const sdl3d_value *value, yyjson_val *control, float fallback)
+{
+    if (value != NULL && value->type == SDL3D_VALUE_INT)
+        return (float)value->as_int;
+    if (value != NULL && value->type == SDL3D_VALUE_FLOAT)
+        return value->as_float;
+    return json_float(control, "default", fallback);
+}
+
+bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime, const sdl3d_game_data_menu_item *item,
+                                              int direction)
+{
+    if (direction == 0)
+        return false;
     if (runtime == NULL || item == NULL || item->control_type == SDL3D_GAME_DATA_MENU_CONTROL_NONE ||
         item->control_target == NULL || item->control_key == NULL)
         return false;
@@ -3842,6 +3864,7 @@ bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, c
         return false;
 
     yyjson_val *control = find_menu_item_control_json(runtime, item);
+    const int step_direction = direction < 0 ? -1 : 1;
     switch (item->control_type)
     {
     case SDL3D_GAME_DATA_MENU_CONTROL_TOGGLE: {
@@ -3866,7 +3889,12 @@ bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, c
                 break;
             }
         }
-        const int next_index = (current_index + 1) % (int)yyjson_arr_size(choices);
+        const int choice_count = (int)yyjson_arr_size(choices);
+        int next_index =
+            current_index >= 0 ? current_index + step_direction : (step_direction < 0 ? choice_count - 1 : 0);
+        next_index %= choice_count;
+        if (next_index < 0)
+            next_index += choice_count;
         yyjson_val *next = yyjson_arr_get(choices, (size_t)next_index);
         return set_property_from_json(actor->props, item->control_key,
                                       yyjson_is_obj(next) ? obj_get(next, "value") : next);
@@ -3875,18 +3903,24 @@ bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, c
         const float min_value = json_float(control, "min", 0.0f);
         const float max_value = json_float(control, "max", 1.0f);
         const float step = json_float(control, "step", 1.0f);
-        float value =
-            sdl3d_properties_get_float(actor->props, item->control_key, json_float(control, "default", min_value));
-        value += step;
-        if (value > max_value)
-            value = min_value;
-        sdl3d_properties_set_float(actor->props, item->control_key, SDL_clamp(value, min_value, max_value));
+        const sdl3d_value *current = sdl3d_properties_get_value(actor->props, item->control_key);
+        float value = menu_control_numeric_value(current, control, min_value);
+        value = SDL_clamp(value + step * (float)step_direction, min_value, max_value);
+        if (menu_range_is_integer(control))
+            sdl3d_properties_set_int(actor->props, item->control_key, (int)SDL_lroundf(value));
+        else
+            sdl3d_properties_set_float(actor->props, item->control_key, value);
         return true;
     }
     case SDL3D_GAME_DATA_MENU_CONTROL_NONE:
         return false;
     }
     return false;
+}
+
+bool sdl3d_game_data_apply_menu_item_control(sdl3d_game_data_runtime *runtime, const sdl3d_game_data_menu_item *item)
+{
+    return sdl3d_game_data_adjust_menu_item_control(runtime, item, 1);
 }
 
 int sdl3d_game_data_scene_shortcut_count(const sdl3d_game_data_runtime *runtime)
@@ -4041,9 +4075,33 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
     }
     if (type == SDL3D_GAME_DATA_MENU_CONTROL_RANGE)
     {
-        const float current =
-            value != NULL && value->type == SDL3D_VALUE_FLOAT ? value->as_float : json_float(control, "default", 0.0f);
-        SDL_snprintf(buffer, buffer_size, "%s: %.2g", label, current);
+        const float min_value = json_float(control, "min", 0.0f);
+        const float max_value = json_float(control, "max", 1.0f);
+        const float current = SDL_clamp(menu_control_numeric_value(value, control, min_value), min_value, max_value);
+        if (SDL_strcmp(json_string(control, "display", ""), "slider") == 0)
+        {
+            const int slots = SDL_max(1, json_int(control, "slots", 10));
+            const float t = max_value > min_value ? (current - min_value) / (max_value - min_value) : 0.0f;
+            int filled = (int)SDL_lroundf(SDL_clamp(t, 0.0f, 1.0f) * (float)slots);
+            filled = SDL_clamp(filled, 0, slots);
+            char slider[64];
+            size_t pos = 0;
+            slider[pos++] = '[';
+            for (int i = 0; i < slots && pos + 2 < sizeof(slider); ++i)
+                slider[pos++] = i < filled ? '#' : '-';
+            slider[pos++] = ']';
+            slider[pos] = '\0';
+            if (menu_range_is_integer(control))
+                SDL_snprintf(buffer, buffer_size, "%s  %s %d/%d", label, slider, (int)SDL_lroundf(current),
+                             (int)SDL_lroundf(max_value));
+            else
+                SDL_snprintf(buffer, buffer_size, "%s  %s %.2g", label, slider, current);
+            return;
+        }
+        if (menu_range_is_integer(control))
+            SDL_snprintf(buffer, buffer_size, "%s: %d", label, (int)SDL_lroundf(current));
+        else
+            SDL_snprintf(buffer, buffer_size, "%s: %.2g", label, current);
         return;
     }
     SDL_strlcpy(buffer, label, buffer_size);
@@ -5781,8 +5839,12 @@ static float action_float_or_property(sdl3d_game_data_runtime *runtime, yyjson_v
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(source, "target", NULL));
         const char *property = json_string(source, "key", NULL);
-        if (actor != NULL && property != NULL)
-            return sdl3d_properties_get_float(actor->props, property, fallback);
+        const sdl3d_value *value =
+            actor != NULL && property != NULL ? sdl3d_properties_get_value(actor->props, property) : NULL;
+        if (value != NULL && value->type == SDL3D_VALUE_FLOAT)
+            return value->as_float * json_float(source, "scale", 1.0f);
+        if (value != NULL && value->type == SDL3D_VALUE_INT)
+            return (float)value->as_int * json_float(source, "scale", 1.0f);
     }
     return json_float(action, key, fallback);
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -101,6 +101,30 @@ typedef struct sensor_entry
     bool was_active;
 } sensor_entry;
 
+typedef struct input_binding_spec
+{
+    const char *action;
+    int action_id;
+    sdl3d_input_source source;
+    int required_modifiers;
+    int excluded_modifiers;
+    union {
+        SDL_Scancode scancode;
+        Uint8 mouse_button;
+        sdl3d_mouse_axis mouse_axis;
+        SDL_GamepadButton gamepad_button;
+        SDL_GamepadAxis gamepad_axis;
+    };
+    float scale;
+} input_binding_spec;
+
+typedef struct menu_key_binding_capture
+{
+    bool active;
+    const char *menu;
+    int item_index;
+} menu_key_binding_capture;
+
 typedef struct scene_menu_state
 {
     yyjson_val *menu;
@@ -222,6 +246,10 @@ typedef struct sdl3d_game_data_runtime
     int binding_count;
     sensor_entry *sensors;
     int sensor_count;
+    input_binding_spec *input_bindings;
+    int input_binding_count;
+    int input_binding_capacity;
+    menu_key_binding_capture key_capture;
     sdl3d_script_engine *scripts;
     script_entry *script_entries;
     int script_count;
@@ -260,6 +288,8 @@ static void set_error(char *buffer, int buffer_size, const char *message)
         SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown game data error");
     }
 }
+
+static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
 
 static bool path_is_absolute(const char *path)
 {
@@ -1733,6 +1763,14 @@ static SDL_Scancode scancode_from_json(const char *name)
     if (SDL_strlen(name) == 1)
         return SDL_GetScancodeFromKey(SDL_GetKeyFromName(name), NULL);
     return SDL_GetScancodeFromName(name);
+}
+
+static const char *scancode_display_name(SDL_Scancode scancode)
+{
+    if (scancode == SDL_SCANCODE_UNKNOWN)
+        return "-";
+    const char *name = SDL_GetScancodeName(scancode);
+    return name != NULL && name[0] != '\0' ? name : "-";
 }
 
 static SDL_GamepadAxis gamepad_axis_from_json(const char *name)
@@ -3508,6 +3546,7 @@ bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runt
 
     const char *previous = sdl3d_game_data_active_scene(runtime);
     runtime->active_scene_index = (int)(scene - runtime->scenes);
+    runtime->key_capture.active = false;
     apply_scene_camera(runtime, scene);
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data scene set: %s -> %s",
                  previous != NULL ? previous : "<none>", scene->name != NULL ? scene->name : "<none>");
@@ -3715,6 +3754,8 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
         return SDL3D_GAME_DATA_MENU_CONTROL_CHOICE;
     if (SDL_strcmp(type, "range") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_RANGE;
+    if (SDL_strcmp(type, "key_binding") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING;
     return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
 }
 
@@ -3760,6 +3801,8 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
     out_item->control_key = json_string(control, "key", NULL);
     out_item->choice_count =
         yyjson_is_arr(obj_get(control, "choices")) ? (int)yyjson_arr_size(obj_get(control, "choices")) : 0;
+    out_item->key_binding_count =
+        yyjson_is_arr(obj_get(control, "bindings")) ? (int)yyjson_arr_size(obj_get(control, "bindings")) : 0;
     return yyjson_is_obj(item) && out_item->label != NULL;
 }
 
@@ -3784,6 +3827,171 @@ static yyjson_val *find_menu_item_control_json(const sdl3d_game_data_runtime *ru
         }
     }
     return NULL;
+}
+
+static yyjson_val *find_menu_item_at(const sdl3d_game_data_runtime *runtime, const char *menu_name, int item_index)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    if (runtime == NULL || menu == NULL || !yyjson_is_arr(items) || item_index < 0 || item_index >= menu->item_count)
+        return NULL;
+    return yyjson_arr_get(items, (size_t)item_index);
+}
+
+static void set_key_binding_status(sdl3d_game_data_runtime *runtime, const char *status)
+{
+    if (runtime != NULL && runtime->scene_state != NULL)
+        sdl3d_properties_set_string(runtime->scene_state, "keyboard_binding_status", status != NULL ? status : "");
+}
+
+static SDL_Scancode current_action_keyboard_binding(const sdl3d_game_data_runtime *runtime, const char *action)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    for (int i = 0; runtime != NULL && action_id >= 0 && i < runtime->input_binding_count; ++i)
+    {
+        const input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_KEYBOARD)
+            return spec->scancode;
+    }
+    return SDL_SCANCODE_UNKNOWN;
+}
+
+static SDL_Scancode current_key_binding_control_scancode(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "keyboard") != 0)
+            continue;
+        const SDL_Scancode current = current_action_keyboard_binding(runtime, json_string(binding, "action", NULL));
+        if (current != SDL_SCANCODE_UNKNOWN)
+            return current;
+    }
+    return scancode_from_json(json_string(control, "default", NULL));
+}
+
+static bool set_key_binding_control_scancode(sdl3d_game_data_runtime *runtime, yyjson_val *control,
+                                             SDL_Scancode scancode)
+{
+    bool changed = false;
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "keyboard") != 0)
+            continue;
+        if (set_action_keyboard_binding(runtime, json_string(binding, "action", NULL), scancode))
+            changed = true;
+    }
+    return changed;
+}
+
+static const char *key_binding_conflict_label(const sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                              int item_index, SDL_Scancode scancode)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    for (int i = 0; yyjson_is_arr(items) && i < menu->item_count; ++i)
+    {
+        if (i == item_index)
+            continue;
+        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
+        yyjson_val *control = obj_get(item, "control");
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            continue;
+        if (current_key_binding_control_scancode(runtime, control) == scancode)
+            return json_string(item, "label", NULL);
+    }
+    return NULL;
+}
+
+bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                    int item_index)
+{
+    yyjson_val *item = find_menu_item_at(runtime, menu_name, item_index);
+    yyjson_val *control = obj_get(item, "control");
+    if (runtime == NULL || menu_name == NULL ||
+        parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+        return false;
+
+    runtime->key_capture.active = true;
+    runtime->key_capture.menu = menu_name;
+    runtime->key_capture.item_index = item_index;
+    char status[128];
+    SDL_snprintf(status, sizeof(status), "Press a key for %s", json_string(item, "label", "binding"));
+    set_key_binding_status(runtime, status);
+    return true;
+}
+
+bool sdl3d_game_data_menu_key_binding_capture_active(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->key_capture.active;
+}
+
+sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_binding_capture(
+    sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
+{
+    if (runtime == NULL || !runtime->key_capture.active)
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_NONE;
+
+    const SDL_Scancode scancode = sdl3d_input_get_pressed_scancode(input);
+    if (scancode == SDL_SCANCODE_UNKNOWN)
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+
+    yyjson_val *item = find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index);
+    yyjson_val *control = obj_get(item, "control");
+    const SDL_Scancode cancel = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
+    if (scancode == cancel && !json_bool(control, "allow_escape", false))
+    {
+        runtime->key_capture.active = false;
+        set_key_binding_status(runtime, "Canceled");
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED;
+    }
+
+    const char *conflict =
+        key_binding_conflict_label(runtime, runtime->key_capture.menu, runtime->key_capture.item_index, scancode);
+    if (conflict != NULL)
+    {
+        char status[128];
+        SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, scancode_display_name(scancode));
+        set_key_binding_status(runtime, status);
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
+    }
+
+    if (!set_key_binding_control_scancode(runtime, control, scancode))
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+
+    char status[128];
+    SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
+                 scancode_display_name(scancode));
+    runtime->key_capture.active = false;
+    set_key_binding_status(runtime, status);
+    return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
+}
+
+bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    bool changed = false;
+    for (int i = 0; yyjson_is_arr(items) && i < menu->item_count; ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
+        yyjson_val *control = obj_get(item, "control");
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            continue;
+        const SDL_Scancode key = scancode_from_json(json_string(control, "default", NULL));
+        if (key != SDL_SCANCODE_UNKNOWN && set_key_binding_control_scancode(runtime, control, key))
+            changed = true;
+    }
+    runtime->key_capture.active = false;
+    if (changed)
+        set_key_binding_status(runtime, "Keyboard settings reset");
+    return changed;
 }
 
 static bool set_property_from_json(sdl3d_properties *props, const char *key, yyjson_val *value)
@@ -3913,6 +4121,7 @@ bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime, 
         return true;
     }
     case SDL3D_GAME_DATA_MENU_CONTROL_NONE:
+    case SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING:
         return false;
     }
     return false;
@@ -3951,6 +4160,8 @@ bool sdl3d_game_data_scene_shortcut_at(const sdl3d_game_data_runtime *runtime, i
 
 bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
 {
+    if (sdl3d_game_data_menu_key_binding_capture_active(runtime))
+        return false;
     sdl3d_game_data_menu menu;
     if (!sdl3d_game_data_get_active_menu(runtime, &menu))
         return true;
@@ -3961,6 +4172,10 @@ bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *ru
             !sdl3d_input_is_held(input, menu.up_action_id)) &&
            (menu.down_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.down_action_id) ||
             !sdl3d_input_is_held(input, menu.down_action_id)) &&
+           (menu.left_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.left_action_id) ||
+            !sdl3d_input_is_held(input, menu.left_action_id)) &&
+           (menu.right_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.right_action_id) ||
+            !sdl3d_input_is_held(input, menu.right_action_id)) &&
            (menu.select_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu.select_action_id) ||
             !sdl3d_input_is_held(input, menu.select_action_id));
 }
@@ -4052,6 +4267,18 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
     if (type == SDL3D_GAME_DATA_MENU_CONTROL_NONE)
     {
         SDL_strlcpy(buffer, label, buffer_size);
+        return;
+    }
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+    {
+        if (runtime != NULL && runtime->key_capture.active &&
+            item == find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index))
+        {
+            SDL_snprintf(buffer, buffer_size, "%s: Press a key", label);
+            return;
+        }
+        SDL_snprintf(buffer, buffer_size, "%s: %s", label,
+                     scancode_display_name(current_key_binding_control_scancode(runtime, control)));
         return;
     }
 
@@ -4354,6 +4581,99 @@ static bool load_signals(sdl3d_game_data_runtime *runtime, yyjson_val *root, cha
     return true;
 }
 
+static bool append_input_binding_spec(sdl3d_game_data_runtime *runtime, const input_binding_spec *spec)
+{
+    if (runtime == NULL || spec == NULL)
+        return false;
+    if (runtime->input_binding_count >= runtime->input_binding_capacity)
+    {
+        const int next_capacity = runtime->input_binding_capacity > 0 ? runtime->input_binding_capacity * 2 : 32;
+        input_binding_spec *next = (input_binding_spec *)SDL_realloc(
+            runtime->input_bindings, (size_t)next_capacity * sizeof(*runtime->input_bindings));
+        if (next == NULL)
+            return false;
+        SDL_memset(next + runtime->input_binding_capacity, 0,
+                   (size_t)(next_capacity - runtime->input_binding_capacity) * sizeof(*runtime->input_bindings));
+        runtime->input_bindings = next;
+        runtime->input_binding_capacity = next_capacity;
+    }
+    runtime->input_bindings[runtime->input_binding_count++] = *spec;
+    return true;
+}
+
+static void bind_input_spec(sdl3d_input_manager *input, const input_binding_spec *spec)
+{
+    if (input == NULL || spec == NULL || spec->action_id < 0)
+        return;
+
+    switch (spec->source)
+    {
+    case SDL3D_INPUT_KEYBOARD:
+        sdl3d_input_bind_key_mod_mask(input, spec->action_id, spec->scancode, spec->required_modifiers,
+                                      spec->excluded_modifiers);
+        break;
+    case SDL3D_INPUT_MOUSE_BUTTON:
+        sdl3d_input_bind_mouse_button(input, spec->action_id, spec->mouse_button);
+        break;
+    case SDL3D_INPUT_MOUSE_AXIS:
+        sdl3d_input_bind_mouse_axis(input, spec->action_id, spec->mouse_axis, spec->scale);
+        break;
+    case SDL3D_INPUT_GAMEPAD_BUTTON:
+        sdl3d_input_bind_gamepad_button(input, spec->action_id, spec->gamepad_button);
+        break;
+    case SDL3D_INPUT_GAMEPAD_AXIS:
+        sdl3d_input_bind_gamepad_axis(input, spec->action_id, spec->gamepad_axis, spec->scale);
+        break;
+    }
+}
+
+static void rebind_action_from_specs(sdl3d_game_data_runtime *runtime, int action_id)
+{
+    sdl3d_input_manager *input = runtime_input(runtime);
+    if (input == NULL || action_id < 0)
+        return;
+
+    sdl3d_input_unbind_action(input, action_id);
+    for (int i = 0; i < runtime->input_binding_count; ++i)
+    {
+        if (runtime->input_bindings[i].action_id == action_id)
+            bind_input_spec(input, &runtime->input_bindings[i]);
+    }
+}
+
+static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    if (runtime == NULL || action == NULL || action_id < 0 || scancode == SDL_SCANCODE_UNKNOWN)
+        return false;
+
+    for (int i = 0; i < runtime->input_binding_count;)
+    {
+        input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_KEYBOARD)
+        {
+            *spec = runtime->input_bindings[runtime->input_binding_count - 1];
+            runtime->input_binding_count--;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    input_binding_spec spec;
+    SDL_zero(spec);
+    spec.action = action;
+    spec.action_id = action_id;
+    spec.source = SDL3D_INPUT_KEYBOARD;
+    spec.scancode = scancode;
+    spec.scale = 1.0f;
+    if (!append_input_binding_spec(runtime, &spec))
+        return false;
+    rebind_action_from_specs(runtime, action_id);
+    return true;
+}
+
 static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -4399,16 +4719,57 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                 {
                     SDL_Scancode code = scancode_from_json(json_string(binding, "key", NULL));
                     if (code != SDL_SCANCODE_UNKNOWN)
-                        sdl3d_input_bind_key(input, action_id, code);
+                    {
+                        input_binding_spec spec;
+                        SDL_zero(spec);
+                        spec.action = name;
+                        spec.action_id = action_id;
+                        spec.source = SDL3D_INPUT_KEYBOARD;
+                        spec.scancode = code;
+                        spec.scale = 1.0f;
+                        if (!append_input_binding_spec(runtime, &spec))
+                            return false;
+                        bind_input_spec(input, &spec);
+                    }
                 }
                 else if (SDL_strcmp(device, "gamepad") == 0)
                 {
                     const char *axis = json_string(binding, "axis", NULL);
                     const char *button = json_string(binding, "button", NULL);
                     if (axis != NULL)
-                        sdl3d_input_bind_gamepad_axis(input, action_id, gamepad_axis_from_json(axis), scale);
+                    {
+                        const SDL_GamepadAxis gamepad_axis = gamepad_axis_from_json(axis);
+                        if (gamepad_axis != SDL_GAMEPAD_AXIS_INVALID)
+                        {
+                            input_binding_spec spec;
+                            SDL_zero(spec);
+                            spec.action = name;
+                            spec.action_id = action_id;
+                            spec.source = SDL3D_INPUT_GAMEPAD_AXIS;
+                            spec.gamepad_axis = gamepad_axis;
+                            spec.scale = scale;
+                            if (!append_input_binding_spec(runtime, &spec))
+                                return false;
+                            bind_input_spec(input, &spec);
+                        }
+                    }
                     else if (button != NULL)
-                        sdl3d_input_bind_gamepad_button(input, action_id, gamepad_button_from_json(button));
+                    {
+                        const SDL_GamepadButton gamepad_button = gamepad_button_from_json(button);
+                        if (gamepad_button != SDL_GAMEPAD_BUTTON_INVALID)
+                        {
+                            input_binding_spec spec;
+                            SDL_zero(spec);
+                            spec.action = name;
+                            spec.action_id = action_id;
+                            spec.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+                            spec.gamepad_button = gamepad_button;
+                            spec.scale = 1.0f;
+                            if (!append_input_binding_spec(runtime, &spec))
+                                return false;
+                            bind_input_spec(input, &spec);
+                        }
+                    }
                 }
             }
         }
@@ -5281,6 +5642,37 @@ static bool read_ui_binding_value(const sdl3d_game_data_runtime *runtime, yyjson
             return false;
         }
     }
+    if (SDL_strcmp(type, "scene_state") == 0)
+    {
+        const char *key = json_string(binding, "key", NULL);
+        const sdl3d_value *value = runtime != NULL && runtime->scene_state != NULL && key != NULL
+                                       ? sdl3d_properties_get_value(runtime->scene_state, key)
+                                       : NULL;
+        if (value == NULL)
+            return false;
+        switch (value->type)
+        {
+        case SDL3D_VALUE_INT:
+            out_value->type = UI_VALUE_INT;
+            out_value->as_int = value->as_int;
+            return true;
+        case SDL3D_VALUE_FLOAT:
+            out_value->type = UI_VALUE_FLOAT;
+            out_value->as_float = value->as_float;
+            return true;
+        case SDL3D_VALUE_BOOL:
+            out_value->type = UI_VALUE_BOOL;
+            out_value->as_bool = value->as_bool;
+            return true;
+        case SDL3D_VALUE_STRING:
+            out_value->type = UI_VALUE_STRING;
+            out_value->as_string = value->as_string != NULL ? value->as_string : "";
+            return true;
+        case SDL3D_VALUE_VEC3:
+        case SDL3D_VALUE_COLOR:
+            return false;
+        }
+    }
     return false;
 }
 
@@ -6088,6 +6480,9 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "property.reset_defaults") == 0)
         return reset_actor_properties_to_authored_defaults(runtime, action);
+
+    if (SDL_strcmp(type, "input.reset_key_bindings") == 0)
+        return sdl3d_game_data_reset_menu_key_bindings(runtime, json_string(action, "menu", NULL));
 
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
@@ -7443,6 +7838,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->adapters);
     SDL_free(runtime->bindings);
     SDL_free(runtime->sensors);
+    SDL_free(runtime->input_bindings);
     SDL_free(runtime->ui_states);
     SDL_free(runtime->animations);
     SDL_free(runtime->audio_files);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -125,6 +125,12 @@ typedef struct menu_key_binding_capture
     int item_index;
 } menu_key_binding_capture;
 
+typedef enum menu_binding_device
+{
+    MENU_BINDING_DEVICE_KEYBOARD = 0,
+    MENU_BINDING_DEVICE_GAMEPAD_BUTTON = 1,
+} menu_binding_device;
+
 typedef struct scene_menu_state
 {
     yyjson_val *menu;
@@ -290,6 +296,8 @@ static void set_error(char *buffer, int buffer_size, const char *message)
 }
 
 static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
+static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
+                                              SDL_GamepadButton button);
 
 static bool path_is_absolute(const char *path)
 {
@@ -1775,6 +1783,14 @@ static const char *scancode_display_name(SDL_Scancode scancode)
     return name != NULL && name[0] != '\0' ? name : "-";
 }
 
+static const char *gamepad_button_display_name(SDL_GamepadButton button)
+{
+    if (button == SDL_GAMEPAD_BUTTON_INVALID)
+        return "-";
+    const char *name = SDL_GetGamepadStringForButton(button);
+    return name != NULL && name[0] != '\0' ? name : "-";
+}
+
 static SDL_GamepadAxis gamepad_axis_from_json(const char *name)
 {
     if (name == NULL)
@@ -1810,6 +1826,14 @@ static SDL_GamepadButton gamepad_button_from_json(const char *name)
         return SDL_GAMEPAD_BUTTON_EAST;
     if (SDL_strcmp(name, "WEST") == 0)
         return SDL_GAMEPAD_BUTTON_WEST;
+    if (SDL_strcmp(name, "LEFT_STICK") == 0)
+        return SDL_GAMEPAD_BUTTON_LEFT_STICK;
+    if (SDL_strcmp(name, "RIGHT_STICK") == 0)
+        return SDL_GAMEPAD_BUTTON_RIGHT_STICK;
+    if (SDL_strcmp(name, "LEFT_SHOULDER") == 0)
+        return SDL_GAMEPAD_BUTTON_LEFT_SHOULDER;
+    if (SDL_strcmp(name, "RIGHT_SHOULDER") == 0)
+        return SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER;
     if (SDL_strcmp(name, "DPAD_UP") == 0)
         return SDL_GAMEPAD_BUTTON_DPAD_UP;
     if (SDL_strcmp(name, "DPAD_DOWN") == 0)
@@ -1818,6 +1842,20 @@ static SDL_GamepadButton gamepad_button_from_json(const char *name)
         return SDL_GAMEPAD_BUTTON_DPAD_LEFT;
     if (SDL_strcmp(name, "DPAD_RIGHT") == 0)
         return SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
+    if (SDL_strcmp(name, "GUIDE") == 0)
+        return SDL_GAMEPAD_BUTTON_GUIDE;
+    if (SDL_strcmp(name, "MISC1") == 0)
+        return SDL_GAMEPAD_BUTTON_MISC1;
+    if (SDL_strcmp(name, "RIGHT_PADDLE1") == 0)
+        return SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1;
+    if (SDL_strcmp(name, "LEFT_PADDLE1") == 0)
+        return SDL_GAMEPAD_BUTTON_LEFT_PADDLE1;
+    if (SDL_strcmp(name, "RIGHT_PADDLE2") == 0)
+        return SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2;
+    if (SDL_strcmp(name, "LEFT_PADDLE2") == 0)
+        return SDL_GAMEPAD_BUTTON_LEFT_PADDLE2;
+    if (SDL_strcmp(name, "TOUCHPAD") == 0)
+        return SDL_GAMEPAD_BUTTON_TOUCHPAD;
     return SDL_GAMEPAD_BUTTON_INVALID;
 }
 
@@ -3841,10 +3879,25 @@ static yyjson_val *find_menu_item_at(const sdl3d_game_data_runtime *runtime, con
     return yyjson_arr_get(items, (size_t)item_index);
 }
 
-static void set_key_binding_status(sdl3d_game_data_runtime *runtime, const char *status)
+static void set_menu_binding_status(sdl3d_game_data_runtime *runtime, const char *status)
 {
     if (runtime != NULL && runtime->scene_state != NULL)
+    {
         sdl3d_properties_set_string(runtime->scene_state, "keyboard_binding_status", status != NULL ? status : "");
+        sdl3d_properties_set_string(runtime->scene_state, "gamepad_binding_status", status != NULL ? status : "");
+    }
+}
+
+static menu_binding_device menu_binding_control_device(yyjson_val *control)
+{
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "gamepad") == 0)
+            return MENU_BINDING_DEVICE_GAMEPAD_BUTTON;
+    }
+    return MENU_BINDING_DEVICE_KEYBOARD;
 }
 
 static SDL_Scancode current_action_keyboard_binding(const sdl3d_game_data_runtime *runtime, const char *action)
@@ -3857,6 +3910,19 @@ static SDL_Scancode current_action_keyboard_binding(const sdl3d_game_data_runtim
             return spec->scancode;
     }
     return SDL_SCANCODE_UNKNOWN;
+}
+
+static SDL_GamepadButton current_action_gamepad_button_binding(const sdl3d_game_data_runtime *runtime,
+                                                               const char *action)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    for (int i = 0; runtime != NULL && action_id >= 0 && i < runtime->input_binding_count; ++i)
+    {
+        const input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_GAMEPAD_BUTTON)
+            return spec->gamepad_button;
+    }
+    return SDL_GAMEPAD_BUTTON_INVALID;
 }
 
 static SDL_Scancode current_key_binding_control_scancode(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
@@ -3872,6 +3938,23 @@ static SDL_Scancode current_key_binding_control_scancode(const sdl3d_game_data_r
             return current;
     }
     return scancode_from_json(json_string(control, "default", NULL));
+}
+
+static SDL_GamepadButton current_key_binding_control_gamepad_button(const sdl3d_game_data_runtime *runtime,
+                                                                    yyjson_val *control)
+{
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "gamepad") != 0)
+            continue;
+        const SDL_GamepadButton current =
+            current_action_gamepad_button_binding(runtime, json_string(binding, "action", NULL));
+        if (current != SDL_GAMEPAD_BUTTON_INVALID)
+            return current;
+    }
+    return gamepad_button_from_json(json_string(control, "default", NULL));
 }
 
 static bool set_key_binding_control_scancode(sdl3d_game_data_runtime *runtime, yyjson_val *control,
@@ -3890,8 +3973,24 @@ static bool set_key_binding_control_scancode(sdl3d_game_data_runtime *runtime, y
     return changed;
 }
 
-static const char *key_binding_conflict_label(const sdl3d_game_data_runtime *runtime, const char *menu_name,
-                                              int item_index, SDL_Scancode scancode)
+static bool set_key_binding_control_gamepad_button(sdl3d_game_data_runtime *runtime, yyjson_val *control,
+                                                   SDL_GamepadButton button)
+{
+    bool changed = false;
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "gamepad") != 0)
+            continue;
+        if (set_action_gamepad_button_binding(runtime, json_string(binding, "action", NULL), button))
+            changed = true;
+    }
+    return changed;
+}
+
+static const char *keyboard_binding_conflict_label(const sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                   int item_index, SDL_Scancode scancode)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
     const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
@@ -3904,7 +4003,31 @@ static const char *key_binding_conflict_label(const sdl3d_game_data_runtime *run
         yyjson_val *control = obj_get(item, "control");
         if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
             continue;
+        if (menu_binding_control_device(control) != MENU_BINDING_DEVICE_KEYBOARD)
+            continue;
         if (current_key_binding_control_scancode(runtime, control) == scancode)
+            return json_string(item, "label", NULL);
+    }
+    return NULL;
+}
+
+static const char *gamepad_button_binding_conflict_label(const sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                         int item_index, SDL_GamepadButton button)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    for (int i = 0; yyjson_is_arr(items) && i < menu->item_count; ++i)
+    {
+        if (i == item_index)
+            continue;
+        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
+        yyjson_val *control = obj_get(item, "control");
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            continue;
+        if (menu_binding_control_device(control) != MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+            continue;
+        if (current_key_binding_control_gamepad_button(runtime, control) == button)
             return json_string(item, "label", NULL);
     }
     return NULL;
@@ -3923,8 +4046,10 @@ bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *run
     runtime->key_capture.menu = menu_name;
     runtime->key_capture.item_index = item_index;
     char status[128];
-    SDL_snprintf(status, sizeof(status), "Press a key for %s", json_string(item, "label", "binding"));
-    set_key_binding_status(runtime, status);
+    const char *device_name =
+        menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
+    SDL_snprintf(status, sizeof(status), "Press a %s for %s", device_name, json_string(item, "label", "binding"));
+    set_menu_binding_status(runtime, status);
     return true;
 }
 
@@ -3939,27 +4064,62 @@ sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_bindi
     if (runtime == NULL || !runtime->key_capture.active)
         return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_NONE;
 
+    yyjson_val *item = find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index);
+    yyjson_val *control = obj_get(item, "control");
+    if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+    {
+        const SDL_Scancode cancel_key = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
+        if (sdl3d_input_get_pressed_scancode(input) == cancel_key)
+        {
+            runtime->key_capture.active = false;
+            set_menu_binding_status(runtime, "Canceled");
+            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED;
+        }
+
+        const SDL_GamepadButton button = sdl3d_input_get_pressed_gamepad_button(input);
+        if (button == SDL_GAMEPAD_BUTTON_INVALID)
+            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+
+        const char *conflict = gamepad_button_binding_conflict_label(runtime, runtime->key_capture.menu,
+                                                                     runtime->key_capture.item_index, button);
+        if (conflict != NULL)
+        {
+            char status[128];
+            SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, gamepad_button_display_name(button));
+            set_menu_binding_status(runtime, status);
+            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
+        }
+
+        if (!set_key_binding_control_gamepad_button(runtime, control, button))
+            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+
+        char status[128];
+        SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
+                     gamepad_button_display_name(button));
+        runtime->key_capture.active = false;
+        set_menu_binding_status(runtime, status);
+        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
+    }
+
     const SDL_Scancode scancode = sdl3d_input_get_pressed_scancode(input);
     if (scancode == SDL_SCANCODE_UNKNOWN)
         return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
 
-    yyjson_val *item = find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index);
-    yyjson_val *control = obj_get(item, "control");
     const SDL_Scancode cancel = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
     if (scancode == cancel && !json_bool(control, "allow_escape", false))
     {
         runtime->key_capture.active = false;
-        set_key_binding_status(runtime, "Canceled");
+        set_menu_binding_status(runtime, "Canceled");
         return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED;
     }
 
     const char *conflict =
-        key_binding_conflict_label(runtime, runtime->key_capture.menu, runtime->key_capture.item_index, scancode);
+        keyboard_binding_conflict_label(runtime, runtime->key_capture.menu, runtime->key_capture.item_index, scancode);
     if (conflict != NULL)
     {
         char status[128];
         SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, scancode_display_name(scancode));
-        set_key_binding_status(runtime, status);
+        set_menu_binding_status(runtime, status);
         return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
     }
 
@@ -3970,7 +4130,7 @@ sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_bindi
     SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
                  scancode_display_name(scancode));
     runtime->key_capture.active = false;
-    set_key_binding_status(runtime, status);
+    set_menu_binding_status(runtime, status);
     return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
 }
 
@@ -3986,13 +4146,23 @@ bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, c
         yyjson_val *control = obj_get(item, "control");
         if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
             continue;
-        const SDL_Scancode key = scancode_from_json(json_string(control, "default", NULL));
-        if (key != SDL_SCANCODE_UNKNOWN && set_key_binding_control_scancode(runtime, control, key))
-            changed = true;
+        if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+        {
+            const SDL_GamepadButton button = gamepad_button_from_json(json_string(control, "default", NULL));
+            if (button != SDL_GAMEPAD_BUTTON_INVALID &&
+                set_key_binding_control_gamepad_button(runtime, control, button))
+                changed = true;
+        }
+        else
+        {
+            const SDL_Scancode key = scancode_from_json(json_string(control, "default", NULL));
+            if (key != SDL_SCANCODE_UNKNOWN && set_key_binding_control_scancode(runtime, control, key))
+                changed = true;
+        }
     }
     runtime->key_capture.active = false;
     if (changed)
-        set_key_binding_status(runtime, "Keyboard settings reset");
+        set_menu_binding_status(runtime, "Input settings reset");
     return changed;
 }
 
@@ -4276,11 +4446,21 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
         if (runtime != NULL && runtime->key_capture.active &&
             item == find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index))
         {
-            SDL_snprintf(buffer, buffer_size, "%s: Press a key", label);
+            const char *device_name =
+                menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
+            SDL_snprintf(buffer, buffer_size, "%s: Press a %s", label, device_name);
             return;
         }
-        SDL_snprintf(buffer, buffer_size, "%s: %s", label,
-                     scancode_display_name(current_key_binding_control_scancode(runtime, control)));
+        if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+        {
+            SDL_snprintf(buffer, buffer_size, "%s: %s", label,
+                         gamepad_button_display_name(current_key_binding_control_gamepad_button(runtime, control)));
+        }
+        else
+        {
+            SDL_snprintf(buffer, buffer_size, "%s: %s", label,
+                         scancode_display_name(current_key_binding_control_scancode(runtime, control)));
+        }
         return;
     }
 
@@ -4669,6 +4849,40 @@ static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const 
     spec.action_id = action_id;
     spec.source = SDL3D_INPUT_KEYBOARD;
     spec.scancode = scancode;
+    spec.scale = 1.0f;
+    if (!append_input_binding_spec(runtime, &spec))
+        return false;
+    rebind_action_from_specs(runtime, action_id);
+    return true;
+}
+
+static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
+                                              SDL_GamepadButton button)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    if (runtime == NULL || action == NULL || action_id < 0 || button == SDL_GAMEPAD_BUTTON_INVALID)
+        return false;
+
+    for (int i = 0; i < runtime->input_binding_count;)
+    {
+        input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_GAMEPAD_BUTTON)
+        {
+            *spec = runtime->input_bindings[runtime->input_binding_count - 1];
+            runtime->input_binding_count--;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    input_binding_spec spec;
+    SDL_zero(spec);
+    spec.action = action;
+    spec.action_id = action_id;
+    spec.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+    spec.gamepad_button = button;
     spec.scale = 1.0f;
     if (!append_input_binding_spec(runtime, &spec))
         return false;
@@ -6483,7 +6697,7 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
     if (SDL_strcmp(type, "property.reset_defaults") == 0)
         return reset_actor_properties_to_authored_defaults(runtime, action);
 
-    if (SDL_strcmp(type, "input.reset_key_bindings") == 0)
+    if (SDL_strcmp(type, "input.reset_bindings") == 0)
         return sdl3d_game_data_reset_menu_key_bindings(runtime, json_string(action, "menu", NULL));
 
     if (SDL_strcmp(type, "ui.animate") == 0)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1111,6 +1111,22 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "%s requires a value", type);
         return true;
     }
+    if (SDL_strcmp(type, "property.snapshot") == 0 || SDL_strcmp(type, "property.restore_snapshot") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "%s requires a non-empty name", type);
+        yyjson_val *keys = obj_get(action, "keys");
+        if (keys != NULL && !yyjson_is_arr(keys))
+            return validation_error(ctx, json_path, "%s keys must be an array", type);
+        for (size_t i = 0; yyjson_is_arr(keys) && i < yyjson_arr_size(keys); ++i)
+        {
+            if (!yyjson_is_str(yyjson_arr_get(keys, i)))
+                return validation_error(ctx, json_path, "%s keys must be strings", type);
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "property.animate") == 0)
     {
         if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1149,10 +1149,10 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
-    if (SDL_strcmp(type, "input.reset_key_bindings") == 0)
+    if (SDL_strcmp(type, "input.reset_bindings") == 0)
     {
         if (!is_non_empty_string(action, "menu"))
-            return validation_error(ctx, json_path, "input.reset_key_bindings requires a non-empty menu");
+            return validation_error(ctx, json_path, "input.reset_bindings requires a non-empty menu");
         return true;
     }
     if (SDL_strcmp(type, "ui.animate") == 0)
@@ -2054,15 +2054,15 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
         if (!yyjson_is_arr(bindings) || yyjson_arr_size(bindings) == 0)
             return validation_error(ctx, path, "key_binding control requires at least one binding");
         if (!is_non_empty_string(control, "default"))
-            return validation_error(ctx, path, "key_binding control requires a default key");
+            return validation_error(ctx, path, "key_binding control requires a default input");
         for (size_t i = 0; i < yyjson_arr_size(bindings); ++i)
         {
             yyjson_val *binding = yyjson_arr_get(bindings, i);
             if (!require_ref(ctx, &names->actions, "input action", json_string(binding, "action"), path))
                 return false;
             const char *device = json_string(binding, "device");
-            if (device != NULL && SDL_strcmp(device, "keyboard") != 0)
-                return validation_error(ctx, path, "key_binding controls currently support keyboard bindings only");
+            if (device != NULL && SDL_strcmp(device, "keyboard") != 0 && SDL_strcmp(device, "gamepad") != 0)
+                return validation_error(ctx, path, "key_binding controls support keyboard or gamepad bindings");
         }
     }
     return true;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1518,6 +1518,16 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     if (window_apply_signal != NULL &&
         !require_ref(ctx, &names->signals, "signal", window_apply_signal, "$.app.window.apply_signal"))
         return false;
+    yyjson_val *window_apply_signals = obj_get(window, "apply_signals");
+    if (window_apply_signals != NULL && !yyjson_is_arr(window_apply_signals))
+        return validation_error(ctx, "$.app.window.apply_signals", "apply_signals must be an array");
+    for (size_t i = 0; yyjson_is_arr(window_apply_signals) && i < yyjson_arr_size(window_apply_signals); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.app.window.apply_signals[%zu]", i);
+        if (!require_ref(ctx, &names->signals, "signal", yyjson_get_str(yyjson_arr_get(window_apply_signals, i)), path))
+            return false;
+    }
     yyjson_val *window_settings = obj_get(window, "settings");
     if (window_settings != NULL && !yyjson_is_obj(window_settings))
         return validation_error(ctx, "$.app.window.settings", "window settings must be an object");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1069,6 +1069,16 @@ static bool validate_audio_action(validation_context *ctx, yyjson_val *action, c
     yyjson_val *volume = obj_get(action, "volume");
     if (volume != NULL && !yyjson_is_num(volume))
         return validation_error(ctx, json_path, "audio volume must be numeric");
+    yyjson_val *source = obj_get(action, "source");
+    if (source != NULL)
+    {
+        if (!yyjson_is_obj(source))
+            return validation_error(ctx, json_path, "audio source must be an object");
+        if (!require_ref(ctx, &names->entities, "entity", json_string(source, "target"), json_path))
+            return false;
+        if (!is_non_empty_string(source, "key"))
+            return validation_error(ctx, json_path, "audio source requires a non-empty key");
+    }
     yyjson_val *fade = obj_get(action, "fade");
     if (fade != NULL && !yyjson_is_num(fade))
         return validation_error(ctx, json_path, "audio fade must be numeric");
@@ -1108,6 +1118,20 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (!is_non_empty_string(action, "key"))
             return validation_error(ctx, json_path, "property.animate requires a non-empty key");
         return validate_animation_common(ctx, action, json_path, names);
+    }
+    if (SDL_strcmp(type, "property.reset_defaults") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+            return false;
+        yyjson_val *keys = obj_get(action, "keys");
+        if (keys != NULL && !yyjson_is_arr(keys))
+            return validation_error(ctx, json_path, "property.reset_defaults keys must be an array");
+        for (size_t i = 0; yyjson_is_arr(keys) && i < yyjson_arr_size(keys); ++i)
+        {
+            if (!yyjson_is_str(yyjson_arr_get(keys, i)))
+                return validation_error(ctx, json_path, "property.reset_defaults keys must be strings");
+        }
+        return true;
     }
     if (SDL_strcmp(type, "ui.animate") == 0)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2186,6 +2186,12 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             !require_ref(ctx, &names->actions, "input action", json_string(menu, "down_action"), menu_path) ||
             !require_ref(ctx, &names->actions, "input action", json_string(menu, "select_action"), menu_path))
             return false;
+        const char *left_action = json_string(menu, "left_action");
+        if (left_action != NULL && !require_ref(ctx, &names->actions, "input action", left_action, menu_path))
+            return false;
+        const char *right_action = json_string(menu, "right_action");
+        if (right_action != NULL && !require_ref(ctx, &names->actions, "input action", right_action, menu_path))
+            return false;
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.active_if", menu_path);
         if (!validate_scene_ui_condition(ctx, obj_get(menu, "active_if"), condition_path, names))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1149,6 +1149,12 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "input.reset_key_bindings") == 0)
+    {
+        if (!is_non_empty_string(action, "menu"))
+            return validation_error(ctx, json_path, "input.reset_key_bindings requires a non-empty menu");
+        return true;
+    }
     if (SDL_strcmp(type, "ui.animate") == 0)
     {
         if (!is_non_empty_string(action, "target") && !is_non_empty_string(action, "ui"))
@@ -1774,8 +1780,11 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
             }
             else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
             {
-                return validation_error(ctx, binding_path, "unsupported UI binding type '%s'",
-                                        type != NULL ? type : "<missing>");
+                if (SDL_strcmp(type != NULL ? type : "", "scene_state") != 0)
+                    return validation_error(ctx, binding_path, "unsupported UI binding type '%s'",
+                                            type != NULL ? type : "<missing>");
+                if (!is_non_empty_string(binding, "key"))
+                    return validation_error(ctx, binding_path, "UI scene_state binding requires a non-empty key");
             }
         }
     }
@@ -2015,13 +2024,17 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
         return validation_error(ctx, path, "menu item control must be an object");
 
     const char *type = json_string(control, "type");
-    if (type == NULL ||
-        (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 && SDL_strcmp(type, "range") != 0))
-        return validation_error(ctx, path, "menu item control requires type toggle, choice, or range");
-    if (!require_ref(ctx, &names->entities, "entity", json_string(control, "target"), path))
-        return false;
-    if (!is_non_empty_string(control, "key"))
-        return validation_error(ctx, path, "menu item control requires a non-empty key");
+    if (type == NULL || (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 &&
+                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "key_binding") != 0))
+        return validation_error(ctx, path, "menu item control requires type toggle, choice, range, or key_binding");
+
+    if (SDL_strcmp(type, "key_binding") != 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(control, "target"), path))
+            return false;
+        if (!is_non_empty_string(control, "key"))
+            return validation_error(ctx, path, "menu item control requires a non-empty key");
+    }
 
     if (SDL_strcmp(type, "choice") == 0)
     {
@@ -2034,6 +2047,23 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
         if (!yyjson_is_num(obj_get(control, "min")) || !yyjson_is_num(obj_get(control, "max")) ||
             !yyjson_is_num(obj_get(control, "step")))
             return validation_error(ctx, path, "range control requires numeric min, max, and step");
+    }
+    if (SDL_strcmp(type, "key_binding") == 0)
+    {
+        yyjson_val *bindings = obj_get(control, "bindings");
+        if (!yyjson_is_arr(bindings) || yyjson_arr_size(bindings) == 0)
+            return validation_error(ctx, path, "key_binding control requires at least one binding");
+        if (!is_non_empty_string(control, "default"))
+            return validation_error(ctx, path, "key_binding control requires a default key");
+        for (size_t i = 0; i < yyjson_arr_size(bindings); ++i)
+        {
+            yyjson_val *binding = yyjson_arr_get(bindings, i);
+            if (!require_ref(ctx, &names->actions, "input action", json_string(binding, "action"), path))
+                return false;
+            const char *device = json_string(binding, "device");
+            if (device != NULL && SDL_strcmp(device, "keyboard") != 0)
+                return validation_error(ctx, path, "key_binding controls currently support keyboard bindings only");
+        }
     }
     return true;
 }
@@ -2320,8 +2350,11 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             }
             else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
             {
-                return validation_error(ctx, binding_path, "unsupported scene UI binding type '%s'",
-                                        type != NULL ? type : "<missing>");
+                if (SDL_strcmp(type != NULL ? type : "", "scene_state") != 0)
+                    return validation_error(ctx, binding_path, "unsupported scene UI binding type '%s'",
+                                            type != NULL ? type : "<missing>");
+                if (!is_non_empty_string(binding, "key"))
+                    return validation_error(ctx, binding_path, "scene UI scene_state binding requires a non-empty key");
             }
         }
     }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1511,6 +1511,21 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
         return validation_error(ctx, "$.app.startup_transition", "unknown transition reference '%s'",
                                 startup_transition);
 
+    yyjson_val *window = obj_get(app, "window");
+    if (window != NULL && !yyjson_is_obj(window))
+        return validation_error(ctx, "$.app.window", "window must be an object");
+    const char *window_apply_signal = json_string(window, "apply_signal");
+    if (window_apply_signal != NULL &&
+        !require_ref(ctx, &names->signals, "signal", window_apply_signal, "$.app.window.apply_signal"))
+        return false;
+    yyjson_val *window_settings = obj_get(window, "settings");
+    if (window_settings != NULL && !yyjson_is_obj(window_settings))
+        return validation_error(ctx, "$.app.window.settings", "window settings must be an object");
+    const char *window_settings_target = json_string(window_settings, "target");
+    if (window_settings_target != NULL &&
+        !require_ref(ctx, &names->entities, "entity", window_settings_target, "$.app.window.settings.target"))
+        return false;
+
     yyjson_val *quit = obj_get(app, "quit");
     if (!yyjson_is_obj(quit))
         return true;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1115,7 +1115,7 @@ static bool app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_con
 
     if (result.signal_id >= 0)
         sdl3d_signal_emit(bus, result.signal_id, NULL);
-    if (result.signal_id >= 0 && result.signal_id == flow->app.window_apply_signal_id)
+    if (sdl3d_game_data_app_signal_applies_window_settings(runtime, result.signal_id))
         (void)app_flow_apply_window_settings(flow, ctx, runtime);
 
     sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -44,6 +44,49 @@ typedef struct particle_update_context
     bool ok;
 } particle_update_context;
 
+static sdl3d_window_mode parse_window_mode_setting(const char *value, sdl3d_window_mode fallback)
+{
+    if (value == NULL || value[0] == '\0')
+        return fallback;
+    if (SDL_strcasecmp(value, "windowed") == 0 || SDL_strcasecmp(value, "window") == 0)
+        return SDL3D_WINDOW_MODE_WINDOWED;
+    if (SDL_strcasecmp(value, "fullscreen_exclusive") == 0 || SDL_strcasecmp(value, "exclusive") == 0)
+        return SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE;
+    if (SDL_strcasecmp(value, "fullscreen_borderless") == 0 || SDL_strcasecmp(value, "borderless") == 0 ||
+        SDL_strcasecmp(value, "desktop_fullscreen") == 0)
+        return SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS;
+    return fallback;
+}
+
+static const char *window_mode_setting_name(sdl3d_window_mode mode)
+{
+    switch (mode)
+    {
+    case SDL3D_WINDOW_MODE_WINDOWED:
+        return "windowed";
+    case SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE:
+        return "fullscreen_exclusive";
+    case SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS:
+        return "fullscreen_borderless";
+    case SDL3D_WINDOW_MODE_DEFAULT:
+    default:
+        return "default";
+    }
+}
+
+static sdl3d_backend parse_backend_setting(const char *value, sdl3d_backend fallback)
+{
+    if (value == NULL || value[0] == '\0')
+        return fallback;
+    if (SDL_strcasecmp(value, "software") == 0 || SDL_strcasecmp(value, "sw") == 0)
+        return SDL3D_BACKEND_SOFTWARE;
+    if (SDL_strcasecmp(value, "opengl") == 0 || SDL_strcasecmp(value, "gl") == 0)
+        return SDL3D_BACKEND_OPENGL;
+    if (SDL_strcasecmp(value, "auto") == 0)
+        return SDL3D_BACKEND_AUTO;
+    return fallback;
+}
+
 static sdl3d_camera3d default_camera(void)
 {
     sdl3d_camera3d camera;
@@ -1006,6 +1049,48 @@ static void app_flow_apply_pause_command(sdl3d_game_context *ctx, sdl3d_game_dat
         ctx->paused = !ctx->paused;
 }
 
+static bool app_flow_apply_window_settings(const sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
+                                           sdl3d_game_data_runtime *runtime)
+{
+    if (flow == NULL || ctx == NULL || runtime == NULL || ctx->window == NULL || ctx->renderer == NULL)
+        return false;
+
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, flow->app.window_settings_target);
+    if (settings == NULL)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D window settings skipped: settings actor '%s' was not found",
+                    flow->app.window_settings_target != NULL ? flow->app.window_settings_target : "");
+        return false;
+    }
+
+    int width = 0;
+    int height = 0;
+    SDL_GetWindowSize(ctx->window, &width, &height);
+
+    sdl3d_window_config config;
+    sdl3d_init_window_config(&config);
+    config.width = width;
+    config.height = height;
+    config.logical_width = sdl3d_get_render_context_width(ctx->renderer);
+    config.logical_height = sdl3d_get_render_context_height(ctx->renderer);
+    config.title = SDL_GetWindowTitle(ctx->window);
+    config.display_mode = parse_window_mode_setting(
+        sdl3d_properties_get_string(settings->props, flow->app.window_display_mode_key, "windowed"),
+        SDL3D_WINDOW_MODE_WINDOWED);
+    config.backend =
+        parse_backend_setting(sdl3d_properties_get_string(settings->props, flow->app.window_renderer_key, "opengl"),
+                              sdl3d_get_render_context_backend(ctx->renderer));
+    config.vsync = sdl3d_properties_get_bool(settings->props, flow->app.window_vsync_key, true);
+    config.maximized = true;
+    config.resizable = true;
+    config.allow_backend_fallback = false;
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D authored window apply requested: mode=%s renderer=%s vsync=%s",
+                window_mode_setting_name(config.display_mode), sdl3d_get_backend_name(config.backend),
+                config.vsync ? "on" : "off");
+    return sdl3d_apply_window_config(&ctx->window, &ctx->renderer, &config);
+}
+
 static bool app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_context *ctx,
                                   sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input, sdl3d_signal_bus *bus)
 {
@@ -1030,6 +1115,8 @@ static bool app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_con
 
     if (result.signal_id >= 0)
         sdl3d_signal_emit(bus, result.signal_id, NULL);
+    if (result.signal_id >= 0 && result.signal_id == flow->app.window_apply_signal_id)
+        (void)app_flow_apply_window_settings(flow, ctx, runtime);
 
     sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
     if (result.return_to != NULL && scene_state != NULL)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -736,6 +736,21 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         out_result->selected_index = menu.selected_index;
     }
 
+    if (sdl3d_game_data_menu_key_binding_capture_active(runtime))
+    {
+        const sdl3d_game_data_key_binding_capture_status capture_status =
+            sdl3d_game_data_update_menu_key_binding_capture(runtime, input);
+        if (out_result != NULL)
+        {
+            out_result->handled_input = true;
+            out_result->key_binding_changed = capture_status == SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
+            out_result->key_binding_conflict = capture_status == SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
+            out_result->selected = out_result->key_binding_changed;
+            out_result->select_signal_id = out_result->key_binding_changed ? menu.select_signal_id : -1;
+        }
+        return true;
+    }
+
     if (!*input_armed)
     {
         if (menu_input_is_idle(runtime, input, &menu))
@@ -798,7 +813,28 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         {
             out_result->menu = refreshed.name;
             out_result->selected_index = refreshed.selected_index;
-            out_result->control_changed = sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
+            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            {
+                out_result->key_binding_capture_started =
+                    sdl3d_game_data_start_menu_key_binding_capture(runtime, refreshed.name, refreshed.selected_index);
+                out_result->selected = out_result->key_binding_capture_started;
+                out_result->select_signal_id = out_result->selected ? refreshed.select_signal_id : -1;
+                out_result->signal_id = -1;
+                out_result->quit = false;
+                out_result->scene = NULL;
+                out_result->return_to = NULL;
+                out_result->return_scene = false;
+                out_result->pause_command = SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+                out_result->has_return_paused = false;
+                out_result->return_paused = false;
+                out_result->control_changed = false;
+                out_result->handled_input = true;
+                return true;
+            }
+            out_result->control_changed =
+                control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING
+                    ? false
+                    : sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
             out_result->selected = !control_adjust_input || out_result->control_changed;
             out_result->select_signal_id = out_result->selected ? refreshed.select_signal_id : -1;
             out_result->quit = !control_adjust_input && !out_result->control_changed && item.quit;
@@ -815,7 +851,10 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         }
         else
         {
-            (void)sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
+            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+                (void)sdl3d_game_data_start_menu_key_binding_capture(runtime, refreshed.name, refreshed.selected_index);
+            else if (item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+                (void)sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
         }
     }
     else if (handled && out_result != NULL)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -702,6 +702,10 @@ static bool menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl
             !sdl3d_input_is_held(input, menu->up_action_id)) &&
            (menu->down_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->down_action_id) ||
             !sdl3d_input_is_held(input, menu->down_action_id)) &&
+           (menu->left_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->left_action_id) ||
+            !sdl3d_input_is_held(input, menu->left_action_id)) &&
+           (menu->right_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->right_action_id) ||
+            !sdl3d_input_is_held(input, menu->right_action_id)) &&
            (menu->select_action_id < 0 ||
             !sdl3d_game_data_active_scene_allows_action(runtime, menu->select_action_id) ||
             !sdl3d_input_is_held(input, menu->select_action_id));
@@ -756,11 +760,32 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         if (moved && out_result != NULL)
             out_result->move_signal_id = menu.move_signal_id;
     }
+    int control_direction = 0;
+    bool control_adjust_input = false;
+    if (menu.left_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.left_action_id) &&
+        sdl3d_input_is_pressed(input, menu.left_action_id))
+    {
+        handled = true;
+        control_direction = -1;
+        control_adjust_input = true;
+    }
+    if (menu.right_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.right_action_id) &&
+        sdl3d_input_is_pressed(input, menu.right_action_id))
+    {
+        handled = true;
+        control_direction = 1;
+        control_adjust_input = true;
+    }
     if (menu.select_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.select_action_id) &&
         sdl3d_input_is_pressed(input, menu.select_action_id))
     {
         handled = true;
+        control_direction = 1;
+        control_adjust_input = false;
+    }
 
+    if (control_direction != 0)
+    {
         sdl3d_game_data_menu refreshed;
         if (!sdl3d_game_data_get_active_menu_for_metrics(runtime, metrics, &refreshed))
             return true;
@@ -773,22 +798,24 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         {
             out_result->menu = refreshed.name;
             out_result->selected_index = refreshed.selected_index;
-            out_result->selected = true;
-            out_result->select_signal_id = refreshed.select_signal_id;
-            out_result->control_changed = sdl3d_game_data_apply_menu_item_control(runtime, &item);
-            out_result->quit = !out_result->control_changed && item.quit;
-            out_result->scene = !out_result->control_changed ? item.scene : NULL;
-            out_result->return_to = !out_result->control_changed ? item.return_to : NULL;
-            out_result->return_scene = !out_result->control_changed && item.return_scene;
-            out_result->signal_id = item.signal_id;
-            out_result->pause_command =
-                !out_result->control_changed ? item.pause_command : SDL3D_GAME_DATA_MENU_PAUSE_NONE;
-            out_result->has_return_paused = !out_result->control_changed && item.has_return_paused;
+            out_result->control_changed = sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
+            out_result->selected = !control_adjust_input || out_result->control_changed;
+            out_result->select_signal_id = out_result->selected ? refreshed.select_signal_id : -1;
+            out_result->quit = !control_adjust_input && !out_result->control_changed && item.quit;
+            out_result->scene = !control_adjust_input && !out_result->control_changed ? item.scene : NULL;
+            out_result->return_to = !control_adjust_input && !out_result->control_changed ? item.return_to : NULL;
+            out_result->return_scene = !control_adjust_input && !out_result->control_changed && item.return_scene;
+            out_result->signal_id = out_result->selected ? item.signal_id : -1;
+            out_result->pause_command = !control_adjust_input && !out_result->control_changed
+                                            ? item.pause_command
+                                            : SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+            out_result->has_return_paused =
+                !control_adjust_input && !out_result->control_changed && item.has_return_paused;
             out_result->return_paused = item.return_paused;
         }
         else
         {
-            (void)sdl3d_game_data_apply_menu_item_control(runtime, &item);
+            (void)sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
         }
     }
     else if (handled && out_result != NULL)

--- a/src/input.c
+++ b/src/input.c
@@ -67,6 +67,7 @@ struct sdl3d_input_manager
 
     sdl3d_input_snapshot snapshot;
     bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
+    SDL_Scancode pressed_scancode;
 
     SDL_Gamepad *gamepad;
     SDL_JoystickID gamepad_id;
@@ -443,6 +444,23 @@ static bool sdl3d_input_physical_any_pressed(const sdl3d_input_manager *input)
         }
     }
     return false;
+}
+
+static SDL_Scancode sdl3d_input_first_pressed_scancode(const sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return SDL_SCANCODE_UNKNOWN;
+    }
+
+    for (int i = 0; i < SDL_SCANCODE_COUNT; ++i)
+    {
+        if (input->key_pressed_this_frame[i])
+        {
+            return (SDL_Scancode)i;
+        }
+    }
+    return SDL_SCANCODE_UNKNOWN;
 }
 
 static bool sdl3d_demo_recorder_append(sdl3d_demo_recorder *recorder, const sdl3d_input_snapshot *snapshot)
@@ -918,6 +936,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
         if (player->cursor < player->count)
         {
             input->snapshot = player->snapshots[player->cursor++];
+            input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
             SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
             for (int i = 0; i < SDL3D_INPUT_MAX_ACTIONS; ++i)
             {
@@ -934,6 +953,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
     next.mouse_dx = input->mouse_dx_accum;
     next.mouse_dy = input->mouse_dy_accum;
     next.any_pressed = sdl3d_input_physical_any_pressed(input);
+    input->pressed_scancode = sdl3d_input_first_pressed_scancode(input);
 
     for (int action_id = 0; action_id < input->action_count; ++action_id)
     {
@@ -989,6 +1009,11 @@ bool sdl3d_input_is_held(const sdl3d_input_manager *input, int action_id)
 float sdl3d_input_get_value(const sdl3d_input_manager *input, int action_id)
 {
     return input != NULL && sdl3d_input_action_id_valid(action_id) ? input->snapshot.actions[action_id].value : 0.0f;
+}
+
+SDL_Scancode sdl3d_input_get_pressed_scancode(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->pressed_scancode : SDL_SCANCODE_UNKNOWN;
 }
 
 bool sdl3d_input_any_pressed(const sdl3d_input_manager *input)

--- a/src/input.c
+++ b/src/input.c
@@ -68,6 +68,7 @@ struct sdl3d_input_manager
     sdl3d_input_snapshot snapshot;
     bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
     SDL_Scancode pressed_scancode;
+    SDL_GamepadButton pressed_gamepad_button;
 
     SDL_Gamepad *gamepad;
     SDL_JoystickID gamepad_id;
@@ -463,6 +464,23 @@ static SDL_Scancode sdl3d_input_first_pressed_scancode(const sdl3d_input_manager
     return SDL_SCANCODE_UNKNOWN;
 }
 
+static SDL_GamepadButton sdl3d_input_first_pressed_gamepad_button(const sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return SDL_GAMEPAD_BUTTON_INVALID;
+    }
+
+    for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i)
+    {
+        if (input->gamepad_button_pressed_this_frame[i])
+        {
+            return (SDL_GamepadButton)i;
+        }
+    }
+    return SDL_GAMEPAD_BUTTON_INVALID;
+}
+
 static bool sdl3d_demo_recorder_append(sdl3d_demo_recorder *recorder, const sdl3d_input_snapshot *snapshot)
 {
     sdl3d_input_snapshot *grown;
@@ -686,6 +704,8 @@ sdl3d_input_manager *sdl3d_input_create(void)
     }
 
     input->deadzone = SDL3D_INPUT_DEFAULT_DEADZONE;
+    input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
+    input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
     return input;
 }
 
@@ -937,6 +957,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
         {
             input->snapshot = player->snapshots[player->cursor++];
             input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
+            input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
             SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
             for (int i = 0; i < SDL3D_INPUT_MAX_ACTIONS; ++i)
             {
@@ -954,6 +975,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
     next.mouse_dy = input->mouse_dy_accum;
     next.any_pressed = sdl3d_input_physical_any_pressed(input);
     input->pressed_scancode = sdl3d_input_first_pressed_scancode(input);
+    input->pressed_gamepad_button = sdl3d_input_first_pressed_gamepad_button(input);
 
     for (int action_id = 0; action_id < input->action_count; ++action_id)
     {
@@ -1014,6 +1036,11 @@ float sdl3d_input_get_value(const sdl3d_input_manager *input, int action_id)
 SDL_Scancode sdl3d_input_get_pressed_scancode(const sdl3d_input_manager *input)
 {
     return input != NULL ? input->pressed_scancode : SDL_SCANCODE_UNKNOWN;
+}
+
+SDL_GamepadButton sdl3d_input_get_pressed_gamepad_button(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->pressed_gamepad_button : SDL_GAMEPAD_BUTTON_INVALID;
 }
 
 bool sdl3d_input_any_pressed(const sdl3d_input_manager *input)

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -7,6 +7,7 @@
 #include "gl_renderer.h"
 #include "rasterizer.h"
 #include "render_context_internal.h"
+#include "sdl3d/image.h"
 #include "texture_internal.h"
 
 static const char *const SDL3D_BACKEND_ENV = "SDL3D_BACKEND";
@@ -65,9 +66,9 @@ static bool sdl3d_parse_backend_name(const char *name, sdl3d_backend *backend)
         return true;
     }
 
-    if (SDL_strcasecmp(name, "sdlgpu") == 0 || SDL_strcasecmp(name, "gpu") == 0)
+    if (SDL_strcasecmp(name, "opengl") == 0 || SDL_strcasecmp(name, "gl") == 0 || SDL_strcasecmp(name, "gpu") == 0)
     {
-        *backend = SDL3D_BACKEND_SDLGPU;
+        *backend = SDL3D_BACKEND_OPENGL;
         return true;
     }
 
@@ -88,9 +89,9 @@ static bool sdl3d_resolve_backend(sdl3d_backend requested_backend, bool allow_ba
     case SDL3D_BACKEND_SOFTWARE:
         *resolved_backend = SDL3D_BACKEND_SOFTWARE;
         return true;
-    case SDL3D_BACKEND_SDLGPU:
+    case SDL3D_BACKEND_OPENGL:
         (void)allow_backend_fallback;
-        *resolved_backend = SDL3D_BACKEND_SDLGPU;
+        *resolved_backend = SDL3D_BACKEND_OPENGL;
         return true;
     default:
         return SDL_SetError("Unknown SDL3D backend value: %d", (int)requested_backend);
@@ -120,8 +121,8 @@ const char *sdl3d_get_backend_name(sdl3d_backend backend)
         return "auto";
     case SDL3D_BACKEND_SOFTWARE:
         return "software";
-    case SDL3D_BACKEND_SDLGPU:
-        return "sdlgpu";
+    case SDL3D_BACKEND_OPENGL:
+        return "opengl";
     default:
         return "unknown";
     }
@@ -297,7 +298,7 @@ bool sdl3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer, con
     context->backend = resolved_backend;
 
     /* Initialize the backend dispatch table. */
-    if (resolved_backend == SDL3D_BACKEND_SDLGPU)
+    if (resolved_backend == SDL3D_BACKEND_OPENGL)
     {
         sdl3d_gl_backend_init(&context->backend_iface);
     }
@@ -557,10 +558,69 @@ void sdl3d_init_window_config(sdl3d_window_config *config)
     SDL_zerop(config);
     config->width = 1280;
     config->height = 720;
+    config->logical_width = 1280;
+    config->logical_height = 720;
     config->title = "SDL3D";
+    config->icon_path = NULL;
     config->backend = SDL3D_BACKEND_AUTO;
     config->allow_backend_fallback = true;
+    config->display_mode = SDL3D_WINDOW_MODE_WINDOWED;
+    config->vsync = true;
+    config->maximized = false;
     config->resizable = true;
+}
+
+static void sdl3d_apply_window_icon(SDL_Window *window, const char *icon_path)
+{
+    if (window == NULL || icon_path == NULL || icon_path[0] == '\0')
+        return;
+
+    sdl3d_image icon;
+    SDL_zero(icon);
+    if (!sdl3d_load_image_from_file(icon_path, &icon))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D window icon load failed: %s", SDL_GetError());
+        SDL_ClearError();
+        return;
+    }
+
+    SDL_Surface *surface =
+        SDL_CreateSurfaceFrom(icon.width, icon.height, SDL_PIXELFORMAT_RGBA32, icon.pixels, icon.width * 4);
+    if (surface != NULL)
+    {
+        SDL_SetWindowIcon(window, surface);
+        SDL_DestroySurface(surface);
+    }
+    else
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D window icon surface creation failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
+    sdl3d_free_image(&icon);
+}
+
+static void sdl3d_apply_window_mode(SDL_Window *window, sdl3d_window_mode mode)
+{
+    if (window == NULL)
+        return;
+
+    if (mode == SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS)
+    {
+        SDL_SetWindowFullscreenMode(window, NULL);
+        SDL_SetWindowFullscreen(window, true);
+    }
+    else if (mode == SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE)
+    {
+        SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+        const SDL_DisplayMode *desktop = display != 0 ? SDL_GetDesktopDisplayMode(display) : NULL;
+        if (desktop != NULL)
+            SDL_SetWindowFullscreenMode(window, desktop);
+        SDL_SetWindowFullscreen(window, true);
+    }
+    else
+    {
+        SDL_SetWindowFullscreen(window, false);
+    }
 }
 
 bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_window, sdl3d_render_context **out_context)
@@ -592,8 +652,14 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
         local.width = 1280;
     if (local.height <= 0)
         local.height = 720;
+    if (local.logical_width <= 0)
+        local.logical_width = local.width;
+    if (local.logical_height <= 0)
+        local.logical_height = local.height;
     if (local.title == NULL)
         local.title = "SDL3D";
+    if (local.display_mode == SDL3D_WINDOW_MODE_DEFAULT)
+        local.display_mode = SDL3D_WINDOW_MODE_WINDOWED;
 
     /* Resolve which backend we'll actually use. */
     if (!sdl3d_resolve_backend(local.backend, local.allow_backend_fallback, &resolved))
@@ -605,8 +671,10 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
     SDL_WindowFlags flags = 0;
     if (local.resizable)
         flags |= SDL_WINDOW_RESIZABLE;
+    if (local.maximized)
+        flags |= SDL_WINDOW_MAXIMIZED;
 
-    if (resolved == SDL3D_BACKEND_SDLGPU)
+    if (resolved == SDL3D_BACKEND_OPENGL)
     {
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
@@ -621,9 +689,11 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
     {
         return false;
     }
+    sdl3d_apply_window_icon(window, local.icon_path);
+    sdl3d_apply_window_mode(window, local.display_mode);
 
     /* Software backend needs an SDL_Renderer; GL does not. */
-    if (resolved != SDL3D_BACKEND_SDLGPU)
+    if (resolved != SDL3D_BACKEND_OPENGL)
     {
         renderer = SDL_CreateRenderer(window, NULL);
         if (renderer == NULL)
@@ -631,13 +701,14 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
             SDL_DestroyWindow(window);
             return false;
         }
+        (void)SDL_SetRenderVSync(renderer, local.vsync ? 1 : 0);
     }
 
     sdl3d_init_render_context_config(&rcfg);
     rcfg.backend = resolved;
     rcfg.allow_backend_fallback = false; /* already resolved */
-    rcfg.logical_width = local.width;
-    rcfg.logical_height = local.height;
+    rcfg.logical_width = local.logical_width;
+    rcfg.logical_height = local.logical_height;
 
     if (!sdl3d_create_render_context(window, renderer, &rcfg, &context))
     {
@@ -645,6 +716,12 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
             SDL_DestroyRenderer(renderer);
         SDL_DestroyWindow(window);
         return false;
+    }
+
+    if (resolved == SDL3D_BACKEND_OPENGL && !SDL_GL_SetSwapInterval(local.vsync ? 1 : 0))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D GL vsync request failed: %s", SDL_GetError());
+        SDL_ClearError();
     }
 
     *out_window = window;
@@ -720,7 +797,7 @@ bool sdl3d_is_feature_available(const sdl3d_render_context *context, sdl3d_featu
         return false;
     }
 
-    bool is_gl = (context->backend == SDL3D_BACKEND_SDLGPU);
+    bool is_gl = (context->backend == SDL3D_BACKEND_OPENGL);
 
     switch (feature)
     {

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -599,28 +599,63 @@ static void sdl3d_apply_window_icon(SDL_Window *window, const char *icon_path)
     sdl3d_free_image(&icon);
 }
 
-static void sdl3d_apply_window_mode(SDL_Window *window, sdl3d_window_mode mode)
+static const char *sdl3d_window_mode_name(sdl3d_window_mode mode)
+{
+    switch (mode)
+    {
+    case SDL3D_WINDOW_MODE_WINDOWED:
+        return "windowed";
+    case SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE:
+        return "fullscreen_exclusive";
+    case SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS:
+        return "fullscreen_borderless";
+    case SDL3D_WINDOW_MODE_DEFAULT:
+    default:
+        return "default";
+    }
+}
+
+static bool sdl3d_apply_window_mode(SDL_Window *window, sdl3d_window_mode mode)
 {
     if (window == NULL)
-        return;
+        return SDL_InvalidParamError("window");
 
     if (mode == SDL3D_WINDOW_MODE_FULLSCREEN_BORDERLESS)
     {
-        SDL_SetWindowFullscreenMode(window, NULL);
-        SDL_SetWindowFullscreen(window, true);
+        if (!SDL_SetWindowFullscreenMode(window, NULL))
+            return false;
+        return SDL_SetWindowFullscreen(window, true);
     }
     else if (mode == SDL3D_WINDOW_MODE_FULLSCREEN_EXCLUSIVE)
     {
         SDL_DisplayID display = SDL_GetDisplayForWindow(window);
         const SDL_DisplayMode *desktop = display != 0 ? SDL_GetDesktopDisplayMode(display) : NULL;
-        if (desktop != NULL)
-            SDL_SetWindowFullscreenMode(window, desktop);
-        SDL_SetWindowFullscreen(window, true);
+        if (desktop == NULL)
+            return SDL_SetError("Unable to resolve desktop display mode for exclusive fullscreen");
+        if (!SDL_SetWindowFullscreenMode(window, desktop))
+            return false;
+        return SDL_SetWindowFullscreen(window, true);
     }
-    else
-    {
-        SDL_SetWindowFullscreen(window, false);
-    }
+
+    return SDL_SetWindowFullscreen(window, false);
+}
+
+static bool sdl3d_apply_context_vsync(sdl3d_render_context *context, bool vsync)
+{
+    if (context == NULL)
+        return SDL_InvalidParamError("context");
+    if (context->backend == SDL3D_BACKEND_OPENGL)
+        return SDL_GL_SetSwapInterval(vsync ? 1 : 0);
+    if (context->renderer != NULL)
+        return SDL_SetRenderVSync(context->renderer, vsync ? 1 : 0);
+    return true;
+}
+
+static const char *sdl3d_actual_window_mode_name(SDL_Window *window)
+{
+    if (window == NULL || (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) == 0)
+        return "windowed";
+    return SDL_GetWindowFullscreenMode(window) == NULL ? "fullscreen_borderless" : "fullscreen_exclusive";
 }
 
 bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_window, sdl3d_render_context **out_context)
@@ -690,7 +725,11 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
         return false;
     }
     sdl3d_apply_window_icon(window, local.icon_path);
-    sdl3d_apply_window_mode(window, local.display_mode);
+    if (!sdl3d_apply_window_mode(window, local.display_mode))
+    {
+        SDL_DestroyWindow(window);
+        return false;
+    }
 
     /* Software backend needs an SDL_Renderer; GL does not. */
     if (resolved != SDL3D_BACKEND_OPENGL)
@@ -726,6 +765,76 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
 
     *out_window = window;
     *out_context = context;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D window created: mode=%s backend=%s vsync=%s size=%dx%d",
+                sdl3d_window_mode_name(local.display_mode), sdl3d_get_backend_name(resolved),
+                local.vsync ? "on" : "off", local.width, local.height);
+    return true;
+}
+
+bool sdl3d_apply_window_config(SDL_Window **window, sdl3d_render_context **context, const sdl3d_window_config *config)
+{
+    sdl3d_window_config local;
+    sdl3d_backend requested_backend;
+    sdl3d_backend current_backend;
+
+    if (window == NULL || context == NULL || *window == NULL || *context == NULL || config == NULL)
+        return SDL_InvalidParamError("window/context/config");
+
+    local = *config;
+    if (local.display_mode == SDL3D_WINDOW_MODE_DEFAULT)
+        local.display_mode = SDL3D_WINDOW_MODE_WINDOWED;
+    if (local.title == NULL)
+        local.title = SDL_GetWindowTitle(*window);
+    if (local.width <= 0 || local.height <= 0)
+        SDL_GetWindowSize(*window, &local.width, &local.height);
+    if (local.logical_width <= 0)
+        local.logical_width = sdl3d_get_render_context_width(*context);
+    if (local.logical_height <= 0)
+        local.logical_height = sdl3d_get_render_context_height(*context);
+
+    if (!sdl3d_resolve_backend(local.backend, local.allow_backend_fallback, &requested_backend))
+        return false;
+    current_backend = sdl3d_get_render_context_backend(*context);
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D applying window settings: mode=%s backend=%s vsync=%s",
+                sdl3d_window_mode_name(local.display_mode), sdl3d_get_backend_name(requested_backend),
+                local.vsync ? "on" : "off");
+
+    if (requested_backend != current_backend)
+    {
+        SDL_Window *new_window = NULL;
+        sdl3d_render_context *new_context = NULL;
+        local.backend = requested_backend;
+        local.allow_backend_fallback = false;
+        if (!sdl3d_create_window(&local, &new_window, &new_context))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D backend switch failed, keeping current window: %s",
+                        SDL_GetError());
+            return false;
+        }
+
+        sdl3d_destroy_window(*window, *context);
+        *window = new_window;
+        *context = new_context;
+    }
+    else
+    {
+        if (!sdl3d_apply_window_mode(*window, local.display_mode))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D display mode apply failed: %s", SDL_GetError());
+            return false;
+        }
+        if (!sdl3d_apply_context_vsync(*context, local.vsync))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D vsync apply failed: %s", SDL_GetError());
+            SDL_ClearError();
+        }
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "SDL3D window settings applied: requested_mode=%s actual_mode=%s backend=%s vsync=%s",
+                sdl3d_window_mode_name(local.display_mode), sdl3d_actual_window_mode_name(*window),
+                sdl3d_get_backend_name(sdl3d_get_render_context_backend(*context)), local.vsync ? "on" : "off");
     return true;
 }
 

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -651,6 +651,21 @@ static bool sdl3d_apply_context_vsync(sdl3d_render_context *context, bool vsync)
     return true;
 }
 
+static bool sdl3d_get_context_vsync(const sdl3d_render_context *context, int *out_interval)
+{
+    if (context == NULL)
+        return SDL_InvalidParamError("context");
+    if (out_interval == NULL)
+        return SDL_InvalidParamError("out_interval");
+    if (context->backend == SDL3D_BACKEND_OPENGL)
+        return SDL_GL_GetSwapInterval(out_interval);
+    if (context->renderer != NULL)
+        return SDL_GetRenderVSync(context->renderer, out_interval);
+
+    *out_interval = 0;
+    return true;
+}
+
 static const char *sdl3d_actual_window_mode_name(SDL_Window *window)
 {
     if (window == NULL || (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) == 0)
@@ -740,7 +755,11 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
             SDL_DestroyWindow(window);
             return false;
         }
-        (void)SDL_SetRenderVSync(renderer, local.vsync ? 1 : 0);
+        if (!SDL_SetRenderVSync(renderer, local.vsync ? 1 : 0))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D renderer vsync request failed: %s", SDL_GetError());
+            SDL_ClearError();
+        }
     }
 
     sdl3d_init_render_context_config(&rcfg);
@@ -764,11 +783,20 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
         SDL_ClearError();
     }
 
+    int actual_vsync = 0;
+    bool have_actual_vsync = sdl3d_get_context_vsync(context, &actual_vsync);
+    if (!have_actual_vsync)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D vsync query failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
+
     *out_window = window;
     *out_context = context;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D window created: mode=%s backend=%s vsync=%s size=%dx%d",
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "SDL3D window created: mode=%s backend=%s requested_vsync=%s actual_vsync=%d size=%dx%d",
                 sdl3d_window_mode_name(local.display_mode), sdl3d_get_backend_name(resolved),
-                local.vsync ? "on" : "off", local.width, local.height);
+                local.vsync ? "on" : "off", have_actual_vsync ? actual_vsync : -999, local.width, local.height);
     return true;
 }
 
@@ -832,10 +860,20 @@ bool sdl3d_apply_window_config(SDL_Window **window, sdl3d_render_context **conte
         }
     }
 
+    int actual_vsync = 0;
+    bool have_actual_vsync = sdl3d_get_context_vsync(*context, &actual_vsync);
+    if (!have_actual_vsync)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D vsync query failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
+
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "SDL3D window settings applied: requested_mode=%s actual_mode=%s backend=%s vsync=%s",
+                "SDL3D window settings applied: requested_mode=%s actual_mode=%s backend=%s requested_vsync=%s "
+                "actual_vsync=%d",
                 sdl3d_window_mode_name(local.display_mode), sdl3d_actual_window_mode_name(*window),
-                sdl3d_get_backend_name(sdl3d_get_render_context_backend(*context)), local.vsync ? "on" : "off");
+                sdl3d_get_backend_name(sdl3d_get_render_context_backend(*context)), local.vsync ? "on" : "off",
+                have_actual_vsync ? actual_vsync : -999);
     return true;
 }
 

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -680,7 +680,7 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
     SDL_Renderer *renderer = NULL;
     sdl3d_render_context *context = NULL;
     sdl3d_render_context_config rcfg;
-    sdl3d_backend resolved;
+    sdl3d_backend resolved = SDL3D_BACKEND_SOFTWARE;
 
     if (out_window == NULL || out_context == NULL)
     {
@@ -803,8 +803,8 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
 bool sdl3d_apply_window_config(SDL_Window **window, sdl3d_render_context **context, const sdl3d_window_config *config)
 {
     sdl3d_window_config local;
-    sdl3d_backend requested_backend;
-    sdl3d_backend current_backend;
+    sdl3d_backend requested_backend = SDL3D_BACKEND_SOFTWARE;
+    sdl3d_backend current_backend = SDL3D_BACKEND_SOFTWARE;
 
     if (window == NULL || context == NULL || *window == NULL || *context == NULL || config == NULL)
         return SDL_InvalidParamError("window/context/config");

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -748,6 +748,7 @@ bool sdl3d_create_window(const sdl3d_window_config *config, SDL_Window **out_win
     rcfg.allow_backend_fallback = false; /* already resolved */
     rcfg.logical_width = local.logical_width;
     rcfg.logical_height = local.logical_height;
+    rcfg.logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
 
     if (!sdl3d_create_render_context(window, renderer, &rcfg, &context))
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -915,13 +915,17 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
-    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 4);
+    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 8);
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 0), "scene.splash");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 1), "scene.title");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.options");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.play");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.options.display");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 4), "scene.options.keyboard");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.options.gamepad");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.options.audio");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 7), "scene.play");
     EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, -1), nullptr);
-    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 4), nullptr);
+    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 8), nullptr);
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_renders_world(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
@@ -933,16 +937,26 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
 
 TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 {
+    const std::filesystem::path dir = unique_test_dir("pong_presentation");
+    const std::filesystem::path user_root = dir / "user";
+    const std::filesystem::path cache_root = dir / "cache";
+    const std::filesystem::path game_path = copy_pong_data_with_storage_overrides(dir, user_root, cache_root);
+
     sdl3d_game_config config{};
     char title[128]{};
     char app_error[512]{};
-    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(SDL3D_PONG_DATA_PATH, &config, title, sizeof(title), app_error,
-                                                     sizeof(app_error)))
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(game_path.string().c_str(), &config, title, sizeof(title),
+                                                     app_error, sizeof(app_error)))
         << app_error;
     EXPECT_STREQ(config.title, "SDL3D Pong");
-    EXPECT_EQ(config.width, 1280);
-    EXPECT_EQ(config.height, 720);
-    EXPECT_EQ(config.backend, SDL3D_BACKEND_AUTO);
+    EXPECT_EQ(config.width, 0);
+    EXPECT_EQ(config.height, 0);
+    EXPECT_EQ(config.logical_width, 1280);
+    EXPECT_EQ(config.logical_height, 720);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_SOFTWARE);
+    EXPECT_EQ(config.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
+    EXPECT_GT(config.vsync, 0);
+    EXPECT_GT(config.maximized, 0);
     EXPECT_NEAR(config.tick_rate, 1.0f / 120.0f, 0.00001f);
     EXPECT_EQ(config.max_ticks_per_frame, 12);
 
@@ -951,15 +965,18 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     char error[512]{};
     sdl3d_game_data_runtime *runtime = nullptr;
-    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_load_file(game_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
 
     sdl3d_storage_config storage{};
     ASSERT_TRUE(sdl3d_game_data_get_storage_config(runtime, &storage));
     EXPECT_STREQ(storage.organization, "Blue Sentinel Security");
     EXPECT_STREQ(storage.application, "SDL3D Pong");
     EXPECT_STREQ(storage.profile, "default");
-    EXPECT_EQ(storage.user_root_override, nullptr);
-    EXPECT_EQ(storage.cache_root_override, nullptr);
+    const std::string user_root_text = user_root.generic_string();
+    const std::string cache_root_text = cache_root.generic_string();
+    EXPECT_STREQ(storage.user_root_override, user_root_text.c_str());
+    EXPECT_STREQ(storage.cache_root_override, cache_root_text.c_str());
     char storage_root[256]{};
     ASSERT_TRUE(sdl3d_storage_build_root_path(&storage, SDL3D_STORAGE_PLATFORM_UNIX, SDL3D_STORAGE_ROOT_USER,
                                               "/home/player/.local/share", storage_root, sizeof(storage_root)));
@@ -1145,6 +1162,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
@@ -1280,27 +1298,35 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
+    EXPECT_EQ(menu.item_count, 8);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Display");
+    EXPECT_STREQ(item.scene, "scene.options.display");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.display");
     EXPECT_EQ(menu.item_count, 5);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
-    EXPECT_STREQ(item.label, "Difficulty");
+    EXPECT_STREQ(item.label, "Display Mode");
     EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
     EXPECT_STREQ(item.control_target, "entity.settings");
-    EXPECT_STREQ(item.control_key, "difficulty");
+    EXPECT_STREQ(item.control_key, "display_mode");
     EXPECT_EQ(item.choice_count, 3);
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "normal");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
     ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
-    EXPECT_STREQ(item.scene, "scene.title");
+    EXPECT_STREQ(item.scene, "scene.options");
 
     bool saw_options_value = false;
     auto find_options_value = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
         auto *saw = static_cast<bool *>(userdata);
         const std::string name = text->name != nullptr ? text->name : "";
         const std::string value = text->text != nullptr ? text->text : "";
-        if (name == "ui.options.menu" && value == "Difficulty: Hard")
+        if (name == "ui.options.display.menu" && value == "Display Mode: Windowed")
         {
             *saw = true;
             return false;
@@ -1321,6 +1347,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_NE(payload, nullptr);
     sdl3d_properties_set_string(payload, "from_scene", "scene.options");
     sdl3d_properties_set_string(payload, "selected_level", "level.test");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload));
     EXPECT_TRUE(payload_capture.called);
     EXPECT_EQ(payload_capture.from_scene, "scene.options");
@@ -1648,7 +1675,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_properties_set_bool(scene_state, "return_paused", true);
 
     sdl3d_game_data_menu_item item{};
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 7, &item));
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(item.scene, "scene.title");
 
@@ -1664,7 +1691,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
     ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
-    EXPECT_EQ(result.selected_index, 4);
+    EXPECT_EQ(result.selected_index, 7);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -1693,12 +1720,12 @@ TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
     char error[512]{};
     sdl3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
 
     const int menu_select_signal = sdl3d_game_data_find_signal(runtime, "signal.ui.menu.select");
-    const int save_options_signal = sdl3d_game_data_find_signal(runtime, "signal.persistence.save_options");
+    const int apply_settings_signal = sdl3d_game_data_find_signal(runtime, "signal.settings.apply");
     ASSERT_GE(menu_select_signal, 0);
-    ASSERT_GE(save_options_signal, 0);
+    ASSERT_GE(apply_settings_signal, 0);
 
     sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
@@ -1715,11 +1742,40 @@ TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
     EXPECT_TRUE(result.selected);
     EXPECT_TRUE(result.control_changed);
     EXPECT_EQ(result.select_signal_id, menu_select_signal);
-    EXPECT_EQ(result.signal_id, save_options_signal);
+    EXPECT_EQ(result.signal_id, apply_settings_signal);
     EXPECT_EQ(result.scene, nullptr);
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
+    sdl3d_properties_set_bool(settings->props, "vsync", false);
+    sdl3d_properties_set_string(settings->props, "renderer", "opengl");
+    sdl3d_properties_set_string(settings->props, "difficulty", "hard");
+
+    const int reset_display = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_display");
+    ASSERT_GE(reset_display, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_display, nullptr);
+
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
+    EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "software");
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
 
     sdl3d_game_data_destroy(runtime);
@@ -3055,8 +3111,15 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
 
         sdl3d_properties_set_string(settings->props, "difficulty", "hard");
         sdl3d_properties_set_string(settings->props, "lighting_profile", "arcade");
+        sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
+        sdl3d_properties_set_bool(settings->props, "vsync", false);
+        sdl3d_properties_set_string(settings->props, "renderer", "opengl");
         sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
-        sdl3d_properties_set_bool(settings->props, "fullscreen", true);
+        sdl3d_properties_set_string(settings->props, "keyboard_preset", "classic_pc");
+        sdl3d_properties_set_string(settings->props, "gamepad_icons", "playstation");
+        sdl3d_properties_set_bool(settings->props, "vibration", false);
+        sdl3d_properties_set_float(settings->props, "sfx_volume", 0.4f);
+        sdl3d_properties_set_float(settings->props, "music_volume", 0.7f);
         emit(session, runtime, "signal.persistence.save_options");
 
         emit(session, runtime, "signal.match.player_won");
@@ -3073,6 +3136,16 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
     EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
 
+    sdl3d_game_config persisted_config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(game_path.string().c_str(), &persisted_config, title,
+                                                     sizeof(title), app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_EQ(persisted_config.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
+    EXPECT_EQ(persisted_config.backend, SDL3D_BACKEND_OPENGL);
+    EXPECT_LT(persisted_config.vsync, 0);
+
     {
         sdl3d_game_session *session = nullptr;
         ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -3088,8 +3161,15 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
         ASSERT_NE(settings, nullptr);
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "arcade");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vsync", true));
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
-        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "fullscreen", false));
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "classic_pc");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "playstation");
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vibration", true));
+        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "sfx_volume", 0.0f), 0.4f, 0.0001f);
+        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "music_volume", 0.0f), 0.7f, 0.0001f);
 
         sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");
         ASSERT_NE(scores, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -953,7 +953,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_EQ(config.height, 0);
     EXPECT_EQ(config.logical_width, 1280);
     EXPECT_EQ(config.logical_height, 720);
-    EXPECT_EQ(config.backend, SDL3D_BACKEND_SOFTWARE);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_OPENGL);
     EXPECT_EQ(config.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
     EXPECT_GT(config.vsync, 0);
     EXPECT_GT(config.maximized, 0);
@@ -1315,11 +1315,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_EQ(item.choice_count, 3);
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
-    ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 6, &item));
-    EXPECT_STREQ(item.scene, "scene.options");
 
     bool saw_options_value = false;
     auto find_options_value = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
@@ -1335,6 +1331,11 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     };
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_options_value, &saw_options_value));
     EXPECT_TRUE(saw_options_value);
+
+    ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_exclusive");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 6, &item));
+    EXPECT_STREQ(item.scene, "scene.options");
 
     ScenePayloadCapture payload_capture{};
     const int start_signal = sdl3d_game_data_find_signal(runtime, "signal.game.start");
@@ -1783,7 +1784,7 @@ TEST(GameDataRuntime, OptionControlsStageValuesUntilApply)
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_exclusive");
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -1800,18 +1801,18 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
-    sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
+    sdl3d_properties_set_string(settings->props, "display_mode", "fullscreen_exclusive");
     sdl3d_properties_set_bool(settings->props, "vsync", false);
-    sdl3d_properties_set_string(settings->props, "renderer", "opengl");
+    sdl3d_properties_set_string(settings->props, "renderer", "software");
     sdl3d_properties_set_string(settings->props, "difficulty", "hard");
 
     const int reset_display = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_display");
     ASSERT_GE(reset_display, 0);
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_display, nullptr);
 
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "software");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
 
     sdl3d_game_data_destroy(runtime);
@@ -3212,7 +3213,7 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
                                                      sizeof(title), app_error, sizeof(app_error)))
         << app_error;
     EXPECT_EQ(persisted_config.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
-    EXPECT_EQ(persisted_config.backend, SDL3D_BACKEND_SOFTWARE);
+    EXPECT_EQ(persisted_config.backend, SDL3D_BACKEND_OPENGL);
     EXPECT_GT(persisted_config.vsync, 0);
 
     {
@@ -3230,9 +3231,9 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         ASSERT_NE(settings, nullptr);
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "normal");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "cinematic");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "software");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "keyboard");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "xbox_parity");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1298,7 +1298,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
-    EXPECT_EQ(menu.item_count, 8);
+    EXPECT_EQ(menu.item_count, 10);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display");
     EXPECT_STREQ(item.scene, "scene.options.display");
@@ -1306,7 +1306,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options.display");
-    EXPECT_EQ(menu.item_count, 5);
+    EXPECT_EQ(menu.item_count, 7);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display Mode");
     EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
@@ -1318,7 +1318,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
     ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 6, &item));
     EXPECT_STREQ(item.scene, "scene.options");
 
     bool saw_options_value = false;
@@ -1675,7 +1675,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_properties_set_bool(scene_state, "return_paused", true);
 
     sdl3d_game_data_menu_item item{};
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 7, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 9, &item));
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(item.scene, "scene.title");
 
@@ -1691,7 +1691,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
     ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
-    EXPECT_EQ(result.selected_index, 7);
+    EXPECT_EQ(result.selected_index, 9);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -1712,7 +1712,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
+TEST(GameDataRuntime, OptionControlsStageValuesUntilApply)
 {
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -1723,9 +1723,7 @@ TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
 
     const int menu_select_signal = sdl3d_game_data_find_signal(runtime, "signal.ui.menu.select");
-    const int apply_settings_signal = sdl3d_game_data_find_signal(runtime, "signal.settings.apply");
     ASSERT_GE(menu_select_signal, 0);
-    ASSERT_GE(apply_settings_signal, 0);
 
     sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
@@ -1742,7 +1740,7 @@ TEST(GameDataRuntime, OptionControlsCanEmitAuthoredSignals)
     EXPECT_TRUE(result.selected);
     EXPECT_TRUE(result.control_changed);
     EXPECT_EQ(result.select_signal_id, menu_select_signal);
-    EXPECT_EQ(result.signal_id, apply_settings_signal);
+    EXPECT_EQ(result.signal_id, -1);
     EXPECT_EQ(result.scene, nullptr);
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
@@ -1777,6 +1775,35 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "software");
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AuthoredSettingsCancelRestoresSceneEntrySnapshot)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
+    sdl3d_properties_set_bool(settings->props, "vsync", true);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+    sdl3d_properties_set_string(settings->props, "display_mode", "fullscreen_exclusive");
+    sdl3d_properties_set_bool(settings->props, "vsync", false);
+
+    const int cancel_display = sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_display");
+    ASSERT_GE(cancel_display, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), cancel_display, nullptr);
+
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+    EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1712,6 +1712,44 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "return_scene", "scene.title");
+    sdl3d_properties_set_bool(scene_state, "return_paused", false);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 0, &item));
+    EXPECT_STREQ(item.label, "Display");
+    EXPECT_STREQ(item.scene, "scene.options.display");
+    EXPECT_EQ(item.return_to, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.display", 6, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.options");
+    EXPECT_FALSE(item.return_scene);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 9, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_TRUE(item.return_scene);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "return_scene", ""), "scene.title");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "return_paused", true));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, OptionControlsStageValuesUntilApply)
 {
     sdl3d_game_session *session = nullptr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1345,6 +1345,39 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
     EXPECT_STREQ(item.scene, "scene.options");
 
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.audio"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.audio");
+    EXPECT_EQ(menu.item_count, 4);
+    EXPECT_GE(menu.left_action_id, 0);
+    EXPECT_GE(menu.right_action_id, 0);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Sound Effects");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_RANGE);
+    EXPECT_STREQ(item.control_target, "entity.settings");
+    EXPECT_STREQ(item.control_key, "sfx_volume");
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
+
+    bool saw_sfx_slider = false;
+    bool saw_music_slider = false;
+    auto find_audio_sliders = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *flags = static_cast<std::pair<bool *, bool *> *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.options.audio.menu" && value == "Sound Effects  [########--] 8/10")
+            *flags->first = true;
+        if (name == "ui.options.audio.menu" && value == "Music  [#######---] 7/10")
+            *flags->second = true;
+        if (*flags->first && *flags->second)
+            return false;
+        return true;
+    };
+    std::pair<bool *, bool *> audio_slider_flags{&saw_sfx_slider, &saw_music_slider};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_audio_sliders, &audio_slider_flags));
+    EXPECT_TRUE(saw_sfx_slider);
+    EXPECT_TRUE(saw_music_slider);
+
     ScenePayloadCapture payload_capture{};
     const int start_signal = sdl3d_game_data_find_signal(runtime, "signal.game.start");
     ASSERT_GE(start_signal, 0);
@@ -1799,6 +1832,84 @@ TEST(GameDataRuntime, DisplayOptionControlsApplyImmediately)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, AudioOptionSlidersApplyImmediatelyWithLeftRightInput)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.audio"));
+
+    const int menu_select_signal = sdl3d_game_data_find_signal(runtime, "signal.ui.menu.select");
+    const int apply_audio_signal = sdl3d_game_data_find_signal(runtime, "signal.settings.apply_audio");
+    ASSERT_GE(menu_select_signal, 0);
+    ASSERT_GE(apply_audio_signal, 0);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LEFT;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.selected);
+    EXPECT_TRUE(result.control_changed);
+    EXPECT_EQ(result.select_signal_id, menu_select_signal);
+    EXPECT_EQ(result.signal_id, apply_audio_signal);
+    EXPECT_EQ(result.scene, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 7);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RIGHT;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.selected);
+    EXPECT_TRUE(result.control_changed);
+    EXPECT_EQ(result.signal_id, apply_audio_signal);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, "menu.options.audio", 3));
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LEFT;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_FALSE(result.selected);
+    EXPECT_FALSE(result.control_changed);
+    EXPECT_EQ(result.select_signal_id, -1);
+    EXPECT_EQ(result.signal_id, -1);
+    EXPECT_EQ(result.scene, nullptr);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
 {
     sdl3d_game_session *session = nullptr;
@@ -1814,6 +1925,8 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     sdl3d_properties_set_bool(settings->props, "vsync", false);
     sdl3d_properties_set_string(settings->props, "renderer", "software");
     sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
+    sdl3d_properties_set_int(settings->props, "sfx_volume", 2);
+    sdl3d_properties_set_int(settings->props, "music_volume", 3);
 
     const int reset_display = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_display");
     ASSERT_GE(reset_display, 0);
@@ -1824,6 +1937,12 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
+
+    const int reset_audio = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_audio");
+    ASSERT_GE(reset_audio, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_audio, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -3193,8 +3312,8 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         sdl3d_properties_set_string(settings->props, "keyboard_preset", "classic_pc");
         sdl3d_properties_set_string(settings->props, "gamepad_icons", "playstation");
         sdl3d_properties_set_bool(settings->props, "vibration", false);
-        sdl3d_properties_set_float(settings->props, "sfx_volume", 0.4f);
-        sdl3d_properties_set_float(settings->props, "music_volume", 0.7f);
+        sdl3d_properties_set_int(settings->props, "sfx_volume", 4);
+        sdl3d_properties_set_int(settings->props, "music_volume", 7);
         emit(session, runtime, "signal.persistence.save_options");
 
         emit(session, runtime, "signal.match.player_won");
@@ -3212,7 +3331,7 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
     write_text(
         user_root / "settings" / "options.json",
-        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":0.4,"music_volume":0.7})json");
+        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":4,"music_volume":7})json");
 
     sdl3d_game_config persisted_config{};
     char title[128]{};
@@ -3244,8 +3363,8 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "xbox_parity");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vibration", false));
-        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "sfx_volume", 0.0f), 1.0f, 0.0001f);
-        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "music_volume", 0.0f), 1.0f, 0.0001f);
+        EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+        EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
 
         sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");
         ASSERT_NE(scores, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1303,7 +1303,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
-    EXPECT_EQ(menu.item_count, 10);
+    EXPECT_EQ(menu.item_count, 5);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display");
     EXPECT_STREQ(item.scene, "scene.options.display");
@@ -1684,7 +1684,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_properties_set_bool(scene_state, "return_paused", true);
 
     sdl3d_game_data_menu_item item{};
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 9, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(item.scene, "scene.title");
 
@@ -1700,7 +1700,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
     ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
-    EXPECT_EQ(result.selected_index, 9);
+    EXPECT_EQ(result.selected_index, 4);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -1749,7 +1749,7 @@ TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
     EXPECT_FALSE(item.return_scene);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 9, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
     EXPECT_STREQ(item.label, "Back");
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "return_scene", ""), "scene.title");
@@ -1813,7 +1813,7 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     sdl3d_properties_set_string(settings->props, "display_mode", "fullscreen_exclusive");
     sdl3d_properties_set_bool(settings->props, "vsync", false);
     sdl3d_properties_set_string(settings->props, "renderer", "software");
-    sdl3d_properties_set_string(settings->props, "difficulty", "hard");
+    sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
 
     const int reset_display = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_display");
     ASSERT_GE(reset_display, 0);
@@ -1823,7 +1823,7 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -3179,15 +3179,13 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "options_persistence_enabled", true));
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "score_persistence_enabled", false));
 
-        sdl3d_properties_set_string(settings->props, "difficulty", "hard");
+        sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
         emit(session, runtime, "signal.persistence.save_options");
         EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
 
         emit(session, runtime, "signal.persistence.load");
         EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "options_persistence_enabled", true));
 
-        sdl3d_properties_set_string(settings->props, "difficulty", "hard");
-        sdl3d_properties_set_string(settings->props, "lighting_profile", "arcade");
         sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
         sdl3d_properties_set_bool(settings->props, "vsync", false);
         sdl3d_properties_set_string(settings->props, "renderer", "opengl");
@@ -3214,7 +3212,7 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
     write_text(
         user_root / "settings" / "options.json",
-        R"json({"schema":"sdl3d.pong.options.v1","difficulty":"hard","lighting_profile":"arcade","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":0.4,"music_volume":0.7})json");
+        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":0.4,"music_volume":0.7})json");
 
     sdl3d_game_config persisted_config{};
     char title[128]{};
@@ -3239,8 +3237,6 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
 
         sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
         ASSERT_NE(settings, nullptr);
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "normal");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "cinematic");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3102,7 +3102,7 @@ return storage
     remove_test_dir(dir);
 }
 
-TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
+TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStorage)
 {
     const std::filesystem::path dir = unique_test_dir("pong_persistence");
     const std::filesystem::path user_root = dir / "user";
@@ -3127,14 +3127,15 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
 
         sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
         ASSERT_NE(settings, nullptr);
-        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "persistence_enabled", true));
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "options_persistence_enabled", true));
+        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "score_persistence_enabled", false));
 
         sdl3d_properties_set_string(settings->props, "difficulty", "hard");
         emit(session, runtime, "signal.persistence.save_options");
         EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
 
         emit(session, runtime, "signal.persistence.load");
-        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "persistence_enabled", false));
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "options_persistence_enabled", true));
 
         sdl3d_properties_set_string(settings->props, "difficulty", "hard");
         sdl3d_properties_set_string(settings->props, "lighting_profile", "arcade");
@@ -3160,8 +3161,11 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
         sdl3d_game_session_destroy(session);
     }
 
-    EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
+    EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
+    write_text(
+        user_root / "settings" / "options.json",
+        R"json({"schema":"sdl3d.pong.options.v1","difficulty":"hard","lighting_profile":"arcade","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":0.4,"music_volume":0.7})json");
 
     sdl3d_game_config persisted_config{};
     char title[128]{};
@@ -3170,8 +3174,8 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
                                                      sizeof(title), app_error, sizeof(app_error)))
         << app_error;
     EXPECT_EQ(persisted_config.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
-    EXPECT_EQ(persisted_config.backend, SDL3D_BACKEND_OPENGL);
-    EXPECT_LT(persisted_config.vsync, 0);
+    EXPECT_EQ(persisted_config.backend, SDL3D_BACKEND_SOFTWARE);
+    EXPECT_GT(persisted_config.vsync, 0);
 
     {
         sdl3d_game_session *session = nullptr;
@@ -3186,17 +3190,17 @@ TEST(GameDataRuntime, PongPersistenceLoadsOptionsAndHighScoresFromUserStorage)
 
         sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
         ASSERT_NE(settings, nullptr);
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "hard");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "arcade");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
-        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vsync", true));
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "classic_pc");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "playstation");
-        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vibration", true));
-        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "sfx_volume", 0.0f), 0.4f, 0.0001f);
-        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "music_volume", 0.0f), 0.7f, 0.0001f);
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "difficulty", ""), "normal");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "lighting_profile", ""), "cinematic");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
+        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "software");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "keyboard");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "xbox_parity");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");
+        EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vibration", false));
+        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "sfx_volume", 0.0f), 1.0f, 0.0001f);
+        EXPECT_NEAR(sdl3d_properties_get_float(settings->props, "music_volume", 0.0f), 1.0f, 0.0001f);
 
         sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");
         ASSERT_NE(scores, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2069,6 +2069,143 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.gamepad"));
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.gamepad");
+    EXPECT_EQ(menu.item_count, 12);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Button Icons");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Up");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
+    EXPECT_EQ(item.key_binding_count, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 10, &item));
+    EXPECT_STREQ(item.label, "Reset Settings");
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int paddle_up = sdl3d_game_data_find_action(runtime, "action.paddle.up");
+    ASSERT_GE(paddle_up, 0);
+    const int menu_up = sdl3d_game_data_find_action(runtime, "action.menu.up");
+    ASSERT_GE(menu_up, 0);
+    const int exit_action = sdl3d_game_data_find_action(runtime, "action.exit");
+    ASSERT_GE(exit_action, 0);
+
+    ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, "menu.options.gamepad", 2));
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_SOUTH;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.key_binding_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_WEST;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.key_binding_changed);
+    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_WEST;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 5);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, paddle_up));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_up));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 6);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, "menu.options.gamepad", 1));
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_SOUTH;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 7);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.key_binding_capture_started);
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 8);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_WEST;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 9);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.key_binding_conflict);
+    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 10);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 11);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    const int reset_gamepad = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_gamepad");
+    ASSERT_GE(reset_gamepad, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_gamepad, nullptr);
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 12);
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 13);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, paddle_up));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_up));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 14);
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_BACK;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 15);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, exit_action));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
 {
     sdl3d_game_session *session = nullptr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1311,7 +1311,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options.display");
-    EXPECT_EQ(menu.item_count, 7);
+    EXPECT_EQ(menu.item_count, 5);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display Mode");
     EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
@@ -1339,7 +1339,10 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
 
     ASSERT_TRUE(sdl3d_game_data_apply_menu_item_control(runtime, &item));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_exclusive");
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 6, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 3, &item));
+    EXPECT_STREQ(item.label, "Reset Settings");
+    EXPECT_TRUE(sdl3d_game_data_app_signal_applies_window_settings(runtime, item.signal_id));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
     EXPECT_STREQ(item.scene, "scene.options");
 
     ScenePayloadCapture payload_capture{};
@@ -1740,7 +1743,7 @@ TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
     EXPECT_EQ(item.return_to, nullptr);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.display", 6, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.display", 4, &item));
     EXPECT_STREQ(item.label, "Back");
     EXPECT_STREQ(item.scene, "scene.options");
     EXPECT_FALSE(item.return_scene);
@@ -1756,7 +1759,7 @@ TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
     sdl3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, OptionControlsStageValuesUntilApply)
+TEST(GameDataRuntime, DisplayOptionControlsApplyImmediately)
 {
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -1784,7 +1787,8 @@ TEST(GameDataRuntime, OptionControlsStageValuesUntilApply)
     EXPECT_TRUE(result.selected);
     EXPECT_TRUE(result.control_changed);
     EXPECT_EQ(result.select_signal_id, menu_select_signal);
-    EXPECT_EQ(result.signal_id, -1);
+    EXPECT_EQ(result.signal_id, sdl3d_game_data_find_signal(runtime, "signal.settings.apply"));
+    EXPECT_TRUE(sdl3d_game_data_app_signal_applies_window_settings(runtime, result.signal_id));
     EXPECT_EQ(result.scene, nullptr);
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
@@ -1813,6 +1817,7 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
 
     const int reset_display = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_display");
     ASSERT_GE(reset_display, 0);
+    EXPECT_TRUE(sdl3d_game_data_app_signal_applies_window_settings(runtime, reset_display));
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_display, nullptr);
 
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1308,6 +1308,30 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(item.label, "Display");
     EXPECT_STREQ(item.scene, "scene.options.display");
 
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.keyboard"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.keyboard");
+    EXPECT_EQ(menu.item_count, 9);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Up");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
+    EXPECT_EQ(item.key_binding_count, 2);
+
+    bool saw_keyboard_up = false;
+    auto find_keyboard_up = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *saw = static_cast<bool *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.options.keyboard.menu" && value == "Up: W")
+        {
+            *saw = true;
+            return false;
+        }
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_keyboard_up, &saw_keyboard_up));
+    EXPECT_TRUE(saw_keyboard_up);
+
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options.display");
@@ -1910,6 +1934,120 @@ TEST(GameDataRuntime, AudioOptionSlidersApplyImmediatelyWithLeftRightInput)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.keyboard"));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int paddle_up = sdl3d_game_data_find_action(runtime, "action.paddle.up");
+    ASSERT_GE(paddle_up, 0);
+    const int menu_up = sdl3d_game_data_find_action(runtime, "action.menu.up");
+    ASSERT_GE(menu_up, 0);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.selected);
+    EXPECT_TRUE(result.key_binding_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_I;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.key_binding_changed);
+    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_I;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, paddle_up));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_up));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 6);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, "menu.options.keyboard", 1));
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 7);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.key_binding_capture_started);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 8);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_I;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 9);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.key_binding_conflict);
+    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 10);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 11);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+
+    const int reset_keyboard = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_keyboard");
+    ASSERT_GE(reset_keyboard, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_keyboard, nullptr);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 12);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_W;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 13);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, paddle_up));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_up));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
 {
     sdl3d_game_session *session = nullptr;
@@ -1924,7 +2062,6 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     sdl3d_properties_set_string(settings->props, "display_mode", "fullscreen_exclusive");
     sdl3d_properties_set_bool(settings->props, "vsync", false);
     sdl3d_properties_set_string(settings->props, "renderer", "software");
-    sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
     sdl3d_properties_set_int(settings->props, "sfx_volume", 2);
     sdl3d_properties_set_int(settings->props, "music_volume", 3);
 
@@ -1936,7 +2073,6 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
-    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "gamepad");
 
     const int reset_audio = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_audio");
     ASSERT_GE(reset_audio, 0);
@@ -3298,7 +3434,6 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "options_persistence_enabled", true));
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "score_persistence_enabled", false));
 
-        sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
         emit(session, runtime, "signal.persistence.save_options");
         EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
 
@@ -3308,8 +3443,6 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
         sdl3d_properties_set_bool(settings->props, "vsync", false);
         sdl3d_properties_set_string(settings->props, "renderer", "opengl");
-        sdl3d_properties_set_string(settings->props, "input_style", "gamepad");
-        sdl3d_properties_set_string(settings->props, "keyboard_preset", "classic_pc");
         sdl3d_properties_set_string(settings->props, "gamepad_icons", "playstation");
         sdl3d_properties_set_bool(settings->props, "vibration", false);
         sdl3d_properties_set_int(settings->props, "sfx_volume", 4);
@@ -3331,7 +3464,7 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
     write_text(
         user_root / "settings" / "options.json",
-        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","input_style":"gamepad","keyboard_preset":"classic_pc","gamepad_icons":"playstation","vibration":false,"sfx_volume":4,"music_volume":7})json");
+        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","gamepad_icons":"playstation","vibration":false,"sfx_volume":4,"music_volume":7})json");
 
     sdl3d_game_config persisted_config{};
     char title[128]{};
@@ -3359,8 +3492,6 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "input_style", ""), "keyboard");
-        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "keyboard_preset", ""), "xbox_parity");
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vibration", false));
         EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1005,6 +1005,11 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_STREQ(app.startup_transition, "startup");
     EXPECT_STREQ(app.quit_transition, "quit");
     EXPECT_GE(app.quit_signal_id, 0);
+    EXPECT_EQ(app.window_apply_signal_id, sdl3d_game_data_find_signal(runtime, "signal.settings.apply"));
+    EXPECT_STREQ(app.window_settings_target, "entity.settings");
+    EXPECT_STREQ(app.window_display_mode_key, "display_mode");
+    EXPECT_STREQ(app.window_renderer_key, "renderer");
+    EXPECT_STREQ(app.window_vsync_key, "vsync");
 
     sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
     ASSERT_NE(match, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1316,21 +1316,31 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(item.label, "Up");
     EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
     EXPECT_EQ(item.key_binding_count, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 5, &item));
+    EXPECT_STREQ(item.label, "Cancel");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
+    EXPECT_EQ(item.key_binding_count, 1);
 
     bool saw_keyboard_up = false;
+    bool saw_keyboard_cancel = false;
     auto find_keyboard_up = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
-        auto *saw = static_cast<bool *>(userdata);
+        auto *saw = static_cast<std::pair<bool *, bool *> *>(userdata);
         const std::string name = text->name != nullptr ? text->name : "";
         const std::string value = text->text != nullptr ? text->text : "";
-        if (name == "ui.options.keyboard.menu" && value == "Up: W")
+        if (name == "ui.options.keyboard.menu" && value == "Up: Up")
         {
-            *saw = true;
-            return false;
+            *saw->first = true;
         }
-        return true;
+        if (name == "ui.options.keyboard.menu" && value == "Cancel: Backspace")
+        {
+            *saw->second = true;
+        }
+        return !*saw->first || !*saw->second;
     };
-    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_keyboard_up, &saw_keyboard_up));
+    std::pair<bool *, bool *> keyboard_binding_labels{&saw_keyboard_up, &saw_keyboard_cancel};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_keyboard_up, &keyboard_binding_labels));
     EXPECT_TRUE(saw_keyboard_up);
+    EXPECT_TRUE(saw_keyboard_cancel);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
@@ -1950,6 +1960,8 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     ASSERT_GE(paddle_up, 0);
     const int menu_up = sdl3d_game_data_find_action(runtime, "action.menu.up");
     ASSERT_GE(menu_up, 0);
+    const int exit_action = sdl3d_game_data_find_action(runtime, "action.exit");
+    ASSERT_GE(exit_action, 0);
 
     bool armed = true;
     sdl3d_game_data_menu_update_result result{};
@@ -2038,11 +2050,20 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 12);
     key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_W;
+    key.key.scancode = SDL_SCANCODE_UP;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 13);
     EXPECT_TRUE(sdl3d_input_is_pressed(input, paddle_up));
     EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_up));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 14);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_BACKSPACE;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 15);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, exit_action));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -2207,7 +2228,7 @@ TEST(GameDataRuntime, AppFlowConsumesAuthoredLifecycleAndSceneShortcutControls)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 10);
     key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    key.key.scancode = SDL_SCANCODE_BACKSPACE;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 11);
     ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -56,7 +56,7 @@ class GLRendererTest : public ::testing::Test
 
         sdl3d_render_context_config cfg;
         sdl3d_init_render_context_config(&cfg);
-        cfg.backend = SDL3D_BACKEND_SDLGPU;
+        cfg.backend = SDL3D_BACKEND_OPENGL;
         cfg.logical_width = 320;
         cfg.logical_height = 240;
 
@@ -714,7 +714,7 @@ TEST_F(GLRendererTest, ToggleRecreateProducesCorrectOutput)
 
     sdl3d_render_context_config cfg;
     sdl3d_init_render_context_config(&cfg);
-    cfg.backend = SDL3D_BACKEND_SDLGPU;
+    cfg.backend = SDL3D_BACKEND_OPENGL;
     cfg.logical_width = 320;
     cfg.logical_height = 240;
     ASSERT_TRUE(sdl3d_create_render_context(win, nullptr, &cfg, &ctx));

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -161,6 +161,19 @@ TEST(Input, PressedEdgeDetection)
     EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
 }
 
+TEST(Input, PressedScancodeIsCapturedForCurrentTick)
+{
+    InputPtr input;
+
+    EXPECT_EQ(sdl3d_input_get_pressed_scancode(input.input), SDL_SCANCODE_UNKNOWN);
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_I);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_EQ(sdl3d_input_get_pressed_scancode(input.input), SDL_SCANCODE_I);
+
+    sdl3d_input_update(input.input, 2);
+    EXPECT_EQ(sdl3d_input_get_pressed_scancode(input.input), SDL_SCANCODE_UNKNOWN);
+}
+
 TEST(Input, ReleasedEdgeDetection)
 {
     InputPtr input;

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -271,11 +271,13 @@ TEST(Input, GamepadButtonPressAndRelease)
     sdl3d_input_update(input.input, 1);
     EXPECT_TRUE(sdl3d_input_is_held(input.input, pause));
     EXPECT_TRUE(sdl3d_input_is_pressed(input.input, pause));
+    EXPECT_EQ(sdl3d_input_get_pressed_gamepad_button(input.input), SDL_GAMEPAD_BUTTON_START);
 
     push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, SDL_GAMEPAD_BUTTON_START);
     sdl3d_input_update(input.input, 2);
     EXPECT_FALSE(sdl3d_input_is_held(input.input, pause));
     EXPECT_TRUE(sdl3d_input_is_released(input.input, pause));
+    EXPECT_EQ(sdl3d_input_get_pressed_gamepad_button(input.input), SDL_GAMEPAD_BUTTON_INVALID);
 }
 
 TEST(Input, MultipleBindingsSameAction)

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -169,6 +169,38 @@ TEST_F(SDLVideoFixture, LogicalPresentationConfigIsApplied)
     sdl3d_destroy_render_context(context);
 }
 
+TEST_F(SDLVideoFixture, HighLevelSoftwareWindowLetterboxesLogicalPresentation)
+{
+    SDL3DBackendOverrideGuard backend_override("software");
+    sdl3d_window_config config;
+    sdl3d_init_window_config(&config);
+    config.width = 640;
+    config.height = 480;
+    config.logical_width = 320;
+    config.logical_height = 180;
+    config.backend = SDL3D_BACKEND_SOFTWARE;
+    config.allow_backend_fallback = false;
+    config.vsync = false;
+
+    SDL_Window *window = nullptr;
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_window(&config, &window, &context)) << SDL_GetError();
+    ASSERT_NE(window, nullptr);
+    ASSERT_NE(context, nullptr);
+    SDL_Renderer *renderer = SDL_GetRenderer(window);
+    ASSERT_NE(renderer, nullptr);
+
+    int logical_width = 0;
+    int logical_height = 0;
+    SDL_RendererLogicalPresentation mode = SDL_LOGICAL_PRESENTATION_DISABLED;
+    ASSERT_TRUE(SDL_GetRenderLogicalPresentation(renderer, &logical_width, &logical_height, &mode)) << SDL_GetError();
+    EXPECT_EQ(320, logical_width);
+    EXPECT_EQ(180, logical_height);
+    EXPECT_EQ(SDL_LOGICAL_PRESENTATION_LETTERBOX, mode);
+
+    sdl3d_destroy_window(window, context);
+}
+
 TEST_F(SDLVideoFixture, OpenGLBackendAcceptsRequest)
 {
     SDLWindowRendererPair pair;

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -201,6 +201,42 @@ TEST_F(SDLVideoFixture, HighLevelSoftwareWindowLetterboxesLogicalPresentation)
     sdl3d_destroy_window(window, context);
 }
 
+TEST_F(SDLVideoFixture, HighLevelSoftwareWindowAppliesVSyncAtRuntime)
+{
+    SDL3DBackendOverrideGuard backend_override("software");
+    sdl3d_window_config config;
+    sdl3d_init_window_config(&config);
+    config.backend = SDL3D_BACKEND_SOFTWARE;
+    config.allow_backend_fallback = false;
+    config.vsync = false;
+
+    SDL_Window *window = nullptr;
+    sdl3d_render_context *context = nullptr;
+    ASSERT_TRUE(sdl3d_create_window(&config, &window, &context)) << SDL_GetError();
+    SDL_Renderer *renderer = SDL_GetRenderer(window);
+    ASSERT_NE(renderer, nullptr);
+
+    int vsync = -1;
+    ASSERT_TRUE(SDL_GetRenderVSync(renderer, &vsync)) << SDL_GetError();
+    EXPECT_EQ(SDL_RENDERER_VSYNC_DISABLED, vsync);
+
+    config.vsync = true;
+    ASSERT_TRUE(sdl3d_apply_window_config(&window, &context, &config)) << SDL_GetError();
+    renderer = SDL_GetRenderer(window);
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(SDL_GetRenderVSync(renderer, &vsync)) << SDL_GetError();
+    EXPECT_EQ(1, vsync);
+
+    config.vsync = false;
+    ASSERT_TRUE(sdl3d_apply_window_config(&window, &context, &config)) << SDL_GetError();
+    renderer = SDL_GetRenderer(window);
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(SDL_GetRenderVSync(renderer, &vsync)) << SDL_GetError();
+    EXPECT_EQ(SDL_RENDERER_VSYNC_DISABLED, vsync);
+
+    sdl3d_destroy_window(window, context);
+}
+
 TEST_F(SDLVideoFixture, OpenGLBackendAcceptsRequest)
 {
     SDLWindowRendererPair pair;

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -169,14 +169,14 @@ TEST_F(SDLVideoFixture, LogicalPresentationConfigIsApplied)
     sdl3d_destroy_render_context(context);
 }
 
-TEST_F(SDLVideoFixture, SdlGpuBackendAcceptsRequest)
+TEST_F(SDLVideoFixture, OpenGLBackendAcceptsRequest)
 {
     SDLWindowRendererPair pair;
     ASSERT_TRUE(pair.is_valid()) << SDL_GetError();
 
     sdl3d_render_context_config config;
     sdl3d_init_render_context_config(&config);
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.allow_backend_fallback = false;
 
     sdl3d_render_context *context = nullptr;
@@ -201,7 +201,7 @@ TEST_F(SDLVideoFixture, EnvironmentOverrideCanForceSoftwareBackend)
     SDL3DBackendOverrideGuard backend_override("software");
     sdl3d_render_context_config config;
     sdl3d_init_render_context_config(&config);
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.allow_backend_fallback = false;
 
     sdl3d_render_context *context = nullptr;
@@ -262,14 +262,14 @@ TEST_F(SDLVideoFixture, SoftwareBackendVtableIsFullyPopulated)
     sdl3d_destroy_render_context(context);
 }
 
-TEST_F(SDLVideoFixture, SdlGpuBackendClearAndPresentSucceedWhenAvailable)
+TEST_F(SDLVideoFixture, OpenGLBackendClearAndPresentSucceedWhenAvailable)
 {
     SDLWindowRendererPair pair;
     ASSERT_TRUE(pair.is_valid());
 
     sdl3d_render_context_config config;
     sdl3d_init_render_context_config(&config);
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.allow_backend_fallback = false;
 
     sdl3d_render_context *context = nullptr;
@@ -285,7 +285,7 @@ TEST_F(SDLVideoFixture, SdlGpuBackendClearAndPresentSucceedWhenAvailable)
     EXPECT_TRUE(sdl3d_clear_render_context(context, red));
     EXPECT_TRUE(sdl3d_present_render_context(context));
 
-    EXPECT_EQ(SDL3D_BACKEND_SDLGPU, sdl3d_get_render_context_backend(context));
+    EXPECT_EQ(SDL3D_BACKEND_OPENGL, sdl3d_get_render_context_backend(context));
 
     sdl3d_destroy_render_context(context);
 }

--- a/tests/test_render_context_unit.cpp
+++ b/tests/test_render_context_unit.cpp
@@ -63,7 +63,7 @@ class SDL3DBackendEnvGuard
 TEST(SDL3DRenderContextConfig, InitRenderContextConfigSetsDocumentedDefaults)
 {
     sdl3d_render_context_config config{};
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.allow_backend_fallback = false;
     config.logical_width = 42;
     config.logical_height = 42;
@@ -98,7 +98,7 @@ TEST(SDL3DBackendName, MapsKnownBackendsToStableStrings)
 {
     EXPECT_EQ(std::string_view("auto"), sdl3d_get_backend_name(SDL3D_BACKEND_AUTO));
     EXPECT_EQ(std::string_view("software"), sdl3d_get_backend_name(SDL3D_BACKEND_SOFTWARE));
-    EXPECT_EQ(std::string_view("sdlgpu"), sdl3d_get_backend_name(SDL3D_BACKEND_SDLGPU));
+    EXPECT_EQ(std::string_view("opengl"), sdl3d_get_backend_name(SDL3D_BACKEND_OPENGL));
 }
 
 TEST(SDL3DBackendName, UnknownBackendsMapToUnknown)
@@ -110,19 +110,19 @@ TEST(SDL3DBackendName, UnknownBackendsMapToUnknown)
 TEST(SDL3DBackendEnvOverride, UnsetEnvReturnsFalseWithoutTouchingOutput)
 {
     SDL3DBackendEnvGuard guard(nullptr);
-    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+    sdl3d_backend backend = SDL3D_BACKEND_OPENGL;
 
     EXPECT_FALSE(sdl3d_get_backend_override_from_environment(&backend));
-    EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+    EXPECT_EQ(SDL3D_BACKEND_OPENGL, backend);
 }
 
 TEST(SDL3DBackendEnvOverride, EmptyEnvReturnsFalseWithoutTouchingOutput)
 {
     SDL3DBackendEnvGuard guard("");
-    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+    sdl3d_backend backend = SDL3D_BACKEND_OPENGL;
 
     EXPECT_FALSE(sdl3d_get_backend_override_from_environment(&backend));
-    EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+    EXPECT_EQ(SDL3D_BACKEND_OPENGL, backend);
 }
 
 TEST(SDL3DBackendEnvOverride, ParsesSoftware)
@@ -137,26 +137,26 @@ TEST(SDL3DBackendEnvOverride, ParsesSoftware)
 TEST(SDL3DBackendEnvOverride, ParsesAuto)
 {
     SDL3DBackendEnvGuard guard("AUTO");
-    sdl3d_backend backend = SDL3D_BACKEND_SDLGPU;
+    sdl3d_backend backend = SDL3D_BACKEND_OPENGL;
 
     EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
     EXPECT_EQ(SDL3D_BACKEND_AUTO, backend);
 }
 
-TEST(SDL3DBackendEnvOverride, ParsesSdlGpuAndGpuAliasCaseInsensitively)
+TEST(SDL3DBackendEnvOverride, ParsesOpenGlAndGpuAliasesCaseInsensitively)
 {
     {
-        SDL3DBackendEnvGuard guard("SdlGpu");
+        SDL3DBackendEnvGuard guard("OpenGL");
         sdl3d_backend backend = SDL3D_BACKEND_AUTO;
         EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
-        EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+        EXPECT_EQ(SDL3D_BACKEND_OPENGL, backend);
     }
 
     {
         SDL3DBackendEnvGuard guard("GPU");
         sdl3d_backend backend = SDL3D_BACKEND_AUTO;
         EXPECT_TRUE(sdl3d_get_backend_override_from_environment(&backend));
-        EXPECT_EQ(SDL3D_BACKEND_SDLGPU, backend);
+        EXPECT_EQ(SDL3D_BACKEND_OPENGL, backend);
     }
 }
 
@@ -251,12 +251,12 @@ TEST(SDL3DCreateRenderContext, InvalidEnvOverrideFailsBeforeTouchingRenderer)
     EXPECT_NE(std::string_view(SDL_GetError()).find("Unsupported SDL3D backend override"), std::string_view::npos);
 }
 
-TEST(SDL3DCreateRenderContext, SdlGpuBackendAcceptsRequest)
+TEST(SDL3DCreateRenderContext, OpenGLBackendAcceptsRequest)
 {
     SDL3DBackendEnvGuard guard(nullptr);
     sdl3d_render_context_config config;
     sdl3d_init_render_context_config(&config);
-    config.backend = SDL3D_BACKEND_SDLGPU;
+    config.backend = SDL3D_BACKEND_OPENGL;
     config.allow_backend_fallback = false;
 
     /* The GL backend is now implemented. Creating with a fake window will
@@ -357,9 +357,15 @@ TEST(SDL3DWindowConfig, DefaultsAreReasonable)
     sdl3d_init_window_config(&cfg);
     EXPECT_EQ(cfg.width, 1280);
     EXPECT_EQ(cfg.height, 720);
+    EXPECT_EQ(cfg.logical_width, 1280);
+    EXPECT_EQ(cfg.logical_height, 720);
     EXPECT_NE(cfg.title, nullptr);
+    EXPECT_EQ(cfg.icon_path, nullptr);
     EXPECT_EQ(cfg.backend, SDL3D_BACKEND_AUTO);
     EXPECT_TRUE(cfg.allow_backend_fallback);
+    EXPECT_EQ(cfg.display_mode, SDL3D_WINDOW_MODE_WINDOWED);
+    EXPECT_TRUE(cfg.vsync);
+    EXPECT_FALSE(cfg.maximized);
     EXPECT_TRUE(cfg.resizable);
 }
 

--- a/tests/test_render_context_unit.cpp
+++ b/tests/test_render_context_unit.cpp
@@ -369,6 +369,17 @@ TEST(SDL3DWindowConfig, DefaultsAreReasonable)
     EXPECT_TRUE(cfg.resizable);
 }
 
+TEST(SDL3DWindowConfig, ApplyWindowConfigRejectsInvalidArguments)
+{
+    sdl3d_window_config cfg;
+    sdl3d_init_window_config(&cfg);
+
+    SDL_ClearError();
+    EXPECT_FALSE(sdl3d_apply_window_config(nullptr, nullptr, &cfg));
+    EXPECT_NE(std::string_view(SDL_GetError()).find("Parameter 'window/context/config' is invalid"),
+              std::string_view::npos);
+}
+
 TEST(SDL3DFeatureQuery, SoftwareHasNoPostProcessing)
 {
     /* We can't create a real context in unit tests without a display,


### PR DESCRIPTION
## Summary
- Add logical/window startup configuration, resizable windowed mode, fullscreen modes, vsync, maximized startup, title/icon config, and clean OpenGL backend naming.
- Add generic data actions for settings defaults and property-backed audio bus volume.
- Expand Pong into a data-driven options hierarchy: Display, Keyboard, Gamepad, Audio, reset-defaults, persistence, and startup application of saved display/audio settings.
- Update docs and tests for the generalized options/windowing contract.

## Verification
- cmake --build build/release -j8
- ctest --test-dir build/release --output-on-failure -j8
- ./build/release/tests/sdl3d_game_data_test
- ./build/release/tests/sdl3d_render_context_unit_test
- git diff --check