### PR TITLE
Implement Pong direct-connect multiplayer and join flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,5 @@ This file gives working guidance for AI agents maintaining SDL_3D.
 - Run the relevant build/test targets before finishing.
 - Update documentation or sample data if the public behavior changed.
 - Run `clang-format` on all touched C and C++ files before submitting a PR.
+- Always work through a pull request. Do not push directly to `main`.
+- Do not force-push unless the user explicitly approves that exact push once for the current change.

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -891,7 +891,12 @@
           ]
         },
         { "type": "collision.aabb", "half_extents": [0.18, 0.95, 0.14] },
-        { "type": "adapter.controller", "adapter": "adapter.pong.cpu_track_ball", "target": "entity.ball" },
+        {
+          "type": "adapter.controller",
+          "adapter": "adapter.pong.cpu_track_ball",
+          "target": "entity.ball",
+          "enabled_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "single" }
+        },
         { "type": "control.axis_1d", "axis": "y", "negative": "action.paddle.local.down", "positive": "action.paddle.local.up" }
       ]
     },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1632,7 +1632,22 @@
         "signal": "signal.game.start",
         "actions": [
           { "type": "adapter.invoke", "adapter": "adapter.pong.configure_play_input" },
-          { "type": "timer.start", "timer": "timer.round.serve" }
+          {
+            "type": "branch",
+            "if": {
+              "type": "not",
+              "condition": {
+                "type": "scene_state.compare",
+                "key": "network_role",
+                "op": "==",
+                "value": "client"
+              }
+            },
+            "then": [
+              { "type": "timer.start", "timer": "timer.round.serve" }
+            ],
+            "else": []
+          }
         ]
       },
       {

--- a/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
+++ b/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
@@ -24,62 +24,20 @@
     "exit": "scene_out"
   },
   "menus": [
-    {
-      "name": "menu.multiplayer.direct_connect",
-      "up_action": "action.menu.up",
-      "down_action": "action.menu.down",
-      "select_action": "action.menu.select",
-      "back_action": "action.menu.back",
-      "move_signal": "signal.ui.menu.move",
-      "select_signal": "signal.ui.menu.select",
-      "selected": 0,
-      "items": [
-        { "label": "Back", "scene": "scene.multiplayer.lan" }
-      ]
-    }
   ],
   "ui": {
     "text": [
       {
         "name": "ui.multiplayer.direct.title",
         "font": "font.title",
-        "text": "DIRECT CONNECT",
+        "text": "JOIN MATCH",
         "x": 0.5,
         "y": 0.18,
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
-      },
-      {
-        "name": "ui.multiplayer.direct.status",
-        "font": "font.hud",
-        "text": "ENTER HOST / IP AND PORT",
-        "x": 0.5,
-        "y": 0.34,
-        "normalized": true,
-        "centered": true,
-        "color": [225, 236, 255, 245]
       }
     ],
-    "menus": [
-      {
-        "name": "ui.multiplayer.direct.menu",
-        "menu": "menu.multiplayer.direct_connect",
-        "font": "font.hud",
-        "x": 0.45,
-        "y": 0.52,
-        "gap": 0.09,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245],
-        "selected_color": [255, 245, 208, 255],
-        "cursor": {
-          "text": ">",
-          "offset_x": -0.035,
-          "align": "right",
-          "color": [255, 222, 140, 255]
-        }
-      }
-    ]
+    "menus": []
   }
 }

--- a/demos/pong/data/scenes/multiplayer_discovery.scene.json
+++ b/demos/pong/data/scenes/multiplayer_discovery.scene.json
@@ -56,7 +56,7 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Back", "scene": "scene.multiplayer.lan" }
+        { "label": "Back", "scene": "scene.multiplayer.join" }
       ]
     }
   ],

--- a/demos/pong/data/scenes/multiplayer_join.scene.json
+++ b/demos/pong/data/scenes/multiplayer_join.scene.json
@@ -9,8 +9,7 @@
     "entity.multiplayer.background.core",
     "entity.multiplayer.background.glow.cyan",
     "entity.multiplayer.background.glow.violet",
-    "entity.multiplayer.background.stream",
-    "entity.multiplayer.discovery"
+    "entity.multiplayer.background.stream"
   ],
   "input": {
     "actions": [
@@ -23,27 +22,6 @@
   "transitions": {
     "enter": "scene_in",
     "exit": "scene_out"
-  },
-  "activity": {
-    "enabled": true,
-    "input": "any",
-    "reset_periodic_on_input": false,
-    "on_enter": [
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "status", "value": "Scanning for hosts..." },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_0", "value": "No sessions discovered yet" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_1", "value": "" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_2", "value": "" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_3", "value": "" },
-      { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
-    ],
-    "periodic": [
-      {
-        "interval": 15.0,
-        "actions": [
-          { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
-        ]
-      }
-    ]
   },
   "menus": [
     {
@@ -91,71 +69,6 @@
         "normalized": true,
         "centered": true,
         "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.join.discovery.status",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "status" }
-        ],
-        "x": 0.30,
-        "y": 0.42,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.join.discovery.session_0",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_0" }
-        ],
-        "x": 0.30,
-        "y": 0.50,
-        "normalized": true,
-        "align": "left",
-        "color": [255, 245, 208, 255]
-      },
-      {
-        "name": "ui.multiplayer.join.discovery.session_1",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_1" }
-        ],
-        "x": 0.30,
-        "y": 0.58,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.join.discovery.session_2",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_2" }
-        ],
-        "x": 0.30,
-        "y": 0.66,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.join.discovery.session_3",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_3" }
-        ],
-        "x": 0.30,
-        "y": 0.74,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
       }
     ],
     "menus": [
@@ -164,8 +77,8 @@
         "menu": "menu.multiplayer.join",
         "font": "font.hud",
         "x": 0.30,
-        "y": 0.82,
-        "gap": 0.085,
+        "y": 0.40,
+        "gap": 0.10,
         "normalized": true,
         "align": "left",
         "color": [225, 236, 255, 245],

--- a/demos/pong/data/scenes/multiplayer_join.scene.json
+++ b/demos/pong/data/scenes/multiplayer_join.scene.json
@@ -56,6 +56,16 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
+        {
+          "label": "Search for local matches",
+          "scene": "scene.multiplayer.discovery",
+          "scene_state": { "key": "network_flow", "value": "lan_discovery" }
+        },
+        {
+          "label": "Join match with IP address or hostname",
+          "scene": "scene.multiplayer.direct_connect",
+          "scene_state": { "key": "network_flow", "value": "direct" }
+        },
         { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
@@ -75,7 +85,7 @@
       {
         "name": "ui.multiplayer.join.status",
         "font": "font.hud",
-        "text": "AUTOMATIC LAN DISCOVERY",
+        "text": "CHOOSE HOW TO JOIN",
         "x": 0.5,
         "y": 0.30,
         "normalized": true,

--- a/demos/pong/data/scenes/multiplayer_lan.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lan.scene.json
@@ -44,11 +44,6 @@
           "scene": "scene.multiplayer.join",
           "scene_state": { "key": "network_flow", "value": "join" }
         },
-        {
-          "label": "Direct Connect",
-          "scene": "scene.multiplayer.direct_connect",
-          "scene_state": { "key": "network_flow", "value": "direct" }
-        },
         { "label": "Back", "scene": "scene.multiplayer" }
       ]
     }

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -40,6 +40,19 @@
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "update_phases": {
+    "simulation": {
+      "active_if": {
+        "type": "not",
+        "condition": {
+          "type": "scene_state.compare",
+          "key": "network_role",
+          "op": "==",
+          "value": "client"
+        }
+      }
+    }
+  },
   "menus": [
     {
       "name": "menu.match_over",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -1334,7 +1334,17 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
     pong_state *state = (pong_state *)userdata;
     if (state != NULL && is_direct_connect_scene(state) && state->direct_connect_ui != NULL && event != NULL)
     {
+        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
+        const bool key_event =
+            event->type == SDL_EVENT_KEY_DOWN || event->type == SDL_EVENT_KEY_UP || event->type == SDL_EVENT_TEXT_INPUT;
+
         (void)sdl3d_ui_process_event(state->direct_connect_ui, event);
+
+        if (mouse_event || key_event)
+        {
+            ctx->input_event_consumed = true;
+        }
     }
     (void)ctx;
     return true;

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -50,8 +50,127 @@ typedef struct pong_state
 
 typedef enum pong_network_message_kind
 {
-    PONG_NETWORK_MESSAGE_START_GAME = 1,
+    PONG_NETWORK_MESSAGE_INPUT = 1,
+    PONG_NETWORK_MESSAGE_STATE = 2,
+    PONG_NETWORK_MESSAGE_START_GAME = 3,
 } pong_network_message_kind;
+
+static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
+static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
+
+static bool pong_network_write_u8(Uint8 **cursor, Uint8 *end, Uint8 value)
+{
+    if (cursor == NULL || *cursor == NULL || end == NULL || *cursor >= end)
+    {
+        return false;
+    }
+
+    **cursor = value;
+    (*cursor)++;
+    return true;
+}
+
+static bool pong_network_write_u32(Uint8 **cursor, Uint8 *end, Uint32 value)
+{
+    Uint8 bytes[4];
+    bytes[0] = (Uint8)(value & 0xffU);
+    bytes[1] = (Uint8)((value >> 8U) & 0xffU);
+    bytes[2] = (Uint8)((value >> 16U) & 0xffU);
+    bytes[3] = (Uint8)((value >> 24U) & 0xffU);
+    if (cursor == NULL || *cursor == NULL || end == NULL || (size_t)(end - *cursor) < sizeof(bytes))
+    {
+        return false;
+    }
+
+    SDL_memcpy(*cursor, bytes, sizeof(bytes));
+    *cursor += sizeof(bytes);
+    return true;
+}
+
+static bool pong_network_write_i32(Uint8 **cursor, Uint8 *end, int value)
+{
+    return pong_network_write_u32(cursor, end, (Uint32)(Sint32)value);
+}
+
+static bool pong_network_write_f32(Uint8 **cursor, Uint8 *end, float value)
+{
+    Uint32 bits = 0U;
+    SDL_memcpy(&bits, &value, sizeof(bits));
+    return pong_network_write_u32(cursor, end, bits);
+}
+
+static bool pong_network_write_vec2(Uint8 **cursor, Uint8 *end, sdl3d_vec2 value)
+{
+    return pong_network_write_f32(cursor, end, value.x) && pong_network_write_f32(cursor, end, value.y);
+}
+
+static bool pong_network_write_vec3(Uint8 **cursor, Uint8 *end, sdl3d_vec3 value)
+{
+    return pong_network_write_f32(cursor, end, value.x) && pong_network_write_f32(cursor, end, value.y) &&
+           pong_network_write_f32(cursor, end, value.z);
+}
+
+static bool pong_network_read_u8(const Uint8 **cursor, const Uint8 *end, Uint8 *out_value)
+{
+    if (cursor == NULL || *cursor == NULL || out_value == NULL || *cursor >= end)
+    {
+        return false;
+    }
+
+    *out_value = **cursor;
+    (*cursor)++;
+    return true;
+}
+
+static bool pong_network_read_u32(const Uint8 **cursor, const Uint8 *end, Uint32 *out_value)
+{
+    Uint8 bytes[4];
+    if (cursor == NULL || *cursor == NULL || out_value == NULL || (size_t)(end - *cursor) < sizeof(bytes))
+    {
+        return false;
+    }
+
+    SDL_memcpy(bytes, *cursor, sizeof(bytes));
+    *cursor += sizeof(bytes);
+    *out_value = (Uint32)bytes[0] | ((Uint32)bytes[1] << 8U) | ((Uint32)bytes[2] << 16U) | ((Uint32)bytes[3] << 24U);
+    return true;
+}
+
+static bool pong_network_read_i32(const Uint8 **cursor, const Uint8 *end, int *out_value)
+{
+    Uint32 value = 0U;
+    if (!pong_network_read_u32(cursor, end, &value) || out_value == NULL)
+    {
+        return false;
+    }
+
+    *out_value = (int)(Sint32)value;
+    return true;
+}
+
+static bool pong_network_read_f32(const Uint8 **cursor, const Uint8 *end, float *out_value)
+{
+    Uint32 bits = 0U;
+    if (!pong_network_read_u32(cursor, end, &bits) || out_value == NULL)
+    {
+        return false;
+    }
+
+    SDL_memcpy(out_value, &bits, sizeof(bits));
+    return true;
+}
+
+static bool pong_network_read_vec2(const Uint8 **cursor, const Uint8 *end, sdl3d_vec2 *out_value)
+{
+    return out_value != NULL && pong_network_read_f32(cursor, end, &out_value->x) &&
+           pong_network_read_f32(cursor, end, &out_value->y);
+}
+
+static bool pong_network_read_vec3(const Uint8 **cursor, const Uint8 *end, sdl3d_vec3 *out_value)
+{
+    return out_value != NULL && pong_network_read_f32(cursor, end, &out_value->x) &&
+           pong_network_read_f32(cursor, end, &out_value->y) && pong_network_read_f32(cursor, end, &out_value->z);
+}
 
 static const char *active_scene_name(const pong_state *state)
 {
@@ -100,6 +219,64 @@ static bool is_network_flow_direct(const pong_state *state)
     const char *network_flow =
         scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", NULL) : NULL;
     return network_flow != NULL && SDL_strcmp(network_flow, "direct") == 0;
+}
+
+static const char *network_role_name(const pong_state *state)
+{
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
+}
+
+static bool is_network_role_host(const pong_state *state)
+{
+    return SDL_strcmp(network_role_name(state), "host") == 0;
+}
+
+static bool is_network_role_client(const pong_state *state)
+{
+    return SDL_strcmp(network_role_name(state), "client") == 0;
+}
+
+static void clear_network_action_overrides(pong_state *state)
+{
+    if (state == NULL || state->input == NULL || state->data == NULL)
+    {
+        return;
+    }
+
+    const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
+    const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
+    const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
+    const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
+    if (p1_up >= 0)
+    {
+        sdl3d_input_clear_action_override(state->input, p1_up);
+    }
+    if (p1_down >= 0)
+    {
+        sdl3d_input_clear_action_override(state->input, p1_down);
+    }
+    if (p2_up >= 0)
+    {
+        sdl3d_input_clear_action_override(state->input, p2_up);
+    }
+    if (p2_down >= 0)
+    {
+        sdl3d_input_clear_action_override(state->input, p2_down);
+    }
+}
+
+static void set_network_action_override(pong_state *state, const char *action_name, float value)
+{
+    const int action_id =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, action_name) : -1;
+    if (state == NULL || state->input == NULL || action_id < 0)
+    {
+        return;
+    }
+
+    sdl3d_input_set_action_override(state->input, action_id, value);
 }
 
 static void update_host_session_scene_state(pong_state *state)
@@ -200,6 +377,39 @@ static void bind_local_play_controls(pong_state *state)
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong local input configured: gamepads=%d", gamepad_count);
 }
 
