### PR TITLE
Add multi-gamepad input slots and rumble support

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -134,13 +134,15 @@
         "down": "action.menu.down",
         "left": "action.menu.left",
         "right": "action.menu.right",
-        "select": "action.menu.select"
+        "select": "action.menu.select",
+        "back": "action.menu.back"
       },
       "signals": {
         "move": "signal.ui.menu.move",
         "select": "signal.ui.menu.select",
         "apply": "signal.settings.apply",
         "apply_audio": "signal.settings.apply_audio",
+        "vibration": "signal.settings.vibration",
         "reset_display": "signal.settings.reset_display",
         "reset_keyboard": "signal.settings.reset_keyboard",
         "reset_mouse": "signal.settings.reset_mouse",
@@ -569,14 +571,16 @@
             "name": "action.menu.up",
             "bindings": [
               { "device": "keyboard", "key": "UP" },
-              { "device": "gamepad", "button": "DPAD_UP" }
+              { "device": "gamepad", "button": "DPAD_UP" },
+              { "device": "gamepad", "axis": "left_y", "scale": -1.0 }
             ]
           },
           {
             "name": "action.menu.down",
             "bindings": [
               { "device": "keyboard", "key": "DOWN" },
-              { "device": "gamepad", "button": "DPAD_DOWN" }
+              { "device": "gamepad", "button": "DPAD_DOWN" },
+              { "device": "gamepad", "axis": "left_y", "scale": 1.0 }
             ]
           },
           {
@@ -584,7 +588,8 @@
             "bindings": [
               { "device": "keyboard", "key": "LEFT" },
               { "device": "keyboard", "key": "A" },
-              { "device": "gamepad", "button": "DPAD_LEFT" }
+              { "device": "gamepad", "button": "DPAD_LEFT" },
+              { "device": "gamepad", "axis": "left_x", "scale": -1.0 }
             ]
           },
           {
@@ -592,7 +597,15 @@
             "bindings": [
               { "device": "keyboard", "key": "RIGHT" },
               { "device": "keyboard", "key": "D" },
-              { "device": "gamepad", "button": "DPAD_RIGHT" }
+              { "device": "gamepad", "button": "DPAD_RIGHT" },
+              { "device": "gamepad", "axis": "left_x", "scale": 1.0 }
+            ]
+          },
+          {
+            "name": "action.menu.back",
+            "bindings": [
+              { "device": "keyboard", "key": "ESCAPE" },
+              { "device": "gamepad", "button": "EAST" }
             ]
           },
           {
@@ -1280,6 +1293,7 @@
     "signal.persistence.save_options",
     "signal.settings.apply",
     "signal.settings.apply_audio",
+    "signal.settings.vibration",
     "signal.settings.reset_display",
     "signal.settings.reset_keyboard",
     "signal.settings.reset_mouse",
@@ -1459,6 +1473,12 @@
         "actions": [
           { "type": "property.reset_defaults", "target": "entity.settings", "keys": ["gamepad_icons", "vibration"] },
           { "type": "input.reset_bindings", "menu": "menu.options.gamepad" },
+          { "type": "signal.emit", "signal": "signal.persistence.save_options" }
+        ]
+      },
+      {
+        "signal": "signal.settings.vibration",
+        "actions": [
           { "type": "signal.emit", "signal": "signal.persistence.save_options" }
         ]
       },

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -50,8 +50,8 @@ static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_prope
     {
         if (!sdl3d_input_rumble_all_gamepads(state->input, 0.30f, 0.70f, 100))
         {
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "Pong vibration feedback requested but no rumble-capable gamepad accepted it");
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Pong vibration feedback requested but no rumble-capable gamepad accepted it");
         }
         return;
     }
@@ -66,8 +66,8 @@ static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_prope
     {
         if (!sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120))
         {
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "Pong paddle hit rumble requested but no rumble-capable gamepad accepted it");
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Pong paddle hit rumble requested but no rumble-capable gamepad accepted it");
         }
     }
 }
@@ -143,6 +143,13 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     }
 
     state->input = sdl3d_game_session_get_input(ctx->session);
+    const int gamepad_count = state->input != NULL ? sdl3d_input_gamepad_count(state->input) : 0;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong gamepad count at init: %d", gamepad_count);
+    for (int i = 0; i < gamepad_count; ++i)
+    {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong gamepad slot: slot=%d id=%d connected=%d", i,
+                    sdl3d_input_gamepad_id_at(state->input, i), sdl3d_input_gamepad_is_connected(state->input, i));
+    }
     state->paddle_hit_connection = 0;
     state->vibration_connection = 0;
     state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -27,21 +27,38 @@ typedef struct pong_state
     sdl3d_game_data_frame_state frame_state;
     sdl3d_input_manager *input;
     int paddle_hit_connection;
+    int vibration_connection;
+    int ball_hit_signal_id;
+    int vibration_signal_id;
 } pong_state;
 
-static void on_ball_hit_paddle(void *userdata, int signal_id, const sdl3d_properties *payload)
+static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
     pong_state *state = (pong_state *)userdata;
+    const sdl3d_registered_actor *settings =
+        state != NULL ? sdl3d_game_data_find_actor(state->data, "entity.settings") : NULL;
+    const bool vibration_enabled = settings != NULL && sdl3d_properties_get_bool(settings->props, "vibration", false);
     const char *other_actor_name =
         payload != NULL ? sdl3d_properties_get_string(payload, "other_actor_name", NULL) : NULL;
-    (void)signal_id;
 
-    if (state == NULL || state->input == NULL || other_actor_name == NULL)
+    if (state == NULL || state->input == NULL)
     {
         return;
     }
 
-    if (SDL_strcmp(other_actor_name, "entity.paddle.player") == 0)
+    if (signal_id == state->vibration_signal_id)
+    {
+        (void)sdl3d_input_rumble_all_gamepads(state->input, 0.30f, 0.70f, 100);
+        return;
+    }
+
+    if (!vibration_enabled)
+    {
+        return;
+    }
+
+    if (signal_id == state->ball_hit_signal_id && other_actor_name != NULL &&
+        SDL_strcmp(other_actor_name, "entity.paddle.player") == 0)
     {
         (void)sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120);
     }
@@ -119,13 +136,20 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
 
     state->input = sdl3d_game_session_get_input(ctx->session);
     state->paddle_hit_connection = 0;
+    state->vibration_connection = 0;
+    state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
+    state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
     if (state->input != NULL)
     {
-        const int signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
-        if (signal_id >= 0)
+        if (state->ball_hit_signal_id >= 0)
         {
             state->paddle_hit_connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
-                                                                signal_id, on_ball_hit_paddle, state);
+                                                                state->ball_hit_signal_id, on_gamepad_feedback, state);
+        }
+        if (state->vibration_signal_id >= 0)
+        {
+            state->vibration_connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
+                                                               state->vibration_signal_id, on_gamepad_feedback, state);
         }
     }
     return true;
@@ -196,6 +220,11 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->paddle_hit_connection);
         state->paddle_hit_connection = 0;
+    }
+    if (state->vibration_connection > 0)
+    {
+        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->vibration_connection);
+        state->vibration_connection = 0;
     }
     state->input = NULL;
     sdl3d_game_data_destroy(state->data);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -4,11 +4,13 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include <stdbool.h>
+#include <string.h>
 
 #include "sdl3d/asset.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
 #include "sdl3d/game_presentation.h"
+#include "sdl3d/properties.h"
 
 #if SDL3D_PONG_EMBEDDED_ASSETS
 #include "sdl3d_pong_assets.h"
@@ -23,7 +25,27 @@ typedef struct pong_state
     sdl3d_game_data_particle_cache particle_cache;
     sdl3d_game_data_app_flow app_flow;
     sdl3d_game_data_frame_state frame_state;
+    sdl3d_input_manager *input;
+    int paddle_hit_connection;
 } pong_state;
+
+static void on_ball_hit_paddle(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    pong_state *state = (pong_state *)userdata;
+    const char *other_actor_name =
+        payload != NULL ? sdl3d_properties_get_string(payload, "other_actor_name", NULL) : NULL;
+    (void)signal_id;
+
+    if (state == NULL || state->input == NULL || other_actor_name == NULL)
+    {
+        return;
+    }
+
+    if (SDL_strcmp(other_actor_name, "entity.paddle.player") == 0)
+    {
+        (void)sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120);
+    }
+}
 
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
 {
@@ -94,6 +116,18 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         state->assets = NULL;
         return false;
     }
