### PR TITLE
Add LAN discovery to Pong multiplayer

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1400,11 +1400,15 @@
       "active": true,
       "tags": ["state", "multiplayer", "discovery"],
       "properties": {
-        "status": { "type": "string", "value": "Scanning for hosts..." },
-        "session_0": { "type": "string", "value": "No sessions discovered yet" },
+        "status": { "type": "string", "value": "" },
+        "session_0": { "type": "string", "value": "" },
         "session_1": { "type": "string", "value": "" },
         "session_2": { "type": "string", "value": "" },
-        "session_3": { "type": "string", "value": "" }
+        "session_3": { "type": "string", "value": "" },
+        "session_4": { "type": "string", "value": "" },
+        "session_5": { "type": "string", "value": "" },
+        "session_6": { "type": "string", "value": "" },
+        "session_7": { "type": "string", "value": "" }
       }
     }
   ],

--- a/demos/pong/data/scenes/multiplayer_discovery.scene.json
+++ b/demos/pong/data/scenes/multiplayer_discovery.scene.json
@@ -28,14 +28,7 @@
     "enabled": true,
     "input": "any",
     "reset_periodic_on_input": false,
-    "on_enter": [
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "status", "value": "Scanning for hosts..." },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_0", "value": "No sessions discovered yet" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_1", "value": "" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_2", "value": "" },
-      { "type": "property.set", "target": "entity.multiplayer.discovery", "key": "session_3", "value": "" },
-      { "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }
-    ],
+    "on_enter": [{ "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }],
     "periodic": [
       {
         "interval": 15.0,
@@ -45,21 +38,6 @@
       }
     ]
   },
-  "menus": [
-    {
-      "name": "menu.multiplayer.discovery",
-      "up_action": "action.menu.up",
-      "down_action": "action.menu.down",
-      "select_action": "action.menu.select",
-      "back_action": "action.menu.back",
-      "move_signal": "signal.ui.menu.move",
-      "select_signal": "signal.ui.menu.select",
-      "selected": 0,
-      "items": [
-        { "label": "Back", "scene": "scene.multiplayer.join" }
-      ]
-    }
-  ],
   "ui": {
     "text": [
       {
@@ -71,92 +49,8 @@
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
-      },
-      {
-        "name": "ui.multiplayer.discovery.status",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "status" }
-        ],
-        "x": 0.30,
-        "y": 0.30,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.discovery.session_0",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_0" }
-        ],
-        "x": 0.30,
-        "y": 0.40,
-        "normalized": true,
-        "align": "left",
-        "color": [255, 245, 208, 255]
-      },
-      {
-        "name": "ui.multiplayer.discovery.session_1",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_1" }
-        ],
-        "x": 0.30,
-        "y": 0.48,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.discovery.session_2",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_2" }
-        ],
-        "x": 0.30,
-        "y": 0.56,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
-      },
-      {
-        "name": "ui.multiplayer.discovery.session_3",
-        "font": "font.hud",
-        "format": "%s",
-        "bindings": [
-          { "type": "property", "entity": "entity.multiplayer.discovery", "key": "session_3" }
-        ],
-        "x": 0.30,
-        "y": 0.64,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245]
       }
     ],
-    "menus": [
-      {
-        "name": "ui.multiplayer.discovery.menu",
-        "menu": "menu.multiplayer.discovery",
-        "font": "font.hud",
-        "x": 0.30,
-        "y": 0.80,
-        "gap": 0.09,
-        "normalized": true,
-        "align": "left",
-        "color": [225, 236, 255, 245],
-        "selected_color": [255, 245, 208, 255],
-        "cursor": {
-          "text": ">",
-          "offset_x": -0.035,
-          "align": "right",
-          "color": [255, 222, 140, 255]
-        }
-      }
-    ]
+    "menus": []
   }
 }

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -33,8 +33,10 @@ typedef struct pong_state
     sdl3d_input_manager *input;
     sdl3d_font direct_connect_font;
     sdl3d_ui_context *direct_connect_ui;
+    sdl3d_ui_context *discovery_ui;
     sdl3d_network_session *host_session;
     sdl3d_network_session *direct_connect_session;
+    sdl3d_network_discovery_session *discovery_session;
     char host_status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     char host_endpoint[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     char direct_connect_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
@@ -46,6 +48,8 @@ typedef struct pong_state
     int host_start_signal_id;
     int ball_hit_signal_id;
     int vibration_signal_id;
+    int discovery_refresh_signal_id;
+    int discovery_refresh_connection;
     int local_input_gamepad_count;
 } pong_state;
 
@@ -246,6 +250,12 @@ static bool is_multiplayer_lobby_scene(const pong_state *state)
 {
     const char *active_scene = active_scene_name(state);
     return active_scene != NULL && SDL_strcmp(active_scene, "scene.multiplayer.lobby") == 0;
+}
+
+static bool is_multiplayer_discovery_scene(const pong_state *state)
+{
+    const char *active_scene = active_scene_name(state);
+    return active_scene != NULL && SDL_strcmp(active_scene, "scene.multiplayer.discovery") == 0;
 }
 
 static bool is_multiplayer_play_scene(const pong_state *state)
@@ -641,6 +651,7 @@ static bool start_host_session(pong_state *state)
     desc.local_port = 0;
     desc.handshake_timeout = 5.0f;
     desc.idle_timeout = 10.0f;
+    desc.session_name = "Pong";
 
     if (!sdl3d_network_session_create(&desc, &state->host_session))
     {
@@ -1101,6 +1112,232 @@ static void update_direct_connect_session_status(pong_state *state)
     }
 }
 