+static void bind_network_play_controls(pong_state *state, const char *up_action_name, const char *down_action_name)
+{
+    if (state == NULL || state->data == NULL || state->input == NULL)
+    {
+        return;
+    }
+
+    const int up_action = sdl3d_game_data_find_action(state->data, up_action_name);
+    const int down_action = sdl3d_game_data_find_action(state->data, down_action_name);
+    if (up_action < 0 || down_action < 0)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong network input rebinding skipped: required paddle actions were not registered");
+        return;
+    }
+
+    sdl3d_input_unbind_action(state->input, up_action);
+    sdl3d_input_unbind_action(state->input, down_action);
+    sdl3d_input_bind_key(state->input, up_action, SDL_SCANCODE_UP);
+    sdl3d_input_bind_key(state->input, down_action, SDL_SCANCODE_DOWN);
+
+    if (sdl3d_input_gamepad_count(state->input) > 0)
+    {
+        sdl3d_input_bind_gamepad_button_at(state->input, up_action, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
+        sdl3d_input_bind_gamepad_button_at(state->input, down_action, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+        sdl3d_input_bind_gamepad_axis_at(state->input, up_action, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
+        sdl3d_input_bind_gamepad_axis_at(state->input, down_action, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong network input configured: role=%s actions=%s/%s gamepads=%d",
+                network_role_name(state), up_action_name, down_action_name, sdl3d_input_gamepad_count(state->input));
+}
+
 static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                                  sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -214,9 +424,39 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
         return false;
     }
 
+    clear_network_action_overrides(state);
     if (is_local_match_mode(state))
     {
         bind_local_play_controls(state);
+    }
+    else if (is_network_role_host(state))
+    {
+        bind_network_play_controls(state, "action.paddle.up", "action.paddle.down");
+        const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
+        const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
+        if (p2_up >= 0)
+        {
+            sdl3d_input_unbind_action(state->input, p2_up);
+        }
+        if (p2_down >= 0)
+        {
+            sdl3d_input_unbind_action(state->input, p2_down);
+        }
+    }
+    else if (is_network_role_client(state))
+    {
+        const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
+        const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
+        if (p1_up >= 0)
+        {
+            sdl3d_input_unbind_action(state->input, p1_up);
+        }
+        if (p1_down >= 0)
+        {
+            sdl3d_input_unbind_action(state->input, p1_down);
+        }
+
+        bind_network_play_controls(state, "action.paddle.local.up", "action.paddle.local.down");
     }
     else
     {
@@ -336,6 +576,259 @@ static bool send_host_start_packet(pong_state *state)
     return true;
 }
 
+static bool send_client_input_packet(pong_state *state)
+{
+    Uint8 packet[32];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+    const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
+    const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
+
+    if (state == NULL || state->direct_connect_session == NULL || state->input == NULL || p2_up < 0 || p2_down < 0 ||
+        !sdl3d_network_session_is_connected(state->direct_connect_session))
+    {
+        return false;
+    }
+
+    const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(state->input);
+    const float up_value = snapshot != NULL ? snapshot->actions[p2_up].value : 0.0f;
+    const float down_value = snapshot != NULL ? snapshot->actions[p2_down].value : 0.0f;
+
+    if (!pong_network_write_u32(&cursor, end, PONG_NETWORK_PACKET_MAGIC) ||
+        !pong_network_write_u8(&cursor, end, PONG_NETWORK_PACKET_VERSION) ||
+        !pong_network_write_u8(&cursor, end, (Uint8)PONG_NETWORK_MESSAGE_INPUT) ||
+        !pong_network_write_u8(&cursor, end, 0U) || !pong_network_write_u8(&cursor, end, 0U) ||
+        !pong_network_write_u32(&cursor, end, snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U) ||
+        !pong_network_write_f32(&cursor, end, up_value) || !pong_network_write_f32(&cursor, end, down_value))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet encode failed");
+        return false;
+    }
+
+    if (!sdl3d_network_session_send(state->direct_connect_session, packet, (int)(cursor - packet)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", SDL_GetError());
+        return false;
+    }
+
+    return true;
+}
+
+static bool apply_play_state_snapshot(pong_state *state, const Uint8 **cursor, const Uint8 *end)
+{
+    sdl3d_registered_actor *player = NULL;
+    sdl3d_registered_actor *cpu = NULL;
+    sdl3d_registered_actor *ball = NULL;
+    sdl3d_registered_actor *match = NULL;
+    sdl3d_registered_actor *presentation = NULL;
+    sdl3d_registered_actor *score_player_actor = NULL;
+    sdl3d_registered_actor *score_cpu_actor = NULL;
+    sdl3d_vec3 player_position;
+    sdl3d_vec3 cpu_position;
+    sdl3d_vec3 ball_position;
+    sdl3d_vec2 ball_velocity;
+    float border_flash = 0.0f;
+    float paddle_flash = 0.0f;
+    float last_reflect_y = 0.0f;
+    int score_player = 0;
+    int score_cpu = 0;
+    int finished = 0;
+    int winner = 0;
+    int active_motion = 0;
+    int has_last_reflect_y = 0;
+    int stagnant_reflect_count = 0;
+
+    if (state == NULL || state->data == NULL || cursor == NULL || *cursor == NULL)
+    {
+        return false;
+    }
+
+    player = sdl3d_game_data_find_actor(state->data, "entity.paddle.player");
+    cpu = sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu");
+    ball = sdl3d_game_data_find_actor(state->data, "entity.ball");
+    match = sdl3d_game_data_find_actor(state->data, "entity.match");
+    presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    score_player_actor = sdl3d_game_data_find_actor(state->data, "entity.score.player");
+    score_cpu_actor = sdl3d_game_data_find_actor(state->data, "entity.score.cpu");
+    if (player == NULL || cpu == NULL || ball == NULL || match == NULL || presentation == NULL ||
+        score_player_actor == NULL || score_cpu_actor == NULL ||
+        !pong_network_read_vec3(cursor, end, &player_position) || !pong_network_read_vec3(cursor, end, &cpu_position) ||
+        !pong_network_read_vec3(cursor, end, &ball_position) || !pong_network_read_vec2(cursor, end, &ball_velocity) ||
+        !pong_network_read_f32(cursor, end, &border_flash) || !pong_network_read_f32(cursor, end, &paddle_flash) ||
+        !pong_network_read_i32(cursor, end, &score_player) || !pong_network_read_i32(cursor, end, &score_cpu) ||
+        !pong_network_read_i32(cursor, end, &finished) || !pong_network_read_i32(cursor, end, &winner) ||
+        !pong_network_read_i32(cursor, end, &active_motion) ||
+        !pong_network_read_i32(cursor, end, &has_last_reflect_y) ||
+        !pong_network_read_f32(cursor, end, &last_reflect_y) ||
+        !pong_network_read_i32(cursor, end, &stagnant_reflect_count))
+    {
+        return false;
+    }
+
+    player->position = player_position;
+    cpu->position = cpu_position;
+    ball->position = ball_position;
+    sdl3d_properties_set_vec3(ball->props, "velocity", sdl3d_vec3_make(ball_velocity.x, ball_velocity.y, 0.0f));
+    sdl3d_properties_set_bool(ball->props, "active_motion", active_motion != 0);
+    sdl3d_properties_set_bool(ball->props, "has_last_reflect_y", has_last_reflect_y != 0);
+    sdl3d_properties_set_float(ball->props, "last_reflect_y", last_reflect_y);
+    sdl3d_properties_set_int(ball->props, "stagnant_reflect_count", stagnant_reflect_count);
+
+    sdl3d_properties_set_int(score_player_actor->props, "value", score_player);
+    sdl3d_properties_set_int(score_cpu_actor->props, "value", score_cpu);
+    sdl3d_properties_set_bool(match->props, "finished", finished != 0);
+    sdl3d_properties_set_string(match->props, "winner", winner == 1 ? "player" : winner == 2 ? "cpu" : "none");
+    sdl3d_properties_set_float(presentation->props, "border_flash", border_flash);
+    sdl3d_properties_set_float(presentation->props, "paddle_flash", paddle_flash);
+    return true;
+}
+
+static bool process_host_input_packet(pong_state *state, const Uint8 *packet, int packet_size)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+    float up_value = 0.0f;
+    float down_value = 0.0f;
+
+    if (state == NULL || packet == NULL || packet_size < 12)
+    {
+        return false;
+    }
+
+    if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
+        !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
+        !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT ||
+        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u32(&cursor, end, &tick) ||
+        !pong_network_read_f32(&cursor, end, &up_value) || !pong_network_read_f32(&cursor, end, &down_value))
+    {
+        return false;
+    }
+
+    (void)tick;
+    set_network_action_override(state, "action.paddle.local.up", up_value);
+    set_network_action_override(state, "action.paddle.local.down", down_value);
+    return true;
+}
+
+static bool process_client_state_packet(pong_state *state, const Uint8 *packet, int packet_size)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+    float p1_up = 0.0f;
+    float p1_down = 0.0f;
+    bool ok = false;
+
+    if (state == NULL || packet == NULL || packet_size < 12)
+    {
+        return false;
+    }
+
+    if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
+        !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
+        !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_STATE ||
+        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u32(&cursor, end, &tick) ||
+        !pong_network_read_f32(&cursor, end, &p1_up) || !pong_network_read_f32(&cursor, end, &p1_down))
+    {
+        return false;
+    }
+
+    set_network_action_override(state, "action.paddle.up", p1_up);
+    set_network_action_override(state, "action.paddle.down", p1_down);
+    ok = apply_play_state_snapshot(state, &cursor, end);
+    (void)tick;
+    return ok;
+}
+
+static bool send_host_state_packet(pong_state *state)
+{
+    Uint8 packet[160];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+    const sdl3d_registered_actor *player = NULL;
+    const sdl3d_registered_actor *cpu = NULL;
+    const sdl3d_registered_actor *ball = NULL;
+    const sdl3d_registered_actor *match = NULL;
+    const sdl3d_registered_actor *presentation = NULL;
+    const sdl3d_registered_actor *score_player_actor = NULL;
+    const sdl3d_registered_actor *score_cpu_actor = NULL;
+    const sdl3d_input_snapshot *snapshot = NULL;
+    const int p1_up_action =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.paddle.up") : -1;
+    const int p1_down_action =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.paddle.down") : -1;
+    const float p1_up = state != NULL && state->input != NULL && p1_up_action >= 0
+                            ? sdl3d_input_get_value(state->input, p1_up_action)
+                            : 0.0f;
+    const float p1_down = state != NULL && state->input != NULL && p1_down_action >= 0
+                              ? sdl3d_input_get_value(state->input, p1_down_action)
+                              : 0.0f;
+
+    if (state == NULL || state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session) ||
+        state->data == NULL || state->input == NULL)
+    {
+        return false;
+    }
+
+    player = sdl3d_game_data_find_actor(state->data, "entity.paddle.player");
+    cpu = sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu");
+    ball = sdl3d_game_data_find_actor(state->data, "entity.ball");
+    match = sdl3d_game_data_find_actor(state->data, "entity.match");
+    presentation = sdl3d_game_data_find_actor(state->data, "entity.presentation");
+    score_player_actor = sdl3d_game_data_find_actor(state->data, "entity.score.player");
+    score_cpu_actor = sdl3d_game_data_find_actor(state->data, "entity.score.cpu");
+    snapshot = sdl3d_input_get_snapshot(state->input);
+    if (player == NULL || cpu == NULL || ball == NULL || match == NULL || presentation == NULL ||
+        score_player_actor == NULL || score_cpu_actor == NULL || snapshot == NULL ||
+        !pong_network_write_u32(&cursor, end, PONG_NETWORK_PACKET_MAGIC) ||
+        !pong_network_write_u8(&cursor, end, PONG_NETWORK_PACKET_VERSION) ||
+        !pong_network_write_u8(&cursor, end, (Uint8)PONG_NETWORK_MESSAGE_STATE) ||
+        !pong_network_write_u8(&cursor, end, 0U) || !pong_network_write_u8(&cursor, end, 0U) ||
+        !pong_network_write_u32(&cursor, end, (Uint32)SDL_max(snapshot->tick, 0)) ||
+        !pong_network_write_f32(&cursor, end, p1_up) || !pong_network_write_f32(&cursor, end, p1_down) ||
+        !pong_network_write_vec3(&cursor, end, player->position) ||
+        !pong_network_write_vec3(&cursor, end, cpu->position) ||
+        !pong_network_write_vec3(&cursor, end, ball->position) ||
+        !pong_network_write_vec3(
+            &cursor, end, sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))) ||
+        !pong_network_write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "border_flash", 0.0f)) ||
+        !pong_network_write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f)) ||
+        !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(score_player_actor->props, "value", 0)) ||
+        !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(score_cpu_actor->props, "value", 0)) ||
+        !pong_network_write_i32(&cursor, end, sdl3d_properties_get_bool(match->props, "finished", false) ? 1 : 0) ||
+        !pong_network_write_i32(
+            &cursor, end,
+            SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "player") == 0 ? 1
+            : SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "cpu") == 0  ? 2
+                                                                                                   : 0) ||
+        !pong_network_write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "active_motion", false) ? 1 : 0) ||
+        !pong_network_write_i32(&cursor, end,
+                                sdl3d_properties_get_bool(ball->props, "has_last_reflect_y", false) ? 1 : 0) ||
+        !pong_network_write_f32(&cursor, end, sdl3d_properties_get_float(ball->props, "last_reflect_y", 0.0f)) ||
+        !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(ball->props, "stagnant_reflect_count", 0)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed");
+        return false;
+    }
+
+    if (!sdl3d_network_session_send(state->host_session, packet, (int)(cursor - packet)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet send failed: %s", SDL_GetError());
+        return false;
+    }
+
+    return true;
+}
+
 static bool start_direct_connect_session(pong_state *state)
 {
     sdl3d_network_session_desc desc;
@@ -403,10 +896,19 @@ static void update_direct_connect_session_status(pong_state *state)
                     if (scene_state != NULL)
                     {
                         sdl3d_properties_set_string(scene_state, "match_mode", "lan");
+                        sdl3d_properties_set_string(scene_state, "network_role", "client");
                     }
                 }
+                clear_network_action_overrides(state);
                 (void)sdl3d_game_data_set_active_scene(state->data, "scene.play");
                 break;
+            }
+            if (is_multiplayer_play_scene(state) && packet_size >= 12)
+            {
+                if (process_client_state_packet(state, packet, packet_size))
+                {
+                    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong client applied authoritative state packet");
+                }
             }
         }
 
@@ -433,12 +935,33 @@ static void update_host_session_status(pong_state *state, float dt)
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host session update failed: %s", SDL_GetError());
         }
 
