### PR TITLE
Document Pong template checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+This file gives working guidance for AI agents maintaining SDL_3D.
+
+## Core expectations
+
+- Prefer clean, human-readable, professional-grade C.
+- Fix root causes. Do not leave obvious bugs in place.
+- Do not paper over defects with workaround logic when a real fix is feasible.
+- Breaking changes are acceptable before 1.0 when they improve correctness or API clarity.
+- Keep the engine generalized and data driven. New features should extend the architecture rather than hard-code game-specific behavior where possible.
+
+## Repository priorities
+
+- Keep demos working.
+- Keep tests passing.
+- Keep docs in sync with behavior and public API changes.
+- Update data files and runtime defaults together so authored content matches actual behavior.
+- Favor reusable engine primitives over Pong-specific or demo-specific glue.
+
+## Code quality rules
+
+- Keep modules focused on a single responsibility.
+- Prefer explicit, local logic over clever abstractions.
+- Match existing project style and naming conventions.
+- Document public APIs with Doxygen-style comments.
+- Add or update tests when behavior changes.
+
+## When changing behavior
+
+- Verify the change against existing demos, not just the immediate target feature.
+- If a bug is discovered along the way, fix it in the same change when practical.
+- If a generalized engine helper can replace duplicated demo logic, prefer the helper.
+- If a change affects authored data, update validation, examples, and docs together.
+
+## Data-driven direction
+
+- Treat JSON, Lua, and authored scene/data files as first-class game-definition inputs.
+- Keep gameplay rules, menus, transitions, and reusable presentation behavior data-authored where possible.
+- Reserve host-side C for true engine integration points and platform-specific work.
+
+## Suggested workflow
+
+- Read the existing code and docs before editing.
+- Make the smallest correct change that addresses the root cause.
+- Add focused tests for the changed behavior.
+- Run the relevant build/test targets before finishing.
+- Update documentation or sample data if the public behavior changed.
+

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -457,6 +457,8 @@ window and audio examples.
 
 For a project-oriented adoption checklist and a minimal reference game file,
 see [docs/standard-options.md](standard-options.md).
+For a concise new-game checklist that mirrors the Pong template structure,
+see [docs/pong-template-checklist.md](pong-template-checklist.md).
 
 Standard display properties:
 

--- a/docs/pong-template-checklist.md
+++ b/docs/pong-template-checklist.md
@@ -1,0 +1,68 @@
+# Pong Template Checklist
+
+Use this checklist when starting a new SDL3D game from the Pong template.
+It keeps reusable engine data separate from game-specific content and makes
+scene handoff behavior explicit.
+
+## Recommended project shape
+
+- `game.json` at the project root for startup policy, storage, and standard
+  game-wide config.
+- `scenes/*.scene.json` for title, options, play, pause, splash, and level
+  scenes.
+- `scripts/*.lua` for game-specific behavior that should stay outside the
+  engine.
+- `assets/` for textures, audio, icons, and other raw source media.
+- `pack/` or generated asset pack output for packaged runtime delivery.
+- `user://` storage config for settings, profiles, and save data.
+
+## What belongs in reusable engine data
+
+- Window and renderer policy.
+- Scene transition policy.
+- Managed loop policy.
+- Standard options menus and their controls.
+- Input bindings and defaults.
+- Scene-state handoff keys and return-scene behavior.
+- Persistence paths and schema names.
+
+## What should stay game-specific
+
+- Scoring, rules, and win/lose conditions.
+- Scene order and the set of scenes a game actually ships.
+- Game-specific Lua scripts.
+- Unique assets, music, and effects.
+- Game-specific menu labels and custom settings categories.
+
+## New-game checklist
+
+1. Define the startup config in `game.json`.
+2. Author a splash scene if the game needs one.
+3. Author the title scene and point it at the initial play scene.
+4. Add the standard options package if the game uses common settings screens.
+5. Wire input defaults for keyboard, mouse, and gamepad.
+6. Define any persistent scene-state keys before using them in transitions.
+7. Keep scene return behavior explicit:
+   - submenu `Back` returns to the parent options scene
+   - top-level `Back` returns to the title or caller-provided return scene
+8. Put game-specific rules in Lua or game data, not in the host unless the
+   behavior truly cannot be generalized.
+9. Add tests for any new reusable behavior.
+
+## Scene handoff rules
+
+- Use authored scene transitions when a scene needs a fade, delay, or outro.
+- Use scene-state for values that must survive a transition, such as the
+  selected options page, the last play scene, or a restart target.
+- Treat `return_scene` as an authored fallback for leaving a top-level flow,
+  not as a substitute for submenu navigation.
+
+## Practical target
+
+If the template is healthy, a new arcade demo should be able to start with:
+
+- a `game.json`
+- a small set of scene JSON files
+- one or more Lua scripts
+- mostly assets and authored data
+- only a thin amount of host code for true engine integration points


### PR DESCRIPTION
Refines the Pong reusable-template work by adding a concise new-game checklist and linking it from the data-model docs. This slice focuses on template/project hygiene from issue #158.