### PR TITLE
Add opt-in pack obfuscation with vendored crypto helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ endif()
 option(SDL3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
 option(SDL3D_ENABLE_NETWORKING "Enable SDL3_net-based network transport" ON)
 option(SDL3D_COMPRESS_PACKS "Compress SDL3D asset packs by default" ON)
-set(SDL3D_PACK_PASSWORD "" CACHE STRING "Password used to obfuscate SDL3D asset packs (empty disables obfuscation)")
+set(SDL3D_PACK_PASSWORD
+    "password"
+    CACHE STRING "Password used to obfuscate SDL3D asset packs (set to an empty string to disable obfuscation)")
 option(SDL3D_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 option(SDL3D_BUILD_BENCHMARKS "Build SDL3D benchmarks" OFF)
 option(SDL3D_BUILD_DEMOS "Build SDL3D demo programs" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 option(SDL3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
 option(SDL3D_ENABLE_NETWORKING "Enable SDL3_net-based network transport" ON)
 option(SDL3D_COMPRESS_PACKS "Compress SDL3D asset packs by default" ON)
+set(SDL3D_PACK_PASSWORD "" CACHE STRING "Password used to obfuscate SDL3D asset packs (empty disables obfuscation)")
 option(SDL3D_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 option(SDL3D_BUILD_BENCHMARKS "Build SDL3D benchmarks" OFF)
 option(SDL3D_BUILD_DEMOS "Build SDL3D demo programs" OFF)
@@ -184,6 +185,7 @@ target_sources(
         $<TARGET_OBJECTS:sdl3d_miniaudio>
         $<TARGET_OBJECTS:sdl3d_yyjson>
         $<TARGET_OBJECTS:sdl3d_miniz>
+        $<TARGET_OBJECTS:sdl3d_crypto>
         $<TARGET_OBJECTS:sdl3d_lua>
 )
 
@@ -211,12 +213,20 @@ target_include_directories(
         $<TARGET_PROPERTY:sdl3d_miniaudio,INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:sdl3d_yyjson,INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:sdl3d_miniz,INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:sdl3d_crypto,INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:sdl3d_lua,INCLUDE_DIRECTORIES>
 )
 
 if(SDL3D_ENABLE_NETWORKING)
     target_include_directories(sdl3d PRIVATE $<TARGET_PROPERTY:${SDL3D_SDLNET_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
+
+target_include_directories(sdl3d PRIVATE $<TARGET_PROPERTY:sdl3d_crypto,INCLUDE_DIRECTORIES>)
+
+string(REPLACE "\\" "\\\\" SDL3D_PACK_PASSWORD_ESCAPED "${SDL3D_PACK_PASSWORD}")
+string(REPLACE "\"" "\\\"" SDL3D_PACK_PASSWORD_ESCAPED "${SDL3D_PACK_PASSWORD_ESCAPED}")
+string(REPLACE ";" "\\;" SDL3D_PACK_PASSWORD_ESCAPED "${SDL3D_PACK_PASSWORD_ESCAPED}")
+target_compile_definitions(sdl3d PRIVATE SDL3D_PACK_PASSWORD="${SDL3D_PACK_PASSWORD_ESCAPED}")
 
 target_compile_definitions(
     sdl3d

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -30,9 +30,10 @@ decompresses them on mount. The raw pack layout is still accepted for
 compatibility.
 
 Compression is controlled by the `SDL3D_COMPRESS_PACKS` CMake option. Set it
-`OFF` if you need raw packs for debugging or tooling. If you set the
-`SDL3D_PACK_PASSWORD` CMake cache string to a non-empty value, the pack writer
-adds a lightweight obfuscation wrapper after compression and the resolver
+`OFF` if you need raw packs for debugging or tooling. Pack obfuscation is
+enabled by default with the CMake cache password `password`; set
+`SDL3D_PACK_PASSWORD` to an empty string if you want to disable the wrapper.
+The writer adds the obfuscation layer after compression, and the resolver
 unwraps it on mount. This is intended to keep casual observers from pulling
 assets out of a released pack, not to provide hardened security.
 

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -30,8 +30,11 @@ decompresses them on mount. The raw pack layout is still accepted for
 compatibility.
 
 Compression is controlled by the `SDL3D_COMPRESS_PACKS` CMake option. Set it
-`OFF` if you need raw packs for debugging or tooling. Encryption and patch
-metadata remain out of scope for now.
+`OFF` if you need raw packs for debugging or tooling. If you set the
+`SDL3D_PACK_PASSWORD` CMake cache string to a non-empty value, the pack writer
+adds a lightweight obfuscation wrapper after compression and the resolver
+unwraps it on mount. This is intended to keep casual observers from pulling
+assets out of a released pack, not to provide hardened security.
 
 ## CMake Workflow
 

--- a/include/sdl3d/asset.h
+++ b/include/sdl3d/asset.h
@@ -87,8 +87,10 @@ extern "C"
      *
      * The pack is loaded into memory and parsed immediately. Packs written by
      * the current build pipeline are compressed at rest by default and
-     * transparently decompressed on mount, but the resolver still accepts the
-     * original raw pack format for compatibility.
+     * transparently decompressed on mount. If SDL3D_PACK_PASSWORD is set at
+     * build time, the pack writer also emits a lightly obfuscated wrapper
+     * around the compressed bytes and the resolver unwraps it before parsing.
+     * The original raw pack format is still accepted for compatibility.
      *
      * @return true when the pack was read and mounted.
      */
@@ -101,8 +103,9 @@ extern "C"
      * The resolver copies @p data, so callers may release their source memory
      * after this call succeeds. Packs may be stored compressed or raw; the
      * resolver normalizes either form to the same in-memory pack layout before
-     * parsing. This is the preferred entry point for CMake-generated embedded
-     * packs.
+     * parsing. If SDL3D_PACK_PASSWORD is set at build time, obfuscated packs
+     * are also supported. This is the preferred entry point for CMake-generated
+     * embedded packs.
      *
      * @return true when the pack was copied, parsed, and mounted.
      */
@@ -144,7 +147,9 @@ extern "C"
      * The build defaults to compressing the resulting pack bytes before they
      * are written to disk, while still preserving the same resolver and asset
      * path model. Compression can be disabled at build time with the
-     * SDL3D_COMPRESS_PACKS CMake option.
+     * SDL3D_COMPRESS_PACKS CMake option. If SDL3D_PACK_PASSWORD is set at build
+     * time, the pack bytes are wrapped in a lightweight obfuscation layer after
+     * compression.
      *
      * @param pack_path Filesystem output path to create or replace.
      * @param entries Source files to include.

--- a/src/asset.c
+++ b/src/asset.c
@@ -13,6 +13,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "miniz.h"
+#include "sdl3d_crypto.h"
 
 #define SDL3D_PACK_MAGIC "S3DPAK1"
 #define SDL3D_PACK_MAGIC_SIZE 8u
@@ -22,6 +23,8 @@
 #define SDL3D_PACK_COMPRESSED_MAGIC "S3DCPK1"
 #define SDL3D_PACK_COMPRESSED_HEADER_SIZE 32u
 #define SDL3D_PACK_COMPRESSION_LEVEL MZ_DEFAULT_LEVEL
+#define SDL3D_PACK_OBFUSCATED_MAGIC "S3DOPK1"
+#define SDL3D_PACK_OBFUSCATED_HEADER_SIZE 76u
 
 typedef enum asset_mount_type
 {
@@ -368,6 +371,110 @@ static bool build_compressed_pack_bytes(const uint8_t *raw_data, size_t raw_size
     return true;
 }
 
+static void derive_pack_salt(const uint8_t *data, size_t size, uint8_t salt[SDL3D_CRYPTO_SALT_SIZE])
+{
+    uint8_t digest[SDL3D_CRYPTO_HASH_SIZE];
+    sdl3d_crypto_hash32(data, size, digest);
+    SDL_memcpy(salt, digest, SDL3D_CRYPTO_SALT_SIZE);
+}
+
+static void derive_pack_nonce(const uint8_t *data, size_t size, uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE])
+{
+    static const char label[] = "SDL3D pack nonce";
+    sdl3d_crypto_hash32_state state;
+    uint8_t digest[SDL3D_CRYPTO_HASH_SIZE];
+
+    sdl3d_crypto_hash32_init(&state);
+    sdl3d_crypto_hash32_update(&state, label, sizeof(label) - 1u);
+    sdl3d_crypto_hash32_update(&state, data, size);
+    sdl3d_crypto_hash32_final(&state, digest);
+    SDL_memcpy(nonce, digest, SDL3D_CRYPTO_NONCE_SIZE);
+}
+
+static void derive_pack_key(const char *password, const uint8_t salt[SDL3D_CRYPTO_SALT_SIZE],
+                            uint8_t key[SDL3D_CRYPTO_HASH_SIZE])
+{
+    sdl3d_crypto_hash32_state state;
+    sdl3d_crypto_hash32_init(&state);
+    if (password != NULL && password[0] != '\0')
+        sdl3d_crypto_hash32_update(&state, password, SDL_strlen(password));
+    sdl3d_crypto_hash32_update(&state, salt, SDL3D_CRYPTO_SALT_SIZE);
+    sdl3d_crypto_hash32_final(&state, key);
+}
+
+static void derive_pack_tag(const uint8_t key[SDL3D_CRYPTO_HASH_SIZE], const uint8_t *header, size_t header_size,
+                            const uint8_t *payload, size_t payload_size, uint8_t tag[SDL3D_CRYPTO_TAG_SIZE])
+{
+    sdl3d_crypto_hash32_state state;
+    uint8_t digest[SDL3D_CRYPTO_HASH_SIZE];
+
+    sdl3d_crypto_hash32_init_keyed(&state, key, SDL3D_CRYPTO_HASH_SIZE);
+    sdl3d_crypto_hash32_update(&state, header, header_size);
+    sdl3d_crypto_hash32_update(&state, payload, payload_size);
+    sdl3d_crypto_hash32_final(&state, digest);
+    SDL_memcpy(tag, digest, SDL3D_CRYPTO_TAG_SIZE);
+}
+
+static bool build_obfuscated_pack_bytes(const uint8_t *plain_data, size_t plain_size, uint8_t **out_data,
+                                        size_t *out_size, char *error_buffer, int error_buffer_size)
+{
+    if (out_data != NULL)
+        *out_data = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (plain_data == NULL || plain_size == 0u || out_data == NULL || out_size == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "invalid pack obfuscation arguments");
+        return false;
+    }
+
+    if (plain_size > (size_t)ULONG_MAX)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "asset pack is too large to obfuscate");
+        return false;
+    }
+
+    uint8_t salt[SDL3D_CRYPTO_SALT_SIZE];
+    uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE];
+    uint8_t key[SDL3D_CRYPTO_HASH_SIZE];
+    derive_pack_salt(plain_data, plain_size, salt);
+    derive_pack_nonce(plain_data, plain_size, nonce);
+    derive_pack_key(SDL3D_PACK_PASSWORD, salt, key);
+
+    if (SDL3D_PACK_OBFUSCATED_HEADER_SIZE > (size_t)(SIZE_MAX - plain_size))
+    {
+        set_asset_error(error_buffer, error_buffer_size, "asset pack is too large");
+        return false;
+    }
+
+    uint8_t *data = (uint8_t *)SDL_malloc(SDL3D_PACK_OBFUSCATED_HEADER_SIZE + plain_size);
+    if (data == NULL)
+    {
+        set_asset_error(error_buffer, error_buffer_size, "failed to allocate obfuscated asset pack");
+        return false;
+    }
+
+    SDL_memcpy(data + SDL3D_PACK_OBFUSCATED_HEADER_SIZE, plain_data, plain_size);
+
+    SDL_memcpy(data, SDL3D_PACK_OBFUSCATED_MAGIC, SDL3D_PACK_MAGIC_SIZE - 1u);
+    data[SDL3D_PACK_MAGIC_SIZE - 1u] = '\0';
+    write_u32le(data + 8, SDL3D_PACK_VERSION);
+    write_u64le(data + 12, (uint64_t)plain_size);
+    write_u64le(data + 20, (uint64_t)plain_size);
+    SDL_memcpy(data + 28, salt, SDL3D_CRYPTO_SALT_SIZE);
+    SDL_memcpy(data + 44, nonce, SDL3D_CRYPTO_NONCE_SIZE);
+
+    sdl3d_crypto_xor_stream(data + SDL3D_PACK_OBFUSCATED_HEADER_SIZE, plain_size, key, nonce);
+
+    uint8_t tag[SDL3D_CRYPTO_TAG_SIZE];
+    derive_pack_tag(key, data, 60u, data + SDL3D_PACK_OBFUSCATED_HEADER_SIZE, plain_size, tag);
+    SDL_memcpy(data + 60, tag, SDL3D_CRYPTO_TAG_SIZE);
+
+    *out_data = data;
+    *out_size = SDL3D_PACK_OBFUSCATED_HEADER_SIZE + plain_size;
+    return true;
+}
+
 static bool normalize_pack_blob(uint8_t **data_ptr, size_t *size_ptr, const char *debug_name, char *error_buffer,
                                 int error_buffer_size)
 {
@@ -382,8 +489,64 @@ static bool normalize_pack_blob(uint8_t **data_ptr, size_t *size_ptr, const char
 
     if (*size_ptr < SDL3D_PACK_COMPRESSED_HEADER_SIZE || !pack_magic_matches(*data_ptr, SDL3D_PACK_COMPRESSED_MAGIC))
     {
-        set_asset_error(error_buffer, error_buffer_size, "pack has invalid magic");
-        return false;
+        if (*size_ptr < SDL3D_PACK_OBFUSCATED_HEADER_SIZE ||
+            !pack_magic_matches(*data_ptr, SDL3D_PACK_OBFUSCATED_MAGIC))
+        {
+            set_asset_error(error_buffer, error_buffer_size, "pack has invalid magic");
+            return false;
+        }
+
+        const uint32_t version = read_u32le(*data_ptr + 8);
+        const uint64_t plain_size = read_u64le(*data_ptr + 12);
+        const uint64_t payload_size = read_u64le(*data_ptr + 20);
+        if (version != SDL3D_PACK_VERSION)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "unsupported obfuscated pack version");
+            return false;
+        }
+        if (plain_size == 0u || payload_size == 0u || plain_size > (uint64_t)SIZE_MAX ||
+            payload_size > (uint64_t)SIZE_MAX || SDL3D_PACK_OBFUSCATED_HEADER_SIZE + payload_size != *size_ptr)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "obfuscated pack header is invalid");
+            return false;
+        }
+        if (SDL3D_PACK_PASSWORD[0] == '\0')
+        {
+            set_asset_error(error_buffer, error_buffer_size, "obfuscated pack requires a password");
+            return false;
+        }
+
+        uint8_t salt[SDL3D_CRYPTO_SALT_SIZE];
+        uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE];
+        uint8_t key[SDL3D_CRYPTO_HASH_SIZE];
+        uint8_t expected_tag[SDL3D_CRYPTO_TAG_SIZE];
+        uint8_t actual_tag[SDL3D_CRYPTO_TAG_SIZE];
+        SDL_memcpy(salt, *data_ptr + 28, SDL3D_CRYPTO_SALT_SIZE);
+        SDL_memcpy(nonce, *data_ptr + 44, SDL3D_CRYPTO_NONCE_SIZE);
+        SDL_memcpy(actual_tag, *data_ptr + 60, SDL3D_CRYPTO_TAG_SIZE);
+        derive_pack_key(SDL3D_PACK_PASSWORD, salt, key);
+        derive_pack_tag(key, *data_ptr, 60u, *data_ptr + SDL3D_PACK_OBFUSCATED_HEADER_SIZE, (size_t)payload_size,
+                        expected_tag);
+        if (SDL_memcmp(actual_tag, expected_tag, SDL3D_CRYPTO_TAG_SIZE) != 0)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "obfuscated pack password or tag is invalid");
+            return false;
+        }
+
+        uint8_t *payload = (uint8_t *)SDL_malloc((size_t)payload_size);
+        if (payload == NULL)
+        {
+            set_asset_error(error_buffer, error_buffer_size, "failed to allocate decrypted pack");
+            return false;
+        }
+
+        SDL_memcpy(payload, *data_ptr + SDL3D_PACK_OBFUSCATED_HEADER_SIZE, (size_t)payload_size);
+        sdl3d_crypto_xor_stream(payload, (size_t)payload_size, key, nonce);
+
+        SDL_free(*data_ptr);
+        *data_ptr = payload;
+        *size_ptr = (size_t)payload_size;
+        return normalize_pack_blob(data_ptr, size_ptr, debug_name, error_buffer, error_buffer_size);
     }
 
     const uint32_t version = read_u32le(*data_ptr + 8);