+
+    state->input = sdl3d_game_session_get_input(ctx->session);
+    state->paddle_hit_connection = 0;
+    if (state->input != NULL)
+    {
+        const int signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
+        if (signal_id >= 0)
+        {
+            state->paddle_hit_connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
+                                                                signal_id, on_ball_hit_paddle, state);
+        }
+    }
     return true;
 }
 
@@ -158,6 +192,12 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     sdl3d_game_data_particle_cache_free(&state->particle_cache);
     sdl3d_game_data_image_cache_free(&state->image_cache);
     sdl3d_game_data_font_cache_free(&state->font_cache);
+    if (state->paddle_hit_connection > 0)
+    {
+        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->paddle_hit_connection);
+        state->paddle_hit_connection = 0;
+    }
+    state->input = NULL;
     sdl3d_game_data_destroy(state->data);
     state->data = NULL;
     sdl3d_asset_resolver_destroy(state->assets);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -48,7 +48,11 @@ static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_prope
 
     if (signal_id == state->vibration_signal_id)
     {
-        (void)sdl3d_input_rumble_all_gamepads(state->input, 0.30f, 0.70f, 100);
+        if (!sdl3d_input_rumble_all_gamepads(state->input, 0.30f, 0.70f, 100))
+        {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "Pong vibration feedback requested but no rumble-capable gamepad accepted it");
+        }
         return;
     }
 
@@ -60,7 +64,11 @@ static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_prope
     if (signal_id == state->ball_hit_signal_id && other_actor_name != NULL &&
         SDL_strcmp(other_actor_name, "entity.paddle.player") == 0)
     {
-        (void)sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120);
+        if (!sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120))
+        {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "Pong paddle hit rumble requested but no rumble-capable gamepad accepted it");
+        }
     }
 }
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -468,6 +468,8 @@ extern "C"
         int right_action_id;
         /** @brief Input action that activates the selected item, or -1. */
         int select_action_id;
+        /** @brief Input action that activates the menu's back item, or -1. */
+        int back_action_id;
         /** @brief Signal emitted after successful navigation, or -1. */
         int move_signal_id;
         /** @brief Signal emitted when the selected item is activated, or -1. */

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -30,6 +30,7 @@ extern "C"
 #define SDL3D_INPUT_MAX_ACTIONS 64
 #define SDL3D_INPUT_MAX_BINDINGS 128
 #define SDL3D_INPUT_ACTION_NAME_MAX 32
+#define SDL3D_INPUT_MAX_GAMEPADS 4
 
     /**
      * @brief Physical input source kind for an action binding.
@@ -196,6 +197,85 @@ extern "C"
     void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id);
 
     /* ================================================================== */
+    /* Gamepad state                                                      */
+    /* ================================================================== */
+
+    /**
+     * @brief Return the number of connected gamepad slots.
+     *
+     * SDL3D tracks up to four simultaneous gamepads. Slots remain stable for
+     * the lifetime of a connected controller and are reused when controllers
+     * disconnect and new ones are added.
+     */
+    int sdl3d_input_gamepad_count(const sdl3d_input_manager *input);
+
+    /**
+     * @brief Return true if a gamepad slot is connected.
+     *
+     * @param gamepad_index Slot index in [0, SDL3D_INPUT_MAX_GAMEPADS).
+     */
+    bool sdl3d_input_gamepad_is_connected(const sdl3d_input_manager *input, int gamepad_index);
+
+    /**
+     * @brief Return the SDL joystick instance id for a gamepad slot.
+     *
+     * Returns 0 when the slot is invalid or disconnected.
+     */
+    SDL_JoystickID sdl3d_input_gamepad_id_at(const sdl3d_input_manager *input, int gamepad_index);
+
+    /**
+     * @brief Return true when a gamepad button is held for a given slot.
+     *
+     * This is a direct state query, separate from the action system's
+     * pressed/released edge tracking.
+     */
+    bool sdl3d_input_is_gamepad_button_held(const sdl3d_input_manager *input, int gamepad_index,
+                                            SDL_GamepadButton button);
+
+    /** @brief Return the normalized axis value for one gamepad slot. */
+    float sdl3d_input_get_gamepad_axis(const sdl3d_input_manager *input, int gamepad_index, SDL_GamepadAxis axis);
+
+    /** @brief Return the left stick vector for one gamepad slot. */
+    sdl3d_vec2 sdl3d_input_get_gamepad_left_stick(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return the right stick vector for one gamepad slot. */
+    sdl3d_vec2 sdl3d_input_get_gamepad_right_stick(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return true when the left stick press is held for one gamepad slot. */
+    bool sdl3d_input_is_gamepad_left_stick_pressed(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return true when the right stick press is held for one gamepad slot. */
+    bool sdl3d_input_is_gamepad_right_stick_pressed(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return true when any face button is held for one gamepad slot. */
+    bool sdl3d_input_is_gamepad_face_button_pressed(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return true when Start is held for one gamepad slot. */
+    bool sdl3d_input_is_gamepad_start_pressed(const sdl3d_input_manager *input, int gamepad_index);
+
+    /** @brief Return true when Select/Back is held for one gamepad slot. */
+    bool sdl3d_input_is_gamepad_select_pressed(const sdl3d_input_manager *input, int gamepad_index);
+
+    /**
+     * @brief Start rumble on one connected gamepad slot.
+     *
+     * The strength values are normalized in [0, 1]. Returns false when the
+     * slot is invalid, disconnected, or rumble is unavailable.
+     */
+    bool sdl3d_input_rumble_gamepad(sdl3d_input_manager *input, int gamepad_index, float low_frequency_rumble,
+                                    float high_frequency_rumble, Uint32 duration_ms);
+
+    /**
+     * @brief Start rumble on every connected gamepad slot.
+     *
+     * Returns true when at least one controller accepted rumble. If no
+     * controllers are connected, or none support rumble, the call returns
+     * false.
+     */
+    bool sdl3d_input_rumble_all_gamepads(sdl3d_input_manager *input, float low_frequency_rumble,
+                                         float high_frequency_rumble, Uint32 duration_ms);
+
+    /* ================================================================== */
     /* Per-frame processing                                                */
     /* ================================================================== */
 
@@ -203,7 +283,8 @@ extern "C"
      * @brief Process one SDL event.
      *
      * Call this before gameplay event handling so the input manager can track
-     * key/button edges, mouse deltas, wheel deltas, and gamepad hotplug.
+     * key/button edges, mouse deltas, wheel deltas, and hot-plugged gamepad
+     * slots.
      */
     void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *event);
 

--- a/src/game.c
+++ b/src/game.c
@@ -180,6 +180,7 @@ bool sdl3d_game_session_create(const sdl3d_game_session_desc *desc, sdl3d_game_s
             sdl3d_game_session_destroy(session);
             return false;
         }
+        sdl3d_input_bind_ui_defaults(session->input);
     }
 
     if (session_owns_service(effective, SDL3D_GAME_SESSION_SERVICE_AUDIO))

--- a/src/game.c
+++ b/src/game.c
@@ -460,7 +460,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
     SDL_zero(ctx);
     SDL_SetMainReady();
 
-    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD))
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC))
     {
         return 1;
     }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3831,6 +3831,7 @@ bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *
         out_menu->left_action_id = -1;
         out_menu->right_action_id = -1;
         out_menu->select_action_id = -1;
+        out_menu->back_action_id = -1;
         out_menu->move_signal_id = -1;
         out_menu->select_signal_id = -1;
     }
@@ -3847,6 +3848,7 @@ bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *
     out_menu->left_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "left_action", NULL));
     out_menu->right_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "right_action", NULL));
     out_menu->select_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "select_action", NULL));
+    out_menu->back_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "back_action", NULL));
     out_menu->move_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "move_signal", NULL));
     out_menu->select_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "select_signal", NULL));
     out_menu->selected_index = state->selected_index;

--- a/src/game_data_standard_options.c
+++ b/src/game_data_standard_options.c
@@ -59,10 +59,12 @@ typedef struct standard_options_config
     const char *left_action;
     const char *right_action;
     const char *select_action;
+    const char *back_action;
     const char *move_signal;
     const char *select_signal;
     const char *apply_signal;
     const char *apply_audio_signal;
+    const char *vibration_signal;
     const char *reset_display_signal;
     const char *reset_keyboard_signal;
     const char *reset_mouse_signal;
