### PR TITLE
Add generic settings persistence actions

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -11,6 +11,32 @@
     "application": "SDL3D Pong",
     "profile": "default"
   },
+  "persistence": {
+    "entries": [
+      {
+        "name": "persistence.options",
+        "path": "user://settings/options.json",
+        "schema": "sdl3d.options.v1",
+        "version": 1,
+        "target": "entity.settings",
+        "enabled_if": {
+          "type": "property.bool",
+          "target": "entity.settings",
+          "key": "options_persistence_enabled",
+          "equals": true
+        },
+        "properties": [
+          "display_mode",
+          "vsync",
+          "renderer",
+          "gamepad_icons",
+          "vibration",
+          "sfx_volume",
+          "music_volume"
+        ]
+      }
+    ]
+  },
   "app": {
     "title": "SDL3D Pong",
     "logical_width": 1280,
@@ -1128,6 +1154,7 @@
       {
         "signal": "signal.persistence.load",
         "actions": [
+          { "type": "persistence.load", "entry": "persistence.options" },
           { "type": "adapter.invoke", "adapter": "adapter.pong.load_persistence" },
           { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
         ]
@@ -1135,7 +1162,7 @@
       {
         "signal": "signal.persistence.save_options",
         "actions": [
-          { "type": "adapter.invoke", "adapter": "adapter.pong.save_options" }
+          { "type": "persistence.save", "entry": "persistence.options" }
         ]
       },
       {
@@ -1155,7 +1182,8 @@
       {
         "signal": "signal.settings.reset_display",
         "actions": [
-          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] },
+          { "type": "signal.emit", "signal": "signal.persistence.save_options" }
         ]
       },
       {
@@ -1168,14 +1196,16 @@
         "signal": "signal.settings.reset_gamepad",
         "actions": [
           { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
-          { "type": "input.reset_bindings", "menu": "menu.options.gamepad" }
+          { "type": "input.reset_bindings", "menu": "menu.options.gamepad" },
+          { "type": "signal.emit", "signal": "signal.persistence.save_options" }
         ]
       },
       {
         "signal": "signal.settings.reset_audio",
         "actions": [
           { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume"] },
-          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" },
+          { "type": "signal.emit", "signal": "signal.persistence.save_options" }
         ]
       },
       {
@@ -1385,14 +1415,7 @@
       "kind": "action",
       "script": "script.pong",
       "function": "load_persistence",
-      "description": "Load persisted Pong options and score records from user storage."
-    },
-    {
-      "name": "adapter.pong.save_options",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "save_options",
-      "description": "Persist current Pong options to user storage."
+      "description": "Load persisted Pong score records from user storage."
     },
     {
       "name": "adapter.pong.record_player_win",

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -1,6 +1,5 @@
 local pong = {}
 
-local options_path = "user://settings/options.json"
 local scores_path = "user://scores/pong_scores.json"
 
 local function random_signed_angle(ctx, min_angle, max_angle)
@@ -132,48 +131,6 @@ local function write_json(ctx, path, value)
     return ctx.storage.write(path, text)
 end
 
-local function apply_options(settings, options)
-    if settings == nil or type(options) ~= "table" then
-        return
-    end
-    if type(options.display_mode) == "string" then
-        settings:set_string("display_mode", options.display_mode)
-    elseif type(options.fullscreen) == "boolean" then
-        settings:set_string("display_mode", options.fullscreen and "fullscreen_borderless" or "windowed")
-    end
-    if type(options.vsync) == "boolean" then
-        settings:set_bool("vsync", options.vsync)
-    end
-    if type(options.renderer) == "string" then
-        settings:set_string("renderer", options.renderer)
-    end
-    if type(options.gamepad_icons) == "string" then
-        settings:set_string("gamepad_icons", options.gamepad_icons)
-    end
-    if type(options.vibration) == "boolean" then
-        settings:set_bool("vibration", options.vibration)
-    end
-    if type(options.sfx_volume) == "number" then
-        settings:set_int("sfx_volume", math.floor(math.clamp(options.sfx_volume, 0, 10) + 0.5))
-    end
-    if type(options.music_volume) == "number" then
-        settings:set_int("music_volume", math.floor(math.clamp(options.music_volume, 0, 10) + 0.5))
-    end
-end
-
-local function current_options(settings)
-    return {
-        schema = "sdl3d.pong.options.v1",
-        display_mode = settings:get_string("display_mode", "fullscreen_borderless"),
-        vsync = settings:get_bool("vsync", true),
-        renderer = settings:get_string("renderer", "software"),
-        gamepad_icons = settings:get_string("gamepad_icons", "xbox"),
-        vibration = settings:get_bool("vibration", true),
-        sfx_volume = settings:get_int("sfx_volume", 8),
-        music_volume = settings:get_int("music_volume", 7),
-    }
-end
-
 local function apply_scores(scores, data)
     if scores == nil or type(data) ~= "table" then
         return
@@ -203,36 +160,16 @@ local function save_scores(ctx, scores)
     return write_json(ctx, scores_path, current_scores(scores))
 end
 
-local function options_persistence_enabled(ctx)
-    local settings = settings_actor(ctx)
-    return settings ~= nil and settings:get_bool("options_persistence_enabled", false)
-end
-
 local function score_persistence_enabled(ctx)
     local settings = settings_actor(ctx)
     return settings ~= nil and settings:get_bool("score_persistence_enabled", false)
 end
 
 function pong.load_persistence(_, _, ctx)
-    local settings = settings_actor(ctx)
-    if options_persistence_enabled(ctx) then
-        apply_options(settings, read_json(ctx, options_path))
-    end
     if score_persistence_enabled(ctx) then
         apply_scores(scores_actor(ctx), read_json(ctx, scores_path))
     end
     return true
-end
-
-function pong.save_options(_, _, ctx)
-    if not options_persistence_enabled(ctx) then
-        return true
-    end
-    local settings = settings_actor(ctx)
-    if settings == nil then
-        return false
-    end
-    return write_json(ctx, options_path, current_options(settings))
 end
 
 function pong.record_player_win(_, _, ctx)

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -22,6 +22,7 @@ Every file is a JSON object with these fields:
 | `schema` | yes | Schema id. First value: `sdl3d.game.v0`. |
 | `metadata` | yes | Human-readable identity and versioning. |
 | `storage` | no | Writable storage identity used to resolve `user://` and `cache://` roots. |
+| `persistence` | no | Reusable actor-property persistence entries for settings, saves, and profiles. |
 | `app` | no | Managed-loop startup config such as title, logical resolution, window mode, backend, tick rate, and tick cap. |
 | `profiles` | no | Genre/profile hints and required modules. |
 | `assets` | no | Stable asset ids mapped to paths or future archive refs. |
@@ -69,6 +70,54 @@ become part of the writable save/settings/cache paths on every platform.
 `profile` is optional and scopes roots below `profiles/<profile>`. Test tools
 may also author `user_root_override` and `cache_root_override`, but shipped
 games should normally let SDL3D choose platform-idiomatic locations.
+
+## Persistence
+
+The optional `persistence` block declares reusable save files for actor
+properties. Each entry owns one storage path and an allowlist of properties from
+one actor. Logic can load or save the entry without game-specific Lua:
+
+```json
+{
+  "persistence": {
+    "entries": [
+      {
+        "name": "persistence.options",
+        "path": "user://settings/options.json",
+        "schema": "sdl3d.options.v1",
+        "version": 1,
+        "target": "entity.settings",
+        "enabled_if": {
+          "type": "property.bool",
+          "target": "entity.settings",
+          "key": "options_persistence_enabled",
+          "equals": true
+        },
+        "properties": [
+          "display_mode",
+          "vsync",
+          "renderer",
+          "sfx_volume",
+          "music_volume"
+        ]
+      }
+    ]
+  }
+}
+```
+
+The generated JSON stores `schema` and `version` when authored, then writes the
+allowlisted properties at the top level. Load ignores missing files and
+incompatible schema/version files, which lets games reset defaults or migrate
+old data explicitly. `enabled_if` uses the same condition language as UI and
+logic, so games can disable persistence during development or per profile.
+
+Persistence actions are regular logic actions:
+
+```json
+{ "type": "persistence.load", "entry": "persistence.options" }
+{ "type": "persistence.save", "entry": "persistence.options" }
+```
 
 ## World
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6202,6 +6202,195 @@ static bool ensure_runtime_storage(sdl3d_game_data_runtime *runtime, char *error
     return sdl3d_storage_create(&runtime->storage_config, &runtime->storage, error_buffer, error_buffer_size);
 }
 
+static yyjson_val *find_persistence_entry(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *entries = obj_get(obj_get(runtime_root(runtime), "persistence"), "entries");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(entries) && i < yyjson_arr_size(entries); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(entries, i);
+        const char *entry_name = json_string(entry, "name", NULL);
+        if (entry_name != NULL && SDL_strcmp(entry_name, name) == 0)
+            return entry;
+    }
+    return NULL;
+}
+
+static const char *action_persistence_entry_name(yyjson_val *action)
+{
+    const char *entry = json_string(action, "entry", NULL);
+    return entry != NULL ? entry : json_string(action, "name", NULL);
+}
+
+static bool persistence_entry_is_enabled(sdl3d_game_data_runtime *runtime, yyjson_val *entry)
+{
+    yyjson_val *condition = obj_get(entry, "enabled_if");
+    return condition == NULL || eval_data_condition(runtime, condition, NULL);
+}
+
+static const char *persistence_property_key(yyjson_val *property)
+{
+    if (yyjson_is_str(property))
+        return yyjson_get_str(property);
+    return json_string(property, "key", NULL);
+}
+
+static bool json_add_property_value(yyjson_mut_doc *doc, yyjson_mut_val *object, const char *key,
+                                    const sdl3d_value *value)
+{
+    if (doc == NULL || object == NULL || key == NULL || value == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        return yyjson_mut_obj_add_int(doc, object, key, value->as_int);
+    case SDL3D_VALUE_FLOAT:
+        return yyjson_mut_obj_add_real(doc, object, key, value->as_float);
+    case SDL3D_VALUE_BOOL:
+        return yyjson_mut_obj_add_bool(doc, object, key, value->as_bool);
+    case SDL3D_VALUE_STRING:
+        return yyjson_mut_obj_add_strcpy(doc, object, key, value->as_string != NULL ? value->as_string : "");
+    case SDL3D_VALUE_VEC3: {
+        yyjson_mut_val *arr = yyjson_mut_arr(doc);
+        return arr != NULL && yyjson_mut_arr_add_real(doc, arr, value->as_vec3.x) &&
+               yyjson_mut_arr_add_real(doc, arr, value->as_vec3.y) &&
+               yyjson_mut_arr_add_real(doc, arr, value->as_vec3.z) && yyjson_mut_obj_add_val(doc, object, key, arr);
+    }
+    case SDL3D_VALUE_COLOR: {
+        yyjson_mut_val *arr = yyjson_mut_arr(doc);
+        return arr != NULL && yyjson_mut_arr_add_int(doc, arr, value->as_color.r) &&
+               yyjson_mut_arr_add_int(doc, arr, value->as_color.g) &&
+               yyjson_mut_arr_add_int(doc, arr, value->as_color.b) &&
+               yyjson_mut_arr_add_int(doc, arr, value->as_color.a) && yyjson_mut_obj_add_val(doc, object, key, arr);
+    }
+    }
+    return false;
+}
+
+static bool execute_persistence_save(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *entry = find_persistence_entry(runtime, action_persistence_entry_name(action));
+    const char *path = json_string(entry, "path", NULL);
+    const char *target = json_string(entry, "target", NULL);
+    yyjson_val *properties = obj_get(entry, "properties");
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    if (entry == NULL || path == NULL || actor == NULL || !yyjson_is_arr(properties))
+        return false;
+    if (!persistence_entry_is_enabled(runtime, entry))
+        return true;
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    if (root == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        return false;
+    }
+    yyjson_mut_doc_set_root(doc, root);
+
+    const char *schema = json_string(entry, "schema", NULL);
+    if (schema != NULL && !yyjson_mut_obj_add_strcpy(doc, root, "schema", schema))
+    {
+        yyjson_mut_doc_free(doc);
+        return false;
+    }
+    yyjson_val *version = obj_get(entry, "version");
+    if (yyjson_is_int(version) && !yyjson_mut_obj_add_int(doc, root, "version", (int)yyjson_get_int(version)))
+    {
+        yyjson_mut_doc_free(doc);
+        return false;
+    }
+
+    for (size_t i = 0; i < yyjson_arr_size(properties); ++i)
+    {
+        const char *key = persistence_property_key(yyjson_arr_get(properties, i));
+        if (key == NULL || key[0] == '\0')
+            continue;
+        const sdl3d_value *value = sdl3d_properties_get_value(actor->props, key);
+        if (value != NULL && !json_add_property_value(doc, root, key, value))
+        {
+            yyjson_mut_doc_free(doc);
+            return false;
+        }
+    }
+
+    size_t size = 0u;
+    char *json = yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size);
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+        return false;
+
+    char storage_error[256];
+    const bool ok =
+        ensure_runtime_storage(runtime, storage_error, (int)sizeof(storage_error)) &&
+        sdl3d_storage_write_file(runtime->storage, path, json, size, storage_error, (int)sizeof(storage_error));
+    free(json);
+    if (!ok)
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D persistence save failed: %s", storage_error);
+    return ok;
+}
+
+static bool execute_persistence_load(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *entry = find_persistence_entry(runtime, action_persistence_entry_name(action));
+    const char *path = json_string(entry, "path", NULL);
+    const char *target = json_string(entry, "target", NULL);
+    yyjson_val *properties = obj_get(entry, "properties");
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    if (entry == NULL || path == NULL || actor == NULL || !yyjson_is_arr(properties))
+        return false;
+    if (!persistence_entry_is_enabled(runtime, entry))
+        return true;
+
+    char storage_error[256];
+    if (!ensure_runtime_storage(runtime, storage_error, (int)sizeof(storage_error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D persistence storage unavailable: %s", storage_error);
+        return false;
+    }
+
+    sdl3d_storage_buffer buffer;
+    SDL_zero(buffer);
+    if (!sdl3d_storage_read_file(runtime->storage, path, &buffer, storage_error, (int)sizeof(storage_error)))
+        return true;
+
+    yyjson_doc *doc = yyjson_read_opts((char *)buffer.data, buffer.size, YYJSON_READ_NOFLAG, NULL, NULL);
+    yyjson_val *root = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    const char *schema = json_string(entry, "schema", NULL);
+    yyjson_val *version = obj_get(entry, "version");
+    const bool schema_ok = schema == NULL || SDL_strcmp(json_string(root, "schema", ""), schema) == 0;
+    const bool version_ok =
+        !yyjson_is_int(version) || (yyjson_is_int(obj_get(root, "version")) &&
+                                    yyjson_get_int(obj_get(root, "version")) == yyjson_get_int(version));
+    if (yyjson_is_obj(root) && schema_ok && version_ok)
+    {
+        for (size_t i = 0; i < yyjson_arr_size(properties); ++i)
+        {
+            const char *key = persistence_property_key(yyjson_arr_get(properties, i));
+            yyjson_val *value = key != NULL ? obj_get(root, key) : NULL;
+            if (value != NULL)
+                set_actor_property_from_json(actor, key, value);
+        }
+    }
+    else
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D persistence ignored incompatible file: %s", path);
+    }
+
+    yyjson_doc_free(doc);
+    sdl3d_storage_buffer_free(&buffer);
+    return true;
+}
+
+static bool execute_persistence_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const char *type)
+{
+    if (SDL_strcmp(type, "persistence.save") == 0)
+        return execute_persistence_save(runtime, action);
+    if (SDL_strcmp(type, "persistence.load") == 0)
+        return execute_persistence_load(runtime, action);
+    return false;
+}
+
 static bool ensure_audio_cache_storage(sdl3d_game_data_runtime *runtime)
 {
     char storage_error[256];
@@ -6706,6 +6895,9 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strncmp(type, "audio.", 6) == 0)
         return execute_audio_action(runtime, action, type);
+
+    if (SDL_strncmp(type, "persistence.", 12) == 0)
+        return execute_persistence_action(runtime, action, type);
 
     if (SDL_strcmp(type, "entity.set_active") == 0)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -60,6 +60,7 @@ typedef struct validation_names
     name_table music;
     name_table scenes;
     name_table sensors;
+    name_table persistence;
     name_table used_adapters;
     name_table used_scripts;
     script_manifest *script_manifests;
@@ -69,6 +70,11 @@ typedef struct validation_names
 static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
                                     validation_names *names);
 static bool validate_storage(validation_context *ctx, yyjson_val *root);
+static bool require_unique_name(validation_context *ctx, name_table *table, const char *kind, const char *name,
+                                const char *json_path);
+static bool require_ref(validation_context *ctx, const name_table *table, const char *kind, const char *name,
+                        const char *json_path);
+static void format_path(char *buffer, size_t buffer_size, const char *format, ...);
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
 {
@@ -94,6 +100,11 @@ static bool is_storage_path_segment(const char *value)
     if (SDL_strcmp(value, ".") == 0 || SDL_strcmp(value, "..") == 0)
         return false;
     return SDL_strchr(value, '/') == NULL && SDL_strchr(value, '\\') == NULL && SDL_strchr(value, ':') == NULL;
+}
+
+static bool is_virtual_storage_path(const char *value)
+{
+    return value != NULL && (SDL_strncmp(value, "user://", 7) == 0 || SDL_strncmp(value, "cache://", 8) == 0);
 }
 
 static void set_first_error(validation_context *ctx, const char *json_path, const char *message)
@@ -179,6 +190,76 @@ static bool validate_storage(validation_context *ctx, yyjson_val *root)
            validate_storage_string(ctx, storage, "profile", "$.storage.profile", true) &&
            validate_storage_string(ctx, storage, "user_root_override", "$.storage.user_root_override", false) &&
            validate_storage_string(ctx, storage, "cache_root_override", "$.storage.cache_root_override", false);
+}
+
+static bool validate_persistence_properties(validation_context *ctx, yyjson_val *properties, const char *json_path)
+{
+    if (!yyjson_is_arr(properties) || yyjson_arr_size(properties) == 0)
+        return validation_error(ctx, json_path, "persistence properties must be a non-empty array");
+
+    for (size_t i = 0; i < yyjson_arr_size(properties); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *property = yyjson_arr_get(properties, i);
+        if (yyjson_is_str(property) && yyjson_get_str(property)[0] != '\0')
+            continue;
+        if (yyjson_is_obj(property) && is_non_empty_string(property, "key"))
+            continue;
+        return validation_error(ctx, path, "persistence property must be a non-empty string or object with key");
+    }
+    return true;
+}
+
+static bool validate_persistence(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *persistence = obj_get(root, "persistence");
+    if (persistence == NULL)
+        return true;
+    if (!yyjson_is_obj(persistence))
+        return validation_error(ctx, "$.persistence", "persistence must be an object");
+
+    yyjson_val *entries = obj_get(persistence, "entries");
+    if (entries == NULL)
+        return true;
+    if (!yyjson_is_arr(entries))
+        return validation_error(ctx, "$.persistence.entries", "persistence.entries must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(entries); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.persistence.entries[%zu]", i);
+        yyjson_val *entry = yyjson_arr_get(entries, i);
+        if (!yyjson_is_obj(entry))
+            return validation_error(ctx, path, "persistence entry must be an object");
+        if (!require_unique_name(ctx, &names->persistence, "persistence entry", json_string(entry, "name"), path))
+            return false;
+
+        char field_path[PATH_BUFFER_SIZE];
+        format_path(field_path, sizeof(field_path), "%s.path", path);
+        const char *storage_path = json_string(entry, "path");
+        if (storage_path == NULL || storage_path[0] == '\0' || !is_virtual_storage_path(storage_path))
+            return validation_error(ctx, field_path, "persistence path must use user:// or cache://");
+        if (!require_ref(ctx, &names->entities, "entity", json_string(entry, "target"), path))
+            return false;
+        format_path(field_path, sizeof(field_path), "%s.properties", path);
+        if (!validate_persistence_properties(ctx, obj_get(entry, "properties"), field_path))
+            return false;
+        yyjson_val *schema = obj_get(entry, "schema");
+        if (schema != NULL && (!yyjson_is_str(schema) || yyjson_get_str(schema)[0] == '\0'))
+            return validation_error(ctx, path, "persistence schema must be a non-empty string");
+        yyjson_val *version = obj_get(entry, "version");
+        if (version != NULL && !yyjson_is_int(version))
+            return validation_error(ctx, path, "persistence version must be an integer");
+        yyjson_val *condition = obj_get(entry, "enabled_if");
+        if (condition != NULL)
+        {
+            format_path(field_path, sizeof(field_path), "%s.enabled_if", path);
+            if (!validate_data_condition(ctx, condition, field_path, names))
+                return false;
+        }
+    }
+    return true;
 }
 
 static void format_path(char *buffer, size_t buffer_size, const char *format, ...)