+static void destroy_discovery_session(pong_state *state)
+{
+    if (state != NULL && state->discovery_session != NULL)
+    {
+        sdl3d_network_discovery_session_destroy(state->discovery_session);
+        state->discovery_session = NULL;
+    }
+}
+
+static bool start_discovery_session(pong_state *state)
+{
+    sdl3d_network_discovery_session_desc desc;
+
+    if (state == NULL)
+    {
+        return false;
+    }
+
+    if (state->discovery_session != NULL)
+    {
+        return sdl3d_network_discovery_session_refresh(state->discovery_session);
+    }
+
+    sdl3d_network_discovery_session_desc_init(&desc);
+    desc.host = NULL;
+    desc.port = SDL3D_NETWORK_DEFAULT_PORT;
+    desc.local_port = 0;
+
+    if (!sdl3d_network_discovery_session_create(&desc, &state->discovery_session))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery create failed: %s", SDL_GetError());
+        return false;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery scanner ready for UDP %u",
+                (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
+    return sdl3d_network_discovery_session_refresh(state->discovery_session);
+}
+
+static void update_discovery_scene_state(pong_state *state)
+{
+    sdl3d_properties *scene_state = NULL;
+    const int result_count = state != NULL && state->discovery_session != NULL
+                                 ? sdl3d_network_discovery_session_result_count(state->discovery_session)
+                                 : 0;
+
+    if (state == NULL || state->data == NULL)
+    {
+        return;
+    }
+
+    scene_state = sdl3d_game_data_mutable_scene_state(state->data);
+    if (scene_state == NULL)
+    {
+        return;
+    }
+
+    sdl3d_properties_set_int(scene_state, "multiplayer_discovery_count", result_count);
+    sdl3d_properties_set_string(
+        scene_state, "multiplayer_discovery_status",
+        state->discovery_session != NULL ? sdl3d_network_discovery_session_status(state->discovery_session) : "Idle");
+    for (int i = 0; i < SDL3D_NETWORK_MAX_DISCOVERY_RESULTS; ++i)
+    {
+        const char *key = NULL;
+        sdl3d_network_discovery_result result;
+        char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
+        SDL_zero(result);
+        label[0] = '\0';
+        switch (i)
+        {
+        case 0:
+            key = "session_0";
+            break;
+        case 1:
+            key = "session_1";
+            break;
+        case 2:
+            key = "session_2";
+            break;
+        case 3:
+            key = "session_3";
+            break;
+        case 4:
+            key = "session_4";
+            break;
+        case 5:
+            key = "session_5";
+            break;
+        case 6:
+            key = "session_6";
+            break;
+        case 7:
+            key = "session_7";
+            break;
+        default:
+            break;
+        }
+
+        if (key == NULL)
+        {
+            continue;
+        }
+
+        if (i < result_count && sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
+        {
+            SDL_snprintf(label, sizeof(label), "%s  %s:%u%s%s",
+                         result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", result.host,
+                         (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
+                         result.status[0] != '\0' ? result.status : "");
+        }
+        sdl3d_properties_set_string(scene_state, key, label);
+    }
+}
+
+static bool refresh_discovery_session(pong_state *state)
+{
+    if (state == NULL)
+    {
+        return false;
+    }
+
+    if (!start_discovery_session(state))
+    {
+        return false;
+    }
+
+    update_discovery_scene_state(state);
+    return true;
+}
+
+static void handle_discovery_result_selection(pong_state *state, int index)
+{
+    sdl3d_network_discovery_result result;
+    char port_buffer[16];
+
+    if (state == NULL || state->discovery_session == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(result);
+    if (!sdl3d_network_discovery_session_get_result(state->discovery_session, index, &result))
+    {
+        return;
+    }
+
+    SDL_strlcpy(state->direct_connect_host, result.host, sizeof(state->direct_connect_host));
+    SDL_snprintf(port_buffer, sizeof(port_buffer), "%u", (unsigned int)result.port);
+    SDL_strlcpy(state->direct_connect_port, port_buffer, sizeof(state->direct_connect_port));
+    destroy_discovery_session(state);
+    if (start_direct_connect_session(state))
+    {
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.direct_connect");
+    }
+}
+
+static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
+{
+    const int result_count = state != NULL && state->discovery_session != NULL
+                                 ? sdl3d_network_discovery_session_result_count(state->discovery_session)
+                                 : 0;
+    float panel_w;
+    float panel_h;
+    float panel_x;
+    float panel_y;
+
+    if (ctx == NULL || state == NULL || state->discovery_ui == NULL)
+    {
+        return;
+    }
+
+    panel_w = 820.0f;
+    panel_h = 500.0f;
+    panel_x = ((float)sdl3d_get_render_context_width(ctx->renderer) - panel_w) * 0.5f;
+    panel_y = ((float)sdl3d_get_render_context_height(ctx->renderer) - panel_h) * 0.5f;
+
+    sdl3d_ui_begin_panel(state->discovery_ui, panel_x, panel_y, panel_w, panel_h);
+    sdl3d_ui_begin_vbox(state->discovery_ui, panel_x + 28.0f, panel_y + 24.0f, panel_w - 56.0f, panel_h - 48.0f);
+    sdl3d_ui_layout_label(state->discovery_ui, "DISCOVER LOCAL MATCHES");
+    sdl3d_ui_separator(state->discovery_ui);
+
+    if (state->discovery_session != NULL)
+    {
+        const char *status = sdl3d_network_discovery_session_status(state->discovery_session);
+        if (status != NULL && status[0] != '\0')
+        {
+            sdl3d_ui_layout_label(state->discovery_ui, status);
+        }
+    }
+
+    for (int i = 0; i < result_count; ++i)
+    {
+        sdl3d_network_discovery_result result;
+        char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
+        if (!sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
+        {
+            continue;
+        }
+
+        SDL_snprintf(label, sizeof(label), "%s  %s:%u%s%s",
+                     result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", result.host,
+                     (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
+                     result.status[0] != '\0' ? result.status : "");
+        if (sdl3d_ui_layout_button(state->discovery_ui, label))
+        {
+            handle_discovery_result_selection(state, i);
+            break;
+        }
+    }
+
+    if (result_count == 0)
+    {
+        sdl3d_ui_layout_label(state->discovery_ui, "Searching local network...");
+    }
+
+    sdl3d_ui_separator(state->discovery_ui);
+    if (sdl3d_ui_layout_button(state->discovery_ui, "Back"))
+    {
+        destroy_discovery_session(state);
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+    }
+
+    sdl3d_ui_end_vbox(state->discovery_ui);
+    sdl3d_ui_end_panel(state->discovery_ui);
+}
+
 static void update_host_session_status(pong_state *state, float dt)
 {
     if (state == NULL)
@@ -1164,6 +1401,26 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
     if (state->host_session != NULL)
     {
         update_host_session_scene_state(state);
+    }
+
+    if (is_multiplayer_discovery_scene(state))
+    {
+        if (state->discovery_session == NULL)
+        {
+            (void)refresh_discovery_session(state);
+        }
+        else
+        {
+            if (!sdl3d_network_discovery_session_update(state->discovery_session, dt))
+            {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery update failed: %s", SDL_GetError());
+            }
+            update_discovery_scene_state(state);
+        }
+    }
+    else if (state->discovery_session != NULL)
+    {
+        destroy_discovery_session(state);
     }
 
     if (state->direct_connect_session != NULL)
@@ -1385,6 +1642,19 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
     }
 }
 
+static void on_multiplayer_discovery_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    pong_state *state = (pong_state *)userdata;
+    (void)payload;
+
+    if (state == NULL || signal_id != state->discovery_refresh_signal_id)
+    {
+        return;
+    }
+
+    (void)refresh_discovery_session(state);
+}
+
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
 {
 #if SDL3D_PONG_EMBEDDED_ASSETS
@@ -1474,6 +1744,18 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         state->assets = NULL;
         return false;
     }
+    if (!sdl3d_ui_create(&state->direct_connect_font, &state->discovery_ui))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong discovery UI create failed: %s", SDL_GetError());
+        sdl3d_ui_destroy(state->direct_connect_ui);
+        state->direct_connect_ui = NULL;
+        sdl3d_free_font(&state->direct_connect_font);
+        sdl3d_game_data_destroy(state->data);
+        state->data = NULL;
+        sdl3d_asset_resolver_destroy(state->assets);
+        state->assets = NULL;
+        return false;
+    }
     reset_direct_connect_defaults(state);
     if (ctx != NULL && ctx->window != NULL)
     {
@@ -1483,10 +1765,19 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_begin_frame_ex(state->direct_connect_ui, ctx->renderer, ctx->window);
     }
+    if (state->discovery_ui != NULL && ctx != NULL && ctx->renderer != NULL && ctx->window != NULL)
+    {
+        sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
+    }
     sdl3d_game_data_image_cache_init(&state->image_cache, state->assets);
     if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
     {
         sdl3d_game_data_image_cache_free(&state->image_cache);
+        if (state->discovery_ui != NULL)
+        {
+            sdl3d_ui_destroy(state->discovery_ui);
+            state->discovery_ui = NULL;
+        }
         if (state->direct_connect_ui != NULL)
         {
             sdl3d_ui_destroy(state->direct_connect_ui);
@@ -1515,9 +1806,12 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     state->paddle_hit_connection = 0;
     state->vibration_connection = 0;
     state->lobby_start_connection = 0;
+    state->discovery_refresh_connection = 0;
     state->host_start_signal_id = sdl3d_game_data_find_signal(state->data, "signal.multiplayer.lobby.start");
     state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
     state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
+    state->discovery_refresh_signal_id =
+        sdl3d_game_data_find_signal(state->data, "signal.multiplayer.discovery.refresh");
     state->local_input_gamepad_count = -1;
     SDL_snprintf(state->host_status, sizeof(state->host_status), "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",
@@ -1541,6 +1835,16 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
                 sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session), state->host_start_signal_id,
                                      on_multiplayer_lobby_signal, state);
         }
+        if (state->discovery_refresh_signal_id >= 0)
+        {
+            state->discovery_refresh_connection =
+                sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
+                                     state->discovery_refresh_signal_id, on_multiplayer_discovery_signal, state);
+        }
+    }
+    if (is_multiplayer_discovery_scene(state))
+    {
+        (void)refresh_discovery_session(state);
     }
     return true;
 }
