### PR TITLE
Document JSON and Lua gameplay APIs

### DIFF
--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -2,6 +2,12 @@ local pong = {}
 
 local scores_path = "user://scores/pong_scores.json"
 
+-- Exported adapters:
+--   serve_random(ball, _, ctx): choose a constrained serve vector.
+--   reflect_from_paddle(ball, payload, ctx): deflect the ball from a paddle hit.
+--   cpu_track_ball(paddle, payload, ctx): steer the CPU paddle in single-player only.
+-- Persistence helpers below use the shared storage + JSON bridge.
+
 local function random_signed_angle(ctx, min_angle, max_angle)
     if max_angle <= 0.0 then
         return 0.0

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -2,7 +2,7 @@
 
 This document defines the first JSON-family authoring format for SDL3D game data. It is intentionally small, explicit, and module-oriented so it can express Pong without assuming sectors, while still leaving room for Doom's FPS/sector modules.
 
-The format is data-first: game rules should primarily be expressed as entities, components, sensors, signals, timers, conditions, and actions. Game-specific code should appear as named adapters only where a rule is not genuinely reusable.
+The format is data-first: game rules should primarily be expressed as entities, components, sensors, signals, timers, conditions, and actions. Game-specific code should appear as named adapters only where a rule is not genuinely reusable. For a function-level Lua reference, see [docs/game-data-lua.md](game-data-lua.md).
 
 ## Format Goals
 
@@ -1007,6 +1007,8 @@ Lua adapters receive `(target, payload, ctx)`:
   `ctx:state_set(key, value)`, `ctx:random()`, `ctx:log(message)`, and
   `ctx.storage` safe access to `user://` and `cache://` paths.
 
+Use exact actor names when they are stable. `ctx:actor_with_tags(...)` performs a registry scan and is best reserved for authored role lookup, scene setup, and other non-hot-path rules.
+
 The preferred Lua API is intentionally game-script oriented. Scripts can check `sdl3d.api`, currently `sdl3d.lua.v1`, when they need to guard version-specific behavior:
 
 ```lua
@@ -1015,12 +1017,15 @@ ball.position = Vec3(0, 0, 0.12)
 ball.velocity = Vec3.normalize(ball.velocity) * speed
 ```
 
-Actor wrappers expose property helpers (`get_float`, `set_float`, `get_int`, `set_int`, `get_bool`, `set_bool`, `get_string`, `set_string`, `get_vec3`, `set_vec3`) plus `position` and `velocity` convenience fields. `Vec3` provides `new`, `length`, `normalize`, `clamp`, and arithmetic operators. `math.clamp` and `math.lerp` are also available. The lower-level `sdl3d.get_*` and `sdl3d.set_*` functions remain available as implementation primitives, but gameplay scripts should prefer the wrapper API.
+Actor wrappers expose property helpers (`get_float`, `set_float`, `get_int`, `set_int`, `get_bool`, `set_bool`, `get_string`, `set_string`, `get_vec3`, `set_vec3`) plus `position` and `velocity` convenience fields. Missing actor names return `nil` from `sdl3d.actor(name)` and from `get_position()` / `get_vec3()`. `Vec3` provides `new`, `length`, `normalize`, `clamp`, and arithmetic operators. `math.clamp` and `math.lerp` are also available. The lower-level `sdl3d.get_*` and `sdl3d.set_*` functions remain available as implementation primitives, but gameplay scripts should prefer the wrapper API.
 
 Scripts can persist structured data through `sdl3d.json.decode(text)` and
 `sdl3d.json.encode(value)`. The JSON bridge accepts Lua booleans, numbers,
 strings, nil, array-like tables, and string-keyed object tables. It is intended
-for save files, settings, high scores, and other small gameplay data blobs:
+for save files, settings, high scores, and other small gameplay data blobs.
+Decode returns `nil, error_message` on invalid JSON. Encode returns
+`nil, error_message` when a table is cyclic, too deeply nested, or uses
+non-string object keys:
 
 ```lua
 local scores = sdl3d.json.decode(ctx.storage.read("user://scores/pong.json") or "{}")
@@ -1029,6 +1034,8 @@ ctx.storage.write("user://scores/pong.json", sdl3d.json.encode(scores))
 ```
 
 Native C registration remains available for host applications that need engine-facing integrations or highly optimized behavior; re-registering an adapter name overrides the authored Lua binding.