@@ -242,7 +244,9 @@ static bool add_scene_input(yyjson_mut_doc *doc, yyjson_mut_val *scene, const st
     if (include_lr &&
         (!add_arr_str(doc, actions, config->left_action) || !add_arr_str(doc, actions, config->right_action)))
         return false;
-    return add_arr_str(doc, actions, config->select_action);
+    if (!add_arr_str(doc, actions, config->select_action))
+        return false;
+    return config->back_action == NULL || add_arr_str(doc, actions, config->back_action);
 }
 
 static bool add_scene_transitions(yyjson_mut_doc *doc, yyjson_mut_val *scene, const standard_options_config *config)
@@ -295,6 +299,7 @@ static yyjson_mut_val *add_menu(yyjson_mut_doc *doc, yyjson_mut_val *scene, cons
                        !add_str(doc, menu, "right_action", config->right_action)))
         return NULL;
     if (!add_str(doc, menu, "select_action", config->select_action) ||
+        (config->back_action != NULL && !add_str(doc, menu, "back_action", config->back_action)) ||
         !add_str(doc, menu, "move_signal", config->move_signal) ||
         !add_str(doc, menu, "select_signal", config->select_signal) ||
         !add_scene_state_condition(doc, menu, "active_if", config, active_state, default_active) ||
@@ -637,7 +642,7 @@ static bool add_gamepad_content(yyjson_mut_doc *doc, yyjson_mut_val *scene, cons
     yyjson_mut_val *ui = NULL;
     yyjson_mut_val *texts = NULL;
     return items != NULL && add_gamepad_icons_item(doc, items, config) &&
-           add_toggle_item(doc, items, "Vibration", NULL, config->settings_actor, "vibration") &&
+           add_toggle_item(doc, items, "Vibration", config->vibration_signal, config->settings_actor, "vibration") &&
            add_input_binding_items(doc, items, obj_get(config->bindings, "gamepad")) &&
            add_reset_item(doc, items, config->reset_gamepad_signal) &&
            (active_state != NULL ? add_menu_state_item(doc, items, config, "Back", "root")
@@ -691,9 +696,9 @@ static yyjson_doc *build_root_scene(const standard_options_config *config)
 static yyjson_doc *build_display_scene(const standard_options_config *config)
 {
     yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
-    yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->display_scene, false) : NULL;
+    yyjson_mut_val *scene = doc != NULL ? create_scene(doc, config, config->display_scene, true) : NULL;
     yyjson_mut_val *items =
-        scene != NULL ? add_menu(doc, scene, config, config->display_menu, false, NULL, false) : NULL;
+        scene != NULL ? add_menu(doc, scene, config, config->display_menu, true, NULL, false) : NULL;
     if (items == NULL || !add_display_mode_item(doc, items, config) ||
         !add_toggle_item(doc, items, "Vsync", config->apply_signal, config->settings_actor, "vsync") ||
         !add_renderer_item(doc, items, config) || !add_reset_item(doc, items, config->reset_display_signal) ||
@@ -869,10 +874,12 @@ static bool load_config(yyjson_val *game_root, const char *package_name, standar
     config->left_action = section_string(root, "actions", "left", "action.menu.left");
     config->right_action = section_string(root, "actions", "right", "action.menu.right");
     config->select_action = section_string(root, "actions", "select", "action.menu.select");
+    config->back_action = section_string(root, "actions", "back", NULL);
     config->move_signal = section_string(root, "signals", "move", "signal.ui.menu.move");
     config->select_signal = section_string(root, "signals", "select", "signal.ui.menu.select");
     config->apply_signal = section_string(root, "signals", "apply", "signal.settings.apply");
     config->apply_audio_signal = section_string(root, "signals", "apply_audio", "signal.settings.apply_audio");
+    config->vibration_signal = section_string(root, "signals", "vibration", "signal.settings.vibration");
     config->reset_display_signal = section_string(root, "signals", "reset_display", "signal.settings.reset_display");
     config->reset_keyboard_signal = section_string(root, "signals", "reset_keyboard", "signal.settings.reset_keyboard");
     config->reset_mouse_signal = section_string(root, "signals", "reset_mouse", "signal.settings.reset_mouse");

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -860,10 +860,10 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
                 out_result->select_signal_id = refreshed.select_signal_id;
                 out_result->quit = item.quit;
                 out_result->scene = item.scene;
-                out_result->return_to = item.return_to != NULL ? item.return_to : item.scene;
+                out_result->return_to = item.return_to;
                 out_result->scene_state_key = item.scene_state_key;
                 out_result->scene_state_value = item.scene_state_value;
-                out_result->return_scene = true;
+                out_result->return_scene = item.return_scene;
                 out_result->signal_id = item.signal_id;
                 out_result->pause_command = item.pause_command;
                 out_result->has_return_paused = item.has_return_paused;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -154,6 +154,48 @@ static bool run_frame_hook(const sdl3d_game_data_frame_desc *frame, sdl3d_game_d
     return hook == NULL || hook(frame->userdata, frame);
 }
 
+static bool menu_action_pressed(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, int action_id,
+                                const char *fallback_name)
+{
+    if (action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, action_id) &&
+        sdl3d_input_is_pressed(input, action_id))
+    {
+        return true;
+    }
+
+    if (fallback_name != NULL && input != NULL)
+    {
+        const int fallback_id = sdl3d_input_find_action(input, fallback_name);
+        if (fallback_id >= 0 && sdl3d_input_is_pressed(input, fallback_id))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool menu_action_held(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, int action_id,
+                             const char *fallback_name)
+{
+    if (action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, action_id) &&
+        sdl3d_input_is_held(input, action_id))
+    {
+        return true;
+    }
+
+    if (fallback_name != NULL && input != NULL)
+    {
+        const int fallback_id = sdl3d_input_find_action(input, fallback_name);
+        if (fallback_id >= 0 && sdl3d_input_is_held(input, fallback_id))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static bool ensure_font_cache_capacity(sdl3d_game_data_font_cache *cache, int required)
 {
     if (cache == NULL || required <= cache->capacity)
@@ -703,17 +745,12 @@ static bool menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl
     if (input == NULL)
         return false;
 
-    return (menu->up_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->up_action_id) ||
-            !sdl3d_input_is_held(input, menu->up_action_id)) &&
-           (menu->down_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->down_action_id) ||
-            !sdl3d_input_is_held(input, menu->down_action_id)) &&
-           (menu->left_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->left_action_id) ||
-            !sdl3d_input_is_held(input, menu->left_action_id)) &&
-           (menu->right_action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, menu->right_action_id) ||
-            !sdl3d_input_is_held(input, menu->right_action_id)) &&
-           (menu->select_action_id < 0 ||
-            !sdl3d_game_data_active_scene_allows_action(runtime, menu->select_action_id) ||
-            !sdl3d_input_is_held(input, menu->select_action_id));
+    return !menu_action_held(runtime, input, menu->up_action_id, "ui_up") &&
+           !menu_action_held(runtime, input, menu->down_action_id, "ui_down") &&
+           !menu_action_held(runtime, input, menu->left_action_id, "ui_left") &&
+           !menu_action_held(runtime, input, menu->right_action_id, "ui_right") &&
+           !menu_action_held(runtime, input, menu->select_action_id, "ui_accept") &&
+           !menu_action_held(runtime, input, menu->back_action_id, "ui_back");
 }
 
 bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
@@ -764,16 +801,14 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
     }
 
     bool handled = false;
-    if (menu.up_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.up_action_id) &&
-        sdl3d_input_is_pressed(input, menu.up_action_id))
+    if (menu_action_pressed(runtime, input, menu.up_action_id, "ui_up"))
     {
         const bool moved = sdl3d_game_data_menu_move(runtime, menu.name, -1);
         handled = moved || handled;
         if (moved && out_result != NULL)
             out_result->move_signal_id = menu.move_signal_id;
     }
-    if (menu.down_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.down_action_id) &&
-        sdl3d_input_is_pressed(input, menu.down_action_id))
+    if (menu_action_pressed(runtime, input, menu.down_action_id, "ui_down"))
     {
         const bool moved = sdl3d_game_data_menu_move(runtime, menu.name, 1);
         handled = moved || handled;
@@ -782,26 +817,67 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
     }
     int control_direction = 0;
     bool control_adjust_input = false;
-    if (menu.left_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.left_action_id) &&
-        sdl3d_input_is_pressed(input, menu.left_action_id))
+    if (menu_action_pressed(runtime, input, menu.left_action_id, "ui_left"))
     {
         handled = true;
         control_direction = -1;
         control_adjust_input = true;
     }
-    if (menu.right_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.right_action_id) &&
-        sdl3d_input_is_pressed(input, menu.right_action_id))
+    if (menu_action_pressed(runtime, input, menu.right_action_id, "ui_right"))
     {
         handled = true;
         control_direction = 1;
         control_adjust_input = true;
     }