+        Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+        int packet_size = 0;
+        while ((packet_size = sdl3d_network_session_receive(state->host_session, packet, (int)sizeof(packet))) > 0)
+        {
+            if (packet_size >= 12 && is_multiplayer_play_scene(state) && packet[0] == 'P' && packet[1] == 'O' &&
+                packet[2] == 'N' && packet[3] == 'G')
+            {
+                if (process_host_input_packet(state, packet, packet_size))
+                {
+                    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong host applied remote input packet");
+                }
+            }
+        }
+
         update_host_session_scene_state(state);
 
         const char *active_scene = active_scene_name(state);
         if (active_scene == NULL || (!is_multiplayer_lobby_scene(state) && !is_multiplayer_play_scene(state)))
         {
             destroy_host_session(state);
+        }
+        else if (is_multiplayer_play_scene(state) && state->host_session != NULL &&
+                 sdl3d_network_session_state(state->host_session) != SDL3D_NETWORK_STATE_CONNECTED)
+        {
+            clear_network_action_overrides(state);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host client disconnected, returning to lobby");
+            (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
         }
         return;
     }
@@ -477,6 +1000,25 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
         {
             destroy_direct_connect_session(state);
         }
+    }
+
+    if (state->direct_connect_session != NULL && is_multiplayer_play_scene(state) && is_network_role_client(state))
+    {
+        (void)send_client_input_packet(state);
+    }
+}
+
+static void publish_multiplayer_state(pong_state *state)
+{
+    if (state == NULL || state->host_session == NULL || !is_multiplayer_play_scene(state) ||
+        !is_network_role_host(state))
+    {
+        return;
+    }
+
+    if (!send_host_state_packet(state))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to publish multiplayer state");
     }
 }
 
@@ -614,8 +1156,11 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
         if (scene_state != NULL)
         {
             sdl3d_properties_set_string(scene_state, "match_mode", "lan");
+            sdl3d_properties_set_string(scene_state, "network_role", "host");
         }
     }
+
+    clear_network_action_overrides(state);
 
     if (!sdl3d_game_data_set_active_scene(state->data, "scene.play"))
     {
@@ -799,6 +1344,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
+    update_multiplayer_sessions(state, dt);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -806,14 +1352,14 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
                                                      .particle_cache = &state->particle_cache,
                                                      .dt = dt};
     (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
-
-    update_multiplayer_sessions(state, dt);
+    publish_multiplayer_state(state);
 }
 
 static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
+    update_multiplayer_sessions(state, real_dt);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -821,8 +1367,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
                                                      .particle_cache = &state->particle_cache,
                                                      .dt = real_dt};
     (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
-
-    update_multiplayer_sessions(state, real_dt);
+    publish_multiplayer_state(state);
 }
 
 static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -2,8 +2,8 @@
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_main.h>
-#include <SDL3/SDL_timer.h>
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
 
 #include <stdbool.h>
 #include <string.h>
@@ -86,31 +86,35 @@ static void pong_log_multiplayer_state(const char *prefix, const pong_state *sta
     const sdl3d_vec3 player_position = player != NULL ? player->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
     const sdl3d_vec3 cpu_position = cpu != NULL ? cpu->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
     const sdl3d_vec3 ball_position = ball != NULL ? ball->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const sdl3d_vec3 ball_velocity = ball != NULL
-                                         ? sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
-                                         : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const int score_player = score_player_actor != NULL ? sdl3d_properties_get_int(score_player_actor->props, "value", 0) : 0;
+    const sdl3d_vec3 ball_velocity =
+        ball != NULL ? sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
+                     : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const int score_player =
+        score_player_actor != NULL ? sdl3d_properties_get_int(score_player_actor->props, "value", 0) : 0;
     const int score_cpu = score_cpu_actor != NULL ? sdl3d_properties_get_int(score_cpu_actor->props, "value", 0) : 0;
     const bool finished = match != NULL && sdl3d_properties_get_bool(match->props, "finished", false);
     const char *winner = match != NULL ? sdl3d_properties_get_string(match->props, "winner", "none") : "none";
-    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", "none") : "none";
-    const char *network_role = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
-    const char *network_flow = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", "none") : "none";
+    const char *match_mode =
+        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", "none") : "none";
+    const char *network_role =
+        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
+    const char *network_flow =
+        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", "none") : "none";
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong %s tick=%u scene=%s match_mode=%s network_role=%s network_flow=%s "
-                "scores=%d:%d finished=%d winner=%s player=(%.2f,%.2f,%.2f) cpu=(%.2f,%.2f,%.2f) "
-                "ball=(%.2f,%.2f,%.2f) vel=(%.2f,%.2f)%s%s",
-                (unsigned long long)pong_log_timestamp_ms(), prefix != NULL ? prefix : "state", (unsigned int)packet_tick,
-                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
-                    ? sdl3d_game_data_active_scene(state->data)
-                    : "<none>",
-                match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
-                network_flow != NULL ? network_flow : "none", score_player, score_cpu, finished ? 1 : 0,
-                winner != NULL ? winner : "none", player_position.x, player_position.y, player_position.z,
-                cpu_position.x, cpu_position.y, cpu_position.z, ball_position.x, ball_position.y, ball_position.z,
-                ball_velocity.x, ball_velocity.y, extra != NULL && extra[0] != '\0' ? " " : "",
-                extra != NULL ? extra : "");
+    SDL_LogInfo(
+        SDL_LOG_CATEGORY_APPLICATION,
+        "[%llu ms] Pong %s tick=%u scene=%s match_mode=%s network_role=%s network_flow=%s "
+        "scores=%d:%d finished=%d winner=%s player=(%.2f,%.2f,%.2f) cpu=(%.2f,%.2f,%.2f) "
+        "ball=(%.2f,%.2f,%.2f) vel=(%.2f,%.2f)%s%s",
+        (unsigned long long)pong_log_timestamp_ms(), prefix != NULL ? prefix : "state", (unsigned int)packet_tick,
+        state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
+            ? sdl3d_game_data_active_scene(state->data)
+            : "<none>",
+        match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
+        network_flow != NULL ? network_flow : "none", score_player, score_cpu, finished ? 1 : 0,
+        winner != NULL ? winner : "none", player_position.x, player_position.y, player_position.z, cpu_position.x,
+        cpu_position.y, cpu_position.z, ball_position.x, ball_position.y, ball_position.z, ball_velocity.x,
+        ball_velocity.y, extra != NULL && extra[0] != '\0' ? " " : "", extra != NULL ? extra : "");
 }
 
 static bool pong_network_write_u8(Uint8 **cursor, Uint8 *end, Uint8 value)
@@ -662,7 +666,7 @@ static void reset_direct_connect_defaults(pong_state *state)
     SDL_strlcpy(state->direct_connect_host, "127.0.0.1", sizeof(state->direct_connect_host));
     SDL_snprintf(state->direct_connect_port, sizeof(state->direct_connect_port), "%u",
                  (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
-    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Enter host and port");
+    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Ready to connect");
 }
 
 static bool send_host_start_packet(pong_state *state)
@@ -724,9 +728,8 @@ static bool send_client_input_packet(pong_state *state)
 
     if ((size_t)(cursor - packet) != PONG_NETWORK_INPUT_PACKET_SIZE)
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong client input packet size mismatch: expected=%zu actual=%zu", PONG_NETWORK_INPUT_PACKET_SIZE,
-                    (size_t)(cursor - packet));
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet size mismatch: expected=%zu actual=%zu",
+                    PONG_NETWORK_INPUT_PACKET_SIZE, (size_t)(cursor - packet));
         return false;
     }
 
@@ -736,11 +739,9 @@ static bool send_client_input_packet(pong_state *state)
         return false;
     }
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong client->host input tick=%u up=%.3f down=%.3f scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(), snapshot != NULL ? (unsigned int)SDL_max(snapshot->tick, 0)
-                                                                               : 0U,
-                up_value, down_value,
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client->host input tick=%u up=%.3f down=%.3f scene=%s",
+                (unsigned long long)pong_log_timestamp_ms(),
+                snapshot != NULL ? (unsigned int)SDL_max(snapshot->tick, 0) : 0U, up_value, down_value,
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
                     : "<none>");
@@ -808,8 +809,7 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
 
     if (packet_begin == NULL || *cursor != end)
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong client state packet size mismatch: expected=%zu actual=%zu",
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client state packet size mismatch: expected=%zu actual=%zu",
                     PONG_NETWORK_STATE_PACKET_SIZE, packet_begin != NULL ? (size_t)(end - packet_begin) : 0U);
         return false;
     }
@@ -854,25 +854,23 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
         !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
         !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT ||
         !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
-        !pong_network_read_u32(&cursor, end, &tick) ||
-        !pong_network_read_f32(&cursor, end, &up_value) || !pong_network_read_f32(&cursor, end, &down_value))
+        !pong_network_read_u32(&cursor, end, &tick) || !pong_network_read_f32(&cursor, end, &up_value) ||
+        !pong_network_read_f32(&cursor, end, &down_value))
     {
         return false;
     }
 
     if ((size_t)packet_size != PONG_NETWORK_INPUT_PACKET_SIZE)
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong host input packet size mismatch: expected=%zu actual=%d", PONG_NETWORK_INPUT_PACKET_SIZE,
-                    packet_size);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host input packet size mismatch: expected=%zu actual=%d",
+                    PONG_NETWORK_INPUT_PACKET_SIZE, packet_size);
         return false;
     }
 
     (void)tick;
     set_network_action_override(state, "action.paddle.local.up", up_value);
     set_network_action_override(state, "action.paddle.local.down", down_value);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong host<-client input tick=%u up=%.3f down=%.3f scene=%s",
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host<-client input tick=%u up=%.3f down=%.3f scene=%s",
                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, up_value, down_value,
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
@@ -905,17 +903,16 @@ static bool process_client_state_packet(pong_state *state, const Uint8 *packet, 
         !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
         !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_STATE ||
         !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
-        !pong_network_read_u32(&cursor, end, &tick) ||
-        !pong_network_read_f32(&cursor, end, &p1_up) || !pong_network_read_f32(&cursor, end, &p1_down))
+        !pong_network_read_u32(&cursor, end, &tick) || !pong_network_read_f32(&cursor, end, &p1_up) ||
+        !pong_network_read_f32(&cursor, end, &p1_down))
     {
         return false;
     }
 
     if ((size_t)packet_size != PONG_NETWORK_STATE_PACKET_SIZE)
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong client state packet size mismatch: expected=%zu actual=%d", PONG_NETWORK_STATE_PACKET_SIZE,
-                    packet_size);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client state packet size mismatch: expected=%zu actual=%d",
+                    PONG_NETWORK_STATE_PACKET_SIZE, packet_size);
         return false;
     }
 
@@ -1001,9 +998,8 @@ static bool send_host_state_packet(pong_state *state)
 
     if ((size_t)(cursor - packet) != PONG_NETWORK_STATE_PACKET_SIZE)
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong host state packet size mismatch: expected=%zu actual=%zu", PONG_NETWORK_STATE_PACKET_SIZE,
-                    (size_t)(cursor - packet));
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet size mismatch: expected=%zu actual=%zu",
+                    PONG_NETWORK_STATE_PACKET_SIZE, (size_t)(cursor - packet));
         return false;
     }
 
@@ -1288,10 +1284,15 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
         }
     }
 
+    if (sdl3d_ui_layout_button(state->direct_connect_ui, "Back"))
+    {
+        destroy_direct_connect_session(state);
+        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Returning to Join Match");
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+    }
+
     sdl3d_ui_layout_label(state->direct_connect_ui, "Status");
     sdl3d_ui_layout_label(state->direct_connect_ui, state->direct_connect_status);
-    sdl3d_ui_separator(state->direct_connect_ui);
-    sdl3d_ui_layout_label(state->direct_connect_ui, "Back returns to the LAN menu.");
 
     sdl3d_ui_end_vbox(state->direct_connect_ui);
     sdl3d_ui_end_panel(state->direct_connect_ui);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -58,6 +58,8 @@ typedef enum pong_network_message_kind
 
 static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
 static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
+static const size_t PONG_NETWORK_INPUT_PACKET_SIZE = 20U;
+static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 108U;
 
 static Uint64 pong_log_timestamp_ms(void)
 {
@@ -720,6 +722,14 @@ static bool send_client_input_packet(pong_state *state)
         return false;
     }
 
+    if ((size_t)(cursor - packet) != PONG_NETWORK_INPUT_PACKET_SIZE)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong client input packet size mismatch: expected=%zu actual=%zu", PONG_NETWORK_INPUT_PACKET_SIZE,
+                    (size_t)(cursor - packet));
+        return false;
+    }
+
     if (!sdl3d_network_session_send(state->direct_connect_session, packet, (int)(cursor - packet)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", SDL_GetError());
@@ -734,11 +744,19 @@ static bool send_client_input_packet(pong_state *state)
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
                     : "<none>");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong client input packet queued: role=%s flow=%s p2_up=%.3f p2_down=%.3f",
+                (unsigned long long)pong_log_timestamp_ms(), network_role_name(state),
+                state != NULL && state->data != NULL && sdl3d_game_data_scene_state(state->data) != NULL
+                    ? sdl3d_properties_get_string(sdl3d_game_data_scene_state(state->data), "network_flow", "none")
+                    : "none",
+                up_value, down_value);
     return true;
 }
 
 static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, const Uint8 **cursor, const Uint8 *end)
 {
+    const Uint8 *packet_begin = cursor != NULL ? *cursor : NULL;
     sdl3d_registered_actor *player = NULL;
     sdl3d_registered_actor *cpu = NULL;
     sdl3d_registered_actor *ball = NULL;
@@ -749,7 +767,7 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
     sdl3d_vec3 player_position;
     sdl3d_vec3 cpu_position;
     sdl3d_vec3 ball_position;
-    sdl3d_vec2 ball_velocity;
+    sdl3d_vec3 ball_velocity;
     float border_flash = 0.0f;
     float paddle_flash = 0.0f;
     float last_reflect_y = 0.0f;
@@ -776,7 +794,7 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
     if (player == NULL || cpu == NULL || ball == NULL || match == NULL || presentation == NULL ||
         score_player_actor == NULL || score_cpu_actor == NULL ||
         !pong_network_read_vec3(cursor, end, &player_position) || !pong_network_read_vec3(cursor, end, &cpu_position) ||
-        !pong_network_read_vec3(cursor, end, &ball_position) || !pong_network_read_vec2(cursor, end, &ball_velocity) ||
+        !pong_network_read_vec3(cursor, end, &ball_position) || !pong_network_read_vec3(cursor, end, &ball_velocity) ||
         !pong_network_read_f32(cursor, end, &border_flash) || !pong_network_read_f32(cursor, end, &paddle_flash) ||
         !pong_network_read_i32(cursor, end, &score_player) || !pong_network_read_i32(cursor, end, &score_cpu) ||
         !pong_network_read_i32(cursor, end, &finished) || !pong_network_read_i32(cursor, end, &winner) ||
@@ -788,10 +806,18 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
         return false;
     }
 
+    if (packet_begin == NULL || *cursor != end)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong client state packet size mismatch: expected=%zu actual=%zu",
+                    PONG_NETWORK_STATE_PACKET_SIZE, packet_begin != NULL ? (size_t)(end - packet_begin) : 0U);
+        return false;
+    }
+
     player->position = player_position;
     cpu->position = cpu_position;
     ball->position = ball_position;