@@ -1556,6 +1860,20 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
             event->type == SDL_EVENT_KEY_DOWN || event->type == SDL_EVENT_KEY_UP || event->type == SDL_EVENT_TEXT_INPUT;
 
         (void)sdl3d_ui_process_event(state->direct_connect_ui, event);
+
+        if (mouse_event || key_event)
+        {
+            ctx->input_event_consumed = true;
+        }
+    }
+    if (state != NULL && is_multiplayer_discovery_scene(state) && state->discovery_ui != NULL && event != NULL)
+    {
+        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
+        const bool key_event =
+            event->type == SDL_EVENT_KEY_DOWN || event->type == SDL_EVENT_KEY_UP || event->type == SDL_EVENT_TEXT_INPUT;
+
+        (void)sdl3d_ui_process_event(state->discovery_ui, event);
 
         if (mouse_event || key_event)
         {
@@ -1622,12 +1940,22 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     {
         draw_direct_connect_overlay(ctx, state);
     }
+    if (is_multiplayer_discovery_scene(state))
+    {
+        draw_discovery_overlay(ctx, state);
+    }
 
     if (state->direct_connect_ui != NULL)
     {
         sdl3d_ui_end_frame(state->direct_connect_ui);
         sdl3d_ui_render(state->direct_connect_ui, ctx->renderer);
         sdl3d_ui_begin_frame_ex(state->direct_connect_ui, ctx->renderer, ctx->window);
+    }
+    if (state->discovery_ui != NULL)
+    {
+        sdl3d_ui_end_frame(state->discovery_ui);
+        sdl3d_ui_render(state->discovery_ui, ctx->renderer);
+        sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
     }
 }
 
@@ -1653,6 +1981,17 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->lobby_start_connection);
         state->lobby_start_connection = 0;