-    if (menu.select_action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, menu.select_action_id) &&
-        sdl3d_input_is_pressed(input, menu.select_action_id))
+    if (menu_action_pressed(runtime, input, menu.select_action_id, "ui_accept"))
     {
         handled = true;
         control_direction = 1;
         control_adjust_input = false;
+    }
+    if (menu_action_pressed(runtime, input, menu.back_action_id, "ui_back"))
+    {
+        handled = true;
+        sdl3d_game_data_menu refreshed;
+        if (!sdl3d_game_data_get_active_menu_for_metrics(runtime, metrics, &refreshed))
+            return true;
+
+        sdl3d_game_data_menu_item item;
+        bool found_back_item = false;
+        for (int i = 0; i < refreshed.item_count; ++i)
+        {
+            if (!sdl3d_game_data_get_menu_item(runtime, refreshed.name, i, &item))
+                continue;
+            if (!item.return_scene && !(item.label != NULL && SDL_strcasecmp(item.label, "Back") == 0))
+                continue;
+            found_back_item = true;
+            if (out_result != NULL)
+            {
+                out_result->menu = refreshed.name;
+                out_result->selected_index = i;
+                out_result->control_changed = false;
+                out_result->selected = true;
+                out_result->select_signal_id = refreshed.select_signal_id;
+                out_result->quit = item.quit;
+                out_result->scene = item.scene;
+                out_result->return_to = item.return_to != NULL ? item.return_to : item.scene;
+                out_result->scene_state_key = item.scene_state_key;
+                out_result->scene_state_value = item.scene_state_value;
+                out_result->return_scene = true;
+                out_result->signal_id = item.signal_id;
+                out_result->pause_command = item.pause_command;
+                out_result->has_return_paused = item.has_return_paused;
+                out_result->return_paused = item.return_paused;
+                out_result->handled_input = true;
+            }
+            break;
+        }
+        if (!found_back_item)
+        {
+            if (out_result != NULL)
+                out_result->handled_input = true;
+        }
+        return true;
     }
 
     if (control_direction != 0)

--- a/src/input.c
+++ b/src/input.c
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
 #include <stdint.h>
@@ -212,6 +213,8 @@ static void sdl3d_input_close_gamepad(sdl3d_input_manager *input, sdl3d_input_ga
         return;
     }
 
+    const int slot_index = (int)(slot - input->gamepads);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad slot closing: slot=%d id=%d", slot_index, slot->id);
     if (slot->gamepad != NULL)
     {
         SDL_CloseGamepad(slot->gamepad);
@@ -264,6 +267,10 @@ static bool sdl3d_input_open_gamepad_slot(sdl3d_input_manager *input, SDL_Joysti
     {
         sdl3d_input_sync_gamepad_slot(slot);
     }
+    const char *name = slot->gamepad != NULL ? SDL_GetGamepadName(slot->gamepad) : NULL;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad slot open: slot=%d id=%d name=%s connected=%d",
+                (int)(slot - input->gamepads), joystick_id, name != NULL ? name : "<unopened>",
+                slot->gamepad != NULL ? 1 : 0);
     return true;
 }
 
@@ -1141,9 +1148,11 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
         }
         break;
     case SDL_EVENT_GAMEPAD_ADDED:
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad added event: id=%d", event->gdevice.which);
         (void)sdl3d_input_open_gamepad_slot(input, event->gdevice.which);
         break;
     case SDL_EVENT_GAMEPAD_REMOVED: {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad removed event: id=%d", event->gdevice.which);
         sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, event->gdevice.which);
         if (slot != NULL)
         {
@@ -1172,6 +1181,9 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
                 value = -1.0f;
             }
             slot->axis_value[event->gaxis.axis] = sdl3d_input_clampf(value, -1.0f, 1.0f);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "SDL3D gamepad axis motion: id=%d axis=%d value=%d normalized=%.3f", event->gaxis.which,
+                        event->gaxis.axis, event->gaxis.value, slot->axis_value[event->gaxis.axis]);
         }
         break;
     }
@@ -1191,6 +1203,8 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
         {
             slot->button_down[event->gbutton.button] = true;
             slot->button_pressed_this_frame[event->gbutton.button] = true;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad button down: id=%d button=%d",
+                        event->gbutton.which, event->gbutton.button);
         }
         break;
     }
@@ -1210,6 +1224,8 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
         {
             slot->button_down[event->gbutton.button] = false;
             slot->button_released_this_frame[event->gbutton.button] = true;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad button up: id=%d button=%d", event->gbutton.which,
+                        event->gbutton.button);
         }
         break;
     }
@@ -1463,8 +1479,14 @@ bool sdl3d_input_rumble_gamepad(sdl3d_input_manager *input, int gamepad_index, f
         return false;
     }
 
-    return SDL_RumbleGamepad(slot->gamepad, sdl3d_input_rumble_scale(low_frequency_rumble),
-                             sdl3d_input_rumble_scale(high_frequency_rumble), duration_ms);
+    const bool ok = SDL_RumbleGamepad(slot->gamepad, sdl3d_input_rumble_scale(low_frequency_rumble),
+                                      sdl3d_input_rumble_scale(high_frequency_rumble), duration_ms);
+    const char *name = SDL_GetGamepadName(slot->gamepad);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "SDL3D gamepad rumble: slot=%d id=%d name=%s low=%.3f high=%.3f duration=%u result=%s error=%s",
+                gamepad_index, slot->id, name != NULL ? name : "<unknown>", low_frequency_rumble, high_frequency_rumble,
+                duration_ms, ok ? "ok" : "failed", ok ? "" : SDL_GetError());
+    return ok;
 }
 
 bool sdl3d_input_rumble_all_gamepads(sdl3d_input_manager *input, float low_frequency_rumble,
@@ -1482,8 +1504,10 @@ bool sdl3d_input_rumble_all_gamepads(sdl3d_input_manager *input, float low_frequ
         {
             continue;
         }
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad rumble request routed to slot=%d", i);
         any = sdl3d_input_rumble_gamepad(input, i, low_frequency_rumble, high_frequency_rumble, duration_ms) || any;
     }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D gamepad rumble all result=%s", any ? "accepted" : "rejected");
     return any;
 }
 

--- a/src/input.c
+++ b/src/input.c
@@ -39,6 +39,17 @@ struct sdl3d_demo_player
     float tick_rate;
 };
 