-    sdl3d_properties_set_vec3(ball->props, "velocity", sdl3d_vec3_make(ball_velocity.x, ball_velocity.y, 0.0f));
+    sdl3d_properties_set_vec3(ball->props, "velocity", ball_velocity);
     sdl3d_properties_set_bool(ball->props, "active_motion", active_motion != 0);
     sdl3d_properties_set_bool(ball->props, "has_last_reflect_y", has_last_reflect_y != 0);
     sdl3d_properties_set_float(ball->props, "last_reflect_y", last_reflect_y);
@@ -827,9 +853,18 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
     if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
         !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
         !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT ||
-        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u32(&cursor, end, &tick) ||
+        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
+        !pong_network_read_u32(&cursor, end, &tick) ||
         !pong_network_read_f32(&cursor, end, &up_value) || !pong_network_read_f32(&cursor, end, &down_value))
     {
+        return false;
+    }
+
+    if ((size_t)packet_size != PONG_NETWORK_INPUT_PACKET_SIZE)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong host input packet size mismatch: expected=%zu actual=%d", PONG_NETWORK_INPUT_PACKET_SIZE,
+                    packet_size);
         return false;
     }
 
@@ -842,6 +877,9 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
                     : "<none>");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong host applied remote paddle input: p2_up=%.3f p2_down=%.3f",
+                (unsigned long long)pong_log_timestamp_ms(), up_value, down_value);
     return true;
 }
 
@@ -866,14 +904,26 @@ static bool process_client_state_packet(pong_state *state, const Uint8 *packet, 
     if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
         !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
         !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_STATE ||
-        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u32(&cursor, end, &tick) ||
+        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
+        !pong_network_read_u32(&cursor, end, &tick) ||
         !pong_network_read_f32(&cursor, end, &p1_up) || !pong_network_read_f32(&cursor, end, &p1_down))
     {
         return false;
     }
 
+    if ((size_t)packet_size != PONG_NETWORK_STATE_PACKET_SIZE)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong client state packet size mismatch: expected=%zu actual=%d", PONG_NETWORK_STATE_PACKET_SIZE,
+                    packet_size);
+        return false;
+    }
+
     set_network_action_override(state, "action.paddle.up", p1_up);
     set_network_action_override(state, "action.paddle.down", p1_down);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong client received state packet tick=%u p1_up=%.3f p1_down=%.3f",
+                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, p1_up, p1_down);
     ok = apply_play_state_snapshot(state, tick, &cursor, end);
     return ok;
 }
@@ -946,6 +996,14 @@ static bool send_host_state_packet(pong_state *state)
         !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(ball->props, "stagnant_reflect_count", 0)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed");
+        return false;
+    }
+
+    if ((size_t)(cursor - packet) != PONG_NETWORK_STATE_PACKET_SIZE)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Pong host state packet size mismatch: expected=%zu actual=%zu", PONG_NETWORK_STATE_PACKET_SIZE,
+                    (size_t)(cursor - packet));
         return false;
     }
 
@@ -1146,6 +1204,48 @@ static void publish_multiplayer_state(pong_state *state)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to publish multiplayer state");
     }
+}
+
+static void predict_client_paddle_motion(pong_state *state, float dt)
+{
+    sdl3d_registered_actor *cpu = NULL;
+    const sdl3d_input_snapshot *snapshot = NULL;
+    const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
+    const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
+
+    if (state == NULL || state->input == NULL || state->data == NULL || !is_multiplayer_play_scene(state) ||
+        !is_network_role_client(state) || p2_up < 0 || p2_down < 0)
+    {
+        return;
+    }
+
+    cpu = sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu");
+    snapshot = sdl3d_input_get_snapshot(state->input);
+    if (cpu == NULL || snapshot == NULL)
+    {
+        return;
+    }
+
+    const float up_value = snapshot->actions[p2_up].value;
+    const float down_value = snapshot->actions[p2_down].value;
+    const float input_value = SDL_clamp(up_value - down_value, -1.0f, 1.0f);
+    if (SDL_fabsf(input_value) <= 0.0001f)
+    {
+        return;
+    }
+
+    const float speed = sdl3d_properties_get_float(cpu->props, "speed", 0.0f);
+    const float half_height = sdl3d_properties_get_float(cpu->props, "half_height", 0.0f);
+    const float lo = -4.78f + half_height;
+    const float hi = 4.78f - half_height;
+    sdl3d_vec3 position = cpu->position;
+    const float old_y = position.y;
+    position.y = SDL_clamp(position.y + input_value * speed * dt, lo, hi);
+    cpu->position = position;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong client predicted paddle2 motion: input=%.3f dt=%.3f y=%.3f->%.3f scene=%s",
+                (unsigned long long)pong_log_timestamp_ms(), input_value, dt, old_y, position.y,
+                active_scene_name(state) != NULL ? active_scene_name(state) : "<none>");
 }
 
 static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *state)
@@ -1470,6 +1570,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, dt);
+    predict_client_paddle_motion(state, dt);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -1485,6 +1586,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, real_dt);
+    predict_client_paddle_motion(state, real_dt);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -238,6 +238,52 @@ static bool is_network_role_client(const pong_state *state)
     return SDL_strcmp(network_role_name(state), "client") == 0;
 }
 
+static const char *scene_payload_string(const sdl3d_properties *payload, const char *key)
+{
+    return payload != NULL ? sdl3d_properties_get_string(payload, key, NULL) : NULL;
+}
+
+static const char *scene_context_string(const sdl3d_properties *payload, const sdl3d_properties *scene_state,
+                                        const char *key, const char *fallback)
+{
+    const char *value = scene_payload_string(payload, key);
+    if (value != NULL)
+    {
+        return value;
+    }
+    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
+}
+
+static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode, const char *network_role)
+{
+    sdl3d_properties *payload = NULL;
+    bool ok = false;
+
+    if (state == NULL || state->data == NULL)
+    {
+        return false;
+    }
+
+    payload = sdl3d_properties_create();
+    if (payload == NULL)
+    {
+        return false;
+    }
+
+    if (match_mode != NULL)
+    {
+        sdl3d_properties_set_string(payload, "match_mode", match_mode);
+    }
+    if (network_role != NULL)
+    {
+        sdl3d_properties_set_string(payload, "network_role", network_role);
+    }
+
+    ok = sdl3d_game_data_set_active_scene_with_payload(state->data, "scene.play", payload);
+    sdl3d_properties_destroy(payload);
+    return ok;
+}
+
 static void clear_network_action_overrides(pong_state *state)
 {
     if (state == NULL || state->input == NULL || state->data == NULL)
@@ -417,19 +463,35 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
     (void)runtime;
     (void)adapter_name;
     (void)target;
-    (void)payload;
 
     if (state == NULL || state->data == NULL || state->input == NULL)
     {
         return false;
     }
 
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(state->data);
+    sdl3d_properties *mutable_scene_state = sdl3d_game_data_mutable_scene_state(state->data);
+    const char *match_mode = scene_context_string(payload, scene_state, "match_mode", "single");
+    const char *network_role = scene_context_string(payload, scene_state, "network_role", "none");
+    const char *network_flow = scene_context_string(payload, scene_state, "network_flow", "none");
+
     clear_network_action_overrides(state);
-    if (is_local_match_mode(state))
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong play input context: match_mode=%s network_role=%s network_flow=%s",
+                match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
+                network_flow != NULL ? network_flow : "none");
+
+    if (mutable_scene_state != NULL)
+    {
+        sdl3d_properties_set_string(mutable_scene_state, "match_mode", match_mode != NULL ? match_mode : "single");
+        sdl3d_properties_set_string(mutable_scene_state, "network_role", network_role != NULL ? network_role : "none");
+        sdl3d_properties_set_string(mutable_scene_state, "network_flow", network_flow != NULL ? network_flow : "none");
+    }
+
+    if (SDL_strcmp(match_mode != NULL ? match_mode : "single", "local") == 0)
     {
         bind_local_play_controls(state);
     }
-    else if (is_network_role_host(state))
+    else if (SDL_strcmp(network_role != NULL ? network_role : "none", "host") == 0)
     {
         bind_network_play_controls(state, "action.paddle.up", "action.paddle.down");
         const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
@@ -443,7 +505,7 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
             sdl3d_input_unbind_action(state->input, p2_down);
         }
     }
-    else if (is_network_role_client(state))
+    else if (SDL_strcmp(network_role != NULL ? network_role : "none", "client") == 0)
     {
         const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
         const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
@@ -890,17 +952,12 @@ static void update_direct_connect_session_status(pong_state *state)
             if (packet_size >= 1 && packet[0] == (Uint8)PONG_NETWORK_MESSAGE_START_GAME)
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
-                if (state->data != NULL)
-                {
-                    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-                    if (scene_state != NULL)
-                    {
-                        sdl3d_properties_set_string(scene_state, "match_mode", "lan");
-                        sdl3d_properties_set_string(scene_state, "network_role", "client");
-                    }
-                }
                 clear_network_action_overrides(state);
-                (void)sdl3d_game_data_set_active_scene(state->data, "scene.play");
+                if (!enter_multiplayer_play_scene(state, "lan", "client"))
+                {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
+                                SDL_GetError());
+                }
                 break;
             }
             if (is_multiplayer_play_scene(state) && packet_size >= 12)
@@ -1150,19 +1207,8 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
         return;
     }
 
-    if (state->data != NULL)
-    {
-        sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-        if (scene_state != NULL)
-        {
-            sdl3d_properties_set_string(scene_state, "match_mode", "lan");
-            sdl3d_properties_set_string(scene_state, "network_role", "host");
-        }
-    }
-
     clear_network_action_overrides(state);
-
-    if (!sdl3d_game_data_set_active_scene(state->data, "scene.play"))
+    if (!enter_multiplayer_play_scene(state, "lan", "host"))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to enter multiplayer play scene: %s",
                     SDL_GetError());

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -2,6 +2,7 @@
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_timer.h>
 #include <SDL3/SDL_stdinc.h>
 
 #include <stdbool.h>
@@ -57,6 +58,58 @@ typedef enum pong_network_message_kind
 
 static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
 static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
+
+static Uint64 pong_log_timestamp_ms(void)
+{
+    return SDL_GetTicks();
+}
+
+static void pong_log_multiplayer_state(const char *prefix, const pong_state *state, Uint32 packet_tick,
+                                       const char *extra)
+{
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    const sdl3d_registered_actor *player =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.paddle.player") : NULL;
+    const sdl3d_registered_actor *cpu =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu") : NULL;
+    const sdl3d_registered_actor *ball =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.ball") : NULL;
+    const sdl3d_registered_actor *match =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.match") : NULL;
+    const sdl3d_registered_actor *score_player_actor =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.score.player") : NULL;
+    const sdl3d_registered_actor *score_cpu_actor =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.score.cpu") : NULL;
+    const sdl3d_vec3 player_position = player != NULL ? player->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 cpu_position = cpu != NULL ? cpu->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 ball_position = ball != NULL ? ball->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 ball_velocity = ball != NULL
+                                         ? sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
+                                         : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const int score_player = score_player_actor != NULL ? sdl3d_properties_get_int(score_player_actor->props, "value", 0) : 0;
+    const int score_cpu = score_cpu_actor != NULL ? sdl3d_properties_get_int(score_cpu_actor->props, "value", 0) : 0;
+    const bool finished = match != NULL && sdl3d_properties_get_bool(match->props, "finished", false);
+    const char *winner = match != NULL ? sdl3d_properties_get_string(match->props, "winner", "none") : "none";
+    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", "none") : "none";
+    const char *network_role = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
+    const char *network_flow = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", "none") : "none";
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong %s tick=%u scene=%s match_mode=%s network_role=%s network_flow=%s "
+                "scores=%d:%d finished=%d winner=%s player=(%.2f,%.2f,%.2f) cpu=(%.2f,%.2f,%.2f) "
+                "ball=(%.2f,%.2f,%.2f) vel=(%.2f,%.2f)%s%s",
+                (unsigned long long)pong_log_timestamp_ms(), prefix != NULL ? prefix : "state", (unsigned int)packet_tick,
+                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
+                    ? sdl3d_game_data_active_scene(state->data)
+                    : "<none>",
+                match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
+                network_flow != NULL ? network_flow : "none", score_player, score_cpu, finished ? 1 : 0,
+                winner != NULL ? winner : "none", player_position.x, player_position.y, player_position.z,
+                cpu_position.x, cpu_position.y, cpu_position.z, ball_position.x, ball_position.y, ball_position.z,
+                ball_velocity.x, ball_velocity.y, extra != NULL && extra[0] != '\0' ? " " : "",
+                extra != NULL ? extra : "");
+}
 
 static bool pong_network_write_u8(Uint8 **cursor, Uint8 *end, Uint8 value)
 {
@@ -673,10 +726,18 @@ static bool send_client_input_packet(pong_state *state)
         return false;
     }
 
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong client->host input tick=%u up=%.3f down=%.3f scene=%s",
+                (unsigned long long)pong_log_timestamp_ms(), snapshot != NULL ? (unsigned int)SDL_max(snapshot->tick, 0)
+                                                                               : 0U,
+                up_value, down_value,
+                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
+                    ? sdl3d_game_data_active_scene(state->data)
+                    : "<none>");
     return true;
 }
 
-static bool apply_play_state_snapshot(pong_state *state, const Uint8 **cursor, const Uint8 *end)
+static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, const Uint8 **cursor, const Uint8 *end)
 {
     sdl3d_registered_actor *player = NULL;
     sdl3d_registered_actor *cpu = NULL;
@@ -742,6 +803,7 @@ static bool apply_play_state_snapshot(pong_state *state, const Uint8 **cursor, c
     sdl3d_properties_set_string(match->props, "winner", winner == 1 ? "player" : winner == 2 ? "cpu" : "none");
     sdl3d_properties_set_float(presentation->props, "border_flash", border_flash);
     sdl3d_properties_set_float(presentation->props, "paddle_flash", paddle_flash);
+    pong_log_multiplayer_state("client<-host state", state, packet_tick, "applied");
     return true;
 }
 
@@ -774,6 +836,12 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
     (void)tick;
     set_network_action_override(state, "action.paddle.local.up", up_value);
     set_network_action_override(state, "action.paddle.local.down", down_value);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "[%llu ms] Pong host<-client input tick=%u up=%.3f down=%.3f scene=%s",
+                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, up_value, down_value,
+                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
+                    ? sdl3d_game_data_active_scene(state->data)
+                    : "<none>");
     return true;
 }
 
@@ -806,8 +874,7 @@ static bool process_client_state_packet(pong_state *state, const Uint8 *packet, 
 
     set_network_action_override(state, "action.paddle.up", p1_up);
     set_network_action_override(state, "action.paddle.down", p1_down);
-    ok = apply_play_state_snapshot(state, &cursor, end);
-    (void)tick;
+    ok = apply_play_state_snapshot(state, tick, &cursor, end);
     return ok;
 }
 
