### PR TITLE
Add Pong multiplayer menu scene graph

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -8,6 +8,12 @@ set(SDL3D_PONG_ASSET_FILES
     ${SDL3D_PONG_AUDIO_FILES}
     images/splash-logo.jpg
     pong.game.json
+    scenes/multiplayer.scene.json
+    scenes/multiplayer_direct_connect.scene.json
+    scenes/multiplayer_discovery.scene.json
+    scenes/multiplayer_join.scene.json
+    scenes/multiplayer_lan.scene.json
+    scenes/multiplayer_lobby.scene.json
     scenes/play.scene.json
     scenes/splash.scene.json
     scenes/title.scene.json

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1276,6 +1276,124 @@
           "random_seed": 19088743
         }
       ]
+    },
+    {
+      "name": "entity.multiplayer.background.base",
+      "active": true,
+      "tags": ["render", "multiplayer", "background"],
+      "transform": { "position": [0.0, 0.0, -0.70] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [22.0, 13.0, 0.08],
+          "color": [4, 8, 20, 255],
+          "lighting": false
+        }
+      ]
+    },
+    {
+      "name": "entity.multiplayer.background.core",
+      "active": true,
+      "tags": ["render", "multiplayer", "background"],
+      "transform": { "position": [0.0, -0.6, -0.45] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 2.45,
+          "rings": 18,
+          "slices": 28,
+          "color": [22, 54, 112, 56],
+          "emissive": true,
+          "effects": [
+            { "type": "drift", "offset": [0.55, 0.35, 0.0], "rates": [0.18, 0.12, 0.0], "phase": 0.4 },
+            { "type": "pulse", "rate": 0.90, "phase": 0.4, "radius_add": 0.42, "color": [54, 110, 224, 86], "emissive_base": [0.04, 0.06, 0.12], "emissive_add": [0.10, 0.18, 0.34] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.multiplayer.background.glow.cyan",
+      "active": true,
+      "tags": ["render", "multiplayer", "background"],
+      "transform": { "position": [-4.8, 1.8, -0.33] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 1.12,
+          "rings": 16,
+          "slices": 24,
+          "color": [45, 204, 255, 118],
+          "emissive": true,
+          "effects": [
+            { "type": "drift", "offset": [0.90, 0.48, 0.0], "rates": [0.25, 0.19, 0.0], "phase": 1.2 },
+            { "type": "pulse", "rate": 1.10, "phase": 1.2, "radius_add": 0.28, "color": [108, 236, 255, 156], "emissive_base": [0.02, 0.12, 0.18], "emissive_add": [0.06, 0.28, 0.42] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.multiplayer.background.glow.violet",
+      "active": true,
+      "tags": ["render", "multiplayer", "background"],
+      "transform": { "position": [4.2, -1.5, -0.30] },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 1.02,
+          "rings": 16,
+          "slices": 24,
+          "color": [168, 92, 255, 102],
+          "emissive": true,
+          "effects": [
+            { "type": "drift", "offset": [0.88, 0.42, 0.0], "rates": [0.21, 0.26, 0.0], "phase": 2.0 },
+            { "type": "pulse", "rate": 1.05, "phase": 2.0, "radius_add": 0.30, "color": [206, 138, 255, 144], "emissive_base": [0.10, 0.03, 0.16], "emissive_add": [0.24, 0.07, 0.34] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.multiplayer.background.stream",
+      "active": true,
+      "tags": ["effect", "particles", "multiplayer"],
+      "transform": { "position": [0.0, -5.0, -0.16] },
+      "components": [
+        {
+          "type": "particles.emitter",
+          "shape": "box",
+          "extents": [10.0, 0.34, 0.05],
+          "direction": [0.04, 1.0, 0.0],
+          "spread": 0.50,
+          "speed_min": 0.10,
+          "speed_max": 0.34,
+          "lifetime_min": 5.2,
+          "lifetime_max": 9.6,
+          "size_start": 0.022,
+          "size_end": 0.006,
+          "gravity": 0.0,
+          "max_particles": 110,
+          "emit_rate": 11.0,
+          "color_start": [54, 126, 255, 74],
+          "color_end": [148, 104, 255, 0],
+          "emissive_intensity": 1.55,
+          "camera_facing": true,
+          "depth_test": false,
+          "additive_blend": true,
+          "draw_emissive": [0.18, 0.46, 1.0],
+          "random_seed": 2917413
+        }
+      ]
+    },
+    {
+      "name": "entity.multiplayer.discovery",
+      "active": true,
+      "tags": ["state", "multiplayer", "discovery"],
+      "properties": {
+        "status": { "type": "string", "value": "Scanning for hosts..." },
+        "session_0": { "type": "string", "value": "No sessions discovered yet" },
+        "session_1": { "type": "string", "value": "" },
+        "session_2": { "type": "string", "value": "" },
+        "session_3": { "type": "string", "value": "" }
+      }
     }
   ],
   "signals": [
@@ -1305,6 +1423,7 @@
     "signal.settings.reset_mouse",
     "signal.settings.reset_gamepad",
     "signal.settings.reset_audio",
+    "signal.multiplayer.discovery.refresh",
     "signal.ui.menu.move",
     "signal.ui.menu.select",
     "signal.app.quit_fade_done"

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -105,6 +105,12 @@
     "files": [
       "scenes/splash.scene.json",
       "scenes/title.scene.json",
+      "scenes/multiplayer.scene.json",
+      "scenes/multiplayer_lan.scene.json",
+      "scenes/multiplayer_lobby.scene.json",
+      "scenes/multiplayer_join.scene.json",
+      "scenes/multiplayer_direct_connect.scene.json",
+      "scenes/multiplayer_discovery.scene.json",
       { "package": "standard_options" },
       "scenes/play.scene.json"
     ],

--- a/demos/pong/data/scenes/multiplayer.scene.json
+++ b/demos/pong/data/scenes/multiplayer.scene.json
@@ -1,0 +1,79 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        {
+          "label": "Local",
+          "scene": "scene.play",
+          "scene_state": { "key": "match_mode", "value": "local" }
+        },
+        {
+          "label": "LAN",
+          "scene": "scene.multiplayer.lan",
+          "scene_state": { "key": "match_mode", "value": "lan" }
+        },
+        { "label": "Back", "scene": "scene.title" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.title",
+        "font": "font.title",
+        "text": "MULTIPLAYER",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.menu",
+        "menu": "menu.multiplayer",
+        "font": "font.hud",
+        "x": 0.45,
+        "y": 0.38,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/multiplayer.scene.json
+++ b/demos/pong/data/scenes/multiplayer.scene.json
@@ -2,7 +2,15 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream"
+  ],
   "input": {
     "actions": [
       "action.menu.up",

--- a/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
+++ b/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
@@ -1,0 +1,77 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer.direct_connect",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer.direct_connect",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Back", "scene": "scene.multiplayer.join" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.direct.title",
+        "font": "font.title",
+        "text": "DIRECT CONNECT",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.direct.status",
+        "font": "font.hud",
+        "text": "ENTER HOST / IP AND PORT",
+        "x": 0.5,
+        "y": 0.34,
+        "normalized": true,
+        "centered": true,
+        "color": [225, 236, 255, 245]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.direct.menu",
+        "menu": "menu.multiplayer.direct_connect",
+        "font": "font.hud",
+        "x": 0.45,
+        "y": 0.52,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255]
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
+++ b/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
@@ -2,7 +2,15 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer.direct_connect",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream"
+  ],
   "input": {
     "actions": [
       "action.menu.up",
@@ -26,7 +34,7 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Back", "scene": "scene.multiplayer.join" }
+        { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/multiplayer_discovery.scene.json
+++ b/demos/pong/data/scenes/multiplayer_discovery.scene.json
@@ -2,7 +2,16 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer.discovery",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream",
+    "entity.multiplayer.discovery"
+  ],
   "input": {
     "actions": [
       "action.menu.up",
@@ -15,6 +24,27 @@
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "activity": {
+    "enabled": true,
+    "input": "any",
+    "reset_periodic_on_input": false,
+    "on_enter": [
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "status", "value": "Scanning for hosts..." },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_0", "value": "No sessions discovered yet" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_1", "value": "" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_2", "value": "" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_3", "value": "" },
+      { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
+    ],
+    "periodic": [
+      {
+        "interval": 15.0,
+        "actions": [
+          { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
+        ]
+      }
+    ]
+  },
   "menus": [
     {
       "name": "menu.multiplayer.discovery",
@@ -26,7 +56,7 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Back", "scene": "scene.multiplayer.join" }
+        { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
   ],
@@ -45,11 +75,66 @@
       {
         "name": "ui.multiplayer.discovery.status",
         "font": "font.hud",
-        "text": "SCAN THE LAN FOR HOSTS",
-        "x": 0.5,
-        "y": 0.34,
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "status" }
+        ],
+        "x": 0.30,
+        "y": 0.30,
         "normalized": true,
-        "centered": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.discovery.session_0",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_0" }
+        ],
+        "x": 0.30,
+        "y": 0.40,
+        "normalized": true,
+        "align": "left",
+        "color": [255, 245, 208, 255]
+      },
+      {
+        "name": "ui.multiplayer.discovery.session_1",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_1" }
+        ],
+        "x": 0.30,
+        "y": 0.48,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.discovery.session_2",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_2" }
+        ],
+        "x": 0.30,
+        "y": 0.56,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.discovery.session_3",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_3" }
+        ],
+        "x": 0.30,
+        "y": 0.64,
+        "normalized": true,
+        "align": "left",
         "color": [225, 236, 255, 245]
       }
     ],
@@ -58,8 +143,8 @@
         "name": "ui.multiplayer.discovery.menu",
         "menu": "menu.multiplayer.discovery",
         "font": "font.hud",
-        "x": 0.45,
-        "y": 0.52,
+        "x": 0.30,
+        "y": 0.80,
         "gap": 0.09,
         "normalized": true,
         "align": "left",

--- a/demos/pong/data/scenes/multiplayer_discovery.scene.json
+++ b/demos/pong/data/scenes/multiplayer_discovery.scene.json
@@ -1,0 +1,77 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer.discovery",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer.discovery",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Back", "scene": "scene.multiplayer.join" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.discovery.title",
+        "font": "font.title",
+        "text": "DISCOVER GAME SESSIONS",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.discovery.status",
+        "font": "font.hud",
+        "text": "SCAN THE LAN FOR HOSTS",
+        "x": 0.5,
+        "y": 0.34,
+        "normalized": true,
+        "centered": true,
+        "color": [225, 236, 255, 245]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.discovery.menu",
+        "menu": "menu.multiplayer.discovery",
+        "font": "font.hud",
+        "x": 0.45,
+        "y": 0.52,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255]
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/multiplayer_join.scene.json
+++ b/demos/pong/data/scenes/multiplayer_join.scene.json
@@ -2,7 +2,16 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer.join",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream",
+    "entity.multiplayer.discovery"
+  ],
   "input": {
     "actions": [
       "action.menu.up",
@@ -15,6 +24,27 @@
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "activity": {
+    "enabled": true,
+    "input": "any",
+    "reset_periodic_on_input": false,
+    "on_enter": [
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "status", "value": "Scanning for hosts..." },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_0", "value": "No sessions discovered yet" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_1", "value": "" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_2", "value": "" },
+      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_3", "value": "" },
+      { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
+    ],
+    "periodic": [
+      {
+        "interval": 15.0,
+        "actions": [
+          { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
+        ]
+      }
+    ]
+  },
   "menus": [
     {
       "name": "menu.multiplayer.join",
@@ -26,16 +56,6 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        {
-          "label": "Discover Game Sessions",
-          "scene": "scene.multiplayer.discovery",
-          "scene_state": { "key": "join_mode", "value": "discover" }
-        },
-        {
-          "label": "Direct Connect",
-          "scene": "scene.multiplayer.direct_connect",
-          "scene_state": { "key": "join_mode", "value": "direct" }
-        },
         { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
@@ -51,6 +71,81 @@
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.join.status",
+        "font": "font.hud",
+        "text": "AUTOMATIC LAN DISCOVERY",
+        "x": 0.5,
+        "y": 0.30,
+        "normalized": true,
+        "centered": true,
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.join.discovery.status",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "status" }
+        ],
+        "x": 0.30,
+        "y": 0.42,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.join.discovery.session_0",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_0" }
+        ],
+        "x": 0.30,
+        "y": 0.50,
+        "normalized": true,
+        "align": "left",
+        "color": [255, 245, 208, 255]
+      },
+      {
+        "name": "ui.multiplayer.join.discovery.session_1",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_1" }
+        ],
+        "x": 0.30,
+        "y": 0.58,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.join.discovery.session_2",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_2" }
+        ],
+        "x": 0.30,
+        "y": 0.66,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
+      },
+      {
+        "name": "ui.multiplayer.join.discovery.session_3",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_3" }
+        ],
+        "x": 0.30,
+        "y": 0.74,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245]
       }
     ],
     "menus": [
@@ -59,7 +154,7 @@
         "menu": "menu.multiplayer.join",
         "font": "font.hud",
         "x": 0.30,
-        "y": 0.40,
+        "y": 0.82,
         "gap": 0.085,
         "normalized": true,
         "align": "left",

--- a/demos/pong/data/scenes/multiplayer_join.scene.json
+++ b/demos/pong/data/scenes/multiplayer_join.scene.json
@@ -1,0 +1,79 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer.join",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer.join",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        {
+          "label": "Discover Game Sessions",
+          "scene": "scene.multiplayer.discovery",
+          "scene_state": { "key": "join_mode", "value": "discover" }
+        },
+        {
+          "label": "Direct Connect",
+          "scene": "scene.multiplayer.direct_connect",
+          "scene_state": { "key": "join_mode", "value": "direct" }
+        },
+        { "label": "Back", "scene": "scene.multiplayer.lan" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.join.title",
+        "font": "font.title",
+        "text": "JOIN MATCH",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.join.menu",
+        "menu": "menu.multiplayer.join",
+        "font": "font.hud",
+        "x": 0.30,
+        "y": 0.40,
+        "gap": 0.085,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/multiplayer_lan.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lan.scene.json
@@ -1,0 +1,84 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer.lan",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer.lan",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        {
+          "label": "Create Match",
+          "scene": "scene.multiplayer.lobby",
+          "scene_state": { "key": "network_flow", "value": "host" }
+        },
+        {
+          "label": "Join Match",
+          "scene": "scene.multiplayer.join",
+          "scene_state": { "key": "network_flow", "value": "join" }
+        },
+        {
+          "label": "Direct Connect",
+          "scene": "scene.multiplayer.direct_connect",
+          "scene_state": { "key": "network_flow", "value": "direct" }
+        },
+        { "label": "Back", "scene": "scene.multiplayer" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.lan.title",
+        "font": "font.title",
+        "text": "LAN",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.lan.menu",
+        "menu": "menu.multiplayer.lan",
+        "font": "font.hud",
+        "x": 0.40,
+        "y": 0.36,
+        "gap": 0.082,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/multiplayer_lan.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lan.scene.json
@@ -2,7 +2,15 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer.lan",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream"
+  ],
   "input": {
     "actions": [
       "action.menu.up",

--- a/demos/pong/data/scenes/multiplayer_lobby.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lobby.scene.json
@@ -2,7 +2,15 @@
   "schema": "sdl3d.scene.v0",
   "name": "scene.multiplayer.lobby",
   "updates_game": false,
-  "renders_world": false,
+  "renders_world": true,
+  "camera": "camera.overhead",
+  "entities": [
+    "entity.multiplayer.background.base",
+    "entity.multiplayer.background.core",
+    "entity.multiplayer.background.glow.cyan",
+    "entity.multiplayer.background.glow.violet",
+    "entity.multiplayer.background.stream"
+  ],
   "input": {
     "actions": [
       "action.menu.up",

--- a/demos/pong/data/scenes/multiplayer_lobby.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lobby.scene.json
@@ -1,0 +1,77 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.multiplayer.lobby",
+  "updates_game": false,
+  "renders_world": false,
+  "input": {
+    "actions": [
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select",
+      "action.menu.back"
+    ]
+  },
+  "transitions": {
+    "enter": "scene_in",
+    "exit": "scene_out"
+  },
+  "menus": [
+    {
+      "name": "menu.multiplayer.lobby",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Back", "scene": "scene.multiplayer.lan" }
+      ]
+    }
+  ],
+  "ui": {
+    "text": [
+      {
+        "name": "ui.multiplayer.lobby.title",
+        "font": "font.title",
+        "text": "LOBBY",
+        "x": 0.5,
+        "y": 0.18,
+        "normalized": true,
+        "centered": true,
+        "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.lobby.status",
+        "font": "font.hud",
+        "text": "WAITING FOR PLAYER 2",
+        "x": 0.5,
+        "y": 0.34,
+        "normalized": true,
+        "centered": true,
+        "color": [225, 236, 255, 245]
+      }
+    ],
+    "menus": [
+      {
+        "name": "ui.multiplayer.lobby.menu",
+        "menu": "menu.multiplayer.lobby",
+        "font": "font.hud",
+        "x": 0.45,
+        "y": 0.52,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255]
+        }
+      }
+    ]
+  }
+}

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -73,7 +73,16 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Play", "scene": "scene.play" },
+        {
+          "label": "Single Player",
+          "scene": "scene.play",
+          "scene_state": { "key": "match_mode", "value": "single" }
+        },
+        {
+          "label": "Multiplayer",
+          "scene": "scene.multiplayer",
+          "scene_state": { "key": "match_mode", "value": "multiplayer" }
+        },
         { "label": "Options", "scene": "scene.options", "return_to": "scene.title", "return_paused": false },
         { "label": "Exit", "quit": true }
       ]

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -955,18 +955,24 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
-    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 9);
+    EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 0), "scene.splash");
     EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 1), "scene.title");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.options");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.options.display");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 4), "scene.options.keyboard");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.options.mouse");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.options.gamepad");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 7), "scene.options.audio");
