### PR TITLE
Add generalized sprite asset loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ target_sources(
         src/script.c
         src/signal_bus.c
         src/trigger.c
+        src/sprite_asset.c
         src/sprite_actor.c
         src/sdl3d.c
         src/shading.c

--- a/demos/doom_level/entities.c
+++ b/demos/doom_level/entities.c
@@ -16,10 +16,61 @@
 #define DOOM_SIGNAL_ROBOT_IDLE_STARTED 6203
 #define DOOM_SIGNAL_ROBOT_WALK_STARTED 6204
 
+static const char *const ROBOT_BASE_DIRECTION_NAMES[SDL3D_SPRITE_ROTATION_COUNT] = {
+    "south", "south-east", "east", "north-east", "north", "north-west", "west", "south-west",
+};
+
+static const char *const ROBOT_WALK_DIRECTION_NAMES[SDL3D_SPRITE_ROTATION_COUNT] = {
+    "south", "south-east", "east", "north-east", "north", "north-west", "west", "south-west",
+};
+
+static char robot_base_paths[SDL3D_SPRITE_ROTATION_COUNT][512];
+static char robot_walk_paths[DOOM_ROBOT_WALK_FRAME_COUNT * SDL3D_SPRITE_ROTATION_COUNT][512];
+static const char *robot_base_path_ptrs[SDL3D_SPRITE_ROTATION_COUNT];
+static const char *robot_walk_path_ptrs[DOOM_ROBOT_WALK_FRAME_COUNT * SDL3D_SPRITE_ROTATION_COUNT];
+static bool robot_paths_initialized = false;
+
 static void configure_sprite_texture(sdl3d_texture2d *texture)
 {
     sdl3d_set_texture_filter(texture, SDL3D_TEXTURE_FILTER_NEAREST);
     sdl3d_set_texture_wrap(texture, SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP);
+}
+
+static void configure_sprite_asset_textures(sdl3d_sprite_asset_runtime *asset)
+{
+    if (asset == NULL)
+        return;
+    for (int i = 0; i < asset->base_texture_count; ++i)
+        configure_sprite_texture(&asset->base_textures[i]);
+    for (int i = 0; i < asset->animation_texture_count; ++i)
+        configure_sprite_texture(&asset->animation_textures[i]);
+}
+
+static void init_robot_sprite_paths(void)
+{
+    if (robot_paths_initialized)
+        return;
+
+    for (int dir = 0; dir < SDL3D_SPRITE_ROTATION_COUNT; ++dir)
+    {
+        SDL_snprintf(robot_base_paths[dir], sizeof(robot_base_paths[dir]),
+                     SDL3D_MEDIA_DIR "/sprites/skeletal_robot/%s.png", ROBOT_BASE_DIRECTION_NAMES[dir]);
+        robot_base_path_ptrs[dir] = robot_base_paths[dir];
+    }
+
+    for (int frame = 0; frame < DOOM_ROBOT_WALK_FRAME_COUNT; ++frame)
+    {
+        for (int dir = 0; dir < SDL3D_SPRITE_ROTATION_COUNT; ++dir)
+        {
+            const int index = frame * SDL3D_SPRITE_ROTATION_COUNT + dir;
+            SDL_snprintf(robot_walk_paths[index], sizeof(robot_walk_paths[index]),
+                         SDL3D_MEDIA_DIR "/sprites/skeletal_robot/walking_frames/%s_%02d.png",
+                         ROBOT_WALK_DIRECTION_NAMES[dir], frame);
+            robot_walk_path_ptrs[index] = robot_walk_paths[index];
+        }
+    }
+
+    robot_paths_initialized = true;
 }
 
 static void robot_set_floor_position(sdl3d_sprite_actor *actor, const sdl3d_level *level)
@@ -158,41 +209,29 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
     e->registry = registry;
     e->bus = bus;
 
-    /* Load enemy rotation sprites. */
-    const char *rot_paths[SDL3D_SPRITE_ROTATION_COUNT] = {
-        SDL3D_MEDIA_DIR "/sprites/skeletal_robot/south.png", SDL3D_MEDIA_DIR "/sprites/skeletal_robot/south-east.png",
-        SDL3D_MEDIA_DIR "/sprites/skeletal_robot/east.png",  SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north-east.png",
-        SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north.png", SDL3D_MEDIA_DIR "/sprites/skeletal_robot/north-west.png",
-        SDL3D_MEDIA_DIR "/sprites/skeletal_robot/west.png",  SDL3D_MEDIA_DIR "/sprites/skeletal_robot/south-west.png",
-    };
-    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
-    {
-        if (!sdl3d_load_texture_from_file(rot_paths[i], &e->enemy_rot_tex[i]))
-        {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Sprite load failed: %s", SDL_GetError());
-            return false;
-        }
-        configure_sprite_texture(&e->enemy_rot_tex[i]);
-    }
+    init_robot_sprite_paths();
 
-    const char *rot_names[SDL3D_SPRITE_ROTATION_COUNT] = {
-        "south", "south-east", "east", "north-east", "north", "north-west", "west", "south-west",
+    sdl3d_sprite_asset_source robot_source = {
+        .kind = SDL3D_SPRITE_ASSET_SOURCE_FILES,
+        .base_paths = robot_base_path_ptrs,
+        .frame_paths = robot_walk_path_ptrs,
+        .frame_count = DOOM_ROBOT_WALK_FRAME_COUNT,
+        .direction_count = SDL3D_SPRITE_ROTATION_COUNT,
+        .fps = 8.0f,
+        .loop = true,
+        .lighting = true,
+        .emissive = false,
+        .visual_ground_offset = 0.0f,
     };
-    for (int frame = 0; frame < DOOM_ROBOT_WALK_FRAME_COUNT; ++frame)
+    char robot_error[256];
+    if (!sdl3d_sprite_asset_load(NULL, &robot_source, &e->robot_sprite, robot_error, (int)sizeof(robot_error)))
     {
-        for (int dir = 0; dir < SDL3D_SPRITE_ROTATION_COUNT; ++dir)
-        {
-            char path[512];
-            SDL_snprintf(path, sizeof(path), SDL3D_MEDIA_DIR "/sprites/skeletal_robot/walking_frames/%s_%02d.png",
-                         rot_names[dir], frame);
-            if (!sdl3d_load_texture_from_file(path, &e->enemy_walk_tex[frame][dir]))
-            {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Robot walk sprite load failed: %s", SDL_GetError());
-                return false;
-            }
-            configure_sprite_texture(&e->enemy_walk_tex[frame][dir]);
-        }
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Robot sprite load failed: %s", robot_error);
+        return false;
     }
+    configure_sprite_asset_textures(&e->robot_sprite);
+    e->enemy_rotations = sdl3d_sprite_asset_base_rotations(&e->robot_sprite);
+    e->enemy_walk_rotations = sdl3d_sprite_asset_animation_frames(&e->robot_sprite);
 
     if (!sdl3d_load_texture_from_file(SDL3D_MEDIA_DIR "/sprites/health-pack.png", &e->health_tex))
     {
@@ -220,15 +259,6 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
         sdl3d_set_texture_wrap(&e->sky[i], SDL3D_TEXTURE_WRAP_CLAMP, SDL3D_TEXTURE_WRAP_CLAMP);
     }
 
-    /* Rotation set */
-    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
-        e->enemy_rotations.frames[i] = &e->enemy_rot_tex[i];
-    for (int frame = 0; frame < DOOM_ROBOT_WALK_FRAME_COUNT; ++frame)
-    {
-        for (int dir = 0; dir < SDL3D_SPRITE_ROTATION_COUNT; ++dir)
-            e->enemy_walk_rotations[frame].frames[dir] = &e->enemy_walk_tex[frame][dir];
-    }
-
     /* Sprite scene */
     sdl3d_sprite_scene_init(&e->sprites);
     struct
@@ -239,15 +269,15 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
         bool robot;
         float walk_x, walk_z, patrol_distance, speed, idle_duration;
     } defs[] = {
-        {NULL, &e->enemy_rotations, 5.8f, 0.0f, 6.8f, 3.4f, 5.2f, 0.0f, 0.0f, true, 1.0f, 0.0f, 2.4f, 0.75f, 1.4f},
+        {NULL, e->enemy_rotations, 5.8f, 0.0f, 6.8f, 3.4f, 5.2f, 0.0f, 0.0f, true, 1.0f, 0.0f, 2.4f, 0.75f, 1.4f},
         {&e->health_tex, NULL, 5.0f, 0.25f, 10.8f, 1.0f, 1.0f, 0.12f, 1.8f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 4.2f, 0.0f, 21.5f, 3.2f, 4.8f, 0.0f, 0.0f, true, 1.0f, 0.0f, 3.0f, 0.65f, 1.8f},
+        {NULL, e->enemy_rotations, 4.2f, 0.0f, 21.5f, 3.2f, 4.8f, 0.0f, 0.0f, true, 1.0f, 0.0f, 3.0f, 0.65f, 1.8f},
         {&e->health_tex, NULL, 24.0f, 0.25f, 4.5f, 1.0f, 1.0f, 0.15f, 1.5f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 19.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.8f, 1.2f},
+        {NULL, e->enemy_rotations, 24.0f, 0.0f, 19.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.8f, 1.2f},
         {&e->health_tex, NULL, 24.0f, 0.25f, 28.5f, 1.0f, 1.0f, 0.12f, 2.1f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 37.5f, 3.4f, 5.2f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.7f, 1.6f},
+        {NULL, e->enemy_rotations, 24.0f, 0.0f, 37.5f, 3.4f, 5.2f, 0.0f, 0.0f, true, 0.0f, 1.0f, 4.0f, 0.7f, 1.6f},
         {&e->health_tex, NULL, 35.5f, 0.25f, 27.0f, 1.0f, 1.0f, 0.1f, 1.7f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-        {NULL, &e->enemy_rotations, 24.0f, 0.0f, 72.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 1.0f, 0.0f, 8.0f, 1.0f, 1.5f},
+        {NULL, e->enemy_rotations, 24.0f, 0.0f, 72.0f, 3.6f, 5.6f, 0.0f, 0.0f, true, 1.0f, 0.0f, 8.0f, 1.0f, 1.5f},
         {&e->health_tex, NULL, 10.0f, 0.25f, 84.0f, 1.0f, 1.0f, 0.14f, 1.6f, false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     };
     for (int i = 0; i < (int)SDL_arraysize(defs); ++i)
@@ -260,7 +290,7 @@ bool entities_init(entities *e, const sdl3d_level *level, sdl3d_actor_registry *
         }
         a->position = sdl3d_vec3_make(defs[i].x, defs[i].y, defs[i].z);
         a->size = (sdl3d_vec2){defs[i].w, defs[i].h};
-        a->texture = defs[i].tex ? defs[i].tex : e->enemy_rotations.frames[0];
+        a->texture = defs[i].tex ? defs[i].tex : (e->enemy_rotations != NULL ? e->enemy_rotations->frames[0] : NULL);
         a->rotations = defs[i].rot;
         a->bob_amplitude = defs[i].amp;
         a->bob_speed = defs[i].spd;
@@ -351,16 +381,10 @@ void entities_free(entities *e)
     if (e == NULL)
         return;
     sdl3d_sprite_scene_free(&e->sprites);
+    sdl3d_sprite_asset_free(&e->robot_sprite);
     sdl3d_destroy_scene(e->scene);
     if (e->has_dragon)
         sdl3d_free_model(&e->dragon_model);
-    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
-        sdl3d_free_texture(&e->enemy_rot_tex[i]);
-    for (int frame = 0; frame < DOOM_ROBOT_WALK_FRAME_COUNT; ++frame)
-    {
-        for (int dir = 0; dir < SDL3D_SPRITE_ROTATION_COUNT; ++dir)
-            sdl3d_free_texture(&e->enemy_walk_tex[frame][dir]);
-    }
     sdl3d_free_texture(&e->health_tex);
     sdl3d_free_texture(&e->crate_tex);
     for (int i = 0; i < 6; ++i)

--- a/demos/doom_level/entities.h
+++ b/demos/doom_level/entities.h
@@ -8,7 +8,7 @@
 #include "sdl3d/scene.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/sprite_actor.h"
-#include "sdl3d/texture.h"
+#include "sdl3d/sprite_asset.h"
 
 #include "level_data.h"
 
@@ -28,13 +28,12 @@ typedef struct doom_robot_npc
 typedef struct entities
 {
     /* Textures */
-    sdl3d_texture2d enemy_rot_tex[SDL3D_SPRITE_ROTATION_COUNT];
-    sdl3d_texture2d enemy_walk_tex[DOOM_ROBOT_WALK_FRAME_COUNT][SDL3D_SPRITE_ROTATION_COUNT];
+    sdl3d_sprite_asset_runtime robot_sprite;
     sdl3d_texture2d health_tex;
     sdl3d_texture2d crate_tex;
     sdl3d_texture2d sky[6]; /* px, nx, py, ny, pz, nz */
-    sdl3d_sprite_rotation_set enemy_rotations;
-    sdl3d_sprite_rotation_set enemy_walk_rotations[DOOM_ROBOT_WALK_FRAME_COUNT];
+    const sdl3d_sprite_rotation_set *enemy_rotations;
+    const sdl3d_sprite_rotation_set *enemy_walk_rotations;
 
     /* Sprites */
     sdl3d_sprite_scene sprites;

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -73,3 +73,16 @@ For Emscripten tests or demos that still use loose source directories:
 ```cmake
 sdl3d_target_preload_asset_directory(my_target "${CMAKE_CURRENT_SOURCE_DIR}/data" "/data")
 ```
+
+## Sprite Runtime Loading
+
+`sdl3d_game_data_load_sprite_asset()` turns an authored sprite descriptor into
+runtime-owned billboard textures and rotation sets. The loader accepts either a
+sprite sheet description from `assets.sprites` or a file-list source used by
+generalized game code, then decodes the source once and keeps the resulting
+textures until `sdl3d_sprite_asset_free()`.
+
+Prefer a sheet when many frames share the same metadata. The loader slices a
+sheet in memory after one decode, which is cheaper than reading many tiny
+files. Use the file-list source only when the authored asset layout genuinely
+does not fit a sheet.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -671,10 +671,17 @@ Sprite assets can be authored under `assets.sprites`:
 ```
 
 The current sprite metadata API records the image source, atlas/grid layout,
-animation timing, directional frame count, and lighting participation. It does
-not load GPU resources on its own; callers can use the descriptor to build
-billboard sprites, 2D-in-3D sheets, or directional animation sets without
-changing the authored JSON shape.
+animation timing, directional frame count, and lighting participation. Callers
+can use `sdl3d_game_data_load_sprite_asset()` to resolve the asset through the
+runtime's resolver and build billboard sprites, 2D-in-3D sheets, or
+directional animation sets without changing the authored JSON shape. The load
+path decodes the source once and keeps the runtime-owned textures alive until
+`sdl3d_sprite_asset_free()`.
+
+Performance note: sprite sheets are decoded and sliced during load, not per
+frame. For large sprite families, prefer a single authored sheet over many tiny
+source files so the loader does one decode and one texture allocation pass
+instead of repeated file-system reads.
 
 ## Scenes
 

--- a/docs/game-data-model.md
+++ b/docs/game-data-model.md
@@ -159,7 +159,8 @@ Useful reusable modules:
 
 - transform/state
 - renderable sprite, billboard, model, mesh, tile, debug primitive
-- authored sprite asset metadata for sheets, directional frames, and lighting-aware 2D-in-3D sprites
+- authored sprite asset metadata for sheets, directional frames, and lighting-aware 2D-in-3D sprites that can be
+  loaded through a shared runtime bridge
 - collider or trigger volume
 - movement controller
 - input controller

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -25,6 +25,7 @@
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/properties.h"
+#include "sdl3d/sprite_asset.h"
 #include "sdl3d/storage.h"
 #include "sdl3d/transition.h"
 
@@ -987,6 +988,17 @@ extern "C"
     /** @brief Read a sprite asset descriptor by id from `assets.sprites`. */
     bool sdl3d_game_data_get_sprite_asset(const sdl3d_game_data_runtime *runtime, const char *id,
                                           sdl3d_game_data_sprite_asset *out_sprite);
+
+    /**
+     * @brief Load a sprite asset by id from `assets.sprites`.
+     *
+     * The runtime looks up the authored sprite descriptor, resolves the
+     * source image through the game's asset resolver, and builds billboard
+     * textures plus rotation sets ready for sprite actors.
+     */
+    bool sdl3d_game_data_load_sprite_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                           sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer,
+                                           int error_buffer_size);
 
     /**
      * @brief Resolve an authored audio path to a filesystem path usable by audio backends.

--- a/include/sdl3d/sprite_asset.h
+++ b/include/sdl3d/sprite_asset.h
@@ -1,0 +1,109 @@
+#ifndef SDL3D_SPRITE_ASSET_H
+#define SDL3D_SPRITE_ASSET_H
+
+#include <stdbool.h>
+
+#include "sdl3d/asset.h"
+#include "sdl3d/sprite_actor.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef enum sdl3d_sprite_asset_source_kind
+    {
+        SDL3D_SPRITE_ASSET_SOURCE_SHEET = 0,
+        SDL3D_SPRITE_ASSET_SOURCE_FILES = 1
+    } sdl3d_sprite_asset_source_kind;
+
+    /**
+     * @brief Generic authored sprite source description.
+     *
+     * The source can be a sprite sheet or an explicit file list. Sheet sources
+     * use @p sheet_path plus the grid metadata. File-list sources use
+     * @p base_paths for the fallback rotation set and @p frame_paths for the
+     * animation frames, both in frame-major, direction-minor order.
+     */
+    typedef struct sdl3d_sprite_asset_source
+    {
+        sdl3d_sprite_asset_source_kind kind;
+        const char *sheet_path;
+        const char *const *base_paths;
+        const char *const *frame_paths;
+        int frame_width;
+        int frame_height;
+        int columns;
+        int rows;
+        int frame_count;
+        int direction_count;
+        float fps;
+        bool loop;
+        bool lighting;
+        bool emissive;
+        float visual_ground_offset;
+    } sdl3d_sprite_asset_source;
+
+    /**
+     * @brief Loaded sprite textures and rotation sets.
+     *
+     * The runtime owns the generated textures and rotation sets. Use
+     * sdl3d_sprite_asset_free() to release them.
+     */
+    typedef struct sdl3d_sprite_asset_runtime
+    {
+        sdl3d_texture2d *base_textures;
+        int base_texture_count;
+        sdl3d_texture2d *animation_textures;
+        int animation_texture_count;
+        sdl3d_sprite_rotation_set base_rotations;
+        sdl3d_sprite_rotation_set *animation_frames;
+        int animation_frame_count;
+        int direction_count;
+        float fps;
+        bool loop;
+        bool lighting;
+        bool emissive;
+        float visual_ground_offset;
+    } sdl3d_sprite_asset_runtime;
+
+    /**
+     * @brief Load a sprite asset from a generic source description.
+     *
+     * Sheet sources are decoded once and sliced into textures. File-list
+     * sources load the explicit fallback rotation set and animation frames
+     * directly. The loader keeps the generic runtime behavior unchanged:
+     * callers still receive billboard-ready textures and rotation sets.
+     *
+     * @param assets Optional asset resolver for authored asset:// paths.
+     * @param source Generic source description.
+     * @param out_sprite Receives the loaded runtime.
+     * @param error_buffer Optional human-readable error output.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the sprite was loaded successfully.
+     */
+    bool sdl3d_sprite_asset_load(const sdl3d_asset_resolver *assets, const sdl3d_sprite_asset_source *source,
+                                 sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Release textures and rotation sets owned by a sprite runtime.
+     */
+    void sdl3d_sprite_asset_free(sdl3d_sprite_asset_runtime *sprite);
+
+    /** @brief Return the authored fallback rotation set, or NULL. */
+    const sdl3d_sprite_rotation_set *sdl3d_sprite_asset_base_rotations(const sdl3d_sprite_asset_runtime *sprite);
+
+    /** @brief Return the authored animation frame rotation sets, or NULL. */
+    const sdl3d_sprite_rotation_set *sdl3d_sprite_asset_animation_frames(const sdl3d_sprite_asset_runtime *sprite);
+
+    /** @brief Return the number of authored animation frames. */
+    int sdl3d_sprite_asset_animation_frame_count(const sdl3d_sprite_asset_runtime *sprite);
+
+    /** @brief Apply a loaded sprite runtime to a sprite actor. */
+    void sdl3d_sprite_asset_apply_actor(sdl3d_sprite_actor *actor, const sdl3d_sprite_asset_runtime *sprite);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_SPRITE_ASSET_H */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2460,6 +2460,44 @@ bool sdl3d_game_data_get_sprite_asset(const sdl3d_game_data_runtime *runtime, co
     return true;
 }
 
+bool sdl3d_game_data_load_sprite_asset(const sdl3d_game_data_runtime *runtime, const char *id,
+                                       sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer,
+                                       int error_buffer_size)
+{
+    sdl3d_game_data_sprite_asset sprite;
+    sdl3d_sprite_asset_source source;
+
+    if (out_sprite != NULL)
+        SDL_zero(*out_sprite);
+    if (runtime == NULL || id == NULL || out_sprite == NULL)
+        return false;
+
+    if (!sdl3d_game_data_get_sprite_asset(runtime, id, &sprite))
+    {
+        set_error(error_buffer, error_buffer_size, "sprite asset not found");
+        return false;
+    }
+
+    SDL_zero(source);
+    source.kind = SDL3D_SPRITE_ASSET_SOURCE_SHEET;
+    source.sheet_path = sprite.path;
+    source.frame_width = sprite.frame_width;
+    source.frame_height = sprite.frame_height;
+    source.columns = sprite.columns;
+    source.rows = sprite.rows;
+    source.frame_count = sprite.frame_count;
+    source.direction_count = sprite.direction_count;
+    source.fps = sprite.fps;
+    source.loop = sprite.loop;
+    source.lighting = sprite.lighting;
+    source.emissive = sprite.emissive;
+    source.visual_ground_offset = sprite.visual_ground_offset;
+
+    if (!sdl3d_sprite_asset_load(runtime->assets, &source, out_sprite, error_buffer, error_buffer_size))
+        return false;
+    return true;
+}
+
 const char *sdl3d_game_data_active_camera(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? runtime->active_camera : NULL;

--- a/src/sprite_asset.c
+++ b/src/sprite_asset.c
@@ -87,7 +87,8 @@ static bool sprite_asset_load_texture_slice(const sdl3d_image *source, int x, in
         return false;
 
     const bool ok = sdl3d_create_texture_from_image(&slice, out_texture);
-    sdl3d_free_image(&slice);
+    SDL_free(slice.pixels);
+    SDL_zero(slice);
     return ok;
 }
 

--- a/src/sprite_asset.c
+++ b/src/sprite_asset.c
@@ -1,0 +1,357 @@
+#include "sdl3d/sprite_asset.h"
+
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/image.h"
+
+static void sprite_asset_set_error(char *buffer, int buffer_size, const char *message)
+{
+    if (buffer != NULL && buffer_size > 0)
+        SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "sprite asset load failed");
+}
+
+static bool sprite_asset_path_uses_resolver(const char *path)
+{
+    return path != NULL && SDL_strstr(path, "://") != NULL;
+}
+
+static bool sprite_asset_path_is_absolute(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+    if (path[0] == '/' || path[0] == '\\')
+        return true;
+    return SDL_strlen(path) > 2 && path[1] == ':';
+}
+
+static bool sprite_asset_load_image(const sdl3d_asset_resolver *assets, const char *path, sdl3d_image *out_image,
+                                    char *error_buffer, int error_buffer_size)
+{
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+
+    if (path == NULL || out_image == NULL)
+    {
+        sprite_asset_set_error(error_buffer, error_buffer_size, "sprite asset requires a valid image path");
+        return SDL_InvalidParamError(path == NULL ? "path" : "out_image");
+    }
+
+    if (assets != NULL && (sprite_asset_path_uses_resolver(path) || !sprite_asset_path_is_absolute(path)))
+    {
+        if (!sdl3d_asset_resolver_read_file(assets, path, &buffer, error_buffer, error_buffer_size))
+            return false;
+        const bool decoded = sdl3d_load_image_from_memory(buffer.data, buffer.size, out_image);
+        sdl3d_asset_buffer_free(&buffer);
+        return decoded;
+    }
+
+    return sdl3d_load_image_from_file(path, out_image);
+}
+
+static void sprite_asset_free_textures(sdl3d_texture2d *textures, int count)
+{
+    if (textures == NULL || count <= 0)
+        return;
+    for (int i = 0; i < count; ++i)
+        sdl3d_free_texture(&textures[i]);
+    SDL_free(textures);
+}
+
+static bool sprite_asset_copy_slice(const sdl3d_image *source, int x, int y, int width, int height, sdl3d_image *out)
+{
+    const size_t bytes = (size_t)width * (size_t)height * 4u;
+    Uint8 *pixels = (Uint8 *)SDL_malloc(bytes);
+    if (pixels == NULL)
+        return SDL_OutOfMemory();
+
+    for (int row = 0; row < height; ++row)
+    {
+        const Uint8 *src = &source->pixels[((y + row) * source->width + x) * 4];
+        Uint8 *dst = &pixels[(size_t)row * (size_t)width * 4u];
+        SDL_memcpy(dst, src, (size_t)width * 4u);
+    }
+
+    out->pixels = pixels;
+    out->width = width;
+    out->height = height;
+    return true;
+}
+
+static bool sprite_asset_load_texture_slice(const sdl3d_image *source, int x, int y, int width, int height,
+                                            sdl3d_texture2d *out_texture)
+{
+    sdl3d_image slice;
+    SDL_zero(slice);
+    if (!sprite_asset_copy_slice(source, x, y, width, height, &slice))
+        return false;
+
+    const bool ok = sdl3d_create_texture_from_image(&slice, out_texture);
+    sdl3d_free_image(&slice);
+    return ok;
+}
+
+static bool sprite_asset_load_base_from_sheet(const sdl3d_image *sheet, const sdl3d_sprite_asset_source *source,
+                                              sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer,
+                                              int error_buffer_size)
+{
+    for (int direction = 0; direction < source->direction_count; ++direction)
+    {
+        const int cell_index = direction;
+        const int cell_x = (cell_index % source->columns) * source->frame_width;
+        const int cell_y = (cell_index / source->columns) * source->frame_height;
+        if (!sprite_asset_load_texture_slice(sheet, cell_x, cell_y, source->frame_width, source->frame_height,
+                                             &out_sprite->base_textures[direction]))
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to slice sprite base frame");
+            return false;
+        }
+    }
+
+    out_sprite->base_texture_count = source->direction_count;
+    return true;
+}
+
+static bool sprite_asset_load_animation_from_sheet(const sdl3d_image *sheet, const sdl3d_sprite_asset_source *source,
+                                                   sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer,
+                                                   int error_buffer_size)
+{
+    const int total_cells = source->frame_count * source->direction_count;
+    for (int frame = 0; frame < source->frame_count; ++frame)
+    {
+        for (int direction = 0; direction < source->direction_count; ++direction)
+        {
+            const int cell_index = frame * source->direction_count + direction;
+            if (cell_index >= source->columns * source->rows)
+            {
+                sprite_asset_set_error(error_buffer, error_buffer_size,
+                                       "sprite sheet is too small for the declared layout");
+                return false;
+            }
+
+            const int cell_x = (cell_index % source->columns) * source->frame_width;
+            const int cell_y = (cell_index / source->columns) * source->frame_height;
+            if (!sprite_asset_load_texture_slice(sheet, cell_x, cell_y, source->frame_width, source->frame_height,
+                                                 &out_sprite->animation_textures[cell_index]))
+            {
+                sprite_asset_set_error(error_buffer, error_buffer_size, "failed to slice sprite animation frame");
+                return false;
+            }
+        }
+    }
+
+    out_sprite->animation_texture_count = total_cells;
+    return true;
+}
+
+static bool sprite_asset_load_textures_from_paths(const sdl3d_asset_resolver *assets, const char *const *paths,
+                                                  int count, sdl3d_texture2d *out_textures, char *error_buffer,
+                                                  int error_buffer_size)
+{
+    for (int i = 0; i < count; ++i)
+    {
+        sdl3d_image image;
+        SDL_zero(image);
+        if (!sprite_asset_load_image(assets, paths[i], &image, error_buffer, error_buffer_size))
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to load sprite source image");
+            return false;
+        }
+
+        if (!sdl3d_create_texture_from_image(&image, &out_textures[i]))
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to create sprite texture");
+            sdl3d_free_image(&image);
+            return false;
+        }
+        sdl3d_free_image(&image);
+    }
+    return true;
+}
+
+static void sprite_asset_assign_rotation_set(sdl3d_sprite_rotation_set *set, sdl3d_texture2d *textures, int count)
+{
+    SDL_zero(*set);
+    for (int i = 0; i < SDL3D_SPRITE_ROTATION_COUNT; ++i)
+        set->frames[i] = (i < count) ? &textures[i] : NULL;
+}
+
+static bool sprite_asset_validate_source(const sdl3d_sprite_asset_source *source, char *error_buffer,
+                                         int error_buffer_size)
+{
+    if (source == NULL)
+    {
+        sprite_asset_set_error(error_buffer, error_buffer_size, "sprite asset source is required");
+        return SDL_InvalidParamError("source");
+    }
+    if (source->direction_count <= 0 || source->direction_count > SDL3D_SPRITE_ROTATION_COUNT)
+    {
+        sprite_asset_set_error(error_buffer, error_buffer_size, "sprite direction count must be between 1 and 8");
+        return SDL_SetError("sprite direction count must be between 1 and 8");
+    }
+    if (source->kind == SDL3D_SPRITE_ASSET_SOURCE_SHEET)
+    {
+        if (source->sheet_path == NULL || source->sheet_path[0] == '\0' || source->frame_width <= 0 ||
+            source->frame_height <= 0 || source->columns <= 0 || source->rows <= 0 || source->frame_count <= 0)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "invalid sprite sheet metadata");
+            return SDL_SetError("invalid sprite sheet metadata");
+        }
+        if (source->columns * source->rows < source->direction_count ||
+            source->columns * source->rows < source->frame_count * source->direction_count)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "sprite sheet dimensions do not cover all frames");
+            return SDL_SetError("sprite sheet dimensions do not cover all frames");
+        }
+    }
+    else if (source->kind == SDL3D_SPRITE_ASSET_SOURCE_FILES)
+    {
+        if (source->base_paths == NULL || source->frame_paths == NULL || source->frame_count <= 0)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size,
+                                   "file-list sprite assets require base and frame paths");
+            return SDL_SetError("file-list sprite assets require base and frame paths");
+        }
+    }
+    else
+    {
+        sprite_asset_set_error(error_buffer, error_buffer_size, "unknown sprite asset source kind");
+        return SDL_SetError("unknown sprite asset source kind");
+    }
+    return true;
+}
+
+bool sdl3d_sprite_asset_load(const sdl3d_asset_resolver *assets, const sdl3d_sprite_asset_source *source,
+                             sdl3d_sprite_asset_runtime *out_sprite, char *error_buffer, int error_buffer_size)
+{
+    sdl3d_image sheet;
+    SDL_zero(sheet);
+
+    if (out_sprite != NULL)
+        SDL_zero(*out_sprite);
+    if (out_sprite == NULL)
+        return SDL_InvalidParamError("out_sprite");
+    if (!sprite_asset_validate_source(source, error_buffer, error_buffer_size))
+        return false;
+
+    out_sprite->direction_count = source->direction_count;
+    out_sprite->fps = source->fps;
+    out_sprite->loop = source->loop;
+    out_sprite->lighting = source->lighting;
+    out_sprite->emissive = source->emissive;
+    out_sprite->visual_ground_offset = source->visual_ground_offset;
+
+    if (source->kind == SDL3D_SPRITE_ASSET_SOURCE_SHEET)
+    {
+        if (!sprite_asset_load_image(assets, source->sheet_path, &sheet, error_buffer, error_buffer_size))
+            goto fail;
+
+        out_sprite->base_texture_count = source->direction_count;
+        out_sprite->base_textures =
+            (sdl3d_texture2d *)SDL_calloc((size_t)out_sprite->base_texture_count, sizeof(sdl3d_texture2d));
+        if (out_sprite->base_textures == NULL)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to allocate sprite base textures");
+            goto fail;
+        }
+        if (!sprite_asset_load_base_from_sheet(&sheet, source, out_sprite, error_buffer, error_buffer_size))
+            goto fail;
+
+        out_sprite->animation_texture_count = source->frame_count * source->direction_count;
+        out_sprite->animation_textures =
+            (sdl3d_texture2d *)SDL_calloc((size_t)out_sprite->animation_texture_count, sizeof(sdl3d_texture2d));
+        out_sprite->animation_frames =
+            (sdl3d_sprite_rotation_set *)SDL_calloc((size_t)source->frame_count, sizeof(sdl3d_sprite_rotation_set));
+        if (out_sprite->animation_textures == NULL || out_sprite->animation_frames == NULL)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to allocate sprite animation textures");
+            goto fail;
+        }
+        if (!sprite_asset_load_animation_from_sheet(&sheet, source, out_sprite, error_buffer, error_buffer_size))
+            goto fail;
+    }
+    else
+    {
+        out_sprite->base_texture_count = source->direction_count;
+        out_sprite->base_textures =
+            (sdl3d_texture2d *)SDL_calloc((size_t)out_sprite->base_texture_count, sizeof(sdl3d_texture2d));
+        out_sprite->animation_texture_count = source->frame_count * source->direction_count;
+        out_sprite->animation_textures =
+            (sdl3d_texture2d *)SDL_calloc((size_t)out_sprite->animation_texture_count, sizeof(sdl3d_texture2d));
+        out_sprite->animation_frames =
+            (sdl3d_sprite_rotation_set *)SDL_calloc((size_t)source->frame_count, sizeof(sdl3d_sprite_rotation_set));
+        if (out_sprite->base_textures == NULL || out_sprite->animation_textures == NULL ||
+            out_sprite->animation_frames == NULL)
+        {
+            sprite_asset_set_error(error_buffer, error_buffer_size, "failed to allocate sprite textures");
+            goto fail;
+        }
+
+        if (!sprite_asset_load_textures_from_paths(assets, source->base_paths, source->direction_count,
+                                                   out_sprite->base_textures, error_buffer, error_buffer_size))
+            goto fail;
+        if (!sprite_asset_load_textures_from_paths(assets, source->frame_paths,
+                                                   source->frame_count * source->direction_count,
+                                                   out_sprite->animation_textures, error_buffer, error_buffer_size))
+            goto fail;
+    }
+
+    sprite_asset_assign_rotation_set(&out_sprite->base_rotations, out_sprite->base_textures,
+                                     out_sprite->base_texture_count);
+    for (int frame = 0; frame < source->frame_count; ++frame)
+    {
+        sprite_asset_assign_rotation_set(&out_sprite->animation_frames[frame],
+                                         &out_sprite->animation_textures[frame * source->direction_count],
+                                         source->direction_count);
+    }
+    out_sprite->animation_frame_count = source->frame_count;
+    sdl3d_free_image(&sheet);
+    return true;
+
+fail:
+    sdl3d_free_image(&sheet);
+    sdl3d_sprite_asset_free(out_sprite);
+    return false;
+}
+
+void sdl3d_sprite_asset_free(sdl3d_sprite_asset_runtime *sprite)
+{
+    if (sprite == NULL)
+        return;
+
+    if (sprite->base_textures != NULL)
+        sprite_asset_free_textures(sprite->base_textures, sprite->base_texture_count);
+    if (sprite->animation_textures != NULL)
+        sprite_asset_free_textures(sprite->animation_textures, sprite->animation_texture_count);
+    SDL_free(sprite->animation_frames);
+    SDL_zero(*sprite);
+}
+
+const sdl3d_sprite_rotation_set *sdl3d_sprite_asset_base_rotations(const sdl3d_sprite_asset_runtime *sprite)
+{
+    return sprite != NULL ? &sprite->base_rotations : NULL;
+}
+
+const sdl3d_sprite_rotation_set *sdl3d_sprite_asset_animation_frames(const sdl3d_sprite_asset_runtime *sprite)
+{
+    return sprite != NULL ? sprite->animation_frames : NULL;
+}
+
+int sdl3d_sprite_asset_animation_frame_count(const sdl3d_sprite_asset_runtime *sprite)
+{
+    return sprite != NULL ? sprite->animation_frame_count : 0;
+}
+
+void sdl3d_sprite_asset_apply_actor(sdl3d_sprite_actor *actor, const sdl3d_sprite_asset_runtime *sprite)
+{
+    if (actor == NULL || sprite == NULL)
+        return;
+
+    actor->texture = sprite->base_texture_count > 0 ? sprite->base_textures : NULL;
+    actor->rotations = sdl3d_sprite_asset_base_rotations(sprite);
+    actor->animation_frames = sdl3d_sprite_asset_animation_frames(sprite);
+    actor->animation_frame_count = sdl3d_sprite_asset_animation_frame_count(sprite);
+    actor->animation_fps = sprite->fps;
+    actor->animation_loop = sprite->loop;
+    actor->visual_ground_offset = sprite->visual_ground_offset;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,6 +245,7 @@ else()
     sdl3d_add_test(sdl3d_trigger_test test_trigger.cpp unit)
     sdl3d_add_test(sdl3d_timer_pool_test test_timer_pool.cpp unit)
     sdl3d_add_test(sdl3d_fps_mover_test test_fps_mover.cpp unit)
+    sdl3d_add_test(sdl3d_sprite_asset_test test_sprite_asset.cpp unit)
     if(NOT EMSCRIPTEN)
         sdl3d_add_test(sdl3d_pong_multiplayer_test test_pong_multiplayer.cpp unit)
         target_compile_definitions(

--- a/tests/test_sprite_asset.cpp
+++ b/tests/test_sprite_asset.cpp
@@ -1,0 +1,290 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+extern "C"
+{
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/asset.h"
+#include "sdl3d/game.h"
+#include "sdl3d/game_data.h"
+#include "sdl3d/image.h"
+#include "sdl3d/sprite_asset.h"
+}
+
+namespace
+{
+
+std::filesystem::path make_temp_dir(const char *leaf)
+{
+    const std::filesystem::path root = std::filesystem::temp_directory_path();
+    const auto unique =
+        std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
+    const std::filesystem::path dir = root / (std::string(leaf) + "_" + unique);
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+void write_text(const std::filesystem::path &path, const std::string &text)
+{
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << text;
+}
+
+void write_png(const std::filesystem::path &path, const sdl3d_image &image)
+{
+    std::filesystem::create_directories(path.parent_path());
+    ASSERT_TRUE(sdl3d_save_image_png(&image, path.string().c_str())) << SDL_GetError();
+}
+
+std::vector<Uint8> make_rgba_sheet_pixels(int cell_width, int cell_height, int columns, int rows,
+                                          const std::array<std::array<Uint8, 4>, 4> &cell_colors)
+{
+    std::vector<Uint8> pixels((size_t)cell_width * (size_t)cell_height * (size_t)columns * (size_t)rows * 4u, 0);
+    const int image_width = cell_width * columns;
+    for (int row = 0; row < rows; ++row)
+    {
+        for (int column = 0; column < columns; ++column)
+        {
+            const int cell_index = row * columns + column;
+            const auto &color = cell_colors[(size_t)cell_index];
+            for (int y = 0; y < cell_height; ++y)
+            {
+                for (int x = 0; x < cell_width; ++x)
+                {
+                    const size_t offset =
+                        ((size_t)(row * cell_height + y) * (size_t)image_width + (size_t)(column * cell_width + x)) *
+                        4u;
+                    pixels[offset + 0] = color[0];
+                    pixels[offset + 1] = color[1];
+                    pixels[offset + 2] = color[2];
+                    pixels[offset + 3] = color[3];
+                }
+            }
+        }
+    }
+    return pixels;
+}
+
+void expect_texture_color(const sdl3d_texture2d *texture, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+{
+    ASSERT_NE(texture, nullptr);
+    ASSERT_NE(texture->pixels, nullptr);
+    EXPECT_EQ(texture->pixels[0], r);
+    EXPECT_EQ(texture->pixels[1], g);
+    EXPECT_EQ(texture->pixels[2], b);
+    EXPECT_EQ(texture->pixels[3], a);
+}
+
+} // namespace
+
+TEST(SpriteAsset, LoadsSheetAndSlicesFrames)
+{
+    const std::filesystem::path dir = make_temp_dir("sprite_sheet");
+    const std::filesystem::path png_path = dir / "sheet.png";
+
+    const int cell_width = 2;
+    const int cell_height = 2;
+    const int columns = 2;
+    const int rows = 2;
+    const std::array<std::array<Uint8, 4>, 4> colors = {
+        {{255, 0, 0, 255}, {0, 255, 0, 255}, {0, 0, 255, 255}, {255, 255, 0, 255}}};
+    std::vector<Uint8> pixels = make_rgba_sheet_pixels(cell_width, cell_height, columns, rows, colors);
+
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = cell_width * columns;
+    image.height = cell_height * rows;
+    write_png(png_path, image);
+
+    sdl3d_sprite_asset_source source{};
+    source.kind = SDL3D_SPRITE_ASSET_SOURCE_SHEET;
+    const std::string sheet_path_text = png_path.string();
+    source.sheet_path = sheet_path_text.c_str();
+    source.frame_width = cell_width;
+    source.frame_height = cell_height;
+    source.columns = columns;
+    source.rows = rows;
+    source.frame_count = 2;
+    source.direction_count = 2;
+    source.fps = 12.0f;
+    source.loop = true;
+    source.lighting = true;
+    source.emissive = false;
+    source.visual_ground_offset = 0.25f;
+
+    sdl3d_sprite_asset_runtime runtime{};
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_sprite_asset_load(nullptr, &source, &runtime, error, sizeof(error))) << error;
+
+    ASSERT_EQ(runtime.base_texture_count, 2);
+    ASSERT_EQ(runtime.animation_texture_count, 4);
+    ASSERT_EQ(runtime.animation_frame_count, 2);
+    ASSERT_NE(runtime.base_textures, nullptr);
+    ASSERT_NE(runtime.animation_textures, nullptr);
+    ASSERT_NE(runtime.animation_frames, nullptr);
+    EXPECT_FLOAT_EQ(runtime.fps, 12.0f);
+    EXPECT_TRUE(runtime.loop);
+    EXPECT_TRUE(runtime.lighting);
+    EXPECT_FALSE(runtime.emissive);
+    EXPECT_FLOAT_EQ(runtime.visual_ground_offset, 0.25f);
+
+    expect_texture_color(&runtime.base_textures[0], 255, 0, 0, 255);
+    expect_texture_color(&runtime.base_textures[1], 0, 255, 0, 255);
+    expect_texture_color(runtime.animation_frames[0].frames[0], 255, 0, 0, 255);
+    expect_texture_color(runtime.animation_frames[0].frames[1], 0, 255, 0, 255);
+    expect_texture_color(runtime.animation_frames[1].frames[0], 0, 0, 255, 255);
+    expect_texture_color(runtime.animation_frames[1].frames[1], 255, 255, 0, 255);
+
+    sdl3d_sprite_actor actor{};
+    sdl3d_sprite_asset_apply_actor(&actor, &runtime);
+    EXPECT_EQ(actor.texture, runtime.base_textures);
+    EXPECT_EQ(actor.rotations, sdl3d_sprite_asset_base_rotations(&runtime));
+    EXPECT_EQ(actor.animation_frames, sdl3d_sprite_asset_animation_frames(&runtime));
+    EXPECT_EQ(actor.animation_frame_count, 2);
+    EXPECT_FLOAT_EQ(actor.animation_fps, 12.0f);
+    EXPECT_TRUE(actor.animation_loop);
+    EXPECT_FLOAT_EQ(actor.visual_ground_offset, 0.25f);
+
+    sdl3d_sprite_asset_free(&runtime);
+}
+
+TEST(SpriteAsset, LoadsExplicitFileListSources)
+{
+    const std::filesystem::path dir = make_temp_dir("sprite_files");
+
+    const std::array<std::array<Uint8, 4>, 6> colors = {{{255, 0, 0, 255},
+                                                         {0, 255, 0, 255},
+                                                         {0, 0, 255, 255},
+                                                         {255, 255, 0, 255},
+                                                         {255, 0, 255, 255},
+                                                         {0, 255, 255, 255}}};
+    std::array<std::filesystem::path, 6> paths = {
+        dir / "base_south.png",  dir / "base_east.png",    dir / "walk_0_south.png",
+        dir / "walk_0_east.png", dir / "walk_1_south.png", dir / "walk_1_east.png",
+    };
+    std::array<std::string, 6> path_strings;
+
+    for (size_t i = 0; i < paths.size(); ++i)
+    {
+        std::vector<Uint8> pixels = {colors[i][0], colors[i][1], colors[i][2], colors[i][3]};
+        sdl3d_image image{};
+        image.pixels = pixels.data();
+        image.width = 1;
+        image.height = 1;
+        write_png(paths[i], image);
+        path_strings[i] = paths[i].string();
+    }
+
+    const char *base_paths[2] = {path_strings[0].c_str(), path_strings[1].c_str()};
+    const char *frame_paths[4] = {path_strings[2].c_str(), path_strings[3].c_str(), path_strings[4].c_str(),
+                                  path_strings[5].c_str()};
+
+    sdl3d_sprite_asset_source source{};
+    source.kind = SDL3D_SPRITE_ASSET_SOURCE_FILES;
+    source.base_paths = base_paths;
+    source.frame_paths = frame_paths;
+    source.frame_count = 2;
+    source.direction_count = 2;
+    source.fps = 8.0f;
+    source.loop = false;
+    source.lighting = false;
+    source.emissive = true;
+    source.visual_ground_offset = 0.5f;
+
+    sdl3d_sprite_asset_runtime runtime{};
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_sprite_asset_load(nullptr, &source, &runtime, error, sizeof(error))) << error;
+
+    ASSERT_EQ(runtime.base_texture_count, 2);
+    ASSERT_EQ(runtime.animation_texture_count, 4);
+    ASSERT_EQ(runtime.animation_frame_count, 2);
+    expect_texture_color(&runtime.base_textures[0], 255, 0, 0, 255);
+    expect_texture_color(&runtime.base_textures[1], 0, 255, 0, 255);
+    expect_texture_color(runtime.animation_frames[0].frames[0], 0, 0, 255, 255);
+    expect_texture_color(runtime.animation_frames[0].frames[1], 255, 255, 0, 255);
+    expect_texture_color(runtime.animation_frames[1].frames[0], 255, 0, 255, 255);
+    expect_texture_color(runtime.animation_frames[1].frames[1], 0, 255, 255, 255);
+
+    sdl3d_sprite_asset_free(&runtime);
+}
+
+TEST(SpriteAsset, LoadsThroughGameDataSpriteBridge)
+{
+    const std::filesystem::path dir = make_temp_dir("sprite_bridge");
+    const std::filesystem::path json_path = dir / "sprite.game.json";
+    const std::filesystem::path image_path = dir / "sprites" / "robot" / "walk.png";
+
+    const int cell_width = 2;
+    const int cell_height = 2;
+    const int columns = 2;
+    const int rows = 2;
+    const std::array<std::array<Uint8, 4>, 4> colors = {
+        {{10, 20, 30, 255}, {40, 50, 60, 255}, {70, 80, 90, 255}, {100, 110, 120, 255}}};
+    std::vector<Uint8> pixels = make_rgba_sheet_pixels(cell_width, cell_height, columns, rows, colors);
+
+    sdl3d_image image{};
+    image.pixels = pixels.data();
+    image.width = cell_width * columns;
+    image.height = cell_height * rows;
+    write_png(image_path, image);
+
+    write_text(json_path,
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sprite Bridge", "id": "test.sprite_bridge", "version": "0.1.0" },
+  "world": { "name": "world.sprite_bridge", "kind": "fixed_screen" },
+  "assets": {
+    "sprites": [
+      {
+        "id": "sprite.robot.walk",
+        "path": "asset://sprites/robot/walk.png",
+        "frame_width": 2,
+        "frame_height": 2,
+        "columns": 2,
+        "rows": 2,
+        "frame_count": 2,
+        "direction_count": 2,
+        "fps": 8.0,
+        "loop": true,
+        "lighting": true,
+        "emissive": false,
+        "visual_ground_offset": 0.25
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char load_error[256]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(
+        sdl3d_game_data_load_file(json_path.string().c_str(), session, &runtime, load_error, sizeof(load_error)))
+        << load_error;
+
+    sdl3d_sprite_asset_runtime sprite{};
+    ASSERT_TRUE(
+        sdl3d_game_data_load_sprite_asset(runtime, "sprite.robot.walk", &sprite, load_error, sizeof(load_error)))
+        << load_error;
+
+    ASSERT_EQ(sprite.base_texture_count, 2);
+    ASSERT_EQ(sprite.animation_frame_count, 2);
+    expect_texture_color(&sprite.base_textures[0], 10, 20, 30, 255);
+    expect_texture_color(&sprite.base_textures[1], 40, 50, 60, 255);
+    expect_texture_color(sprite.animation_frames[1].frames[0], 70, 80, 90, 255);
+    expect_texture_color(sprite.animation_frames[1].frames[1], 100, 110, 120, 255);
+    EXPECT_FLOAT_EQ(sprite.visual_ground_offset, 0.25f);
+
+    sdl3d_sprite_asset_free(&sprite);
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}

--- a/tests/test_sprite_asset.cpp
+++ b/tests/test_sprite_asset.cpp
@@ -8,7 +8,9 @@
 
 extern "C"
 {
+#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
 
 #include "sdl3d/asset.h"
 #include "sdl3d/game.h"
@@ -22,25 +24,38 @@ namespace
 
 std::filesystem::path make_temp_dir(const char *leaf)
 {
-    const std::filesystem::path root = std::filesystem::temp_directory_path();
-    const auto unique =
-        std::to_string((long long)std::filesystem::file_time_type::clock::now().time_since_epoch().count());
+    std::filesystem::path root;
+    char *pref_path = SDL_GetPrefPath("bluesentinelsec", "SDL3DTests");
+    if (pref_path != nullptr)
+    {
+        root = pref_path;
+        SDL_free(pref_path);
+    }
+    else
+    {
+        SDL_ClearError();
+        root = std::filesystem::temp_directory_path();
+    }
+
+    const auto unique = std::to_string((unsigned long long)SDL_GetTicksNS());
     const std::filesystem::path dir = root / (std::string(leaf) + "_" + unique);
     std::filesystem::create_directories(dir);
     return dir;
 }
 
-void write_text(const std::filesystem::path &path, const std::string &text)
+bool write_text(const std::filesystem::path &path, const std::string &text)
 {
     std::filesystem::create_directories(path.parent_path());
     std::ofstream out(path, std::ios::binary);
     out << text;
+    return out.good();
 }
 
-void write_png(const std::filesystem::path &path, const sdl3d_image &image)
+bool write_png(const std::filesystem::path &path, const sdl3d_image &image)
 {
     std::filesystem::create_directories(path.parent_path());
-    ASSERT_TRUE(sdl3d_save_image_png(&image, path.string().c_str())) << SDL_GetError();
+    const std::string path_text = path.string();
+    return sdl3d_save_image_png(&image, path_text.c_str());
 }
 
 std::vector<Uint8> make_rgba_sheet_pixels(int cell_width, int cell_height, int columns, int rows,
@@ -101,7 +116,7 @@ TEST(SpriteAsset, LoadsSheetAndSlicesFrames)
     image.pixels = pixels.data();
     image.width = cell_width * columns;
     image.height = cell_height * rows;
-    write_png(png_path, image);
+    ASSERT_TRUE(write_png(png_path, image)) << SDL_GetError();
 
     sdl3d_sprite_asset_source source{};
     source.kind = SDL3D_SPRITE_ASSET_SOURCE_SHEET;
@@ -178,7 +193,7 @@ TEST(SpriteAsset, LoadsExplicitFileListSources)
         image.pixels = pixels.data();
         image.width = 1;
         image.height = 1;
-        write_png(paths[i], image);
+        ASSERT_TRUE(write_png(paths[i], image)) << SDL_GetError();
         path_strings[i] = paths[i].string();
     }
 
@@ -233,10 +248,10 @@ TEST(SpriteAsset, LoadsThroughGameDataSpriteBridge)
     image.pixels = pixels.data();
     image.width = cell_width * columns;
     image.height = cell_height * rows;
-    write_png(image_path, image);
+    ASSERT_TRUE(write_png(image_path, image)) << SDL_GetError();
 
-    write_text(json_path,
-               R"json({
+    ASSERT_TRUE(write_text(json_path,
+                           R"json({
   "schema": "sdl3d.game.v0",
   "metadata": { "name": "Sprite Bridge", "id": "test.sprite_bridge", "version": "0.1.0" },
   "world": { "name": "world.sprite_bridge", "kind": "fixed_screen" },
@@ -260,7 +275,7 @@ TEST(SpriteAsset, LoadsThroughGameDataSpriteBridge)
     ]
   },
   "entities": []
-})json");
+})json"));
 
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));


### PR DESCRIPTION
## Summary

Adds a reusable sprite asset runtime bridge that loads authored sprite metadata into runtime-owned textures and rotation sets. The loader supports both sprite sheets and explicit file-list sources, and the Doom robot now consumes that shared path instead of hand-loading each texture directly.

## Changes

- Added `sdl3d_sprite_asset.h` / `src/sprite_asset.c` for generic sprite loading and cleanup.
- Added `sdl3d_game_data_load_sprite_asset(...)` to bridge JSON-authored sprite ids to loaded runtime sprite assets.
- Refactored `demos/doom_level/entities.c` to load the robot presentation through the shared sprite loader.
- Added coverage for sheet slicing, file-list loading, and the JSON-to-runtime bridge.
- Updated asset and game-data docs to describe the new runtime loader and its performance tradeoffs.

## Validation

- `cmake --build build/release --target sdl3d_sprite_asset_test sdl3d_game_data_test doom_level -j 8`
- `./build/release/tests/sdl3d_sprite_asset_test`
- `./build/release/tests/sdl3d_game_data_test`
- `./scripts/check_clang_format.sh`
- `git diff --check`

## Notes

The JSON schema still authors sprite metadata as a sheet/grid descriptor. The new runtime loader now consumes that descriptor and also supports file-list sources for generalized code paths.