### PR TITLE
Polish Pong menu layout alignment

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -111,6 +111,8 @@
     "standard_options": {
       "settings": "entity.settings",
       "return_scene": "scene.title",
+      "single_scene": true,
+      "menu_state_key": "options_menu",
       "scenes": {
         "root": "scene.options",
         "display": "scene.options.display",
@@ -1064,10 +1066,10 @@
         {
           "type": "render.cube",
           "size": [22.0, 13.0, 0.08],
-          "color": [9, 10, 24, 255],
+          "color": [0, 0, 0, 255],
           "emissive": true,
           "effects": [
-            { "type": "pulse", "rate": 0.55, "phase": 0.4, "color": [22, 18, 48, 255], "emissive_base": [0.015, 0.010, 0.035], "emissive_add": [0.030, 0.010, 0.060] }
+            { "type": "emissive", "color": [0.005, 0.004, 0.010] }
           ]
         }
       ]
@@ -1076,17 +1078,18 @@
       "name": "entity.options.glow.magenta",
       "active": true,
       "tags": ["render", "options", "background"],
-      "transform": { "position": [-4.8, -1.8, -0.30] },
+      "transform": { "position": [-4.6, -1.9, -0.30] },
       "components": [
         {
           "type": "render.sphere",
-          "radius": 1.35,
+          "radius": 1.05,
           "rings": 16,
           "slices": 24,
-          "color": [226, 52, 174, 118],
+          "color": [205, 42, 178, 118],
           "emissive": true,
           "effects": [
-            { "type": "pulse", "rate": 0.75, "phase": 0.3, "color": [255, 96, 208, 160], "emissive_base": [0.28, 0.04, 0.22], "emissive_add": [0.24, 0.02, 0.16] }
+            { "type": "drift", "offset": [0.95, 0.55, 0.0], "rates": [0.34, 0.27, 0.0], "phase": 0.3 },
+            { "type": "pulse", "rate": 1.25, "phase": 0.3, "radius_add": 0.28, "color": [255, 78, 212, 154], "emissive_base": [0.16, 0.02, 0.14], "emissive_add": [0.42, 0.05, 0.30] }
           ]
         }
       ]
@@ -1099,13 +1102,14 @@
       "components": [
         {
           "type": "render.sphere",
-          "radius": 1.60,
+          "radius": 1.18,
           "rings": 16,
           "slices": 24,
-          "color": [52, 212, 231, 112],
+          "color": [38, 198, 220, 112],
           "emissive": true,
           "effects": [
-            { "type": "pulse", "rate": 0.62, "phase": 1.4, "color": [105, 242, 255, 152], "emissive_base": [0.04, 0.23, 0.28], "emissive_add": [0.02, 0.18, 0.22] }
+            { "type": "drift", "offset": [0.75, 0.70, 0.0], "rates": [0.22, 0.31, 0.0], "phase": 1.4 },
+            { "type": "pulse", "rate": 1.05, "phase": 1.4, "radius_add": 0.34, "color": [80, 236, 255, 146], "emissive_base": [0.03, 0.16, 0.19], "emissive_add": [0.05, 0.34, 0.42] }
           ]
         }
       ]
@@ -1114,17 +1118,18 @@
       "name": "entity.options.glow.gold",
       "active": true,
       "tags": ["render", "options", "background"],
-      "transform": { "position": [0.9, -3.15, -0.22] },
+      "transform": { "position": [0.7, -3.20, -0.22] },
       "components": [
         {
           "type": "render.sphere",
-          "radius": 1.05,
+          "radius": 0.82,
           "rings": 16,
           "slices": 24,
-          "color": [255, 175, 64, 100],
+          "color": [255, 155, 42, 96],
           "emissive": true,
           "effects": [
-            { "type": "pulse", "rate": 0.90, "phase": 2.1, "color": [255, 214, 95, 145], "emissive_base": [0.25, 0.12, 0.02], "emissive_add": [0.20, 0.10, 0.03] }
+            { "type": "drift", "offset": [1.10, 0.45, 0.0], "rates": [0.29, 0.19, 0.0], "phase": 2.1 },
+            { "type": "pulse", "rate": 1.40, "phase": 2.1, "radius_add": 0.22, "color": [255, 206, 84, 138], "emissive_base": [0.15, 0.07, 0.01], "emissive_add": [0.34, 0.18, 0.04] }
           ]
         }
       ]
@@ -1140,19 +1145,19 @@
           "shape": "box",
           "extents": [2.2, 0.35, 0.05],
           "direction": [0.16, 1.0, 0.0],
-          "spread": 0.65,
-          "speed_min": 0.45,
-          "speed_max": 1.15,
-          "lifetime_min": 4.6,
-          "lifetime_max": 7.8,
-          "size_start": 0.16,
-          "size_end": 0.52,
+          "spread": 0.48,
+          "speed_min": 0.18,
+          "speed_max": 0.48,
+          "lifetime_min": 6.0,
+          "lifetime_max": 9.5,
+          "size_start": 0.035,
+          "size_end": 0.008,
           "gravity": 0.0,
-          "max_particles": 140,
-          "emit_rate": 24.0,
-          "color_start": [245, 62, 195, 58],
+          "max_particles": 130,
+          "emit_rate": 20.0,
+          "color_start": [245, 62, 195, 82],
           "color_end": [255, 104, 223, 0],
-          "emissive_intensity": 1.9,
+          "emissive_intensity": 1.45,
           "camera_facing": true,
           "depth_test": false,
           "additive_blend": true,
@@ -1172,19 +1177,19 @@
           "shape": "box",
           "extents": [2.6, 0.35, 0.05],
           "direction": [-0.12, 1.0, 0.0],
-          "spread": 0.72,
-          "speed_min": 0.36,
-          "speed_max": 1.0,
-          "lifetime_min": 5.0,
-          "lifetime_max": 8.2,
-          "size_start": 0.18,
-          "size_end": 0.58,
+          "spread": 0.52,
+          "speed_min": 0.16,
+          "speed_max": 0.42,
+          "lifetime_min": 6.4,
+          "lifetime_max": 10.0,
+          "size_start": 0.035,
+          "size_end": 0.008,
           "gravity": 0.0,
-          "max_particles": 150,
-          "emit_rate": 24.0,
-          "color_start": [62, 222, 255, 54],
+          "max_particles": 135,
+          "emit_rate": 20.0,
+          "color_start": [62, 222, 255, 78],
           "color_end": [120, 245, 255, 0],
-          "emissive_intensity": 1.85,
+          "emissive_intensity": 1.45,
           "camera_facing": true,
           "depth_test": false,
           "additive_blend": true,
@@ -1204,19 +1209,19 @@
           "shape": "box",
           "extents": [1.8, 0.25, 0.05],
           "direction": [0.05, 1.0, 0.0],
-          "spread": 0.55,
-          "speed_min": 0.28,
-          "speed_max": 0.78,
-          "lifetime_min": 4.2,
-          "lifetime_max": 7.2,
-          "size_start": 0.12,
-          "size_end": 0.42,
+          "spread": 0.38,
+          "speed_min": 0.12,
+          "speed_max": 0.36,
+          "lifetime_min": 5.8,
+          "lifetime_max": 9.0,
+          "size_start": 0.03,
+          "size_end": 0.007,
           "gravity": 0.0,
-          "max_particles": 95,
-          "emit_rate": 16.0,
-          "color_start": [255, 178, 54, 48],
+          "max_particles": 85,
+          "emit_rate": 12.0,
+          "color_start": [255, 178, 54, 72],
           "color_end": [255, 225, 104, 0],
-          "emissive_intensity": 1.65,
+          "emissive_intensity": 1.35,
           "camera_facing": true,
           "depth_test": false,
           "additive_blend": true,

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -153,6 +153,19 @@
         "enter": "scene_in",
         "exit": "scene_out"
       },
+      "background": {
+        "renders_world": true,
+        "camera": "camera.overhead",
+        "entities": [
+          "entity.options.background.base",
+          "entity.options.glow.magenta",
+          "entity.options.glow.cyan",
+          "entity.options.glow.gold",
+          "entity.options.flow.magenta",
+          "entity.options.flow.cyan",
+          "entity.options.flow.gold"
+        ]
+      },
       "theme": {
         "title_color": [242, 248, 255, 255],
         "menu_color": [225, 236, 255, 245],
@@ -1041,6 +1054,176 @@
         "matches_played": { "type": "int", "value": 0 },
         "latest_winner": { "type": "string", "value": "none" }
       }