@@ -1170,6 +1251,13 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     }
     if (SDL_strncmp(type, "audio.", 6) == 0)
         return validate_audio_action(ctx, action, json_path, names, type);
+    if (SDL_strcmp(type, "persistence.load") == 0 || SDL_strcmp(type, "persistence.save") == 0)
+    {
+        const char *entry = json_string(action, "entry");
+        if (entry == NULL)
+            entry = json_string(action, "name");
+        return require_ref(ctx, &names->persistence, "persistence entry", entry, json_path);
+    }
     if (SDL_strcmp(type, "entity.set_active") == 0)
     {
         if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
@@ -2512,7 +2600,8 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
-    return validate_storage(ctx, root) && validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+    return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
+           validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases") &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
@@ -2544,6 +2633,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->music);
     name_table_destroy(&names->scenes);
     name_table_destroy(&names->sensors);
+    name_table_destroy(&names->persistence);
     name_table_destroy(&names->used_adapters);
     name_table_destroy(&names->used_scripts);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3578,7 +3578,7 @@ return storage
     remove_test_dir(dir);
 }
 
-TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStorage)
+TEST(GameDataRuntime, GenericPersistenceSavesOptionsAndPongLuaLoadsHighScores)
 {
     const std::filesystem::path dir = unique_test_dir("pong_persistence");
     const std::filesystem::path user_root = dir / "user";
@@ -3619,6 +3619,7 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         sdl3d_properties_set_bool(settings->props, "vibration", false);
         sdl3d_properties_set_int(settings->props, "sfx_volume", 4);
         sdl3d_properties_set_int(settings->props, "music_volume", 7);
+        sdl3d_properties_set_bool(settings->props, "options_persistence_enabled", true);
         emit(session, runtime, "signal.persistence.save_options");
 
         emit(session, runtime, "signal.match.player_won");
@@ -3632,11 +3633,13 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         sdl3d_game_session_destroy(session);
     }
 