-    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 8), "scene.play");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 2), "scene.multiplayer");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 3), "scene.multiplayer.lan");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 4), "scene.multiplayer.lobby");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 5), "scene.multiplayer.join");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 6), "scene.multiplayer.direct_connect");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 7), "scene.multiplayer.discovery");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 8), "scene.options");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 9), "scene.options.display");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 10), "scene.options.keyboard");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 11), "scene.options.mouse");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 12), "scene.options.gamepad");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 13), "scene.options.audio");
+    EXPECT_STREQ(sdl3d_game_data_scene_name_at(runtime, 14), "scene.play");
     EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, -1), nullptr);
-    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 9), nullptr);
+    EXPECT_EQ(sdl3d_game_data_scene_name_at(runtime, 15), nullptr);
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_renders_world(runtime));
     EXPECT_FALSE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.ball"));
@@ -1290,7 +1296,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     sdl3d_game_data_menu menu{};
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.title");
-    EXPECT_EQ(menu.item_count, 3);
+    EXPECT_EQ(menu.item_count, 4);
     EXPECT_EQ(menu.selected_index, 0);
     EXPECT_GE(menu.up_action_id, 0);
     EXPECT_GE(menu.down_action_id, 0);
@@ -1311,14 +1317,26 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_TRUE(sdl3d_game_data_active_menu_input_is_idle(runtime, input));
 
     sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Single Player");