+typedef struct sdl3d_input_gamepad_slot
+{
+    SDL_Gamepad *gamepad;
+    SDL_JoystickID id;
+    bool connected;
+    bool button_down[SDL_GAMEPAD_BUTTON_COUNT];
+    bool button_pressed_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
+    bool button_released_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
+    float axis_value[SDL_GAMEPAD_AXIS_COUNT];
+} sdl3d_input_gamepad_slot;
+
 struct sdl3d_input_manager
 {
     sdl3d_input_action_entry actions[SDL3D_INPUT_MAX_ACTIONS];
@@ -61,9 +72,8 @@ struct sdl3d_input_manager
     bool mouse_down[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
     bool mouse_pressed_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
     bool mouse_released_this_frame[SDL3D_INPUT_MAX_MOUSE_BUTTONS];
-    bool gamepad_button_down[SDL_GAMEPAD_BUTTON_COUNT];
-    bool gamepad_button_pressed_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
-    bool gamepad_button_released_this_frame[SDL_GAMEPAD_BUTTON_COUNT];
+    sdl3d_input_gamepad_slot gamepads[SDL3D_INPUT_MAX_GAMEPADS];
+    int gamepad_count;
 
     sdl3d_input_snapshot snapshot;
     bool prev_held[SDL3D_INPUT_MAX_ACTIONS];
@@ -71,8 +81,6 @@ struct sdl3d_input_manager
     Uint8 pressed_mouse_button;
     SDL_GamepadButton pressed_gamepad_button;
 
-    SDL_Gamepad *gamepad;
-    SDL_JoystickID gamepad_id;
     float deadzone;
 
     sdl3d_demo_recorder *recorder;
@@ -154,40 +162,116 @@ static void sdl3d_input_add_binding(sdl3d_input_manager *input, const sdl3d_inpu
     input->bindings[input->binding_count++] = *binding;
 }
 
-static void sdl3d_input_close_gamepad(sdl3d_input_manager *input)
+static sdl3d_input_gamepad_slot *sdl3d_input_find_gamepad_slot(sdl3d_input_manager *input, SDL_JoystickID joystick_id)
 {
-    if (input != NULL && input->gamepad != NULL)
+    if (input == NULL)
     {
-        SDL_CloseGamepad(input->gamepad);
-        input->gamepad = NULL;
-        input->gamepad_id = 0;
-        SDL_memset(input->gamepad_button_down, 0, sizeof(input->gamepad_button_down));
-        SDL_memset(input->gamepad_button_pressed_this_frame, 0, sizeof(input->gamepad_button_pressed_this_frame));
-        SDL_memset(input->gamepad_button_released_this_frame, 0, sizeof(input->gamepad_button_released_this_frame));
+        return NULL;
     }
+
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        sdl3d_input_gamepad_slot *slot = &input->gamepads[i];
+        if (slot->connected && slot->id == joystick_id)
+        {
+            return slot;
+        }
+    }
+    return NULL;
 }
 
-static void sdl3d_input_open_gamepad(sdl3d_input_manager *input, SDL_JoystickID joystick_id)
+static sdl3d_input_gamepad_slot *sdl3d_input_find_free_gamepad_slot(sdl3d_input_manager *input)
 {
-    if (input == NULL || input->gamepad != NULL)
+    if (input == NULL)
+    {
+        return NULL;
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        sdl3d_input_gamepad_slot *slot = &input->gamepads[i];
+        if (!slot->connected)
+        {
+            return slot;
+        }
+    }
+    return NULL;
+}
+
+static bool sdl3d_input_slot_is_open(const sdl3d_input_gamepad_slot *slot)
+{
+    return slot != NULL && slot->connected;
+}
+
+static void sdl3d_input_sync_gamepad_slot(sdl3d_input_gamepad_slot *slot);
+
+static void sdl3d_input_close_gamepad(sdl3d_input_manager *input, sdl3d_input_gamepad_slot *slot)
+{
+    if (input == NULL || slot == NULL || !slot->connected)
     {
         return;
     }
 
-    SDL_Gamepad *gamepad = SDL_OpenGamepad(joystick_id);
-    if (gamepad != NULL)
+    if (slot->gamepad != NULL)
     {
-        input->gamepad = gamepad;
-        input->gamepad_id = joystick_id;
+        SDL_CloseGamepad(slot->gamepad);
+    }
+    SDL_zero(*slot);
+    if (input->gamepad_count > 0)
+    {
+        input->gamepad_count--;
     }
 }
 
-static void sdl3d_input_try_open_first_gamepad(sdl3d_input_manager *input)
+static bool sdl3d_input_open_gamepad_slot(sdl3d_input_manager *input, SDL_JoystickID joystick_id)
+{
+    sdl3d_input_gamepad_slot *slot;
+    if (input == NULL)
+    {
+        return false;
+    }
+
+    slot = sdl3d_input_find_gamepad_slot(input, joystick_id);
+    if (slot == NULL)
+    {
+        slot = sdl3d_input_find_free_gamepad_slot(input);
+    }
+    if (slot == NULL)
+    {
+        return false;
+    }
+
+    if (slot->connected && slot->id == joystick_id && slot->gamepad != NULL)
+    {
+        return true;
+    }
+
+    if (!slot->connected)
+    {
+        SDL_zero(*slot);
+        slot->connected = true;
+        slot->id = joystick_id;
+        input->gamepad_count++;
+    }
+
+    if (slot->gamepad != NULL)
+    {
+        SDL_CloseGamepad(slot->gamepad);
+        slot->gamepad = NULL;
+    }
+    slot->gamepad = SDL_OpenGamepad(joystick_id);
+    if (slot->gamepad != NULL)
+    {
+        sdl3d_input_sync_gamepad_slot(slot);
+    }
+    return true;
+}
+
+static void sdl3d_input_refresh_gamepads(sdl3d_input_manager *input)
 {
     int count = 0;
     SDL_JoystickID *gamepads;
-
-    if (input == NULL || input->gamepad != NULL)
+    if (input == NULL)
     {
         return;
     }
@@ -198,29 +282,82 @@ static void sdl3d_input_try_open_first_gamepad(sdl3d_input_manager *input)
         return;
     }
 
-    for (int i = 0; i < count && input->gamepad == NULL; ++i)
+    for (int i = 0; i < count; ++i)
     {
-        sdl3d_input_open_gamepad(input, gamepads[i]);
+        if (input->gamepad_count >= SDL3D_INPUT_MAX_GAMEPADS)
+        {
+            break;
+        }
+        sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, gamepads[i]);
+        if (slot == NULL || slot->gamepad == NULL)
+        {
+            (void)sdl3d_input_open_gamepad_slot(input, gamepads[i]);
+        }
     }
 
     SDL_free(gamepads);
 }
 
+static float sdl3d_input_gamepad_slot_axis_value(const sdl3d_input_gamepad_slot *slot, SDL_GamepadAxis axis,
+                                                 float deadzone)
+{
+    if (!sdl3d_input_slot_is_open(slot) || axis < 0 || axis >= SDL_GAMEPAD_AXIS_COUNT)
+    {
+        return 0.0f;
+    }
+    float value = slot->axis_value[axis];
+    if (sdl3d_input_absf(value) < deadzone)
+    {
+        return 0.0f;
+    }
+
+    return value;
+}
+
+static void sdl3d_input_sync_gamepad_slot(sdl3d_input_gamepad_slot *slot)
+{
+    if (slot == NULL || slot->gamepad == NULL)
+    {
+        return;
+    }
+
+    for (int button = 0; button < SDL_GAMEPAD_BUTTON_COUNT; ++button)
+    {
+        slot->button_down[button] = SDL_GetGamepadButton(slot->gamepad, (SDL_GamepadButton)button) != 0;
+    }
+    for (int axis = 0; axis < SDL_GAMEPAD_AXIS_COUNT; ++axis)
+    {
+        float value = (float)SDL_GetGamepadAxis(slot->gamepad, (SDL_GamepadAxis)axis) / 32767.0f;
+        if (value < -1.0f)
+        {
+            value = -1.0f;
+        }
+        else if (value > 1.0f)
+        {
+            value = 1.0f;
+        }
+        slot->axis_value[axis] = value;
+    }
+}
+
 static float sdl3d_input_gamepad_axis_value(const sdl3d_input_manager *input, SDL_GamepadAxis axis)
 {
-    if (input == NULL || input->gamepad == NULL)
+    if (input == NULL)
     {
         return 0.0f;
     }
 
-    float value = (float)SDL_GetGamepadAxis(input->gamepad, axis) / 32767.0f;
-    value = sdl3d_input_clampf(value, -1.0f, 1.0f);
-
-    if (sdl3d_input_absf(value) < input->deadzone)
+    float value = 0.0f;
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
     {
-        return 0.0f;
+        const sdl3d_input_gamepad_slot *slot = &input->gamepads[i];
+        if (!slot->connected)
+        {
+            continue;
+        }
+        value =
+            sdl3d_input_signed_max_magnitude(value, sdl3d_input_gamepad_slot_axis_value(slot, axis, input->deadzone));
     }
-
     return value;
 }
 
@@ -232,6 +369,28 @@ static bool sdl3d_input_mouse_button_valid(Uint8 button)
 static bool sdl3d_input_gamepad_button_valid(SDL_GamepadButton button)
 {
     return button >= 0 && button < SDL_GAMEPAD_BUTTON_COUNT;
+}
+
+static bool sdl3d_input_gamepad_axis_valid(SDL_GamepadAxis axis)
+{
+    return axis >= 0 && axis < SDL_GAMEPAD_AXIS_COUNT;
+}
+
+static bool sdl3d_input_gamepad_slot_button_down(const sdl3d_input_gamepad_slot *slot, SDL_GamepadButton button)
+{
+    return sdl3d_input_slot_is_open(slot) && sdl3d_input_gamepad_button_valid(button) && slot->button_down[button];
+}
+
+static bool sdl3d_input_gamepad_slot_button_pressed(const sdl3d_input_gamepad_slot *slot, SDL_GamepadButton button)
+{
+    return sdl3d_input_slot_is_open(slot) && sdl3d_input_gamepad_button_valid(button) &&
+           slot->button_pressed_this_frame[button];
+}
+
+static bool sdl3d_input_gamepad_slot_button_released(const sdl3d_input_gamepad_slot *slot, SDL_GamepadButton button)
+{
+    return sdl3d_input_slot_is_open(slot) && sdl3d_input_gamepad_button_valid(button) &&
+           slot->button_released_this_frame[button];
 }
 
 static float sdl3d_input_mouse_axis_value(const sdl3d_input_manager *input, sdl3d_mouse_axis axis)