+    }
+    if (state->discovery_refresh_connection > 0)
+    {
+        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->discovery_refresh_connection);
+        state->discovery_refresh_connection = 0;
+    }
+    destroy_discovery_session(state);
+    if (state->discovery_ui != NULL)
+    {
+        sdl3d_ui_destroy(state->discovery_ui);
+        state->discovery_ui = NULL;
     }
     if (state->direct_connect_ui != NULL)
     {

--- a/include/sdl3d/network.h
+++ b/include/sdl3d/network.h
@@ -27,6 +27,7 @@ extern "C"
 #define SDL3D_NETWORK_MAX_STATUS_LENGTH 128
 #define SDL3D_NETWORK_MAX_PACKET_SIZE 1024
 #define SDL3D_NETWORK_MAX_QUEUE_SIZE 8
+#define SDL3D_NETWORK_MAX_DISCOVERY_RESULTS 8
 #define SDL3D_NETWORK_DEFAULT_PORT 27183
 
     /** @brief Operating role for a direct-connect network session. */
@@ -58,13 +59,49 @@ extern "C"
      */
     typedef struct sdl3d_network_session_desc
     {
-        sdl3d_network_role role; /**< Host or client. */
-        const char *host;        /**< Remote host name or IP for client sessions. */
-        Uint16 port;             /**< Host listen port or client remote port. */
-        Uint16 local_port;       /**< Optional local bind port, or 0 for ephemeral. */
-        float handshake_timeout; /**< Client handshake timeout in seconds. */
-        float idle_timeout;      /**< Connected-session inactivity timeout in seconds. */
+        sdl3d_network_role role;  /**< Host or client. */
+        const char *host;         /**< Remote host name or IP for client sessions. */
+        Uint16 port;              /**< Host listen port or client remote port. */
+        Uint16 local_port;        /**< Optional local bind port, or 0 for ephemeral. */
+        float handshake_timeout;  /**< Client handshake timeout in seconds. */
+        float idle_timeout;       /**< Connected-session inactivity timeout in seconds. */
+        const char *session_name; /**< Optional host session name advertised to discovery clients. */
     } sdl3d_network_session_desc;
+
+    /** @brief Session discovery announcement returned by LAN scans. */
+    typedef struct sdl3d_network_discovery_result
+    {
+        /** @brief Advertised session name. */
+        char session_name[SDL3D_NETWORK_MAX_HOST_LENGTH];
+        /** @brief Advertised host or IP address. */
+        char host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+        /** @brief Advertised UDP port. */
+        Uint16 port;
+        /** @brief Human-readable status string. */
+        char status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
+        /** @brief Last time this session was seen, in SDL ticks. */
+        Uint64 last_seen_ms;
+    } sdl3d_network_discovery_result;
+
+    /**
+     * @brief Creation descriptor for a LAN discovery scanner.
+     *
+     * When @p host is NULL, discovery probes are broadcast to the local
+     * network. Otherwise the scanner probes the named host directly, which is
+     * useful for tests or manual overrides.
+     */
+    typedef struct sdl3d_network_discovery_session_desc
+    {
+        /** @brief Optional probe host or broadcast address, or NULL. */
+        const char *host;
+        /** @brief Probe target port. */
+        Uint16 port;
+        /** @brief Optional local bind port, or 0 for ephemeral. */
+        Uint16 local_port;
+    } sdl3d_network_discovery_session_desc;
+
+    /** @brief Opaque LAN discovery scanner. */
+    typedef struct sdl3d_network_discovery_session sdl3d_network_discovery_session;
 
     /** @brief Opaque direct-connect UDP session. */
     typedef struct sdl3d_network_session sdl3d_network_session;
@@ -81,6 +118,16 @@ extern "C"
      * - idle_timeout: 10 seconds
      */
     void sdl3d_network_session_desc_init(sdl3d_network_session_desc *desc);
+
+    /**
+     * @brief Initialize a discovery session descriptor with sane defaults.
+     *
+     * Defaults:
+     * - host: NULL, meaning broadcast discovery
+     * - port: SDL3D_NETWORK_DEFAULT_PORT
+     * - local_port: 0
+     */
+    void sdl3d_network_discovery_session_desc_init(sdl3d_network_discovery_session_desc *desc);
 
     /**
      * @brief Create a direct-connect network session.
@@ -156,6 +203,46 @@ extern "C"
      */
     bool sdl3d_network_session_get_peer_endpoint(const sdl3d_network_session *session, char *host_buffer,
                                                  int host_buffer_size, Uint16 *out_port);
+
+    /**
+     * @brief Create a LAN discovery scanner.
+     *
+     * The scanner sends discovery probes and collects session announcements
+     * from host sessions that are waiting for clients.
+     */
+    bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_session_desc *desc,
+                                                sdl3d_network_discovery_session **out_session);
+
+    /** @brief Destroy a discovery scanner. Safe to call with NULL. */
+    void sdl3d_network_discovery_session_destroy(sdl3d_network_discovery_session *session);
+
+    /**
+     * @brief Send a discovery probe and clear stale results.
+     *
+     * Call this when a scan should begin or restart.
+     */
+    bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *session);
+
+    /**
+     * @brief Advance discovery polling and collect new announcements.
+     *
+     * Call once per frame or tick while discovery is active.
+     */
+    bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *session, float dt);
+
+    /** @brief Return the number of discovered sessions. */
+    int sdl3d_network_discovery_session_result_count(const sdl3d_network_discovery_session *session);
+
+    /**
+     * @brief Copy one discovered session into @p out_result.
+     *
+     * @return true when @p index refers to a valid discovered session.
+     */
+    bool sdl3d_network_discovery_session_get_result(const sdl3d_network_discovery_session *session, int index,
+                                                    sdl3d_network_discovery_result *out_result);
+
+    /** @brief Return the current discovery status string, or NULL. */
+    const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery_session *session);
 
 #ifdef __cplusplus
 }

--- a/src/network.c
+++ b/src/network.c
@@ -61,6 +61,8 @@ typedef enum sdl3d_network_packet_kind
     SDL3D_NETWORK_PACKET_REJECT = 3,
     SDL3D_NETWORK_PACKET_KEEPALIVE = 4,
     SDL3D_NETWORK_PACKET_USER = 5,
+    SDL3D_NETWORK_PACKET_DISCOVERY_QUERY = 6,
+    SDL3D_NETWORK_PACKET_DISCOVERY_REPLY = 7,
 } sdl3d_network_packet_kind;
 
 typedef struct sdl3d_network_packet_entry
@@ -73,6 +75,7 @@ struct sdl3d_network_session
 {
     sdl3d_network_session_desc desc;
     char host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    char session_name[SDL3D_NETWORK_MAX_HOST_LENGTH];
     char status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     sdl3d_network_state state;
     float handshake_elapsed;
@@ -89,6 +92,21 @@ struct sdl3d_network_session
     sdl3d_network_packet_entry queue[SDL3D_NETWORK_MAX_QUEUE_SIZE];
     int queue_head;
     int queue_count;
+};
+
+struct sdl3d_network_discovery_session
+{
+    sdl3d_network_discovery_session_desc desc;
+    char status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
+    NET_DatagramSocket *socket;
+    NET_Address *target_address;
+    char target_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    Uint16 target_port;
+    sdl3d_network_discovery_result results[SDL3D_NETWORK_MAX_DISCOVERY_RESULTS];
+    int result_count;
+    float elapsed;
+    float refresh_elapsed;
+    bool scanning;
 };
 
 #if SDL3D_NETWORKING_ENABLED
@@ -157,7 +175,30 @@ static void sdl3d_network_destroy_remote_address(sdl3d_network_session *session)
     }
 }
 
+static void sdl3d_network_discovery_destroy_target_address(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL)
+    {
+        return;
+    }
+
+    if (session->target_address != NULL)
+    {
+        NET_UnrefAddress(session->target_address);
+        session->target_address = NULL;
+    }
+}
+
 #if SDL3D_NETWORKING_ENABLED
+static int sdl3d_network_encode_packet(Uint8 *buffer, int buffer_size, sdl3d_network_packet_kind kind,
+                                       const void *payload, int payload_size);
+static bool sdl3d_network_decode_packet(const Uint8 *buffer, int size, sdl3d_network_packet_kind *out_kind,
+                                        const Uint8 **out_payload, int *out_payload_size);
+static void sdl3d_network_write_u16(Uint8 *dst, Uint16 value);
+static Uint16 sdl3d_network_read_u16(const Uint8 *src);
+static bool sdl3d_network_send_packet_to(sdl3d_network_session *session, NET_Address *address, Uint16 port,
+                                         sdl3d_network_packet_kind kind, const void *payload, int payload_size);
+
 static void sdl3d_network_queue_packet(sdl3d_network_session *session, const Uint8 *data, int size)
 {
     if (session == NULL || data == NULL || size <= 0 || size > SDL3D_NETWORK_MAX_PACKET_SIZE ||
@@ -192,6 +233,190 @@ static void sdl3d_network_library_release(void)
             NET_Quit();
         }
     }