+
+Lua and JSON helpers are intentionally not frame-hot APIs. Use them for startup, scene setup, adapter callbacks, persistence, and reload flows. For repeated per-frame entity access, prefer caching the actor wrapper or using exact names over repeated tag scans.
 
 ### Script Hot Reload
 
@@ -1058,7 +1065,8 @@ Good Pong adapters:
 - `adapter.pong.cpu_track_ball`: move the CPU paddle toward the ball.
 
 Lua scripts should prefer `ctx:actor_with_tags("role", "qualifier")` for role lookups when exact entity names
-are not part of the rule. This keeps data free to rename actors while preserving their authored tags.
+are not part of the rule. This keeps data free to rename actors while preserving their authored tags. On hot paths,
+prefer exact names and cached references because tag-based resolution scans the actor registry.
 
 Bad Pong adapters:
 
@@ -1109,7 +1117,7 @@ The JSON decides when those adapters run and handles the ordinary composition ar
 
 ## Loader Acceptance Criteria
 
-The first runtime loader should:
+The runtime loader should:
 
 - parse `schema` and reject unsupported versions
 - reject duplicate entity, signal, timer, sensor, and binding names

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -1,0 +1,213 @@
+# SDL3D Gameplay Lua API
+
+SDL3D exposes a compact Lua API for game-specific rules that should remain data-driven and reloadable. The runtime owns the Lua state, loads script modules from authored game data, and injects a small helper surface that is stable across games.
+
+The API version is currently `sdl3d.lua.v1`.
+
+## Script Model
+
+Lua scripts are authored as modules that return a table:
+
+```lua
+local pong = {}
+
+function pong.reflect_from_paddle(ball, payload, ctx)
+  -- rule code
+  return true
+end
+
+return pong
+```
+
+When game data declares a script module:
+
+- the loader resolves the script path relative to the JSON file
+- the module must return a table
+- module dependencies load in authored order before dependent adapters run
+- module names may be published into the global Lua environment for debug access
+- adapter functions are resolved once at load time and stored as Lua registry references
+
+If a script is missing, returns a non-table, fails to load, or drops a referenced adapter function, the game data load fails before gameplay starts.
+
+## Adapter Call Contract
+
+Lua-backed adapters are invoked as:
+
+```lua
+target, payload, ctx
+```
+
+- `target` is an actor wrapper for the authored action/component target, or `nil` if the target could not be resolved.
+- `payload` is a plain Lua table copied from the authored signal or component payload, or `nil` when the action has no payload.
+- `ctx` is the runtime helper table for the current adapter call.
+
+Adapters should return `true` when they accept the request and `false` when they reject it.
+
+## Context Helpers
+
+The `ctx` table provides:
+
+- `ctx.adapter`: the adapter name being executed
+- `ctx.name`: alias of `ctx.adapter`
+- `ctx.dt`: delta time for this update
+- `ctx:actor(name)`: resolve an actor wrapper by exact name; returns `nil` when missing
+- `ctx:actor_with_tags(...)`: resolve the first actor matching one or more tags; returns `nil` when no actor matches
+- `ctx:state_get(key, fallback)`: read persistent scene state
+- `ctx:state_set(key, value)`: write persistent scene state; passing `nil` removes the key
+- `ctx:random()`: deterministic per-runtime pseudo-random value in `[0, 1)`
+- `ctx:log(message)`: write a gameplay log line
+- `ctx.storage`: safe storage access table with `read`, `write`, `exists`, `mkdir`, and `delete`
+
+### Performance Notes
+
+- `ctx:actor(name)` is the cheapest way to reach a known entity name.
+- `ctx:actor_with_tags(...)` scans the actor registry and should be used for authored role discovery, not inner-loop per-frame work.
+- `ctx.storage.*` performs filesystem I/O and should be used for saves, settings, caches, and similar infrequent tasks.
+- `ctx:random()` is deterministic within a runtime session, which makes it safe for gameplay logic that should replay or sync consistently.
+
+## Actor Wrapper
+
+`sdl3d.actor(name)` returns a lightweight wrapper for the named actor. The wrapper does not own the actor and does not copy its state. It is just a convenient handle for property access.
+
+The wrapper exposes:
+
+- `name`
+- `position`
+- `velocity`
+
+And helper methods:
+
+- `get_position()` / `set_position(Vec3)`
+- `get_float(key, fallback)`
+- `set_float(key, value)`
+- `get_int(key, fallback)`
+- `set_int(key, value)`
+- `get_bool(key, fallback)`
+- `set_bool(key, value)`
+- `get_string(key, fallback)`
+- `set_string(key, value)`
+- `get_vec3(key, fallback)`
+- `set_vec3(key, value)`
+
+Behavior notes:
+
+- Missing actor names return `nil` from `sdl3d.actor(name)`.
+- `get_position()` returns `nil` if the actor is missing.
+- `get_vec3()` returns `nil` if the actor is missing.
+- Property getters fall back to authored defaults when the property is absent.
+- `position` and `velocity` are convenience fields backed by the same property accessors.
+
+Example:
+
+```lua
+local ball = ctx:actor("entity.ball")
+if ball ~= nil then
+  ball.position = Vec3(0, 0, 0.12)
+  ball.velocity = Vec3.normalize(ball.velocity) * 5.6
+end
+```
+
+## `sdl3d` Global Helpers
+
+The runtime installs a small `sdl3d` table for low-level access and utility helpers:
+
+- `sdl3d.api` - current API version string
+- `sdl3d.actor(name)` - create an actor wrapper
+- `sdl3d.get_position(actor)`
+- `sdl3d.set_position(actor, x, y, z)`
+- `sdl3d.get_float(actor, key, fallback)`
+- `sdl3d.set_float(actor, key, value)`
+- `sdl3d.get_int(actor, key, fallback)`
+- `sdl3d.set_int(actor, key, value)`
+- `sdl3d.get_bool(actor, key, fallback)`
+- `sdl3d.set_bool(actor, key, value)`
+- `sdl3d.get_string(actor, key, fallback)`
+- `sdl3d.set_string(actor, key, value)`
+- `sdl3d.get_vec3(actor, key)`
+- `sdl3d.set_vec3(actor, key, x, y, z)`
+- `sdl3d.dt()`
+- `sdl3d.state_get(key, fallback)`
+- `sdl3d.state_set(key, value)`
+- `sdl3d.random()`
+- `sdl3d.actor_with_tags(...)`
+- `sdl3d.log(message)`
+- `sdl3d.storage.*`
+- `sdl3d.json.*`
+
+The low-level `sdl3d.get_*` and `sdl3d.set_*` helpers are useful for compact scripts and host integration. Gameplay scripts should generally prefer the `Actor` wrapper for readability.
+
+## `Vec3`
+
+`Vec3` is available both as `sdl3d.Vec3` and as a global `Vec3` constructor.
+
+It supports:
+
+- `Vec3.new(x, y, z)` and `Vec3(x, y, z)`
+- `Vec3.length(v)`
+- `Vec3.normalize(v)`
+- `Vec3.clamp(v, lo, hi)`
+- `+`, `-`, and `*` arithmetic operators
+
+`Vec3` accepts tables with `x/y/z` or array-style `[1]/[2]/[3]` fields through the helper conversion rules.
+
+## JSON Helpers
+
+`sdl3d.json.decode(text)` parses JSON text and returns the equivalent Lua value. On failure it returns `nil, error_message`.
+
+`sdl3d.json.encode(value)` converts Lua values to JSON text. On failure it returns `nil, error_message`.
+
+Supported values:
+
+- `nil`
+- booleans
+- numbers
+- strings
+- arrays of supported values
+- string-keyed object tables of supported values
+
+Known limitations:
+
+- object keys must be strings
+- cyclic tables are not supported
+- deeply nested values are rejected after a fixed recursion limit
+
+Performance note: JSON encode/decode allocates and validates data. Use it for saves, settings, and import/export flows, not every frame.
+
+## Storage Helpers
+
+`ctx.storage` exposes the same safe storage API as `sdl3d.storage`:
+
+- `read(path)` -> `text` on success, or `nil, error` on failure
+- `write(path, text)` -> `true` on success, or `false, error`
+- `exists(path)` -> `bool` only; invalid paths and missing storage collapse to `false`
+- `mkdir(path)` -> `true` on success, or `false, error`
+- `delete(path)` -> `true` on success, or `false, error`
+
+Paths must use `user://` or `cache://`. Absolute paths, `..`, empty segments, backslashes, and extra URI schemes are rejected.
+
+## Common Error Conditions
+
+- Missing actor name: `ctx:actor()` returns `nil`.
+- Missing actor tags: `ctx:actor_with_tags()` returns `nil`.
+- Missing state key: `ctx:state_get()` returns the authored fallback.
+- Missing JSON data: `sdl3d.json.decode()` returns `nil, error`.
+- Unsupported JSON value: `sdl3d.json.encode()` returns `nil, error`.
+- Storage path violation: storage helpers return `false, error` or `nil, error` depending on the call.
+
+## Recommended Usage
+
+- Use exact actor names for deterministic gameplay rules when the name is stable.
+- Use tags for authored role discovery during scene setup or adapter initialization.
+- Use `ctx.storage` and `sdl3d.json` for persistent data, not transient gameplay state.
+- Keep per-frame Lua small and declarative; move heavy math or broad searches into C helpers when a rule becomes hot.
+
+## Pong Example
+
+Pong’s script module shows the intended style:
+
+- `serve_random(ball, _, ctx)` chooses a constrained serve direction
+- `reflect_from_paddle(ball, payload, ctx)` handles paddle deflection and jitter
+- `cpu_track_ball(paddle, payload, ctx)` handles single-player CPU steering
+- persistence helpers use `ctx.storage` and `sdl3d.json` for score save files
+
+That module is a reference for how to keep game rules readable without pushing the engine into game-specific code.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -57,6 +57,8 @@ local text, read_err = sdl3d.storage.read("user://settings/options.json")
 local exists = sdl3d.storage.exists("cache://generated/status.txt")
 ```
 
+See [docs/game-data-lua.md](game-data-lua.md) for the full Lua helper reference, including the storage return contract and error behavior.
+
 Scripts can pair storage with the gameplay JSON helpers when persisting
 structured settings, saves, scores, or generated cache metadata:
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -538,9 +538,12 @@ static int lua_get_vec3(lua_State *lua)
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
     sdl3d_registered_actor *actor = lua_actor_arg(lua, runtime, 1);
     const char *key = luaL_checkstring(lua, 2);
-    const sdl3d_vec3 value = actor != NULL
-                                 ? sdl3d_properties_get_vec3(actor->props, key, sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
-                                 : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (actor == NULL)
+    {
+        lua_pushnil(lua);
+        return 1;
+    }
+    const sdl3d_vec3 value = sdl3d_properties_get_vec3(actor->props, key, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
     lua_pushnumber(lua, value.x);
     lua_pushnumber(lua, value.y);
     lua_pushnumber(lua, value.z);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4029,6 +4029,12 @@ function storage.roundtrip(_, _, ctx)
         return false
     end
 
+    local ghost = { _name = "entity.missing" }
+    local gx, gy, gz = sdl3d.get_vec3(ghost, "velocity")
+    if gx ~= nil or gy ~= nil or gz ~= nil then
+        return false
+    end
+
     local ok = ctx.storage.write("user://settings/options.json", "{\"difficulty\":\"hard\"}")
     if not ok or not ctx.storage.exists("user://settings/options.json") then
         return false


### PR DESCRIPTION
## Summary

- Added a dedicated Lua gameplay API reference covering `sdl3d.lua.v1`, the adapter call contract, `ctx`, `Actor`, `Vec3`, JSON helpers, storage helpers, and performance/error notes.
- Updated the JSON schema docs to link to the Lua reference and to describe the documented runtime behavior more precisely.
- Added a Pong Lua script header comment that documents the exported adapters and persistence helpers.
- Fixed `sdl3d.get_vec3()` so missing actors now return `nil`, matching the documented helper behavior.
- Added a regression test covering the Lua storage helper path and the missing-actor vec3 helper behavior.

## Validation

- `./scripts/check_clang_format.sh`
- `cmake --build build/release --target sdl3d_game_data_test -j 8`
- `./build/release/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LuaStorageBindingsUseSafeVirtualRoots'`
- `./build/release/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LuaAdapterReflectsBallFromPaddle:GameDataRuntime.LuaControllerMovesCpuPaddleTowardBall'`
- `git diff --check`