@@ -331,10 +490,14 @@ static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const s
         {
             return 0.0f;
         }
-        return (input->gamepad_button_down[binding->gamepad_button] ||
-                (input->gamepad != NULL && SDL_GetGamepadButton(input->gamepad, binding->gamepad_button)))
-                   ? binding->scale
-                   : 0.0f;
+        for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+        {
+            if (sdl3d_input_gamepad_slot_button_down(&input->gamepads[i], binding->gamepad_button))
+            {
+                return binding->scale;
+            }
+        }
+        return 0.0f;
     case SDL3D_INPUT_GAMEPAD_AXIS:
         return sdl3d_input_axis_binding_value(input, binding,
                                               sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
@@ -364,8 +527,18 @@ static bool sdl3d_input_binding_pressed(const sdl3d_input_manager *input, const 
         return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
                input->mouse_pressed_this_frame[binding->mouse_button];
     case SDL3D_INPUT_GAMEPAD_BUTTON:
-        return sdl3d_input_gamepad_button_valid(binding->gamepad_button) &&
-               input->gamepad_button_pressed_this_frame[binding->gamepad_button];
+        if (!sdl3d_input_gamepad_button_valid(binding->gamepad_button))
+        {
+            return false;
+        }
+        for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+        {
+            if (sdl3d_input_gamepad_slot_button_pressed(&input->gamepads[i], binding->gamepad_button))
+            {
+                return true;
+            }
+        }
+        return false;
     default:
         return false;
     }
@@ -389,8 +562,18 @@ static bool sdl3d_input_binding_released(const sdl3d_input_manager *input, const
         return sdl3d_input_mouse_button_valid(binding->mouse_button) &&
                input->mouse_released_this_frame[binding->mouse_button];
     case SDL3D_INPUT_GAMEPAD_BUTTON:
-        return sdl3d_input_gamepad_button_valid(binding->gamepad_button) &&
-               input->gamepad_button_released_this_frame[binding->gamepad_button];
+        if (!sdl3d_input_gamepad_button_valid(binding->gamepad_button))
+        {
+            return false;
+        }
+        for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+        {
+            if (sdl3d_input_gamepad_slot_button_released(&input->gamepads[i], binding->gamepad_button))
+            {
+                return true;
+            }
+        }
+        return false;
     default:
         return false;
     }
@@ -413,8 +596,13 @@ static void sdl3d_input_reset_transients(sdl3d_input_manager *input)
     SDL_memset(input->key_released_modifiers_this_frame, 0, sizeof(input->key_released_modifiers_this_frame));
     SDL_memset(input->mouse_pressed_this_frame, 0, sizeof(input->mouse_pressed_this_frame));
     SDL_memset(input->mouse_released_this_frame, 0, sizeof(input->mouse_released_this_frame));
-    SDL_memset(input->gamepad_button_pressed_this_frame, 0, sizeof(input->gamepad_button_pressed_this_frame));
-    SDL_memset(input->gamepad_button_released_this_frame, 0, sizeof(input->gamepad_button_released_this_frame));
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        SDL_memset(input->gamepads[i].button_pressed_this_frame, 0,
+                   sizeof(input->gamepads[i].button_pressed_this_frame));
+        SDL_memset(input->gamepads[i].button_released_this_frame, 0,
+                   sizeof(input->gamepads[i].button_released_this_frame));
+    }
 }
 
 static bool sdl3d_input_physical_any_pressed(const sdl3d_input_manager *input)
@@ -438,11 +626,19 @@ static bool sdl3d_input_physical_any_pressed(const sdl3d_input_manager *input)
             return true;
         }
     }
-    for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i)
+    for (int slot_index = 0; slot_index < SDL3D_INPUT_MAX_GAMEPADS; ++slot_index)
     {
-        if (input->gamepad_button_pressed_this_frame[i])
+        const sdl3d_input_gamepad_slot *slot = &input->gamepads[slot_index];
+        if (!slot->connected)
         {
-            return true;
+            continue;
+        }
+        for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i)
+        {
+            if (slot->button_pressed_this_frame[i])
+            {
+                return true;
+            }
         }
     }
     return false;
@@ -472,11 +668,19 @@ static SDL_GamepadButton sdl3d_input_first_pressed_gamepad_button(const sdl3d_in
         return SDL_GAMEPAD_BUTTON_INVALID;
     }
 
-    for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i)
+    for (int slot_index = 0; slot_index < SDL3D_INPUT_MAX_GAMEPADS; ++slot_index)
     {
-        if (input->gamepad_button_pressed_this_frame[i])
+        const sdl3d_input_gamepad_slot *slot = &input->gamepads[slot_index];
+        if (!slot->connected)
         {
-            return (SDL_GamepadButton)i;
+            continue;
+        }
+        for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i)
+        {
+            if (slot->button_pressed_this_frame[i])
+            {
+                return (SDL_GamepadButton)i;
+            }
         }
     }
     return SDL_GAMEPAD_BUTTON_INVALID;
@@ -724,6 +928,7 @@ sdl3d_input_manager *sdl3d_input_create(void)
     input->deadzone = SDL3D_INPUT_DEFAULT_DEADZONE;
     input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
     input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
+    sdl3d_input_refresh_gamepads(input);
     return input;
 }
 
@@ -739,7 +944,10 @@ void sdl3d_input_destroy(sdl3d_input_manager *input)
         input->recorder->input = NULL;
         input->recorder->recording = false;
     }
-    sdl3d_input_close_gamepad(input);
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        sdl3d_input_close_gamepad(input, &input->gamepads[i]);
+    }
     SDL_free(input);
 }
 
@@ -933,29 +1141,78 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
         }
         break;
     case SDL_EVENT_GAMEPAD_ADDED:
-        sdl3d_input_open_gamepad(input, event->gdevice.which);
+        (void)sdl3d_input_open_gamepad_slot(input, event->gdevice.which);
         break;
-    case SDL_EVENT_GAMEPAD_REMOVED:
-        if (input->gamepad != NULL && input->gamepad_id == event->gdevice.which)
+    case SDL_EVENT_GAMEPAD_REMOVED: {
+        sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, event->gdevice.which);
+        if (slot != NULL)
         {
-            sdl3d_input_close_gamepad(input);
-            sdl3d_input_try_open_first_gamepad(input);
+            sdl3d_input_close_gamepad(input, slot);
+            sdl3d_input_refresh_gamepads(input);
         }
         break;
-    case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-        if (sdl3d_input_gamepad_button_valid(event->gbutton.button))
+    }
+    case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
+        sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, event->gaxis.which);
+        if (slot == NULL)
         {
-            input->gamepad_button_down[event->gbutton.button] = true;
-            input->gamepad_button_pressed_this_frame[event->gbutton.button] = true;
+            slot = sdl3d_input_find_free_gamepad_slot(input);
+            if (slot != NULL)
+            {
+                slot->connected = true;
+                slot->id = event->gaxis.which;
+                input->gamepad_count++;
+            }
+        }
+        if (slot != NULL && sdl3d_input_gamepad_axis_valid((SDL_GamepadAxis)event->gaxis.axis))
+        {
+            float value = (float)event->gaxis.value / 32767.0f;
+            if (event->gaxis.value == -32768)
+            {
+                value = -1.0f;
+            }
+            slot->axis_value[event->gaxis.axis] = sdl3d_input_clampf(value, -1.0f, 1.0f);
         }
         break;
-    case SDL_EVENT_GAMEPAD_BUTTON_UP:
-        if (sdl3d_input_gamepad_button_valid(event->gbutton.button))
+    }
+    case SDL_EVENT_GAMEPAD_BUTTON_DOWN: {
+        sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, event->gbutton.which);
+        if (slot == NULL)
         {
-            input->gamepad_button_down[event->gbutton.button] = false;
-            input->gamepad_button_released_this_frame[event->gbutton.button] = true;
+            slot = sdl3d_input_find_free_gamepad_slot(input);
+            if (slot != NULL)
+            {
+                slot->connected = true;
+                slot->id = event->gbutton.which;
+                input->gamepad_count++;
+            }
+        }
+        if (slot != NULL && sdl3d_input_gamepad_button_valid((SDL_GamepadButton)event->gbutton.button))
+        {
+            slot->button_down[event->gbutton.button] = true;
+            slot->button_pressed_this_frame[event->gbutton.button] = true;
         }
         break;