-    EXPECT_FALSE(std::filesystem::exists(user_root / "settings" / "options.json"));
+    EXPECT_TRUE(std::filesystem::exists(user_root / "settings" / "options.json"));
     EXPECT_TRUE(std::filesystem::exists(user_root / "scores" / "pong_scores.json"));
-    write_text(
-        user_root / "settings" / "options.json",
-        R"json({"schema":"sdl3d.pong.options.v1","display_mode":"windowed","vsync":false,"renderer":"opengl","gamepad_icons":"playstation","vibration":false,"sfx_volume":4,"music_volume":7})json");
+    const std::string options_text = read_text(user_root / "settings" / "options.json");
+    EXPECT_NE(options_text.find("\"schema\": \"sdl3d.options.v1\""), std::string::npos);
+    EXPECT_NE(options_text.find("\"version\": 1"), std::string::npos);
+    EXPECT_NE(options_text.find("\"display_mode\": \"windowed\""), std::string::npos);
+    EXPECT_NE(options_text.find("\"gamepad_icons\": \"playstation\""), std::string::npos);
 
     sdl3d_game_config persisted_config{};
     char title[128]{};
@@ -3667,6 +3670,16 @@ TEST(GameDataRuntime, PongPersistenceSkipsOptionsAndLoadsHighScoresFromUserStora
         EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "xbox");
         EXPECT_TRUE(sdl3d_properties_get_bool(settings->props, "vibration", false));
         EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+        EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