+    },
+    {
+      "name": "entity.options.background.base",
+      "active": true,
+      "tags": ["render", "options", "background"],
+      "transform": { "position": [0.0, 0.0, -0.65] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [22.0, 13.0, 0.08],
+          "color": [9, 10, 24, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 0.55, "phase": 0.4, "color": [22, 18, 48, 255], "emissive_base": [0.015, 0.010, 0.035], "emissive_add": [0.030, 0.010, 0.060] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.options.glow.magenta",
+      "active": true,
+      "tags": ["render", "options", "background"],
+      "transform": { "position": [-4.8, -1.8, -0.30] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 1.35,
+          "rings": 16,
+          "slices": 24,
+          "color": [226, 52, 174, 118],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 0.75, "phase": 0.3, "color": [255, 96, 208, 160], "emissive_base": [0.28, 0.04, 0.22], "emissive_add": [0.24, 0.02, 0.16] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.options.glow.cyan",
+      "active": true,
+      "tags": ["render", "options", "background"],
+      "transform": { "position": [3.9, 0.65, -0.28] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 1.60,
+          "rings": 16,
+          "slices": 24,
+          "color": [52, 212, 231, 112],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 0.62, "phase": 1.4, "color": [105, 242, 255, 152], "emissive_base": [0.04, 0.23, 0.28], "emissive_add": [0.02, 0.18, 0.22] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.options.glow.gold",
+      "active": true,
+      "tags": ["render", "options", "background"],
+      "transform": { "position": [0.9, -3.15, -0.22] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 1.05,
+          "rings": 16,
+          "slices": 24,
+          "color": [255, 175, 64, 100],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 0.90, "phase": 2.1, "color": [255, 214, 95, 145], "emissive_base": [0.25, 0.12, 0.02], "emissive_add": [0.20, 0.10, 0.03] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.options.flow.magenta",
+      "active": true,
+      "tags": ["effect", "particles", "options"],
+      "transform": { "position": [-3.8, -4.8, -0.10] },
+      "components": [
+        {
+          "type": "particles.emitter",
+          "shape": "box",
+          "extents": [2.2, 0.35, 0.05],
+          "direction": [0.16, 1.0, 0.0],
+          "spread": 0.65,
+          "speed_min": 0.45,
+          "speed_max": 1.15,
+          "lifetime_min": 4.6,
+          "lifetime_max": 7.8,
+          "size_start": 0.16,
+          "size_end": 0.52,
+          "gravity": 0.0,
+          "max_particles": 140,
+          "emit_rate": 24.0,
+          "color_start": [245, 62, 195, 58],
+          "color_end": [255, 104, 223, 0],
+          "emissive_intensity": 1.9,
+          "camera_facing": true,
+          "depth_test": false,
+          "additive_blend": true,
+          "draw_emissive": [1.0, 0.15, 0.78],
+          "random_seed": 3093511
+        }
+      ]
+    },
+    {
+      "name": "entity.options.flow.cyan",
+      "active": true,
+      "tags": ["effect", "particles", "options"],
+      "transform": { "position": [3.2, -4.5, -0.08] },
+      "components": [
+        {
+          "type": "particles.emitter",
+          "shape": "box",
+          "extents": [2.6, 0.35, 0.05],
+          "direction": [-0.12, 1.0, 0.0],
+          "spread": 0.72,
+          "speed_min": 0.36,
+          "speed_max": 1.0,
+          "lifetime_min": 5.0,
+          "lifetime_max": 8.2,
+          "size_start": 0.18,
+          "size_end": 0.58,
+          "gravity": 0.0,
+          "max_particles": 150,
+          "emit_rate": 24.0,
+          "color_start": [62, 222, 255, 54],
+          "color_end": [120, 245, 255, 0],
+          "emissive_intensity": 1.85,
+          "camera_facing": true,
+          "depth_test": false,
+          "additive_blend": true,
+          "draw_emissive": [0.18, 0.95, 1.0],
+          "random_seed": 742019
+        }
+      ]
+    },
+    {
+      "name": "entity.options.flow.gold",
+      "active": true,
+      "tags": ["effect", "particles", "options"],
+      "transform": { "position": [0.1, -5.0, -0.05] },
+      "components": [
+        {
+          "type": "particles.emitter",
+          "shape": "box",
+          "extents": [1.8, 0.25, 0.05],
+          "direction": [0.05, 1.0, 0.0],
+          "spread": 0.55,
+          "speed_min": 0.28,
+          "speed_max": 0.78,
+          "lifetime_min": 4.2,
+          "lifetime_max": 7.2,
+          "size_start": 0.12,
+          "size_end": 0.42,
+          "gravity": 0.0,
+          "max_particles": 95,
+          "emit_rate": 16.0,
+          "color_start": [255, 178, 54, 48],
+          "color_end": [255, 225, 104, 0],
+          "emissive_intensity": 1.65,
+          "camera_facing": true,
+          "depth_test": false,
+          "additive_blend": true,
+          "draw_emissive": [1.0, 0.62, 0.12],
+          "random_seed": 919571
+        }
+      ]
     },
     {
       "name": "entity.effect.ambient_particles",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -159,6 +159,7 @@
         "selected_color": [255, 245, 208, 255],
         "cursor_color": [255, 222, 140, 255],
         "status_color": [255, 222, 140, 230],
+        "divider_color": [126, 168, 238, 170],
         "cursor": ">",
         "slider_left": "[",
         "slider_fill": "#",
@@ -173,6 +174,7 @@
         "menu_align": "left",
         "cursor_align": "right",
         "selected_pulse_alpha": true,
+        "title_divider": true,
         "root": {
           "title_y": 0.18,
           "menu_x": 0.43,
@@ -190,7 +192,7 @@
         "keyboard": {
           "title_y": 0.13,
           "menu_x": 0.36,
-          "menu_y": 0.25,
+          "menu_y": 0.29,
           "gap": 0.062,
           "cursor_offset_x": -0.035
         },
@@ -204,13 +206,13 @@
         "gamepad": {
           "title_y": 0.105,
           "menu_x": 0.34,
-          "menu_y": 0.15,
-          "gap": 0.061,
+          "menu_y": 0.24,
+          "gap": 0.055,
           "cursor_offset_x": -0.035
         },
         "audio": {
           "title_y": 0.18,
-          "menu_x": 0.28,
+          "menu_x": 0.34,
           "menu_y": 0.39,
           "gap": 0.078,
           "cursor_offset_x": -0.035

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1067,10 +1067,7 @@
           "type": "render.cube",
           "size": [22.0, 13.0, 0.08],
           "color": [0, 0, 0, 255],
-          "emissive": true,
-          "effects": [
-            { "type": "emissive", "color": [0.005, 0.004, 0.010] }
-          ]
+          "lighting": false
         }
       ]
     },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -170,44 +170,50 @@
         "menu_x": 0.5,
         "status_x": 0.5,
         "status_y": 0.88,
-        "menu_align": "center",
-        "cursor_align": "center",
+        "menu_align": "left",
+        "cursor_align": "right",
         "selected_pulse_alpha": true,
         "root": {
           "title_y": 0.18,
+          "menu_x": 0.43,
           "menu_y": 0.36,
           "gap": 0.078,
-          "cursor_offset_x": -0.14
+          "cursor_offset_x": -0.035
         },
         "display": {
           "title_y": 0.2,
+          "menu_x": 0.3,
           "menu_y": 0.38,
           "gap": 0.074,
-          "cursor_offset_x": -0.18
+          "cursor_offset_x": -0.035
         },
         "keyboard": {
           "title_y": 0.13,
+          "menu_x": 0.36,
           "menu_y": 0.25,
           "gap": 0.062,
-          "cursor_offset_x": -0.18
+          "cursor_offset_x": -0.035
         },
         "mouse": {
           "title_y": 0.13,
+          "menu_x": 0.4,
           "menu_y": 0.30,
           "gap": 0.062,
-          "cursor_offset_x": -0.18
+          "cursor_offset_x": -0.035
         },
         "gamepad": {
-          "title_y": 0.12,
-          "menu_y": 0.22,
-          "gap": 0.052,
-          "cursor_offset_x": -0.18
+          "title_y": 0.105,
+          "menu_x": 0.34,
+          "menu_y": 0.15,
+          "gap": 0.061,
+          "cursor_offset_x": -0.035
         },
         "audio": {
           "title_y": 0.18,
+          "menu_x": 0.28,
           "menu_y": 0.39,
           "gap": 0.078,
-          "cursor_offset_x": -0.18
+          "cursor_offset_x": -0.035
         }
       },
       "bindings": {

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -97,18 +97,18 @@
         "name": "ui.title.menu",
         "menu": "menu.title",
         "font": "font.hud",
-        "x": 0.5,
+        "x": 0.45,
         "y": 0.48,
         "gap": 0.09,
         "normalized": true,
-        "align": "center",
+        "align": "left",
         "color": [225, 236, 255, 245],
         "selected_color": [255, 245, 208, 255],
         "selected_pulse_alpha": true,
         "cursor": {
           "text": ">",
-          "offset_x": -0.12,
-          "align": "center",
+          "offset_x": -0.035,
+          "align": "right",
           "color": [255, 222, 140, 255],
           "pulse_alpha": true
         }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -780,6 +780,7 @@ Render primitives may also author generic visual effects:
   "type": "render.sphere",
   "radius": 0.22,
   "color": [255, 184, 82, 255],
+  "lighting": true,
   "effects": [
     {
       "type": "pulse",
@@ -798,6 +799,10 @@ Render primitives may also author generic visual effects:
   ]
 }
 ```
+
+Set `lighting` to `false` on a render primitive for solid-color unlit geometry
+such as menu backplates, sky cards, debug overlays, and other presentation
+surfaces that should not be affected by world lights.
 
 Supported primitive effects are:
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -548,15 +548,15 @@ colors, and player-facing input binding rows:
         "menu_x": 0.5,
         "status_x": 0.5,
         "status_y": 0.88,
-        "menu_align": "center",
-        "cursor_align": "center",
+        "menu_align": "left",
+        "cursor_align": "right",
         "selected_pulse_alpha": true,
-        "root": { "title_y": 0.18, "menu_y": 0.36, "gap": 0.078, "cursor_offset_x": -0.14 },
-        "display": { "title_y": 0.2, "menu_y": 0.38, "gap": 0.074, "cursor_offset_x": -0.18 },
-        "keyboard": { "title_y": 0.13, "menu_y": 0.25, "gap": 0.062, "cursor_offset_x": -0.18 },
-        "mouse": { "title_y": 0.13, "menu_y": 0.30, "gap": 0.062, "cursor_offset_x": -0.18 },
-        "gamepad": { "title_y": 0.12, "menu_y": 0.22, "gap": 0.052, "cursor_offset_x": -0.18 },
-        "audio": { "title_y": 0.18, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.18 }
+        "root": { "title_y": 0.18, "menu_x": 0.43, "menu_y": 0.36, "gap": 0.078, "cursor_offset_x": -0.035 },
+        "display": { "title_y": 0.2, "menu_x": 0.3, "menu_y": 0.38, "gap": 0.074, "cursor_offset_x": -0.035 },
+        "keyboard": { "title_y": 0.13, "menu_x": 0.36, "menu_y": 0.25, "gap": 0.062, "cursor_offset_x": -0.035 },
+        "mouse": { "title_y": 0.13, "menu_x": 0.4, "menu_y": 0.30, "gap": 0.062, "cursor_offset_x": -0.035 },
+        "gamepad": { "title_y": 0.105, "menu_x": 0.34, "menu_y": 0.15, "gap": 0.061, "cursor_offset_x": -0.035 },
+        "audio": { "title_y": 0.18, "menu_x": 0.28, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
       },
       "bindings": {
         "keyboard": [

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -531,6 +531,14 @@ colors, and player-facing input binding rows:
         "title": "font.title",
         "menu": "font.hud"
       },
+      "background": {
+        "renders_world": true,
+        "camera": "camera.overhead",
+        "entities": [
+          "entity.options.background.base",
+          "entity.options.flow.magenta"
+        ]
+      },
       "theme": {
         "title_color": [242, 248, 255, 255],
         "menu_color": [225, 236, 255, 245],
@@ -602,7 +610,10 @@ colors, cursor text, and slider glyphs. `layout` controls normalized title,
 menu, status, row gap, cursor offset, alignment, and selected-item pulse values
 for each generated scene. Games can omit `theme` or `layout` fields to use sane
 defaults, or author fully custom options scenes when they need a different
-structure.
+structure. `background` is optional; when present, generated options scenes
+render the listed entities with the named camera. This gives every standard
+options submenu the same authored backdrop while keeping gameplay actors out of
+the menu scene.
 
 Audio bus volume can also be driven from actor properties so options menus can
 share one generic settings actor. Use `source.scale` when the authored setting

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -537,6 +537,7 @@ colors, and player-facing input binding rows:
         "selected_color": [255, 245, 208, 255],
         "cursor_color": [255, 222, 140, 255],
         "status_color": [255, 222, 140, 230],
+        "divider_color": [126, 168, 238, 170],
         "cursor": ">",
         "slider_left": "[",
         "slider_fill": "#",
@@ -551,12 +552,13 @@ colors, and player-facing input binding rows:
         "menu_align": "left",
         "cursor_align": "right",
         "selected_pulse_alpha": true,
+        "title_divider": true,
         "root": { "title_y": 0.18, "menu_x": 0.43, "menu_y": 0.36, "gap": 0.078, "cursor_offset_x": -0.035 },
         "display": { "title_y": 0.2, "menu_x": 0.3, "menu_y": 0.38, "gap": 0.074, "cursor_offset_x": -0.035 },
-        "keyboard": { "title_y": 0.13, "menu_x": 0.36, "menu_y": 0.25, "gap": 0.062, "cursor_offset_x": -0.035 },
+        "keyboard": { "title_y": 0.13, "menu_x": 0.36, "menu_y": 0.29, "gap": 0.062, "cursor_offset_x": -0.035 },
         "mouse": { "title_y": 0.13, "menu_x": 0.4, "menu_y": 0.30, "gap": 0.062, "cursor_offset_x": -0.035 },
-        "gamepad": { "title_y": 0.105, "menu_x": 0.34, "menu_y": 0.15, "gap": 0.061, "cursor_offset_x": -0.035 },
-        "audio": { "title_y": 0.18, "menu_x": 0.28, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
+        "gamepad": { "title_y": 0.105, "menu_x": 0.34, "menu_y": 0.24, "gap": 0.055, "cursor_offset_x": -0.035 },
+        "audio": { "title_y": 0.18, "menu_x": 0.34, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
       },
       "bindings": {
         "keyboard": [

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -292,7 +292,7 @@ UI descriptors can bind text to engine metrics or actor properties and can use g
 Supported UI binding sources are `metric` (`fps`, `frame`, `paused`), `property`,
 and `scene_state`.
 Supported UI conditions include `always`, `app.paused`, `camera.active`, `property.compare`,
-`property.bool`, `all`, `any`, and `not`.
+`property.bool`, `scene_state.compare`, `all`, `any`, and `not`.
 
 Scene UI can also declare data-driven menu presenters. A presenter turns a
 scene `menus[]` controller into a visible stack with authored alignment, colors,
@@ -317,6 +317,16 @@ selected styling, and cursor styling:
       }
     ]
   }
+}
+```
+
+Menu items can set scene state instead of changing scenes. This is useful for
+submenus that should share one scene, camera, background, and transition state:
+
+```json
+{
+  "label": "Display",
+  "scene_state": { "key": "options_menu", "value": "display" }
 }
 ```
 
@@ -501,6 +511,8 @@ colors, and player-facing input binding rows:
     "standard_options": {
       "settings": "entity.settings",
       "return_scene": "scene.title",
+      "single_scene": true,
+      "menu_state_key": "options_menu",
       "scenes": {
         "root": "scene.options",
         "display": "scene.options.display",
@@ -613,7 +625,10 @@ defaults, or author fully custom options scenes when they need a different
 structure. `background` is optional; when present, generated options scenes
 render the listed entities with the named camera. This gives every standard
 options submenu the same authored backdrop while keeping gameplay actors out of
-the menu scene.
+the menu scene. `single_scene` makes root and child options menus live inside
+the root scene; child menu selections set `menu_state_key` in scene state
+instead of requesting scene transitions. Use it when a family of menus should
+feel like one screen.
 
 Audio bus volume can also be driven from actor properties so options menus can
 share one generic settings actor. Use `source.scale` when the authored setting
@@ -770,8 +785,15 @@ Render primitives may also author generic visual effects:
       "type": "pulse",
       "rate": 9.0,
       "color": [255, 245, 156, 255],
+      "radius_add": 0.06,
       "emissive_base": [0.75, 0.48, 0.08],
       "emissive_add": [0.65, 0.30, 0.0]
+    },
+    {
+      "type": "drift",
+      "offset": [0.4, 0.2, 0.0],
+      "rates": [0.7, 0.5, 0.0],
+      "phase": 1.2
     }
   ]
 }
@@ -780,7 +802,8 @@ Render primitives may also author generic visual effects:
 Supported primitive effects are:
 
 - `flash`: reads a float property from a source entity and uses it to blend color, add size, and add emissive color.
-- `pulse`: uses presentation time to animate color and emissive color.
+- `pulse`: uses presentation time to animate color, emissive color, optional `size_add`, and optional `radius_add`.
+- `drift`: uses presentation time to offset primitive position with sinusoidal motion. Use `offset`, `rates`, and optional `phase`.
 - `emissive`: adds a constant emissive color.
 
 Particle emitters may include `draw_emissive` for host renderers that draw particles through emissive lighting.

--- a/docs/standard-options.md
+++ b/docs/standard-options.md
@@ -118,6 +118,14 @@ Configure the package under `scenes.standard_options`:
       "reset_mouse": "signal.settings.reset_mouse",
       "reset_gamepad": "signal.settings.reset_gamepad",
       "reset_audio": "signal.settings.reset_audio"
+    },
+    "background": {
+      "renders_world": true,
+      "camera": "camera.overhead",
+      "entities": [
+        "entity.options.background.base",
+        "entity.options.flow.magenta"
+      ]
     }
   }
 }
@@ -126,6 +134,14 @@ Configure the package under `scenes.standard_options`:
 Omitted names fall back to the values shown above. Games should still author the
 names explicitly once the project is more than a prototype; explicit IDs make
 large projects easier to search and review.
+
+## Backgrounds
+
+`background` is optional. If omitted, generated options scenes render no world
+entities. If present, every generated options scene uses the same `renders_world`
+value, camera, and entity filter. This is intended for reusable menu backdrops
+such as particles, animated logo geometry, or authored lighting effects while
+keeping unrelated gameplay entities out of options scenes.
 
 ## Rebindable Actions
 

--- a/docs/standard-options.md
+++ b/docs/standard-options.md
@@ -85,6 +85,8 @@ Configure the package under `scenes.standard_options`:
   "standard_options": {
     "settings": "entity.settings",
     "return_scene": "scene.title",
+    "single_scene": true,
+    "menu_state_key": "options_menu",
     "scenes": {
       "root": "scene.options",
       "display": "scene.options.display",
@@ -134,6 +136,12 @@ Configure the package under `scenes.standard_options`:
 Omitted names fall back to the values shown above. Games should still author the
 names explicitly once the project is more than a prototype; explicit IDs make
 large projects easier to search and review.
+
+`single_scene` is optional and defaults to `false`. When enabled, the root
+options scene contains every standard options menu. Root menu items and child
+Back items set `menu_state_key` in scene state instead of changing scenes, so
+related submenus switch instantly and keep the same animated background,
+particles, and lighting.
 
 ## Backgrounds
 

--- a/docs/standard-options.md
+++ b/docs/standard-options.md
@@ -244,6 +244,7 @@ slider glyphs, alignment, and per-screen layout:
     "selected_color": [255, 245, 208, 255],
     "cursor_color": [255, 222, 140, 255],
     "status_color": [255, 222, 140, 230],
+    "divider_color": [126, 168, 238, 170],
     "cursor": ">",
     "slider_left": "[",
     "slider_fill": "#",
@@ -258,7 +259,8 @@ slider glyphs, alignment, and per-screen layout:
     "menu_align": "left",
     "cursor_align": "right",
     "selected_pulse_alpha": true,
-    "audio": { "title_y": 0.18, "menu_x": 0.28, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
+    "title_divider": true,
+    "audio": { "title_y": 0.18, "menu_x": 0.34, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
   }
 }
 ```

--- a/docs/standard-options.md
+++ b/docs/standard-options.md
@@ -255,10 +255,10 @@ slider glyphs, alignment, and per-screen layout:
     "menu_x": 0.5,
     "status_x": 0.5,
     "status_y": 0.88,
-    "menu_align": "center",
-    "cursor_align": "center",
+    "menu_align": "left",
+    "cursor_align": "right",
     "selected_pulse_alpha": true,
-    "audio": { "title_y": 0.18, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.18 }
+    "audio": { "title_y": 0.18, "menu_x": 0.28, "menu_y": 0.39, "gap": 0.078, "cursor_offset_x": -0.035 }
   }
 }
 ```

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -535,6 +535,10 @@ extern "C"
         const char *scene;
         /** @brief Scene stored as the return target when this item changes scene, or NULL. */
         const char *return_to;
+        /** @brief Scene-state key to set when this item is selected, or NULL. */
+        const char *scene_state_key;
+        /** @brief String value assigned to scene_state_key when this item is selected, or NULL. */
+        const char *scene_state_value;
         /** @brief True when selecting this item requests the stored return scene. */
         bool return_scene;
         /** @brief True when selecting this item requests application quit. */

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1324,9 +1324,28 @@ extern "C"
     bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime,
                                                    const sdl3d_input_manager *input);
 
-    /** @brief Iterate authored UI text descriptors. */
+    /**
+     * @brief Iterate authored UI text descriptors.
+     *
+     * This is equivalent to sdl3d_game_data_for_each_ui_text_for_metrics()
+     * with a NULL metrics pointer. Use the metrics-aware iterator when menu
+     * presenters or authored visibility conditions depend on frame state such
+     * as pause, FPS, or active scene transition state.
+     */
     bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
                                           void *userdata);
+
+    /**
+     * @brief Iterate authored UI text descriptors using current frame metrics.
+     *
+     * Iteration includes global `ui.text`, active-scene `ui.text`, and menu
+     * presenters from global and active-scene `ui.menus`. Conditions on
+     * generated menu presenters are evaluated with `metrics`, so app-state
+     * dependent menus such as pause overlays can be rendered correctly.
+     */
+    bool sdl3d_game_data_for_each_ui_text_for_metrics(const sdl3d_game_data_runtime *runtime,
+                                                      const sdl3d_game_data_ui_metrics *metrics,
+                                                      sdl3d_game_data_ui_text_fn callback, void *userdata);
 
     /**
      * @brief Iterate authored UI images visible to the active scene.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -197,6 +197,8 @@ extern "C"
         int rings;
         /** @brief Authored tint color. */
         sdl3d_color color;
+        /** @brief True when the primitive should use scene lighting. */
+        bool lighting_enabled;
         /** @brief Whether the primitive should be treated as emissive by the caller. */
         bool emissive;
         /** @brief Evaluated emissive RGB contribution. */

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -116,13 +116,15 @@ extern "C"
      */
     typedef struct sdl3d_game_data_menu_update_result
     {
-        const char *menu;      /**< Runtime-owned active menu name, or NULL. */
-        const char *scene;     /**< Runtime-owned selected target scene, or NULL. */
-        const char *return_to; /**< Runtime-owned scene to store as return target, or NULL. */
-        int selected_index;    /**< Selected item index after this update, or -1. */
-        int signal_id;         /**< Selected item signal id, including data-bound controls, or -1. */
-        int move_signal_id;    /**< Menu navigation signal id emitted by the host, or -1. */
-        int select_signal_id;  /**< Menu activation signal id emitted by the host, or -1. */
+        const char *menu;              /**< Runtime-owned active menu name, or NULL. */
+        const char *scene;             /**< Runtime-owned selected target scene, or NULL. */
+        const char *return_to;         /**< Runtime-owned scene to store as return target, or NULL. */
+        const char *scene_state_key;   /**< Runtime-owned scene-state key to set, or NULL. */
+        const char *scene_state_value; /**< Runtime-owned scene-state string value to assign, or NULL. */
+        int selected_index;            /**< Selected item index after this update, or -1. */
+        int signal_id;                 /**< Selected item signal id, including data-bound controls, or -1. */
+        int move_signal_id;            /**< Menu navigation signal id emitted by the host, or -1. */
+        int select_signal_id;          /**< Menu activation signal id emitted by the host, or -1. */
         sdl3d_game_data_menu_pause_command pause_command; /**< Pause command requested by selected item. */
         bool handled_input;                               /**< True when a menu action was consumed. */
         bool selected;                                    /**< True when the selected item was activated. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2720,6 +2720,25 @@ static void apply_render_effects(const sdl3d_game_data_runtime *runtime, yyjson_
             primitive->emissive_color.x += base.x + add.x * pulse;
             primitive->emissive_color.y += base.y + add.y * pulse;
             primitive->emissive_color.z += base.z + add.z * pulse;
+
+            const sdl3d_vec3 size_add = json_vec3(effect, "size_add", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            primitive->size.x += size_add.x * pulse;
+            primitive->size.y += size_add.y * pulse;
+            primitive->size.z += size_add.z * pulse;
+            primitive->radius += json_float(effect, "radius_add", 0.0f) * pulse;
+        }
+        else if (SDL_strcmp(type, "drift") == 0)
+        {
+            const float time = eval != NULL ? eval->time : 0.0f;
+            const float phase = json_float(effect, "phase", 0.0f);
+            const sdl3d_vec3 offset = json_vec3(effect, "offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+            const sdl3d_vec3 rates =
+                json_vec3(effect, "rates",
+                          sdl3d_vec3_make(json_float(effect, "rate", 1.0f), json_float(effect, "rate", 1.0f),
+                                          json_float(effect, "rate", 1.0f)));
+            primitive->position.x += offset.x * SDL_sinf(time * rates.x + phase);
+            primitive->position.y += offset.y * SDL_cosf(time * rates.y + phase * 1.37f);
+            primitive->position.z += offset.z * SDL_sinf(time * rates.z + phase * 0.73f);
         }
         else if (SDL_strcmp(type, "emissive") == 0)
         {
@@ -3898,6 +3917,9 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
     out_item->label = json_string(item, "label", NULL);
     out_item->scene = json_string(item, "scene", NULL);
     out_item->return_to = json_string(item, "return_to", NULL);
+    yyjson_val *scene_state = obj_get(item, "scene_state");
+    out_item->scene_state_key = json_string(scene_state, "key", NULL);
+    out_item->scene_state_value = json_string(scene_state, "value", NULL);
     out_item->return_scene = json_bool(item, "return_scene", false);
     out_item->quit = json_bool(item, "quit", false);
     out_item->signal_id = sdl3d_game_data_find_signal(runtime, json_string(item, "signal", NULL));
@@ -4726,6 +4748,13 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
     const scene_menu_state *menu_state = find_scene_menu_const(scene, json_string(presenter, "menu", NULL));
     yyjson_val *items = menu_state != NULL ? obj_get(menu_state->menu, "items") : NULL;
     if (menu_state == NULL || !yyjson_is_arr(items))
+        return true;
+
+    yyjson_val *presenter_active_if = obj_get(presenter, "active_if");
+    if (presenter_active_if != NULL && !eval_data_condition(runtime, presenter_active_if, NULL))
+        return true;
+    yyjson_val *menu_active_if = obj_get(menu_state->menu, "active_if");
+    if (menu_active_if != NULL && !eval_data_condition(runtime, menu_active_if, NULL))
         return true;
 
     const float x = json_float(presenter, "x", 0.0f);
@@ -5676,6 +5705,39 @@ static bool compare_value(const sdl3d_value *left, const char *op, yyjson_val *r
     return false;
 }
 
+static bool json_scalar_to_value(yyjson_val *json, sdl3d_value *out_value)
+{
+    if (json == NULL || out_value == NULL)
+        return false;
+
+    SDL_zero(*out_value);
+    if (yyjson_is_str(json))
+    {
+        out_value->type = SDL3D_VALUE_STRING;
+        out_value->as_string = (char *)yyjson_get_str(json);
+        return out_value->as_string != NULL;
+    }
+    if (yyjson_is_bool(json))
+    {
+        out_value->type = SDL3D_VALUE_BOOL;
+        out_value->as_bool = yyjson_get_bool(json);
+        return true;
+    }
+    if (yyjson_is_int(json))
+    {
+        out_value->type = SDL3D_VALUE_INT;
+        out_value->as_int = (int)yyjson_get_sint(json);
+        return true;
+    }
+    if (yyjson_is_num(json))
+    {
+        out_value->type = SDL3D_VALUE_FLOAT;
+        out_value->as_float = (float)yyjson_get_real(json);
+        return true;
+    }
+    return false;
+}
+
 static yyjson_val *find_ui_text_json(const sdl3d_game_data_runtime *runtime, const char *name)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
@@ -5778,6 +5840,18 @@ static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_v
         const char *op = json_string(condition, "op", NULL);
         return target != NULL && key != NULL &&
                compare_value(sdl3d_properties_get_value(target->props, key), op, obj_get(condition, "value"));
+    }
+    if (SDL_strcmp(type, "scene_state.compare") == 0)
+    {
+        const char *key = json_string(condition, "key", NULL);
+        const char *op = json_string(condition, "op", NULL);
+        const sdl3d_value *left = runtime != NULL && runtime->scene_state != NULL && key != NULL
+                                      ? sdl3d_properties_get_value(runtime->scene_state, key)
+                                      : NULL;
+        sdl3d_value fallback;
+        if (left == NULL && json_scalar_to_value(obj_get(condition, "default"), &fallback))
+            left = &fallback;
+        return key != NULL && compare_value(left, op, obj_get(condition, "value"));
     }
     if (SDL_strcmp(type, "property.bool") == 0)
     {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2782,6 +2782,7 @@ static bool for_each_render_primitive_internal(const sdl3d_game_data_runtime *ru
             primitive.position.y += offset.y;
             primitive.position.z += offset.z;
             primitive.color = json_color(component, "color", (sdl3d_color){255, 255, 255, 255});
+            primitive.lighting_enabled = json_bool(component, "lighting", true);
             primitive.emissive = json_bool(component, "emissive", false);
             primitive.emissive_color =
                 primitive.emissive ? sdl3d_vec3_make(0.2f, 0.2f, 0.2f) : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -4741,7 +4741,8 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
 }
 
 static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, const scene_entry *scene,
-                                       yyjson_val *presenter, sdl3d_game_data_ui_text_fn callback, void *userdata)
+                                       const sdl3d_game_data_ui_metrics *metrics, yyjson_val *presenter,
+                                       sdl3d_game_data_ui_text_fn callback, void *userdata)
 {
     if (scene == NULL || presenter == NULL)
         return true;
@@ -4752,10 +4753,10 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
         return true;
 
     yyjson_val *presenter_active_if = obj_get(presenter, "active_if");
-    if (presenter_active_if != NULL && !eval_data_condition(runtime, presenter_active_if, NULL))
+    if (presenter_active_if != NULL && !eval_data_condition(runtime, presenter_active_if, metrics))
         return true;
     yyjson_val *menu_active_if = obj_get(menu_state->menu, "active_if");
-    if (menu_active_if != NULL && !eval_data_condition(runtime, menu_active_if, NULL))
+    if (menu_active_if != NULL && !eval_data_condition(runtime, menu_active_if, metrics))
         return true;
 
     const float x = json_float(presenter, "x", 0.0f);
@@ -4798,20 +4799,22 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
     return true;
 }
 
-static bool for_each_ui_menu_root(const sdl3d_game_data_runtime *runtime, const scene_entry *scene, yyjson_val *root,
+static bool for_each_ui_menu_root(const sdl3d_game_data_runtime *runtime, const scene_entry *scene,
+                                  const sdl3d_game_data_ui_metrics *metrics, yyjson_val *root,
                                   sdl3d_game_data_ui_text_fn callback, void *userdata)
 {
     yyjson_val *menus = obj_get(obj_get(root, "ui"), "menus");
     for (size_t i = 0; yyjson_is_arr(menus) && i < yyjson_arr_size(menus); ++i)
     {
-        if (!for_each_ui_menu_presenter(runtime, scene, yyjson_arr_get(menus, i), callback, userdata))
+        if (!for_each_ui_menu_presenter(runtime, scene, metrics, yyjson_arr_get(menus, i), callback, userdata))
             return false;
     }
     return true;
 }
 
-bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
-                                      void *userdata)
+bool sdl3d_game_data_for_each_ui_text_for_metrics(const sdl3d_game_data_runtime *runtime,
+                                                  const sdl3d_game_data_ui_metrics *metrics,
+                                                  sdl3d_game_data_ui_text_fn callback, void *userdata)
 {
     if (runtime == NULL || callback == NULL)
         return false;
@@ -4823,9 +4826,15 @@ bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sd
 
     for (int root_index = 0; root_index < 2; ++root_index)
         if (!for_each_authored_ui_text_root(roots[root_index], callback, userdata) ||
-            !for_each_ui_menu_root(runtime, scene, roots[root_index], callback, userdata))
+            !for_each_ui_menu_root(runtime, scene, metrics, roots[root_index], callback, userdata))
             return true;
     return true;
+}
+
+bool sdl3d_game_data_for_each_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_text_fn callback,
+                                      void *userdata)
+{
+    return sdl3d_game_data_for_each_ui_text_for_metrics(runtime, NULL, callback, userdata);
 }
 
 static void ui_image_from_json(yyjson_val *item, sdl3d_game_data_ui_image *image)

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -10,6 +10,7 @@
 typedef struct standard_options_scene_layout
 {
     double title_y;
+    double menu_x;
     double menu_y;
     double gap;
     double cursor_offset_x;
@@ -103,11 +104,12 @@ static const char *section_string(yyjson_val *object, const char *section, const
     return json_string(obj_get(object, section), key, fallback);
 }
 
-static standard_options_scene_layout scene_layout_defaults(double title_y, double menu_y, double gap,
+static standard_options_scene_layout scene_layout_defaults(double title_y, double menu_x, double menu_y, double gap,
                                                            double cursor_offset_x)
 {
     return (standard_options_scene_layout){
         .title_y = title_y,
+        .menu_x = menu_x,
         .menu_y = menu_y,
         .gap = gap,
         .cursor_offset_x = cursor_offset_x,
@@ -119,6 +121,7 @@ static standard_options_scene_layout load_scene_layout(yyjson_val *layout, const
 {
     yyjson_val *scene = obj_get(layout, section);
     fallback.title_y = json_double(scene, "title_y", fallback.title_y);
+    fallback.menu_x = json_double(scene, "menu_x", json_double(layout, "menu_x", fallback.menu_x));
     fallback.menu_y = json_double(scene, "menu_y", fallback.menu_y);
     fallback.gap = json_double(scene, "gap", fallback.gap);
     fallback.cursor_offset_x =
@@ -133,15 +136,18 @@ static void load_layout(standard_options_config *config)
     config->layout.menu_x = json_double(layout, "menu_x", 0.5);
     config->layout.status_x = json_double(layout, "status_x", 0.5);
     config->layout.status_y = json_double(layout, "status_y", 0.88);
-    config->layout.menu_align = json_string(layout, "menu_align", "center");
-    config->layout.cursor_align = json_string(layout, "cursor_align", "center");
+    config->layout.menu_align = json_string(layout, "menu_align", "left");
+    config->layout.cursor_align = json_string(layout, "cursor_align", "right");
     config->layout.selected_pulse_alpha = json_bool(layout, "selected_pulse_alpha", true);
-    config->layout.root = load_scene_layout(layout, "root", scene_layout_defaults(0.18, 0.36, 0.078, -0.14));
-    config->layout.display = load_scene_layout(layout, "display", scene_layout_defaults(0.20, 0.38, 0.074, -0.18));
-    config->layout.keyboard = load_scene_layout(layout, "keyboard", scene_layout_defaults(0.13, 0.25, 0.062, -0.18));
-    config->layout.mouse = load_scene_layout(layout, "mouse", scene_layout_defaults(0.13, 0.30, 0.062, -0.18));
-    config->layout.gamepad = load_scene_layout(layout, "gamepad", scene_layout_defaults(0.12, 0.22, 0.052, -0.18));
-    config->layout.audio = load_scene_layout(layout, "audio", scene_layout_defaults(0.18, 0.39, 0.078, -0.18));
+    config->layout.root = load_scene_layout(layout, "root", scene_layout_defaults(0.18, 0.43, 0.36, 0.078, -0.035));
+    config->layout.display =
+        load_scene_layout(layout, "display", scene_layout_defaults(0.20, 0.30, 0.38, 0.074, -0.035));
+    config->layout.keyboard =
+        load_scene_layout(layout, "keyboard", scene_layout_defaults(0.13, 0.36, 0.25, 0.062, -0.035));
+    config->layout.mouse = load_scene_layout(layout, "mouse", scene_layout_defaults(0.13, 0.40, 0.30, 0.062, -0.035));
+    config->layout.gamepad =
+        load_scene_layout(layout, "gamepad", scene_layout_defaults(0.105, 0.34, 0.15, 0.061, -0.035));
+    config->layout.audio = load_scene_layout(layout, "audio", scene_layout_defaults(0.18, 0.28, 0.39, 0.078, -0.035));
 }
 
 static void set_error(char *buffer, int buffer_size, const char *message)
@@ -416,15 +422,15 @@ static bool add_status_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const st
 }
 
 static bool add_menu_presenter(yyjson_mut_doc *doc, yyjson_mut_val *ui, const standard_options_config *config,
-                               const char *name, const char *menu_name, double y, double gap, double cursor_offset)
+                               const char *name, const char *menu_name, double x, double y, double gap,
+                               double cursor_offset)
 {
     yyjson_mut_val *menus = add_arr(doc, ui, "menus");
     yyjson_mut_val *presenter = yyjson_mut_obj(doc);
     yyjson_mut_val *cursor = NULL;
     return menus != NULL && presenter != NULL && yyjson_mut_arr_add_val(menus, presenter) &&
            add_str(doc, presenter, "name", name) && add_str(doc, presenter, "menu", menu_name) &&
-           add_str(doc, presenter, "font", config->menu_font) &&
-           yyjson_mut_obj_add_real(doc, presenter, "x", config->layout.menu_x) &&
+           add_str(doc, presenter, "font", config->menu_font) && yyjson_mut_obj_add_real(doc, presenter, "x", x) &&
            yyjson_mut_obj_add_real(doc, presenter, "y", y) && yyjson_mut_obj_add_real(doc, presenter, "gap", gap) &&
            yyjson_mut_obj_add_bool(doc, presenter, "normalized", true) &&
            add_str(doc, presenter, "align", config->layout.menu_align) &&
@@ -440,12 +446,12 @@ static bool add_menu_presenter(yyjson_mut_doc *doc, yyjson_mut_val *ui, const st
 
 static bool add_basic_ui(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
                          const char *title_name, const char *title, double title_y, const char *presenter_name,
-                         const char *menu_name, double menu_y, double gap, double cursor_offset)
+                         const char *menu_name, double menu_x, double menu_y, double gap, double cursor_offset)
 {
     yyjson_mut_val *ui = add_ui(doc, scene);
     yyjson_mut_val *texts = ui != NULL ? add_arr(doc, ui, "text") : NULL;
     return texts != NULL && add_title_text(doc, texts, config, title_name, title, title_y) &&
-           add_menu_presenter(doc, ui, config, presenter_name, menu_name, menu_y, gap, cursor_offset);
+           add_menu_presenter(doc, ui, config, presenter_name, menu_name, menu_x, menu_y, gap, cursor_offset);
 }
 
 static yyjson_doc *finish_scene_doc(yyjson_mut_doc *doc, yyjson_mut_val *scene)
@@ -471,8 +477,8 @@ static yyjson_doc *build_root_scene(const standard_options_config *config)
         !add_scene_item(doc, items, "Gamepad", config->gamepad_scene) ||
         !add_scene_item(doc, items, "Audio", config->audio_scene) || !add_back_item(doc, items, config, NULL) ||
         !add_basic_ui(doc, scene, config, "ui.options.title", "OPTIONS", config->layout.root.title_y, "ui.options.menu",
-                      config->root_menu, config->layout.root.menu_y, config->layout.root.gap,
-                      config->layout.root.cursor_offset_x))
+                      config->root_menu, config->layout.root.menu_x, config->layout.root.menu_y,
+                      config->layout.root.gap, config->layout.root.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -490,8 +496,9 @@ static yyjson_doc *build_display_scene(const standard_options_config *config)
         !add_renderer_item(doc, items, config) || !add_reset_item(doc, items, config->reset_display_signal) ||
         !add_back_item(doc, items, config, config->root_scene) ||
         !add_basic_ui(doc, scene, config, "ui.options.display.title", "DISPLAY", config->layout.display.title_y,
-                      "ui.options.display.menu", config->display_menu, config->layout.display.menu_y,
-                      config->layout.display.gap, config->layout.display.cursor_offset_x))
+                      "ui.options.display.menu", config->display_menu, config->layout.display.menu_x,
+                      config->layout.display.menu_y, config->layout.display.gap,
+                      config->layout.display.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -512,8 +519,8 @@ static yyjson_doc *build_audio_scene(const standard_options_config *config)
         !add_reset_item(doc, items, config->reset_audio_signal) ||
         !add_back_item(doc, items, config, config->root_scene) ||
         !add_basic_ui(doc, scene, config, "ui.options.audio.title", "AUDIO", config->layout.audio.title_y,
-                      "ui.options.audio.menu", config->audio_menu, config->layout.audio.menu_y,
-                      config->layout.audio.gap, config->layout.audio.cursor_offset_x))
+                      "ui.options.audio.menu", config->audio_menu, config->layout.audio.menu_x,
+                      config->layout.audio.menu_y, config->layout.audio.gap, config->layout.audio.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -540,7 +547,7 @@ static yyjson_doc *build_keyboard_scene(const standard_options_config *config)
     if (!add_status_text(doc, texts, config, "ui.options.keyboard.status", config->keyboard_status_key, 255, 222,
                          140) ||
         !add_menu_presenter(doc, ui, config, "ui.options.keyboard.menu", config->keyboard_menu,
-                            config->layout.keyboard.menu_y, config->layout.keyboard.gap,
+                            config->layout.keyboard.menu_x, config->layout.keyboard.menu_y, config->layout.keyboard.gap,
                             config->layout.keyboard.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);
@@ -566,8 +573,9 @@ static yyjson_doc *build_mouse_scene(const standard_options_config *config)
         return NULL;
     }
     if (!add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140) ||
-        !add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_y,
-                            config->layout.mouse.gap, config->layout.mouse.cursor_offset_x))
+        !add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_x,
+                            config->layout.mouse.menu_y, config->layout.mouse.gap,
+                            config->layout.mouse.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -591,7 +599,7 @@ static yyjson_doc *build_gamepad_scene(const standard_options_config *config)
         !add_title_text(doc, texts, config, "ui.options.gamepad.title", "GAMEPAD", config->layout.gamepad.title_y) ||
         !add_status_text(doc, texts, config, "ui.options.gamepad.status", config->gamepad_status_key, 172, 206, 255) ||
         !add_menu_presenter(doc, ui, config, "ui.options.gamepad.menu", config->gamepad_menu,
-                            config->layout.gamepad.menu_y, config->layout.gamepad.gap,
+                            config->layout.gamepad.menu_x, config->layout.gamepad.menu_y, config->layout.gamepad.gap,
                             config->layout.gamepad.cursor_offset_x))
     {
         yyjson_mut_doc_free(doc);

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -25,6 +25,7 @@ typedef struct standard_options_layout
     const char *menu_align;
     const char *cursor_align;
     bool selected_pulse_alpha;
+    bool title_divider;
     standard_options_scene_layout root;
     standard_options_scene_layout display;
     standard_options_scene_layout keyboard;
@@ -139,15 +140,16 @@ static void load_layout(standard_options_config *config)
     config->layout.menu_align = json_string(layout, "menu_align", "left");
     config->layout.cursor_align = json_string(layout, "cursor_align", "right");
     config->layout.selected_pulse_alpha = json_bool(layout, "selected_pulse_alpha", true);
+    config->layout.title_divider = json_bool(layout, "title_divider", true);
     config->layout.root = load_scene_layout(layout, "root", scene_layout_defaults(0.18, 0.43, 0.36, 0.078, -0.035));
     config->layout.display =
         load_scene_layout(layout, "display", scene_layout_defaults(0.20, 0.30, 0.38, 0.074, -0.035));
     config->layout.keyboard =
-        load_scene_layout(layout, "keyboard", scene_layout_defaults(0.13, 0.36, 0.25, 0.062, -0.035));
+        load_scene_layout(layout, "keyboard", scene_layout_defaults(0.13, 0.36, 0.29, 0.062, -0.035));
     config->layout.mouse = load_scene_layout(layout, "mouse", scene_layout_defaults(0.13, 0.40, 0.30, 0.062, -0.035));
     config->layout.gamepad =
-        load_scene_layout(layout, "gamepad", scene_layout_defaults(0.105, 0.34, 0.15, 0.061, -0.035));
-    config->layout.audio = load_scene_layout(layout, "audio", scene_layout_defaults(0.18, 0.28, 0.39, 0.078, -0.035));
+        load_scene_layout(layout, "gamepad", scene_layout_defaults(0.105, 0.34, 0.24, 0.055, -0.035));
+    config->layout.audio = load_scene_layout(layout, "audio", scene_layout_defaults(0.18, 0.34, 0.39, 0.078, -0.035));
 }
 
 static void set_error(char *buffer, int buffer_size, const char *message)
@@ -403,6 +405,27 @@ static bool add_title_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const sta
            add_color(doc, title, "color", config->theme, "title_color", 242, 248, 255, 255);
 }
 
+static bool add_title_divider(yyjson_mut_doc *doc, yyjson_mut_val *texts, const standard_options_config *config,
+                              const char *name, double title_y)
+{
+    if (!config->layout.title_divider)
+        return true;
+
+    char divider_name[128];
+    SDL_snprintf(divider_name, sizeof(divider_name), "%s.divider", name != NULL ? name : "ui.options.title");
+
+    yyjson_mut_val *divider = yyjson_mut_obj(doc);
+    return texts != NULL && divider != NULL && yyjson_mut_arr_add_val(texts, divider) &&
+           add_str(doc, divider, "name", divider_name) && add_str(doc, divider, "font", config->menu_font) &&
+           add_str(doc, divider, "text", "----------------") &&
+           yyjson_mut_obj_add_real(doc, divider, "x", config->layout.title_x) &&
+           yyjson_mut_obj_add_real(doc, divider, "y", title_y + 0.095) &&
+           yyjson_mut_obj_add_bool(doc, divider, "normalized", true) &&
+           yyjson_mut_obj_add_bool(doc, divider, "centered", true) &&
+           yyjson_mut_obj_add_real(doc, divider, "scale", 0.55) &&
+           add_color(doc, divider, "color", config->theme, "divider_color", 126, 168, 238, 170);
+}
+
 static bool add_status_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const standard_options_config *config,
                             const char *name, const char *status_key, int r, int g, int b)
 {
@@ -451,6 +474,7 @@ static bool add_basic_ui(yyjson_mut_doc *doc, yyjson_mut_val *scene, const stand
     yyjson_mut_val *ui = add_ui(doc, scene);
     yyjson_mut_val *texts = ui != NULL ? add_arr(doc, ui, "text") : NULL;
     return texts != NULL && add_title_text(doc, texts, config, title_name, title, title_y) &&
+           add_title_divider(doc, texts, config, title_name, title_y) &&
            add_menu_presenter(doc, ui, config, presenter_name, menu_name, menu_x, menu_y, gap, cursor_offset);
 }
 
@@ -546,6 +570,7 @@ static yyjson_doc *build_keyboard_scene(const standard_options_config *config)
     }
     if (!add_status_text(doc, texts, config, "ui.options.keyboard.status", config->keyboard_status_key, 255, 222,
                          140) ||
+        !add_title_divider(doc, texts, config, "ui.options.keyboard.title", config->layout.keyboard.title_y) ||
         !add_menu_presenter(doc, ui, config, "ui.options.keyboard.menu", config->keyboard_menu,
                             config->layout.keyboard.menu_x, config->layout.keyboard.menu_y, config->layout.keyboard.gap,
                             config->layout.keyboard.cursor_offset_x))
@@ -573,6 +598,7 @@ static yyjson_doc *build_mouse_scene(const standard_options_config *config)
         return NULL;
     }
     if (!add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140) ||
+        !add_title_divider(doc, texts, config, "ui.options.mouse.title", config->layout.mouse.title_y) ||
         !add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_x,
                             config->layout.mouse.menu_y, config->layout.mouse.gap,
                             config->layout.mouse.cursor_offset_x))
@@ -598,6 +624,7 @@ static yyjson_doc *build_gamepad_scene(const standard_options_config *config)
         (texts = add_arr(doc, ui, "text")) == NULL ||
         !add_title_text(doc, texts, config, "ui.options.gamepad.title", "GAMEPAD", config->layout.gamepad.title_y) ||
         !add_status_text(doc, texts, config, "ui.options.gamepad.status", config->gamepad_status_key, 172, 206, 255) ||
+        !add_title_divider(doc, texts, config, "ui.options.gamepad.title", config->layout.gamepad.title_y) ||
         !add_menu_presenter(doc, ui, config, "ui.options.gamepad.menu", config->gamepad_menu,
                             config->layout.gamepad.menu_x, config->layout.gamepad.menu_y, config->layout.gamepad.gap,
                             config->layout.gamepad.cursor_offset_x))

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -75,6 +75,9 @@ typedef struct standard_options_config
     const char *gamepad_status_key;
     const char *enter_transition;
     const char *exit_transition;
+    yyjson_val *background;
+    const char *background_camera;
+    bool background_renders_world;
 } standard_options_config;
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
@@ -222,18 +225,33 @@ static bool add_scene_transitions(yyjson_mut_doc *doc, yyjson_mut_val *scene, co
            add_str(doc, transitions, "exit", config->exit_transition);
 }
 
+static bool add_scene_entities(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config)
+{
+    yyjson_mut_val *entities = add_arr(doc, scene, "entities");
+    yyjson_val *authored_entities = obj_get(config->background, "entities");
+    if (entities == NULL)
+        return false;
+
+    for (size_t i = 0; yyjson_is_arr(authored_entities) && i < yyjson_arr_size(authored_entities); ++i)
+    {
+        const char *entity = yyjson_get_str(yyjson_arr_get(authored_entities, i));
+        if (entity != NULL && !add_arr_str(doc, entities, entity))
+            return false;
+    }
+    return true;
+}
+
 static yyjson_mut_val *create_scene(yyjson_mut_doc *doc, const standard_options_config *config, const char *name,
                                     bool include_lr)
 {
     yyjson_mut_val *scene = yyjson_mut_obj(doc);
-    yyjson_mut_val *entities = NULL;
     if (scene == NULL || !add_str(doc, scene, "schema", "sdl3d.scene.v0") || !add_str(doc, scene, "name", name) ||
         !yyjson_mut_obj_add_bool(doc, scene, "updates_game", false) ||
-        !yyjson_mut_obj_add_bool(doc, scene, "renders_world", false) ||
-        (entities = add_arr(doc, scene, "entities")) == NULL || !add_scene_input(doc, scene, config, include_lr) ||
+        !yyjson_mut_obj_add_bool(doc, scene, "renders_world", config->background_renders_world) ||
+        (config->background_camera != NULL && !add_str(doc, scene, "camera", config->background_camera)) ||
+        !add_scene_entities(doc, scene, config) || !add_scene_input(doc, scene, config, include_lr) ||
         !add_scene_transitions(doc, scene, config))
         return NULL;
-    (void)entities;
     return scene;
 }
 
@@ -655,6 +673,10 @@ static bool load_config(yyjson_val *game_root, const char *package_name, standar
     config->root = root;
     config->theme = obj_get(root, "theme");
     config->bindings = obj_get(root, "bindings");
+    config->background = obj_get(root, "background");
+    config->background_camera = json_string(config->background, "camera", NULL);
+    config->background_renders_world =
+        yyjson_is_obj(config->background) ? json_bool(config->background, "renders_world", true) : false;
     config->settings_actor = json_string(root, "settings", "entity.settings");
     config->return_scene = json_string(root, "return_scene", "scene.title");
     config->root_scene = section_string(root, "scenes", "root", "scene.options");

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -78,6 +78,8 @@ typedef struct standard_options_config
     yyjson_val *background;
     const char *background_camera;
     bool background_renders_world;
+    const char *menu_state_key;
+    bool single_scene;
 } standard_options_config;
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
@@ -171,6 +173,19 @@ static bool add_arr_str(yyjson_mut_doc *doc, yyjson_mut_val *arr, const char *va
     return value != NULL && yyjson_mut_arr_add_strcpy(doc, arr, value);
 }
 
+static bool add_scene_state_condition(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *field,
+                                      const standard_options_config *config, const char *value, bool default_active)
+{
+    if (value == NULL)
+        return true;
+
+    yyjson_mut_val *condition = yyjson_mut_obj(doc);
+    return condition != NULL && yyjson_mut_obj_add_val(doc, obj, field, condition) &&
+           add_str(doc, condition, "type", "scene_state.compare") &&
+           add_str(doc, condition, "key", config->menu_state_key) && add_str(doc, condition, "op", "==") &&
+           add_str(doc, condition, "value", value) && (!default_active || add_str(doc, condition, "default", value));
+}
+
 static bool add_color(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, yyjson_val *theme,
                       const char *theme_key, int r, int g, int b, int a)
 {
@@ -195,12 +210,24 @@ static yyjson_mut_val *add_obj(yyjson_mut_doc *doc, yyjson_mut_val *parent, cons
     return obj;
 }
 
+static yyjson_mut_val *get_or_add_obj(yyjson_mut_doc *doc, yyjson_mut_val *parent, const char *key)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj_get(parent, key);
+    return obj != NULL ? obj : add_obj(doc, parent, key);
+}
+
 static yyjson_mut_val *add_arr(yyjson_mut_doc *doc, yyjson_mut_val *parent, const char *key)
 {
     yyjson_mut_val *arr = yyjson_mut_arr(doc);
     if (arr == NULL || !yyjson_mut_obj_add_val(doc, parent, key, arr))
         return NULL;
     return arr;
+}
+
+static yyjson_mut_val *get_or_add_arr(yyjson_mut_doc *doc, yyjson_mut_val *parent, const char *key)
+{
+    yyjson_mut_val *arr = yyjson_mut_obj_get(parent, key);
+    return arr != NULL ? arr : add_arr(doc, parent, key);
 }
 
 static bool add_scene_input(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
@@ -256,9 +283,9 @@ static yyjson_mut_val *create_scene(yyjson_mut_doc *doc, const standard_options_
 }
 
 static yyjson_mut_val *add_menu(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
-                                const char *name, bool include_lr)
+                                const char *name, bool include_lr, const char *active_state, bool default_active)
 {
-    yyjson_mut_val *menus = add_arr(doc, scene, "menus");
+    yyjson_mut_val *menus = get_or_add_arr(doc, scene, "menus");
     yyjson_mut_val *menu = yyjson_mut_obj(doc);
     yyjson_mut_val *items = NULL;
     if (menus == NULL || menu == NULL || !yyjson_mut_arr_add_val(menus, menu) || !add_str(doc, menu, "name", name) ||
@@ -270,6 +297,7 @@ static yyjson_mut_val *add_menu(yyjson_mut_doc *doc, yyjson_mut_val *scene, cons
     if (!add_str(doc, menu, "select_action", config->select_action) ||
         !add_str(doc, menu, "move_signal", config->move_signal) ||
         !add_str(doc, menu, "select_signal", config->select_signal) ||
+        !add_scene_state_condition(doc, menu, "active_if", config, active_state, default_active) ||
         !yyjson_mut_obj_add_int(doc, menu, "selected", 0) || (items = add_arr(doc, menu, "items")) == NULL)
         return NULL;
     return items;
@@ -287,6 +315,15 @@ static bool add_scene_item(yyjson_mut_doc *doc, yyjson_mut_val *items, const cha
 {
     yyjson_mut_val *item = add_menu_item(doc, items, label);
     return item != NULL && add_str(doc, item, "scene", scene);
+}
+
+static bool add_menu_state_item(yyjson_mut_doc *doc, yyjson_mut_val *items, const standard_options_config *config,
+                                const char *label, const char *state)
+{
+    yyjson_mut_val *item = add_menu_item(doc, items, label);
+    yyjson_mut_val *scene_state = item != NULL ? add_obj(doc, item, "scene_state") : NULL;
+    return scene_state != NULL && add_str(doc, scene_state, "key", config->menu_state_key) &&
+           add_str(doc, scene_state, "value", state);
 }
 
 static bool add_back_item(yyjson_mut_doc *doc, yyjson_mut_val *items, const standard_options_config *config,
@@ -408,11 +445,11 @@ static bool add_input_binding_items(yyjson_mut_doc *doc, yyjson_mut_val *items, 
 
 static yyjson_mut_val *add_ui(yyjson_mut_doc *doc, yyjson_mut_val *scene)
 {
-    return add_obj(doc, scene, "ui");
+    return get_or_add_obj(doc, scene, "ui");
 }
 
 static bool add_title_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const standard_options_config *config,
-                           const char *name, const char *text, double y)
+                           const char *name, const char *text, double y, const char *active_state, bool default_active)
 {
     yyjson_mut_val *title = yyjson_mut_obj(doc);
     return texts != NULL && title != NULL && yyjson_mut_arr_add_val(texts, title) &&
@@ -420,11 +457,12 @@ static bool add_title_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const sta
            add_str(doc, title, "text", text) && yyjson_mut_obj_add_real(doc, title, "x", config->layout.title_x) &&
            yyjson_mut_obj_add_real(doc, title, "y", y) && yyjson_mut_obj_add_bool(doc, title, "normalized", true) &&
            yyjson_mut_obj_add_bool(doc, title, "centered", true) &&
+           add_scene_state_condition(doc, title, "visible_if", config, active_state, default_active) &&
            add_color(doc, title, "color", config->theme, "title_color", 242, 248, 255, 255);
 }
 
 static bool add_title_divider(yyjson_mut_doc *doc, yyjson_mut_val *texts, const standard_options_config *config,
-                              const char *name, double title_y)
+                              const char *name, double title_y, const char *active_state, bool default_active)
 {
     if (!config->layout.title_divider)
         return true;
@@ -441,11 +479,12 @@ static bool add_title_divider(yyjson_mut_doc *doc, yyjson_mut_val *texts, const 
            yyjson_mut_obj_add_bool(doc, divider, "normalized", true) &&
            yyjson_mut_obj_add_bool(doc, divider, "centered", true) &&
            yyjson_mut_obj_add_real(doc, divider, "scale", 0.55) &&
+           add_scene_state_condition(doc, divider, "visible_if", config, active_state, default_active) &&
            add_color(doc, divider, "color", config->theme, "divider_color", 126, 168, 238, 170);
 }
 
 static bool add_status_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const standard_options_config *config,
-                            const char *name, const char *status_key, int r, int g, int b)
+                            const char *name, const char *status_key, int r, int g, int b, const char *active_state)
 {
     yyjson_mut_val *text = yyjson_mut_obj(doc);
     yyjson_mut_val *bindings = NULL;
@@ -459,14 +498,15 @@ static bool add_status_text(yyjson_mut_doc *doc, yyjson_mut_val *texts, const st
            yyjson_mut_obj_add_real(doc, text, "y", config->layout.status_y) &&
            yyjson_mut_obj_add_bool(doc, text, "normalized", true) &&
            yyjson_mut_obj_add_bool(doc, text, "centered", true) &&
+           add_scene_state_condition(doc, text, "visible_if", config, active_state, false) &&
            add_color(doc, text, "color", config->theme, "status_color", r, g, b, 230);
 }
 
 static bool add_menu_presenter(yyjson_mut_doc *doc, yyjson_mut_val *ui, const standard_options_config *config,
                                const char *name, const char *menu_name, double x, double y, double gap,
-                               double cursor_offset)
+                               double cursor_offset, const char *active_state, bool default_active)
 {
-    yyjson_mut_val *menus = add_arr(doc, ui, "menus");
+    yyjson_mut_val *menus = get_or_add_arr(doc, ui, "menus");
     yyjson_mut_val *presenter = yyjson_mut_obj(doc);
     yyjson_mut_val *cursor = NULL;
     return menus != NULL && presenter != NULL && yyjson_mut_arr_add_val(menus, presenter) &&
@@ -475,6 +515,7 @@ static bool add_menu_presenter(yyjson_mut_doc *doc, yyjson_mut_val *ui, const st
            yyjson_mut_obj_add_real(doc, presenter, "y", y) && yyjson_mut_obj_add_real(doc, presenter, "gap", gap) &&
            yyjson_mut_obj_add_bool(doc, presenter, "normalized", true) &&
            add_str(doc, presenter, "align", config->layout.menu_align) &&
+           add_scene_state_condition(doc, presenter, "active_if", config, active_state, default_active) &&
            add_color(doc, presenter, "color", config->theme, "menu_color", 225, 236, 255, 245) &&
            add_color(doc, presenter, "selected_color", config->theme, "selected_color", 255, 245, 208, 255) &&
            yyjson_mut_obj_add_bool(doc, presenter, "selected_pulse_alpha", config->layout.selected_pulse_alpha) &&
@@ -487,13 +528,16 @@ static bool add_menu_presenter(yyjson_mut_doc *doc, yyjson_mut_val *ui, const st
 
 static bool add_basic_ui(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
                          const char *title_name, const char *title, double title_y, const char *presenter_name,
-                         const char *menu_name, double menu_x, double menu_y, double gap, double cursor_offset)
+                         const char *menu_name, double menu_x, double menu_y, double gap, double cursor_offset,
+                         const char *active_state, bool default_active)
 {
     yyjson_mut_val *ui = add_ui(doc, scene);
-    yyjson_mut_val *texts = ui != NULL ? add_arr(doc, ui, "text") : NULL;
-    return texts != NULL && add_title_text(doc, texts, config, title_name, title, title_y) &&
-           add_title_divider(doc, texts, config, title_name, title_y) &&
-           add_menu_presenter(doc, ui, config, presenter_name, menu_name, menu_x, menu_y, gap, cursor_offset);
+    yyjson_mut_val *texts = ui != NULL ? get_or_add_arr(doc, ui, "text") : NULL;
+    return texts != NULL &&
+           add_title_text(doc, texts, config, title_name, title, title_y, active_state, default_active) &&
+           add_title_divider(doc, texts, config, title_name, title_y, active_state, default_active) &&
+           add_menu_presenter(doc, ui, config, presenter_name, menu_name, menu_x, menu_y, gap, cursor_offset,
+                              active_state, default_active);
 }
 
 static yyjson_doc *finish_scene_doc(yyjson_mut_doc *doc, yyjson_mut_val *scene)
@@ -508,19 +552,135 @@ static yyjson_doc *finish_scene_doc(yyjson_mut_doc *doc, yyjson_mut_val *scene)
     return immutable;
 }
 
+static bool add_display_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
+                                const char *active_state)
+{
+    yyjson_mut_val *items = add_menu(doc, scene, config, config->display_menu, false, active_state, false);
+    return items != NULL && add_display_mode_item(doc, items, config) &&
+           add_toggle_item(doc, items, "Vsync", config->apply_signal, config->settings_actor, "vsync") &&
+           add_renderer_item(doc, items, config) && add_reset_item(doc, items, config->reset_display_signal) &&
+           (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
+                                 : add_back_item(doc, items, config, config->root_scene)) &&
+           add_basic_ui(doc, scene, config, "ui.options.display.title", "DISPLAY", config->layout.display.title_y,
+                        "ui.options.display.menu", config->display_menu, config->layout.display.menu_x,
+                        config->layout.display.menu_y, config->layout.display.gap,
+                        config->layout.display.cursor_offset_x, active_state, false);
+}
+
+static bool add_audio_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
+                              const char *active_state)
+{
+    yyjson_mut_val *items = add_menu(doc, scene, config, config->audio_menu, true, active_state, false);
+    return items != NULL &&
+           add_range_item(doc, items, config, "Sound Effects", config->apply_audio_signal, config->settings_actor,
+                          "sfx_volume", 8) &&
+           add_range_item(doc, items, config, "Music", config->apply_audio_signal, config->settings_actor,
+                          "music_volume", 7) &&
+           add_reset_item(doc, items, config->reset_audio_signal) &&
+           (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
+                                 : add_back_item(doc, items, config, config->root_scene)) &&
+           add_basic_ui(doc, scene, config, "ui.options.audio.title", "AUDIO", config->layout.audio.title_y,
+                        "ui.options.audio.menu", config->audio_menu, config->layout.audio.menu_x,
+                        config->layout.audio.menu_y, config->layout.audio.gap, config->layout.audio.cursor_offset_x,
+                        active_state, false);
+}
+
+static bool add_keyboard_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
+                                 const char *active_state)
+{
+    yyjson_mut_val *items = add_menu(doc, scene, config, config->keyboard_menu, false, active_state, false);
+    yyjson_mut_val *ui = NULL;
+    yyjson_mut_val *texts = NULL;
+    return items != NULL && add_input_binding_items(doc, items, obj_get(config->bindings, "keyboard")) &&
+           add_reset_item(doc, items, config->reset_keyboard_signal) &&
+           (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
+                                 : add_back_item(doc, items, config, config->root_scene)) &&
+           (ui = add_ui(doc, scene)) != NULL && (texts = get_or_add_arr(doc, ui, "text")) != NULL &&
+           add_title_text(doc, texts, config, "ui.options.keyboard.title", "KEYBOARD", config->layout.keyboard.title_y,
+                          active_state, false) &&
+           add_status_text(doc, texts, config, "ui.options.keyboard.status", config->keyboard_status_key, 255, 222, 140,
+                           active_state) &&
+           add_title_divider(doc, texts, config, "ui.options.keyboard.title", config->layout.keyboard.title_y,
+                             active_state, false) &&
+           add_menu_presenter(doc, ui, config, "ui.options.keyboard.menu", config->keyboard_menu,
+                              config->layout.keyboard.menu_x, config->layout.keyboard.menu_y,
+                              config->layout.keyboard.gap, config->layout.keyboard.cursor_offset_x, active_state,
+                              false);
+}
+
+static bool add_mouse_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
+                              const char *active_state)
+{
+    yyjson_mut_val *items = add_menu(doc, scene, config, config->mouse_menu, false, active_state, false);
+    yyjson_mut_val *ui = NULL;
+    yyjson_mut_val *texts = NULL;
+    return items != NULL && add_input_binding_items(doc, items, obj_get(config->bindings, "mouse")) &&
+           add_reset_item(doc, items, config->reset_mouse_signal) &&
+           (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
+                                 : add_back_item(doc, items, config, config->root_scene)) &&
+           (ui = add_ui(doc, scene)) != NULL && (texts = get_or_add_arr(doc, ui, "text")) != NULL &&
+           add_title_text(doc, texts, config, "ui.options.mouse.title", "MOUSE", config->layout.mouse.title_y,
+                          active_state, false) &&
+           add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140,
+                           active_state) &&
+           add_title_divider(doc, texts, config, "ui.options.mouse.title", config->layout.mouse.title_y, active_state,
+                             false) &&
+           add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_x,
+                              config->layout.mouse.menu_y, config->layout.mouse.gap,
+                              config->layout.mouse.cursor_offset_x, active_state, false);
+}
+
+static bool add_gamepad_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config,
+                                const char *active_state)
+{
+    yyjson_mut_val *items = add_menu(doc, scene, config, config->gamepad_menu, true, active_state, false);
+    yyjson_mut_val *ui = NULL;
+    yyjson_mut_val *texts = NULL;
+    return items != NULL && add_gamepad_icons_item(doc, items, config) &&
+           add_toggle_item(doc, items, "Vibration", NULL, config->settings_actor, "vibration") &&
+           add_input_binding_items(doc, items, obj_get(config->bindings, "gamepad")) &&
+           add_reset_item(doc, items, config->reset_gamepad_signal) &&
+           (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
+                                 : add_back_item(doc, items, config, config->root_scene)) &&
+           (ui = add_ui(doc, scene)) != NULL && (texts = get_or_add_arr(doc, ui, "text")) != NULL &&
+           add_title_text(doc, texts, config, "ui.options.gamepad.title", "GAMEPAD", config->layout.gamepad.title_y,
+                          active_state, false) &&
+           add_status_text(doc, texts, config, "ui.options.gamepad.status", config->gamepad_status_key, 172, 206, 255,
+                           active_state) &&
+           add_title_divider(doc, texts, config, "ui.options.gamepad.title", config->layout.gamepad.title_y,
+                             active_state, false) &&
+           add_menu_presenter(doc, ui, config, "ui.options.gamepad.menu", config->gamepad_menu,
+                              config->layout.gamepad.menu_x, config->layout.gamepad.menu_y, config->layout.gamepad.gap,
+                              config->layout.gamepad.cursor_offset_x, active_state, false);
+}
+
 static yyjson_doc *build_root_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->root_scene, false) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->root_menu, false) : NULL;
-    if (items == NULL || !add_scene_item(doc, items, "Display", config->display_scene) ||
-        !add_scene_item(doc, items, "Keyboard", config->keyboard_scene) ||
-        !add_scene_item(doc, items, "Mouse", config->mouse_scene) ||
-        !add_scene_item(doc, items, "Gamepad", config->gamepad_scene) ||
-        !add_scene_item(doc, items, "Audio", config->audio_scene) || !add_back_item(doc, items, config, NULL) ||
+    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->root_menu, false,
+                                                     config->single_scene ? "root" : NULL, config->single_scene)
+                                          : NULL;
+    if (items == NULL ||
+        !(config->single_scene ? add_menu_state_item(doc, items, config, "Display", "display")
+                               : add_scene_item(doc, items, "Display", config->display_scene)) ||
+        !(config->single_scene ? add_menu_state_item(doc, items, config, "Keyboard", "keyboard")
+                               : add_scene_item(doc, items, "Keyboard", config->keyboard_scene)) ||
+        !(config->single_scene ? add_menu_state_item(doc, items, config, "Mouse", "mouse")
+                               : add_scene_item(doc, items, "Mouse", config->mouse_scene)) ||
+        !(config->single_scene ? add_menu_state_item(doc, items, config, "Gamepad", "gamepad")
+                               : add_scene_item(doc, items, "Gamepad", config->gamepad_scene)) ||
+        !(config->single_scene ? add_menu_state_item(doc, items, config, "Audio", "audio")
+                               : add_scene_item(doc, items, "Audio", config->audio_scene)) ||
+        !add_back_item(doc, items, config, NULL) ||
         !add_basic_ui(doc, scene, config, "ui.options.title", "OPTIONS", config->layout.root.title_y, "ui.options.menu",
                       config->root_menu, config->layout.root.menu_x, config->layout.root.menu_y,
-                      config->layout.root.gap, config->layout.root.cursor_offset_x))
+                      config->layout.root.gap, config->layout.root.cursor_offset_x,
+                      config->single_scene ? "root" : NULL, config->single_scene) ||
+        (config->single_scene &&
+         (!add_display_content(doc, scene, config, "display") ||
+          !add_keyboard_content(doc, scene, config, "keyboard") || !add_mouse_content(doc, scene, config, "mouse") ||
+          !add_gamepad_content(doc, scene, config, "gamepad") || !add_audio_content(doc, scene, config, "audio"))))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -532,15 +692,16 @@ static yyjson_doc *build_display_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->display_scene, false) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->display_menu, false) : NULL;
+    yyjson_mut_val *items =
+        scene != NULL ? add_menu(doc, scene, config, config->display_menu, false, NULL, false) : NULL;
     if (items == NULL || !add_display_mode_item(doc, items, config) ||
         !add_toggle_item(doc, items, "Vsync", config->apply_signal, config->settings_actor, "vsync") ||
         !add_renderer_item(doc, items, config) || !add_reset_item(doc, items, config->reset_display_signal) ||
         !add_back_item(doc, items, config, config->root_scene) ||
         !add_basic_ui(doc, scene, config, "ui.options.display.title", "DISPLAY", config->layout.display.title_y,
                       "ui.options.display.menu", config->display_menu, config->layout.display.menu_x,
-                      config->layout.display.menu_y, config->layout.display.gap,
-                      config->layout.display.cursor_offset_x))
+                      config->layout.display.menu_y, config->layout.display.gap, config->layout.display.cursor_offset_x,
+                      NULL, false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -552,7 +713,7 @@ static yyjson_doc *build_audio_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->audio_scene, true) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->audio_menu, true) : NULL;
+    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->audio_menu, true, NULL, false) : NULL;
     if (items == NULL ||
         !add_range_item(doc, items, config, "Sound Effects", config->apply_audio_signal, config->settings_actor,
                         "sfx_volume", 8) ||
@@ -562,7 +723,8 @@ static yyjson_doc *build_audio_scene(const standard_options_config *config)
         !add_back_item(doc, items, config, config->root_scene) ||
         !add_basic_ui(doc, scene, config, "ui.options.audio.title", "AUDIO", config->layout.audio.title_y,
                       "ui.options.audio.menu", config->audio_menu, config->layout.audio.menu_x,
-                      config->layout.audio.menu_y, config->layout.audio.gap, config->layout.audio.cursor_offset_x))
+                      config->layout.audio.menu_y, config->layout.audio.gap, config->layout.audio.cursor_offset_x, NULL,
+                      false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -574,24 +736,27 @@ static yyjson_doc *build_keyboard_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->keyboard_scene, false) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->keyboard_menu, false) : NULL;
+    yyjson_mut_val *items =
+        scene != NULL ? add_menu(doc, scene, config, config->keyboard_menu, false, NULL, false) : NULL;
     yyjson_mut_val *ui = NULL;
     yyjson_mut_val *texts = NULL;
     if (items == NULL || !add_input_binding_items(doc, items, obj_get(config->bindings, "keyboard")) ||
         !add_reset_item(doc, items, config->reset_keyboard_signal) ||
         !add_back_item(doc, items, config, config->root_scene) || (ui = add_ui(doc, scene)) == NULL ||
         (texts = add_arr(doc, ui, "text")) == NULL ||
-        !add_title_text(doc, texts, config, "ui.options.keyboard.title", "KEYBOARD", config->layout.keyboard.title_y))
+        !add_title_text(doc, texts, config, "ui.options.keyboard.title", "KEYBOARD", config->layout.keyboard.title_y,
+                        NULL, false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
     }
-    if (!add_status_text(doc, texts, config, "ui.options.keyboard.status", config->keyboard_status_key, 255, 222,
-                         140) ||
-        !add_title_divider(doc, texts, config, "ui.options.keyboard.title", config->layout.keyboard.title_y) ||
+    if (!add_status_text(doc, texts, config, "ui.options.keyboard.status", config->keyboard_status_key, 255, 222, 140,
+                         NULL) ||
+        !add_title_divider(doc, texts, config, "ui.options.keyboard.title", config->layout.keyboard.title_y, NULL,
+                           false) ||
         !add_menu_presenter(doc, ui, config, "ui.options.keyboard.menu", config->keyboard_menu,
                             config->layout.keyboard.menu_x, config->layout.keyboard.menu_y, config->layout.keyboard.gap,
-                            config->layout.keyboard.cursor_offset_x))
+                            config->layout.keyboard.cursor_offset_x, NULL, false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -603,23 +768,25 @@ static yyjson_doc *build_mouse_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->mouse_scene, false) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->mouse_menu, false) : NULL;
+    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->mouse_menu, false, NULL, false) : NULL;
     yyjson_mut_val *ui = NULL;
     yyjson_mut_val *texts = NULL;
     if (items == NULL || !add_input_binding_items(doc, items, obj_get(config->bindings, "mouse")) ||
         !add_reset_item(doc, items, config->reset_mouse_signal) ||
         !add_back_item(doc, items, config, config->root_scene) || (ui = add_ui(doc, scene)) == NULL ||
         (texts = add_arr(doc, ui, "text")) == NULL ||
-        !add_title_text(doc, texts, config, "ui.options.mouse.title", "MOUSE", config->layout.mouse.title_y))
+        !add_title_text(doc, texts, config, "ui.options.mouse.title", "MOUSE", config->layout.mouse.title_y, NULL,
+                        false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
     }
-    if (!add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140) ||
-        !add_title_divider(doc, texts, config, "ui.options.mouse.title", config->layout.mouse.title_y) ||
+    if (!add_status_text(doc, texts, config, "ui.options.mouse.status", config->mouse_status_key, 255, 222, 140,
+                         NULL) ||
+        !add_title_divider(doc, texts, config, "ui.options.mouse.title", config->layout.mouse.title_y, NULL, false) ||
         !add_menu_presenter(doc, ui, config, "ui.options.mouse.menu", config->mouse_menu, config->layout.mouse.menu_x,
-                            config->layout.mouse.menu_y, config->layout.mouse.gap,
-                            config->layout.mouse.cursor_offset_x))
+                            config->layout.mouse.menu_y, config->layout.mouse.gap, config->layout.mouse.cursor_offset_x,
+                            NULL, false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -631,7 +798,8 @@ static yyjson_doc *build_gamepad_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
     yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->gamepad_scene, true) : NULL;
-    yyjson_mut_val *items = scene != NULL ? add_menu(doc, scene, config, config->gamepad_menu, true) : NULL;
+    yyjson_mut_val *items =
+        scene != NULL ? add_menu(doc, scene, config, config->gamepad_menu, true, NULL, false) : NULL;
     yyjson_mut_val *ui = NULL;
     yyjson_mut_val *texts = NULL;
     if (items == NULL || !add_gamepad_icons_item(doc, items, config) ||
@@ -640,12 +808,15 @@ static yyjson_doc *build_gamepad_scene(const standard_options_config *config)
         !add_reset_item(doc, items, config->reset_gamepad_signal) ||
         !add_back_item(doc, items, config, config->root_scene) || (ui = add_ui(doc, scene)) == NULL ||
         (texts = add_arr(doc, ui, "text")) == NULL ||
-        !add_title_text(doc, texts, config, "ui.options.gamepad.title", "GAMEPAD", config->layout.gamepad.title_y) ||
-        !add_status_text(doc, texts, config, "ui.options.gamepad.status", config->gamepad_status_key, 172, 206, 255) ||
-        !add_title_divider(doc, texts, config, "ui.options.gamepad.title", config->layout.gamepad.title_y) ||
+        !add_title_text(doc, texts, config, "ui.options.gamepad.title", "GAMEPAD", config->layout.gamepad.title_y, NULL,
+                        false) ||
+        !add_status_text(doc, texts, config, "ui.options.gamepad.status", config->gamepad_status_key, 172, 206, 255,
+                         NULL) ||
+        !add_title_divider(doc, texts, config, "ui.options.gamepad.title", config->layout.gamepad.title_y, NULL,
+                           false) ||
         !add_menu_presenter(doc, ui, config, "ui.options.gamepad.menu", config->gamepad_menu,
                             config->layout.gamepad.menu_x, config->layout.gamepad.menu_y, config->layout.gamepad.gap,
-                            config->layout.gamepad.cursor_offset_x))
+                            config->layout.gamepad.cursor_offset_x, NULL, false))
     {
         yyjson_mut_doc_free(doc);
         return NULL;
@@ -677,6 +848,8 @@ static bool load_config(yyjson_val *game_root, const char *package_name, standar
     config->background_camera = json_string(config->background, "camera", NULL);
     config->background_renders_world =
         yyjson_is_obj(config->background) ? json_bool(config->background, "renders_world", true) : false;
+    config->single_scene = json_bool(root, "single_scene", false);
+    config->menu_state_key = json_string(root, "menu_state_key", "standard_options_menu");
     config->settings_actor = json_string(root, "settings", "entity.settings");
     config->return_scene = json_string(root, "return_scene", "scene.title");
     config->root_scene = section_string(root, "scenes", "root", "scene.options");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1042,6 +1042,12 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (json_string(component, "rate_property") == NULL && !yyjson_is_num(obj_get(component, "rate")))
                     return validation_error(ctx, path, "property.decay requires rate or rate_property");
             }
+            else if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0)
+            {
+                yyjson_val *lighting = obj_get(component, "lighting");
+                if (lighting != NULL && !yyjson_is_bool(lighting))
+                    return validation_error(ctx, path, "render primitive lighting must be a boolean");
+            }
         }
     }
     return true;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1806,6 +1806,17 @@ static bool validate_data_condition(validation_context *ctx, yyjson_val *conditi
             return validation_error(ctx, path, "property.compare condition requires a value");
         return true;
     }
+    if (SDL_strcmp(type != NULL ? type : "", "scene_state.compare") == 0)
+    {
+        if (!is_non_empty_string(condition, "key"))
+            return validation_error(ctx, path, "scene_state.compare condition requires a non-empty key");
+        if (!is_compare_op(json_string(condition, "op")))
+            return validation_error(ctx, path,
+                                    "scene_state.compare condition requires a supported comparison operator");
+        if (obj_get(condition, "value") == NULL)
+            return validation_error(ctx, path, "scene_state.compare condition requires a value");
+        return true;
+    }
     if (SDL_strcmp(type != NULL ? type : "", "not") == 0)
     {
         char child_path[PATH_BUFFER_SIZE];
@@ -1949,6 +1960,7 @@ static bool validate_render_effects(validation_context *ctx, yyjson_val *root, v
                         return validation_error(ctx, path, "flash effect requires a non-empty property");
                 }
                 else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0 &&
+                         SDL_strcmp(type != NULL ? type : "", "drift") != 0 &&
                          SDL_strcmp(type != NULL ? type : "", "emissive") != 0)
                 {
                     return validation_error(ctx, path, "unsupported render effect type '%s'",
@@ -2403,6 +2415,15 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             const char *signal = json_string(item, "signal");
             if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, item_path))
                 return false;
+            yyjson_val *scene_state = obj_get(item, "scene_state");
+            if (scene_state != NULL)
+            {
+                if (!yyjson_is_obj(scene_state))
+                    return validation_error(ctx, item_path, "scene menu item scene_state must be an object");
+                if (!is_non_empty_string(scene_state, "key") || !is_non_empty_string(scene_state, "value"))
+                    return validation_error(ctx, item_path,
+                                            "scene menu item scene_state requires non-empty key and value");
+            }
             yyjson_val *return_scene = obj_get(item, "return_scene");
             if (return_scene != NULL && !yyjson_is_bool(return_scene))
                 return validation_error(ctx, item_path, "scene menu item return_scene must be a boolean");
@@ -2450,6 +2471,9 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.visible_if", menu_path);
         if (!validate_scene_ui_condition(ctx, obj_get(presenter, "visible_if"), condition_path, names))
+            return false;
+        format_path(condition_path, sizeof(condition_path), "%s.active_if", menu_path);
+        if (!validate_scene_ui_condition(ctx, obj_get(presenter, "active_if"), condition_path, names))
             return false;
     }
 

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -617,7 +617,7 @@ bool sdl3d_game_data_draw_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_
     context.pulse_phase = pulse_phase;
     context.ok = true;
 
-    return sdl3d_game_data_for_each_ui_text(runtime, draw_ui_text, &context) && context.ok;
+    return sdl3d_game_data_for_each_ui_text_for_metrics(runtime, metrics, draw_ui_text, &context) && context.ok;
 }
 
 bool sdl3d_game_data_draw_ui_images(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -823,6 +823,8 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
                 out_result->quit = false;
                 out_result->scene = NULL;
                 out_result->return_to = NULL;
+                out_result->scene_state_key = NULL;
+                out_result->scene_state_value = NULL;
                 out_result->return_scene = false;
                 out_result->pause_command = SDL3D_GAME_DATA_MENU_PAUSE_NONE;
                 out_result->has_return_paused = false;
@@ -840,6 +842,10 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
             out_result->quit = !control_adjust_input && !out_result->control_changed && item.quit;
             out_result->scene = !control_adjust_input && !out_result->control_changed ? item.scene : NULL;
             out_result->return_to = !control_adjust_input && !out_result->control_changed ? item.return_to : NULL;
+            out_result->scene_state_key =
+                !control_adjust_input && !out_result->control_changed ? item.scene_state_key : NULL;
+            out_result->scene_state_value =
+                !control_adjust_input && !out_result->control_changed ? item.scene_state_value : NULL;
             out_result->return_scene = !control_adjust_input && !out_result->control_changed && item.return_scene;
             out_result->signal_id = out_result->selected ? item.signal_id : -1;
             out_result->pause_command = !control_adjust_input && !out_result->control_changed
@@ -1188,6 +1194,8 @@ static bool app_flow_consume_menu(sdl3d_game_data_app_flow *flow, sdl3d_game_con
     sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
     if (result.return_to != NULL && scene_state != NULL)
         sdl3d_properties_set_string(scene_state, "return_scene", result.return_to);
+    if (result.scene_state_key != NULL && result.scene_state_value != NULL && scene_state != NULL)
+        sdl3d_properties_set_string(scene_state, result.scene_state_key, result.scene_state_value);
     if (result.has_return_paused && scene_state != NULL)
         sdl3d_properties_set_bool(scene_state, "return_paused", result.return_paused);
 

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -358,6 +358,9 @@ static bool draw_primitive(void *userdata, const sdl3d_game_data_render_primitiv
     if (context == NULL || context->renderer == NULL || primitive == NULL)
         return false;
 
+    const bool restore_lighting = sdl3d_is_lighting_enabled(context->renderer);
+    if (!primitive->lighting_enabled)
+        sdl3d_set_lighting_enabled(context->renderer, false);
     sdl3d_set_emissive(context->renderer, primitive->emissive_color.x, primitive->emissive_color.y,
                        primitive->emissive_color.z);
     if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
@@ -370,6 +373,8 @@ static bool draw_primitive(void *userdata, const sdl3d_game_data_render_primitiv
                           primitive->rings, primitive->color);
     }
     sdl3d_set_emissive(context->renderer, 0.0f, 0.0f, 0.0f);
+    if (!primitive->lighting_enabled)
+        sdl3d_set_lighting_enabled(context->renderer, restore_lighting);
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -51,6 +51,8 @@ struct RenderPrimitiveCapture
     int spheres = 0;
     bool saw_player_paddle = false;
     bool saw_ball = false;
+    bool saw_options_background = false;
+    bool saw_options_glow = false;
 };
 
 struct UiTextCapture
@@ -70,6 +72,7 @@ struct ParticleCapture
 {
     int count = 0;
     bool saw_ambient = false;
+    bool saw_options_flow = false;
 };
 
 struct EvaluatedPrimitiveCapture
@@ -793,6 +796,24 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_EQ(primitive->slices, 18);
         EXPECT_TRUE(primitive->emissive);
     }
+    if (std::string(primitive->entity_name) == "entity.options.background.base")
+    {
+        capture->saw_options_background = true;
+        EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_CUBE);
+        EXPECT_NEAR(primitive->position.z, -0.65f, 0.0001f);
+        EXPECT_NEAR(primitive->size.x, 22.0f, 0.0001f);
+        EXPECT_EQ(primitive->color.r, 9);
+        EXPECT_EQ(primitive->color.g, 10);
+        EXPECT_EQ(primitive->color.b, 24);
+        EXPECT_TRUE(primitive->emissive);
+    }
+    if (std::string(primitive->entity_name) == "entity.options.glow.magenta")
+    {
+        capture->saw_options_glow = true;
+        EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_SPHERE);
+        EXPECT_NEAR(primitive->radius, 1.35f, 0.0001f);
+        EXPECT_TRUE(primitive->emissive);
+    }
     return true;
 }
 
@@ -826,6 +847,14 @@ bool capture_particle(void *userdata, const sdl3d_game_data_particle_emitter *em
         capture->saw_ambient = true;
         EXPECT_EQ(emitter->config.max_particles, 360);
         EXPECT_NEAR(emitter->draw_emissive.x, 0.8f, 0.0001f);
+    }
+    if (std::string(emitter->entity_name) == "entity.options.flow.magenta")
+    {
+        capture->saw_options_flow = true;
+        EXPECT_EQ(emitter->config.max_particles, 140);
+        EXPECT_NEAR(emitter->draw_emissive.x, 1.0f, 0.0001f);
+        EXPECT_FALSE(emitter->config.depth_test);
+        EXPECT_TRUE(emitter->config.additive_blend);
     }
     return true;
 }
@@ -1303,6 +1332,37 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_TRUE(saw_title_exit);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_renders_world(runtime));
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
+    EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.options.background.base"));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.options.flow.magenta"));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
+
+    RenderPrimitiveCapture options_render{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &options_render));
+    EXPECT_EQ(options_render.cubes, 1);
+    EXPECT_EQ(options_render.spheres, 3);
+    EXPECT_TRUE(options_render.saw_options_background);
+    EXPECT_TRUE(options_render.saw_options_glow);
+
+    ParticleCapture options_particles{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_particle_emitter(runtime, capture_particle, &options_particles));
+    EXPECT_EQ(options_particles.count, 3);
+    EXPECT_TRUE(options_particles.saw_options_flow);
+
+    const char *option_submenus[] = {"scene.options.display", "scene.options.keyboard", "scene.options.mouse",
+                                     "scene.options.gamepad", "scene.options.audio"};
+    for (const char *scene : option_submenus)
+    {
+        ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, scene));
+        EXPECT_TRUE(sdl3d_game_data_active_scene_renders_world(runtime)) << scene;
+        EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead") << scene;
+        EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.options.background.base")) << scene;
+        EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball")) << scene;
+    }
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.options");
     EXPECT_EQ(menu.item_count, 6);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -806,7 +806,9 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_EQ(primitive->color.r, 0);
         EXPECT_EQ(primitive->color.g, 0);
         EXPECT_EQ(primitive->color.b, 0);
-        EXPECT_TRUE(primitive->emissive);
+        EXPECT_FALSE(primitive->lighting_enabled);
+        EXPECT_FALSE(primitive->emissive);
+        EXPECT_NEAR(primitive->emissive_color.x, 0.0f, 0.0001f);
     }
     if (std::string(primitive->entity_name) == "entity.options.glow.magenta")
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -79,6 +79,7 @@ struct EvaluatedPrimitiveCapture
 {
     bool saw_border = false;
     bool saw_ball = false;
+    bool saw_options_drift = false;
 };
 
 struct ScenePayloadCapture
@@ -802,16 +803,16 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_CUBE);
         EXPECT_NEAR(primitive->position.z, -0.65f, 0.0001f);
         EXPECT_NEAR(primitive->size.x, 22.0f, 0.0001f);
-        EXPECT_EQ(primitive->color.r, 9);
-        EXPECT_EQ(primitive->color.g, 10);
-        EXPECT_EQ(primitive->color.b, 24);
+        EXPECT_EQ(primitive->color.r, 0);
+        EXPECT_EQ(primitive->color.g, 0);
+        EXPECT_EQ(primitive->color.b, 0);
         EXPECT_TRUE(primitive->emissive);
     }
     if (std::string(primitive->entity_name) == "entity.options.glow.magenta")
     {
         capture->saw_options_glow = true;
         EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_SPHERE);
-        EXPECT_NEAR(primitive->radius, 1.35f, 0.0001f);
+        EXPECT_NEAR(primitive->radius, 1.05f, 0.0001f);
         EXPECT_TRUE(primitive->emissive);
     }
     return true;
@@ -851,10 +852,11 @@ bool capture_particle(void *userdata, const sdl3d_game_data_particle_emitter *em
     if (std::string(emitter->entity_name) == "entity.options.flow.magenta")
     {
         capture->saw_options_flow = true;
-        EXPECT_EQ(emitter->config.max_particles, 140);
+        EXPECT_EQ(emitter->config.max_particles, 130);
         EXPECT_NEAR(emitter->draw_emissive.x, 1.0f, 0.0001f);
         EXPECT_FALSE(emitter->config.depth_test);
         EXPECT_TRUE(emitter->config.additive_blend);
+        EXPECT_LT(emitter->config.size_start, 0.04f);
     }
     return true;
 }
@@ -873,6 +875,13 @@ bool capture_evaluated_primitive(void *userdata, const sdl3d_game_data_render_pr
     {
         capture->saw_ball = true;
         EXPECT_GT(primitive->emissive_color.x, 0.7f);
+    }
+    if (std::string(primitive->entity_name) == "entity.options.glow.magenta")
+    {
+        capture->saw_options_drift = true;
+        EXPECT_NE(primitive->position.x, -4.6f);
+        EXPECT_GT(primitive->radius, 1.05f);
+        EXPECT_GT(primitive->emissive_color.x, 0.2f);
     }
     return true;
 }
@@ -1161,7 +1170,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     UiTextCapture ui{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui));
-    EXPECT_EQ(ui.count, 14);
+    EXPECT_EQ(ui.count, 7);
     EXPECT_TRUE(ui.saw_score);
     EXPECT_TRUE(ui.saw_pause);
 
@@ -1351,6 +1360,13 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_EQ(options_particles.count, 3);
     EXPECT_TRUE(options_particles.saw_options_flow);
 
+    sdl3d_game_data_render_eval options_eval{};
+    options_eval.time = 1.0f;
+    EvaluatedPrimitiveCapture options_evaluated{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive_evaluated(runtime, &options_eval, capture_evaluated_primitive,
+                                                                    &options_evaluated));
+    EXPECT_TRUE(options_evaluated.saw_options_drift);
+
     const char *option_submenus[] = {"scene.options.display", "scene.options.keyboard", "scene.options.mouse",
                                      "scene.options.gamepad", "scene.options.audio"};
     for (const char *scene : option_submenus)
@@ -1368,10 +1384,14 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_EQ(menu.item_count, 6);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Display");
-    EXPECT_STREQ(item.scene, "scene.options.display");
+    EXPECT_EQ(item.scene, nullptr);
+    EXPECT_STREQ(item.scene_state_key, "options_menu");
+    EXPECT_STREQ(item.scene_state_value, "display");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
     EXPECT_STREQ(item.label, "Mouse");
-    EXPECT_STREQ(item.scene, "scene.options.mouse");
+    EXPECT_EQ(item.scene, nullptr);
+    EXPECT_STREQ(item.scene_state_key, "options_menu");
+    EXPECT_STREQ(item.scene_state_value, "mouse");
     bool saw_options_display = false;
     bool saw_options_divider = false;
     auto find_options_display = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
@@ -1904,16 +1924,25 @@ TEST(GameDataRuntime, OptionsSubmenusDoNotOverwriteCallerReturnScene)
     sdl3d_game_data_menu_item item{};
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 0, &item));
     EXPECT_STREQ(item.label, "Display");
-    EXPECT_STREQ(item.scene, "scene.options.display");
+    EXPECT_EQ(item.scene, nullptr);
+    EXPECT_STREQ(item.scene_state_key, "options_menu");
+    EXPECT_STREQ(item.scene_state_value, "display");
     EXPECT_EQ(item.return_to, nullptr);
 
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+    sdl3d_properties_set_string(scene_state, "options_menu", "display");
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options.display");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options.display", 4, &item));
     EXPECT_STREQ(item.label, "Back");
-    EXPECT_STREQ(item.scene, "scene.options");
+    EXPECT_EQ(item.scene, nullptr);
+    EXPECT_STREQ(item.scene_state_key, "options_menu");
+    EXPECT_STREQ(item.scene_state_value, "root");
     EXPECT_FALSE(item.return_scene);
 
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
+    sdl3d_properties_set_string(scene_state, "options_menu", "root");
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.options");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, "menu.options", 5, &item));
     EXPECT_STREQ(item.label, "Back");
     EXPECT_TRUE(item.return_scene);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1313,23 +1313,31 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(item.label, "Mouse");
     EXPECT_STREQ(item.scene, "scene.options.mouse");
     bool saw_options_display = false;
+    bool saw_options_divider = false;
     auto find_options_display = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
-        auto *saw = static_cast<bool *>(userdata);
+        auto *flags = static_cast<std::pair<bool *, bool *> *>(userdata);
         const std::string name = text->name != nullptr ? text->name : "";
         const std::string value = text->text != nullptr ? text->text : "";
         if (name == "ui.options.menu" && value == "Display")
         {
-            *saw = true;
+            *flags->first = true;
             EXPECT_FLOAT_EQ(text->x, 0.43f);
             EXPECT_FLOAT_EQ(text->y, 0.36f);
             EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
             EXPECT_TRUE(text->pulse_alpha);
-            return false;
         }
-        return true;
+        if (name == "ui.options.title.divider" && value == "----------------")
+        {
+            *flags->second = true;
+            EXPECT_FLOAT_EQ(text->x, 0.5f);
+            EXPECT_FLOAT_EQ(text->y, 0.275f);
+        }
+        return !*flags->first || !*flags->second;
     };
-    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_options_display, &saw_options_display));
+    std::pair<bool *, bool *> options_display_flags{&saw_options_display, &saw_options_divider};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_options_display, &options_display_flags));
     EXPECT_TRUE(saw_options_display);
+    EXPECT_TRUE(saw_options_divider);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.keyboard"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
@@ -1353,6 +1361,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         if (name == "ui.options.keyboard.menu" && value == "Up: Up")
         {
             *saw->first = true;
+            EXPECT_FLOAT_EQ(text->y, 0.29f);
         }
         if (name == "ui.options.keyboard.menu" && value == "Cancel: Backspace")
         {
@@ -1427,7 +1436,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         if (name == "ui.options.audio.menu" && value == "Sound Effects  [########--] 8/10")
         {
             *flags->first = true;
-            EXPECT_FLOAT_EQ(text->x, 0.28f);
+            EXPECT_FLOAT_EQ(text->x, 0.34f);
             EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
         }
         if (name == "ui.options.audio.menu" && value == "Music  [#######---] 7/10")
@@ -2134,14 +2143,14 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredInputBindings)
         {
             *flags->first = true;
             EXPECT_FLOAT_EQ(text->x, 0.34f);
-            EXPECT_FLOAT_EQ(text->y, 0.15f);
+            EXPECT_FLOAT_EQ(text->y, 0.24f);
             EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
         }
         if (name == "ui.options.gamepad.menu" && value.rfind("Ball Camera:", 0) == 0)
         {
             *flags->second = true;
             EXPECT_FLOAT_EQ(text->x, 0.34f);
-            EXPECT_NEAR(text->y, 0.699f, 0.0001f);
+            EXPECT_NEAR(text->y, 0.735f, 0.0001f);
             EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
         }
         return !*flags->first || !*flags->second;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1289,7 +1289,8 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         if (name == "ui.title.menu" && value == "Exit")
         {
             *flags->second = true;
-            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_CENTER);
+            EXPECT_FLOAT_EQ(text->x, 0.45f);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
             EXPECT_TRUE(text->pulse_alpha);
         }
         if (*flags->first && *flags->second)
@@ -1319,9 +1320,9 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         if (name == "ui.options.menu" && value == "Display")
         {
             *saw = true;
-            EXPECT_FLOAT_EQ(text->x, 0.5f);
+            EXPECT_FLOAT_EQ(text->x, 0.43f);
             EXPECT_FLOAT_EQ(text->y, 0.36f);
-            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_CENTER);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
             EXPECT_TRUE(text->pulse_alpha);
             return false;
         }
@@ -1386,6 +1387,8 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         if (name == "ui.options.display.menu" && value == "Display Mode: Windowed")
         {
             *saw = true;
+            EXPECT_FLOAT_EQ(text->x, 0.3f);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
             return false;
         }
         return true;
@@ -1422,7 +1425,11 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
         const std::string name = text->name != nullptr ? text->name : "";
         const std::string value = text->text != nullptr ? text->text : "";
         if (name == "ui.options.audio.menu" && value == "Sound Effects  [########--] 8/10")
+        {
             *flags->first = true;
+            EXPECT_FLOAT_EQ(text->x, 0.28f);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
+        }
         if (name == "ui.options.audio.menu" && value == "Music  [#######---] 7/10")
             *flags->second = true;
         if (*flags->first && *flags->second)
@@ -2116,6 +2123,33 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredInputBindings)
     EXPECT_EQ(item.input_binding_count, 2);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 10, &item));
     EXPECT_STREQ(item.label, "Reset Settings");
+
+    bool saw_button_icons = false;
+    bool saw_ball_camera = false;
+    auto find_gamepad_labels = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *flags = static_cast<std::pair<bool *, bool *> *>(userdata);
+        const std::string name = text->name != nullptr ? text->name : "";
+        const std::string value = text->text != nullptr ? text->text : "";
+        if (name == "ui.options.gamepad.menu" && value == "Button Icons: Xbox")
+        {
+            *flags->first = true;
+            EXPECT_FLOAT_EQ(text->x, 0.34f);
+            EXPECT_FLOAT_EQ(text->y, 0.15f);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
+        }
+        if (name == "ui.options.gamepad.menu" && value.rfind("Ball Camera:", 0) == 0)
+        {
+            *flags->second = true;
+            EXPECT_FLOAT_EQ(text->x, 0.34f);
+            EXPECT_NEAR(text->y, 0.699f, 0.0001f);
+            EXPECT_EQ(text->align, SDL3D_GAME_DATA_UI_ALIGN_LEFT);
+        }
+        return !*flags->first || !*flags->second;
+    };
+    std::pair<bool *, bool *> gamepad_label_flags{&saw_button_icons, &saw_ball_camera};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_gamepad_labels, &gamepad_label_flags));
+    EXPECT_TRUE(saw_button_icons);
+    EXPECT_TRUE(saw_ball_camera);
 
     sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1206,6 +1206,25 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_pause_visible, &pause_args));
     EXPECT_TRUE(pause_visible);
 
+    struct PauseMenuTextArgs
+    {
+        bool saw_resume = false;
+        bool saw_options = false;
+    } pause_menu_text;
+    auto find_pause_menu_text = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *args = static_cast<PauseMenuTextArgs *>(userdata);
+        if (std::string(text->name) != "ui.pause.menu")
+            return true;
+        const std::string value = text->text != nullptr ? text->text : "";
+        args->saw_resume = args->saw_resume || value == "Resume";
+        args->saw_options = args->saw_options || value == "Options";
+        return !(args->saw_resume && args->saw_options);
+    };
+    ASSERT_TRUE(
+        sdl3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, find_pause_menu_text, &pause_menu_text));
+    EXPECT_TRUE(pause_menu_text.saw_resume);
+    EXPECT_TRUE(pause_menu_text.saw_options);
+
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
     remove_test_dir(dir);

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -227,6 +227,8 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     yyjson_val *options = required_object(scenes, "standard_options");
     EXPECT_EQ(required_string(options, "settings"), "entity.settings");
     EXPECT_EQ(required_string(options, "return_scene"), "scene.title");
+    EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(options, "single_scene")));
+    EXPECT_EQ(required_string(options, "menu_state_key"), "options_menu");
     yyjson_val *background = required_object(options, "background");
     EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(background, "renders_world")));
     EXPECT_EQ(required_string(background, "camera"), "camera.overhead");

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -227,6 +227,13 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     yyjson_val *options = required_object(scenes, "standard_options");
     EXPECT_EQ(required_string(options, "settings"), "entity.settings");
     EXPECT_EQ(required_string(options, "return_scene"), "scene.title");
+    yyjson_val *background = required_object(options, "background");
+    EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(background, "renders_world")));
+    EXPECT_EQ(required_string(background, "camera"), "camera.overhead");
+    yyjson_val *background_entities = required_array(background, "entities");
+    ASSERT_GE(yyjson_arr_size(background_entities), 7u);
+    EXPECT_STREQ(yyjson_get_str(yyjson_arr_get(background_entities, 0)), "entity.options.background.base");
+    EXPECT_STREQ(yyjson_get_str(yyjson_arr_get(background_entities, 4)), "entity.options.flow.magenta");
     yyjson_val *theme = required_object(options, "theme");
     EXPECT_EQ(required_string(theme, "cursor"), ">");
     EXPECT_EQ(required_string(theme, "slider_fill"), "#");

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -234,7 +234,8 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     yyjson_val *layout = required_object(options, "layout");
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(layout, "title_x")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(layout, "status_y")));
-    EXPECT_EQ(required_string(layout, "menu_align"), "center");
+    EXPECT_EQ(required_string(layout, "menu_align"), "left");
+    EXPECT_EQ(required_string(layout, "cursor_align"), "right");
     EXPECT_TRUE(yyjson_is_bool(yyjson_obj_get(layout, "selected_pulse_alpha")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "root"), "menu_y")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "audio"), "cursor_offset_x")));

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -237,6 +237,7 @@ TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
     EXPECT_EQ(required_string(layout, "menu_align"), "left");
     EXPECT_EQ(required_string(layout, "cursor_align"), "right");
     EXPECT_TRUE(yyjson_is_bool(yyjson_obj_get(layout, "selected_pulse_alpha")));
+    EXPECT_TRUE(yyjson_is_bool(yyjson_obj_get(layout, "title_divider")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "root"), "menu_y")));
     EXPECT_TRUE(yyjson_is_num(yyjson_obj_get(required_object(layout, "audio"), "cursor_offset_x")));
     EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(required_object(options, "bindings"), "keyboard")));


### PR DESCRIPTION
## Summary
- left-align Pong title, options, and child menu labels around centered menu columns
- add per-scene menu_x support to the standard options generator so reusable templates can center left-aligned menu blocks cleanly
- give the gamepad options scene more vertical spacing and a higher starting point so the dense binding list breathes
- update standard-options docs and tests for the new layout contract

## Verification
- cmake --build build/release --target sdl3d_game_data_test game_data_json_test pong_demo -j 8
- ctest --test-dir build/release -R 'GameDataRuntime|GameDataJson' --output-on-failure
- ctest --test-dir build/release --output-on-failure (993 passed, 1 skipped OpenGL availability fixture)
- make format
- git diff --check