+    }
+    case SDL_EVENT_GAMEPAD_BUTTON_UP: {
+        sdl3d_input_gamepad_slot *slot = sdl3d_input_find_gamepad_slot(input, event->gbutton.which);
+        if (slot == NULL)
+        {
+            slot = sdl3d_input_find_free_gamepad_slot(input);
+            if (slot != NULL)
+            {
+                slot->connected = true;
+                slot->id = event->gbutton.which;
+                input->gamepad_count++;
+            }
+        }
+        if (slot != NULL && sdl3d_input_gamepad_button_valid((SDL_GamepadButton)event->gbutton.button))
+        {
+            slot->button_down[event->gbutton.button] = false;
+            slot->button_released_this_frame[event->gbutton.button] = true;
+        }
+        break;
+    }
     default:
         break;
     }
@@ -985,6 +1242,11 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
             sdl3d_input_reset_transients(input);
             return &input->snapshot;
         }
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        sdl3d_input_sync_gamepad_slot(&input->gamepads[i]);
     }
 
     sdl3d_input_snapshot next;
@@ -1090,6 +1352,139 @@ sdl3d_vec2 sdl3d_input_get_axis_pair(const sdl3d_input_manager *input, int negat
     axis.x = sdl3d_input_get_value(input, positive_x_action) - sdl3d_input_get_value(input, negative_x_action);
     axis.y = sdl3d_input_get_value(input, positive_y_action) - sdl3d_input_get_value(input, negative_y_action);
     return axis;
+}
+
+static const sdl3d_input_gamepad_slot *sdl3d_input_gamepad_slot_at(const sdl3d_input_manager *input, int gamepad_index)
+{
+    if (input == NULL || gamepad_index < 0 || gamepad_index >= SDL3D_INPUT_MAX_GAMEPADS)
+    {
+        return NULL;
+    }
+    return &input->gamepads[gamepad_index];
+}
+
+int sdl3d_input_gamepad_count(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->gamepad_count : 0;
+}
+
+bool sdl3d_input_gamepad_is_connected(const sdl3d_input_manager *input, int gamepad_index)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    return slot != NULL && slot->connected;
+}
+
+SDL_JoystickID sdl3d_input_gamepad_id_at(const sdl3d_input_manager *input, int gamepad_index)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    return slot != NULL && slot->connected ? slot->id : 0;
+}
+
+bool sdl3d_input_is_gamepad_button_held(const sdl3d_input_manager *input, int gamepad_index, SDL_GamepadButton button)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    return slot != NULL && sdl3d_input_gamepad_slot_button_down(slot, button);
+}
+
+float sdl3d_input_get_gamepad_axis(const sdl3d_input_manager *input, int gamepad_index, SDL_GamepadAxis axis)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    if (slot == NULL)
+    {
+        return 0.0f;
+    }
+    return sdl3d_input_gamepad_slot_axis_value(slot, axis,
+                                               input != NULL ? input->deadzone : SDL3D_INPUT_DEFAULT_DEADZONE);
+}
+
+sdl3d_vec2 sdl3d_input_get_gamepad_left_stick(const sdl3d_input_manager *input, int gamepad_index)
+{
+    sdl3d_vec2 stick = {0.0f, 0.0f};
+    stick.x = sdl3d_input_get_gamepad_axis(input, gamepad_index, SDL_GAMEPAD_AXIS_LEFTX);
+    stick.y = sdl3d_input_get_gamepad_axis(input, gamepad_index, SDL_GAMEPAD_AXIS_LEFTY);
+    return stick;
+}
+
+sdl3d_vec2 sdl3d_input_get_gamepad_right_stick(const sdl3d_input_manager *input, int gamepad_index)
+{
+    sdl3d_vec2 stick = {0.0f, 0.0f};
+    stick.x = sdl3d_input_get_gamepad_axis(input, gamepad_index, SDL_GAMEPAD_AXIS_RIGHTX);
+    stick.y = sdl3d_input_get_gamepad_axis(input, gamepad_index, SDL_GAMEPAD_AXIS_RIGHTY);
+    return stick;
+}
+
+bool sdl3d_input_is_gamepad_left_stick_pressed(const sdl3d_input_manager *input, int gamepad_index)
+{
+    return sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_LEFT_STICK);
+}
+
+bool sdl3d_input_is_gamepad_right_stick_pressed(const sdl3d_input_manager *input, int gamepad_index)
+{
+    return sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_RIGHT_STICK);
+}
+
+bool sdl3d_input_is_gamepad_face_button_pressed(const sdl3d_input_manager *input, int gamepad_index)
+{
+    return sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_SOUTH) ||
+           sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_EAST) ||
+           sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_WEST) ||
+           sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_NORTH);
+}
+
+bool sdl3d_input_is_gamepad_start_pressed(const sdl3d_input_manager *input, int gamepad_index)
+{
+    return sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_START);
+}
+
+bool sdl3d_input_is_gamepad_select_pressed(const sdl3d_input_manager *input, int gamepad_index)
+{
+    return sdl3d_input_is_gamepad_button_held(input, gamepad_index, SDL_GAMEPAD_BUTTON_BACK);
+}
+
+static Uint16 sdl3d_input_rumble_scale(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0;
+    }
+    if (value >= 1.0f)
+    {
+        return UINT16_MAX;
+    }
+    return (Uint16)(value * (float)UINT16_MAX);
+}
+
+bool sdl3d_input_rumble_gamepad(sdl3d_input_manager *input, int gamepad_index, float low_frequency_rumble,
+                                float high_frequency_rumble, Uint32 duration_ms)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    if (slot == NULL || slot->gamepad == NULL)
+    {
+        return false;
+    }
+
+    return SDL_RumbleGamepad(slot->gamepad, sdl3d_input_rumble_scale(low_frequency_rumble),
+                             sdl3d_input_rumble_scale(high_frequency_rumble), duration_ms);
+}
+
+bool sdl3d_input_rumble_all_gamepads(sdl3d_input_manager *input, float low_frequency_rumble,
+                                     float high_frequency_rumble, Uint32 duration_ms)
+{
+    bool any = false;
+    if (input == NULL)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        if (!sdl3d_input_gamepad_is_connected(input, i))
+        {
+            continue;
+        }
+        any = sdl3d_input_rumble_gamepad(input, i, low_frequency_rumble, high_frequency_rumble, duration_ms) || any;
+    }
+    return any;
 }
 
 const sdl3d_input_snapshot *sdl3d_input_get_snapshot(const sdl3d_input_manager *input)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2381,6 +2381,62 @@ TEST(GameDataRuntime, GamepadOptionsCaptureAndApplyAuthoredInputBindings)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, OptionsMenusUseGamepadAxesAndBack)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_GE(menu.back_action_id, 0);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_CHOICE);
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 2041;
+    sdl3d_input_process_event(input, &event);
+
+    event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+    event.gaxis.which = 2041;
+    event.gaxis.axis = SDL_GAMEPAD_AXIS_LEFTX;
+    event.gaxis.value = -30000;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.control_changed);
+    sdl3d_registered_actor *settings = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(settings->props, "display_mode", ""), "fullscreen_borderless");
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 2041;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_EAST;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+
+    SDL_zero(result);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.return_scene);
+    EXPECT_STREQ(result.scene, "scene.options");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, MouseOptionsCaptureAndApplyAuthoredInputBindings)
 {
     sdl3d_game_session *session = nullptr;
@@ -2544,6 +2600,7 @@ TEST(GameDataRuntime, PongStandardOptionsUseImmediateApplyContract)
     EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_display"), 0);
     EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_audio"), 0);
     EXPECT_LT(sdl3d_game_data_find_signal(runtime, "signal.settings.cancel_gamepad"), 0);
+    EXPECT_GE(sdl3d_game_data_find_signal(runtime, "signal.settings.vibration"), 0);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options.display"));
     sdl3d_game_data_menu_item display_mode{};

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2430,7 +2430,7 @@ TEST(GameDataRuntime, OptionsMenusUseGamepadAxesAndBack)
 
     SDL_zero(result);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
-    EXPECT_TRUE(result.return_scene);
+    EXPECT_FALSE(result.return_scene);
     EXPECT_STREQ(result.scene, "scene.options");
 
     sdl3d_game_data_destroy(runtime);

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -81,11 +81,30 @@ void push_mouse_button(sdl3d_input_manager *input, SDL_EventType type, Uint8 but
     sdl3d_input_process_event(input, &event);
 }
 
-void push_gamepad_button(sdl3d_input_manager *input, SDL_EventType type, SDL_GamepadButton button)
+void push_gamepad_device(sdl3d_input_manager *input, SDL_EventType type, SDL_JoystickID which)
 {
     SDL_Event event{};
     event.type = type;
+    event.gdevice.which = which;
+    sdl3d_input_process_event(input, &event);
+}
+
+void push_gamepad_button(sdl3d_input_manager *input, SDL_EventType type, SDL_JoystickID which, SDL_GamepadButton button)
+{
+    SDL_Event event{};
+    event.type = type;
+    event.gbutton.which = which;
     event.gbutton.button = button;
+    sdl3d_input_process_event(input, &event);
+}
+
+void push_gamepad_axis(sdl3d_input_manager *input, SDL_JoystickID which, SDL_GamepadAxis axis, Sint16 value)
+{
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+    event.gaxis.which = which;
+    event.gaxis.axis = static_cast<Uint8>(axis);
+    event.gaxis.value = value;
     sdl3d_input_process_event(input, &event);
 }
 
@@ -96,6 +115,18 @@ void push_mouse_motion(sdl3d_input_manager *input, float dx, float dy)
     event.motion.xrel = dx;
     event.motion.yrel = dy;
     sdl3d_input_process_event(input, &event);
+}
+
+int find_gamepad_slot(const sdl3d_input_manager *input, SDL_JoystickID which)
+{
+    for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
+    {
+        if (sdl3d_input_gamepad_is_connected(input, i) && sdl3d_input_gamepad_id_at(input, i) == which)
+        {
+            return i;
+        }
+    }
+    return -1;
 }
 } // namespace
 