@@ -888,6 +955,8 @@ static bool send_host_state_packet(pong_state *state)
         return false;
     }
 
+    pong_log_multiplayer_state("host->client state", state, snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U,
+                               "sent");
     return true;
 }
 

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -221,6 +221,7 @@ extern "C"
         sdl3d_render_context *renderer; /**< SDL3D render context owned by the managed loop. */
         float real_time;                /**< Wall-clock time accumulated by rendered frames. */
         bool paused;                    /**< When true, fixed ticks and timer pools are frozen. */
+        bool input_event_consumed;      /**< Set true by the event callback to skip raw input delivery for one event. */
         bool quit_requested;            /**< Set true from any callback to leave the loop. */
     } sdl3d_game_context;
 
@@ -247,8 +248,10 @@ extern "C"
          * @brief Called for each non-quit SDL event.
          *
          * SDL_EVENT_QUIT is handled by the managed loop and always requests
-         * shutdown. Return false from this callback to request shutdown for
-         * game-specific events such as Escape.
+         * shutdown. Set ctx->input_event_consumed to true to prevent the raw
+         * event from reaching the session input manager. Return false from
+         * this callback to request shutdown for game-specific events such as
+         * Escape.
          *
          * @param ctx      Managed-loop context.
          * @param userdata Caller-owned pointer passed to sdl3d_run_game.

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -215,6 +215,25 @@ extern "C"
     /** @brief Remove all bindings for an action. */
     void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id);
 
+    /**
+     * @brief Override an action's runtime value for the next input update.
+     *
+     * When an override is active, the injected value replaces live bindings
+     * for that action until it is cleared. This is intended for gameplay
+     * systems that need to feed authored actions from non-physical sources
+     * such as network packets, scripted AI, or deterministic playback.
+     *
+     * Passing a value in [-1, 1] is recommended. Digital actions usually use
+     * 0 or 1.
+     */
+    void sdl3d_input_set_action_override(sdl3d_input_manager *input, int action_id, float value);
+
+    /** @brief Clear one action override and resume live bindings for that action. */
+    void sdl3d_input_clear_action_override(sdl3d_input_manager *input, int action_id);
+
+    /** @brief Clear all action overrides and resume live bindings. */
+    void sdl3d_input_clear_action_overrides(sdl3d_input_manager *input);
+
     /* ================================================================== */
     /* Gamepad state                                                      */
     /* ================================================================== */

--- a/src/audio.c
+++ b/src/audio.c
@@ -116,27 +116,6 @@ static void music_slot_destroy(sdl3d_music_slot *slot)
     SDL_free(slot);
 }
 
-static bool grow_active_capacity(sdl3d_audio_engine *audio)
-{
-    int new_capacity = audio->active_capacity > 0 ? audio->active_capacity * 2 : SDL3D_AUDIO_INITIAL_ACTIVE_CAPACITY;
-    if (new_capacity > SDL3D_AUDIO_MAX_ACTIVE_SOUNDS)
-    {
-        new_capacity = SDL3D_AUDIO_MAX_ACTIVE_SOUNDS;
-    }
-    sdl3d_active_sound *active_sounds =
-        SDL_realloc(audio->active_sounds, (size_t)new_capacity * sizeof(*active_sounds));
-    if (active_sounds == NULL)
-    {
-        return SDL_OutOfMemory();
-    }
-
-    SDL_memset(active_sounds + audio->active_capacity, 0,
-               (size_t)(new_capacity - audio->active_capacity) * sizeof(*active_sounds));
-    audio->active_sounds = active_sounds;
-    audio->active_capacity = new_capacity;
-    return true;
-}
-
 static void cleanup_finished_sounds(sdl3d_audio_engine *audio)
 {
     for (int i = 0; i < audio->active_count; ++i)
@@ -167,8 +146,7 @@ static sdl3d_active_sound *reserve_active_sound(sdl3d_audio_engine *audio)
         }
     }
 
-    if (audio->active_count < audio->active_capacity ||
-        (audio->active_capacity < SDL3D_AUDIO_MAX_ACTIVE_SOUNDS && grow_active_capacity(audio)))
+    if (audio->active_count < audio->active_capacity)
     {
         sdl3d_active_sound *active = &audio->active_sounds[audio->active_count];
         SDL_zero(*active);
@@ -384,6 +362,14 @@ bool sdl3d_audio_create(sdl3d_audio_engine **out_audio)
     {
         audio->bus_volumes[i] = 1.0f;
     }
+    audio->active_sounds = SDL_calloc(SDL3D_AUDIO_MAX_ACTIVE_SOUNDS, sizeof(*audio->active_sounds));
+    if (audio->active_sounds == NULL)
+    {
+        ma_engine_uninit(&audio->engine);
+        SDL_free(audio);
+        return SDL_OutOfMemory();
+    }
+    audio->active_capacity = SDL3D_AUDIO_MAX_ACTIVE_SOUNDS;
     audio->current_ambient_id = -1;
     *out_audio = audio;
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D audio engine initialized");

--- a/src/game.c
+++ b/src/game.c
@@ -507,7 +507,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         SDL_Event event;
         while (SDL_PollEvent(&event))
         {
-            sdl3d_input_process_event(sdl3d_game_session_get_input(ctx.session), &event);
+            ctx.input_event_consumed = false;
 
             if (event.type == SDL_EVENT_QUIT)
             {
@@ -519,6 +519,11 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
             {
                 ctx.quit_requested = true;
                 break;
+            }
+
+            if (!ctx.input_event_consumed)
+            {
+                sdl3d_input_process_event(sdl3d_game_session_get_input(ctx.session), &event);
             }
         }
         poll_end_counter = SDL_GetPerformanceCounter();

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3701,12 +3701,19 @@ static bool update_phase_default(const sdl3d_game_data_runtime *runtime, const c
     return !paused;
 }
 
-static bool eval_update_phase_entry(yyjson_val *entry, bool paused, bool fallback)
+static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
+                                const sdl3d_game_data_ui_metrics *metrics);
+
+static bool eval_update_phase_entry(const sdl3d_game_data_runtime *runtime, yyjson_val *entry, bool paused,
+                                    bool fallback)
 {
     if (yyjson_is_bool(entry))
         return yyjson_get_bool(entry);
     if (!yyjson_is_obj(entry))
         return fallback;
+    yyjson_val *active_if = obj_get(entry, "active_if");
+    if (active_if != NULL && !eval_data_condition(runtime, active_if, NULL))
+        return false;
     if (!json_bool(entry, "active", true))
         return false;
     if (paused)
@@ -3723,10 +3730,10 @@ bool sdl3d_game_data_active_scene_update_phase(const sdl3d_game_data_runtime *ru
     const scene_entry *scene = active_scene_entry_const(runtime);
     yyjson_val *scene_entry_json = obj_get(obj_get(scene != NULL ? scene->root : NULL, "update_phases"), phase);
     if (scene_entry_json != NULL)
-        return eval_update_phase_entry(scene_entry_json, paused, fallback);
+        return eval_update_phase_entry(runtime, scene_entry_json, paused, fallback);
 
     yyjson_val *root_entry_json = obj_get(obj_get(runtime_root(runtime), "update_phases"), phase);
-    return eval_update_phase_entry(root_entry_json, paused, fallback);
+    return eval_update_phase_entry(runtime, root_entry_json, paused, fallback);
 }
 
 bool sdl3d_game_data_active_scene_renders_world(const sdl3d_game_data_runtime *runtime)

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7332,12 +7332,7 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
     if (SDL_strcmp(type, "branch") == 0)
     {
         yyjson_val *condition = obj_get(action, "if");
-        sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, json_string(condition, "target", NULL));
-        const char *key = json_string(condition, "key", NULL);
-        const char *op = json_string(condition, "op", NULL);
-        const bool passed =
-            target != NULL && key != NULL &&
-            compare_value(sdl3d_properties_get_value(target->props, key), op, obj_get(condition, "value"));
+        const bool passed = eval_data_condition(runtime, condition, NULL);
         return execute_action_array(runtime, obj_get(action, passed ? "then" : "else"), payload);
     }
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7909,6 +7909,11 @@ static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_v
         {
             yyjson_val *component = yyjson_arr_get(components, c);
             const char *type = json_string(component, "type", "");
+            yyjson_val *enabled_if = obj_get(component, "enabled_if");
+            if (enabled_if != NULL && !eval_data_condition(runtime, enabled_if, NULL))
+            {
+                continue;
+            }
             if (SDL_strcmp(type, "control.axis_1d") == 0 && input != NULL)
             {
                 const int negative = sdl3d_game_data_find_action(runtime, json_string(component, "negative", NULL));

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1316,17 +1316,10 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *condition = obj_get(action, "if");
         if (!yyjson_is_obj(condition))
             return validation_error(ctx, json_path, "branch requires an object 'if' condition");
-        if (SDL_strcmp(json_string(condition, "type") != NULL ? json_string(condition, "type") : "",
-                       "property.compare") != 0)
-            return validation_error(ctx, json_path, "branch currently supports only property.compare conditions");
-        if (!require_ref(ctx, &names->entities, "entity", json_string(condition, "target"), json_path))
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.if", json_path);
+        if (!validate_data_condition(ctx, condition, condition_path, names))
             return false;
-        if (!is_non_empty_string(condition, "key"))
-            return validation_error(ctx, json_path, "property.compare requires a non-empty key");
-        if (!is_compare_op(json_string(condition, "op")))
-            return validation_error(ctx, json_path, "property.compare requires a supported comparison operator");
-        if (obj_get(condition, "value") == NULL)
-            return validation_error(ctx, json_path, "property.compare requires a value");
         char then_path[PATH_BUFFER_SIZE];
         char else_path[PATH_BUFFER_SIZE];
         format_path(then_path, sizeof(then_path), "%s.then", json_path);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1699,7 +1699,8 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     return true;
 }
 
-static bool validate_update_phases(validation_context *ctx, yyjson_val *phases, const char *json_path)
+static bool validate_update_phases(validation_context *ctx, yyjson_val *phases, const char *json_path,
+                                   validation_names *names)
 {
     if (phases == NULL)
         return true;
@@ -1716,6 +1717,13 @@ static bool validate_update_phases(validation_context *ctx, yyjson_val *phases, 
         format_path(path, sizeof(path), "%s.%s", json_path, yyjson_get_str(key));
         if (!yyjson_is_bool(entry) && !yyjson_is_obj(entry))
             return validation_error(ctx, path, "update phase must be a bool or object");
+        if (yyjson_is_obj(entry))
+        {
+            char condition_path[PATH_BUFFER_SIZE];
+            format_path(condition_path, sizeof(condition_path), "%s.active_if", path);
+            if (!validate_data_condition(ctx, obj_get(entry, "active_if"), condition_path, names))
+                return false;
+        }
     }
     return true;
 }
@@ -2282,7 +2290,7 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
 
     char phases_path[PATH_BUFFER_SIZE];
     format_path(phases_path, sizeof(phases_path), "%s.update_phases", json_path);
-    if (!validate_update_phases(ctx, obj_get(root, "update_phases"), phases_path))
+    if (!validate_update_phases(ctx, obj_get(root, "update_phases"), phases_path, names))
         return false;
 
     yyjson_val *timeline = obj_get(root, "timeline");
@@ -2644,7 +2652,7 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
 {
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
            validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
-           validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases") &&
+           validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&

--- a/src/input.c
+++ b/src/input.c
@@ -84,6 +84,9 @@ struct sdl3d_input_manager
 
     float deadzone;
 
+    bool action_override_active[SDL3D_INPUT_MAX_ACTIONS];
+    float action_override_value[SDL3D_INPUT_MAX_ACTIONS];
+
     sdl3d_demo_recorder *recorder;
     sdl3d_demo_player *demo_player;
 };
@@ -1144,6 +1147,40 @@ void sdl3d_input_unbind_action(sdl3d_input_manager *input, int action_id)
     }
 }
 