+}
+
+static const char *sdl3d_network_session_advertised_name(const sdl3d_network_session *session)
+{
+    if (session == NULL || session->session_name[0] == '\0')
+    {
+        return "SDL3D Session";
+    }
+    return session->session_name;
+}
+
+static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL)
+    {
+        return;
+    }
+
+    SDL_zeroa(session->results);
+    session->result_count = 0;
+}
+
+static bool sdl3d_network_discovery_add_result(sdl3d_network_discovery_session *session, const char *session_name,
+                                               const char *host, Uint16 port, const char *status)
+{
+    if (session == NULL || host == NULL || host[0] == '\0' || port == 0)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < session->result_count; ++i)
+    {
+        sdl3d_network_discovery_result *result = &session->results[i];
+        if (SDL_strcmp(result->host, host) == 0 && result->port == port)
+        {
+            SDL_snprintf(result->session_name, sizeof(result->session_name), "%s",
+                         session_name != NULL && session_name[0] != '\0' ? session_name : "SDL3D Session");
+            SDL_snprintf(result->status, sizeof(result->status), "%s", status != NULL ? status : "");
+            result->last_seen_ms = SDL_GetTicks();
+            return true;
+        }
+    }
+
+    if (session->result_count >= SDL3D_NETWORK_MAX_DISCOVERY_RESULTS)
+    {
+        return false;
+    }
+
+    sdl3d_network_discovery_result *result = &session->results[session->result_count++];
+    SDL_snprintf(result->session_name, sizeof(result->session_name), "%s",
+                 session_name != NULL && session_name[0] != '\0' ? session_name : "SDL3D Session");
+    SDL_snprintf(result->host, sizeof(result->host), "%s", host);
+    SDL_snprintf(result->status, sizeof(result->status), "%s", status != NULL ? status : "");
+    result->port = port;
+    result->last_seen_ms = SDL_GetTicks();
+    return true;
+}
+
+static void sdl3d_network_discovery_destroy_socket(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL)
+    {
+        return;
+    }
+
+    if (session->socket != NULL)
+    {
+        NET_DestroyDatagramSocket(session->socket);
+        session->socket = NULL;
+    }
+}
+
+static bool sdl3d_network_discovery_send_packet_to(sdl3d_network_discovery_session *session, NET_Address *address,
+                                                   Uint16 port, sdl3d_network_packet_kind kind, const void *payload,
+                                                   int payload_size)
+{
+    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+    const int size = sdl3d_network_encode_packet(packet, (int)sizeof(packet), kind, payload, payload_size);
+    if (session == NULL || session->socket == NULL || address == NULL || port == 0 || size < 0)
+    {
+        return false;
+    }
+    return NET_SendDatagram(session->socket, address, port, packet, size);
+}
+
+static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL || session->socket == NULL)
+    {
+        return false;
+    }
+
+    if (session->target_address == NULL)
+    {
+        return false;
+    }
+
+    SDL_snprintf(session->status, sizeof(session->status), "Scanning for local matches");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
+                session->target_host[0] != '\0' ? session->target_host : "<unknown>",
+                (unsigned int)session->target_port);
+    return sdl3d_network_discovery_send_packet_to(session, session->target_address, session->target_port,
+                                                  SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0);
+}
+
+typedef struct sdl3d_network_discovery_reply_payload
+{
+    Uint8 port[2];
+    char session_name[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    char status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
+} sdl3d_network_discovery_reply_payload;
+
+static void sdl3d_network_discovery_process_datagram(sdl3d_network_discovery_session *session,
+                                                     const NET_Datagram *dgram)
+{
+    if (session == NULL || dgram == NULL || dgram->buf == NULL || dgram->buflen <= 0)
+    {
+        return;
+    }
+
+    sdl3d_network_packet_kind kind;
+    const Uint8 *payload = NULL;
+    int payload_size = 0;
+    if (!sdl3d_network_decode_packet(dgram->buf, dgram->buflen, &kind, &payload, &payload_size))
+    {
+        return;
+    }
+
+    if (kind != SDL3D_NETWORK_PACKET_DISCOVERY_REPLY ||
+        payload_size != (int)sizeof(sdl3d_network_discovery_reply_payload))
+    {
+        return;
+    }
+
+    const sdl3d_network_discovery_reply_payload *reply = (const sdl3d_network_discovery_reply_payload *)payload;
+    char host_string[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    const Uint16 announced_port = sdl3d_network_read_u16(reply->port);
+
+    SDL_snprintf(host_string, sizeof(host_string), "%s",
+                 NET_GetAddressString(dgram->addr) != NULL ? NET_GetAddressString(dgram->addr) : "");
+
+    if (host_string[0] == '\0')
+    {
+        return;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery reply received: host=%s port=%u", host_string,
+                (unsigned int)announced_port);
+    if (!sdl3d_network_discovery_add_result(session, reply->session_name, host_string, announced_port, reply->status))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery result dropped: list full");
+    }
+    else
+    {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery result added: session=%s host=%s port=%u status=%s",
+                    reply->session_name, host_string, (unsigned int)announced_port, reply->status);
+    }
+}
+
+static void sdl3d_network_discovery_process_query(sdl3d_network_session *session, const NET_Datagram *dgram)
+{
+    if (session == NULL || dgram == NULL || session->state != SDL3D_NETWORK_STATE_WAITING || dgram->addr == NULL ||
+        dgram->port == 0)
+    {
+        return;
+    }
+
+    sdl3d_network_discovery_reply_payload payload;
+    const char *session_name = sdl3d_network_session_advertised_name(session);
+    const char *status = session->status[0] != '\0' ? session->status : "Awaiting client";
+    SDL_zero(payload);
+    SDL_snprintf(payload.session_name, sizeof(payload.session_name), "%s", session_name);
+    SDL_snprintf(payload.status, sizeof(payload.status), "%s", status);
+    sdl3d_network_write_u16(payload.port,
+                            session->local_bound_port != 0 ? session->local_bound_port : session->desc.port);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery query received: host=%s port=%u session=%s status=%s",
+                NET_GetAddressString(dgram->addr) != NULL ? NET_GetAddressString(dgram->addr) : "<unknown>",
+                (unsigned int)dgram->port, session_name, status);
+    SDL_LogInfo(
+        SDL_LOG_CATEGORY_APPLICATION, "SDL3D network discovery reply: session=%s host=%s port=%u status=%s",
+        session_name, NET_GetAddressString(dgram->addr) != NULL ? NET_GetAddressString(dgram->addr) : "<unknown>",
+        (unsigned int)(session->local_bound_port != 0 ? session->local_bound_port : session->desc.port), status);
+    (void)sdl3d_network_send_packet_to(session, dgram->addr, dgram->port, SDL3D_NETWORK_PACKET_DISCOVERY_REPLY,
+                                       &payload, (int)sizeof(payload));
 }
 #else
 static bool sdl3d_network_library_acquire(void)
@@ -337,6 +562,8 @@ static bool sdl3d_network_send_control(sdl3d_network_session *session, sdl3d_net
     return false;
 }
 
