### PR TITLE
Add generalized sprite asset metadata

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -644,6 +644,38 @@ uses player-facing integer units rather than normalized engine volume:
 }
 ```
 
+Sprite assets can be authored under `assets.sprites`:
+
+```json
+{
+  "assets": {
+    "sprites": [
+      {
+        "id": "sprite.robot.walk",
+        "path": "asset://sprites/robot/walk.png",
+        "frame_width": 32,
+        "frame_height": 48,
+        "columns": 8,
+        "rows": 6,
+        "frame_count": 6,
+        "direction_count": 8,
+        "fps": 8.0,
+        "loop": true,
+        "lighting": true,
+        "emissive": false,
+        "visual_ground_offset": 0.125
+      }
+    ]
+  }
+}
+```
+
+The current sprite metadata API records the image source, atlas/grid layout,
+animation timing, directional frame count, and lighting participation. It does
+not load GPU resources on its own; callers can use the descriptor to build
+billboard sprites, 2D-in-3D sheets, or directional animation sets without
+changing the authored JSON shape.
+
 ## Scenes
 
 Games can split authored content across many scene files. The top-level game

--- a/docs/game-data-model.md
+++ b/docs/game-data-model.md
@@ -159,6 +159,7 @@ Useful reusable modules:
 
 - transform/state
 - renderable sprite, billboard, model, mesh, tile, debug primitive
+- authored sprite asset metadata for sheets, directional frames, and lighting-aware 2D-in-3D sprites
 - collider or trigger volume
 - movement controller
 - input controller
@@ -378,6 +379,7 @@ Renderable categories:
 - 2D sprite
 - billboard sprite
 - animated sprite
+- authored sprite asset metadata
 - tile map
 - 3D model
 - generated primitives

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -117,6 +117,37 @@ extern "C"
         bool loop;
     } sdl3d_game_data_music_asset;
 
+    /** @brief Authored sprite asset descriptor. */
+    typedef struct sdl3d_game_data_sprite_asset
+    {
+        /** @brief Stable asset id, such as `sprite.robot.walk`. */
+        const char *id;
+        /** @brief Virtual or filesystem path to the sprite source image. */
+        const char *path;
+        /** @brief Frame width in pixels for a grid or atlas source. */
+        int frame_width;
+        /** @brief Frame height in pixels for a grid or atlas source. */
+        int frame_height;
+        /** @brief Number of frames across the source image. */
+        int columns;
+        /** @brief Number of rows across the source image. */
+        int rows;
+        /** @brief Number of animation frames in the authored source. */
+        int frame_count;
+        /** @brief Number of directional frames per animation frame. */
+        int direction_count;
+        /** @brief Playback rate in frames per second. */
+        float fps;
+        /** @brief Whether playback wraps after the last frame. */
+        bool loop;
+        /** @brief Whether the sprite participates in dynamic lighting. */
+        bool lighting;
+        /** @brief Whether the sprite is emissive. */
+        bool emissive;
+        /** @brief Offset from logical feet/contact point to visible feet. */
+        float visual_ground_offset;
+    } sdl3d_game_data_sprite_asset;
+
     /**
      * @brief Runtime metrics used when evaluating data-authored UI bindings.
      *
@@ -952,6 +983,10 @@ extern "C"
     /** @brief Read a music asset descriptor by id from `assets.music`. */
     bool sdl3d_game_data_get_music_asset(const sdl3d_game_data_runtime *runtime, const char *id,
                                          sdl3d_game_data_music_asset *out_music);
+
+    /** @brief Read a sprite asset descriptor by id from `assets.sprites`. */
+    bool sdl3d_game_data_get_sprite_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                          sdl3d_game_data_sprite_asset *out_sprite);
 
     /**
      * @brief Resolve an authored audio path to a filesystem path usable by audio backends.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1556,6 +1556,19 @@ static yyjson_val *find_music_json(const sdl3d_game_data_runtime *runtime, const
     return NULL;
 }
 
+static yyjson_val *find_sprite_json(const sdl3d_game_data_runtime *runtime, const char *id)
+{
+    yyjson_val *sprites = obj_get(obj_get(runtime_root(runtime), "assets"), "sprites");
+    for (size_t i = 0; id != NULL && yyjson_is_arr(sprites) && i < yyjson_arr_size(sprites); ++i)
+    {
+        yyjson_val *sprite = yyjson_arr_get(sprites, i);
+        const char *sprite_id = json_string(sprite, "id", NULL);
+        if (sprite_id != NULL && SDL_strcmp(sprite_id, id) == 0)
+            return sprite;
+    }
+    return NULL;
+}
+
 static sdl3d_audio_bus parse_audio_bus(const char *bus, sdl3d_audio_bus fallback)
 {
     if (bus == NULL)
@@ -2401,6 +2414,50 @@ bool sdl3d_game_data_get_music_asset(const sdl3d_game_data_runtime *runtime, con
     out_music->volume = json_float(music, "volume", out_music->volume);
     out_music->loop = json_bool(music, "loop", out_music->loop);
     return out_music->id != NULL && out_music->path != NULL;
+}
+
+bool sdl3d_game_data_get_sprite_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                      sdl3d_game_data_sprite_asset *out_sprite)
+{
+    if (out_sprite != NULL)
+    {
+        SDL_zero(*out_sprite);
+        out_sprite->columns = 1;
+        out_sprite->rows = 1;
+        out_sprite->frame_count = 1;
+        out_sprite->direction_count = 1;
+        out_sprite->loop = true;
+        out_sprite->lighting = true;
+    }
+    if (runtime == NULL || id == NULL || out_sprite == NULL)
+        return false;
+
+    yyjson_val *sprite = find_sprite_json(runtime, id);
+    if (!yyjson_is_obj(sprite))
+        return false;
+
+    out_sprite->id = json_string(sprite, "id", NULL);
+    out_sprite->path = json_string(sprite, "path", NULL);
+    out_sprite->frame_width = json_int(sprite, "frame_width", out_sprite->frame_width);
+    out_sprite->frame_height = json_int(sprite, "frame_height", out_sprite->frame_height);
+    out_sprite->columns = json_int(sprite, "columns", out_sprite->columns);
+    out_sprite->rows = json_int(sprite, "rows", out_sprite->rows);
+    out_sprite->frame_count = json_int(sprite, "frame_count", out_sprite->frame_count);
+    out_sprite->direction_count = json_int(sprite, "direction_count", out_sprite->direction_count);
+    out_sprite->fps = json_float(sprite, "fps", out_sprite->fps);
+    out_sprite->loop = json_bool(sprite, "loop", out_sprite->loop);
+    out_sprite->lighting = json_bool(sprite, "lighting", out_sprite->lighting);
+    out_sprite->emissive = json_bool(sprite, "emissive", out_sprite->emissive);
+    out_sprite->visual_ground_offset = json_float(sprite, "visual_ground_offset", out_sprite->visual_ground_offset);
+
+    if (out_sprite->id == NULL || out_sprite->path == NULL || out_sprite->frame_width <= 0 ||
+        out_sprite->frame_height <= 0 || out_sprite->columns <= 0 || out_sprite->rows <= 0 ||
+        out_sprite->frame_count <= 0 || out_sprite->direction_count <= 0)
+    {
+        SDL_zero(*out_sprite);
+        return false;
+    }
+    return true;
 }
 
 const char *sdl3d_game_data_active_camera(const sdl3d_game_data_runtime *runtime)

--- a/tests/assets/game_data/sprite_asset_fixture.game.json
+++ b/tests/assets/game_data/sprite_asset_fixture.game.json
@@ -1,0 +1,32 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "Sprite Asset Fixture",
+    "id": "test.sprite_asset_fixture",
+    "version": "0.1.0"
+  },
+  "world": {
+    "name": "world.fixture",
+    "kind": "fixed_screen"
+  },
+  "assets": {
+    "sprites": [
+      {
+        "id": "sprite.robot.walk",
+        "path": "asset://sprites/robot/walk.png",
+        "frame_width": 32,
+        "frame_height": 48,
+        "columns": 8,
+        "rows": 6,
+        "frame_count": 6,
+        "direction_count": 8,
+        "fps": 8.0,
+        "loop": true,
+        "lighting": true,
+        "emissive": false,
+        "visual_ground_offset": 0.125
+      }
+    ]
+  },
+  "entities": []
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1011,6 +1011,39 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, ReadsSpriteAssetMetadata)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(fixture_path("sprite_asset_fixture.game.json").c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_game_data_sprite_asset sprite{};
+    ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.robot.walk", &sprite));
+    EXPECT_STREQ(sprite.id, "sprite.robot.walk");
+    EXPECT_STREQ(sprite.path, "asset://sprites/robot/walk.png");
+    EXPECT_EQ(sprite.frame_width, 32);
+    EXPECT_EQ(sprite.frame_height, 48);
+    EXPECT_EQ(sprite.columns, 8);
+    EXPECT_EQ(sprite.rows, 6);
+    EXPECT_EQ(sprite.frame_count, 6);
+    EXPECT_EQ(sprite.direction_count, 8);
+    EXPECT_FLOAT_EQ(sprite.fps, 8.0f);
+    EXPECT_TRUE(sprite.loop);
+    EXPECT_TRUE(sprite.lighting);
+    EXPECT_FALSE(sprite.emissive);
+    EXPECT_FLOAT_EQ(sprite.visual_ground_offset, 0.125f);
+
+    EXPECT_FALSE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.missing", &sprite));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 {
     const std::filesystem::path dir = unique_test_dir("pong_presentation");


### PR DESCRIPTION
## Summary

Introduce a first-pass generalized sprite asset descriptor in game data.

This adds:
- `assets.sprites` JSON support
- a runtime lookup API for sprite metadata
- documentation for sprite sheet / atlas metadata
- a regression test fixture that proves the runtime can read sprite asset descriptors

## Scope

This is the first work slice from issue #173.
It establishes the data model and runtime API so future work can build a reusable sprite loader and then migrate Doom's robot/NPC presentation onto the shared path.

## Validation

- `cmake --build build/release --target sdl3d_game_data_test game_data_json_test -j 8`
- `./build/release/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ReadsSpriteAssetMetadata:GameDataRuntime.LoadsPongDataIntoGenericSessionServices:GameDataRuntime.ExposesDataDrivenScenesAndMenus'`
- `./build/release/tests/game_data_json_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`