@@ -266,20 +297,146 @@ TEST(Input, MouseButtonPressAndRelease)
 TEST(Input, GamepadButtonPressAndRelease)
 {
     InputPtr input;
+    if (sdl3d_input_gamepad_count(input.input) >= SDL3D_INPUT_MAX_GAMEPADS)
+    {
+        GTEST_SKIP() << "requires an available gamepad slot";
+    }
     int pause = sdl3d_input_register_action(input.input, "pause");
     sdl3d_input_bind_gamepad_button(input.input, pause, SDL_GAMEPAD_BUTTON_START);
 
-    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, SDL_GAMEPAD_BUTTON_START);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1001);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1001, SDL_GAMEPAD_BUTTON_START);
     sdl3d_input_update(input.input, 1);
     EXPECT_TRUE(sdl3d_input_is_held(input.input, pause));
     EXPECT_TRUE(sdl3d_input_is_pressed(input.input, pause));
     EXPECT_EQ(sdl3d_input_get_pressed_gamepad_button(input.input), SDL_GAMEPAD_BUTTON_START);
 
-    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, SDL_GAMEPAD_BUTTON_START);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, 1001, SDL_GAMEPAD_BUTTON_START);
     sdl3d_input_update(input.input, 2);
     EXPECT_FALSE(sdl3d_input_is_held(input.input, pause));
     EXPECT_TRUE(sdl3d_input_is_released(input.input, pause));
     EXPECT_EQ(sdl3d_input_get_pressed_gamepad_button(input.input), SDL_GAMEPAD_BUTTON_INVALID);
+}
+
+TEST(Input, GamepadAxisAndConvenienceQueries)
+{
+    InputPtr input;
+    if (sdl3d_input_gamepad_count(input.input) != 0)
+    {
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1007);
+    push_gamepad_axis(input.input, 1007, SDL_GAMEPAD_AXIS_LEFTX, 18000);
+    push_gamepad_axis(input.input, 1007, SDL_GAMEPAD_AXIS_LEFTY, -18000);
+    push_gamepad_axis(input.input, 1007, SDL_GAMEPAD_AXIS_RIGHTX, -22000);
+    push_gamepad_axis(input.input, 1007, SDL_GAMEPAD_AXIS_RIGHTY, 23000);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1007, SDL_GAMEPAD_BUTTON_LEFT_STICK);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1007, SDL_GAMEPAD_BUTTON_RIGHT_STICK);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1007, SDL_GAMEPAD_BUTTON_SOUTH);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1007, SDL_GAMEPAD_BUTTON_START);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1007, SDL_GAMEPAD_BUTTON_BACK);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_GE(sdl3d_input_gamepad_count(input.input), 1);
+    const int slot = find_gamepad_slot(input.input, 1007);
+    ASSERT_GE(slot, 0);
+    EXPECT_TRUE(sdl3d_input_is_gamepad_left_stick_pressed(input.input, slot));
+    EXPECT_TRUE(sdl3d_input_is_gamepad_right_stick_pressed(input.input, slot));
+    EXPECT_TRUE(sdl3d_input_is_gamepad_face_button_pressed(input.input, slot));
+    EXPECT_TRUE(sdl3d_input_is_gamepad_start_pressed(input.input, slot));
+    EXPECT_TRUE(sdl3d_input_is_gamepad_select_pressed(input.input, slot));
+
+    sdl3d_vec2 left = sdl3d_input_get_gamepad_left_stick(input.input, slot);
+    sdl3d_vec2 right = sdl3d_input_get_gamepad_right_stick(input.input, slot);
+    EXPECT_GT(left.x, 0.0f);
+    EXPECT_LT(left.y, 0.0f);
+    EXPECT_LT(right.x, 0.0f);
+    EXPECT_GT(right.y, 0.0f);
+}
+
+TEST(Input, GamepadHotplugSupportsMultipleSlots)
+{
+    InputPtr input;
+    if (sdl3d_input_gamepad_count(input.input) != 0)
+    {
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1011);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1012);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1013);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1014);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1015);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_EQ(sdl3d_input_gamepad_count(input.input), 4);
+    EXPECT_TRUE(sdl3d_input_gamepad_is_connected(input.input, 0));
+    EXPECT_TRUE(sdl3d_input_gamepad_is_connected(input.input, 1));
+    EXPECT_TRUE(sdl3d_input_gamepad_is_connected(input.input, 2));
+    EXPECT_TRUE(sdl3d_input_gamepad_is_connected(input.input, 3));
+
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_REMOVED, 1012);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_EQ(sdl3d_input_gamepad_count(input.input), 3);
+
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1016);
+    sdl3d_input_update(input.input, 3);
+    EXPECT_EQ(sdl3d_input_gamepad_count(input.input), 4);
+}
+
+TEST(Input, UiDefaultsRespondToGamepadDirectionsAndBack)
+{
+    InputPtr input;
+    sdl3d_input_bind_ui_defaults(input.input);
+    int ui_left = sdl3d_input_find_action(input.input, "ui_left");
+    int ui_down = sdl3d_input_find_action(input.input, "ui_down");
+    int ui_back = sdl3d_input_find_action(input.input, "ui_back");
+    ASSERT_GE(ui_left, 0);
+    ASSERT_GE(ui_down, 0);
+    ASSERT_GE(ui_back, 0);
+
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1021);
+    push_gamepad_axis(input.input, 1021, SDL_GAMEPAD_AXIS_LEFTX, -22000);
+    push_gamepad_axis(input.input, 1021, SDL_GAMEPAD_AXIS_LEFTY, 22000);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1021, SDL_GAMEPAD_BUTTON_EAST);
+    sdl3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, ui_left));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, ui_down));
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, ui_back));
+}
+
+TEST(Input, MultipleGamepadsCanHoldTheSameAction)
+{
+    InputPtr input;
+    if (sdl3d_input_gamepad_count(input.input) != 0)
+    {
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+    sdl3d_input_bind_ui_defaults(input.input);
+    int accept = sdl3d_input_find_action(input.input, "ui_accept");
+    ASSERT_GE(accept, 0);
+
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1031);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1032);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1031, SDL_GAMEPAD_BUTTON_SOUTH);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1032, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, accept));
+
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, 1031, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, accept));
+
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, 1032, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_update(input.input, 3);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, accept));
+}
+
+TEST(Input, GamepadRumbleNoOpsWithoutConnectedDevices)
+{
+    InputPtr input;
+    EXPECT_FALSE(sdl3d_input_rumble_gamepad(input.input, 0, 0.5f, 0.5f, 50));
+    EXPECT_FALSE(sdl3d_input_rumble_all_gamepads(input.input, 0.5f, 0.5f, 50));
 }
 
 TEST(Input, MultipleBindingsSameAction)


### PR DESCRIPTION
## Summary\n- Track up to four simultaneous gamepads with hot-plug support\n- Add convenience queries for stick/button state and analog stick direction helpers\n- Add input-level rumble helpers\n- Wire Pong paddle hits to controller rumble\n\n## Verification\n- ./build/release/tests/sdl3d_input_test\n- cmake --build build/release --target sdl3d_input_test pong_demo -j 8\n