+static void sdl3d_network_discovery_process_query(sdl3d_network_session *session, const NET_Datagram *dgram);
+
 static void sdl3d_network_update_connected_activity(sdl3d_network_session *session, float dt)
 {
     if (session == NULL || session->state != SDL3D_NETWORK_STATE_CONNECTED)
@@ -391,6 +618,14 @@ static void sdl3d_network_process_datagram(sdl3d_network_session *session, const
 
     switch (kind)
     {
+    case SDL3D_NETWORK_PACKET_DISCOVERY_QUERY:
+        if (session->desc.role == SDL3D_NETWORK_ROLE_HOST)
+        {
+            sdl3d_network_discovery_process_query(session, dgram);
+        }
+        break;
+    case SDL3D_NETWORK_PACKET_DISCOVERY_REPLY:
+        break;
     case SDL3D_NETWORK_PACKET_HELLO:
         if (session->desc.role == SDL3D_NETWORK_ROLE_HOST && session->state == SDL3D_NETWORK_STATE_WAITING)
         {
@@ -521,10 +756,15 @@ bool sdl3d_network_session_create(const sdl3d_network_session_desc *desc, sdl3d_
 
     session->desc = *effective;
     SDL_zero(session->host);
+    SDL_zero(session->session_name);
     SDL_zero(session->status);
     if (effective->host != NULL)
     {
         SDL_snprintf(session->host, sizeof(session->host), "%s", effective->host);
+    }
+    if (effective->session_name != NULL)
+    {
+        SDL_snprintf(session->session_name, sizeof(session->session_name), "%s", effective->session_name);
     }
 
     if (!sdl3d_network_library_acquire())
@@ -808,4 +1048,235 @@ bool sdl3d_network_session_get_peer_endpoint(const sdl3d_network_session *sessio
     (void)out_port;
     return false;
 #endif
+}
+
+void sdl3d_network_discovery_session_desc_init(sdl3d_network_discovery_session_desc *desc)
+{
+    if (desc == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*desc);
+    desc->port = SDL3D_NETWORK_DEFAULT_PORT;
+    desc->local_port = 0;
+}
+
+bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_session_desc *desc,
+                                            sdl3d_network_discovery_session **out_session)
+{
+    sdl3d_network_discovery_session_desc defaults;
+    const sdl3d_network_discovery_session_desc *effective = desc;
+    sdl3d_network_discovery_session *session = NULL;
+
+    if (out_session == NULL)
+    {
+        return false;
+    }
+    *out_session = NULL;
+
+    if (effective == NULL)
+    {
+        sdl3d_network_discovery_session_desc_init(&defaults);
+        effective = &defaults;
+    }
+
+    if (effective->port == 0)
+    {
+        SDL_SetError("Discovery session requires a non-zero port.");
+        return false;
+    }
+
+    session = (sdl3d_network_discovery_session *)SDL_calloc(1, sizeof(*session));
+    if (session == NULL)
+    {
+        SDL_OutOfMemory();
+        return false;
+    }
+
+    session->desc = *effective;
+    session->target_port = effective->port;
+    SDL_zero(session->status);
+    SDL_zero(session->target_host);
+
+    if (!sdl3d_network_library_acquire())
+    {
+        sdl3d_network_discovery_session_destroy(session);
+        return false;
+    }
+
+#if SDL3D_NETWORKING_ENABLED
+    session->socket = NET_CreateDatagramSocket(NULL, effective->local_port != 0 ? effective->local_port : 0);
+    if (session->socket == NULL)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery socket create failed: %s", SDL_GetError());
+        sdl3d_network_discovery_session_destroy(session);
+        return false;
+    }
+
+    if (effective->host != NULL && effective->host[0] != '\0')
+    {
+        SDL_snprintf(session->target_host, sizeof(session->target_host), "%s", effective->host);
+    }
+    else
+    {
+        SDL_snprintf(session->target_host, sizeof(session->target_host), "%s", "255.255.255.255");
+    }
+
+    session->target_address = NET_ResolveHostname(session->target_host);
+    if (session->target_address == NULL)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery hostname resolution failed: %s", SDL_GetError());
+        sdl3d_network_discovery_session_destroy(session);
+        return false;
+    }
+
+    SDL_snprintf(session->status, sizeof(session->status), "Ready to scan");
+#else
+    sdl3d_network_discovery_session_destroy(session);
+    SDL_SetError("Networking disabled.");
+    return false;
+#endif
+
+    *out_session = session;
+    return true;
+}
+
+void sdl3d_network_discovery_session_destroy(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL)
+    {
+        return;
+    }
+
+    sdl3d_network_discovery_destroy_socket(session);
+    sdl3d_network_discovery_destroy_target_address(session);
+    sdl3d_network_library_release();
+    SDL_free(session);
+}
+
+bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *session)
+{
+    if (session == NULL || session->socket == NULL)
+    {
+        return false;
+    }
+
+    sdl3d_network_discovery_clear_results(session);
+    session->elapsed = 0.0f;
+    session->refresh_elapsed = 0.0f;
+    session->scanning = true;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery refresh: target=%s port=%u",
+                session->target_host[0] != '\0' ? session->target_host : "<unknown>",
+                (unsigned int)session->target_port);
+
+#if SDL3D_NETWORKING_ENABLED
+    if (session->target_address != NULL)
+    {
+        NET_Status target_status = NET_GetAddressStatus(session->target_address);
+        if (target_status != NET_SUCCESS)
+        {
+            (void)NET_WaitUntilResolved(session->target_address, 0);
+            target_status = NET_GetAddressStatus(session->target_address);
+        }
+        if (target_status == NET_FAILURE)
+        {
+            SDL_snprintf(session->status, sizeof(session->status), "Discovery target resolution failed");
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target resolution failed: %s", SDL_GetError());
+            return false;
+        }
+        if (target_status != NET_SUCCESS)
+        {
+            SDL_snprintf(session->status, sizeof(session->status), "Resolving discovery target");
+            return true;
+        }
+    }
+#endif
+    return sdl3d_network_discovery_send_probe(session);
+}
+
+bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *session, float dt)
+{
+    if (session == NULL)
+    {
+        return false;
+    }
+
+    if (session->socket == NULL)
+    {
+        return true;
+    }
+
+#if SDL3D_NETWORKING_ENABLED
+    session->elapsed += SDL_max(dt, 0.0f);
+    session->refresh_elapsed += SDL_max(dt, 0.0f);
+
+    const int input_count = NET_WaitUntilInputAvailable((void **)&session->socket, 1, 0);
+    if (input_count < 0)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery poll failed: %s", SDL_GetError());
+        SDL_snprintf(session->status, sizeof(session->status), "Discovery poll failed");
+        return true;
+    }
+
+    if (input_count > 0)
+    {
+        for (;;)
+        {
+            NET_Datagram *dgram = NULL;
+            if (!NET_ReceiveDatagram(session->socket, &dgram))
+            {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery receive failed: %s", SDL_GetError());
+                SDL_snprintf(session->status, sizeof(session->status), "Discovery receive failed");
+                return true;
+            }
+
+            if (dgram == NULL)
+            {
+                break;
+            }
+
+            sdl3d_network_discovery_process_datagram(session, dgram);
+            NET_DestroyDatagram(dgram);
+        }
+    }
+
+    if (session->scanning && session->result_count == 0)
+    {
+        SDL_snprintf(session->status, sizeof(session->status), "Searching for local matches");
+    }
+    else if (session->result_count > 0)
+    {
+        SDL_snprintf(session->status, sizeof(session->status), "%d local match%s found", session->result_count,
+                     session->result_count == 1 ? "" : "es");
+        session->scanning = false;
+    }
+
+    return true;
+#else
+    (void)dt;
+    return false;
+#endif
+}
+
+int sdl3d_network_discovery_session_result_count(const sdl3d_network_discovery_session *session)
+{
+    return session != NULL ? session->result_count : 0;
+}
+
+bool sdl3d_network_discovery_session_get_result(const sdl3d_network_discovery_session *session, int index,
+                                                sdl3d_network_discovery_result *out_result)
+{
+    if (session == NULL || out_result == NULL || index < 0 || index >= session->result_count)
+    {
+        return false;
+    }
+
+    *out_result = session->results[index];
+    return true;
+}
+
+const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery_session *session)
+{
+    return session != NULL ? session->status : NULL;
 }