+void sdl3d_input_set_action_override(sdl3d_input_manager *input, int action_id, float value)
+{
+    if (input == NULL || !sdl3d_input_action_id_valid(action_id) || action_id >= input->action_count ||
+        !input->actions[action_id].registered)
+    {
+        return;
+    }
+
+    input->action_override_active[action_id] = true;
+    input->action_override_value[action_id] = sdl3d_input_clampf(value, -1.0f, 1.0f);
+}
+
+void sdl3d_input_clear_action_override(sdl3d_input_manager *input, int action_id)
+{
+    if (input == NULL || !sdl3d_input_action_id_valid(action_id))
+    {
+        return;
+    }
+
+    input->action_override_active[action_id] = false;
+    input->action_override_value[action_id] = 0.0f;
+}
+
+void sdl3d_input_clear_action_overrides(sdl3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return;
+    }
+
+    SDL_memset(input->action_override_active, 0, sizeof(input->action_override_active));
+    SDL_memset(input->action_override_value, 0, sizeof(input->action_override_value));
+}
+
 void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *event)
 {
     if (input == NULL || event == NULL)
@@ -1332,6 +1369,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
         bool explicit_released = false;
         bool was_held = input->prev_held[action_id];
         float value = 0.0f;
+        const bool override_active = input->action_override_active[action_id];
 
         for (int i = 0; i < input->binding_count; ++i)
         {
@@ -1344,6 +1382,13 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
             value = sdl3d_input_signed_max_magnitude(value, sdl3d_input_binding_value(input, binding));
             explicit_pressed = explicit_pressed || sdl3d_input_binding_pressed(input, binding);
             explicit_released = explicit_released || sdl3d_input_binding_released(input, binding);
+        }
+
+        if (override_active)
+        {
+            value = input->action_override_value[action_id];
+            explicit_pressed = value > 0.0001f;
+            explicit_released = value <= 0.0001f && was_held;
         }
 
         value = sdl3d_input_clampf(value, -1.0f, 1.0f);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SDL3D_TEST_SOURCES
     test_audio.cpp
     test_effects.cpp
     test_game.cpp
+    test_pong_multiplayer.cpp
     test_game_session.cpp
     test_input.cpp
     test_transition.cpp
@@ -202,6 +203,12 @@ else()
     sdl3d_add_test(sdl3d_audio_test test_audio.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_game_test test_game.cpp render)
+    sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
+    target_compile_definitions(
+        sdl3d_pong_multiplayer_test
+        PRIVATE
+            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+    )
     sdl3d_add_test(sdl3d_game_session_test test_game_session.cpp unit)
     if(SDL3D_ENABLE_NETWORKING AND NOT EMSCRIPTEN AND NOT ANDROID AND NOT IOS)
         sdl3d_add_test(sdl3d_network_test test_network.cpp unit)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,12 +245,14 @@ else()
     sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
     sdl3d_add_test(sdl3d_timer_pool_test test_timer_pool.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
-    sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
-    target_compile_definitions(
-        sdl3d_pong_multiplayer_test
-        PRIVATE
-            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
-    )
+    if(NOT EMSCRIPTEN)
+        sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
+        target_compile_definitions(
+            sdl3d_pong_multiplayer_test
+            PRIVATE
+                SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+        )
+    endif()
     sdl3d_add_test(doom_backend_test test_doom_backend.cpp unit)
     target_sources(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level/backend.c)
     target_include_directories(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,6 @@ set(SDL3D_TEST_SOURCES
     test_audio.cpp
     test_effects.cpp
     test_game.cpp
-    test_pong_multiplayer.cpp
     test_game_session.cpp
     test_input.cpp
     test_transition.cpp
@@ -213,22 +212,6 @@ else()
     sdl3d_add_test(sdl3d_audio_test test_audio.cpp unit)
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_game_test test_game.cpp render)
-    sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
-    if(EMSCRIPTEN)
-        target_compile_definitions(
-            sdl3d_pong_multiplayer_test
-            PRIVATE
-                SDL3D_PONG_DATA_PATH="/pong/pong.game.json"
-        )
-        sdl3d_target_preload_asset_directory(sdl3d_pong_multiplayer_test "${CMAKE_SOURCE_DIR}/demos/pong/data"
-                                             "/pong")
-    else()
-        target_compile_definitions(
-            sdl3d_pong_multiplayer_test
-            PRIVATE
-                SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
-        )
-    endif()
     sdl3d_add_test(sdl3d_game_session_test test_game_session.cpp unit)
     if(SDL3D_ENABLE_NETWORKING AND NOT EMSCRIPTEN AND NOT ANDROID AND NOT IOS)
         sdl3d_add_test(sdl3d_network_test test_network.cpp unit)
@@ -262,6 +245,12 @@ else()
     sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
     sdl3d_add_test(sdl3d_timer_pool_test test_timer_pool.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
+    sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
+    target_compile_definitions(
+        sdl3d_pong_multiplayer_test
+        PRIVATE
+            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+    )
     sdl3d_add_test(doom_backend_test test_doom_backend.cpp unit)
     target_sources(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level/backend.c)
     target_include_directories(doom_backend_test PRIVATE ${CMAKE_SOURCE_DIR}/demos/doom_level)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,11 @@ if(ANDROID)
 
     target_compile_features(main PRIVATE cxx_std_17)
     target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_compile_definitions(
+        main
+        PRIVATE
+            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+    )
     sdl3d_enable_sanitizers(main)
 elseif(IOS)
     # iOS apps must be bundled as .app directories and cannot launch bare
@@ -160,6 +165,11 @@ elseif(IOS)
 
     target_compile_features(sdl3d_ios_tests PRIVATE cxx_std_17)
     target_include_directories(sdl3d_ios_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_compile_definitions(
+        sdl3d_ios_tests
+        PRIVATE
+            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+    )
     sdl3d_enable_sanitizers(sdl3d_ios_tests)
 
     set_target_properties(
@@ -204,11 +214,21 @@ else()
     sdl3d_add_test(sdl3d_effects_test test_effects.cpp unit)
     sdl3d_add_test(sdl3d_game_test test_game.cpp render)
     sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
-    target_compile_definitions(
-        sdl3d_pong_multiplayer_test
-        PRIVATE
-            SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
-    )
+    if(EMSCRIPTEN)
+        target_compile_definitions(
+            sdl3d_pong_multiplayer_test
+            PRIVATE
+                SDL3D_PONG_DATA_PATH="/pong/pong.game.json"
+        )
+        sdl3d_target_preload_asset_directory(sdl3d_pong_multiplayer_test "${CMAKE_SOURCE_DIR}/demos/pong/data"
+                                             "/pong")
+    else()
+        target_compile_definitions(
+            sdl3d_pong_multiplayer_test
+            PRIVATE
+                SDL3D_PONG_DATA_PATH="${CMAKE_SOURCE_DIR}/demos/pong/data/pong.game.json"
+        )
+    endif()
     sdl3d_add_test(sdl3d_game_session_test test_game_session.cpp unit)
     if(SDL3D_ENABLE_NETWORKING AND NOT EMSCRIPTEN AND NOT ANDROID AND NOT IOS)
         sdl3d_add_test(sdl3d_network_test test_network.cpp unit)

--- a/tests/test_game.cpp
+++ b/tests/test_game.cpp
@@ -187,6 +187,17 @@ bool event_returns_false(sdl3d_game_context *ctx, void *userdata, const SDL_Even
     return true;
 }
 
+bool consume_key_event_in_callback(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
+{
+    auto *state = static_cast<GameTestState *>(userdata);
+    if (event->type == SDL_EVENT_KEY_DOWN)
+    {
+        ctx->input_event_consumed = true;
+        state->event_called = true;
+    }
+    return true;
+}
+
 void quit_in_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 {
     auto *state = static_cast<GameTestState *>(userdata);
@@ -593,6 +604,21 @@ TEST(ManagedGameLoop, InputManagerProcessesEventsBeforeTick)
     EXPECT_EQ(0, run_test_game(&callbacks, &state));
     EXPECT_GE(state.tick_count, 1);
     EXPECT_TRUE(state.saw_input_action_in_tick);
+}
+
+TEST(ManagedGameLoop, EventCallbackCanConsumeInputBeforeSnapshot)
+{
+    GameTestState state;
+    sdl3d_game_callbacks callbacks{};
+    callbacks.init = bind_and_push_input_in_init;
+    callbacks.event = consume_key_event_in_callback;
+    callbacks.tick = quit_after_input_tick;
+    callbacks.render = stop_after_many_null_frames;
+
+    EXPECT_EQ(0, run_test_game(&callbacks, &state));
+    EXPECT_GE(state.tick_count, 1);
+    EXPECT_TRUE(state.event_called);
+    EXPECT_FALSE(state.saw_input_action_in_tick);
 }
 
 TEST(ManagedGameLoop, InputPressedEdgeIsNotRepeatedAcrossCatchUpTicks)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1454,7 +1454,6 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.join"));
     EXPECT_TRUE(sdl3d_game_data_active_scene_renders_world(runtime));
-    EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.multiplayer.discovery"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.multiplayer.join");
     EXPECT_EQ(menu.item_count, 3);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -108,6 +108,32 @@ bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char 
     return true;
 }
 
+bool configure_play_input_adapter(void *, sdl3d_game_data_runtime *runtime, const char *adapter_name,
+                                  sdl3d_registered_actor *, const sdl3d_properties *payload)
+{
+    EXPECT_STREQ(adapter_name, "adapter.pong.configure_play_input");
+    EXPECT_NE(runtime, nullptr);
+    if (payload != nullptr)
+    {
+        const char *match_mode = sdl3d_properties_get_string(payload, "match_mode", nullptr);
+        const char *network_role = sdl3d_properties_get_string(payload, "network_role", nullptr);
+        const char *network_flow = sdl3d_properties_get_string(payload, "network_flow", nullptr);
+        if (match_mode != nullptr)
+        {
+            sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(runtime), "match_mode", match_mode);
+        }
+        if (network_role != nullptr)
+        {
+            sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(runtime), "network_role", network_role);
+        }
+        if (network_flow != nullptr)
+        {
+            sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(runtime), "network_flow", network_flow);
+        }
+    }
+    return true;
+}
+
 bool reload_native_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                            sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -3448,6 +3474,32 @@ TEST(GameDataRuntime, LuaControllerMovesCpuPaddleTowardBall)
 
     EXPECT_GT(cpu->position.y, 0.0f);
     EXPECT_LE(cpu->position.y, 0.55f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, PongClientDoesNotStartServeTimer)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_register_adapter(runtime, "adapter.pong.configure_play_input",
+                                                 configure_play_input_adapter, nullptr));
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    ASSERT_NE(payload, nullptr);
+    sdl3d_properties_set_string(payload, "match_mode", "lan");
+    sdl3d_properties_set_string(payload, "network_role", "client");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload));
+    sdl3d_properties_destroy(payload);
+
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "network_role", ""), "client");
+    EXPECT_FALSE(sdl3d_game_data_active_scene_update_phase(runtime, "simulation", false));
+    EXPECT_EQ(sdl3d_timer_pool_active_count(sdl3d_game_session_get_timer_pool(session)), 0);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1426,7 +1426,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lan"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.multiplayer.lan");
-    EXPECT_EQ(menu.item_count, 4);
+    EXPECT_EQ(menu.item_count, 3);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
     EXPECT_STREQ(item.label, "Create Match");
     EXPECT_STREQ(item.scene, "scene.multiplayer.lobby");
@@ -1435,6 +1435,9 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
     EXPECT_STREQ(item.label, "Join Match");
     EXPECT_STREQ(item.scene, "scene.multiplayer.join");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lobby"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
@@ -1454,17 +1457,27 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_TRUE(sdl3d_game_data_active_scene_has_entity(runtime, "entity.multiplayer.discovery"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_STREQ(menu.name, "menu.multiplayer.join");
-    EXPECT_EQ(menu.item_count, 1);
+    EXPECT_EQ(menu.item_count, 3);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Search for local matches");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.discovery");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Join match with IP address or hostname");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.direct_connect");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
     EXPECT_STREQ(item.label, "Back");
     EXPECT_STREQ(item.scene, "scene.multiplayer.lan");
 
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lan"));
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.direct_connect"));
+    EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.discovery"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
-    EXPECT_STREQ(menu.name, "menu.multiplayer.lan");
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
-    EXPECT_STREQ(item.label, "Direct Connect");
-    EXPECT_STREQ(item.scene, "scene.multiplayer.direct_connect");
+    EXPECT_STREQ(menu.name, "menu.multiplayer.discovery");
+    EXPECT_EQ(menu.item_count, 1);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.join");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3438,8 +3438,12 @@ TEST(GameDataRuntime, LuaControllerMovesCpuPaddleTowardBall)
     cpu->position.y = 0.0f;
     sdl3d_properties_set_vec3(ball->props, "origin", ball->position);
     sdl3d_properties_set_vec3(cpu->props, "origin", cpu->position);
-
-    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.play"));
+    sdl3d_properties *payload = sdl3d_properties_create();
+    ASSERT_NE(payload, nullptr);
+    sdl3d_properties_set_string(payload, "match_mode", "single");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload));
+    sdl3d_properties_destroy(payload);
+    sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(runtime), "match_mode", "single");
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
 
     EXPECT_GT(cpu->position.y, 0.0f);

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -535,6 +535,33 @@ TEST(Input, UnbindActionRemovesBindings)
     EXPECT_FALSE(sdl3d_input_is_held(input.input, action));
 }
 
