### PR TITLE
Add mouse rebinding to standard options

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -115,6 +115,7 @@
         "root": "scene.options",
         "display": "scene.options.display",
         "keyboard": "scene.options.keyboard",
+        "mouse": "scene.options.mouse",
         "gamepad": "scene.options.gamepad",
         "audio": "scene.options.audio"
       },
@@ -122,6 +123,7 @@
         "root": "menu.options",
         "display": "menu.options.display",
         "keyboard": "menu.options.keyboard",
+        "mouse": "menu.options.mouse",
         "gamepad": "menu.options.gamepad",
         "audio": "menu.options.audio"
       },
@@ -139,6 +141,7 @@
         "apply_audio": "signal.settings.apply_audio",
         "reset_display": "signal.settings.reset_display",
         "reset_keyboard": "signal.settings.reset_keyboard",
+        "reset_mouse": "signal.settings.reset_mouse",
         "reset_gamepad": "signal.settings.reset_gamepad",
         "reset_audio": "signal.settings.reset_audio"
       },
@@ -185,6 +188,12 @@
         "keyboard": {
           "title_y": 0.13,
           "menu_y": 0.25,
+          "gap": 0.062,
+          "cursor_offset_x": -0.18
+        },
+        "mouse": {
+          "title_y": 0.13,
+          "menu_y": 0.30,
           "gap": 0.062,
           "cursor_offset_x": -0.18
         },
@@ -254,6 +263,15 @@
             "default": "B",
             "bindings": [
               { "action": "action.camera.ball.toggle", "device": "keyboard" }
+            ]
+          }
+        ],
+        "mouse": [
+          {
+            "label": "Accept",
+            "default": "LEFT",
+            "bindings": [
+              { "action": "action.menu.select", "device": "mouse" }
             ]
           }
         ],
@@ -559,6 +577,7 @@
             "bindings": [
               { "device": "keyboard", "key": "RETURN" },
               { "device": "keyboard", "key": "SPACE" },
+              { "device": "mouse", "button": "LEFT" },
               { "device": "gamepad", "button": "SOUTH" }
             ]
           },
@@ -1070,6 +1089,7 @@
     "signal.settings.apply_audio",
     "signal.settings.reset_display",
     "signal.settings.reset_keyboard",
+    "signal.settings.reset_mouse",
     "signal.settings.reset_gamepad",
     "signal.settings.reset_audio",
     "signal.ui.menu.move",
@@ -1233,6 +1253,12 @@
         "signal": "signal.settings.reset_keyboard",
         "actions": [
           { "type": "input.reset_bindings", "menu": "menu.options.keyboard" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_mouse",
+        "actions": [
+          { "type": "input.reset_bindings", "menu": "menu.options.mouse" }
         ]
       },
       {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -379,8 +379,8 @@ Range controls clamp to their authored min/max. Adding `"value_type": "int"`
 stores the result as an integer property; adding `"display": "slider"` renders
 the menu value as a compact slider label.
 
-`input_binding` controls capture the next keyboard key or gamepad button and
-immediately rebind all authored actions for that device. This is how games can
+`input_binding` controls capture the next keyboard key, mouse button, or
+gamepad button and immediately rebind all authored actions for that device. This is how games can
 expose one player-facing input such as `Up` while updating both gameplay and
 menu actions:
 
@@ -467,19 +467,23 @@ Standard gamepad properties:
 | `gamepad_icons` | string | `xbox`, `nintendo`, `playstation` |
 | `vibration` | bool | `true` or `false` |
 
-Keyboard and gamepad configuration should be authored as action-oriented
+Keyboard, mouse, and gamepad configuration should be authored as action-oriented
 `input_binding` menu controls. Games decide which actions to expose, but each
 control should represent a player-facing intent such as `Up`, `Accept`,
 `Cancel`, or `Pause`, not a low-level device-specific operation. The same
 player-facing item may update multiple engine actions, such as gameplay
 movement and menu navigation.
 
+Gameplay input bindings may also use authored mouse axes and gamepad axes. The
+standard rebinding UI captures button-like inputs; analog axis rebinding needs
+game-specific policy for threshold, direction, and conflict behavior.
+
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for
 screens that intentionally stage changes before committing them.
 
 The `standard_options` scene package generates root Options, Display, Keyboard,
-Gamepad, and Audio scenes from reusable engine templates. The game controls the
+Mouse, Gamepad, and Audio scenes from reusable engine templates. The game controls the
 scene ids, menu ids, settings actor, signals, input actions, fonts, theme
 colors, and player-facing input binding rows:
 
@@ -498,6 +502,7 @@ colors, and player-facing input binding rows:
         "root": "scene.options",
         "display": "scene.options.display",
         "keyboard": "scene.options.keyboard",
+        "mouse": "scene.options.mouse",
         "gamepad": "scene.options.gamepad",
         "audio": "scene.options.audio"
       },
@@ -515,6 +520,7 @@ colors, and player-facing input binding rows:
         "apply_audio": "signal.settings.apply_audio",
         "reset_display": "signal.settings.reset_display",
         "reset_keyboard": "signal.settings.reset_keyboard",
+        "reset_mouse": "signal.settings.reset_mouse",
         "reset_gamepad": "signal.settings.reset_gamepad",
         "reset_audio": "signal.settings.reset_audio"
       },
