### PR TITLE
Add slot-aware local multiplayer input mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,4 +46,4 @@ This file gives working guidance for AI agents maintaining SDL_3D.
 - Add focused tests for the changed behavior.
 - Run the relevant build/test targets before finishing.
 - Update documentation or sample data if the public behavior changed.
-
+- Run `clang-format` on all touched C and C++ files before submitting a PR.

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -545,6 +545,12 @@
             ]
           },
           {
+            "name": "action.paddle.local.up"
+          },
+          {
+            "name": "action.paddle.local.down"
+          },
+          {
             "name": "action.pause",
             "bindings": [
               { "device": "keyboard", "key": "RETURN" },
@@ -885,7 +891,8 @@
           ]
         },
         { "type": "collision.aabb", "half_extents": [0.18, 0.95, 0.14] },
-        { "type": "adapter.controller", "adapter": "adapter.pong.cpu_track_ball", "target": "entity.ball" }
+        { "type": "adapter.controller", "adapter": "adapter.pong.cpu_track_ball", "target": "entity.ball" },
+        { "type": "control.axis_1d", "axis": "y", "negative": "action.paddle.local.down", "positive": "action.paddle.local.up" }
       ]
     },
     {
@@ -1618,6 +1625,7 @@
       {
         "signal": "signal.game.start",
         "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.pong.configure_play_input" },
           { "type": "timer.start", "timer": "timer.round.serve" }
         ]
       },
@@ -1816,6 +1824,13 @@
       "script": "script.pong",
       "function": "cpu_track_ball",
       "description": "Move the CPU paddle toward the current ball position."