+    EXPECT_STREQ(item.scene, "scene.play");
+    EXPECT_STREQ(item.scene_state_key, "match_mode");
+    EXPECT_STREQ(item.scene_state_value, "single");
+
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Multiplayer");
+    EXPECT_STREQ(item.scene, "scene.multiplayer");
+    EXPECT_STREQ(item.scene_state_key, "match_mode");
+    EXPECT_STREQ(item.scene_state_value, "multiplayer");
+
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
     EXPECT_STREQ(item.label, "Options");
     EXPECT_STREQ(item.scene, "scene.options");
     EXPECT_FALSE(item.quit);
 
     ASSERT_TRUE(sdl3d_game_data_menu_move(runtime, menu.name, -1));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
-    EXPECT_EQ(menu.selected_index, 2);
+    EXPECT_EQ(menu.selected_index, 3);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, menu.selected_index, &item));
     EXPECT_STREQ(item.label, "Exit");
     EXPECT_TRUE(item.quit);
@@ -1360,6 +1378,37 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_title_menu_ui, &title_menu_flags));
     EXPECT_TRUE(saw_title_cursor);
     EXPECT_TRUE(saw_title_exit);
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer");
+    EXPECT_EQ(menu.item_count, 3);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Local");
+    EXPECT_STREQ(item.scene, "scene.play");
+    EXPECT_STREQ(item.scene_state_key, "match_mode");
+    EXPECT_STREQ(item.scene_state_value, "local");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "LAN");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.lan");
+    EXPECT_STREQ(item.scene_state_key, "match_mode");
+    EXPECT_STREQ(item.scene_state_value, "lan");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lan"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.lan");
+    EXPECT_EQ(menu.item_count, 4);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Create Match");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.lobby");
+    EXPECT_STREQ(item.scene_state_key, "network_flow");
+    EXPECT_STREQ(item.scene_state_value, "host");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Join Match");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.join");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Direct Connect");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.direct_connect");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
@@ -1801,7 +1850,7 @@ TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)
     EXPECT_FALSE(result.quit);
     EXPECT_STREQ(result.menu, "menu.title");
     EXPECT_EQ(result.selected_index, 1);
-    EXPECT_STREQ(result.scene, "scene.options");
+    EXPECT_STREQ(result.scene, "scene.multiplayer");
     EXPECT_EQ(result.signal_id, -1);
     EXPECT_EQ(result.move_signal_id, -1);
     EXPECT_EQ(result.select_signal_id, menu_select_signal);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1406,6 +1406,20 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
     EXPECT_STREQ(item.label, "Join Match");
     EXPECT_STREQ(item.scene, "scene.multiplayer.join");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.join"));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_renders_world(runtime));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.multiplayer.discovery"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.join");
+    EXPECT_EQ(menu.item_count, 1);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.lan");
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lan"));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.lan");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
     EXPECT_STREQ(item.label, "Direct Connect");
     EXPECT_STREQ(item.scene, "scene.multiplayer.direct_connect");


### PR DESCRIPTION
Implements the first Pong multiplayer slice from issue #162: title screen branching, multiplayer submenu scenes, LAN submenu routing, and placeholder join/lobby/direct-connect scenes backed by scene-state and validated by game-data tests.