### PR TITLE
Generalize options input binding contract

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -832,14 +832,8 @@
     "signal.presentation.flash_border",
     "signal.persistence.load",
     "signal.persistence.save_options",
-    "signal.settings.snapshot_display",
-    "signal.settings.snapshot_gamepad",
-    "signal.settings.snapshot_audio",
     "signal.settings.apply",
     "signal.settings.apply_audio",
-    "signal.settings.cancel_display",
-    "signal.settings.cancel_gamepad",
-    "signal.settings.cancel_audio",
     "signal.settings.reset_display",
     "signal.settings.reset_keyboard",
     "signal.settings.reset_gamepad",
@@ -991,43 +985,6 @@
         "actions": [
           { "type": "audio.set_bus_volume", "bus": "sfx", "source": { "target": "entity.settings", "key": "sfx_volume", "scale": 0.1 } },
           { "type": "audio.set_bus_volume", "bus": "music", "source": { "target": "entity.settings", "key": "music_volume", "scale": 0.1 } }
-        ]
-      },
-      {
-        "signal": "signal.settings.snapshot_display",
-        "actions": [
-          { "type": "property.snapshot", "name": "options.display", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
-        ]
-      },
-      {
-        "signal": "signal.settings.snapshot_gamepad",
-        "actions": [
-          { "type": "property.snapshot", "name": "options.gamepad", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] }
-        ]
-      },
-      {
-        "signal": "signal.settings.snapshot_audio",
-        "actions": [
-          { "type": "property.snapshot", "name": "options.audio", "target": "entity.settings", "keys": ["sfx_volume", "music_volume"] }
-        ]
-      },
-      {
-        "signal": "signal.settings.cancel_display",
-        "actions": [
-          { "type": "property.restore_snapshot", "name": "options.display", "target": "entity.settings" }
-        ]
-      },
-      {
-        "signal": "signal.settings.cancel_gamepad",
-        "actions": [
-          { "type": "property.restore_snapshot", "name": "options.gamepad", "target": "entity.settings" }
-        ]
-      },
-      {
-        "signal": "signal.settings.cancel_audio",
-        "actions": [
-          { "type": "property.restore_snapshot", "name": "options.audio", "target": "entity.settings" },
-          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
         ]
       },
       {

--- a/demos/pong/data/scenes/options_audio.scene.json
+++ b/demos/pong/data/scenes/options_audio.scene.json
@@ -1,7 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.audio",
-  "on_enter_signal": "signal.settings.snapshot_audio",
   "updates_game": false,
   "renders_world": false,
   "entities": [],

--- a/demos/pong/data/scenes/options_display.scene.json
+++ b/demos/pong/data/scenes/options_display.scene.json
@@ -1,7 +1,6 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.options.display",
-  "on_enter_signal": "signal.settings.snapshot_display",
   "updates_game": false,
   "renders_world": false,
   "entities": [],

--- a/demos/pong/data/scenes/options_gamepad.scene.json
+++ b/demos/pong/data/scenes/options_gamepad.scene.json
@@ -53,7 +53,7 @@
         {
           "label": "Up",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "DPAD_UP",
             "bindings": [
               { "action": "action.paddle.up", "device": "gamepad" },
@@ -64,7 +64,7 @@
         {
           "label": "Down",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "DPAD_DOWN",
             "bindings": [
               { "action": "action.paddle.down", "device": "gamepad" },
@@ -75,7 +75,7 @@
         {
           "label": "Left",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "DPAD_LEFT",
             "bindings": [
               { "action": "action.menu.left", "device": "gamepad" }
@@ -85,7 +85,7 @@
         {
           "label": "Right",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "DPAD_RIGHT",
             "bindings": [
               { "action": "action.menu.right", "device": "gamepad" }
@@ -95,7 +95,7 @@
         {
           "label": "Accept",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "SOUTH",
             "bindings": [
               { "action": "action.menu.select", "device": "gamepad" },
@@ -106,7 +106,7 @@
         {
           "label": "Cancel",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "BACK",
             "bindings": [
               { "action": "action.exit", "device": "gamepad" }
@@ -116,7 +116,7 @@
         {
           "label": "Pause",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "START",
             "bindings": [
               { "action": "action.pause", "device": "gamepad" }
@@ -126,7 +126,7 @@
         {
           "label": "Ball Camera",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "NORTH",
             "bindings": [
               { "action": "action.camera.ball.toggle", "device": "gamepad" }

--- a/demos/pong/data/scenes/options_keyboard.scene.json
+++ b/demos/pong/data/scenes/options_keyboard.scene.json
@@ -28,7 +28,7 @@
         {
           "label": "Up",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "UP",
             "bindings": [
               { "action": "action.paddle.up", "device": "keyboard" },
@@ -39,7 +39,7 @@
         {
           "label": "Down",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "DOWN",
             "bindings": [
               { "action": "action.paddle.down", "device": "keyboard" },
@@ -50,7 +50,7 @@
         {
           "label": "Left",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "A",
             "bindings": [
               { "action": "action.menu.left", "device": "keyboard" }
@@ -60,7 +60,7 @@
         {
           "label": "Right",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "D",
             "bindings": [
               { "action": "action.menu.right", "device": "keyboard" }
@@ -70,7 +70,7 @@
         {
           "label": "Accept",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "RETURN",
             "bindings": [
               { "action": "action.menu.select", "device": "keyboard" },
@@ -82,7 +82,7 @@
         {
           "label": "Cancel",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "BACKSPACE",
             "bindings": [
               { "action": "action.exit", "device": "keyboard" }
@@ -92,7 +92,7 @@
         {
           "label": "Ball Camera",
           "control": {
-            "type": "key_binding",
+            "type": "input_binding",
             "default": "B",
             "bindings": [
               { "action": "action.camera.ball.toggle", "device": "keyboard" }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -292,7 +292,7 @@ Menu items can also author generic settings controls and emit data-authored sign
 }
 ```
 
-Supported control types are `toggle`, `choice`, `range`, and `key_binding`.
+Supported control types are `toggle`, `choice`, `range`, and `input_binding`.
 The generic menu controller applies property controls directly to actor
 properties and the menu UI presenter displays the current value. A menu can
 author `left_action` and `right_action` so range and choice controls can be
@@ -330,7 +330,7 @@ Range controls clamp to their authored min/max. Adding `"value_type": "int"`
 stores the result as an integer property; adding `"display": "slider"` renders
 the menu value as a compact slider label.
 
-`key_binding` controls capture the next keyboard key or gamepad button and
+`input_binding` controls capture the next keyboard key or gamepad button and
 immediately rebind all authored actions for that device. This is how games can
 expose one player-facing input such as `Up` while updating both gameplay and
 menu actions:
@@ -339,7 +339,7 @@ menu actions:
 {
   "label": "Up",
   "control": {
-    "type": "key_binding",
+    "type": "input_binding",
     "default": "UP",
     "bindings": [
       { "action": "action.paddle.up", "device": "keyboard" },
@@ -388,6 +388,46 @@ Settings screens can reset authored defaults without game-specific code:
   "keys": ["display_mode", "vsync", "renderer"]
 }
 ```
+
+### Standard Options Contract
+
+Games that want SDL3D's reusable options behavior should author one settings
+actor and bind option controls to that actor. The actor name is game-defined,
+but `entity.settings` is the recommended default because it matches the app
+window and audio examples.
+
+Standard display properties:
+
+| Property | Type | Expected values |
+| --- | --- | --- |
+| `display_mode` | string | `windowed`, `fullscreen_exclusive`, `fullscreen_borderless` |
+| `vsync` | bool | `true` or `false` |
+| `renderer` | string | `software` or `opengl` |
+
+Standard audio properties:
+
+| Property | Type | Expected values |
+| --- | --- | --- |
+| `sfx_volume` | int | Usually `0` to `10`; use `scale: 0.1` for bus volume |
+| `music_volume` | int | Usually `0` to `10`; use `scale: 0.1` for bus volume |
+
+Standard gamepad properties:
+
+| Property | Type | Expected values |
+| --- | --- | --- |
+| `gamepad_icons` | string | `xbox`, `nintendo`, `playstation` |
+| `vibration` | bool | `true` or `false` |
+
+Keyboard and gamepad configuration should be authored as action-oriented
+`input_binding` menu controls. Games decide which actions to expose, but each
+control should represent a player-facing intent such as `Up`, `Accept`,
+`Cancel`, or `Pause`, not a low-level device-specific operation. The same
+player-facing item may update multiple engine actions, such as gameplay
+movement and menu navigation.
+
+Reusable options scenes should prefer immediate apply for settings where the
+player benefits from real-time feedback. Use Apply/Cancel snapshots only for
+screens that intentionally stage changes before committing them.
 
 Audio bus volume can also be driven from actor properties so options menus can
 share one generic settings actor. Use `source.scale` when the authored setting

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -487,8 +487,8 @@ extern "C"
         SDL3D_GAME_DATA_MENU_CONTROL_CHOICE = 2,
         /** @brief Menu item increments a numeric property within a range. */
         SDL3D_GAME_DATA_MENU_CONTROL_RANGE = 3,
-        /** @brief Menu item captures a keyboard key and rebinds authored actions. */
-        SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING = 4,
+        /** @brief Menu item captures a keyboard key or gamepad button and rebinds authored actions. */
+        SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING = 4,
     } sdl3d_game_data_menu_control_type;
 
     /** @brief App pause command authored on a menu item. */
@@ -504,20 +504,20 @@ extern "C"
         SDL3D_GAME_DATA_MENU_PAUSE_TOGGLE = 3,
     } sdl3d_game_data_menu_pause_command;
 
-    /** @brief Result of advancing an active key-binding capture. */
-    typedef enum sdl3d_game_data_key_binding_capture_status
+    /** @brief Result of advancing an active input-binding capture. */
+    typedef enum sdl3d_game_data_input_binding_capture_status
     {
-        /** @brief No key-binding capture is active. */
-        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_NONE = 0,
-        /** @brief Capture is active and still waiting for a key press. */
-        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING = 1,
-        /** @brief Capture was canceled by its cancel key. */
-        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED = 2,
-        /** @brief The captured key was applied to authored action bindings. */
-        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED = 3,
-        /** @brief The captured key was rejected because another binding uses it. */
-        SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT = 4,
-    } sdl3d_game_data_key_binding_capture_status;
+        /** @brief No input-binding capture is active. */
+        SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_NONE = 0,
+        /** @brief Capture is active and still waiting for an input press. */
+        SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING = 1,
+        /** @brief Capture was canceled by its cancel input. */
+        SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CANCELED = 2,
+        /** @brief The captured input was applied to authored action bindings. */
+        SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED = 3,
+        /** @brief The captured input was rejected because another binding uses it. */
+        SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT = 4,
+    } sdl3d_game_data_input_binding_capture_status;
 
     /**
      * @brief Runtime descriptor for one authored menu item.
@@ -555,8 +555,8 @@ extern "C"
         const char *control_key;
         /** @brief Number of authored choices for choice controls. */
         int choice_count;
-        /** @brief Number of action bindings affected by a key-binding control. */
-        int key_binding_count;
+        /** @brief Number of action bindings affected by an input-binding control. */
+        int input_binding_count;
     } sdl3d_game_data_menu_item;
 
     /** @brief Authored scene transition behavior policy. */
@@ -1261,18 +1261,18 @@ extern "C"
                                                   const sdl3d_game_data_menu_item *item, int direction);
 
     /**
-     * @brief Start capture mode for a key or gamepad-button binding menu item.
+     * @brief Start capture mode for an input-binding menu item.
      *
-     * The menu item must author a `control` with `type: "key_binding"`.
+     * The menu item must author a `control` with `type: "input_binding"`.
      * While capture is active, callers should pass input snapshots to
-     * sdl3d_game_data_update_menu_key_binding_capture() before normal menu
+     * sdl3d_game_data_update_menu_input_binding_capture() before normal menu
      * navigation.
      */
-    bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
-                                                        int item_index);
+    bool sdl3d_game_data_start_menu_input_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                          int item_index);
 
     /** @brief Return true while a binding menu item is waiting for an input. */
-    bool sdl3d_game_data_menu_key_binding_capture_active(const sdl3d_game_data_runtime *runtime);
+    bool sdl3d_game_data_menu_input_binding_capture_active(const sdl3d_game_data_runtime *runtime);
 
     /**
      * @brief Advance active binding capture from current input.
@@ -1282,13 +1282,13 @@ extern "C"
      * Successful captures immediately update the live input manager for every
      * action authored by the menu item.
      */
-    sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_binding_capture(
+    sdl3d_game_data_input_binding_capture_status sdl3d_game_data_update_menu_input_binding_capture(
         sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input);
 
     /**
      * @brief Reset all binding controls in a menu to their authored defaults.
      */
-    bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
+    bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
 
     /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -127,13 +127,13 @@ extern "C"
         bool handled_input;                               /**< True when a menu action was consumed. */
         bool selected;                                    /**< True when the selected item was activated. */
         bool quit;                                        /**< True when the selected item requests quit. */
-        bool return_scene;                /**< True when the selected item requests the stored return scene. */
-        bool has_return_paused;           /**< True when selected item stores a return pause state. */
-        bool return_paused;               /**< Pause state to store for a later return_scene item. */
-        bool control_changed;             /**< True when selecting the item changed a data-bound control. */
-        bool key_binding_capture_started; /**< True when a key-binding item entered capture mode. */
-        bool key_binding_changed;         /**< True when a captured key changed authored action bindings. */
-        bool key_binding_conflict;        /**< True when a captured key was rejected as a duplicate binding. */
+        bool return_scene;                  /**< True when the selected item requests the stored return scene. */
+        bool has_return_paused;             /**< True when selected item stores a return pause state. */
+        bool return_paused;                 /**< Pause state to store for a later return_scene item. */
+        bool control_changed;               /**< True when selecting the item changed a data-bound control. */
+        bool input_binding_capture_started; /**< True when an input-binding item entered capture mode. */
+        bool input_binding_changed;         /**< True when a captured input changed authored action bindings. */
+        bool input_binding_conflict;        /**< True when a captured input was rejected as a duplicate binding. */
     } sdl3d_game_data_menu_update_result;
 
     /**

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -118,12 +118,12 @@ typedef struct input_binding_spec
     float scale;
 } input_binding_spec;
 
-typedef struct menu_key_binding_capture
+typedef struct menu_input_binding_capture
 {
     bool active;
     const char *menu;
     int item_index;
-} menu_key_binding_capture;
+} menu_input_binding_capture;
 
 typedef enum menu_binding_device
 {
@@ -255,7 +255,7 @@ typedef struct sdl3d_game_data_runtime
     input_binding_spec *input_bindings;
     int input_binding_count;
     int input_binding_capacity;
-    menu_key_binding_capture key_capture;
+    menu_input_binding_capture input_capture;
     sdl3d_script_engine *scripts;
     script_entry *script_entries;
     int script_count;
@@ -3586,7 +3586,7 @@ bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runt
 
     const char *previous = sdl3d_game_data_active_scene(runtime);
     runtime->active_scene_index = (int)(scene - runtime->scenes);
-    runtime->key_capture.active = false;
+    runtime->input_capture.active = false;
     apply_scene_camera(runtime, scene);
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data scene set: %s -> %s",
                  previous != NULL ? previous : "<none>", scene->name != NULL ? scene->name : "<none>");
@@ -3794,8 +3794,8 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
         return SDL3D_GAME_DATA_MENU_CONTROL_CHOICE;
     if (SDL_strcmp(type, "range") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_RANGE;
-    if (SDL_strcmp(type, "key_binding") == 0)
-        return SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING;
+    if (SDL_strcmp(type, "input_binding") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING;
     return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
 }
 
@@ -3841,7 +3841,7 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
     out_item->control_key = json_string(control, "key", NULL);
     out_item->choice_count =
         yyjson_is_arr(obj_get(control, "choices")) ? (int)yyjson_arr_size(obj_get(control, "choices")) : 0;
-    out_item->key_binding_count =
+    out_item->input_binding_count =
         yyjson_is_arr(obj_get(control, "bindings")) ? (int)yyjson_arr_size(obj_get(control, "bindings")) : 0;
     return yyjson_is_obj(item) && out_item->label != NULL;
 }
@@ -3925,7 +3925,7 @@ static SDL_GamepadButton current_action_gamepad_button_binding(const sdl3d_game_
     return SDL_GAMEPAD_BUTTON_INVALID;
 }
 
-static SDL_Scancode current_key_binding_control_scancode(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+static SDL_Scancode current_input_binding_control_scancode(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
 {
     yyjson_val *bindings = obj_get(control, "bindings");
     for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
@@ -3940,8 +3940,8 @@ static SDL_Scancode current_key_binding_control_scancode(const sdl3d_game_data_r
     return scancode_from_json(json_string(control, "default", NULL));
 }
 
-static SDL_GamepadButton current_key_binding_control_gamepad_button(const sdl3d_game_data_runtime *runtime,
-                                                                    yyjson_val *control)
+static SDL_GamepadButton current_input_binding_control_gamepad_button(const sdl3d_game_data_runtime *runtime,
+                                                                      yyjson_val *control)
 {
     yyjson_val *bindings = obj_get(control, "bindings");
     for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
@@ -3957,8 +3957,8 @@ static SDL_GamepadButton current_key_binding_control_gamepad_button(const sdl3d_
     return gamepad_button_from_json(json_string(control, "default", NULL));
 }
 
-static bool set_key_binding_control_scancode(sdl3d_game_data_runtime *runtime, yyjson_val *control,
-                                             SDL_Scancode scancode)
+static bool set_input_binding_control_scancode(sdl3d_game_data_runtime *runtime, yyjson_val *control,
+                                               SDL_Scancode scancode)
 {
     bool changed = false;
     yyjson_val *bindings = obj_get(control, "bindings");
@@ -3973,8 +3973,8 @@ static bool set_key_binding_control_scancode(sdl3d_game_data_runtime *runtime, y
     return changed;
 }
 
-static bool set_key_binding_control_gamepad_button(sdl3d_game_data_runtime *runtime, yyjson_val *control,
-                                                   SDL_GamepadButton button)
+static bool set_input_binding_control_gamepad_button(sdl3d_game_data_runtime *runtime, yyjson_val *control,
+                                                     SDL_GamepadButton button)
 {
     bool changed = false;
     yyjson_val *bindings = obj_get(control, "bindings");
@@ -4001,11 +4001,11 @@ static const char *keyboard_binding_conflict_label(const sdl3d_game_data_runtime
             continue;
         yyjson_val *item = yyjson_arr_get(items, (size_t)i);
         yyjson_val *control = obj_get(item, "control");
-        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
             continue;
         if (menu_binding_control_device(control) != MENU_BINDING_DEVICE_KEYBOARD)
             continue;
-        if (current_key_binding_control_scancode(runtime, control) == scancode)
+        if (current_input_binding_control_scancode(runtime, control) == scancode)
             return json_string(item, "label", NULL);
     }
     return NULL;
@@ -4023,28 +4023,28 @@ static const char *gamepad_button_binding_conflict_label(const sdl3d_game_data_r
             continue;
         yyjson_val *item = yyjson_arr_get(items, (size_t)i);
         yyjson_val *control = obj_get(item, "control");
-        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
             continue;
         if (menu_binding_control_device(control) != MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
             continue;
-        if (current_key_binding_control_gamepad_button(runtime, control) == button)
+        if (current_input_binding_control_gamepad_button(runtime, control) == button)
             return json_string(item, "label", NULL);
     }
     return NULL;
 }
 
-bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
-                                                    int item_index)
+bool sdl3d_game_data_start_menu_input_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                      int item_index)
 {
     yyjson_val *item = find_menu_item_at(runtime, menu_name, item_index);
     yyjson_val *control = obj_get(item, "control");
     if (runtime == NULL || menu_name == NULL ||
-        parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+        parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
         return false;
 
-    runtime->key_capture.active = true;
-    runtime->key_capture.menu = menu_name;
-    runtime->key_capture.item_index = item_index;
+    runtime->input_capture.active = true;
+    runtime->input_capture.menu = menu_name;
+    runtime->input_capture.item_index = item_index;
     char status[128];
     const char *device_name =
         menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
@@ -4053,88 +4053,88 @@ bool sdl3d_game_data_start_menu_key_binding_capture(sdl3d_game_data_runtime *run
     return true;
 }
 
-bool sdl3d_game_data_menu_key_binding_capture_active(const sdl3d_game_data_runtime *runtime)
+bool sdl3d_game_data_menu_input_binding_capture_active(const sdl3d_game_data_runtime *runtime)
 {
-    return runtime != NULL && runtime->key_capture.active;
+    return runtime != NULL && runtime->input_capture.active;
 }
 
-sdl3d_game_data_key_binding_capture_status sdl3d_game_data_update_menu_key_binding_capture(
+sdl3d_game_data_input_binding_capture_status sdl3d_game_data_update_menu_input_binding_capture(
     sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
 {
-    if (runtime == NULL || !runtime->key_capture.active)
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_NONE;
+    if (runtime == NULL || !runtime->input_capture.active)
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_NONE;
 
-    yyjson_val *item = find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index);
+    yyjson_val *item = find_menu_item_at(runtime, runtime->input_capture.menu, runtime->input_capture.item_index);
     yyjson_val *control = obj_get(item, "control");
     if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
     {
         const SDL_Scancode cancel_key = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
         if (sdl3d_input_get_pressed_scancode(input) == cancel_key)
         {
-            runtime->key_capture.active = false;
+            runtime->input_capture.active = false;
             set_menu_binding_status(runtime, "Canceled");
-            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED;
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CANCELED;
         }
 
         const SDL_GamepadButton button = sdl3d_input_get_pressed_gamepad_button(input);
         if (button == SDL_GAMEPAD_BUTTON_INVALID)
-            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
 
-        const char *conflict = gamepad_button_binding_conflict_label(runtime, runtime->key_capture.menu,
-                                                                     runtime->key_capture.item_index, button);
+        const char *conflict = gamepad_button_binding_conflict_label(runtime, runtime->input_capture.menu,
+                                                                     runtime->input_capture.item_index, button);
         if (conflict != NULL)
         {
             char status[128];
             SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, gamepad_button_display_name(button));
             set_menu_binding_status(runtime, status);
-            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT;
         }
 
-        if (!set_key_binding_control_gamepad_button(runtime, control, button))
-            return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+        if (!set_input_binding_control_gamepad_button(runtime, control, button))
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
 
         char status[128];
         SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
                      gamepad_button_display_name(button));
-        runtime->key_capture.active = false;
+        runtime->input_capture.active = false;
         set_menu_binding_status(runtime, status);
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED;
     }
 
     const SDL_Scancode scancode = sdl3d_input_get_pressed_scancode(input);
     if (scancode == SDL_SCANCODE_UNKNOWN)
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
 
     const SDL_Scancode cancel = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
     if (scancode == cancel && !json_bool(control, "allow_escape", false))
     {
-        runtime->key_capture.active = false;
+        runtime->input_capture.active = false;
         set_menu_binding_status(runtime, "Canceled");
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CANCELED;
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CANCELED;
     }
 
-    const char *conflict =
-        keyboard_binding_conflict_label(runtime, runtime->key_capture.menu, runtime->key_capture.item_index, scancode);
+    const char *conflict = keyboard_binding_conflict_label(runtime, runtime->input_capture.menu,
+                                                           runtime->input_capture.item_index, scancode);
     if (conflict != NULL)
     {
         char status[128];
         SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, scancode_display_name(scancode));
         set_menu_binding_status(runtime, status);
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT;
     }
 
-    if (!set_key_binding_control_scancode(runtime, control, scancode))
-        return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_WAITING;
+    if (!set_input_binding_control_scancode(runtime, control, scancode))
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
 
     char status[128];
     SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
                  scancode_display_name(scancode));
-    runtime->key_capture.active = false;
+    runtime->input_capture.active = false;
     set_menu_binding_status(runtime, status);
-    return SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
+    return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED;
 }
 
-bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name)
+bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
     const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
@@ -4144,23 +4144,23 @@ bool sdl3d_game_data_reset_menu_key_bindings(sdl3d_game_data_runtime *runtime, c
     {
         yyjson_val *item = yyjson_arr_get(items, (size_t)i);
         yyjson_val *control = obj_get(item, "control");
-        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
             continue;
         if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
         {
             const SDL_GamepadButton button = gamepad_button_from_json(json_string(control, "default", NULL));
             if (button != SDL_GAMEPAD_BUTTON_INVALID &&
-                set_key_binding_control_gamepad_button(runtime, control, button))
+                set_input_binding_control_gamepad_button(runtime, control, button))
                 changed = true;
         }
         else
         {
             const SDL_Scancode key = scancode_from_json(json_string(control, "default", NULL));
-            if (key != SDL_SCANCODE_UNKNOWN && set_key_binding_control_scancode(runtime, control, key))
+            if (key != SDL_SCANCODE_UNKNOWN && set_input_binding_control_scancode(runtime, control, key))
                 changed = true;
         }
     }
-    runtime->key_capture.active = false;
+    runtime->input_capture.active = false;
     if (changed)
         set_menu_binding_status(runtime, "Input settings reset");
     return changed;
@@ -4293,7 +4293,7 @@ bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime, 
         return true;
     }
     case SDL3D_GAME_DATA_MENU_CONTROL_NONE:
-    case SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING:
+    case SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING:
         return false;
     }
     return false;
@@ -4332,7 +4332,7 @@ bool sdl3d_game_data_scene_shortcut_at(const sdl3d_game_data_runtime *runtime, i
 
 bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
 {
-    if (sdl3d_game_data_menu_key_binding_capture_active(runtime))
+    if (sdl3d_game_data_menu_input_binding_capture_active(runtime))
         return false;
     sdl3d_game_data_menu menu;
     if (!sdl3d_game_data_get_active_menu(runtime, &menu))
@@ -4441,10 +4441,10 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
         SDL_strlcpy(buffer, label, buffer_size);
         return;
     }
-    if (type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
     {
-        if (runtime != NULL && runtime->key_capture.active &&
-            item == find_menu_item_at(runtime, runtime->key_capture.menu, runtime->key_capture.item_index))
+        if (runtime != NULL && runtime->input_capture.active &&
+            item == find_menu_item_at(runtime, runtime->input_capture.menu, runtime->input_capture.item_index))
         {
             const char *device_name =
                 menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
@@ -4454,12 +4454,12 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
         if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
         {
             SDL_snprintf(buffer, buffer_size, "%s: %s", label,
-                         gamepad_button_display_name(current_key_binding_control_gamepad_button(runtime, control)));
+                         gamepad_button_display_name(current_input_binding_control_gamepad_button(runtime, control)));
         }
         else
         {
             SDL_snprintf(buffer, buffer_size, "%s: %s", label,
-                         scancode_display_name(current_key_binding_control_scancode(runtime, control)));
+                         scancode_display_name(current_input_binding_control_scancode(runtime, control)));
         }
         return;
     }
@@ -6698,7 +6698,7 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return reset_actor_properties_to_authored_defaults(runtime, action);
 
     if (SDL_strcmp(type, "input.reset_bindings") == 0)
-        return sdl3d_game_data_reset_menu_key_bindings(runtime, json_string(action, "menu", NULL));
+        return sdl3d_game_data_reset_menu_input_bindings(runtime, json_string(action, "menu", NULL));
 
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2025,10 +2025,10 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
 
     const char *type = json_string(control, "type");
     if (type == NULL || (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 &&
-                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "key_binding") != 0))
-        return validation_error(ctx, path, "menu item control requires type toggle, choice, range, or key_binding");
+                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "input_binding") != 0))
+        return validation_error(ctx, path, "menu item control requires type toggle, choice, range, or input_binding");
 
-    if (SDL_strcmp(type, "key_binding") != 0)
+    if (SDL_strcmp(type, "input_binding") != 0)
     {
         if (!require_ref(ctx, &names->entities, "entity", json_string(control, "target"), path))
             return false;
@@ -2048,13 +2048,13 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
             !yyjson_is_num(obj_get(control, "step")))
             return validation_error(ctx, path, "range control requires numeric min, max, and step");
     }
-    if (SDL_strcmp(type, "key_binding") == 0)
+    if (SDL_strcmp(type, "input_binding") == 0)
     {
         yyjson_val *bindings = obj_get(control, "bindings");
         if (!yyjson_is_arr(bindings) || yyjson_arr_size(bindings) == 0)
-            return validation_error(ctx, path, "key_binding control requires at least one binding");
+            return validation_error(ctx, path, "input_binding control requires at least one binding");
         if (!is_non_empty_string(control, "default"))
-            return validation_error(ctx, path, "key_binding control requires a default input");
+            return validation_error(ctx, path, "input_binding control requires a default input");
         for (size_t i = 0; i < yyjson_arr_size(bindings); ++i)
         {
             yyjson_val *binding = yyjson_arr_get(bindings, i);
@@ -2062,7 +2062,7 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
                 return false;
             const char *device = json_string(binding, "device");
             if (device != NULL && SDL_strcmp(device, "keyboard") != 0 && SDL_strcmp(device, "gamepad") != 0)
-                return validation_error(ctx, path, "key_binding controls support keyboard or gamepad bindings");
+                return validation_error(ctx, path, "input_binding controls support keyboard or gamepad bindings");
         }
     }
     return true;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -736,17 +736,17 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         out_result->selected_index = menu.selected_index;
     }
 
-    if (sdl3d_game_data_menu_key_binding_capture_active(runtime))
+    if (sdl3d_game_data_menu_input_binding_capture_active(runtime))
     {
-        const sdl3d_game_data_key_binding_capture_status capture_status =
-            sdl3d_game_data_update_menu_key_binding_capture(runtime, input);
+        const sdl3d_game_data_input_binding_capture_status capture_status =
+            sdl3d_game_data_update_menu_input_binding_capture(runtime, input);
         if (out_result != NULL)
         {
             out_result->handled_input = true;
-            out_result->key_binding_changed = capture_status == SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CHANGED;
-            out_result->key_binding_conflict = capture_status == SDL3D_GAME_DATA_KEY_BINDING_CAPTURE_CONFLICT;
-            out_result->selected = out_result->key_binding_changed;
-            out_result->select_signal_id = out_result->key_binding_changed ? menu.select_signal_id : -1;
+            out_result->input_binding_changed = capture_status == SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED;
+            out_result->input_binding_conflict = capture_status == SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT;
+            out_result->selected = out_result->input_binding_changed;
+            out_result->select_signal_id = out_result->input_binding_changed ? menu.select_signal_id : -1;
         }
         return true;
     }
@@ -813,11 +813,11 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         {
             out_result->menu = refreshed.name;
             out_result->selected_index = refreshed.selected_index;
-            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
             {
-                out_result->key_binding_capture_started =
-                    sdl3d_game_data_start_menu_key_binding_capture(runtime, refreshed.name, refreshed.selected_index);
-                out_result->selected = out_result->key_binding_capture_started;
+                out_result->input_binding_capture_started =
+                    sdl3d_game_data_start_menu_input_binding_capture(runtime, refreshed.name, refreshed.selected_index);
+                out_result->selected = out_result->input_binding_capture_started;
                 out_result->select_signal_id = out_result->selected ? refreshed.select_signal_id : -1;
                 out_result->signal_id = -1;
                 out_result->quit = false;
@@ -832,7 +832,7 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
                 return true;
             }
             out_result->control_changed =
-                control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING
+                control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING
                     ? false
                     : sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
             out_result->selected = !control_adjust_input || out_result->control_changed;
@@ -851,9 +851,10 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         }
         else
         {
-            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
-                (void)sdl3d_game_data_start_menu_key_binding_capture(runtime, refreshed.name, refreshed.selected_index);
-            else if (item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING)
+            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
+                (void)sdl3d_game_data_start_menu_input_binding_capture(runtime, refreshed.name,
+                                                                       refreshed.selected_index);
+            else if (item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
                 (void)sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
         }
     }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1314,12 +1314,12 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_EQ(menu.item_count, 9);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Up");
-    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
-    EXPECT_EQ(item.key_binding_count, 2);
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(item.input_binding_count, 2);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 5, &item));
     EXPECT_STREQ(item.label, "Cancel");
-    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
-    EXPECT_EQ(item.key_binding_count, 1);
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(item.input_binding_count, 1);
 
     bool saw_keyboard_up = false;
     bool saw_keyboard_cancel = false;
@@ -1944,7 +1944,7 @@ TEST(GameDataRuntime, AudioOptionSlidersApplyImmediatelyWithLeftRightInput)
     sdl3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
+TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredInputBindings)
 {
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -1974,8 +1974,8 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
     EXPECT_TRUE(result.handled_input);
     EXPECT_TRUE(result.selected);
-    EXPECT_TRUE(result.key_binding_capture_started);
-    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -1988,8 +1988,8 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_input_update(input, 3);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
     EXPECT_TRUE(result.handled_input);
-    EXPECT_TRUE(result.key_binding_changed);
-    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_changed);
+    EXPECT_FALSE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -2014,7 +2014,7 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 7);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.key_binding_capture_started);
+    EXPECT_TRUE(result.input_binding_capture_started);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -2027,8 +2027,8 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_input_update(input, 9);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
     EXPECT_TRUE(result.handled_input);
-    EXPECT_TRUE(result.key_binding_conflict);
-    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_conflict);
+    EXPECT_TRUE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -2040,7 +2040,7 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 11);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_FALSE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     const int reset_keyboard = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_keyboard");
     ASSERT_GE(reset_keyboard, 0);
@@ -2069,7 +2069,7 @@ TEST(GameDataRuntime, KeyboardOptionsCaptureAndApplyAuthoredKeyBindings)
     sdl3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
+TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredInputBindings)
 {
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -2090,8 +2090,8 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
     EXPECT_STREQ(item.label, "Up");
-    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_KEY_BINDING);
-    EXPECT_EQ(item.key_binding_count, 2);
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(item.input_binding_count, 2);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 10, &item));
     EXPECT_STREQ(item.label, "Reset Settings");
 
@@ -2113,8 +2113,8 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 1);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.key_binding_capture_started);
-    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
     sdl3d_input_process_event(input, &event);
@@ -2126,8 +2126,8 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 3);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.key_binding_changed);
-    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_changed);
+    EXPECT_FALSE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
     sdl3d_input_process_event(input, &event);
@@ -2152,7 +2152,7 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 7);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.key_binding_capture_started);
+    EXPECT_TRUE(result.input_binding_capture_started);
 
     event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
     sdl3d_input_process_event(input, &event);
@@ -2164,8 +2164,8 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 9);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.key_binding_conflict);
-    EXPECT_TRUE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_TRUE(result.input_binding_conflict);
+    EXPECT_TRUE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
     sdl3d_input_process_event(input, &event);
@@ -2177,7 +2177,7 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredButtonBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 11);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_FALSE(sdl3d_game_data_menu_key_binding_capture_active(runtime));
+    EXPECT_FALSE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
 
     const int reset_gamepad = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_gamepad");
     ASSERT_GE(reset_gamepad, 0);
@@ -2242,7 +2242,7 @@ TEST(GameDataRuntime, AuthoredSettingsResetRestoresSelectedDefaults)
     sdl3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, AuthoredSettingsCancelRestoresSceneEntrySnapshot)
+TEST(GameDataRuntime, PongStandardOptionsUseImmediateApplyContract)
 {
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
@@ -2253,19 +2253,33 @@ TEST(GameDataRuntime, AuthoredSettingsCancelRestoresSceneEntrySnapshot)
 
     sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
     ASSERT_NE(settings, nullptr);
-    sdl3d_properties_set_string(settings->props, "display_mode", "windowed");
-    sdl3d_properties_set_bool(settings->props, "vsync", true);
-
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
-    sdl3d_properties_set_string(settings->props, "display_mode", "fullscreen_exclusive");
-    sdl3d_properties_set_bool(settings->props, "vsync", false);
-
-    const int cancel_display = sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_display");
-    ASSERT_GE(cancel_display, 0);
-    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), cancel_display, nullptr);
-
     EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
     EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vsync", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");
+    EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vibration", false));
+
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.snapshot_display"), 0);
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.snapshot_audio"), 0);
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.snapshot_gamepad"), 0);
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_display"), 0);
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_audio"), 0);
+    EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_gamepad"), 0);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+    sdl3d_game_data_menu_item display_mode{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.display", 0, &display_mode));
+    EXPECT_EQ(display_mode.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
+    EXPECT_STREQ(display_mode.control_target, "entity.settings");
+    EXPECT_STREQ(display_mode.control_key, "display_mode");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.keyboard"));
+    sdl3d_game_data_menu_item up_binding{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.keyboard", 0, &up_binding));
+    EXPECT_EQ(up_binding.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(up_binding.input_binding_count, 2);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary

- Opens the first implementation slice for #150 by tightening the standard options contract.
- Renames menu binding controls from keyboard-specific `key_binding` to generic `input_binding` across JSON, validation, public API, presentation results, and tests.
- Removes stale Pong options snapshot/cancel signals from immediate-apply display/audio/gamepad settings.
- Documents the reusable standard options settings actor contract for display, audio, gamepad, and input binding menus.

## Tests

- `cmake --build build/release --target sdl3d_game_data_test -j 8`
- `ctest --test-dir build/release -R 'GameDataRuntime|GameDataJson' --output-on-failure`
- `make format`

Closes #150 only after the remaining priority slices are complete; this PR addresses Priority 1.
