### PR TITLE
Document standard options adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Unit tests use GoogleTest. CMake will use an installed `GTest` package when avai
 Testing and renderer-loop policy are documented in [docs/testing.md](docs/testing.md).
 Error propagation conventions are documented in [docs/error-handling.md](docs/error-handling.md).
 Logging conventions are documented in [docs/logging.md](docs/logging.md).
+The data-driven game model and reusable options package are documented in
+[docs/game-data-json.md](docs/game-data-json.md) and
+[docs/standard-options.md](docs/standard-options.md).
 
 ## Dependencies
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -445,6 +445,9 @@ actor and bind option controls to that actor. The actor name is game-defined,
 but `entity.settings` is the recommended default because it matches the app
 window and audio examples.
 
+For a project-oriented adoption checklist and a minimal reference game file,
+see [docs/standard-options.md](standard-options.md).
+
 Standard display properties:
 
 | Property | Type | Expected values |

--- a/docs/standard-options.md
+++ b/docs/standard-options.md
@@ -1,0 +1,299 @@
+# Standard Options Package
+
+Most games need the same baseline options screens: display, audio, keyboard,
+mouse, and gamepad. SDL3D provides a `standard_options` scene package so a game
+can reuse those screens while keeping game-specific choices in JSON.
+
+The package is data-driven. The engine generates option scenes from
+`scenes.standard_options`, and the game decides which actions are bindable, what
+the scenes are named, which settings actor owns state, and which signals apply
+or reset values.
+
+## Adoption Checklist
+
+1. Create a settings actor, usually `entity.settings`.
+2. Add display, audio, and gamepad settings as actor properties.
+3. Declare menu input actions and any gameplay actions that should be rebindable.
+4. Add the `standard_options` package to `scenes.files`.
+5. Configure `scenes.standard_options` with scene IDs, menu IDs, signals, and
+   binding rows.
+6. Add logic bindings for apply/reset signals.
+7. Wire app window settings and audio bus volume to the same settings actor.
+
+Pong is the reference implementation in
+`demos/pong/data/pong.game.json`. A minimal loadable fixture is kept at
+`tests/assets/game_data/standard_options_minimal.game.json`.
+
+## Settings Actor
+
+The reusable screens expect one actor to hold option state. Games may rename the
+actor, but the default and recommended name is `entity.settings`.
+
+```json
+{
+  "name": "entity.settings",
+  "active": true,
+  "tags": ["state", "settings"],
+  "properties": {
+    "display_mode": { "type": "string", "value": "windowed" },
+    "vsync": { "type": "bool", "value": true },
+    "renderer": { "type": "string", "value": "opengl" },
+    "gamepad_icons": { "type": "string", "value": "xbox" },
+    "vibration": { "type": "bool", "value": true },
+    "sfx_volume": { "type": "int", "value": 8 },
+    "music_volume": { "type": "int", "value": 7 }
+  }
+}
+```
+
+The standard property names are:
+
+| Property | Type | Values |
+| --- | --- | --- |
+| `display_mode` | string | `windowed`, `fullscreen_exclusive`, `fullscreen_borderless` |
+| `vsync` | bool | `true`, `false` |
+| `renderer` | string | `software`, `opengl` |
+| `gamepad_icons` | string | `xbox`, `nintendo`, `playstation` |
+| `vibration` | bool | `true`, `false` |
+| `sfx_volume` | int | `0` through `10` |
+| `music_volume` | int | `0` through `10` |
+
+Game-specific settings can live on the same actor or a different actor. The
+standard package only reads and writes the properties above.
+
+## Scene Package
+
+Insert the package where the generated scenes should appear in scene order:
+
+```json
+{
+  "scenes": {
+    "initial": "scene.title",
+    "files": [
+      "scenes/title.scene.json",
+      { "package": "standard_options" },
+      "scenes/play.scene.json"
+    ]
+  }
+}
+```
+
+Configure the package under `scenes.standard_options`:
+
+```json
+{
+  "standard_options": {
+    "settings": "entity.settings",
+    "return_scene": "scene.title",
+    "scenes": {
+      "root": "scene.options",
+      "display": "scene.options.display",
+      "keyboard": "scene.options.keyboard",
+      "mouse": "scene.options.mouse",
+      "gamepad": "scene.options.gamepad",
+      "audio": "scene.options.audio"
+    },
+    "menus": {
+      "root": "menu.options",
+      "display": "menu.options.display",
+      "keyboard": "menu.options.keyboard",
+      "mouse": "menu.options.mouse",
+      "gamepad": "menu.options.gamepad",
+      "audio": "menu.options.audio"
+    },
+    "actions": {
+      "up": "action.menu.up",
+      "down": "action.menu.down",
+      "left": "action.menu.left",
+      "right": "action.menu.right",
+      "select": "action.menu.select"
+    },
+    "signals": {
+      "move": "signal.ui.menu.move",
+      "select": "signal.ui.menu.select",
+      "apply": "signal.settings.apply",
+      "apply_audio": "signal.settings.apply_audio",
+      "reset_display": "signal.settings.reset_display",
+      "reset_keyboard": "signal.settings.reset_keyboard",
+      "reset_mouse": "signal.settings.reset_mouse",
+      "reset_gamepad": "signal.settings.reset_gamepad",
+      "reset_audio": "signal.settings.reset_audio"
+    }
+  }
+}
+```
+
+Omitted names fall back to the values shown above. Games should still author the
+names explicitly once the project is more than a prototype; explicit IDs make
+large projects easier to search and review.
+
+## Rebindable Actions
+
+Binding rows are game-owned. The engine only knows how to capture and apply the
+new physical input. This keeps the standard screens reusable across Pong,
+shooters, platformers, RPGs, and games with custom action names.
+
+```json
+{
+  "bindings": {
+    "keyboard": [
+      {
+        "label": "Up",
+        "default": "UP",
+        "bindings": [
+          { "action": "action.player.up", "device": "keyboard" },
+          { "action": "action.menu.up", "device": "keyboard" }
+        ]
+      }
+    ],
+    "mouse": [
+      {
+        "label": "Accept",
+        "default": "LEFT",
+        "bindings": [
+          { "action": "action.menu.select", "device": "mouse" }
+        ]
+      }
+    ],
+    "gamepad": [
+      {
+        "label": "Accept",
+        "default": "SOUTH",
+        "bindings": [
+          { "action": "action.menu.select", "device": "gamepad" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each row can update one or more actions. Use this when gameplay and menus share
+a player-facing concept, such as `Up` controlling both a paddle and menu
+navigation. Rows should be named by intent, not by device-specific input.
+
+The standard rebinding UI captures keyboard keys, mouse buttons, and gamepad
+buttons. Authored gameplay input also supports mouse axes and gamepad axes, but
+axis rebinding needs game-specific policy for threshold, direction, and
+conflicts.
+
+## Apply And Reset
+
+Standard controls apply immediately. There is no Apply/Cancel staging for the
+default screens. Reset items emit signals, so games choose exactly what gets
+reset and whether persistence should be updated.
+
+```json
+{
+  "signal": "signal.settings.reset_audio",
+  "actions": [
+    {
+      "type": "property.reset_defaults",
+      "target": "entity.settings",
+      "keys": ["sfx_volume", "music_volume"]
+    },
+    { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+  ]
+}
+```
+
+Window settings should be tied to `app.window.settings` so display changes can
+be applied live:
+
+```json
+{
+  "app": {
+    "window": {
+      "apply_signal": "signal.settings.apply",
+      "apply_signals": ["signal.settings.apply", "signal.settings.reset_display"],
+      "settings": {
+        "target": "entity.settings",
+        "display_mode": "display_mode",
+        "vsync": "vsync",
+        "renderer": "renderer"
+      }
+    }
+  }
+}
+```
+
+Audio settings use normal logic actions:
+
+```json
+{
+  "type": "audio.set_bus_volume",
+  "bus": "music",
+  "source": { "target": "entity.settings", "key": "music_volume", "scale": 0.1 }
+}
+```
+
+## Styling And Layout
+
+The package has defaults, but games can override fonts, colors, cursor glyphs,
+slider glyphs, alignment, and per-screen layout:
+
+```json
+{
+  "fonts": {
+    "title": "font.title",
+    "menu": "font.hud"
+  },
+  "theme": {
+    "title_color": [242, 248, 255, 255],
+    "menu_color": [225, 236, 255, 245],
+    "selected_color": [255, 245, 208, 255],
+    "cursor_color": [255, 222, 140, 255],
+    "status_color": [255, 222, 140, 230],
+    "cursor": ">",
+    "slider_left": "[",
+    "slider_fill": "#",
+    "slider_empty": "-",
+    "slider_right": "]"
+  },
+  "layout": {
+    "title_x": 0.5,
+    "menu_x": 0.5,
+    "status_x": 0.5,
+    "status_y": 0.88,
+    "menu_align": "center",
+    "cursor_align": "center",
+    "selected_pulse_alpha": true,
+    "audio": { "title_y": 0.18, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.18 }
+  }
+}
+```
+
+Use custom authored scenes instead of the package when the structure itself is
+different. Use package overrides when the structure is standard and only the
+presentation or binding list changes.
+
+## Extending The Menu Set
+
+A game can add its own options scenes beside the standard package:
+
+```json
+{
+  "scenes": {
+    "files": [
+      { "package": "standard_options" },
+      "scenes/options_gameplay.scene.json"
+    ]
+  }
+}
+```
+
+The custom scene should use the same settings actor and immediate-apply
+patterns where possible. That keeps the player experience consistent while
+allowing game-specific options such as difficulty, assist settings, reticles,
+subtitles, or camera behavior.
+
+## When Starting A New Game
+
+Start from the minimal fixture, then make these project-specific edits:
+
+1. Rename metadata, scene IDs, menu IDs, and storage metadata.
+2. Replace binding rows with the actions your game exposes.
+3. Keep display/audio/gamepad properties on the settings actor unless the game
+   has a strong reason to split them.
+4. Add persistence once the option set is stable.
+5. Override theme/layout after the menu behavior is correct.

--- a/tests/assets/game_data/scenes/standard_options_title.scene.json
+++ b/tests/assets/game_data/scenes/standard_options_title.scene.json
@@ -1,0 +1,38 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.title",
+  "updates_game": false,
+  "renders_world": false,
+  "entities": [],
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
+    ]
+  },
+  "menus": [
+    {
+      "name": "menu.title",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        { "label": "Options", "scene": "scene.options" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.title",
+        "font": "font.title",
+        "text": "OPTIONS FIXTURE",
+        "x": 0.5,
+        "y": 0.2,
+        "normalized": true,
+        "centered": true
+      }
+    ]
+  }
+}

--- a/tests/assets/game_data/standard_options_minimal.game.json
+++ b/tests/assets/game_data/standard_options_minimal.game.json
@@ -1,0 +1,310 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Standard Options Minimal",
+    "id": "test.standard_options_minimal",
+    "version": "0.1.0"
+  },
+  "app": {
+    "title": "Standard Options Minimal",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "window": {
+      "display_mode": "windowed",
+      "maximized": true,
+      "resizable": true,
+      "vsync": true,
+      "renderer": "opengl",
+      "apply_signal": "signal.settings.apply",
+      "apply_signals": ["signal.settings.apply", "signal.settings.reset_display"],
+      "settings": {
+        "target": "entity.settings",
+        "display_mode": "display_mode",
+        "vsync": "vsync",
+        "renderer": "renderer"
+      }
+    }
+  },
+  "scenes": {
+    "initial": "scene.title",
+    "files": [
+      "scenes/standard_options_title.scene.json",
+      { "package": "standard_options" }
+    ],
+    "standard_options": {
+      "settings": "entity.settings",
+      "return_scene": "scene.title",
+      "scenes": {
+        "root": "scene.options",
+        "display": "scene.options.display",
+        "keyboard": "scene.options.keyboard",
+        "mouse": "scene.options.mouse",
+        "gamepad": "scene.options.gamepad",
+        "audio": "scene.options.audio"
+      },
+      "menus": {
+        "root": "menu.options",
+        "display": "menu.options.display",
+        "keyboard": "menu.options.keyboard",
+        "mouse": "menu.options.mouse",
+        "gamepad": "menu.options.gamepad",
+        "audio": "menu.options.audio"
+      },
+      "actions": {
+        "up": "action.menu.up",
+        "down": "action.menu.down",
+        "left": "action.menu.left",
+        "right": "action.menu.right",
+        "select": "action.menu.select"
+      },
+      "signals": {
+        "move": "signal.ui.menu.move",
+        "select": "signal.ui.menu.select",
+        "apply": "signal.settings.apply",
+        "apply_audio": "signal.settings.apply_audio",
+        "reset_display": "signal.settings.reset_display",
+        "reset_keyboard": "signal.settings.reset_keyboard",
+        "reset_mouse": "signal.settings.reset_mouse",
+        "reset_gamepad": "signal.settings.reset_gamepad",
+        "reset_audio": "signal.settings.reset_audio"
+      },
+      "bindings": {
+        "keyboard": [
+          {
+            "label": "Up",
+            "default": "UP",
+            "bindings": [
+              { "action": "action.player.up", "device": "keyboard" },
+              { "action": "action.menu.up", "device": "keyboard" }
+            ]
+          },
+          {
+            "label": "Down",
+            "default": "DOWN",
+            "bindings": [
+              { "action": "action.player.down", "device": "keyboard" },
+              { "action": "action.menu.down", "device": "keyboard" }
+            ]
+          },
+          {
+            "label": "Accept",
+            "default": "RETURN",
+            "bindings": [
+              { "action": "action.menu.select", "device": "keyboard" }
+            ]
+          },
+          {
+            "label": "Cancel",
+            "default": "BACKSPACE",
+            "bindings": [
+              { "action": "action.cancel", "device": "keyboard" }
+            ]
+          }
+        ],
+        "mouse": [
+          {
+            "label": "Accept",
+            "default": "LEFT",
+            "bindings": [
+              { "action": "action.menu.select", "device": "mouse" }
+            ]
+          }
+        ],
+        "gamepad": [
+          {
+            "label": "Up",
+            "default": "DPAD_UP",
+            "bindings": [
+              { "action": "action.player.up", "device": "gamepad" },
+              { "action": "action.menu.up", "device": "gamepad" }
+            ]
+          },
+          {
+            "label": "Down",
+            "default": "DPAD_DOWN",
+            "bindings": [
+              { "action": "action.player.down", "device": "gamepad" },
+              { "action": "action.menu.down", "device": "gamepad" }
+            ]
+          },
+          {
+            "label": "Accept",
+            "default": "SOUTH",
+            "bindings": [
+              { "action": "action.menu.select", "device": "gamepad" }
+            ]
+          },
+          {
+            "label": "Cancel",
+            "default": "EAST",
+            "bindings": [
+              { "action": "action.cancel", "device": "gamepad" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.title", "builtin": "Inter", "size": 96 },
+      { "id": "font.hud", "builtin": "Inter", "size": 34 }
+    ]
+  },
+  "transitions": {
+    "scene_out": {
+      "type": "fade",
+      "direction": "out",
+      "color": [0, 0, 0, 255],
+      "duration": 0.2
+    },
+    "scene_in": {
+      "type": "fade",
+      "direction": "in",
+      "color": [0, 0, 0, 255],
+      "duration": 0.2
+    }
+  },
+  "entities": [
+    {
+      "name": "entity.settings",
+      "active": true,
+      "tags": ["state", "settings"],
+      "properties": {
+        "display_mode": { "type": "string", "value": "windowed" },
+        "vsync": { "type": "bool", "value": true },
+        "renderer": { "type": "string", "value": "opengl" },
+        "gamepad_icons": { "type": "string", "value": "xbox" },
+        "vibration": { "type": "bool", "value": true },
+        "sfx_volume": { "type": "int", "value": 8 },
+        "music_volume": { "type": "int", "value": 7 }
+      }
+    }
+  ],
+  "signals": [
+    "signal.settings.apply",
+    "signal.settings.apply_audio",
+    "signal.settings.reset_display",
+    "signal.settings.reset_keyboard",
+    "signal.settings.reset_mouse",
+    "signal.settings.reset_gamepad",
+    "signal.settings.reset_audio",
+    "signal.ui.menu.move",
+    "signal.ui.menu.select"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.settings.apply",
+        "actions": [
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+        ]
+      },
+      {
+        "signal": "signal.settings.apply_audio",
+        "actions": [
+          { "type": "audio.set_bus_volume", "bus": "sfx", "source": { "target": "entity.settings", "key": "sfx_volume", "scale": 0.1 } },
+          { "type": "audio.set_bus_volume", "bus": "music", "source": { "target": "entity.settings", "key": "music_volume", "scale": 0.1 } }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_display",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["display_mode", "vsync", "renderer"] }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_keyboard",
+        "actions": [
+          { "type": "input.reset_bindings", "menu": "menu.options.keyboard" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_mouse",
+        "actions": [
+          { "type": "input.reset_bindings", "menu": "menu.options.mouse" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_gamepad",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
+          { "type": "input.reset_bindings", "menu": "menu.options.gamepad" }
+        ]
+      },
+      {
+        "signal": "signal.settings.reset_audio",
+        "actions": [
+          { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["sfx_volume", "music_volume"] },
+          { "type": "signal.emit", "signal": "signal.settings.apply_audio" }
+        ]
+      }
+    ]
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.default",
+        "actions": [
+          {
+            "name": "action.menu.up",
+            "bindings": [
+              { "device": "keyboard", "key": "UP" },
+              { "device": "gamepad", "button": "DPAD_UP" }
+            ]
+          },
+          {
+            "name": "action.menu.down",
+            "bindings": [
+              { "device": "keyboard", "key": "DOWN" },
+              { "device": "gamepad", "button": "DPAD_DOWN" }
+            ]
+          },
+          {
+            "name": "action.menu.left",
+            "bindings": [
+              { "device": "keyboard", "key": "LEFT" },
+              { "device": "gamepad", "button": "DPAD_LEFT" }
+            ]
+          },
+          {
+            "name": "action.menu.right",
+            "bindings": [
+              { "device": "keyboard", "key": "RIGHT" },
+              { "device": "gamepad", "button": "DPAD_RIGHT" }
+            ]
+          },
+          {
+            "name": "action.menu.select",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" },
+              { "device": "mouse", "button": "LEFT" },
+              { "device": "gamepad", "button": "SOUTH" }
+            ]
+          },
+          {
+            "name": "action.cancel",
+            "bindings": [
+              { "device": "keyboard", "key": "BACKSPACE" },
+              { "device": "gamepad", "button": "EAST" }
+            ]
+          },
+          {
+            "name": "action.player.up",
+            "bindings": [
+              { "device": "keyboard", "key": "W" },
+              { "device": "gamepad", "axis": "left_y", "scale": -1.0 }
+            ]
+          },
+          {
+            "name": "action.player.down",
+            "bindings": [
+              { "device": "keyboard", "key": "S" },
+              { "device": "gamepad", "axis": "left_y", "scale": 1.0 }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3486,6 +3486,69 @@ TEST(GameDataRuntime, ValidatesPongDataWithoutDiagnostics)
     EXPECT_EQ(error[0], '\0');
 }
 
+TEST(GameDataRuntime, StandardOptionsAdoptionFixtureLoadsReusablePackage)
+{
+    const std::string path = fixture_path("standard_options_minimal.game.json");
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_validate_file(path.c_str(), nullptr, error, sizeof(error))) << error;
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(path.c_str(), session, &runtime, error, sizeof(error))) << error;
+
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 7);
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 0), "scene.title");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 1), "scene.options");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.options.display");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.options.keyboard");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 4), "scene.options.mouse");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.options.gamepad");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.options.audio");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options");
+    EXPECT_EQ(menu.item_count, 6);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Display");
+    EXPECT_STREQ(item.scene, "scene.options.display");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Mouse");
+    EXPECT_STREQ(item.scene, "scene.options.mouse");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.keyboard"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.keyboard");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Up");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING);
+    EXPECT_EQ(item.input_binding_count, 2);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.audio"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.audio");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Sound Effects");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_RANGE);
+    EXPECT_STREQ(item.control_target, "entity.settings");
+    EXPECT_STREQ(item.control_key, "sfx_volume");
+
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "windowed");
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "sfx_volume", 0), 8);
+    EXPECT_EQ(sdl3d_properties_get_int(settings->props, "music_volume", 0), 7);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, ValidationReportsJsonPathAndMissingReference)
 {
     DiagnosticCapture capture;


### PR DESCRIPTION
## Summary
- add a dedicated standard options adoption guide for new data-driven games
- add a minimal standard_options fixture that demonstrates the required settings actor, package config, signals, input actions, and reset/apply bindings
- add a runtime test that validates and loads the fixture and inspects generated standard option scenes
- link the new guide from README and the JSON reference

## Verification
- cmake --build build/release --target sdl3d_game_data_test game_data_json_test -j 8
- ctest --test-dir build/release -R 'GameDataRuntime.StandardOptionsAdoptionFixtureLoadsReusablePackage|GameDataRuntime.ValidatesPongDataWithoutDiagnostics|GameDataJson.PongUsesStandardOptionsScenePackage' --output-on-failure
- ctest --test-dir build/release -R 'GameDataRuntime|GameDataJson' --output-on-failure
- ctest --test-dir build/release --output-on-failure (993 passed, 1 skipped OpenGL availability fixture)
- make format
- git diff --check