--- a/src/network.c
+++ b/src/network.c
@@ -432,18 +432,7 @@ static void sdl3d_network_discovery_process_query(sdl3d_network_session *session
     (void)sdl3d_network_send_packet_to(session, dgram->addr, dgram->port, SDL3D_NETWORK_PACKET_DISCOVERY_REPLY,
                                        &payload, (int)sizeof(payload));
 }
-#else
-static bool sdl3d_network_library_acquire(void)
-{
-    SDL_SetError("SDL3D networking is disabled at build time.");
-    return false;
-}
-
-static void sdl3d_network_library_release(void)
-{
-}
 #endif
-
 #if SDL3D_NETWORKING_ENABLED
 static void sdl3d_network_write_u16(Uint8 *dst, Uint16 value)
 {
@@ -1310,16 +1299,6 @@ const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery
     return session != NULL ? session->status : NULL;
 }
 #else
-static bool sdl3d_network_library_acquire(void)
-{
-    SDL_SetError("SDL3D networking is disabled at build time.");
-    return false;
-}
-
-static void sdl3d_network_library_release(void)
-{
-}
-
 void sdl3d_network_discovery_session_desc_init(sdl3d_network_discovery_session_desc *desc)
 {
     if (desc == NULL)

--- a/src/network.c
+++ b/src/network.c
@@ -162,6 +162,11 @@ static void sdl3d_network_destroy_socket(sdl3d_network_session *session)
     }
 }
 
+static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session);
+static void sdl3d_network_discovery_destroy_socket(sdl3d_network_discovery_session *session);
+static void sdl3d_network_discovery_destroy_target_address(sdl3d_network_discovery_session *session);
+static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *session);
+
 static void sdl3d_network_destroy_remote_address(sdl3d_network_session *session)
 {
     if (session == NULL)

--- a/src/network.c
+++ b/src/network.c
@@ -162,6 +162,7 @@ static void sdl3d_network_destroy_socket(sdl3d_network_session *session)
     }
 }
 
+#if SDL3D_NETWORKING_ENABLED
 static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session);
 static void sdl3d_network_discovery_destroy_socket(sdl3d_network_discovery_session *session);
 static void sdl3d_network_discovery_destroy_target_address(sdl3d_network_discovery_session *session);
@@ -1306,3 +1307,78 @@ const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery
 {
     return session != NULL ? session->status : NULL;
 }
+#else
+static bool sdl3d_network_library_acquire(void)
+{
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return false;
+}
+
+static void sdl3d_network_library_release(void)
+{
+}
+
+void sdl3d_network_discovery_session_desc_init(sdl3d_network_discovery_session_desc *desc)
+{
+    if (desc == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*desc);
+    desc->port = SDL3D_NETWORK_DEFAULT_PORT;
+    desc->local_port = 0;
+}
+
+bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_session_desc *desc,
+                                            sdl3d_network_discovery_session **out_session)
+{
+    (void)desc;
+    if (out_session != NULL)
+    {
+        *out_session = NULL;
+    }
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return false;
+}
+
+void sdl3d_network_discovery_session_destroy(sdl3d_network_discovery_session *session)
+{
+    (void)session;
+}
+
+bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *session)
+{
+    (void)session;
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return false;
+}
+
+bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *session, float dt)
+{
+    (void)session;
+    (void)dt;
+    return false;
+}
+
+int sdl3d_network_discovery_session_result_count(const sdl3d_network_discovery_session *session)
+{
+    (void)session;
+    return 0;
+}
+
+bool sdl3d_network_discovery_session_get_result(const sdl3d_network_discovery_session *session, int index,
+                                                sdl3d_network_discovery_result *out_result)
+{
+    (void)session;
+    (void)index;
+    (void)out_result;
+    return false;
+}
+
+const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery_session *session)
+{
+    (void)session;
+    return "Networking disabled";
+}
+#endif

--- a/src/network.c
+++ b/src/network.c
@@ -107,6 +107,7 @@ struct sdl3d_network_discovery_session
     float elapsed;
     float refresh_elapsed;
     bool scanning;
+    bool probe_sent;
 };
 
 #if SDL3D_NETWORKING_ENABLED
@@ -334,8 +335,13 @@ static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
                 session->target_host[0] != '\0' ? session->target_host : "<unknown>",
                 (unsigned int)session->target_port);
-    return sdl3d_network_discovery_send_packet_to(session, session->target_address, session->target_port,
-                                                  SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0);
+    if (!sdl3d_network_discovery_send_packet_to(session, session->target_address, session->target_port,
+                                                SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0))
+    {
+        return false;
+    }
+    session->probe_sent = true;
+    return true;
 }
 
 typedef struct sdl3d_network_discovery_reply_payload
@@ -1098,6 +1104,7 @@ bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_sessio
     session->target_port = effective->port;
     SDL_zero(session->status);
     SDL_zero(session->target_host);
+    session->probe_sent = false;
 
     if (!sdl3d_network_library_acquire())
     {
@@ -1166,6 +1173,7 @@ bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *se
     session->elapsed = 0.0f;
     session->refresh_elapsed = 0.0f;
     session->scanning = true;
+    session->probe_sent = false;
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery refresh: target=%s port=%u",
                 session->target_host[0] != '\0' ? session->target_host : "<unknown>",
                 (unsigned int)session->target_port);