+TEST(Input, ActionOverrideReplacesLiveBindings)
+{
+    InputPtr input;
+    int action = sdl3d_input_register_action(input.input, "move");
+    sdl3d_input_bind_key(input.input, action, SDL_SCANCODE_W);
+
+    sdl3d_input_set_action_override(input.input, action, 1.0f);
+    sdl3d_input_update(input.input, 1);
+    EXPECT_TRUE(sdl3d_input_is_pressed(input.input, action));
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+    EXPECT_FLOAT_EQ(1.0f, sdl3d_input_get_value(input.input, action));
+
+    sdl3d_input_clear_action_override(input.input, action);
+    sdl3d_input_update(input.input, 2);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, action));
+    EXPECT_FALSE(sdl3d_input_is_pressed(input.input, action));
+
+    sdl3d_input_set_action_override(input.input, action, -0.5f);
+    sdl3d_input_update(input.input, 3);
+    EXPECT_TRUE(sdl3d_input_is_held(input.input, action));
+    EXPECT_FLOAT_EQ(-0.5f, sdl3d_input_get_value(input.input, action));
+
+    sdl3d_input_clear_action_overrides(input.input);
+    sdl3d_input_update(input.input, 4);
+    EXPECT_FALSE(sdl3d_input_is_held(input.input, action));
+}
+
 TEST(Input, AnyPressedTracksUnboundAndBoundButtonLikeInput)
 {
     InputPtr input;
@@ -640,6 +667,9 @@ TEST(Input, NullSafety)
     EXPECT_EQ(nullptr, sdl3d_input_get_snapshot(nullptr));
     sdl3d_input_bind_fps_defaults(nullptr);
     sdl3d_input_bind_ui_defaults(nullptr);
+    sdl3d_input_set_action_override(nullptr, 0, 1.0f);
+    sdl3d_input_clear_action_override(nullptr, 0);
+    sdl3d_input_clear_action_overrides(nullptr);
     sdl3d_input_set_deadzone(nullptr, 0.2f);
 }
 

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -1,0 +1,521 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+extern "C"
+{
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/game.h"
+#include "sdl3d/game_data.h"
+#include "sdl3d/network.h"
+#include "sdl3d/properties.h"
+}
+
+namespace
+{
+constexpr Uint32 kPongNetworkPacketMagic = 0x474E4F50u;
+constexpr Uint8 kPongNetworkPacketVersion = 1U;
+
+enum PongNetworkMessageKind : Uint8
+{
+    PONG_NETWORK_MESSAGE_INPUT = 1,
+    PONG_NETWORK_MESSAGE_STATE = 2,
+};
+
+static bool write_u8(Uint8 **cursor, Uint8 *end, Uint8 value)
+{
+    if (cursor == nullptr || *cursor == nullptr || end == nullptr || *cursor >= end)
+    {
+        return false;
+    }
+    **cursor = value;
+    ++(*cursor);
+    return true;
+}
+
+static bool write_u32(Uint8 **cursor, Uint8 *end, Uint32 value)
+{
+    Uint8 bytes[4];
+    bytes[0] = (Uint8)(value & 0xffU);
+    bytes[1] = (Uint8)((value >> 8U) & 0xffU);
+    bytes[2] = (Uint8)((value >> 16U) & 0xffU);
+    bytes[3] = (Uint8)((value >> 24U) & 0xffU);
+    if (cursor == nullptr || *cursor == nullptr || end == nullptr || (size_t)(end - *cursor) < sizeof(bytes))
+    {
+        return false;
+    }
+    SDL_memcpy(*cursor, bytes, sizeof(bytes));
+    *cursor += sizeof(bytes);
+    return true;
+}
+
+static bool write_i32(Uint8 **cursor, Uint8 *end, int value)
+{
+    return write_u32(cursor, end, (Uint32)(Sint32)value);
+}
+
+static bool write_f32(Uint8 **cursor, Uint8 *end, float value)
+{
+    Uint32 bits = 0U;
+    SDL_memcpy(&bits, &value, sizeof(bits));
+    return write_u32(cursor, end, bits);
+}
+
+static bool write_vec2(Uint8 **cursor, Uint8 *end, sdl3d_vec2 value)
+{
+    return write_f32(cursor, end, value.x) && write_f32(cursor, end, value.y);
+}
+
+static bool write_vec3(Uint8 **cursor, Uint8 *end, sdl3d_vec3 value)
+{
+    return write_f32(cursor, end, value.x) && write_f32(cursor, end, value.y) && write_f32(cursor, end, value.z);
+}
+
+static bool read_u8(const Uint8 **cursor, const Uint8 *end, Uint8 *out_value)
+{
+    if (cursor == nullptr || *cursor == nullptr || out_value == nullptr || *cursor >= end)
+    {
+        return false;
+    }
+    *out_value = **cursor;
+    ++(*cursor);
+    return true;
+}
+
+static bool read_u32(const Uint8 **cursor, const Uint8 *end, Uint32 *out_value)
+{
+    if (cursor == nullptr || *cursor == nullptr || out_value == nullptr || (size_t)(end - *cursor) < 4)
+    {
+        return false;
+    }
+
+    const Uint8 *src = *cursor;
+    *out_value = (Uint32)src[0] | ((Uint32)src[1] << 8U) | ((Uint32)src[2] << 16U) | ((Uint32)src[3] << 24U);
+    *cursor += 4;
+    return true;
+}
+
+static bool read_i32(const Uint8 **cursor, const Uint8 *end, int *out_value)
+{
+    Uint32 value = 0U;
+    if (!read_u32(cursor, end, &value))
+    {
+        return false;
+    }
+    *out_value = (int)(Sint32)value;
+    return true;
+}
+
+static bool read_f32(const Uint8 **cursor, const Uint8 *end, float *out_value)
+{
+    Uint32 bits = 0U;
+    if (!read_u32(cursor, end, &bits))
+    {
+        return false;
+    }
+    SDL_memcpy(out_value, &bits, sizeof(bits));
+    return true;
+}
+
+static bool read_vec3(const Uint8 **cursor, const Uint8 *end, sdl3d_vec3 *out_value)
+{
+    return read_f32(cursor, end, &out_value->x) && read_f32(cursor, end, &out_value->y) &&
+           read_f32(cursor, end, &out_value->z);
+}
+
+static sdl3d_game_session *create_session(bool include_audio = false)
+{
+    sdl3d_game_session_desc desc{};
+    sdl3d_game_session_desc_init(&desc);
+    if (include_audio)
+    {
+        desc.create_services |= SDL3D_GAME_SESSION_SERVICE_AUDIO;
+        desc.optional_audio = true;
+    }
+    sdl3d_game_session *session = nullptr;
+    EXPECT_TRUE(sdl3d_game_session_create(&desc, &session));
+    return session;
+}
+
+static bool load_pong_runtime(sdl3d_game_session *session, sdl3d_game_data_runtime **out_runtime)
+{
+    char error[256]{};
+    EXPECT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, out_runtime, error, sizeof(error))) << error;
+    return *out_runtime != nullptr;
+}
+
+static void set_multiplayer_scene_state(sdl3d_game_data_runtime *runtime, const char *match_mode,
+                                        const char *network_role, const char *network_flow)
+{
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "match_mode", match_mode != nullptr ? match_mode : "");
+    sdl3d_properties_set_string(scene_state, "network_role", network_role != nullptr ? network_role : "");
+    sdl3d_properties_set_string(scene_state, "network_flow", network_flow != nullptr ? network_flow : "");
+}
+
+static bool enter_multiplayer_play_scene(sdl3d_game_data_runtime *runtime, const char *match_mode,
+                                         const char *network_role, const char *network_flow)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == nullptr)
+    {
+        return false;
+    }
+
+    if (match_mode != nullptr)
+    {
+        sdl3d_properties_set_string(payload, "match_mode", match_mode);
+    }
+    if (network_role != nullptr)
+    {
+        sdl3d_properties_set_string(payload, "network_role", network_role);
+    }
+    if (network_flow != nullptr)
+    {
+        sdl3d_properties_set_string(payload, "network_flow", network_flow);
+    }
+
+    const bool ok = sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload);
+    sdl3d_properties_destroy(payload);
+    return ok;
+}
+
+static bool wait_for_network_pair(sdl3d_network_session *host, sdl3d_network_session *client)
+{
+    for (int i = 0; i < 1200; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client, 0.01f));
+        if (sdl3d_network_session_is_connected(host) && sdl3d_network_session_is_connected(client))
+        {
+            return true;
+        }
+        if (sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_REJECTED ||
+            sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_TIMED_OUT ||
+            sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_ERROR)
+        {
+            return false;
+        }
+    }
+    return false;
+}
+
+static bool send_client_input_packet(sdl3d_game_session *session, sdl3d_network_session *net_session, int p2_up,
+                                     int p2_down)
+{
+    const sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(input);
+    const float up_value = snapshot != nullptr && p2_up >= 0 ? snapshot->actions[p2_up].value : 0.0f;
+    const float down_value = snapshot != nullptr && p2_down >= 0 ? snapshot->actions[p2_down].value : 0.0f;
+    Uint8 packet[32];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+
+    return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
+           write_u8(&cursor, end, PONG_NETWORK_MESSAGE_INPUT) && write_u8(&cursor, end, 0U) &&
+           write_u8(&cursor, end, 0U) && write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
+           write_f32(&cursor, end, up_value) && write_f32(&cursor, end, down_value) &&
+           sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
+}
+
+static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
+                                      const Uint8 *packet, int packet_size)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+    float up_value = 0.0f;
+    float down_value = 0.0f;
+
+    if (runtime == nullptr || packet == nullptr || packet_size < 12)
+    {
+        return false;
+    }
+
+    if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
+        version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
+        kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT || !read_u8(&cursor, end, &reserved) ||
+        !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &up_value) || !read_f32(&cursor, end, &down_value))
+    {
+        return false;
+    }
+
+    (void)tick;
+    const int p2_up = sdl3d_game_data_find_action(runtime, "action.paddle.local.up");
+    const int p2_down = sdl3d_game_data_find_action(runtime, "action.paddle.local.down");
+    if (p2_up >= 0)
+    {
+        sdl3d_input_set_action_override(sdl3d_game_session_get_input(session), p2_up, up_value);
+    }
+    if (p2_down >= 0)
+    {
+        sdl3d_input_set_action_override(sdl3d_game_session_get_input(session), p2_down, down_value);
+    }
+    return true;
+}
+
+static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
+                                   sdl3d_network_session *net_session)
+{
+    const sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.paddle.player");
+    const sdl3d_registered_actor *cpu = sdl3d_game_data_find_actor(runtime, "entity.paddle.cpu");
+    const sdl3d_registered_actor *ball = sdl3d_game_data_find_actor(runtime, "entity.ball");
+    const sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    const sdl3d_registered_actor *presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
+    const sdl3d_registered_actor *score_player_actor = sdl3d_game_data_find_actor(runtime, "entity.score.player");
+    const sdl3d_registered_actor *score_cpu_actor = sdl3d_game_data_find_actor(runtime, "entity.score.cpu");
+    const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(sdl3d_game_session_get_input(session));
+    Uint8 packet[160];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+    const int p1_up = sdl3d_game_data_find_action(runtime, "action.paddle.up");
+    const int p1_down = sdl3d_game_data_find_action(runtime, "action.paddle.down");
+    const float p1_up_value = snapshot != nullptr && p1_up >= 0 ? snapshot->actions[p1_up].value : 0.0f;
+    const float p1_down_value = snapshot != nullptr && p1_down >= 0 ? snapshot->actions[p1_down].value : 0.0f;
+
+    if (player == nullptr || cpu == nullptr || ball == nullptr || match == nullptr || presentation == nullptr ||
+        score_player_actor == nullptr || score_cpu_actor == nullptr)
+    {
+        return false;
+    }
+
+    return write_u32(&cursor, end, kPongNetworkPacketMagic) &&
+           write_u8(&cursor, end, kPongNetworkPacketVersion) &&
+           write_u8(&cursor, end, PONG_NETWORK_MESSAGE_STATE) &&
+           write_u8(&cursor, end, 0U) && write_u8(&cursor, end, 0U) &&
+           write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
+           write_f32(&cursor, end, p1_up_value) && write_f32(&cursor, end, p1_down_value) &&
+           write_vec3(&cursor, end, player->position) && write_vec3(&cursor, end, cpu->position) &&
+           write_vec3(&cursor, end, ball->position) &&
+           write_vec3(&cursor, end, sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))) &&
+           write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "border_flash", 0.0f)) &&
+           write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f)) &&
+           write_i32(&cursor, end, sdl3d_properties_get_int(score_player_actor->props, "value", 0)) &&
+           write_i32(&cursor, end, sdl3d_properties_get_int(score_cpu_actor->props, "value", 0)) &&
+           write_i32(&cursor, end, sdl3d_properties_get_bool(match->props, "finished", false) ? 1 : 0) &&
+           write_i32(&cursor, end, SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "player") == 0
+                                  ? 1
+                                  : SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "cpu") == 0
+                                        ? 2
+                                        : 0) &&
+           write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "active_motion", false) ? 1 : 0) &&
+           write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "has_last_reflect_y", false) ? 1 : 0) &&
+           write_f32(&cursor, end, sdl3d_properties_get_float(ball->props, "last_reflect_y", 0.0f)) &&
+           write_i32(&cursor, end, sdl3d_properties_get_int(ball->props, "stagnant_reflect_count", 0)) &&
+           sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
+}
+
+static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const Uint8 *packet, int packet_size)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+    float p1_up = 0.0f;
+    float p1_down = 0.0f;
+    sdl3d_vec3 player_position{};
+    sdl3d_vec3 cpu_position{};
+    sdl3d_vec3 ball_position{};
+    sdl3d_vec3 ball_velocity{};
+    float border_flash = 0.0f;
+    float paddle_flash = 0.0f;
+    int score_player = 0;
+    int score_cpu = 0;
+    int finished = 0;
+    int winner = 0;
+    int active_motion = 0;
+    int has_last_reflect_y = 0;
+    float last_reflect_y = 0.0f;
+    int stagnant_reflect_count = 0;
+    sdl3d_registered_actor *player = nullptr;
+    sdl3d_registered_actor *cpu = nullptr;
+    sdl3d_registered_actor *ball = nullptr;
+    sdl3d_registered_actor *match = nullptr;
+    sdl3d_registered_actor *presentation = nullptr;
+    sdl3d_registered_actor *score_player_actor = nullptr;
+    sdl3d_registered_actor *score_cpu_actor = nullptr;
+
+    if (runtime == nullptr || packet == nullptr || packet_size < 12)
+    {
+        return false;
+    }
+
+    if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
+        version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
+        kind != (Uint8)PONG_NETWORK_MESSAGE_STATE || !read_u8(&cursor, end, &reserved) ||
+        !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &p1_up) || !read_f32(&cursor, end, &p1_down) ||
+        !read_vec3(&cursor, end, &player_position) || !read_vec3(&cursor, end, &cpu_position) ||
+        !read_vec3(&cursor, end, &ball_position) || !read_vec3(&cursor, end, &ball_velocity) ||
+        !read_f32(&cursor, end, &border_flash) || !read_f32(&cursor, end, &paddle_flash) ||
+        !read_i32(&cursor, end, &score_player) || !read_i32(&cursor, end, &score_cpu) ||
+        !read_i32(&cursor, end, &finished) || !read_i32(&cursor, end, &winner) ||
+        !read_i32(&cursor, end, &active_motion) || !read_i32(&cursor, end, &has_last_reflect_y) ||
+        !read_f32(&cursor, end, &last_reflect_y) || !read_i32(&cursor, end, &stagnant_reflect_count))
+    {
+        return false;
+    }
+
+    (void)tick;
+    player = sdl3d_game_data_find_actor(runtime, "entity.paddle.player");
+    cpu = sdl3d_game_data_find_actor(runtime, "entity.paddle.cpu");
+    ball = sdl3d_game_data_find_actor(runtime, "entity.ball");
+    match = sdl3d_game_data_find_actor(runtime, "entity.match");
+    presentation = sdl3d_game_data_find_actor(runtime, "entity.presentation");
+    score_player_actor = sdl3d_game_data_find_actor(runtime, "entity.score.player");
+    score_cpu_actor = sdl3d_game_data_find_actor(runtime, "entity.score.cpu");
+
+    if (player == nullptr || cpu == nullptr || ball == nullptr || match == nullptr || presentation == nullptr ||
+        score_player_actor == nullptr || score_cpu_actor == nullptr)
+    {
+        return false;
+    }
+
+    player->position = player_position;
+    cpu->position = cpu_position;
+    ball->position = ball_position;
+    sdl3d_properties_set_vec3(ball->props, "velocity", ball_velocity);
+    sdl3d_properties_set_bool(ball->props, "active_motion", active_motion != 0);
+    sdl3d_properties_set_bool(ball->props, "has_last_reflect_y", has_last_reflect_y != 0);
+    sdl3d_properties_set_float(ball->props, "last_reflect_y", last_reflect_y);
+    sdl3d_properties_set_int(ball->props, "stagnant_reflect_count", stagnant_reflect_count);
+    sdl3d_properties_set_int(score_player_actor->props, "value", score_player);
+    sdl3d_properties_set_int(score_cpu_actor->props, "value", score_cpu);
+    sdl3d_properties_set_bool(match->props, "finished", finished != 0);
+    sdl3d_properties_set_string(match->props, "winner", winner == 1 ? "player" : winner == 2 ? "cpu" : "none");
+    sdl3d_properties_set_float(presentation->props, "border_flash", border_flash);
+    sdl3d_properties_set_float(presentation->props, "paddle_flash", paddle_flash);
+    return true;
+}
+
+class PongHeadlessMultiplayerTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        host_session = create_session(false);
+        client_session = create_session(false);
+        ASSERT_NE(host_session, nullptr);
+        ASSERT_NE(client_session, nullptr);
+
+        ASSERT_TRUE(load_pong_runtime(host_session, &host_runtime));
+        ASSERT_TRUE(load_pong_runtime(client_session, &client_runtime));
+
+        ASSERT_TRUE(enter_multiplayer_play_scene(host_runtime, "lan", "host", "host"));
+        ASSERT_TRUE(enter_multiplayer_play_scene(client_runtime, "lan", "client", "direct"));
+
+        set_multiplayer_scene_state(host_runtime, "lan", "host", "host");
+        set_multiplayer_scene_state(client_runtime, "lan", "client", "direct");
+
+        sdl3d_network_session_desc host_desc{};
+        sdl3d_network_session_desc_init(&host_desc);
+        host_desc.role = SDL3D_NETWORK_ROLE_HOST;
+        host_desc.port = SDL3D_NETWORK_DEFAULT_PORT;
+        host_desc.handshake_timeout = 2.0f;
+        host_desc.idle_timeout = 2.0f;
+        ASSERT_TRUE(sdl3d_network_session_create(&host_desc, &host_network));
+
+        sdl3d_network_session_desc client_desc{};
+        sdl3d_network_session_desc_init(&client_desc);
+        client_desc.role = SDL3D_NETWORK_ROLE_CLIENT;
+        client_desc.host = "127.0.0.1";
+        client_desc.port = SDL3D_NETWORK_DEFAULT_PORT;
+        client_desc.handshake_timeout = 2.0f;
+        client_desc.idle_timeout = 2.0f;
+        ASSERT_TRUE(sdl3d_network_session_create(&client_desc, &client_network));
+
+        ASSERT_TRUE(wait_for_network_pair(host_network, client_network));
+
+        p1_up = sdl3d_game_data_find_action(host_runtime, "action.paddle.up");
+        p1_down = sdl3d_game_data_find_action(host_runtime, "action.paddle.down");
+        p2_up = sdl3d_game_data_find_action(client_runtime, "action.paddle.local.up");
+        p2_down = sdl3d_game_data_find_action(client_runtime, "action.paddle.local.down");
+        ASSERT_GE(p1_up, 0);
+        ASSERT_GE(p1_down, 0);
+        ASSERT_GE(p2_up, 0);
+        ASSERT_GE(p2_down, 0);
+    }
+
+    void TearDown() override
+    {
+        sdl3d_network_session_destroy(client_network);
+        sdl3d_network_session_destroy(host_network);
+        sdl3d_game_data_destroy(client_runtime);
+        sdl3d_game_data_destroy(host_runtime);
+        sdl3d_game_session_destroy(client_session);
+        sdl3d_game_session_destroy(host_session);
+    }
+
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *host_runtime = nullptr;
+    sdl3d_game_data_runtime *client_runtime = nullptr;
+    sdl3d_network_session *host_network = nullptr;
+    sdl3d_network_session *client_network = nullptr;
+    int p1_up = -1;
+    int p1_down = -1;
+    int p2_up = -1;
+    int p2_down = -1;
+};
+
+TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAuthoritativeState)
+{
+    sdl3d_registered_actor *host_cpu = sdl3d_game_data_find_actor(host_runtime, "entity.paddle.cpu");
+    sdl3d_registered_actor *client_cpu = sdl3d_game_data_find_actor(client_runtime, "entity.paddle.cpu");
+    ASSERT_NE(host_cpu, nullptr);
+    ASSERT_NE(client_cpu, nullptr);
+
+    const float initial_host_cpu_y = host_cpu->position.y;
+
+    sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_up, 1.0f);
+    sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_down, 0.0f);
+    ASSERT_TRUE(sdl3d_game_session_tick(client_session, 0.016f));
+
+    ASSERT_TRUE(send_client_input_packet(client_session, client_network, p2_up, p2_down));
+
+    std::array<Uint8, SDL3D_NETWORK_MAX_PACKET_SIZE> packet{};
+    int received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(host_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(process_host_input_packet(host_runtime, host_session, packet.data(), received));
+
+    ASSERT_TRUE(sdl3d_game_session_tick(host_session, 0.25f));
+    ASSERT_TRUE(sdl3d_game_data_update(host_runtime, 0.25f));
+
+    EXPECT_NE(host_cpu->position.y, initial_host_cpu_y);
+
+    ASSERT_TRUE(send_host_state_packet(host_runtime, host_session, host_network));
+    received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(process_client_state_packet(client_runtime, packet.data(), received));
+
+    EXPECT_NEAR(client_cpu->position.y, host_cpu->position.y, 0.0001f);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_find_actor(client_runtime, "entity.match")->props,
+                                              "winner", "none"),
+                 sdl3d_properties_get_string(sdl3d_game_data_find_actor(host_runtime, "entity.match")->props, "winner",
+                                             "none"));
+}
+
+} // namespace

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <array>
 #include <cstdint>
 