+    },
+    {
+      "name": "adapter.pong.configure_play_input",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "configure_play_input",
+      "description": "Configure Pong paddle bindings for single-player or local multiplayer layouts."
     },
     {
       "name": "adapter.pong.load_persistence",

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -26,6 +26,8 @@
     "actions": [
       "action.paddle.up",
       "action.paddle.down",
+      "action.paddle.local.up",
+      "action.paddle.local.down",
       "action.pause",
       "action.restart",
       "action.camera.ball.toggle",

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -89,6 +89,10 @@ function pong.reflect_from_paddle(ball, payload, ctx)
 end
 
 function pong.cpu_track_ball(paddle, payload, ctx)
+    if ctx:state_get("match_mode", "single") == "local" then
+        return true
+    end
+
     local ball = payload.target_actor_name and ctx:actor(payload.target_actor_name) or ctx:actor_with_tags("ball")
     local ball_position = ball ~= nil and ball.position or nil
     local paddle_position = paddle.position
@@ -104,6 +108,10 @@ function pong.cpu_track_ball(paddle, payload, ctx)
     local step = math.clamp(ball_position.y - paddle_position.y, -max_step, max_step)
     local next_y = math.clamp(paddle_position.y + step, -field_half_height + half_height, field_half_height - half_height)
     paddle.position = Vec3(paddle_position.x, next_y, paddle_position.z)
+    return true
+end
+
+function pong.configure_play_input(_, _, _)
     return true
 end
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -30,7 +30,134 @@ typedef struct pong_state
     int vibration_connection;
     int ball_hit_signal_id;
     int vibration_signal_id;
+    int local_input_gamepad_count;
 } pong_state;
+
+static bool is_local_match_mode(const pong_state *state)
+{
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", NULL) : NULL;
+    return match_mode != NULL && SDL_strcmp(match_mode, "local") == 0;
+}
+
+static void bind_local_play_controls(pong_state *state)
+{
+    if (state == NULL || state->data == NULL || state->input == NULL)
+    {
+        return;
+    }
+
+    const int gamepad_count = sdl3d_input_gamepad_count(state->input);
+    const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
+    const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
+    const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
+    const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
+
+    if (p1_up < 0 || p1_down < 0 || p2_up < 0 || p2_down < 0)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong local input rebinding skipped: required paddle actions were not registered");
+        return;
+    }
+
+    sdl3d_input_unbind_action(state->input, p1_up);
+    sdl3d_input_unbind_action(state->input, p1_down);
+    sdl3d_input_unbind_action(state->input, p2_up);
+    sdl3d_input_unbind_action(state->input, p2_down);
+
+    sdl3d_input_bind_key(state->input, p1_up, SDL_SCANCODE_UP);
+    sdl3d_input_bind_key(state->input, p1_down, SDL_SCANCODE_DOWN);
+
+    if (gamepad_count >= 2)
+    {
+        sdl3d_input_bind_gamepad_button_at(state->input, p1_up, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
+        sdl3d_input_bind_gamepad_button_at(state->input, p1_down, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p1_up, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p1_down, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+
+        sdl3d_input_bind_gamepad_button_at(state->input, p2_up, 1, SDL_GAMEPAD_BUTTON_DPAD_UP);
+        sdl3d_input_bind_gamepad_button_at(state->input, p2_down, 1, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p2_up, 1, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p2_down, 1, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+    }
+    else if (gamepad_count == 1)
+    {
+        sdl3d_input_bind_gamepad_button_at(state->input, p2_up, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
+        sdl3d_input_bind_gamepad_button_at(state->input, p2_down, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p2_up, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+        sdl3d_input_bind_gamepad_axis_at(state->input, p2_down, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+    }
+
+    state->local_input_gamepad_count = gamepad_count;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong local input configured: gamepads=%d", gamepad_count);
+}
+
+static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
+                                 sdl3d_registered_actor *target, const sdl3d_properties *payload)
+{
+    pong_state *state = (pong_state *)userdata;
+    (void)runtime;
+    (void)adapter_name;
+    (void)target;
+    (void)payload;
+
+    if (state == NULL || state->data == NULL || state->input == NULL)
+    {
+        return false;
+    }
+
+    if (is_local_match_mode(state))
+    {
+        bind_local_play_controls(state);
+    }
+    else
+    {
+        const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
+        const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
+        if (p1_up < 0 || p1_down < 0)
+        {
+            return false;
+        }
+
+        sdl3d_input_unbind_action(state->input, p1_up);
+        sdl3d_input_unbind_action(state->input, p1_down);
+        sdl3d_input_bind_key(state->input, p1_up, SDL_SCANCODE_UP);
+        sdl3d_input_bind_key(state->input, p1_down, SDL_SCANCODE_DOWN);
+        sdl3d_input_bind_gamepad_button(state->input, p1_up, SDL_GAMEPAD_BUTTON_DPAD_UP);
+        sdl3d_input_bind_gamepad_button(state->input, p1_down, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        sdl3d_input_bind_gamepad_axis(state->input, p1_up, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+        sdl3d_input_bind_gamepad_axis(state->input, p1_down, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+
+        const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
+        const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
+        if (p2_up >= 0)
+            sdl3d_input_unbind_action(state->input, p2_up);
+        if (p2_down >= 0)
+            sdl3d_input_unbind_action(state->input, p2_down);
+        state->local_input_gamepad_count = sdl3d_input_gamepad_count(state->input);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong single-player input configured: gamepads=%d",
+                    state->local_input_gamepad_count);
+    }
+
+    return true;
+}
+
+static void refresh_local_play_input(pong_state *state)
+{
+    const char *active_scene = state != NULL && state->data != NULL ? sdl3d_game_data_active_scene(state->data) : NULL;
+    if (state == NULL || state->input == NULL || active_scene == NULL || SDL_strcmp(active_scene, "scene.play") != 0 ||
+        !is_local_match_mode(state))
+    {
+        return;
+    }
+
+    const int gamepad_count = sdl3d_input_gamepad_count(state->input);
+    if (gamepad_count != state->local_input_gamepad_count)
+    {
+        bind_local_play_controls(state);
+    }
+}
 
 static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
@@ -62,7 +189,8 @@ static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_prope
     }
 
     if (signal_id == state->ball_hit_signal_id && other_actor_name != NULL &&
-        SDL_strcmp(other_actor_name, "entity.paddle.player") == 0)
+        (SDL_strcmp(other_actor_name, "entity.paddle.player") == 0 ||
+         (is_local_match_mode(state) && SDL_strcmp(other_actor_name, "entity.paddle.cpu") == 0)))
     {
         if (!sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120))
         {
@@ -115,6 +243,17 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong data loaded: asset=%s active_scene=%s", SDL3D_PONG_DATA_ASSET_PATH,
                 sdl3d_game_data_active_scene(state->data) != NULL ? sdl3d_game_data_active_scene(state->data)
                                                                   : "<none>");
+
+    if (!sdl3d_game_data_register_adapter(state->data, "adapter.pong.configure_play_input", configure_play_input,
+                                          state))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong play input adapter registration failed");
+        sdl3d_game_data_destroy(state->data);
+        state->data = NULL;
+        sdl3d_asset_resolver_destroy(state->assets);
+        state->assets = NULL;
+        return false;
+    }
     return true;
 }
 
@@ -154,6 +293,7 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     state->vibration_connection = 0;
     state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
     state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
+    state->local_input_gamepad_count = -1;
     if (state->input != NULL)
     {
         if (state->ball_hit_signal_id >= 0)
@@ -181,6 +321,7 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
 static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
+    refresh_local_play_input(state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -193,6 +334,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     pong_state *state = (pong_state *)userdata;
+    refresh_local_play_input(state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -74,6 +74,7 @@ extern "C"
     {
         int action_id;             /**< Registered action ID. */
         sdl3d_input_source source; /**< Source device/control kind. */
+        int gamepad_index;         /**< Specific gamepad slot, or -1 for any connected slot. */
         int required_modifiers;    /**< sdl3d_input_modifier mask for keyboard bindings. */
         int excluded_modifiers;    /**< sdl3d_input_modifier mask that must be absent for keyboard bindings. */
         union {
@@ -185,6 +186,15 @@ extern "C"
     void sdl3d_input_bind_gamepad_button(sdl3d_input_manager *input, int action_id, SDL_GamepadButton button);
 
     /**
+     * @brief Bind a gamepad button to an action for one specific slot.
+     *
+     * Pass a slot in [0, SDL3D_INPUT_MAX_GAMEPADS) to require one controller,
+     * or -1 to match any connected controller.
+     */
+    void sdl3d_input_bind_gamepad_button_at(sdl3d_input_manager *input, int action_id, int gamepad_index,
+                                            SDL_GamepadButton button);
+
+    /**
      * @brief Bind a gamepad axis to an action.
      *
      * If the same physical axis is bound to another action with an opposite
@@ -192,6 +202,15 @@ extern "C"
      * directional actions such as move_forward/move_back on one stick axis.
      */
     void sdl3d_input_bind_gamepad_axis(sdl3d_input_manager *input, int action_id, SDL_GamepadAxis axis, float scale);
+
+    /**
+     * @brief Bind a gamepad axis to an action for one specific slot.
+     *
+     * Pass a slot in [0, SDL3D_INPUT_MAX_GAMEPADS) to require one controller,
+     * or -1 to match any connected controller.
+     */
+    void sdl3d_input_bind_gamepad_axis_at(sdl3d_input_manager *input, int action_id, int gamepad_index,
+                                          SDL_GamepadAxis axis, float scale);
 
     /** @brief Remove all bindings for an action. */
     void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -107,6 +107,7 @@ typedef struct input_binding_spec
     const char *action;
     int action_id;
     sdl3d_input_source source;
+    int gamepad_index;
     int required_modifiers;
     int excluded_modifiers;
     union {
@@ -5043,10 +5044,11 @@ static void bind_input_spec(sdl3d_input_manager *input, const input_binding_spec
         sdl3d_input_bind_mouse_axis(input, spec->action_id, spec->mouse_axis, spec->scale);
         break;
     case SDL3D_INPUT_GAMEPAD_BUTTON:
-        sdl3d_input_bind_gamepad_button(input, spec->action_id, spec->gamepad_button);
+        sdl3d_input_bind_gamepad_button_at(input, spec->action_id, spec->gamepad_index, spec->gamepad_button);
         break;
     case SDL3D_INPUT_GAMEPAD_AXIS:
-        sdl3d_input_bind_gamepad_axis(input, spec->action_id, spec->gamepad_axis, spec->scale);
+        sdl3d_input_bind_gamepad_axis_at(input, spec->action_id, spec->gamepad_index, spec->gamepad_axis,
+                                         spec->scale);
         break;
     }
 }
@@ -5090,6 +5092,7 @@ static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const 
     spec.action = action;
     spec.action_id = action_id;
     spec.source = SDL3D_INPUT_KEYBOARD;
+    spec.gamepad_index = -1;
     spec.scancode = scancode;
     spec.scale = 1.0f;
     if (!append_input_binding_spec(runtime, &spec))
@@ -5123,6 +5126,7 @@ static bool set_action_mouse_button_binding(sdl3d_game_data_runtime *runtime, co
     spec.action = action;
     spec.action_id = action_id;
     spec.source = SDL3D_INPUT_MOUSE_BUTTON;
+    spec.gamepad_index = -1;
     spec.mouse_button = button;
     spec.scale = 1.0f;
     if (!append_input_binding_spec(runtime, &spec))
@@ -5157,6 +5161,7 @@ static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, 
     spec.action = action;
     spec.action_id = action_id;
     spec.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+    spec.gamepad_index = -1;
     spec.gamepad_button = button;
     spec.scale = 1.0f;
     if (!append_input_binding_spec(runtime, &spec))
@@ -5216,6 +5221,7 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                         spec.action = name;
                         spec.action_id = action_id;
                         spec.source = SDL3D_INPUT_KEYBOARD;
+                        spec.gamepad_index = -1;
                         spec.scancode = code;
                         spec.scale = 1.0f;
                         if (!append_input_binding_spec(runtime, &spec))
@@ -5238,6 +5244,7 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                             spec.action = name;
                             spec.action_id = action_id;
                             spec.source = SDL3D_INPUT_MOUSE_AXIS;
+                            spec.gamepad_index = -1;
                             spec.mouse_axis = mouse_axis;
                             spec.scale = scale;
                             if (!append_input_binding_spec(runtime, &spec))
@@ -5255,6 +5262,7 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                             spec.action = name;
                             spec.action_id = action_id;
                             spec.source = SDL3D_INPUT_MOUSE_BUTTON;
+                            spec.gamepad_index = -1;
                             spec.mouse_button = mouse_button;
                             spec.scale = 1.0f;
                             if (!append_input_binding_spec(runtime, &spec))
@@ -5277,6 +5285,7 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                             spec.action = name;
                             spec.action_id = action_id;
                             spec.source = SDL3D_INPUT_GAMEPAD_AXIS;
+                            spec.gamepad_index = json_int(binding, "slot", -1);
                             spec.gamepad_axis = gamepad_axis;
                             spec.scale = scale;
                             if (!append_input_binding_spec(runtime, &spec))
@@ -5294,6 +5303,7 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
                             spec.action = name;
                             spec.action_id = action_id;
                             spec.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+                            spec.gamepad_index = json_int(binding, "slot", -1);
                             spec.gamepad_button = gamepad_button;
                             spec.scale = 1.0f;
                             if (!append_input_binding_spec(runtime, &spec))

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5047,8 +5047,7 @@ static void bind_input_spec(sdl3d_input_manager *input, const input_binding_spec
         sdl3d_input_bind_gamepad_button_at(input, spec->action_id, spec->gamepad_index, spec->gamepad_button);
         break;
     case SDL3D_INPUT_GAMEPAD_AXIS:
-        sdl3d_input_bind_gamepad_axis_at(input, spec->action_id, spec->gamepad_index, spec->gamepad_axis,
-                                         spec->scale);
+        sdl3d_input_bind_gamepad_axis_at(input, spec->action_id, spec->gamepad_index, spec->gamepad_axis, spec->scale);
         break;
     }
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -11,6 +11,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "game_data_standard_options.h"
+#include "sdl3d/input.h"
 
 #define PATH_BUFFER_SIZE 256
 
@@ -970,6 +971,10 @@ static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
                 {
                     if (!is_non_empty_string(binding, "axis") && !is_non_empty_string(binding, "button"))
                         return validation_error(ctx, path, "gamepad binding requires an axis or button");
+                    yyjson_val *slot = obj_get(binding, "slot");
+                    if (slot != NULL && (!yyjson_is_num(slot) || yyjson_get_sint(slot) < -1 ||
+                                         yyjson_get_sint(slot) >= SDL3D_INPUT_MAX_GAMEPADS))
+                        return validation_error(ctx, path, "gamepad binding slot must be -1 or a valid slot index");
                 }
                 else if (SDL_strcmp(device != NULL ? device : "", "mouse") == 0)
                 {

--- a/src/input.c
+++ b/src/input.c
@@ -383,7 +383,8 @@ static float sdl3d_input_gamepad_axis_value_at(const sdl3d_input_manager *input,
     {
         return 0.0f;
     }
-    return sdl3d_input_gamepad_slot_axis_value(slot, axis, input != NULL ? input->deadzone : SDL3D_INPUT_DEFAULT_DEADZONE);
+    return sdl3d_input_gamepad_slot_axis_value(slot, axis,
+                                               input != NULL ? input->deadzone : SDL3D_INPUT_DEFAULT_DEADZONE);
 }
 
 static bool sdl3d_input_mouse_button_valid(Uint8 button)
@@ -462,8 +463,7 @@ static bool sdl3d_input_has_opposite_axis_binding(const sdl3d_input_manager *inp
             return true;
         }
         if (binding->source == SDL3D_INPUT_GAMEPAD_AXIS && other->gamepad_axis == binding->gamepad_axis &&
-            other->gamepad_index == binding->gamepad_index &&
-            other->scale * binding->scale < 0.0f)
+            other->gamepad_index == binding->gamepad_index && other->scale * binding->scale < 0.0f)
         {
             return true;
         }
@@ -531,9 +531,9 @@ static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const s
     case SDL3D_INPUT_GAMEPAD_AXIS:
         return sdl3d_input_axis_binding_value(
             input, binding,
-            binding->gamepad_index >= 0 ? sdl3d_input_gamepad_axis_value_at(input, binding->gamepad_index,
-                                                                           binding->gamepad_axis)
-                                        : sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
+            binding->gamepad_index >= 0
+                ? sdl3d_input_gamepad_axis_value_at(input, binding->gamepad_index, binding->gamepad_axis)
+                : sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
     default:
         return 0.0f;
     }

--- a/src/input.c
+++ b/src/input.c
@@ -152,6 +152,11 @@ static bool sdl3d_input_binding_valid(const sdl3d_input_manager *input, int acti
            input->actions[action_id].registered;
 }
 
+static bool sdl3d_input_gamepad_index_valid(int gamepad_index)
+{
+    return gamepad_index >= 0 && gamepad_index < SDL3D_INPUT_MAX_GAMEPADS;
+}
+
 static void sdl3d_input_add_binding(sdl3d_input_manager *input, const sdl3d_input_binding *binding)
 {
     if (input == NULL || binding == NULL || !sdl3d_input_binding_valid(input, binding->action_id) ||
@@ -198,6 +203,8 @@ static sdl3d_input_gamepad_slot *sdl3d_input_find_free_gamepad_slot(sdl3d_input_
     }
     return NULL;
 }
+
+static const sdl3d_input_gamepad_slot *sdl3d_input_gamepad_slot_at(const sdl3d_input_manager *input, int gamepad_index);
 
 static bool sdl3d_input_slot_is_open(const sdl3d_input_gamepad_slot *slot)
 {
@@ -368,6 +375,17 @@ static float sdl3d_input_gamepad_axis_value(const sdl3d_input_manager *input, SD
     return value;
 }
 
+static float sdl3d_input_gamepad_axis_value_at(const sdl3d_input_manager *input, int gamepad_index,
+                                               SDL_GamepadAxis axis)
+{
+    const sdl3d_input_gamepad_slot *slot = sdl3d_input_gamepad_slot_at(input, gamepad_index);
+    if (slot == NULL)
+    {
+        return 0.0f;
+    }
+    return sdl3d_input_gamepad_slot_axis_value(slot, axis, input != NULL ? input->deadzone : SDL3D_INPUT_DEFAULT_DEADZONE);
+}
+
 static bool sdl3d_input_mouse_button_valid(Uint8 button)
 {
     return button < SDL3D_INPUT_MAX_MOUSE_BUTTONS;
@@ -444,6 +462,7 @@ static bool sdl3d_input_has_opposite_axis_binding(const sdl3d_input_manager *inp
             return true;
         }
         if (binding->source == SDL3D_INPUT_GAMEPAD_AXIS && other->gamepad_axis == binding->gamepad_axis &&
+            other->gamepad_index == binding->gamepad_index &&
             other->scale * binding->scale < 0.0f)
         {
             return true;
@@ -499,6 +518,10 @@ static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const s
         }
         for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
         {
+            if (binding->gamepad_index >= 0 && i != binding->gamepad_index)
+            {
+                continue;
+            }
             if (sdl3d_input_gamepad_slot_button_down(&input->gamepads[i], binding->gamepad_button))
             {
                 return binding->scale;
@@ -506,8 +529,11 @@ static float sdl3d_input_binding_value(const sdl3d_input_manager *input, const s
         }
         return 0.0f;
     case SDL3D_INPUT_GAMEPAD_AXIS:
-        return sdl3d_input_axis_binding_value(input, binding,
-                                              sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
+        return sdl3d_input_axis_binding_value(
+            input, binding,
+            binding->gamepad_index >= 0 ? sdl3d_input_gamepad_axis_value_at(input, binding->gamepad_index,
+                                                                           binding->gamepad_axis)
+                                        : sdl3d_input_gamepad_axis_value(input, binding->gamepad_axis));
     default:
         return 0.0f;
     }
@@ -540,6 +566,10 @@ static bool sdl3d_input_binding_pressed(const sdl3d_input_manager *input, const 
         }
         for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
         {
+            if (binding->gamepad_index >= 0 && i != binding->gamepad_index)
+            {
+                continue;
+            }
             if (sdl3d_input_gamepad_slot_button_pressed(&input->gamepads[i], binding->gamepad_button))
             {
                 return true;
@@ -575,6 +605,10 @@ static bool sdl3d_input_binding_released(const sdl3d_input_manager *input, const
         }
         for (int i = 0; i < SDL3D_INPUT_MAX_GAMEPADS; ++i)
         {
+            if (binding->gamepad_index >= 0 && i != binding->gamepad_index)
+            {
+                continue;
+            }
             if (sdl3d_input_gamepad_slot_button_released(&input->gamepads[i], binding->gamepad_button))
             {
                 return true;
@@ -1021,6 +1055,7 @@ void sdl3d_input_bind_key_mod_mask(sdl3d_input_manager *input, int action_id, SD
     SDL_zero(binding);
     binding.action_id = action_id;
     binding.source = SDL3D_INPUT_KEYBOARD;
+    binding.gamepad_index = -1;
     binding.required_modifiers = required_modifiers;
     binding.excluded_modifiers = excluded_modifiers;
     binding.scancode = key;
@@ -1034,6 +1069,7 @@ void sdl3d_input_bind_mouse_button(sdl3d_input_manager *input, int action_id, Ui
     SDL_zero(binding);
     binding.action_id = action_id;
     binding.source = SDL3D_INPUT_MOUSE_BUTTON;
+    binding.gamepad_index = -1;
     binding.mouse_button = button;
     binding.scale = 1.0f;
     sdl3d_input_add_binding(input, &binding);
@@ -1045,6 +1081,7 @@ void sdl3d_input_bind_mouse_axis(sdl3d_input_manager *input, int action_id, sdl3
     SDL_zero(binding);
     binding.action_id = action_id;
     binding.source = SDL3D_INPUT_MOUSE_AXIS;
+    binding.gamepad_index = -1;
     binding.mouse_axis = axis;
     binding.scale = scale;
     sdl3d_input_add_binding(input, &binding);
@@ -1052,10 +1089,17 @@ void sdl3d_input_bind_mouse_axis(sdl3d_input_manager *input, int action_id, sdl3
 
 void sdl3d_input_bind_gamepad_button(sdl3d_input_manager *input, int action_id, SDL_GamepadButton button)
 {
+    sdl3d_input_bind_gamepad_button_at(input, action_id, -1, button);
+}
+
+void sdl3d_input_bind_gamepad_button_at(sdl3d_input_manager *input, int action_id, int gamepad_index,
+                                        SDL_GamepadButton button)
+{
     sdl3d_input_binding binding;
     SDL_zero(binding);
     binding.action_id = action_id;
     binding.source = SDL3D_INPUT_GAMEPAD_BUTTON;
+    binding.gamepad_index = sdl3d_input_gamepad_index_valid(gamepad_index) ? gamepad_index : -1;
     binding.gamepad_button = button;
     binding.scale = 1.0f;
     sdl3d_input_add_binding(input, &binding);
@@ -1063,10 +1107,17 @@ void sdl3d_input_bind_gamepad_button(sdl3d_input_manager *input, int action_id, 
 
 void sdl3d_input_bind_gamepad_axis(sdl3d_input_manager *input, int action_id, SDL_GamepadAxis axis, float scale)
 {
+    sdl3d_input_bind_gamepad_axis_at(input, action_id, -1, axis, scale);
+}
+
+void sdl3d_input_bind_gamepad_axis_at(sdl3d_input_manager *input, int action_id, int gamepad_index,
+                                      SDL_GamepadAxis axis, float scale)
+{
     sdl3d_input_binding binding;
     SDL_zero(binding);
     binding.action_id = action_id;
     binding.source = SDL3D_INPUT_GAMEPAD_AXIS;
+    binding.gamepad_index = sdl3d_input_gamepad_index_valid(gamepad_index) ? gamepad_index : -1;
     binding.gamepad_axis = axis;
     binding.scale = scale;
     sdl3d_input_add_binding(input, &binding);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -950,6 +950,8 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_NE(sdl3d_game_data_find_actor_with_tags(runtime, paddle_tags, 2), nullptr);
     EXPECT_GE(sdl3d_game_data_find_signal(runtime, "signal.ball.serve"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.up"), 0);
+    EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.local.up"), 0);
+    EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.paddle.local.down"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.title"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.options"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1775,8 +1775,10 @@ TEST(GameDataRuntime, DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks)
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
     EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, pause));
-    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.up")));
-    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.down")));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(
+        runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.up")));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(
+        runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.down")));
     EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(runtime, "presentation", true));
     EXPECT_FALSE(sdl3d_game_data_active_scene_update_phase(runtime, "simulation", true));
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1775,6 +1775,8 @@ TEST(GameDataRuntime, DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks)
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
     EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, pause));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.up")));
+    EXPECT_TRUE(sdl3d_game_data_active_scene_allows_action(runtime, sdl3d_game_data_find_action(runtime, "action.paddle.local.down")));
     EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(runtime, "presentation", true));
     EXPECT_FALSE(sdl3d_game_data_active_scene_update_phase(runtime, "simulation", true));
 

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -318,6 +318,33 @@ TEST(Input, GamepadButtonPressAndRelease)
     EXPECT_EQ(sdl3d_input_get_pressed_gamepad_button(input.input), SDL_GAMEPAD_BUTTON_INVALID);
 }
 
+TEST(Input, GamepadBindingsCanTargetSpecificSlots)
+{
+    InputPtr input;
+    if (sdl3d_input_gamepad_count(input.input) != 0)
+    {
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+
+    int player_one = sdl3d_input_register_action(input.input, "player_one");
+    int player_two = sdl3d_input_register_action(input.input, "player_two");
+    sdl3d_input_bind_gamepad_button_at(input.input, player_one, 0, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_bind_gamepad_button_at(input.input, player_two, 1, SDL_GAMEPAD_BUTTON_SOUTH);
+
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1101);
+    push_gamepad_device(input.input, SDL_EVENT_GAMEPAD_ADDED, 1102);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1101, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, player_one));
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, player_two));
+
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_UP, 1101, SDL_GAMEPAD_BUTTON_SOUTH);
+    push_gamepad_button(input.input, SDL_EVENT_GAMEPAD_BUTTON_DOWN, 1102, SDL_GAMEPAD_BUTTON_SOUTH);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, player_one));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, player_two));
+}
+
 TEST(Input, GamepadAxisAndConvenienceQueries)
 {
     InputPtr input;


### PR DESCRIPTION
## Summary

- Added slot-aware gamepad bindings to the input API and JSON loader.
- Wired Pong local multiplayer so input maps correctly for:
  - `1 keyboard + 1 gamepad` -> player 1 on keyboard, player 2 on gamepad slot 0
  - `1 keyboard + 2 gamepads` -> player 1 on keyboard + gamepad slot 0, player 2 on gamepad slot 1
- Added regression coverage for slot-targeted bindings and Pong data validation.

## Verification

- `cmake --build build/release --target sdl3d_input_test sdl3d_game_data_test pong_demo -j 8`
- `./build/release/tests/sdl3d_input_test`
- `./build/release/tests/sdl3d_game_data_test`
- `git diff --check`