+
+        sdl3d_properties_set_bool(settings->props, "options_persistence_enabled", true);
+        emit(session, runtime, "signal.persistence.load");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vsync", true));
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "renderer", ""), "opengl");
+        EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "gamepad_icons", ""), "playstation");
+        EXPECT_FALSE(sdl3d_properties_get_bool(settings->props, "vibration", true));
+        EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 4);
         EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
 
         sdl3d_registered_actor *scores = sdl3d_game_data_find_actor(runtime, "entity.high_scores");

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -231,6 +231,42 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(required_object(options, "bindings"), "gamepad")));
 }
 
+TEST(GameDataJson, PongOptionsUseGenericPersistenceEntry)
+{
+    JsonDoc doc(kPongDataPath);
+    ASSERT_NE(doc.root(), nullptr) << doc.error();
+
+    yyjson_val *persistence = required_object(doc.root(), "persistence");
+    yyjson_val *entries = required_array(persistence, "entries");
+    ASSERT_EQ(yyjson_arr_size(entries), 1u);
+
+    yyjson_val *options = yyjson_arr_get(entries, 0);
+    EXPECT_EQ(required_string(options, "name"), "persistence.options");
+    EXPECT_EQ(required_string(options, "path"), "user://settings/options.json");
+    EXPECT_EQ(required_string(options, "target"), "entity.settings");
+    EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(options, "properties")));
+
+    yyjson_val *logic = required_object(doc.root(), "logic");
+    yyjson_val *bindings = required_array(logic, "bindings");
+    bool saw_generic_save = false;
+    bool saw_legacy_options_adapter = false;
+    for (size_t i = 0; i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *actions = yyjson_obj_get(yyjson_arr_get(bindings, i), "actions");
+        for (size_t j = 0; yyjson_is_arr(actions) && j < yyjson_arr_size(actions); ++j)
+        {
+            yyjson_val *action = yyjson_arr_get(actions, j);
+            const std::string type = required_string(action, "type");
+            if (type == "persistence.save" && required_string(action, "entry") == "persistence.options")
+                saw_generic_save = true;
+            if (type == "adapter.invoke" && required_string(action, "adapter") == "adapter.pong.save_options")
+                saw_legacy_options_adapter = true;
+        }
+    }
+    EXPECT_TRUE(saw_generic_save);
+    EXPECT_FALSE(saw_legacy_options_adapter);
+}
+
 TEST(GameDataJson, PongDataUsesNonSectorFixedScreenWorld)
 {
     JsonDoc doc(kPongDataPath);


### PR DESCRIPTION
## Summary

- add data-driven `persistence.entries` with schema/version, storage path, target actor, property allowlist, and normal data-condition gating
- add generic `persistence.load` and `persistence.save` logic actions backed by SDL3D storage
- migrate Pong option persistence from Pong Lua into the generic logic layer while leaving high-score persistence in Pong-specific Lua
- document the persistence contract and add runtime/JSON tests proving Pong no longer needs an options save adapter

Refs #150

## Tests

- `make format-fix`
- `cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j 8`
- `ctest --test-dir build/release -R 'GameDataRuntime|GameDataJson' --output-on-failure`\n- `ctest --test-dir build/release --output-on-failure` (991/991 passed; existing OpenGL availability test skipped)\n- `make format`\n