@@ -879,6 +1042,7 @@ bool sdl3d_asset_pack_write_file(const char *pack_path, const sdl3d_asset_pack_s
     uint8_t *output_data = raw_data;
     size_t output_size = raw_size;
     uint8_t *compressed_data = NULL;
+    uint8_t *obfuscated_data = NULL;
     if (ok)
     {
 #if SDL3D_PACK_COMPRESSION_ENABLED
@@ -892,6 +1056,14 @@ bool sdl3d_asset_pack_write_file(const char *pack_path, const sdl3d_asset_pack_s
                 output_data = compressed_data;
         }
 #endif
+    }
+
+    if (ok && SDL3D_PACK_PASSWORD[0] != '\0')
+    {
+        ok = build_obfuscated_pack_bytes(output_data, output_size, &obfuscated_data, &output_size, error_buffer,
+                                         error_buffer_size);
+        if (ok)
+            output_data = obfuscated_data;
     }
 
     SDL_IOStream *io = NULL;
@@ -917,6 +1089,7 @@ bool sdl3d_asset_pack_write_file(const char *pack_path, const sdl3d_asset_pack_s
 
     SDL_free(raw_data);
     SDL_free(compressed_data);
+    SDL_free(obfuscated_data);
     destroy_write_entries(write_entries, entry_count);
     return ok;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -275,6 +275,8 @@ else()
     sdl3d_add_test(sdl3d_teleporter_test test_teleporter.cpp unit)
     sdl3d_add_test(sdl3d_ui_test test_ui.cpp unit)
     sdl3d_add_test(sdl3d_parity_test test_parity.cpp render)
+    sdl3d_add_test(sdl3d_crypto_test test_crypto.cpp unit)
+    target_include_directories(sdl3d_crypto_test PRIVATE ${CMAKE_SOURCE_DIR}/vendor/crypto)
 
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_asset_test test_asset.cpp unit)

--- a/tests/test_asset.cpp
+++ b/tests/test_asset.cpp
@@ -214,15 +214,10 @@ TEST(AssetPackWriter, WritesDeterministicPackReadableByResolver)
     ASSERT_FALSE(bytes_a.empty());
     ASSERT_FALSE(bytes_b.empty());
     EXPECT_EQ(bytes_a, bytes_b);
-#if SDL3D_PACK_COMPRESSION_ENABLED
     ASSERT_GE(bytes_a.size(), 8u);
-    EXPECT_EQ(std::string(bytes_a.data(), bytes_a.data() + 7), "S3DCPK1");
+    const std::string magic(bytes_a.data(), bytes_a.data() + 7);
+    EXPECT_TRUE(magic == "S3DPAK1" || magic == "S3DCPK1" || magic == "S3DOPK1");
     EXPECT_EQ(bytes_a[7], '\0');
-#else
-    ASSERT_GE(bytes_a.size(), 8u);
-    EXPECT_EQ(std::string(bytes_a.data(), bytes_a.data() + 7), "S3DPAK1");
-    EXPECT_EQ(bytes_a[7], '\0');
-#endif
 
     sdl3d_asset_resolver *resolver = sdl3d_asset_resolver_create();
     ASSERT_NE(resolver, nullptr);

--- a/tests/test_crypto.cpp
+++ b/tests/test_crypto.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+extern "C"
+{
+#include "sdl3d_crypto.h"
+}
+
+namespace
+{
+void derive_key(const char *password, const uint8_t salt[SDL3D_CRYPTO_SALT_SIZE], uint8_t key[SDL3D_CRYPTO_HASH_SIZE])
+{
+    sdl3d_crypto_hash32_state state;
+    sdl3d_crypto_hash32_init(&state);
+    if (password != nullptr && password[0] != '\0')
+        sdl3d_crypto_hash32_update(&state, password, std::strlen(password));
+    sdl3d_crypto_hash32_update(&state, salt, SDL3D_CRYPTO_SALT_SIZE);
+    sdl3d_crypto_hash32_final(&state, key);
+}
+
+void derive_nonce(const uint8_t *data, size_t size, uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE])
+{
+    static const char label[] = "SDL3D pack nonce";
+    sdl3d_crypto_hash32_state state;
+    uint8_t digest[SDL3D_CRYPTO_HASH_SIZE];
+
+    sdl3d_crypto_hash32_init(&state);
+    sdl3d_crypto_hash32_update(&state, label, sizeof(label) - 1u);
+    sdl3d_crypto_hash32_update(&state, data, size);
+    sdl3d_crypto_hash32_final(&state, digest);
+    std::memcpy(nonce, digest, SDL3D_CRYPTO_NONCE_SIZE);
+}
+} // namespace
+
+TEST(CryptoHelpers, HashIsDeterministicAndSensitive)
+{
+    const char message[] = "SDL3D pack obfuscation";
+    uint8_t first[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t second[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t different[SDL3D_CRYPTO_HASH_SIZE];
+
+    sdl3d_crypto_hash32(message, sizeof(message), first);
+    sdl3d_crypto_hash32(message, sizeof(message), second);
+    EXPECT_EQ(std::memcmp(first, second, sizeof(first)), 0);
+
+    const char altered[] = "SDL3D pack obfuscatioN";
+    sdl3d_crypto_hash32(altered, sizeof(altered), different);
+    EXPECT_NE(std::memcmp(first, different, sizeof(first)), 0);
+}
+
+TEST(CryptoHelpers, StreamCipherRoundTripsWithDerivedKey)
+{
+    const uint8_t plain[] = "A small blob of asset bytes used to test obfuscation.";
+    uint8_t salt_digest[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t salt[SDL3D_CRYPTO_SALT_SIZE];
+    uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE];
+    uint8_t key[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t buffer[sizeof(plain)];
+
+    sdl3d_crypto_hash32(plain, sizeof(plain), salt_digest);
+    std::memcpy(salt, salt_digest, SDL3D_CRYPTO_SALT_SIZE);
+    derive_nonce(plain, sizeof(plain), nonce);
+    derive_key("test-password", salt, key);
+
+    std::memcpy(buffer, plain, sizeof(plain));
+    sdl3d_crypto_xor_stream(buffer, sizeof(buffer), key, nonce);
+    EXPECT_NE(std::memcmp(buffer, plain, sizeof(plain)), 0);
+
+    sdl3d_crypto_xor_stream(buffer, sizeof(buffer), key, nonce);
+    EXPECT_EQ(std::memcmp(buffer, plain, sizeof(plain)), 0);
+}
+
+TEST(CryptoHelpers, KeyedTagChangesWhenPayloadChanges)
+{
+    const uint8_t salt[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    const uint8_t header[] = {'S', '3', 'D', 'O', 'P', 'K', '1', '\0', 1, 0, 0, 0};
+    const uint8_t payload[] = "payload";
+    const uint8_t altered_payload[] = "payloae";
+    uint8_t key[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t tag_a[SDL3D_CRYPTO_HASH_SIZE];
+    uint8_t tag_b[SDL3D_CRYPTO_HASH_SIZE];
+
+    derive_key("tag-key", salt, key);
+    sdl3d_crypto_hash32_state state;
+
+    sdl3d_crypto_hash32_init_keyed(&state, key, sizeof(key));
+    sdl3d_crypto_hash32_update(&state, header, sizeof(header));
+    sdl3d_crypto_hash32_update(&state, payload, sizeof(payload));
+    sdl3d_crypto_hash32_final(&state, tag_a);
+
+    sdl3d_crypto_hash32_init_keyed(&state, key, sizeof(key));
+    sdl3d_crypto_hash32_update(&state, header, sizeof(header));
+    sdl3d_crypto_hash32_update(&state, altered_payload, sizeof(altered_payload));
+    sdl3d_crypto_hash32_final(&state, tag_b);
+
+    EXPECT_NE(std::memcmp(tag_a, tag_b, SDL3D_CRYPTO_TAG_SIZE), 0);
+}

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -149,3 +149,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
 elseif(MSVC)
     target_compile_options(sdl3d_miniz PRIVATE /w)
 endif()
+
+add_library(sdl3d_crypto OBJECT crypto/sdl3d_crypto.c)
+target_include_directories(sdl3d_crypto PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/crypto)
+set_target_properties(sdl3d_crypto PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/vendor/crypto/sdl3d_crypto.c
+++ b/vendor/crypto/sdl3d_crypto.c
@@ -1,0 +1,213 @@
+/*
+ * @file sdl3d_crypto.c
+ * @brief BLAKE2s helpers for SDL3D pack obfuscation.
+ */
+
+#include "sdl3d_crypto.h"
+
+#include <string.h>
+
+static const uint32_t sdl3d_blake2s_iv[8] = {
+    0x6A09E667u, 0xBB67AE85u, 0x3C6EF372u, 0xA54FF53Au, 0x510E527Fu, 0x9B05688Cu, 0x1F83D9ABu, 0x5BE0CD19u,
+};
+
+static const uint8_t sdl3d_blake2s_sigma[10][16] = {
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
+    {11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4}, {7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8},
+    {9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13}, {2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9},
+    {12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11}, {13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10},
+    {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5}, {2, 1, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+};
+
+static uint32_t sdl3d_crypto_rotr32(uint32_t value, unsigned int shift)
+{
+    return (value >> shift) | (value << (32u - shift));
+}
+
+static uint32_t sdl3d_crypto_load_u32le(const uint8_t *data)
+{
+    return (uint32_t)data[0] | ((uint32_t)data[1] << 8u) | ((uint32_t)data[2] << 16u) | ((uint32_t)data[3] << 24u);
+}
+
+static void sdl3d_crypto_store_u32le(uint8_t *data, uint32_t value)
+{
+    data[0] = (uint8_t)(value & 0xFFu);
+    data[1] = (uint8_t)((value >> 8u) & 0xFFu);
+    data[2] = (uint8_t)((value >> 16u) & 0xFFu);
+    data[3] = (uint8_t)((value >> 24u) & 0xFFu);
+}
+
+static void sdl3d_crypto_store_u64le(uint8_t *data, uint64_t value)
+{
+    sdl3d_crypto_store_u32le(data, (uint32_t)(value & UINT32_MAX));
+    sdl3d_crypto_store_u32le(data + 4u, (uint32_t)(value >> 32u));
+}
+
+static void sdl3d_crypto_blake2s_increment_counter(sdl3d_crypto_hash32_state *state, uint32_t increment)
+{
+    state->t[0] += increment;
+    if (state->t[0] < increment)
+        state->t[1] += 1u;
+}
+
+static void sdl3d_crypto_blake2s_compress(sdl3d_crypto_hash32_state *state, const uint8_t block[64])
+{
+    uint32_t m[16];
+    uint32_t v[16];
+
+    for (size_t i = 0; i < 16u; ++i)
+        m[i] = sdl3d_crypto_load_u32le(block + i * 4u);
+
+    for (size_t i = 0; i < 8u; ++i)
+        v[i] = state->h[i];
+    for (size_t i = 0; i < 8u; ++i)
+        v[i + 8u] = sdl3d_blake2s_iv[i];
+
+    v[12] ^= state->t[0];
+    v[13] ^= state->t[1];
+    v[14] ^= state->f[0];
+    v[15] ^= state->f[1];
+
+#define SDL3D_BLAKE2S_G(r, i, a, b, c, d)                                                                              \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        a = a + b + m[sdl3d_blake2s_sigma[(r)][2u * (i) + 0u]];                                                        \
+        d = sdl3d_crypto_rotr32(d ^ a, 16u);                                                                           \
+        c = c + d;                                                                                                     \
+        b = sdl3d_crypto_rotr32(b ^ c, 12u);                                                                           \
+        a = a + b + m[sdl3d_blake2s_sigma[(r)][2u * (i) + 1u]];                                                        \
+        d = sdl3d_crypto_rotr32(d ^ a, 8u);                                                                            \
+        c = c + d;                                                                                                     \
+        b = sdl3d_crypto_rotr32(b ^ c, 7u);                                                                            \
+    } while (0)
+
+    for (size_t round = 0; round < 10u; ++round)
+    {
+        SDL3D_BLAKE2S_G(round, 0, v[0], v[4], v[8], v[12]);
+        SDL3D_BLAKE2S_G(round, 1, v[1], v[5], v[9], v[13]);
+        SDL3D_BLAKE2S_G(round, 2, v[2], v[6], v[10], v[14]);
+        SDL3D_BLAKE2S_G(round, 3, v[3], v[7], v[11], v[15]);
+        SDL3D_BLAKE2S_G(round, 4, v[0], v[5], v[10], v[15]);
+        SDL3D_BLAKE2S_G(round, 5, v[1], v[6], v[11], v[12]);
+        SDL3D_BLAKE2S_G(round, 6, v[2], v[7], v[8], v[13]);
+        SDL3D_BLAKE2S_G(round, 7, v[3], v[4], v[9], v[14]);
+    }
+
+#undef SDL3D_BLAKE2S_G
+
+    for (size_t i = 0; i < 8u; ++i)
+        state->h[i] ^= v[i] ^ v[i + 8u];
+}
+
+void sdl3d_crypto_hash32_init(sdl3d_crypto_hash32_state *state)
+{
+    if (state == NULL)
+        return;
+
+    memset(state, 0, sizeof(*state));
+    for (size_t i = 0; i < 8u; ++i)
+        state->h[i] = sdl3d_blake2s_iv[i];
+    state->h[0] ^= 0x01010020u;
+    state->outlen = SDL3D_CRYPTO_HASH_SIZE;
+}
+
+void sdl3d_crypto_hash32_init_keyed(sdl3d_crypto_hash32_state *state, const void *key, size_t key_size)
+{
+    if (state == NULL)
+        return;
+
+    if (key_size > SDL3D_CRYPTO_HASH_SIZE)
+        key_size = SDL3D_CRYPTO_HASH_SIZE;
+
+    sdl3d_crypto_hash32_init(state);
+    state->h[0] ^= (uint32_t)key_size << 8u;
+    state->keylen = key_size;
+
+    if (key_size > 0u && key != NULL)
+    {
+        uint8_t block[64] = {0};
+        memcpy(block, key, key_size);
+        sdl3d_crypto_hash32_update(state, block, sizeof(block));
+    }
+}
+
+void sdl3d_crypto_hash32_update(sdl3d_crypto_hash32_state *state, const void *data, size_t size)
+{
+    const uint8_t *input = (const uint8_t *)data;
+    if (state == NULL || input == NULL || size == 0u)
+        return;
+
+    while (size > 0u)
+    {
+        const size_t fill = 64u - state->buflen;
+        const size_t take = size < fill ? size : fill;
+        memcpy(state->buf + state->buflen, input, take);
+        state->buflen += take;
+        input += take;
+        size -= take;
+
+        if (state->buflen == 64u)
+        {
+            sdl3d_crypto_blake2s_increment_counter(state, 64u);
+            sdl3d_crypto_blake2s_compress(state, state->buf);
+            state->buflen = 0u;
+        }
+    }
+}
+
+void sdl3d_crypto_hash32_final(sdl3d_crypto_hash32_state *state, uint8_t out[SDL3D_CRYPTO_HASH_SIZE])
+{
+    if (state == NULL || out == NULL)
+        return;
+
+    sdl3d_crypto_blake2s_increment_counter(state, (uint32_t)state->buflen);
+    state->f[0] = UINT32_MAX;
+    memset(state->buf + state->buflen, 0, sizeof(state->buf) - state->buflen);
+    sdl3d_crypto_blake2s_compress(state, state->buf);
+
+    for (size_t i = 0; i < 8u; ++i)
+        sdl3d_crypto_store_u32le(out + i * 4u, state->h[i]);
+
+    memset(state, 0, sizeof(*state));
+}
+
+void sdl3d_crypto_hash32(const void *data, size_t size, uint8_t out[SDL3D_CRYPTO_HASH_SIZE])
+{
+    sdl3d_crypto_hash32_state state;
+    sdl3d_crypto_hash32_init(&state);
+    sdl3d_crypto_hash32_update(&state, data, size);
+    sdl3d_crypto_hash32_final(&state, out);
+}
+
+void sdl3d_crypto_hash32_keyed(const void *key, size_t key_size, const void *data, size_t size,
+                               uint8_t out[SDL3D_CRYPTO_HASH_SIZE])
+{
+    sdl3d_crypto_hash32_state state;
+    sdl3d_crypto_hash32_init_keyed(&state, key, key_size);
+    sdl3d_crypto_hash32_update(&state, data, size);
+    sdl3d_crypto_hash32_final(&state, out);
+}
+
+void sdl3d_crypto_xor_stream(uint8_t *buffer, size_t size, const uint8_t key[SDL3D_CRYPTO_HASH_SIZE],
+                             const uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE])
+{
+    if (buffer == NULL || key == NULL || nonce == NULL || size == 0u)
+        return;
+
+    uint8_t counter_block[SDL3D_CRYPTO_NONCE_SIZE + sizeof(uint64_t)];
+    uint8_t keystream[SDL3D_CRYPTO_STREAM_BLOCK_SIZE];
+    uint64_t counter = 0u;
+    size_t offset = 0u;
+
+    memcpy(counter_block, nonce, SDL3D_CRYPTO_NONCE_SIZE);
+    while (offset < size)
+    {
+        sdl3d_crypto_store_u64le(counter_block + SDL3D_CRYPTO_NONCE_SIZE, counter++);
+        sdl3d_crypto_hash32_keyed(key, SDL3D_CRYPTO_HASH_SIZE, counter_block, sizeof(counter_block), keystream);
+        const size_t chunk =
+            size - offset < SDL3D_CRYPTO_STREAM_BLOCK_SIZE ? size - offset : SDL3D_CRYPTO_STREAM_BLOCK_SIZE;
+        for (size_t i = 0; i < chunk; ++i)
+            buffer[offset + i] ^= keystream[i];
+        offset += chunk;
+    }
+}

--- a/vendor/crypto/sdl3d_crypto.h
+++ b/vendor/crypto/sdl3d_crypto.h
@@ -1,0 +1,56 @@
+/*
+ * @file sdl3d_crypto.h
+ * @brief Small BLAKE2s-based helpers for SDL3D pack obfuscation.
+ *
+ * This is intentionally minimal: a fast hash primitive and a keystream XOR
+ * helper for pack wrapping. It is not exposed as a public SDK surface.
+ */
+
+#ifndef SDL3D_CRYPTO_H
+#define SDL3D_CRYPTO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    enum
+    {
+        SDL3D_CRYPTO_HASH_SIZE = 32,
+        SDL3D_CRYPTO_SALT_SIZE = 16,
+        SDL3D_CRYPTO_NONCE_SIZE = 16,
+        SDL3D_CRYPTO_TAG_SIZE = 16,
+        SDL3D_CRYPTO_STREAM_BLOCK_SIZE = 32,
+    };
+
+    typedef struct sdl3d_crypto_hash32_state
+    {
+        uint32_t h[8];
+        uint32_t t[2];
+        uint32_t f[2];
+        uint8_t buf[64];
+        size_t buflen;
+        size_t outlen;
+        size_t keylen;
+    } sdl3d_crypto_hash32_state;
+
+    void sdl3d_crypto_hash32_init(sdl3d_crypto_hash32_state *state);
+    void sdl3d_crypto_hash32_init_keyed(sdl3d_crypto_hash32_state *state, const void *key, size_t key_size);
+    void sdl3d_crypto_hash32_update(sdl3d_crypto_hash32_state *state, const void *data, size_t size);
+    void sdl3d_crypto_hash32_final(sdl3d_crypto_hash32_state *state, uint8_t out[SDL3D_CRYPTO_HASH_SIZE]);
+
+    void sdl3d_crypto_hash32(const void *data, size_t size, uint8_t out[SDL3D_CRYPTO_HASH_SIZE]);
+    void sdl3d_crypto_hash32_keyed(const void *key, size_t key_size, const void *data, size_t size,
+                                   uint8_t out[SDL3D_CRYPTO_HASH_SIZE]);
+
+    void sdl3d_crypto_xor_stream(uint8_t *buffer, size_t size, const uint8_t key[SDL3D_CRYPTO_HASH_SIZE],
+                                 const uint8_t nonce[SDL3D_CRYPTO_NONCE_SIZE]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_CRYPTO_H */


### PR DESCRIPTION
## Summary

- add a small vendored BLAKE2s-based crypto helper under `vendor/crypto`
- keep pack compression as-is, then optionally wrap the pack bytes in a lightweight obfuscation layer
- enable obfuscation by setting the `SDL3D_PACK_PASSWORD` CMake cache string to a non-empty value
- preserve the existing raw and compressed pack formats for compatibility
- keep runtime mounting and file reads unchanged after unwrap/decompress

## Notes

This is intentionally lightweight obfuscation for release packs, not hardened security.
It is meant to keep casual onlookers from trivially extracting assets.

## Verification

- `cmake --build build/release --target sdl3d_crypto_test sdl3d_asset_test pong_demo -j 8`
- `./build/release/tests/sdl3d_crypto_test`
- `./build/release/tests/sdl3d_asset_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`