@@ -19,6 +20,8 @@ namespace
 {
 constexpr Uint32 kPongNetworkPacketMagic = 0x474E4F50u;
 constexpr Uint8 kPongNetworkPacketVersion = 1U;
+constexpr size_t kPongNetworkInputPacketSize = 20U;
+constexpr size_t kPongNetworkStatePacketSize = 108U;
 
 enum PongNetworkMessageKind : Uint8
 {
@@ -220,6 +223,7 @@ static bool send_client_input_packet(sdl3d_game_session *session, sdl3d_network_
            write_u8(&cursor, end, PONG_NETWORK_MESSAGE_INPUT) && write_u8(&cursor, end, 0U) &&
            write_u8(&cursor, end, 0U) && write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
            write_f32(&cursor, end, up_value) && write_f32(&cursor, end, down_value) &&
+           (size_t)(cursor - packet) == kPongNetworkInputPacketSize &&
            sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
 }
 
@@ -244,7 +248,13 @@ static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_ga
     if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
         version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
         kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT || !read_u8(&cursor, end, &reserved) ||
+        !read_u8(&cursor, end, &reserved) ||
         !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &up_value) || !read_f32(&cursor, end, &down_value))
+    {
+        return false;
+    }
+
+    if ((size_t)packet_size != kPongNetworkInputPacketSize)
     {
         return false;
     }
@@ -311,6 +321,7 @@ static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_
            write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "has_last_reflect_y", false) ? 1 : 0) &&
            write_f32(&cursor, end, sdl3d_properties_get_float(ball->props, "last_reflect_y", 0.0f)) &&
            write_i32(&cursor, end, sdl3d_properties_get_int(ball->props, "stagnant_reflect_count", 0)) &&
+           (size_t)(cursor - packet) == kPongNetworkStatePacketSize &&
            sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
 }
 
@@ -355,6 +366,7 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
     if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
         version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
         kind != (Uint8)PONG_NETWORK_MESSAGE_STATE || !read_u8(&cursor, end, &reserved) ||
+        !read_u8(&cursor, end, &reserved) ||
         !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &p1_up) || !read_f32(&cursor, end, &p1_down) ||
         !read_vec3(&cursor, end, &player_position) || !read_vec3(&cursor, end, &cpu_position) ||
         !read_vec3(&cursor, end, &ball_position) || !read_vec3(&cursor, end, &ball_velocity) ||
@@ -363,6 +375,11 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
         !read_i32(&cursor, end, &finished) || !read_i32(&cursor, end, &winner) ||
         !read_i32(&cursor, end, &active_motion) || !read_i32(&cursor, end, &has_last_reflect_y) ||
         !read_f32(&cursor, end, &last_reflect_y) || !read_i32(&cursor, end, &stagnant_reflect_count))
+    {
+        return false;
+    }
+
+    if ((size_t)packet_size != kPongNetworkStatePacketSize)
     {
         return false;
     }

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -477,6 +477,15 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
     ASSERT_NE(client_cpu, nullptr);
 
     const float initial_host_cpu_y = host_cpu->position.y;
+    const float initial_client_cpu_y = client_cpu->position.y;
+
+    ASSERT_TRUE(sdl3d_game_session_tick(host_session, 0.25f));
+    ASSERT_TRUE(sdl3d_game_data_update(host_runtime, 0.25f));
+    ASSERT_TRUE(sdl3d_game_session_tick(client_session, 0.25f));
+    ASSERT_TRUE(sdl3d_game_data_update(client_runtime, 0.25f));
+
+    EXPECT_FLOAT_EQ(host_cpu->position.y, initial_host_cpu_y);
+    EXPECT_FLOAT_EQ(client_cpu->position.y, initial_client_cpu_y);
 
     sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_up, 1.0f);
     sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_down, 0.0f);

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -478,6 +478,7 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
 
     const float initial_host_cpu_y = host_cpu->position.y;
     const float initial_client_cpu_y = client_cpu->position.y;
+    const sdl3d_vec3 initial_client_ball_position = sdl3d_game_data_find_actor(client_runtime, "entity.ball")->position;
 
     ASSERT_TRUE(sdl3d_game_session_tick(host_session, 0.25f));
     ASSERT_TRUE(sdl3d_game_data_update(host_runtime, 0.25f));
@@ -486,6 +487,10 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
 
     EXPECT_FLOAT_EQ(host_cpu->position.y, initial_host_cpu_y);
     EXPECT_FLOAT_EQ(client_cpu->position.y, initial_client_cpu_y);
+    EXPECT_FLOAT_EQ(sdl3d_game_data_find_actor(client_runtime, "entity.ball")->position.x,
+                    initial_client_ball_position.x);
+    EXPECT_FLOAT_EQ(sdl3d_game_data_find_actor(client_runtime, "entity.ball")->position.y,
+                    initial_client_ball_position.y);
 
     sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_up, 1.0f);
     sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_down, 0.0f);

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 extern "C"
@@ -221,7 +221,8 @@ static bool send_client_input_packet(sdl3d_game_session *session, sdl3d_network_
 
     return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
            write_u8(&cursor, end, PONG_NETWORK_MESSAGE_INPUT) && write_u8(&cursor, end, 0U) &&
-           write_u8(&cursor, end, 0U) && write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
+           write_u8(&cursor, end, 0U) &&
+           write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
            write_f32(&cursor, end, up_value) && write_f32(&cursor, end, down_value) &&
            (size_t)(cursor - packet) == kPongNetworkInputPacketSize &&
            sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
@@ -248,8 +249,8 @@ static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_ga
     if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
         version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
         kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT || !read_u8(&cursor, end, &reserved) ||
-        !read_u8(&cursor, end, &reserved) ||
-        !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &up_value) || !read_f32(&cursor, end, &down_value))
+        !read_u8(&cursor, end, &reserved) || !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &up_value) ||
+        !read_f32(&cursor, end, &down_value))
     {
         return false;
     }
@@ -298,25 +299,24 @@ static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_
         return false;
     }
 
-    return write_u32(&cursor, end, kPongNetworkPacketMagic) &&
-           write_u8(&cursor, end, kPongNetworkPacketVersion) &&
-           write_u8(&cursor, end, PONG_NETWORK_MESSAGE_STATE) &&
-           write_u8(&cursor, end, 0U) && write_u8(&cursor, end, 0U) &&
+    return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
+           write_u8(&cursor, end, PONG_NETWORK_MESSAGE_STATE) && write_u8(&cursor, end, 0U) &&
+           write_u8(&cursor, end, 0U) &&
            write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
            write_f32(&cursor, end, p1_up_value) && write_f32(&cursor, end, p1_down_value) &&
            write_vec3(&cursor, end, player->position) && write_vec3(&cursor, end, cpu->position) &&
            write_vec3(&cursor, end, ball->position) &&
-           write_vec3(&cursor, end, sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))) &&
+           write_vec3(&cursor, end,
+                      sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))) &&
            write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "border_flash", 0.0f)) &&
            write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f)) &&
            write_i32(&cursor, end, sdl3d_properties_get_int(score_player_actor->props, "value", 0)) &&
            write_i32(&cursor, end, sdl3d_properties_get_int(score_cpu_actor->props, "value", 0)) &&
            write_i32(&cursor, end, sdl3d_properties_get_bool(match->props, "finished", false) ? 1 : 0) &&
-           write_i32(&cursor, end, SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "player") == 0
-                                  ? 1
-                                  : SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "cpu") == 0
-                                        ? 2
-                                        : 0) &&
+           write_i32(&cursor, end,
+                     SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "player") == 0 ? 1
+                     : SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "cpu") == 0  ? 2
+                                                                                                            : 0) &&
            write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "active_motion", false) ? 1 : 0) &&
            write_i32(&cursor, end, sdl3d_properties_get_bool(ball->props, "has_last_reflect_y", false) ? 1 : 0) &&
            write_f32(&cursor, end, sdl3d_properties_get_float(ball->props, "last_reflect_y", 0.0f)) &&
@@ -366,13 +366,12 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
     if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
         version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
         kind != (Uint8)PONG_NETWORK_MESSAGE_STATE || !read_u8(&cursor, end, &reserved) ||
-        !read_u8(&cursor, end, &reserved) ||
-        !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &p1_up) || !read_f32(&cursor, end, &p1_down) ||
-        !read_vec3(&cursor, end, &player_position) || !read_vec3(&cursor, end, &cpu_position) ||
-        !read_vec3(&cursor, end, &ball_position) || !read_vec3(&cursor, end, &ball_velocity) ||
-        !read_f32(&cursor, end, &border_flash) || !read_f32(&cursor, end, &paddle_flash) ||
-        !read_i32(&cursor, end, &score_player) || !read_i32(&cursor, end, &score_cpu) ||
-        !read_i32(&cursor, end, &finished) || !read_i32(&cursor, end, &winner) ||
+        !read_u8(&cursor, end, &reserved) || !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &p1_up) ||
+        !read_f32(&cursor, end, &p1_down) || !read_vec3(&cursor, end, &player_position) ||
+        !read_vec3(&cursor, end, &cpu_position) || !read_vec3(&cursor, end, &ball_position) ||
+        !read_vec3(&cursor, end, &ball_velocity) || !read_f32(&cursor, end, &border_flash) ||
+        !read_f32(&cursor, end, &paddle_flash) || !read_i32(&cursor, end, &score_player) ||
+        !read_i32(&cursor, end, &score_cpu) || !read_i32(&cursor, end, &finished) || !read_i32(&cursor, end, &winner) ||
         !read_i32(&cursor, end, &active_motion) || !read_i32(&cursor, end, &has_last_reflect_y) ||
         !read_f32(&cursor, end, &last_reflect_y) || !read_i32(&cursor, end, &stagnant_reflect_count))
     {
@@ -543,10 +542,10 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
     ASSERT_TRUE(process_client_state_packet(client_runtime, packet.data(), received));
 
     EXPECT_NEAR(client_cpu->position.y, host_cpu->position.y, 0.0001f);
-    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_find_actor(client_runtime, "entity.match")->props,
-                                              "winner", "none"),
-                 sdl3d_properties_get_string(sdl3d_game_data_find_actor(host_runtime, "entity.match")->props, "winner",
-                                             "none"));
+    EXPECT_STREQ(
+        sdl3d_properties_get_string(sdl3d_game_data_find_actor(client_runtime, "entity.match")->props, "winner",
+                                    "none"),
+        sdl3d_properties_get_string(sdl3d_game_data_find_actor(host_runtime, "entity.match")->props, "winner", "none"));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

This PR wires Pong's direct-connect multiplayer path end to end and keeps the join flow readable for players. It also adds a headless multiplayer integration test so the network gameplay logic can be validated without the frontend.

### What changed
- Added a host lobby for `Create Match` that binds UDP port `27183`, waits for a single client, and starts the match when the host chooses `Start Game`.
- Simplified the LAN menu to `Create Match`, `Join Match`, and `Back`.
- Split `Join Match` into a separate menu with:
  - `Search for local matches`
  - `Join match with IP address or hostname`
  - `Back`
- Updated the direct-connect scene to read as `JOIN MATCH` and removed the obscured helper text / hidden back path.
- Added a headless Pong multiplayer integration test that exercises host/client direct-connect play-state synchronization.
- Added timestamped multiplayer diagnostics to help compare host/client state and packet flow.
- Added platform wiring so the Pong multiplayer test builds correctly on Android, iOS, and Emscripten.

### Validation
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/release --target sdl3d_pong_multiplayer_test sdl3d_game_data_test pong_demo -j 8`
- `./build/release/tests/sdl3d_pong_multiplayer_test`
- `./build/release/tests/sdl3d_game_data_test`