@@ -1210,6 +1218,19 @@ bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *ses
 #if SDL3D_NETWORKING_ENABLED
     session->elapsed += SDL_max(dt, 0.0f);
     session->refresh_elapsed += SDL_max(dt, 0.0f);
+
+    if (session->scanning && session->target_address != NULL)
+    {
+        const NET_Status target_status = NET_GetAddressStatus(session->target_address);
+        if (target_status != NET_SUCCESS)
+        {
+            (void)NET_WaitUntilResolved(session->target_address, 0);
+        }
+        if (NET_GetAddressStatus(session->target_address) == NET_SUCCESS && !session->probe_sent)
+        {
+            (void)sdl3d_network_discovery_send_probe(session);
+        }
+    }
 
     const int input_count = NET_WaitUntilInputAvailable((void **)&session->socket, 1, 0);
     if (input_count < 0)

--- a/src/network.c
+++ b/src/network.c
@@ -114,6 +114,7 @@ struct sdl3d_network_discovery_session
 static int sdl3d_network_library_refs = 0;
 #endif
 
+#if SDL3D_NETWORKING_ENABLED
 static void sdl3d_network_set_status(sdl3d_network_session *session, sdl3d_network_state state, const char *status)
 {
     if (session == NULL)
@@ -161,6 +162,7 @@ static void sdl3d_network_destroy_socket(sdl3d_network_session *session)
         session->socket = NULL;
     }
 }
+#endif
 
 #if SDL3D_NETWORKING_ENABLED
 static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1471,12 +1471,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.discovery"));
-    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
-    EXPECT_STREQ(menu.name, "menu.multiplayer.discovery");
-    EXPECT_EQ(menu.item_count, 1);
-    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
-    EXPECT_STREQ(item.label, "Back");
-    EXPECT_STREQ(item.scene, "scene.multiplayer.join");
+    EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -21,6 +21,13 @@ struct NetworkPair
     Uint16 port = 0;
 };
 
+struct DiscoveryPair
+{
+    sdl3d_network_session *host = nullptr;
+    sdl3d_network_discovery_session *scanner = nullptr;
+    Uint16 port = 0;
+};
+
 void destroy_pair(NetworkPair *pair)
 {
     if (pair == nullptr)
@@ -50,6 +57,7 @@ bool create_host_client_pair(NetworkPair *pair)
         host_desc.port = port;
         host_desc.handshake_timeout = 2.0f;
         host_desc.idle_timeout = 2.0f;
+        host_desc.session_name = "SDL3D Test Host";
 
         if (!sdl3d_network_session_create(&host_desc, &pair->host))
         {
@@ -97,6 +105,85 @@ bool pump_until_connected(NetworkPair *pair)
     }
     return false;
 }
+
+void destroy_discovery_pair(DiscoveryPair *pair)
+{
+    if (pair == nullptr)
+    {
+        return;
+    }
+
+    sdl3d_network_discovery_session_destroy(pair->scanner);
+    sdl3d_network_session_destroy(pair->host);
+    pair->scanner = nullptr;
+    pair->host = nullptr;
+    pair->port = 0;
+}
+
+bool create_discovery_pair(DiscoveryPair *pair)
+{
+    if (pair == nullptr)
+    {
+        return false;
+    }
+
+    for (Uint16 port = kBasePort; port < (Uint16)(kBasePort + 64); ++port)
+    {
+        sdl3d_network_session_desc host_desc{};
+        sdl3d_network_session_desc_init(&host_desc);
+        host_desc.role = SDL3D_NETWORK_ROLE_HOST;
+        host_desc.port = port;
+        host_desc.session_name = "SDL3D Discovery Host";
+        host_desc.handshake_timeout = 2.0f;
+        host_desc.idle_timeout = 2.0f;
+
+        if (!sdl3d_network_session_create(&host_desc, &pair->host))
+        {
+            continue;
+        }
+
+        sdl3d_network_discovery_session_desc scanner_desc{};
+        sdl3d_network_discovery_session_desc_init(&scanner_desc);
+        scanner_desc.host = "127.0.0.1";
+        scanner_desc.port = port;
+
+        if (!sdl3d_network_discovery_session_create(&scanner_desc, &pair->scanner))
+        {
+            sdl3d_network_session_destroy(pair->host);
+            pair->host = nullptr;
+            continue;
+        }
+
+        pair->port = port;
+        return true;
+    }
+
+    return false;
+}
+
+bool pump_until_discovered(DiscoveryPair *pair, sdl3d_network_discovery_result *out_result)
+{
+    if (pair == nullptr)
+    {
+        return false;
+    }
+
+    EXPECT_TRUE(sdl3d_network_discovery_session_refresh(pair->scanner));
+    for (int i = 0; i < kPumpLimit; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(pair->host, 0.016f));
+        EXPECT_TRUE(sdl3d_network_discovery_session_update(pair->scanner, 0.016f));
+        if (sdl3d_network_discovery_session_result_count(pair->scanner) > 0)
+        {
+            if (out_result != nullptr)
+            {
+                EXPECT_TRUE(sdl3d_network_discovery_session_get_result(pair->scanner, 0, out_result));
+            }
+            return true;
+        }
+    }
+    return false;
+}
 } // namespace
 
 TEST(NetworkSession, HostAndClientCanHandshakeAndExchangePackets)
@@ -131,6 +218,21 @@ TEST(NetworkSession, HostAndClientCanHandshakeAndExchangePackets)
     EXPECT_EQ(std::memcmp(recv_buffer, payload, sizeof(payload)), 0);
 
     destroy_pair(&pair);
+}
+
+TEST(NetworkSession, LanDiscoveryFindsWaitingHost)
+{
+    DiscoveryPair pair{};
+    ASSERT_TRUE(create_discovery_pair(&pair));
+
+    sdl3d_network_discovery_result result{};
+    ASSERT_TRUE(pump_until_discovered(&pair, &result));
+    EXPECT_STREQ(result.session_name, "SDL3D Discovery Host");
+    EXPECT_EQ(result.port, pair.port);
+    EXPECT_STREQ(result.status, "Awaiting client");
+    EXPECT_STRNE(result.host, "");
+
+    destroy_discovery_pair(&pair);
 }
 
 TEST(NetworkSession, HostRejectsSecondClient)


### PR DESCRIPTION
## Summary

- Added a LAN discovery scanner API to `SDL3D` networking.
- Wired Pong's join flow to an automated discovery screen with host/session results.
- Advertised host sessions with session names and status strings.
- Added network and game-data tests covering discovery round-trip and UI/data integration.

## Validation

- `cmake --build build/release --target sdl3d_network_test sdl3d_game_data_test pong_demo -j 8`
- `./build/release/tests/sdl3d_network_test`
- `./build/release/tests/sdl3d_game_data_test`
- `git diff --check`