@@ -545,6 +551,7 @@ colors, and player-facing input binding rows:
         "root": { "title_y": 0.18, "menu_y": 0.36, "gap": 0.078, "cursor_offset_x": -0.14 },
         "display": { "title_y": 0.2, "menu_y": 0.38, "gap": 0.074, "cursor_offset_x": -0.18 },
         "keyboard": { "title_y": 0.13, "menu_y": 0.25, "gap": 0.062, "cursor_offset_x": -0.18 },
+        "mouse": { "title_y": 0.13, "menu_y": 0.30, "gap": 0.062, "cursor_offset_x": -0.18 },
         "gamepad": { "title_y": 0.12, "menu_y": 0.22, "gap": 0.052, "cursor_offset_x": -0.18 },
         "audio": { "title_y": 0.18, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.18 }
       },
@@ -556,6 +563,15 @@ colors, and player-facing input binding rows:
             "bindings": [
               { "action": "action.player.up", "device": "keyboard" },
               { "action": "action.menu.up", "device": "keyboard" }
+            ]
+          }
+        ],
+        "mouse": [
+          {
+            "label": "Accept",
+            "default": "LEFT",
+            "bindings": [
+              { "action": "action.menu.select", "device": "mouse" }
             ]
           }
         ],

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -254,6 +254,15 @@ extern "C"
     SDL_GamepadButton sdl3d_input_get_pressed_gamepad_button(const sdl3d_input_manager *input);
 
     /**
+     * @brief Return the first mouse button pressed during the current input tick.
+     *
+     * The value is captured by sdl3d_input_update() before transient button
+     * edges are cleared. Returns 0 when no mouse button was pressed or live
+     * mouse input is unavailable, such as during demo playback.
+     */
+    Uint8 sdl3d_input_get_pressed_mouse_button(const sdl3d_input_manager *input);
+
+    /**
      * @brief Return true if any button-like input or action was pressed this tick.
      *
      * This supports generic flows such as splash screens where "press anything

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -129,7 +129,8 @@ typedef struct menu_input_binding_capture
 typedef enum menu_binding_device
 {
     MENU_BINDING_DEVICE_KEYBOARD = 0,
-    MENU_BINDING_DEVICE_GAMEPAD_BUTTON = 1,
+    MENU_BINDING_DEVICE_MOUSE_BUTTON = 1,
+    MENU_BINDING_DEVICE_GAMEPAD_BUTTON = 2,
 } menu_binding_device;
 
 typedef struct scene_menu_state
@@ -297,6 +298,7 @@ static void set_error(char *buffer, int buffer_size, const char *message)
 }
 
 static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
+static bool set_action_mouse_button_binding(sdl3d_game_data_runtime *runtime, const char *action, Uint8 button);
 static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
                                               SDL_GamepadButton button);
 
@@ -1788,6 +1790,65 @@ static const char *scancode_display_name(SDL_Scancode scancode)
         return "-";
     const char *name = SDL_GetScancodeName(scancode);
     return name != NULL && name[0] != '\0' ? name : "-";
+}
+
+static Uint8 mouse_button_from_json(const char *name)
+{
+    if (name == NULL)
+        return 0;
+    if (SDL_strcmp(name, "LEFT") == 0)
+        return SDL_BUTTON_LEFT;
+    if (SDL_strcmp(name, "MIDDLE") == 0)
+        return SDL_BUTTON_MIDDLE;
+    if (SDL_strcmp(name, "RIGHT") == 0)
+        return SDL_BUTTON_RIGHT;
+    if (SDL_strcmp(name, "X1") == 0)
+        return SDL_BUTTON_X1;
+    if (SDL_strcmp(name, "X2") == 0)
+        return SDL_BUTTON_X2;
+    return 0;
+}
+
+static const char *mouse_button_display_name(Uint8 button)
+{
+    switch (button)
+    {
+    case SDL_BUTTON_LEFT:
+        return "Left Mouse";
+    case SDL_BUTTON_MIDDLE:
+        return "Middle Mouse";
+    case SDL_BUTTON_RIGHT:
+        return "Right Mouse";
+    case SDL_BUTTON_X1:
+        return "Mouse X1";
+    case SDL_BUTTON_X2:
+        return "Mouse X2";
+    default:
+        return "-";
+    }
+}
+
+static sdl3d_mouse_axis mouse_axis_from_json(const char *name, bool *valid)
+{
+    if (valid != NULL)
+        *valid = true;
+    if (name == NULL)
+    {
+        if (valid != NULL)
+            *valid = false;
+        return SDL3D_MOUSE_AXIS_X;
+    }
+    if (SDL_strcmp(name, "x") == 0)
+        return SDL3D_MOUSE_AXIS_X;
+    if (SDL_strcmp(name, "y") == 0)
+        return SDL3D_MOUSE_AXIS_Y;
+    if (SDL_strcmp(name, "wheel") == 0)
+        return SDL3D_MOUSE_AXIS_WHEEL;
+    if (SDL_strcmp(name, "wheel_x") == 0)
+        return SDL3D_MOUSE_AXIS_WHEEL_X;
+    if (valid != NULL)
+        *valid = false;
+    return SDL3D_MOUSE_AXIS_X;
 }
 
 static const char *gamepad_button_display_name(SDL_GamepadButton button)
@@ -3891,6 +3952,7 @@ static void set_menu_binding_status(sdl3d_game_data_runtime *runtime, const char
     if (runtime != NULL && runtime->scene_state != NULL)
     {
         sdl3d_properties_set_string(runtime->scene_state, "keyboard_binding_status", status != NULL ? status : "");
+        sdl3d_properties_set_string(runtime->scene_state, "mouse_binding_status", status != NULL ? status : "");
         sdl3d_properties_set_string(runtime->scene_state, "gamepad_binding_status", status != NULL ? status : "");
     }
 }
@@ -3901,10 +3963,27 @@ static menu_binding_device menu_binding_control_device(yyjson_val *control)
     for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
     {
         yyjson_val *binding = yyjson_arr_get(bindings, i);
-        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "gamepad") == 0)
+        const char *device = json_string(binding, "device", "keyboard");
+        if (SDL_strcmp(device, "mouse") == 0)
+            return MENU_BINDING_DEVICE_MOUSE_BUTTON;
+        if (SDL_strcmp(device, "gamepad") == 0)
             return MENU_BINDING_DEVICE_GAMEPAD_BUTTON;
     }
     return MENU_BINDING_DEVICE_KEYBOARD;
+}
+
+static const char *menu_binding_device_input_name(menu_binding_device device)
+{
+    switch (device)
+    {
+    case MENU_BINDING_DEVICE_MOUSE_BUTTON:
+        return "mouse button";
+    case MENU_BINDING_DEVICE_GAMEPAD_BUTTON:
+        return "button";
+    case MENU_BINDING_DEVICE_KEYBOARD:
+    default:
+        return "key";
+    }
 }
 
 static SDL_Scancode current_action_keyboard_binding(const sdl3d_game_data_runtime *runtime, const char *action)
@@ -3930,6 +4009,18 @@ static SDL_GamepadButton current_action_gamepad_button_binding(const sdl3d_game_
             return spec->gamepad_button;
     }
     return SDL_GAMEPAD_BUTTON_INVALID;
+}
+
+static Uint8 current_action_mouse_button_binding(const sdl3d_game_data_runtime *runtime, const char *action)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    for (int i = 0; runtime != NULL && action_id >= 0 && i < runtime->input_binding_count; ++i)
+    {
+        const input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_MOUSE_BUTTON)
+            return spec->mouse_button;
+    }
+    return 0;
 }
 
 static SDL_Scancode current_input_binding_control_scancode(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
@@ -3964,6 +4055,21 @@ static SDL_GamepadButton current_input_binding_control_gamepad_button(const sdl3
     return gamepad_button_from_json(json_string(control, "default", NULL));
 }
 
+static Uint8 current_input_binding_control_mouse_button(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "mouse") != 0)
+            continue;
+        const Uint8 current = current_action_mouse_button_binding(runtime, json_string(binding, "action", NULL));
+        if (current != 0)
+            return current;
+    }
+    return mouse_button_from_json(json_string(control, "default", NULL));
+}
+
 static bool set_input_binding_control_scancode(sdl3d_game_data_runtime *runtime, yyjson_val *control,
                                                SDL_Scancode scancode)
 {
@@ -3991,6 +4097,21 @@ static bool set_input_binding_control_gamepad_button(sdl3d_game_data_runtime *ru
         if (SDL_strcmp(json_string(binding, "device", "keyboard"), "gamepad") != 0)
             continue;
         if (set_action_gamepad_button_binding(runtime, json_string(binding, "action", NULL), button))
+            changed = true;
+    }
+    return changed;
+}
+
+static bool set_input_binding_control_mouse_button(sdl3d_game_data_runtime *runtime, yyjson_val *control, Uint8 button)
+{
+    bool changed = false;
+    yyjson_val *bindings = obj_get(control, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        if (SDL_strcmp(json_string(binding, "device", "keyboard"), "mouse") != 0)
+            continue;
+        if (set_action_mouse_button_binding(runtime, json_string(binding, "action", NULL), button))
             changed = true;
     }
     return changed;
@@ -4040,6 +4161,28 @@ static const char *gamepad_button_binding_conflict_label(const sdl3d_game_data_r
     return NULL;
 }
 
+static const char *mouse_button_binding_conflict_label(const sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                       int item_index, Uint8 button)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    const scene_menu_state *menu = find_scene_menu_const(scene, menu_name);
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    for (int i = 0; yyjson_is_arr(items) && i < menu->item_count; ++i)
+    {
+        if (i == item_index)
+            continue;
+        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
+        yyjson_val *control = obj_get(item, "control");
+        if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
+            continue;
+        if (menu_binding_control_device(control) != MENU_BINDING_DEVICE_MOUSE_BUTTON)
+            continue;
+        if (current_input_binding_control_mouse_button(runtime, control) == button)
+            return json_string(item, "label", NULL);
+    }
+    return NULL;
+}
+
 bool sdl3d_game_data_start_menu_input_binding_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
                                                       int item_index)
 {
@@ -4053,9 +4196,9 @@ bool sdl3d_game_data_start_menu_input_binding_capture(sdl3d_game_data_runtime *r
     runtime->input_capture.menu = menu_name;
     runtime->input_capture.item_index = item_index;
     char status[128];
-    const char *device_name =
-        menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
-    SDL_snprintf(status, sizeof(status), "Press a %s for %s", device_name, json_string(item, "label", "binding"));
+    SDL_snprintf(status, sizeof(status), "Press a %s for %s",
+                 menu_binding_device_input_name(menu_binding_control_device(control)),
+                 json_string(item, "label", "binding"));
     set_menu_binding_status(runtime, status);
     return true;
 }
@@ -4073,7 +4216,8 @@ sdl3d_game_data_input_binding_capture_status sdl3d_game_data_update_menu_input_b
 
     yyjson_val *item = find_menu_item_at(runtime, runtime->input_capture.menu, runtime->input_capture.item_index);
     yyjson_val *control = obj_get(item, "control");
-    if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+    const menu_binding_device device = menu_binding_control_device(control);
+    if (device == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
     {
         const SDL_Scancode cancel_key = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
         if (sdl3d_input_get_pressed_scancode(input) == cancel_key)
@@ -4103,6 +4247,40 @@ sdl3d_game_data_input_binding_capture_status sdl3d_game_data_update_menu_input_b
         char status[128];
         SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
                      gamepad_button_display_name(button));
+        runtime->input_capture.active = false;
+        set_menu_binding_status(runtime, status);
+        return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED;
+    }
+    if (device == MENU_BINDING_DEVICE_MOUSE_BUTTON)
+    {
+        const SDL_Scancode cancel_key = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
+        if (sdl3d_input_get_pressed_scancode(input) == cancel_key)
+        {
+            runtime->input_capture.active = false;
+            set_menu_binding_status(runtime, "Canceled");
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CANCELED;
+        }
+
+        const Uint8 button = sdl3d_input_get_pressed_mouse_button(input);
+        if (button == 0)
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
+
+        const char *conflict = mouse_button_binding_conflict_label(runtime, runtime->input_capture.menu,
+                                                                   runtime->input_capture.item_index, button);
+        if (conflict != NULL)
+        {
+            char status[128];
+            SDL_snprintf(status, sizeof(status), "%s already uses %s", conflict, mouse_button_display_name(button));
+            set_menu_binding_status(runtime, status);
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT;
+        }
+
+        if (!set_input_binding_control_mouse_button(runtime, control, button))
+            return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_WAITING;
+
+        char status[128];
+        SDL_snprintf(status, sizeof(status), "%s set to %s", json_string(item, "label", "Binding"),
+                     mouse_button_display_name(button));
         runtime->input_capture.active = false;
         set_menu_binding_status(runtime, status);
         return SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CHANGED;
@@ -4153,11 +4331,18 @@ bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime,
         yyjson_val *control = obj_get(item, "control");
         if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
             continue;
-        if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+        const menu_binding_device device = menu_binding_control_device(control);
+        if (device == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
         {
             const SDL_GamepadButton button = gamepad_button_from_json(json_string(control, "default", NULL));
             if (button != SDL_GAMEPAD_BUTTON_INVALID &&
                 set_input_binding_control_gamepad_button(runtime, control, button))
+                changed = true;
+        }
+        else if (device == MENU_BINDING_DEVICE_MOUSE_BUTTON)
+        {
+            const Uint8 button = mouse_button_from_json(json_string(control, "default", NULL));
+            if (button != 0 && set_input_binding_control_mouse_button(runtime, control, button))
                 changed = true;
         }
         else
@@ -4453,15 +4638,20 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
         if (runtime != NULL && runtime->input_capture.active &&
             item == find_menu_item_at(runtime, runtime->input_capture.menu, runtime->input_capture.item_index))
         {
-            const char *device_name =
-                menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON ? "button" : "key";
-            SDL_snprintf(buffer, buffer_size, "%s: Press a %s", label, device_name);
+            SDL_snprintf(buffer, buffer_size, "%s: Press a %s", label,
+                         menu_binding_device_input_name(menu_binding_control_device(control)));
             return;
         }
-        if (menu_binding_control_device(control) == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
+        const menu_binding_device device = menu_binding_control_device(control);
+        if (device == MENU_BINDING_DEVICE_GAMEPAD_BUTTON)
         {
             SDL_snprintf(buffer, buffer_size, "%s: %s", label,
                          gamepad_button_display_name(current_input_binding_control_gamepad_button(runtime, control)));
+        }
+        else if (device == MENU_BINDING_DEVICE_MOUSE_BUTTON)
+        {
+            SDL_snprintf(buffer, buffer_size, "%s: %s", label,
+                         mouse_button_display_name(current_input_binding_control_mouse_button(runtime, control)));
         }
         else
         {
@@ -4867,6 +5057,39 @@ static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const 
     return true;
 }
 
+static bool set_action_mouse_button_binding(sdl3d_game_data_runtime *runtime, const char *action, Uint8 button)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    if (runtime == NULL || action == NULL || action_id < 0 || button == 0)
+        return false;
+
+    for (int i = 0; i < runtime->input_binding_count;)
+    {
+        input_binding_spec *spec = &runtime->input_bindings[i];
+        if (spec->action_id == action_id && spec->source == SDL3D_INPUT_MOUSE_BUTTON)
+        {
+            *spec = runtime->input_bindings[runtime->input_binding_count - 1];
+            runtime->input_binding_count--;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    input_binding_spec spec;
+    SDL_zero(spec);
+    spec.action = action;
+    spec.action_id = action_id;
+    spec.source = SDL3D_INPUT_MOUSE_BUTTON;
+    spec.mouse_button = button;
+    spec.scale = 1.0f;
+    if (!append_input_binding_spec(runtime, &spec))
+        return false;
+    rebind_action_from_specs(runtime, action_id);
+    return true;
+}
+
 static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
                                               SDL_GamepadButton button)
 {
@@ -4957,6 +5180,46 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                         if (!append_input_binding_spec(runtime, &spec))
                             return false;
                         bind_input_spec(input, &spec);
+                    }
+                }
+                else if (SDL_strcmp(device, "mouse") == 0)
+                {
+                    const char *axis = json_string(binding, "axis", NULL);
+                    const char *button = json_string(binding, "button", NULL);
+                    if (axis != NULL)
+                    {
+                        bool valid_axis = false;
+                        const sdl3d_mouse_axis mouse_axis = mouse_axis_from_json(axis, &valid_axis);
+                        if (valid_axis)
+                        {
+                            input_binding_spec spec;
+                            SDL_zero(spec);
+                            spec.action = name;
+                            spec.action_id = action_id;
+                            spec.source = SDL3D_INPUT_MOUSE_AXIS;
+                            spec.mouse_axis = mouse_axis;
+                            spec.scale = scale;
+                            if (!append_input_binding_spec(runtime, &spec))
+                                return false;
+                            bind_input_spec(input, &spec);
+                        }
+                    }
+                    else if (button != NULL)
+                    {
+                        const Uint8 mouse_button = mouse_button_from_json(button);
+                        if (mouse_button != 0)
+                        {
+                            input_binding_spec spec;
+                            SDL_zero(spec);
+                            spec.action = name;
+                            spec.action_id = action_id;
+                            spec.source = SDL3D_INPUT_MOUSE_BUTTON;
+                            spec.mouse_button = mouse_button;
+                            spec.scale = 1.0f;
+                            if (!append_input_binding_spec(runtime, &spec))
+                                return false;
+                            bind_input_spec(input, &spec);
+                        }
                     }
                 }
                 else if (SDL_strcmp(device, "gamepad") == 0)

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -27,6 +27,7 @@ typedef struct standard_options_layout
     standard_options_scene_layout root;
     standard_options_scene_layout display;
     standard_options_scene_layout keyboard;
+    standard_options_scene_layout mouse;
     standard_options_scene_layout gamepad;
     standard_options_scene_layout audio;
 } standard_options_layout;
@@ -42,11 +43,13 @@ typedef struct standard_options_config
     const char *root_scene;
     const char *display_scene;
     const char *keyboard_scene;
+    const char *mouse_scene;
     const char *gamepad_scene;
     const char *audio_scene;
     const char *root_menu;
     const char *display_menu;
     const char *keyboard_menu;
+    const char *mouse_menu;
     const char *gamepad_menu;
     const char *audio_menu;
     const char *up_action;
@@ -60,11 +63,13 @@ typedef struct standard_options_config
     const char *apply_audio_signal;
     const char *reset_display_signal;
     const char *reset_keyboard_signal;
+    const char *reset_mouse_signal;
     const char *reset_gamepad_signal;
     const char *reset_audio_signal;
     const char *title_font;
     const char *menu_font;
     const char *keyboard_status_key;
+    const char *mouse_status_key;
     const char *gamepad_status_key;
     const char *enter_transition;
     const char *exit_transition;
@@ -134,6 +139,7 @@ static void load_layout(standard_options_config *config)
     config->layout.root = load_scene_layout(layout, "root", scene_layout_defaults(0.18, 0.36, 0.078, -0.14));
     config->layout.display = load_scene_layout(layout, "display", scene_layout_defaults(0.20, 0.38, 0.074, -0.18));
     config->layout.keyboard = load_scene_layout(layout, "keyboard", scene_layout_defaults(0.13, 0.25, 0.062, -0.18));
+    config->layout.mouse = load_scene_layout(layout, "mouse", scene_layout_defaults(0.13, 0.30, 0.062, -0.18));
     config->layout.gamepad = load_scene_layout(layout, "gamepad", scene_layout_defaults(0.12, 0.22, 0.052, -0.18));
     config->layout.audio = load_scene_layout(layout, "audio", scene_layout_defaults(0.18, 0.39, 0.078, -0.18));
 }
@@ -461,6 +467,7 @@ static yyjson_doc *build_root_scene(const standard_options_config *config)
     yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->root_menu, false) : NULL;
     if (items == NULL || !add_scene_item(doc, items, "Display", config->display_scene) ||
         !add_scene_item(doc, items, "Keyboard", config->keyboard_scene) ||
+        !add_scene_item(doc, items, "Mouse", config->mouse_scene) ||
         !add_scene_item(doc, items, "Gamepad", config->gamepad_scene) ||
         !add_scene_item(doc, items, "Audio", config->audio_scene) || !add_back_item(doc, items, config, NULL) ||
         !add_basic_ui(doc, scene, config, "ui.options.title", "OPTIONS", config->layout.root.title_y, "ui.options.menu",
@@ -542,6 +549,32 @@ static yyjson_doc *build_keyboard_scene(const standard_options_config *config)
     return finish_scene_doc(doc, scene);
 }
 
+static yyjson_doc *build_mouse_scene(const standard_options_config *config)
+{
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->mouse_scene, false) : NULL;
+    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->mouse_menu, false) : NULL;
+    yyjson_mut_val *ui = NULL;
+    yyjson_mut_val *texts = NULL;
+    if (items == NULL || !add_input_binding_items(doc, items, obj_get(config->bindings, "mouse")) ||
+        !add_reset_item(doc, items, config->reset_mouse_signal) ||
+        !add_back_item(doc, items, config, config->root_scene) || (ui = add_ui(doc, scene)) == NULL ||
+        (texts = add_arr(doc, ui, "text")) == NULL ||
+        !add_title_text(doc, texts, config, "ui.options.mouse.title", "MOUSE", config->layout.mouse.title_y))
+    {
+        yyjson_mut_doc_free(doc);
+        return NULL;
+    }
+    if (!add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140) ||
+        !add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_y,
+                            config->layout.mouse.gap, config->layout.mouse.cursor_offset_x))
+    {
+        yyjson_mut_doc_free(doc);
+        return NULL;
+    }
+    return finish_scene_doc(doc, scene);
+}
+
 static yyjson_doc *build_gamepad_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
@@ -592,11 +625,13 @@ static bool load_config(yyjson_val *game_root, const char *package_name, standar
     config->root_scene = section_string(root, "scenes", "root", "scene.options");
     config->display_scene = section_string(root, "scenes", "display", "scene.options.display");
     config->keyboard_scene = section_string(root, "scenes", "keyboard", "scene.options.keyboard");
+    config->mouse_scene = section_string(root, "scenes", "mouse", "scene.options.mouse");
     config->gamepad_scene = section_string(root, "scenes", "gamepad", "scene.options.gamepad");
     config->audio_scene = section_string(root, "scenes", "audio", "scene.options.audio");
     config->root_menu = section_string(root, "menus", "root", "menu.options");
     config->display_menu = section_string(root, "menus", "display", "menu.options.display");
     config->keyboard_menu = section_string(root, "menus", "keyboard", "menu.options.keyboard");
+    config->mouse_menu = section_string(root, "menus", "mouse", "menu.options.mouse");
     config->gamepad_menu = section_string(root, "menus", "gamepad", "menu.options.gamepad");
     config->audio_menu = section_string(root, "menus", "audio", "menu.options.audio");
     config->up_action = section_string(root, "actions", "up", "action.menu.up");
@@ -610,11 +645,13 @@ static bool load_config(yyjson_val *game_root, const char *package_name, standar
     config->apply_audio_signal = section_string(root, "signals", "apply_audio", "signal.settings.apply_audio");
     config->reset_display_signal = section_string(root, "signals", "reset_display", "signal.settings.reset_display");
     config->reset_keyboard_signal = section_string(root, "signals", "reset_keyboard", "signal.settings.reset_keyboard");
+    config->reset_mouse_signal = section_string(root, "signals", "reset_mouse", "signal.settings.reset_mouse");
     config->reset_gamepad_signal = section_string(root, "signals", "reset_gamepad", "signal.settings.reset_gamepad");
     config->reset_audio_signal = section_string(root, "signals", "reset_audio", "signal.settings.reset_audio");
     config->title_font = section_string(root, "fonts", "title", "font.title");
     config->menu_font = section_string(root, "fonts", "menu", "font.hud");
     config->keyboard_status_key = json_string(root, "keyboard_status_key", "keyboard_binding_status");
+    config->mouse_status_key = json_string(root, "mouse_status_key", "mouse_binding_status");
     config->gamepad_status_key = json_string(root, "gamepad_status_key", "gamepad_binding_status");
     config->enter_transition = section_string(root, "transitions", "enter", "scene_in");
     config->exit_transition = section_string(root, "transitions", "exit", "scene_out");
@@ -648,8 +685,9 @@ bool sdl3d_standard_options_build_scene_docs(yyjson_val *game_root, const char *
     docs[0] = build_root_scene(&config);
     docs[1] = build_display_scene(&config);
     docs[2] = build_keyboard_scene(&config);
-    docs[3] = build_gamepad_scene(&config);
-    docs[4] = build_audio_scene(&config);
+    docs[3] = build_mouse_scene(&config);
+    docs[4] = build_gamepad_scene(&config);
+    docs[5] = build_audio_scene(&config);
     for (int i = 0; i < SDL3D_STANDARD_OPTIONS_SCENE_COUNT; ++i)
     {
         if (docs[i] == NULL)

--- a/src/game_data_standard_options.h
+++ b/src/game_data_standard_options.h
@@ -17,7 +17,7 @@ extern "C"
 
     enum
     {
-        SDL3D_STANDARD_OPTIONS_SCENE_COUNT = 5
+        SDL3D_STANDARD_OPTIONS_SCENE_COUNT = 6
     };
 
     /**

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -971,6 +971,11 @@ static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
                     if (!is_non_empty_string(binding, "axis") && !is_non_empty_string(binding, "button"))
                         return validation_error(ctx, path, "gamepad binding requires an axis or button");
                 }
+                else if (SDL_strcmp(device != NULL ? device : "", "mouse") == 0)
+                {
+                    if (!is_non_empty_string(binding, "axis") && !is_non_empty_string(binding, "button"))
+                        return validation_error(ctx, path, "mouse binding requires an axis or button");
+                }
                 else
                 {
                     return validation_error(ctx, path, "unsupported input binding device '%s'",
@@ -2205,8 +2210,10 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
             if (!require_ref(ctx, &names->actions, "input action", json_string(binding, "action"), path))
                 return false;
             const char *device = json_string(binding, "device");
-            if (device != NULL && SDL_strcmp(device, "keyboard") != 0 && SDL_strcmp(device, "gamepad") != 0)
-                return validation_error(ctx, path, "input_binding controls support keyboard or gamepad bindings");
+            if (device != NULL && SDL_strcmp(device, "keyboard") != 0 && SDL_strcmp(device, "gamepad") != 0 &&
+                SDL_strcmp(device, "mouse") != 0)
+                return validation_error(ctx, path,
+                                        "input_binding controls support keyboard, mouse, or gamepad bindings");
         }
     }
     return true;

--- a/src/input.c
+++ b/src/input.c
@@ -68,6 +68,7 @@ struct sdl3d_input_manager
     sdl3d_input_snapshot snapshot;
     bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
     SDL_Scancode pressed_scancode;
+    Uint8 pressed_mouse_button;
     SDL_GamepadButton pressed_gamepad_button;
 
     SDL_Gamepad *gamepad;
@@ -479,6 +480,23 @@ static SDL_GamepadButton sdl3d_input_first_pressed_gamepad_button(const sdl3d_in
         }
     }
     return SDL_GAMEPAD_BUTTON_INVALID;
+}
+
+static Uint8 sdl3d_input_first_pressed_mouse_button(const sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_MAX_MOUSE_BUTTONS; ++i)
+    {
+        if (input->mouse_pressed_this_frame[i])
+        {
+            return (Uint8)i;
+        }
+    }
+    return 0;
 }
 
 static bool sdl3d_demo_recorder_append(sdl3d_demo_recorder *recorder, const sdl3d_input_snapshot *snapshot)
@@ -957,6 +975,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
         {
             input->snapshot = player->snapshots[player->cursor++];
             input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
+            input->pressed_mouse_button = 0;
             input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
             SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
             for (int i = 0; i < SDL3D_INPUT_MAX_ACTIONS; ++i)
@@ -975,6 +994,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
     next.mouse_dy = input->mouse_dy_accum;
     next.any_pressed = sdl3d_input_physical_any_pressed(input);
     input->pressed_scancode = sdl3d_input_first_pressed_scancode(input);
+    input->pressed_mouse_button = sdl3d_input_first_pressed_mouse_button(input);
     input->pressed_gamepad_button = sdl3d_input_first_pressed_gamepad_button(input);
 
     for (int action_id = 0; action_id < input->action_count; ++action_id)
@@ -1041,6 +1061,11 @@ SDL_Scancode sdl3d_input_get_pressed_scancode(const sdl3d_input_manager *input)
 SDL_GamepadButton sdl3d_input_get_pressed_gamepad_button(const sdl3d_input_manager *input)
 {
     return input != NULL ? input->pressed_gamepad_button : SDL_GAMEPAD_BUTTON_INVALID;
+}
+
+Uint8 sdl3d_input_get_pressed_mouse_button(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->pressed_mouse_button : 0;
 }
 
 bool sdl3d_input_any_pressed(const sdl3d_input_manager *input)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -915,17 +915,18 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
-    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 8);
+    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 9);
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 0), "scene.splash");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 1), "scene.title");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.options");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.options.display");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 4), "scene.options.keyboard");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.options.gamepad");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.options.audio");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 7), "scene.play");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.options.mouse");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.options.gamepad");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 7), "scene.options.audio");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 8), "scene.play");
     EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, -1), nullptr);
-    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 8), nullptr);
+    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 9), nullptr);
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_renders_world(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
@@ -1303,10 +1304,13 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
-    EXPECT_EQ(menu.item_count, 5);
+    EXPECT_EQ(menu.item_count, 6);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display");
     EXPECT_STREQ(item.scene, "scene.options.display");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Mouse");
+    EXPECT_STREQ(item.scene, "scene.options.mouse");
     bool saw_options_display = false;
     auto find_options_display = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
         auto *saw = static_cast<bool *>(userdata);
@@ -1769,7 +1773,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_properties_set_bool(scene_state, "return_paused", true);
 
     sdl3d_game_data_menu_item item{};
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 5, &item));
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(item.scene, "scene.title");
 
@@ -1785,7 +1789,7 @@ TEST(GameDataRuntime, OptionsMenuCanReturnToAuthoredScene)
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
     ASSERT_TRUE(sdl3d_game_data_update_menus_for_metrics(runtime, input, &armed, &metrics, &result));
-    EXPECT_EQ(result.selected_index, 4);
+    EXPECT_EQ(result.selected_index, 5);
 
     key.type = SDL_EVENT_KEY_UP;
     sdl3d_input_process_event(input, &key);
@@ -1834,7 +1838,7 @@ TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
     EXPECT_FALSE(item.return_scene);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 4, &item));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 5, &item));
     EXPECT_STREQ(item.label, "Back");
     EXPECT_TRUE(item.return_scene);
     EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "return_scene", ""), "scene.title");
@@ -2219,6 +2223,108 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredInputBindings)
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 15);
     EXPECT_TRUE(sdl3d_input_is_pressed(input, exit_action));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, MouseOptionsCaptureAndApplyAuthoredInputBindings)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.mouse"));
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.mouse");
+    EXPECT_EQ(menu.item_count, 3);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Accept");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(item.input_binding_count, 1);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int menu_select = sdl3d_game_data_find_action(runtime, "action.menu.select");
+    ASSERT_GE(menu_select, 0);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.input_binding_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_MIDDLE;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.input_binding_changed);
+    EXPECT_FALSE(sdl3d_game_data_menu_input_binding_capture_active(runtime));
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    bool saw_mouse_label = false;
+    auto find_mouse_accept = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *saw = static_cast<bool *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.options.mouse.menu" && value == "Accept: Middle Mouse")
+        {
+            *saw = true;
+            return false;
+        }
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_mouse_accept, &saw_mouse_label));
+    EXPECT_TRUE(saw_mouse_label);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 5);
+    EXPECT_FALSE(sdl3d_input_is_pressed(input, menu_select));
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 6);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_MIDDLE;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 7);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_select));
+
+    const int reset_mouse = sdl3d_game_data_find_signal(runtime, "signal.settings.reset_mouse");
+    ASSERT_GE(reset_mouse, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), reset_mouse, nullptr);
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 8);
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 9);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input, menu_select));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -239,6 +239,7 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "root"), "menu_y")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "audio"), "cursor_offset_x")));
     EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(required_object(options, "bindings"), "keyboard")));
+    EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(required_object(options, "bindings"), "mouse")));
     EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(required_object(options, "bindings"), "gamepad")));
 }
 

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -254,11 +254,13 @@ TEST(Input, MouseButtonPressAndRelease)
     sdl3d_input_update(input.input, 1);
     EXPECT_TRUE(sdl3d_input_is_pressed(input.input, fire));
     EXPECT_TRUE(sdl3d_input_is_held(input.input, fire));
+    EXPECT_EQ(sdl3d_input_get_pressed_mouse_button(input.input), SDL_BUTTON_LEFT);
 
     push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_UP, SDL_BUTTON_LEFT);
     sdl3d_input_update(input.input, 2);
     EXPECT_TRUE(sdl3d_input_is_released(input.input, fire));
     EXPECT_FALSE(sdl3d_input_is_held(input.input, fire));
+    EXPECT_EQ(sdl3d_input_get_pressed_mouse_button(input.input), 0);
 }
 
 TEST(Input, GamepadButtonPressAndRelease)


### PR DESCRIPTION
## Summary
- add mouse-button capture support to the input API for rebinding workflows
- teach game-data input bindings and validation to load/display keyboard, mouse, and gamepad button controls
- add a reusable standard Mouse options page and wire Pong's menu/select action through it
- document the standard options mouse contract and authored mouse bindings

## Verification
- cmake --build build/release --target sdl3d_input_test sdl3d_game_data_test game_data_json_test pong_demo -j 8
- ctest --test-dir build/release -R 'Input|GameDataRuntime|GameDataJson' --output-on-failure
- ctest --test-dir build/release --output-on-failure (992 passed, 1 skipped OpenGL availability fixture)
- make format
- git diff --check