### PR TITLE
Stabilize Pong LAN multiplayer flow

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SDL3D_PONG_ASSET_FILES
     scenes/play.scene.json
     scenes/splash.scene.json
     scenes/title.scene.json
+    shaders/splash_logo_melt.frag.glsl
     scripts/pong.lua)
 
 sdl3d_add_embedded_asset_pack(pong_assets

--- a/demos/pong/data/scenes/multiplayer_lobby.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lobby.scene.json
@@ -34,7 +34,7 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Start Game", "signal": "signal.multiplayer.lobby.start" },
+        { "label": "Start Selected Match", "signal": "signal.multiplayer.lobby.start" },
         { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
@@ -59,7 +59,7 @@
           { "type": "scene_state", "key": "multiplayer_host_status" }
         ],
         "x": 0.5,
-        "y": 0.34,
+        "y": 0.30,
         "normalized": true,
         "centered": true,
         "color": [225, 236, 255, 245]
@@ -72,7 +72,7 @@
           { "type": "scene_state", "key": "multiplayer_host_endpoint" }
         ],
         "x": 0.5,
-        "y": 0.42,
+        "y": 0.37,
         "normalized": true,
         "centered": true,
         "color": [255, 245, 208, 255]
@@ -80,9 +80,9 @@
       {
         "name": "ui.multiplayer.lobby.hint",
         "font": "font.hud",
-        "text": "Press Start Game after the client joins.",
+        "text": "Select a connected client to begin.",
         "x": 0.5,
-        "y": 0.50,
+        "y": 0.44,
         "normalized": true,
         "centered": true,
         "color": [225, 236, 255, 230]
@@ -94,7 +94,7 @@
         "menu": "menu.multiplayer.lobby",
         "font": "font.hud",
         "x": 0.45,
-        "y": 0.60,
+        "y": 0.75,
         "gap": 0.09,
         "normalized": true,
         "align": "left",

--- a/demos/pong/data/scenes/multiplayer_lobby.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lobby.scene.json
@@ -25,7 +25,14 @@
   },
   "menus": [
     {
-      "name": "menu.multiplayer.lobby",
+      "name": "menu.multiplayer.lobby.connected",
+      "active_if": {
+        "type": "scene_state.compare",
+        "key": "multiplayer_host_connected",
+        "op": "==",
+        "value": true,
+        "default": false
+      },
       "up_action": "action.menu.up",
       "down_action": "action.menu.down",
       "select_action": "action.menu.select",
@@ -34,7 +41,27 @@
       "select_signal": "signal.ui.menu.select",
       "selected": 0,
       "items": [
-        { "label": "Start Selected Match", "signal": "signal.multiplayer.lobby.start" },
+        { "label": "Client 1", "signal": "signal.multiplayer.lobby.start" },
+        { "label": "Back", "scene": "scene.multiplayer.lan" }
+      ]
+    },
+    {
+      "name": "menu.multiplayer.lobby.waiting",
+      "active_if": {
+        "type": "scene_state.compare",
+        "key": "multiplayer_host_connected",
+        "op": "==",
+        "value": false,
+        "default": false
+      },
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
         { "label": "Back", "scene": "scene.multiplayer.lan" }
       ]
     }
@@ -78,23 +105,68 @@
         "color": [255, 245, 208, 255]
       },
       {
-        "name": "ui.multiplayer.lobby.hint",
+        "name": "ui.multiplayer.lobby.clients_title",
         "font": "font.hud",
-        "text": "Select a connected client to begin.",
+        "text": "AVAILABLE CLIENTS",
         "x": 0.5,
         "y": 0.44,
         "normalized": true,
         "centered": true,
         "color": [225, 236, 255, 230]
+      },
+      {
+        "name": "ui.multiplayer.lobby.client_status",
+        "font": "font.hud",
+        "format": "%s",
+        "bindings": [
+          { "type": "scene_state", "key": "multiplayer_host_client" }
+        ],
+        "x": 0.5,
+        "y": 0.51,
+        "normalized": true,
+        "centered": true,
+        "color": [170, 190, 220, 230]
       }
     ],
     "menus": [
       {
-        "name": "ui.multiplayer.lobby.menu",
-        "menu": "menu.multiplayer.lobby",
+        "name": "ui.multiplayer.lobby.menu.connected",
+        "menu": "menu.multiplayer.lobby.connected",
+        "active_if": {
+          "type": "scene_state.compare",
+          "key": "multiplayer_host_connected",
+          "op": "==",
+          "value": true,
+          "default": false
+        },
         "font": "font.hud",
         "x": 0.45,
-        "y": 0.75,
+        "y": 0.58,
+        "gap": 0.09,
+        "normalized": true,
+        "align": "left",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.035,
+          "align": "right",
+          "color": [255, 222, 140, 255]
+        }
+      },
+      {
+        "name": "ui.multiplayer.lobby.menu.waiting",
+        "menu": "menu.multiplayer.lobby.waiting",
+        "active_if": {
+          "type": "scene_state.compare",
+          "key": "multiplayer_host_connected",
+          "op": "==",
+          "value": false,
+          "default": false
+        },
+        "font": "font.hud",
+        "x": 0.45,
+        "y": 0.63,
         "gap": 0.09,
         "normalized": true,
         "align": "left",

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -45,10 +45,11 @@
       "active_if": {
         "type": "not",
         "condition": {
-          "type": "scene_state.compare",
-          "key": "network_role",
-          "op": "==",
-          "value": "client"
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+          ]
         }
       }
     }
@@ -74,8 +75,14 @@
         "type": "all",
         "conditions": [
           { "type": "app.paused", "equals": true },
-          { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" } },
-          { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "" } },
+          { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+          {
+            "type": "any",
+            "conditions": [
+              { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "host" },
+              { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+            ]
+          },
           { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
         ]
       },
@@ -96,7 +103,22 @@
         "type": "all",
         "conditions": [
           { "type": "app.paused", "equals": true },
-          { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" },
+          {
+            "type": "not",
+            "condition": {
+              "type": "all",
+              "conditions": [
+                { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+                {
+                  "type": "any",
+                  "conditions": [
+                    { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "host" },
+                    { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+                  ]
+                }
+              ]
+            }
+          },
           { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
         ]
       },
@@ -250,8 +272,14 @@
           "type": "all",
           "conditions": [
             { "type": "app.paused", "equals": true },
-            { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" } },
-            { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "" } },
+            { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+            {
+              "type": "any",
+              "conditions": [
+                { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "host" },
+                { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+              ]
+            },
             { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
           ]
         },
@@ -279,7 +307,22 @@
           "type": "all",
           "conditions": [
             { "type": "app.paused", "equals": true },
-            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" },
+            {
+              "type": "not",
+              "condition": {
+                "type": "all",
+                "conditions": [
+                  { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+                  {
+                    "type": "any",
+                    "conditions": [
+                      { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "host" },
+                      { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+                    ]
+                  }
+                ]
+              }
+            },
             { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
           ]
         },

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -69,11 +69,34 @@
       ]
     },
     {
+      "name": "menu.pause.network",
+      "active_if": {
+        "type": "all",
+        "conditions": [
+          { "type": "app.paused", "equals": true },
+          { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" } },
+          { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "" } },
+          { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
+        ]
+      },
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Resume", "pause": "resume" },
+        { "label": "Title", "pause": "resume", "signal": "signal.match.reset", "scene": "scene.title" }
+      ]
+    },
+    {
       "name": "menu.pause",
       "active_if": {
         "type": "all",
         "conditions": [
           { "type": "app.paused", "equals": true },
+          { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" },
           { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
         ]
       },
@@ -221,12 +244,42 @@
         }
       },
       {
+        "name": "ui.pause.menu.network",
+        "menu": "menu.pause.network",
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "app.paused", "equals": true },
+            { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" } },
+            { "type": "not", "condition": { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "" } },
+            { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
+          ]
+        },
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.45,
+        "gap": 0.075,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.12,
+          "align": "center",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      },
+      {
         "name": "ui.pause.menu",
         "menu": "menu.pause",
         "visible_if": {
           "type": "all",
           "conditions": [
             { "type": "app.paused", "equals": true },
+            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "none" },
             { "type": "property.compare", "target": "entity.match", "key": "finished", "op": "==", "value": false }
           ]
         },

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -1156,7 +1156,7 @@ static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state 
     clear_network_action_overrides(state);
     if (ctx != NULL)
     {
-        ctx->paused = false;
+        ctx->paused = true;
     }
 
     SDL_snprintf(state->network_match_termination_reason, sizeof(state->network_match_termination_reason), "%s",
@@ -1482,7 +1482,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
     }
 }
 
-static void update_network_match_termination(pong_state *state, float dt)
+static void update_network_match_termination(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     const int select_action =
         state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.menu.select") : -1;
@@ -1490,6 +1490,11 @@ static void update_network_match_termination(pong_state *state, float dt)
     if (state == NULL || !state->network_match_termination_active)
     {
         return;
+    }
+
+    if (ctx != NULL)
+    {
+        ctx->paused = true;
     }
 
     state->network_match_termination_timer += SDL_max(dt, 0.0f);
@@ -1506,6 +1511,10 @@ static void update_network_match_termination(pong_state *state, float dt)
     state->network_match_termination_active = false;
     state->network_match_termination_timer = 0.0f;
     state->network_match_termination_reason[0] = '\0';
+    if (ctx != NULL)
+    {
+        ctx->paused = false;
+    }
     if (state->data != NULL)
     {
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.title");
@@ -2342,7 +2351,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
-    update_network_match_termination(state, dt);
+    update_network_match_termination(ctx, state, dt);
     update_multiplayer_sessions(ctx, state, dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
@@ -2360,7 +2369,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
-    update_network_match_termination(state, real_dt);
+    update_network_match_termination(ctx, state, real_dt);
     update_multiplayer_sessions(ctx, state, real_dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -53,6 +53,7 @@ typedef struct pong_state
     int discovery_refresh_signal_id;
     int discovery_refresh_connection;
     int local_input_gamepad_count;
+    int discovery_selected_index;
 } pong_state;
 
 typedef enum pong_network_message_kind
@@ -1202,6 +1203,7 @@ static bool start_discovery_session(pong_state *state)
 
     if (state->discovery_session != NULL)
     {
+        state->discovery_selected_index = 0;
         return sdl3d_network_discovery_session_refresh(state->discovery_session);
     }
 
@@ -1218,6 +1220,7 @@ static bool start_discovery_session(pong_state *state)
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery scanner ready for UDP %u",
                 (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
+    state->discovery_selected_index = 0;
     return sdl3d_network_discovery_session_refresh(state->discovery_session);
 }
 
@@ -1240,6 +1243,7 @@ static void update_discovery_scene_state(pong_state *state)
     }
 
     sdl3d_properties_set_int(scene_state, "multiplayer_discovery_count", result_count);
+    sdl3d_properties_set_int(scene_state, "multiplayer_discovery_selected", state->discovery_selected_index);
     sdl3d_properties_set_string(
         scene_state, "multiplayer_discovery_status",
         state->discovery_session != NULL ? sdl3d_network_discovery_session_status(state->discovery_session) : "Idle");
@@ -1331,10 +1335,72 @@ static void handle_discovery_result_selection(pong_state *state, int index)
     SDL_strlcpy(state->direct_connect_host, result.host, sizeof(state->direct_connect_host));
     SDL_snprintf(port_buffer, sizeof(port_buffer), "%u", (unsigned int)result.port);
     SDL_strlcpy(state->direct_connect_port, port_buffer, sizeof(state->direct_connect_port));
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery selected result %d: %s:%u session=%s", index,
+                result.host, (unsigned int)result.port,
+                result.session_name[0] != '\0' ? result.session_name : "SDL3D Session");
     destroy_discovery_session(state);
     if (start_direct_connect_session(state))
     {
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.direct_connect");
+    }
+}
+
+static void emit_pong_signal_by_name(sdl3d_game_context *ctx, pong_state *state, const char *signal_name)
+{
+    const int signal_id =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_signal(state->data, signal_name) : -1;
+    if (ctx == NULL || state == NULL || signal_id < 0)
+    {
+        return;
+    }
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(ctx->session), signal_id, NULL);
+}
+
+static void update_discovery_controls(sdl3d_game_context *ctx, pong_state *state)
+{
+    if (ctx == NULL || state == NULL || state->data == NULL || state->input == NULL ||
+        !is_multiplayer_discovery_scene(state))
+    {
+        return;
+    }
+
+    const int result_count =
+        state->discovery_session != NULL ? sdl3d_network_discovery_session_result_count(state->discovery_session) : 0;
+    if (result_count <= 0)
+    {
+        state->discovery_selected_index = 0;
+    }
+    else
+    {
+        state->discovery_selected_index = SDL_clamp(state->discovery_selected_index, 0, result_count - 1);
+    }
+
+    const int up_action = sdl3d_game_data_find_action(state->data, "action.menu.up");
+    const int down_action = sdl3d_game_data_find_action(state->data, "action.menu.down");
+    const int select_action = sdl3d_game_data_find_action(state->data, "action.menu.select");
+    const int back_action = sdl3d_game_data_find_action(state->data, "action.menu.back");
+
+    if (result_count > 1 && up_action >= 0 && sdl3d_input_is_pressed(state->input, up_action))
+    {
+        state->discovery_selected_index = (state->discovery_selected_index + result_count - 1) % result_count;
+        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.move");
+    }
+    if (result_count > 1 && down_action >= 0 && sdl3d_input_is_pressed(state->input, down_action))
+    {
+        state->discovery_selected_index = (state->discovery_selected_index + 1) % result_count;
+        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.move");
+    }
+    if (result_count > 0 && select_action >= 0 && sdl3d_input_is_pressed(state->input, select_action))
+    {
+        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
+        handle_discovery_result_selection(state, state->discovery_selected_index);
+        return;
+    }
+    if (back_action >= 0 && sdl3d_input_is_pressed(state->input, back_action))
+    {
+        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
+        destroy_discovery_session(state);
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
     }
 }
 
@@ -1376,6 +1442,7 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     {
         sdl3d_network_discovery_result result;
         char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
+        char button_label[sizeof(label) + 32];
         if (!sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
         {
             continue;
@@ -1385,7 +1452,9 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
                      result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", result.host,
                      (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
                      result.status[0] != '\0' ? result.status : "");
-        if (sdl3d_ui_layout_button(state->discovery_ui, label))
+        SDL_snprintf(button_label, sizeof(button_label), "%s%s##discovery_%d",
+                     i == state->discovery_selected_index ? "> " : "  ", label, i);
+        if (sdl3d_ui_layout_button(state->discovery_ui, button_label))
         {
             handle_discovery_result_selection(state, i);
             break;
@@ -1395,6 +1464,10 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     if (result_count == 0)
     {
         sdl3d_ui_layout_label(state->discovery_ui, "Searching local network...");
+    }
+    else
+    {
+        sdl3d_ui_layout_label(state->discovery_ui, "Press Enter / A to join the selected match.");
     }
 
     sdl3d_ui_separator(state->discovery_ui);
@@ -1900,13 +1973,10 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
     {
         const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
                                  event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
-        const bool key_event =
-            event->type == SDL_EVENT_KEY_DOWN || event->type == SDL_EVENT_KEY_UP || event->type == SDL_EVENT_TEXT_INPUT;
 
-        (void)sdl3d_ui_process_event(state->discovery_ui, event);
-
-        if (mouse_event || key_event)
+        if (mouse_event)
         {
+            (void)sdl3d_ui_process_event(state->discovery_ui, event);
             ctx->input_event_consumed = true;
         }
     }
@@ -1919,6 +1989,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, dt);
+    update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
@@ -1935,6 +2006,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, real_dt);
+    update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -53,7 +53,6 @@ typedef struct pong_state
     int discovery_refresh_signal_id;
     int discovery_refresh_connection;
     int local_input_gamepad_count;
-    int discovery_selected_index;
 } pong_state;
 
 typedef enum pong_network_message_kind
@@ -1203,7 +1202,6 @@ static bool start_discovery_session(pong_state *state)
 
     if (state->discovery_session != NULL)
     {
-        state->discovery_selected_index = 0;
         return sdl3d_network_discovery_session_refresh(state->discovery_session);
     }
 
@@ -1220,7 +1218,6 @@ static bool start_discovery_session(pong_state *state)
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery scanner ready for UDP %u",
                 (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
-    state->discovery_selected_index = 0;
     return sdl3d_network_discovery_session_refresh(state->discovery_session);
 }
 
@@ -1243,7 +1240,6 @@ static void update_discovery_scene_state(pong_state *state)
     }
 
     sdl3d_properties_set_int(scene_state, "multiplayer_discovery_count", result_count);
-    sdl3d_properties_set_int(scene_state, "multiplayer_discovery_selected", state->discovery_selected_index);
     sdl3d_properties_set_string(
         scene_state, "multiplayer_discovery_status",
         state->discovery_session != NULL ? sdl3d_network_discovery_session_status(state->discovery_session) : "Idle");
@@ -1316,33 +1312,35 @@ static bool refresh_discovery_session(pong_state *state)
     return true;
 }
 
-static void handle_discovery_result_selection(pong_state *state, int index)
+static bool start_discovered_match_connection(pong_state *state, int index)
 {
     sdl3d_network_discovery_result result;
     char port_buffer[16];
 
     if (state == NULL || state->discovery_session == NULL)
     {
-        return;
+        return false;
     }
 
     SDL_zero(result);
     if (!sdl3d_network_discovery_session_get_result(state->discovery_session, index, &result))
     {
-        return;
+        return false;
     }
 
     SDL_strlcpy(state->direct_connect_host, result.host, sizeof(state->direct_connect_host));
     SDL_snprintf(port_buffer, sizeof(port_buffer), "%u", (unsigned int)result.port);
     SDL_strlcpy(state->direct_connect_port, port_buffer, sizeof(state->direct_connect_port));
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery selected result %d: %s:%u session=%s", index,
-                result.host, (unsigned int)result.port,
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery auto-connecting to result %d: %s:%u session=%s",
+                index, result.host, (unsigned int)result.port,
                 result.session_name[0] != '\0' ? result.session_name : "SDL3D Session");
     destroy_discovery_session(state);
-    if (start_direct_connect_session(state))
+    if (!start_direct_connect_session(state))
     {
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.direct_connect");
+        return false;
     }
+    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Match found. Connecting...");
+    return true;
 }
 
 static void emit_pong_signal_by_name(sdl3d_game_context *ctx, pong_state *state, const char *signal_name)
@@ -1364,42 +1362,13 @@ static void update_discovery_controls(sdl3d_game_context *ctx, pong_state *state
         return;
     }
 
-    const int result_count =
-        state->discovery_session != NULL ? sdl3d_network_discovery_session_result_count(state->discovery_session) : 0;
-    if (result_count <= 0)
-    {
-        state->discovery_selected_index = 0;
-    }
-    else
-    {
-        state->discovery_selected_index = SDL_clamp(state->discovery_selected_index, 0, result_count - 1);
-    }
-
-    const int up_action = sdl3d_game_data_find_action(state->data, "action.menu.up");
-    const int down_action = sdl3d_game_data_find_action(state->data, "action.menu.down");
-    const int select_action = sdl3d_game_data_find_action(state->data, "action.menu.select");
     const int back_action = sdl3d_game_data_find_action(state->data, "action.menu.back");
 
-    if (result_count > 1 && up_action >= 0 && sdl3d_input_is_pressed(state->input, up_action))
-    {
-        state->discovery_selected_index = (state->discovery_selected_index + result_count - 1) % result_count;
-        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.move");
-    }
-    if (result_count > 1 && down_action >= 0 && sdl3d_input_is_pressed(state->input, down_action))
-    {
-        state->discovery_selected_index = (state->discovery_selected_index + 1) % result_count;
-        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.move");
-    }
-    if (result_count > 0 && select_action >= 0 && sdl3d_input_is_pressed(state->input, select_action))
-    {
-        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
-        handle_discovery_result_selection(state, state->discovery_selected_index);
-        return;
-    }
     if (back_action >= 0 && sdl3d_input_is_pressed(state->input, back_action))
     {
         emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
         destroy_discovery_session(state);
+        destroy_direct_connect_session(state);
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
     }
 }
@@ -1437,43 +1406,36 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
             sdl3d_ui_layout_label(state->discovery_ui, status);
         }
     }
-
-    for (int i = 0; i < result_count; ++i)
+    else if (state->direct_connect_session != NULL)
     {
-        sdl3d_network_discovery_result result;
-        char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
-        char button_label[sizeof(label) + 32];
-        if (!sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
+        if (sdl3d_network_session_is_connected(state->direct_connect_session))
         {
-            continue;
+            sdl3d_ui_layout_label(state->discovery_ui, "Connected. Waiting for host to start...");
         }
-
-        SDL_snprintf(label, sizeof(label), "%s  %s:%u%s%s",
-                     result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", result.host,
-                     (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
-                     result.status[0] != '\0' ? result.status : "");
-        SDL_snprintf(button_label, sizeof(button_label), "%s%s##discovery_%d",
-                     i == state->discovery_selected_index ? "> " : "  ", label, i);
-        if (sdl3d_ui_layout_button(state->discovery_ui, button_label))
+        else
         {
-            handle_discovery_result_selection(state, i);
-            break;
+            sdl3d_ui_layout_label(state->discovery_ui, state->direct_connect_status);
         }
     }
 
-    if (result_count == 0)
+    if (state->direct_connect_session != NULL)
+    {
+        sdl3d_ui_layout_label(state->discovery_ui, "The host will start the match.");
+    }
+    else if (result_count == 0)
     {
         sdl3d_ui_layout_label(state->discovery_ui, "Searching local network...");
     }
     else
     {
-        sdl3d_ui_layout_label(state->discovery_ui, "Press Enter / A to join the selected match.");
+        sdl3d_ui_layout_label(state->discovery_ui, "Match found. Connecting...");
     }
 
     sdl3d_ui_separator(state->discovery_ui);
     if (sdl3d_ui_layout_button(state->discovery_ui, "Back"))
     {
         destroy_discovery_session(state);
+        destroy_direct_connect_session(state);
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
     }
 
@@ -1546,7 +1508,7 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
         update_host_session_scene_state(state);
     }
 
-    if (is_multiplayer_discovery_scene(state))
+    if (is_multiplayer_discovery_scene(state) && state->direct_connect_session == NULL)
     {
         if (state->discovery_session == NULL)
         {
@@ -1559,6 +1521,10 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery update failed: %s", SDL_GetError());
             }
             update_discovery_scene_state(state);
+            if (sdl3d_network_discovery_session_result_count(state->discovery_session) > 0)
+            {
+                (void)start_discovered_match_connection(state, 0);
+            }
         }
     }
     else if (state->discovery_session != NULL)
@@ -1575,7 +1541,8 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
 
         update_direct_connect_session_status(state);
 
-        const bool keep_direct_connect_session = is_direct_connect_scene(state) || is_multiplayer_play_scene(state);
+        const bool keep_direct_connect_session =
+            is_direct_connect_scene(state) || is_multiplayer_discovery_scene(state) || is_multiplayer_play_scene(state);
         if (!keep_direct_connect_session)
         {
             destroy_direct_connect_session(state);
@@ -1754,7 +1721,10 @@ static void on_multiplayer_discovery_signal(void *userdata, int signal_id, const
         return;
     }
 
-    (void)refresh_discovery_session(state);
+    if (state->direct_connect_session == NULL)
+    {
+        (void)refresh_discovery_session(state);
+    }
 }
 
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -60,12 +60,19 @@ typedef enum pong_network_message_kind
     PONG_NETWORK_MESSAGE_INPUT = 1,
     PONG_NETWORK_MESSAGE_STATE = 2,
     PONG_NETWORK_MESSAGE_START_GAME = 3,
+    PONG_NETWORK_MESSAGE_PAUSE_REQUEST = 4,
+    PONG_NETWORK_MESSAGE_RESUME_REQUEST = 5,
+    PONG_NETWORK_MESSAGE_DISCONNECT = 6,
 } pong_network_message_kind;
 
 static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
 static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
 static const size_t PONG_NETWORK_INPUT_PACKET_SIZE = 20U;
-static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 108U;
+static const size_t PONG_NETWORK_CONTROL_PACKET_SIZE = 12U;
+static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 112U;
+
+static bool send_network_control_packet(sdl3d_network_session *session, pong_network_message_kind kind,
+                                        const char *label);
 
 static Uint64 pong_log_timestamp_ms(void)
 {
@@ -450,10 +457,14 @@ static void update_host_session_scene_state(pong_state *state)
     sdl3d_properties_set_bool(scene_state, "multiplayer_host_connected", client_connected);
 }
 
-static void destroy_host_session(pong_state *state)
+static void destroy_host_session_internal(pong_state *state, bool notify_peer)
 {
     if (state != NULL && state->host_session != NULL)
     {
+        if (notify_peer)
+        {
+            (void)send_network_control_packet(state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT, "host disconnect");
+        }
         sdl3d_network_session_destroy(state->host_session);
         state->host_session = NULL;
     }
@@ -465,6 +476,11 @@ static void destroy_host_session(pong_state *state)
                      (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
         update_host_session_scene_state(state);
     }
+}
+
+static void destroy_host_session(pong_state *state)
+{
+    destroy_host_session_internal(state, true);
 }
 
 static void bind_local_play_controls(pong_state *state)
@@ -648,13 +664,23 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
     return true;
 }
 
-static void destroy_direct_connect_session(pong_state *state)
+static void destroy_direct_connect_session_internal(pong_state *state, bool notify_peer)
 {
     if (state != NULL && state->direct_connect_session != NULL)
     {
+        if (notify_peer)
+        {
+            (void)send_network_control_packet(state->direct_connect_session, PONG_NETWORK_MESSAGE_DISCONNECT,
+                                              "client disconnect");
+        }
         sdl3d_network_session_destroy(state->direct_connect_session);
         state->direct_connect_session = NULL;
     }
+}
+
+static void destroy_direct_connect_session(pong_state *state)
+{
+    destroy_direct_connect_session_internal(state, true);
 }
 
 static bool start_host_session(pong_state *state)
@@ -707,10 +733,81 @@ static void reset_direct_connect_defaults(pong_state *state)
     SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Ready to connect");
 }
 
+static bool send_network_control_packet(sdl3d_network_session *session, pong_network_message_kind kind,
+                                        const char *label)
+{
+    Uint8 packet[32];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+    const Uint32 tick = (Uint32)SDL_GetTicks();
+
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        return false;
+    }
+
+    if (!pong_network_write_u32(&cursor, end, PONG_NETWORK_PACKET_MAGIC) ||
+        !pong_network_write_u8(&cursor, end, PONG_NETWORK_PACKET_VERSION) ||
+        !pong_network_write_u8(&cursor, end, (Uint8)kind) || !pong_network_write_u8(&cursor, end, 0U) ||
+        !pong_network_write_u8(&cursor, end, 0U) || !pong_network_write_u32(&cursor, end, tick))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet encode failed: kind=%u",
+                    (unsigned int)kind);
+        return false;
+    }
+
+    if ((size_t)(cursor - packet) != PONG_NETWORK_CONTROL_PACKET_SIZE)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet size mismatch: expected=%zu actual=%zu",
+                    PONG_NETWORK_CONTROL_PACKET_SIZE, (size_t)(cursor - packet));
+        return false;
+    }
+
+    if (!sdl3d_network_session_send(session, packet, (int)(cursor - packet)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet send failed: %s", SDL_GetError());
+        return false;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong sent network control: %s kind=%u",
+                (unsigned long long)pong_log_timestamp_ms(), label != NULL ? label : "control", (unsigned int)kind);
+    return true;
+}
+
+static bool read_network_control_packet(const Uint8 *packet, int packet_size, pong_network_message_kind expected,
+                                        Uint32 *out_tick)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+
+    if (packet == NULL || (size_t)packet_size != PONG_NETWORK_CONTROL_PACKET_SIZE)
+    {
+        return false;
+    }
+
+    if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
+        !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
+        !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)expected ||
+        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
+        !pong_network_read_u32(&cursor, end, &tick) || cursor != end)
+    {
+        return false;
+    }
+
+    if (out_tick != NULL)
+    {
+        *out_tick = tick;
+    }
+    return true;
+}
+
 static bool send_host_start_packet(pong_state *state)
 {
-    Uint8 command = (Uint8)PONG_NETWORK_MESSAGE_START_GAME;
-
     if (state == NULL)
     {
         return false;
@@ -723,9 +820,8 @@ static bool send_host_start_packet(pong_state *state)
         return false;
     }
 
-    if (!sdl3d_network_session_send(state->host_session, &command, 1))
+    if (!send_network_control_packet(state->host_session, PONG_NETWORK_MESSAGE_START_GAME, "start game"))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host start packet send failed: %s", SDL_GetError());
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s", SDL_GetError());
         update_host_session_scene_state(state);
         return false;
@@ -823,7 +919,28 @@ static bool send_client_input_packet(pong_state *state)
     return true;
 }
 
-static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, const Uint8 **cursor, const Uint8 *end)
+static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_state *state)
+{
+    const int pause_action =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.pause") : -1;
+    pong_network_message_kind request_kind;
+
+    if (ctx == NULL || state == NULL || state->input == NULL || state->direct_connect_session == NULL ||
+        pause_action < 0 || !is_multiplayer_play_scene(state) || !is_network_role_client(state) ||
+        !sdl3d_network_session_is_connected(state->direct_connect_session) ||
+        !sdl3d_input_is_pressed(state->input, pause_action))
+    {
+        return;
+    }
+
+    request_kind = ctx->paused ? PONG_NETWORK_MESSAGE_RESUME_REQUEST : PONG_NETWORK_MESSAGE_PAUSE_REQUEST;
+    (void)send_network_control_packet(state->direct_connect_session, request_kind,
+                                      request_kind == PONG_NETWORK_MESSAGE_PAUSE_REQUEST ? "pause request"
+                                                                                         : "resume request");
+}
+
+static bool apply_play_state_snapshot(sdl3d_game_context *ctx, pong_state *state, Uint32 packet_tick,
+                                      const Uint8 **cursor, const Uint8 *end)
 {
     const Uint8 *packet_begin = cursor != NULL ? *cursor : NULL;
     sdl3d_registered_actor *player = NULL;
@@ -842,6 +959,7 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
     float last_reflect_y = 0.0f;
     int score_player = 0;
     int score_cpu = 0;
+    int paused = 0;
     int finished = 0;
     int winner = 0;
     int active_motion = 0;
@@ -866,8 +984,8 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
         !pong_network_read_vec3(cursor, end, &ball_position) || !pong_network_read_vec3(cursor, end, &ball_velocity) ||
         !pong_network_read_f32(cursor, end, &border_flash) || !pong_network_read_f32(cursor, end, &paddle_flash) ||
         !pong_network_read_i32(cursor, end, &score_player) || !pong_network_read_i32(cursor, end, &score_cpu) ||
-        !pong_network_read_i32(cursor, end, &finished) || !pong_network_read_i32(cursor, end, &winner) ||
-        !pong_network_read_i32(cursor, end, &active_motion) ||
+        !pong_network_read_i32(cursor, end, &paused) || !pong_network_read_i32(cursor, end, &finished) ||
+        !pong_network_read_i32(cursor, end, &winner) || !pong_network_read_i32(cursor, end, &active_motion) ||
         !pong_network_read_i32(cursor, end, &has_last_reflect_y) ||
         !pong_network_read_f32(cursor, end, &last_reflect_y) ||
         !pong_network_read_i32(cursor, end, &stagnant_reflect_count))
@@ -893,6 +1011,12 @@ static bool apply_play_state_snapshot(pong_state *state, Uint32 packet_tick, con
 
     sdl3d_properties_set_int(score_player_actor->props, "value", score_player);
     sdl3d_properties_set_int(score_cpu_actor->props, "value", score_cpu);
+    if (ctx != NULL && ctx->paused != (paused != 0))
+    {
+        ctx->paused = paused != 0;
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client mirrored host pause state: paused=%d",
+                    (unsigned long long)pong_log_timestamp_ms(), ctx->paused ? 1 : 0);
+    }
     sdl3d_properties_set_bool(match->props, "finished", finished != 0);
     sdl3d_properties_set_string(match->props, "winner", winner == 1 ? "player" : winner == 2 ? "cpu" : "none");
     sdl3d_properties_set_float(presentation->props, "border_flash", border_flash);
@@ -949,7 +1073,8 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
     return true;
 }
 
-static bool process_client_state_packet(pong_state *state, const Uint8 *packet, int packet_size)
+static bool process_client_state_packet(sdl3d_game_context *ctx, pong_state *state, const Uint8 *packet,
+                                        int packet_size)
 {
     const Uint8 *cursor = packet;
     const Uint8 *end = packet + packet_size;
@@ -989,11 +1114,79 @@ static bool process_client_state_packet(pong_state *state, const Uint8 *packet, 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "[%llu ms] Pong client received state packet tick=%u p1_up=%.3f p1_down=%.3f",
                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, p1_up, p1_down);
-    ok = apply_play_state_snapshot(state, tick, &cursor, end);
+    ok = apply_play_state_snapshot(ctx, state, tick, &cursor, end);
     return ok;
 }
 
-static bool send_host_state_packet(pong_state *state)
+static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong_state *state, bool local_host,
+                                                   const char *reason)
+{
+    if (state == NULL || state->data == NULL)
+    {
+        return;
+    }
+
+    clear_network_action_overrides(state);
+    if (ctx != NULL)
+    {
+        ctx->paused = false;
+    }
+
+    if (local_host)
+    {
+        SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
+                     reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
+        destroy_host_session_internal(state, false);
+        update_host_session_scene_state(state);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host peer disconnected: %s", state->host_status);
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
+    }
+    else
+    {
+        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
+                     reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
+        destroy_direct_connect_session_internal(state, false);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client peer disconnected: %s", state->direct_connect_status);
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+    }
+}
+
+static bool process_network_control_packet(sdl3d_game_context *ctx, pong_state *state, const Uint8 *packet,
+                                           int packet_size, pong_network_message_kind kind)
+{
+    Uint32 tick = 0U;
+    if (!read_network_control_packet(packet, packet_size, kind, &tick))
+    {
+        return false;
+    }
+
+    switch (kind)
+    {
+    case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
+        if (ctx != NULL && is_network_role_host(state))
+        {
+            ctx->paused = true;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer pause request tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
+        }
+        return true;
+    case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
+        if (ctx != NULL && is_network_role_host(state))
+        {
+            ctx->paused = false;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer resume request tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
+        }
+        return true;
+    case PONG_NETWORK_MESSAGE_DISCONNECT:
+        return_to_multiplayer_after_disconnect(ctx, state, is_network_role_host(state), "Peer disconnected");
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
 {
     Uint8 packet[160];
     Uint8 *cursor = packet;
@@ -1048,6 +1241,7 @@ static bool send_host_state_packet(pong_state *state)
         !pong_network_write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f)) ||
         !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(score_player_actor->props, "value", 0)) ||
         !pong_network_write_i32(&cursor, end, sdl3d_properties_get_int(score_cpu_actor->props, "value", 0)) ||
+        !pong_network_write_i32(&cursor, end, ctx != NULL && ctx->paused ? 1 : 0) ||
         !pong_network_write_i32(&cursor, end, sdl3d_properties_get_bool(match->props, "finished", false) ? 1 : 0) ||
         !pong_network_write_i32(
             &cursor, end,
@@ -1122,7 +1316,7 @@ static bool start_direct_connect_session(pong_state *state)
     return true;
 }
 
-static void update_direct_connect_session_status(pong_state *state)
+static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_state *state)
 {
     if (state == NULL)
     {
@@ -1151,6 +1345,28 @@ static void update_direct_connect_session_status(pong_state *state)
                 }
                 continue;
             }
+            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_START_GAME))
+            {
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
+                clear_network_action_overrides(state);
+                if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
+                {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
+                                SDL_GetError());
+                }
+                continue;
+            }
+            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT))
+            {
+                Uint32 tick = 0U;
+                if (read_network_control_packet(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+                {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
+                                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
+                    return_to_multiplayer_after_disconnect(ctx, state, false, "Host disconnected");
+                }
+                break;
+            }
             if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_STATE))
             {
                 if (!is_multiplayer_play_scene(state))
@@ -1166,18 +1382,35 @@ static void update_direct_connect_session_status(pong_state *state)
                         continue;
                     }
                 }
-                if (process_client_state_packet(state, packet, packet_size))
+                if (process_client_state_packet(ctx, state, packet, packet_size))
                 {
                     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong client applied authoritative state packet");
                 }
             }
         }
 
+        if (state->direct_connect_session == NULL)
+        {
+            return;
+        }
+
         const sdl3d_network_state session_state = sdl3d_network_session_state(state->direct_connect_session);
         if (session_state == SDL3D_NETWORK_STATE_REJECTED || session_state == SDL3D_NETWORK_STATE_TIMED_OUT ||
             session_state == SDL3D_NETWORK_STATE_ERROR)
         {
-            destroy_direct_connect_session(state);
+            const bool was_playing = is_multiplayer_play_scene(state);
+            const char *reason = session_state == SDL3D_NETWORK_STATE_TIMED_OUT  ? "Host timed out"
+                                 : session_state == SDL3D_NETWORK_STATE_REJECTED ? "Host rejected connection"
+                                                                                 : "Host connection error";
+            if (was_playing)
+            {
+                return_to_multiplayer_after_disconnect(ctx, state, false, reason);
+            }
+            else
+            {
+                SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s", reason);
+                destroy_direct_connect_session_internal(state, false);
+            }
         }
     }
 }
@@ -1443,7 +1676,7 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     sdl3d_ui_end_panel(state->discovery_ui);
 }
 
-static void update_host_session_status(pong_state *state, float dt)
+static void update_host_session_status(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     if (state == NULL)
     {
@@ -1461,8 +1694,33 @@ static void update_host_session_status(pong_state *state, float dt)
         int packet_size = 0;
         while ((packet_size = sdl3d_network_session_receive(state->host_session, packet, (int)sizeof(packet))) > 0)
         {
-            if (packet_size >= 12 && is_multiplayer_play_scene(state) && packet[0] == 'P' && packet[1] == 'O' &&
-                packet[2] == 'N' && packet[3] == 'G')
+            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT))
+            {
+                Uint32 tick = 0U;
+                if (read_network_control_packet(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+                {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
+                                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
+                    return_to_multiplayer_after_disconnect(ctx, state, true, "Client disconnected");
+                }
+                break;
+            }
+            if (is_multiplayer_play_scene(state) &&
+                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_PAUSE_REQUEST))
+            {
+                (void)process_network_control_packet(ctx, state, packet, packet_size,
+                                                     PONG_NETWORK_MESSAGE_PAUSE_REQUEST);
+                continue;
+            }
+            if (is_multiplayer_play_scene(state) &&
+                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_RESUME_REQUEST))
+            {
+                (void)process_network_control_packet(ctx, state, packet, packet_size,
+                                                     PONG_NETWORK_MESSAGE_RESUME_REQUEST);
+                continue;
+            }
+            if (is_multiplayer_play_scene(state) &&
+                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_INPUT))
             {
                 if (process_host_input_packet(state, packet, packet_size))
                 {
@@ -1482,7 +1740,12 @@ static void update_host_session_status(pong_state *state, float dt)
                  sdl3d_network_session_state(state->host_session) != SDL3D_NETWORK_STATE_CONNECTED)
         {
             clear_network_action_overrides(state);
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host client disconnected, returning to lobby");
+            if (ctx != NULL)
+            {
+                ctx->paused = false;
+            }
+            SDL_snprintf(state->host_status, sizeof(state->host_status), "Client timed out");
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host client timed out, returning to lobby");
             (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
         }
         return;
@@ -1494,14 +1757,14 @@ static void update_host_session_status(pong_state *state, float dt)
     }
 }
 
-static void update_multiplayer_sessions(pong_state *state, float dt)
+static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     if (state == NULL)
     {
         return;
     }
 
-    update_host_session_status(state, dt);
+    update_host_session_status(ctx, state, dt);
 
     if (state->host_session != NULL)
     {
@@ -1539,7 +1802,7 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong direct-connect session update failed: %s", SDL_GetError());
         }
 
-        update_direct_connect_session_status(state);
+        update_direct_connect_session_status(ctx, state);
 
         const bool keep_direct_connect_session =
             is_direct_connect_scene(state) || is_multiplayer_discovery_scene(state) || is_multiplayer_play_scene(state);
@@ -1551,11 +1814,12 @@ static void update_multiplayer_sessions(pong_state *state, float dt)
 
     if (state->direct_connect_session != NULL && is_multiplayer_play_scene(state) && is_network_role_client(state))
     {
+        send_client_pause_request_if_pressed(ctx, state);
         (void)send_client_input_packet(state);
     }
 }
 
-static void publish_multiplayer_state(pong_state *state)
+static void publish_multiplayer_state(sdl3d_game_context *ctx, pong_state *state)
 {
     if (state == NULL || state->host_session == NULL || !is_multiplayer_play_scene(state) ||
         !is_network_role_host(state))
@@ -1563,7 +1827,7 @@ static void publish_multiplayer_state(pong_state *state)
         return;
     }
 
-    if (!send_host_state_packet(state))
+    if (!send_host_state_packet(ctx, state))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to publish multiplayer state");
     }
@@ -1958,7 +2222,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
-    update_multiplayer_sessions(state, dt);
+    update_multiplayer_sessions(ctx, state, dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
@@ -1968,14 +2232,14 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
                                                      .particle_cache = &state->particle_cache,
                                                      .dt = dt};
     (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
-    publish_multiplayer_state(state);
+    publish_multiplayer_state(ctx, state);
 }
 
 static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
-    update_multiplayer_sessions(state, real_dt);
+    update_multiplayer_sessions(ctx, state, real_dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
@@ -1985,7 +2249,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
                                                      .particle_cache = &state->particle_cache,
                                                      .dt = real_dt};
     (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
-    publish_multiplayer_state(state);
+    publish_multiplayer_state(ctx, state);
 }
 
 static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -76,6 +76,8 @@ static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 112U;
 
 static bool send_network_control_packet(sdl3d_network_session *session, pong_network_message_kind kind,
                                         const char *label);
+static bool send_network_control_packet_repeated(sdl3d_network_session *session, pong_network_message_kind kind,
+                                                 const char *label, int count);
 
 static Uint64 pong_log_timestamp_ms(void)
 {
@@ -466,7 +468,8 @@ static void destroy_host_session_internal(pong_state *state, bool notify_peer)
     {
         if (notify_peer)
         {
-            (void)send_network_control_packet(state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT, "host disconnect");
+            (void)send_network_control_packet_repeated(state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT,
+                                                       "host disconnect", 5);
         }
         sdl3d_network_session_destroy(state->host_session);
         state->host_session = NULL;
@@ -673,8 +676,8 @@ static void destroy_direct_connect_session_internal(pong_state *state, bool noti
     {
         if (notify_peer)
         {
-            (void)send_network_control_packet(state->direct_connect_session, PONG_NETWORK_MESSAGE_DISCONNECT,
-                                              "client disconnect");
+            (void)send_network_control_packet_repeated(state->direct_connect_session, PONG_NETWORK_MESSAGE_DISCONNECT,
+                                                       "client disconnect", 5);
         }
         sdl3d_network_session_destroy(state->direct_connect_session);
         state->direct_connect_session = NULL;
@@ -775,6 +778,27 @@ static bool send_network_control_packet(sdl3d_network_session *session, pong_net
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong sent network control: %s kind=%u",
                 (unsigned long long)pong_log_timestamp_ms(), label != NULL ? label : "control", (unsigned int)kind);
     return true;
+}
+
+static bool send_network_control_packet_repeated(sdl3d_network_session *session, pong_network_message_kind kind,
+                                                 const char *label, int count)
+{
+    bool sent_any = false;
+    const int attempts = SDL_max(count, 1);
+
+    for (int i = 0; i < attempts; ++i)
+    {
+        if (send_network_control_packet(session, kind, label))
+        {
+            sent_any = true;
+        }
+        if (session != NULL)
+        {
+            (void)sdl3d_network_session_update(session, 0.0f);
+        }
+    }
+
+    return sent_any;
 }
 
 static bool read_network_control_packet(const Uint8 *packet, int packet_size, pong_network_message_kind expected,
@@ -1137,7 +1161,7 @@ static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state 
 
     SDL_snprintf(state->network_match_termination_reason, sizeof(state->network_match_termination_reason), "%s",
                  reason != NULL && reason[0] != '\0' ? reason : "Peer disconnected");
-    state->network_match_termination_timer = 2.0f;
+    state->network_match_termination_timer = 0.0f;
     state->network_match_termination_active = true;
 
     if (local_host)
@@ -1406,7 +1430,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                 {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
                                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                    return_to_multiplayer_after_disconnect(ctx, state, false, "Host disconnected");
+                    return_to_multiplayer_after_disconnect(ctx, state, false, "Host exited");
                 }
                 break;
             }
@@ -1460,13 +1484,21 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
 
 static void update_network_match_termination(pong_state *state, float dt)
 {
+    const int select_action =
+        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.menu.select") : -1;
+
     if (state == NULL || !state->network_match_termination_active)
     {
         return;
     }
 
-    state->network_match_termination_timer -= SDL_max(dt, 0.0f);
-    if (state->network_match_termination_timer > 0.0f)
+    state->network_match_termination_timer += SDL_max(dt, 0.0f);
+    if (state->network_match_termination_timer < 0.25f)
+    {
+        return;
+    }
+
+    if (state->input == NULL || select_action < 0 || !sdl3d_input_is_pressed(state->input, select_action))
     {
         return;
     }
@@ -1766,7 +1798,7 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
                 {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
                                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                    return_to_multiplayer_after_disconnect(ctx, state, true, "Client disconnected");
+                    return_to_multiplayer_after_disconnect(ctx, state, true, "Client exited");
                 }
                 break;
             }
@@ -1977,7 +2009,7 @@ static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong
         return;
     }
 
-    SDL_snprintf(message, sizeof(message), "Match terminated: %s - Returning to title screen.",
+    SDL_snprintf(message, sizeof(message), "Match terminated: %s - Press Enter to return to title screen.",
                  state->network_match_termination_reason[0] != '\0' ? state->network_match_termination_reason
                                                                     : "Peer disconnected");
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -286,6 +286,14 @@ static bool is_local_match_mode(const pong_state *state)
     return match_mode != NULL && SDL_strcmp(match_mode, "local") == 0;
 }
 
+static bool is_network_match_mode(const pong_state *state)
+{
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", NULL) : NULL;
+    return match_mode != NULL && SDL_strcmp(match_mode, "lan") == 0;
+}
+
 static bool is_network_flow_host(const pong_state *state)
 {
     const sdl3d_properties *scene_state =
@@ -313,12 +321,12 @@ static const char *network_role_name(const pong_state *state)
 
 static bool is_network_role_host(const pong_state *state)
 {
-    return SDL_strcmp(network_role_name(state), "host") == 0;
+    return is_network_match_mode(state) && SDL_strcmp(network_role_name(state), "host") == 0;
 }
 
 static bool is_network_role_client(const pong_state *state)
 {
-    return SDL_strcmp(network_role_name(state), "client") == 0;
+    return is_network_match_mode(state) && SDL_strcmp(network_role_name(state), "client") == 0;
 }
 
 static bool pong_network_packet_is_kind(const Uint8 *packet, int packet_size, pong_network_message_kind kind)
@@ -589,14 +597,24 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
 
     const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(state->data);
     sdl3d_properties *mutable_scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-    const char *match_mode = scene_context_string(payload, scene_state, "match_mode", "single");
-    const char *network_role = scene_context_string(payload, scene_state, "network_role", "none");
-    const char *network_flow = scene_context_string(payload, scene_state, "network_flow", "none");
+    const char *requested_match_mode = scene_context_string(payload, scene_state, "match_mode", "single");
+    const bool requested_lan = requested_match_mode != NULL && SDL_strcmp(requested_match_mode, "lan") == 0;
+    const char *requested_network_role =
+        requested_lan ? scene_context_string(payload, scene_state, "network_role", "none") : "none";
+    const char *requested_network_flow =
+        requested_lan ? scene_context_string(payload, scene_state, "network_flow", "none") : "none";
+    const bool valid_network_role =
+        requested_network_role != NULL &&
+        (SDL_strcmp(requested_network_role, "host") == 0 || SDL_strcmp(requested_network_role, "client") == 0);
+    const char *match_mode = requested_lan && !valid_network_role ? "single" : requested_match_mode;
+    const char *network_role = requested_lan && valid_network_role ? requested_network_role : "none";
+    const char *network_flow = requested_lan && valid_network_role ? requested_network_flow : "none";
 
     clear_network_action_overrides(state);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong play input context: match_mode=%s network_role=%s network_flow=%s",
-                match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
-                network_flow != NULL ? network_flow : "none");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Pong play input context: requested_match_mode=%s match_mode=%s network_role=%s network_flow=%s",
+                requested_match_mode != NULL ? requested_match_mode : "none", match_mode != NULL ? match_mode : "none",
+                network_role != NULL ? network_role : "none", network_flow != NULL ? network_flow : "none");
 
     if (mutable_scene_state != NULL)
     {
@@ -1838,7 +1856,9 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         update_host_session_scene_state(state);
 
         const char *active_scene = active_scene_name(state);
-        if (active_scene == NULL || (!is_multiplayer_lobby_scene(state) && !is_multiplayer_play_scene(state)))
+        const bool keep_host_session =
+            is_multiplayer_lobby_scene(state) || (is_multiplayer_play_scene(state) && is_network_role_host(state));
+        if (active_scene == NULL || !keep_host_session)
         {
             destroy_host_session(state);
         }
@@ -1896,8 +1916,9 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
 
     if (state->direct_connect_session != NULL)
     {
-        const bool keep_direct_connect_session =
-            is_direct_connect_scene(state) || is_multiplayer_discovery_scene(state) || is_multiplayer_play_scene(state);
+        const bool keep_direct_connect_session = is_direct_connect_scene(state) ||
+                                                 is_multiplayer_discovery_scene(state) ||
+                                                 (is_multiplayer_play_scene(state) && is_network_role_client(state));
         if (!keep_direct_connect_session)
         {
             destroy_direct_connect_session(state);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -53,6 +53,9 @@ typedef struct pong_state
     int discovery_refresh_signal_id;
     int discovery_refresh_connection;
     int local_input_gamepad_count;
+    bool network_match_termination_active;
+    float network_match_termination_timer;
+    char network_match_termination_reason[96];
 } pong_state;
 
 typedef enum pong_network_message_kind
@@ -1118,11 +1121,53 @@ static bool process_client_state_packet(sdl3d_game_context *ctx, pong_state *sta
     return ok;
 }
 
+static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state *state, bool local_host,
+                                            const char *reason)
+{
+    if (state == NULL || state->data == NULL)
+    {
+        return;
+    }
+
+    clear_network_action_overrides(state);
+    if (ctx != NULL)
+    {
+        ctx->paused = false;
+    }
+
+    SDL_snprintf(state->network_match_termination_reason, sizeof(state->network_match_termination_reason), "%s",
+                 reason != NULL && reason[0] != '\0' ? reason : "Peer disconnected");
+    state->network_match_termination_timer = 2.0f;
+    state->network_match_termination_active = true;
+
+    if (local_host)
+    {
+        destroy_host_session_internal(state, false);
+        SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
+                     reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
+        update_host_session_scene_state(state);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host match terminated: %s", state->host_status);
+    }
+    else
+    {
+        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
+                     reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
+        destroy_direct_connect_session_internal(state, false);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client match terminated: %s", state->direct_connect_status);
+    }
+}
+
 static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong_state *state, bool local_host,
                                                    const char *reason)
 {
     if (state == NULL || state->data == NULL)
     {
+        return;
+    }
+
+    if (is_multiplayer_play_scene(state))
+    {
+        begin_network_match_termination(ctx, state, local_host, reason);
         return;
     }
 
@@ -1138,7 +1183,6 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
                      reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
         destroy_host_session_internal(state, false);
         update_host_session_scene_state(state);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host peer disconnected: %s", state->host_status);
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
     }
     else
@@ -1146,7 +1190,6 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
                      reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
         destroy_direct_connect_session_internal(state, false);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client peer disconnected: %s", state->direct_connect_status);
         (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
     }
 }
@@ -1412,6 +1455,28 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                 destroy_direct_connect_session_internal(state, false);
             }
         }
+    }
+}
+
+static void update_network_match_termination(pong_state *state, float dt)
+{
+    if (state == NULL || !state->network_match_termination_active)
+    {
+        return;
+    }
+
+    state->network_match_termination_timer -= SDL_max(dt, 0.0f);
+    if (state->network_match_termination_timer > 0.0f)
+    {
+        return;
+    }
+
+    state->network_match_termination_active = false;
+    state->network_match_termination_timer = 0.0f;
+    state->network_match_termination_reason[0] = '\0';
+    if (state->data != NULL)
+    {
+        (void)sdl3d_game_data_set_active_scene(state->data, "scene.title");
     }
 }
 
@@ -1739,14 +1804,7 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         else if (is_multiplayer_play_scene(state) && state->host_session != NULL &&
                  sdl3d_network_session_state(state->host_session) != SDL3D_NETWORK_STATE_CONNECTED)
         {
-            clear_network_action_overrides(state);
-            if (ctx != NULL)
-            {
-                ctx->paused = false;
-            }
-            SDL_snprintf(state->host_status, sizeof(state->host_status), "Client timed out");
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host client timed out, returning to lobby");
-            (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
+            begin_network_match_termination(ctx, state, true, "Client timed out");
         }
         return;
     }
@@ -1797,19 +1855,20 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
 
     if (state->direct_connect_session != NULL)
     {
+        const bool keep_direct_connect_session =
+            is_direct_connect_scene(state) || is_multiplayer_discovery_scene(state) || is_multiplayer_play_scene(state);
+        if (!keep_direct_connect_session)
+        {
+            destroy_direct_connect_session(state);
+            return;
+        }
+
         if (!sdl3d_network_session_update(state->direct_connect_session, dt))
         {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong direct-connect session update failed: %s", SDL_GetError());
         }
 
         update_direct_connect_session_status(ctx, state);
-
-        const bool keep_direct_connect_session =
-            is_direct_connect_scene(state) || is_multiplayer_discovery_scene(state) || is_multiplayer_play_scene(state);
-        if (!keep_direct_connect_session)
-        {
-            destroy_direct_connect_session(state);
-        }
     }
 
     if (state->direct_connect_session != NULL && is_multiplayer_play_scene(state) && is_network_role_client(state))
@@ -1901,6 +1960,35 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
     sdl3d_ui_layout_label(state->direct_connect_ui, "Status");
     sdl3d_ui_layout_label(state->direct_connect_ui, state->direct_connect_status);
 
+    sdl3d_ui_end_vbox(state->direct_connect_ui);
+    sdl3d_ui_end_panel(state->direct_connect_ui);
+}
+
+static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong_state *state)
+{
+    char message[192];
+    float panel_w;
+    float panel_h;
+    float panel_x;
+    float panel_y;
+
+    if (ctx == NULL || state == NULL || state->direct_connect_ui == NULL || !state->network_match_termination_active)
+    {
+        return;
+    }
+
+    SDL_snprintf(message, sizeof(message), "Match terminated: %s - Returning to title screen.",
+                 state->network_match_termination_reason[0] != '\0' ? state->network_match_termination_reason
+                                                                    : "Peer disconnected");
+
+    panel_w = 880.0f;
+    panel_h = 150.0f;
+    panel_x = ((float)sdl3d_get_render_context_width(ctx->renderer) - panel_w) * 0.5f;
+    panel_y = ((float)sdl3d_get_render_context_height(ctx->renderer) - panel_h) * 0.5f;
+
+    sdl3d_ui_begin_panel(state->direct_connect_ui, panel_x, panel_y, panel_w, panel_h);
+    sdl3d_ui_begin_vbox(state->direct_connect_ui, panel_x + 28.0f, panel_y + 34.0f, panel_w - 56.0f, panel_h - 68.0f);
+    sdl3d_ui_layout_label(state->direct_connect_ui, message);
     sdl3d_ui_end_vbox(state->direct_connect_ui);
     sdl3d_ui_end_panel(state->direct_connect_ui);
 }
@@ -2222,6 +2310,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
+    update_network_match_termination(state, dt);
     update_multiplayer_sessions(ctx, state, dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
@@ -2239,6 +2328,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
 {
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
+    update_network_match_termination(state, real_dt);
     update_multiplayer_sessions(ctx, state, real_dt);
     update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
@@ -2280,6 +2370,7 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     {
         draw_discovery_overlay(ctx, state);
     }
+    draw_network_match_termination_overlay(ctx, state);
     if (state->direct_connect_ui != NULL)
     {
         sdl3d_ui_end_frame(state->direct_connect_ui);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -35,7 +35,6 @@ typedef struct pong_state
     sdl3d_font direct_connect_font;
     sdl3d_ui_context *direct_connect_ui;
     sdl3d_ui_context *discovery_ui;
-    sdl3d_ui_context *lobby_ui;
     sdl3d_network_session *host_session;
     sdl3d_network_session *direct_connect_session;
     sdl3d_network_discovery_session *discovery_session;
@@ -428,20 +427,27 @@ static void update_host_session_scene_state(pong_state *state)
     char client_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 48];
     char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
     Uint16 peer_port = 0;
+    const bool client_connected =
+        state->host_session != NULL && sdl3d_network_session_is_connected(state->host_session);
     SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
                  status != NULL && status[0] != '\0' ? status : "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u", (unsigned int)port);
     SDL_snprintf(client_label, sizeof(client_label), "Waiting for client");
     SDL_zero(peer_host);
-    if (state->host_session != NULL &&
+    if (client_connected &&
         sdl3d_network_session_get_peer_endpoint(state->host_session, peer_host, (int)sizeof(peer_host), &peer_port))
     {
         SDL_snprintf(client_label, sizeof(client_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
+    }
+    else if (client_connected)
+    {
+        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - Connected");
     }
 
     sdl3d_properties_set_string(scene_state, "multiplayer_host_status", state->host_status);
     sdl3d_properties_set_string(scene_state, "multiplayer_host_endpoint", state->host_endpoint);
     sdl3d_properties_set_string(scene_state, "multiplayer_host_client", client_label);
+    sdl3d_properties_set_bool(scene_state, "multiplayer_host_connected", client_connected);
 }
 
 static void destroy_host_session(pong_state *state)
@@ -1402,54 +1408,6 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     sdl3d_ui_end_panel(state->discovery_ui);
 }
 
-static void draw_lobby_overlay(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (ctx == NULL || state == NULL || state->lobby_ui == NULL)
-    {
-        return;
-    }
-
-    const int screen_w = sdl3d_get_render_context_width(ctx->renderer);
-    const int screen_h = sdl3d_get_render_context_height(ctx->renderer);
-    const float panel_w = 620.0f;
-    const float panel_h = 190.0f;
-    const float panel_x = ((float)screen_w - panel_w) * 0.5f;
-    const float panel_y = (float)screen_h * 0.45f;
-    const bool client_connected =
-        state->host_session != NULL && sdl3d_network_session_is_connected(state->host_session);
-    char client_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 64];
-    char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
-    Uint16 peer_port = 0;
-
-    SDL_snprintf(client_label, sizeof(client_label), "Client 1 - Connected");
-    SDL_zero(peer_host);
-    if (state->host_session != NULL &&
-        sdl3d_network_session_get_peer_endpoint(state->host_session, peer_host, (int)sizeof(peer_host), &peer_port))
-    {
-        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
-    }
-
-    sdl3d_ui_begin_panel(state->lobby_ui, panel_x, panel_y, panel_w, panel_h);
-    sdl3d_ui_begin_vbox(state->lobby_ui, panel_x + 28.0f, panel_y + 22.0f, panel_w - 56.0f, panel_h - 44.0f);
-    sdl3d_ui_layout_label(state->lobby_ui, "AVAILABLE CLIENTS");
-    sdl3d_ui_separator(state->lobby_ui);
-
-    if (client_connected)
-    {
-        if (sdl3d_ui_layout_button(state->lobby_ui, client_label))
-        {
-            (void)start_selected_lobby_match(state);
-        }
-    }
-    else
-    {
-        sdl3d_ui_layout_label(state->lobby_ui, "Waiting for client...");
-    }
-
-    sdl3d_ui_end_vbox(state->lobby_ui);
-    sdl3d_ui_end_panel(state->lobby_ui);
-}
-
 static void update_host_session_status(pong_state *state, float dt)
 {
     if (state == NULL)
@@ -1827,20 +1785,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         state->assets = NULL;
         return false;
     }
-    if (!sdl3d_ui_create(&state->direct_connect_font, &state->lobby_ui))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong lobby UI create failed: %s", SDL_GetError());
-        sdl3d_ui_destroy(state->discovery_ui);
-        state->discovery_ui = NULL;
-        sdl3d_ui_destroy(state->direct_connect_ui);
-        state->direct_connect_ui = NULL;
-        sdl3d_free_font(&state->direct_connect_font);
-        sdl3d_game_data_destroy(state->data);
-        state->data = NULL;
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
-        return false;
-    }
     reset_direct_connect_defaults(state);
     if (ctx != NULL && ctx->window != NULL)
     {
@@ -1854,19 +1798,10 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
     }
-    if (state->lobby_ui != NULL && ctx != NULL && ctx->renderer != NULL && ctx->window != NULL)
-    {
-        sdl3d_ui_begin_frame_ex(state->lobby_ui, ctx->renderer, ctx->window);
-    }
     sdl3d_game_data_image_cache_init(&state->image_cache, state->assets);
     if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
     {
         sdl3d_game_data_image_cache_free(&state->image_cache);
-        if (state->lobby_ui != NULL)
-        {
-            sdl3d_ui_destroy(state->lobby_ui);
-            state->lobby_ui = NULL;
-        }
         if (state->discovery_ui != NULL)
         {
             sdl3d_ui_destroy(state->discovery_ui);
@@ -1975,17 +1910,6 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
             ctx->input_event_consumed = true;
         }
     }
-    if (state != NULL && is_multiplayer_lobby_scene(state) && state->lobby_ui != NULL && event != NULL)
-    {
-        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
-                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
-
-        if (mouse_event)
-        {
-            (void)sdl3d_ui_process_event(state->lobby_ui, event);
-            ctx->input_event_consumed = true;
-        }
-    }
     (void)ctx;
     return true;
 }
@@ -2050,11 +1974,6 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     {
         draw_discovery_overlay(ctx, state);
     }
-    if (is_multiplayer_lobby_scene(state))
-    {
-        draw_lobby_overlay(ctx, state);
-    }
-
     if (state->direct_connect_ui != NULL)
     {
         sdl3d_ui_end_frame(state->direct_connect_ui);
@@ -2066,12 +1985,6 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
         sdl3d_ui_end_frame(state->discovery_ui);
         sdl3d_ui_render(state->discovery_ui, ctx->renderer);
         sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
-    }
-    if (state->lobby_ui != NULL)
-    {
-        sdl3d_ui_end_frame(state->lobby_ui);
-        sdl3d_ui_render(state->lobby_ui, ctx->renderer);
-        sdl3d_ui_begin_frame_ex(state->lobby_ui, ctx->renderer, ctx->window);
     }
 }
 
@@ -2108,11 +2021,6 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_destroy(state->discovery_ui);
         state->discovery_ui = NULL;
-    }
-    if (state->lobby_ui != NULL)
-    {
-        sdl3d_ui_destroy(state->lobby_ui);
-        state->lobby_ui = NULL;
     }
     if (state->direct_connect_ui != NULL)
     {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -15,6 +15,7 @@
 #include "sdl3d/game_presentation.h"
 #include "sdl3d/network.h"
 #include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
 #include "sdl3d/ui.h"
 
 #if SDL3D_PONG_EMBEDDED_ASSETS
@@ -34,6 +35,7 @@ typedef struct pong_state
     sdl3d_font direct_connect_font;
     sdl3d_ui_context *direct_connect_ui;
     sdl3d_ui_context *discovery_ui;
+    sdl3d_ui_context *lobby_ui;
     sdl3d_network_session *host_session;
     sdl3d_network_session *direct_connect_session;
     sdl3d_network_discovery_session *discovery_session;
@@ -46,6 +48,7 @@ typedef struct pong_state
     int vibration_connection;
     int lobby_start_connection;
     int host_start_signal_id;
+    int camera_toggle_signal_id;
     int ball_hit_signal_id;
     int vibration_signal_id;
     int discovery_refresh_signal_id;
@@ -307,6 +310,12 @@ static bool is_network_role_client(const pong_state *state)
     return SDL_strcmp(network_role_name(state), "client") == 0;
 }
 
+static bool pong_network_packet_is_kind(const Uint8 *packet, int packet_size, pong_network_message_kind kind)
+{
+    return packet != NULL && packet_size >= 6 && packet[0] == 'P' && packet[1] == 'O' && packet[2] == 'N' &&
+           packet[3] == 'G' && packet[4] == PONG_NETWORK_PACKET_VERSION && packet[5] == (Uint8)kind;
+}
+
 static const char *scene_payload_string(const sdl3d_properties *payload, const char *key)
 {
     return payload != NULL ? sdl3d_properties_get_string(payload, key, NULL) : NULL;
@@ -323,7 +332,8 @@ static const char *scene_context_string(const sdl3d_properties *payload, const s
     return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
 }
 
-static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode, const char *network_role)
+static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode, const char *network_role,
+                                         const char *network_flow)
 {
     sdl3d_properties *payload = NULL;
     bool ok = false;
@@ -346,6 +356,10 @@ static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mo
     if (network_role != NULL)
     {
         sdl3d_properties_set_string(payload, "network_role", network_role);
+    }
+    if (network_flow != NULL)
+    {
+        sdl3d_properties_set_string(payload, "network_flow", network_flow);
     }
 
     ok = sdl3d_game_data_set_active_scene_with_payload(state->data, "scene.play", payload);
@@ -411,16 +425,23 @@ static void update_host_session_scene_state(pong_state *state)
         state->host_session != NULL ? sdl3d_network_session_status(state->host_session) : state->host_status;
     const Uint16 port =
         state->host_session != NULL ? sdl3d_network_session_port(state->host_session) : SDL3D_NETWORK_DEFAULT_PORT;
+    char client_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 48];
+    char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    Uint16 peer_port = 0;
     SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
                  status != NULL && status[0] != '\0' ? status : "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u", (unsigned int)port);
+    SDL_snprintf(client_label, sizeof(client_label), "Waiting for client");
+    SDL_zero(peer_host);
+    if (state->host_session != NULL &&
+        sdl3d_network_session_get_peer_endpoint(state->host_session, peer_host, (int)sizeof(peer_host), &peer_port))
+    {
+        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
+    }
 
     sdl3d_properties_set_string(scene_state, "multiplayer_host_status", state->host_status);
     sdl3d_properties_set_string(scene_state, "multiplayer_host_endpoint", state->host_endpoint);
-    sdl3d_properties_set_string(scene_state, "multiplayer_host_client",
-                                state->host_session != NULL && sdl3d_network_session_is_connected(state->host_session)
-                                    ? "Client connected"
-                                    : "Waiting for client");
+    sdl3d_properties_set_string(scene_state, "multiplayer_host_client", client_label);
 }
 
 static void destroy_host_session(pong_state *state)
@@ -705,6 +726,36 @@ static bool send_host_start_packet(pong_state *state)
     }
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host requested multiplayer start");
+    return true;
+}
+
+static bool start_selected_lobby_match(pong_state *state)
+{
+    if (state == NULL)
+    {
+        return false;
+    }
+
+    if (state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session))
+    {
+        SDL_snprintf(state->host_status, sizeof(state->host_status), "Waiting for client");
+        update_host_session_scene_state(state);
+        return false;
+    }
+
+    if (!send_host_start_packet(state))
+    {
+        return false;
+    }
+
+    clear_network_action_overrides(state);
+    if (!enter_multiplayer_play_scene(state, "lan", "host", "host"))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to enter multiplayer play scene: %s",
+                    SDL_GetError());
+        return false;
+    }
+
     return true;
 }
 
@@ -1087,15 +1138,28 @@ static void update_direct_connect_session_status(pong_state *state)
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
                 clear_network_action_overrides(state);
-                if (!enter_multiplayer_play_scene(state, "lan", "client"))
+                if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
                 {
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
                                 SDL_GetError());
                 }
-                break;
+                continue;
             }
-            if (is_multiplayer_play_scene(state) && packet_size >= 12)
+            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_STATE))
             {
+                if (!is_multiplayer_play_scene(state))
+                {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "Pong client received authoritative state before start command; entering play scene");
+                    clear_network_action_overrides(state);
+                    if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
+                    {
+                        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                    "Pong client failed to enter multiplayer play scene from state packet: %s",
+                                    SDL_GetError());
+                        continue;
+                    }
+                }
                 if (process_client_state_packet(state, packet, packet_size))
                 {
                     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong client applied authoritative state packet");
@@ -1338,6 +1402,54 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     sdl3d_ui_end_panel(state->discovery_ui);
 }
 
+static void draw_lobby_overlay(sdl3d_game_context *ctx, pong_state *state)
+{
+    if (ctx == NULL || state == NULL || state->lobby_ui == NULL)
+    {
+        return;
+    }
+
+    const int screen_w = sdl3d_get_render_context_width(ctx->renderer);
+    const int screen_h = sdl3d_get_render_context_height(ctx->renderer);
+    const float panel_w = 620.0f;
+    const float panel_h = 190.0f;
+    const float panel_x = ((float)screen_w - panel_w) * 0.5f;
+    const float panel_y = (float)screen_h * 0.45f;
+    const bool client_connected =
+        state->host_session != NULL && sdl3d_network_session_is_connected(state->host_session);
+    char client_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 64];
+    char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    Uint16 peer_port = 0;
+
+    SDL_snprintf(client_label, sizeof(client_label), "Client 1 - Connected");
+    SDL_zero(peer_host);
+    if (state->host_session != NULL &&
+        sdl3d_network_session_get_peer_endpoint(state->host_session, peer_host, (int)sizeof(peer_host), &peer_port))
+    {
+        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
+    }
+
+    sdl3d_ui_begin_panel(state->lobby_ui, panel_x, panel_y, panel_w, panel_h);
+    sdl3d_ui_begin_vbox(state->lobby_ui, panel_x + 28.0f, panel_y + 22.0f, panel_w - 56.0f, panel_h - 44.0f);
+    sdl3d_ui_layout_label(state->lobby_ui, "AVAILABLE CLIENTS");
+    sdl3d_ui_separator(state->lobby_ui);
+
+    if (client_connected)
+    {
+        if (sdl3d_ui_layout_button(state->lobby_ui, client_label))
+        {
+            (void)start_selected_lobby_match(state);
+        }
+    }
+    else
+    {
+        sdl3d_ui_layout_label(state->lobby_ui, "Waiting for client...");
+    }
+
+    sdl3d_ui_end_vbox(state->lobby_ui);
+    sdl3d_ui_end_panel(state->lobby_ui);
+}
+
 static void update_host_session_status(pong_state *state, float dt)
 {
     if (state == NULL)
@@ -1459,46 +1571,22 @@ static void publish_multiplayer_state(pong_state *state)
     }
 }
 
-static void predict_client_paddle_motion(pong_state *state, float dt)
+static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_state *state)
 {
-    sdl3d_registered_actor *cpu = NULL;
-    const sdl3d_input_snapshot *snapshot = NULL;
-    const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
-    const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
+    const int camera_toggle_action =
+        sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.camera.ball.toggle");
 
-    if (state == NULL || state->input == NULL || state->data == NULL || !is_multiplayer_play_scene(state) ||
-        !is_network_role_client(state) || p2_up < 0 || p2_down < 0)
+    if (ctx == NULL || state == NULL || state->input == NULL || state->data == NULL ||
+        state->camera_toggle_signal_id < 0 || camera_toggle_action < 0 || !is_multiplayer_play_scene(state) ||
+        !is_network_role_client(state))
     {
         return;
     }
 
-    cpu = sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu");
-    snapshot = sdl3d_input_get_snapshot(state->input);
-    if (cpu == NULL || snapshot == NULL)
+    if (sdl3d_input_is_pressed(state->input, camera_toggle_action))
     {
-        return;
+        sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(ctx->session), state->camera_toggle_signal_id, NULL);
     }
-
-    const float up_value = snapshot->actions[p2_up].value;
-    const float down_value = snapshot->actions[p2_down].value;
-    const float input_value = SDL_clamp(up_value - down_value, -1.0f, 1.0f);
-    if (SDL_fabsf(input_value) <= 0.0001f)
-    {
-        return;
-    }
-
-    const float speed = sdl3d_properties_get_float(cpu->props, "speed", 0.0f);
-    const float half_height = sdl3d_properties_get_float(cpu->props, "half_height", 0.0f);
-    const float lo = -4.78f + half_height;
-    const float hi = 4.78f - half_height;
-    sdl3d_vec3 position = cpu->position;
-    const float old_y = position.y;
-    position.y = SDL_clamp(position.y + input_value * speed * dt, lo, hi);
-    cpu->position = position;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong client predicted paddle2 motion: input=%.3f dt=%.3f y=%.3f->%.3f scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(), input_value, dt, old_y, position.y,
-                active_scene_name(state) != NULL ? active_scene_name(state) : "<none>");
 }
 
 static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *state)
@@ -1518,7 +1606,7 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
     sdl3d_ui_begin_panel(state->direct_connect_ui, panel_x, panel_y, panel_w, panel_h);
     sdl3d_ui_begin_vbox(state->direct_connect_ui, panel_x + 28.0f, panel_y + 24.0f, panel_w - 56.0f, panel_h - 48.0f);
 
-    sdl3d_ui_layout_label(state->direct_connect_ui, "DIRECT CONNECT");
+    sdl3d_ui_layout_label(state->direct_connect_ui, "JOIN MATCH");
     sdl3d_ui_layout_label(state->direct_connect_ui, "Host");
     (void)sdl3d_ui_layout_text_field(state->direct_connect_ui, state->direct_connect_host,
                                      (int)sizeof(state->direct_connect_host));
@@ -1622,24 +1710,7 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
         return;
     }
 
-    if (state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session))
-    {
-        SDL_snprintf(state->host_status, sizeof(state->host_status), "Waiting for client");
-        update_host_session_scene_state(state);
-        return;
-    }
-
-    if (!send_host_start_packet(state))
-    {
-        return;
-    }
-
-    clear_network_action_overrides(state);
-    if (!enter_multiplayer_play_scene(state, "lan", "host"))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to enter multiplayer play scene: %s",
-                    SDL_GetError());
-    }
+    (void)start_selected_lobby_match(state);
 }
 
 static void on_multiplayer_discovery_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -1756,6 +1827,20 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         state->assets = NULL;
         return false;
     }
+    if (!sdl3d_ui_create(&state->direct_connect_font, &state->lobby_ui))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong lobby UI create failed: %s", SDL_GetError());
+        sdl3d_ui_destroy(state->discovery_ui);
+        state->discovery_ui = NULL;
+        sdl3d_ui_destroy(state->direct_connect_ui);
+        state->direct_connect_ui = NULL;
+        sdl3d_free_font(&state->direct_connect_font);
+        sdl3d_game_data_destroy(state->data);
+        state->data = NULL;
+        sdl3d_asset_resolver_destroy(state->assets);
+        state->assets = NULL;
+        return false;
+    }
     reset_direct_connect_defaults(state);
     if (ctx != NULL && ctx->window != NULL)
     {
@@ -1769,10 +1854,19 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
     }
+    if (state->lobby_ui != NULL && ctx != NULL && ctx->renderer != NULL && ctx->window != NULL)
+    {
+        sdl3d_ui_begin_frame_ex(state->lobby_ui, ctx->renderer, ctx->window);
+    }
     sdl3d_game_data_image_cache_init(&state->image_cache, state->assets);
     if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
     {
         sdl3d_game_data_image_cache_free(&state->image_cache);
+        if (state->lobby_ui != NULL)
+        {
+            sdl3d_ui_destroy(state->lobby_ui);
+            state->lobby_ui = NULL;
+        }
         if (state->discovery_ui != NULL)
         {
             sdl3d_ui_destroy(state->discovery_ui);
@@ -1808,6 +1902,7 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     state->lobby_start_connection = 0;
     state->discovery_refresh_connection = 0;
     state->host_start_signal_id = sdl3d_game_data_find_signal(state->data, "signal.multiplayer.lobby.start");
+    state->camera_toggle_signal_id = sdl3d_game_data_find_signal(state->data, "signal.camera.ball.toggle");
     state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
     state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
     state->discovery_refresh_signal_id =
@@ -1880,6 +1975,17 @@ static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL
             ctx->input_event_consumed = true;
         }
     }
+    if (state != NULL && is_multiplayer_lobby_scene(state) && state->lobby_ui != NULL && event != NULL)
+    {
+        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
+
+        if (mouse_event)
+        {
+            (void)sdl3d_ui_process_event(state->lobby_ui, event);
+            ctx->input_event_consumed = true;
+        }
+    }
     (void)ctx;
     return true;
 }
@@ -1889,7 +1995,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, dt);
-    predict_client_paddle_motion(state, dt);
+    update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -1905,7 +2011,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     pong_state *state = (pong_state *)userdata;
     refresh_local_play_input(state);
     update_multiplayer_sessions(state, real_dt);
-    predict_client_paddle_motion(state, real_dt);
+    update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = state->data,
@@ -1944,6 +2050,10 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     {
         draw_discovery_overlay(ctx, state);
     }
+    if (is_multiplayer_lobby_scene(state))
+    {
+        draw_lobby_overlay(ctx, state);
+    }
 
     if (state->direct_connect_ui != NULL)
     {
@@ -1956,6 +2066,12 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
         sdl3d_ui_end_frame(state->discovery_ui);
         sdl3d_ui_render(state->discovery_ui, ctx->renderer);
         sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
+    }
+    if (state->lobby_ui != NULL)
+    {
+        sdl3d_ui_end_frame(state->lobby_ui);
+        sdl3d_ui_render(state->lobby_ui, ctx->renderer);
+        sdl3d_ui_begin_frame_ex(state->lobby_ui, ctx->renderer, ctx->window);
     }
 }
 
@@ -1992,6 +2108,11 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_destroy(state->discovery_ui);
         state->discovery_ui = NULL;
+    }
+    if (state->lobby_ui != NULL)
+    {
+        sdl3d_ui_destroy(state->lobby_ui);
+        state->lobby_ui = NULL;
     }
     if (state->direct_connect_ui != NULL)
     {

--- a/include/sdl3d/network.h
+++ b/include/sdl3d/network.h
@@ -88,8 +88,9 @@ extern "C"
      *
      * When @p host is NULL, discovery probes are sent to all enumerated
      * subnet-directed IPv4 broadcast addresses, then to 255.255.255.255 as a
-     * fallback. Otherwise the scanner probes the named host directly, which is
-     * useful for tests or manual overrides.
+     * fallback, then to same-/24 IPv4 unicast targets in rate-limited batches.
+     * Otherwise the scanner probes the named host directly, which is useful
+     * for tests or manual overrides.
      */
     typedef struct sdl3d_network_discovery_session_desc
     {
@@ -125,7 +126,7 @@ extern "C"
      *
      * Defaults:
      * - host: NULL, meaning subnet broadcast discovery with global broadcast
-     *   fallback
+     *   fallback and same-/24 unicast discovery sweep
      * - port: SDL3D_NETWORK_DEFAULT_PORT
      * - local_port: 0
      */

--- a/include/sdl3d/network.h
+++ b/include/sdl3d/network.h
@@ -86,8 +86,9 @@ extern "C"
     /**
      * @brief Creation descriptor for a LAN discovery scanner.
      *
-     * When @p host is NULL, discovery probes are broadcast to the local
-     * network. Otherwise the scanner probes the named host directly, which is
+     * When @p host is NULL, discovery probes are sent to all enumerated
+     * subnet-directed IPv4 broadcast addresses, then to 255.255.255.255 as a
+     * fallback. Otherwise the scanner probes the named host directly, which is
      * useful for tests or manual overrides.
      */
     typedef struct sdl3d_network_discovery_session_desc
@@ -123,7 +124,8 @@ extern "C"
      * @brief Initialize a discovery session descriptor with sane defaults.
      *
      * Defaults:
-     * - host: NULL, meaning broadcast discovery
+     * - host: NULL, meaning subnet broadcast discovery with global broadcast
+     *   fallback
      * - port: SDL3D_NETWORK_DEFAULT_PORT
      * - local_port: 0
      */

--- a/src/network.c
+++ b/src/network.c
@@ -68,7 +68,9 @@ typedef int NET_Status;
     } while (0)
 #endif
 
-#define SDL3D_NETWORK_MAX_DISCOVERY_TARGETS 16
+#define SDL3D_NETWORK_MAX_DISCOVERY_TARGETS 320
+#define SDL3D_NETWORK_DISCOVERY_BATCH_SIZE 10
+#define SDL3D_NETWORK_DISCOVERY_BATCH_INTERVAL 0.02f
 #define SDL3D_NETWORK_GLOBAL_BROADCAST "255.255.255.255"
 
 typedef enum sdl3d_network_packet_kind
@@ -120,11 +122,13 @@ struct sdl3d_network_discovery_session
     char target_hosts[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS][SDL3D_NETWORK_MAX_HOST_LENGTH];
     bool target_probe_sent[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS];
     int target_count;
+    int next_probe_index;
     Uint16 target_port;
     sdl3d_network_discovery_result results[SDL3D_NETWORK_MAX_DISCOVERY_RESULTS];
     int result_count;
     float elapsed;
     float refresh_elapsed;
+    float probe_batch_elapsed;
     bool scanning;
 };
 
@@ -220,6 +224,7 @@ static void sdl3d_network_discovery_destroy_target_address(sdl3d_network_discove
         session->target_probe_sent[i] = false;
     }
     session->target_count = 0;
+    session->next_probe_index = 0;
 }
 
 #if SDL3D_NETWORKING_ENABLED
@@ -420,8 +425,68 @@ static int sdl3d_network_collect_directed_broadcast_hosts(char hosts[][SDL3D_NET
     freeifaddrs(interfaces);
     return count;
 }
+
+static int sdl3d_network_collect_lan_unicast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
+{
+    struct ifaddrs *interfaces = NULL;
+    int count = 0;
+
+    if (hosts == NULL || max <= 0)
+    {
+        return 0;
+    }
+
+    if (getifaddrs(&interfaces) != 0)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery interface enumeration failed");
+        return 0;
+    }
+
+    for (const struct ifaddrs *iface = interfaces; iface != NULL && count < max; iface = iface->ifa_next)
+    {
+        if (iface->ifa_addr == NULL || iface->ifa_addr->sa_family != AF_INET || (iface->ifa_flags & IFF_UP) == 0 ||
+            (iface->ifa_flags & IFF_LOOPBACK) != 0)
+        {
+            continue;
+        }
+
+        const struct sockaddr_in *addr = (const struct sockaddr_in *)iface->ifa_addr;
+        const Uint32 address_ipv4 = ntohl(addr->sin_addr.s_addr);
+        const Uint32 network24 = address_ipv4 & 0xFFFFFF00u;
+
+        for (Uint32 host_octet = 1; host_octet <= 254u && count < max; ++host_octet)
+        {
+            const Uint32 target_ipv4 = network24 | host_octet;
+            struct in_addr target_addr;
+            char host[INET_ADDRSTRLEN];
+
+            if (target_ipv4 == address_ipv4)
+            {
+                continue;
+            }
+
+            target_addr.s_addr = htonl(target_ipv4);
+            if (inet_ntop(AF_INET, &target_addr, host, sizeof(host)) == NULL)
+            {
+                continue;
+            }
+
+            (void)sdl3d_network_discovery_add_host_to_list(hosts, &count, max, host);
+        }
+    }
+
+    freeifaddrs(interfaces);
+    return count;
+}
 #else
 static int sdl3d_network_collect_directed_broadcast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
+{
+    (void)hosts;
+    (void)max;
+    return 0;
+}
+
+static int sdl3d_network_collect_lan_unicast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
 {
     (void)hosts;
     (void)max;
@@ -446,6 +511,12 @@ static void sdl3d_network_discovery_add_default_targets(sdl3d_network_discovery_
     }
 
     (void)sdl3d_network_discovery_add_target(session, SDL3D_NETWORK_GLOBAL_BROADCAST);
+
+    host_count = sdl3d_network_collect_lan_unicast_hosts(hosts, SDL3D_NETWORK_MAX_DISCOVERY_TARGETS);
+    for (int i = 0; i < host_count; ++i)
+    {
+        (void)sdl3d_network_discovery_add_target(session, hosts[i]);
+    }
 }
 
 static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session)
@@ -526,6 +597,7 @@ static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *
 {
     bool any_sent = false;
     bool any_pending = false;
+    int processed = 0;
 
     if (session == NULL || session->socket == NULL)
     {
@@ -538,11 +610,13 @@ static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *
     }
 
     SDL_snprintf(session->status, sizeof(session->status), "Scanning for local matches");
-    for (int i = 0; i < session->target_count; ++i)
+    for (int i = session->next_probe_index; i < session->target_count && processed < SDL3D_NETWORK_DISCOVERY_BATCH_SIZE;
+         ++i)
     {
         NET_Status target_status;
         if (session->target_addresses[i] == NULL || session->target_probe_sent[i])
         {
+            session->next_probe_index = i + 1;
             continue;
         }
 
@@ -557,17 +631,22 @@ static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target resolution failed: target=%s error=%s",
                         session->target_hosts[i], SDL_GetError());
             session->target_probe_sent[i] = true;
+            session->next_probe_index = i + 1;
+            processed++;
             continue;
         }
         if (target_status != NET_SUCCESS)
         {
             any_pending = true;
-            continue;
+            break;
         }
 
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
-                    session->target_hosts[i][0] != '\0' ? session->target_hosts[i] : "<unknown>",
-                    (unsigned int)session->target_port);
+        if (session->target_count <= 16)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
+                        session->target_hosts[i][0] != '\0' ? session->target_hosts[i] : "<unknown>",
+                        (unsigned int)session->target_port);
+        }
         if (sdl3d_network_discovery_send_packet_to(session, session->target_addresses[i], session->target_port,
                                                    SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0))
         {
@@ -579,6 +658,8 @@ static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *
                         session->target_hosts[i], SDL_GetError());
         }
         session->target_probe_sent[i] = true;
+        session->next_probe_index = i + 1;
+        processed++;
     }
 
     if (any_pending)
@@ -1414,7 +1495,9 @@ bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *se
     sdl3d_network_discovery_clear_results(session);
     session->elapsed = 0.0f;
     session->refresh_elapsed = 0.0f;
+    session->probe_batch_elapsed = 0.0f;
     session->scanning = true;
+    session->next_probe_index = 0;
     for (int i = 0; i < session->target_count; ++i)
     {
         session->target_probe_sent[i] = false;
@@ -1443,7 +1526,7 @@ bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *ses
     if (session->scanning)
     {
         bool has_pending_probe = false;
-        for (int i = 0; i < session->target_count; ++i)
+        for (int i = session->next_probe_index; i < session->target_count; ++i)
         {
             if (!session->target_probe_sent[i])
             {
@@ -1453,7 +1536,12 @@ bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *ses
         }
         if (has_pending_probe)
         {
-            (void)sdl3d_network_discovery_send_probe(session);
+            session->probe_batch_elapsed += SDL_max(dt, 0.0f);
+            if (session->probe_batch_elapsed >= SDL3D_NETWORK_DISCOVERY_BATCH_INTERVAL)
+            {
+                session->probe_batch_elapsed = 0.0f;
+                (void)sdl3d_network_discovery_send_probe(session);
+            }
         }
     }
 

--- a/src/network.c
+++ b/src/network.c
@@ -7,6 +7,16 @@
 
 #if SDL3D_NETWORKING_ENABLED
 #include <SDL3_net/SDL_net.h>
+
+#if (defined(__APPLE__) || defined(__linux__)) && !defined(__ANDROID__)
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#define SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS 1
+#else
+#define SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS 0
+#endif
 #else
 typedef struct NET_Address
 {
@@ -54,6 +64,9 @@ typedef int NET_Status;
     } while (0)
 #endif
 
+#define SDL3D_NETWORK_MAX_DISCOVERY_TARGETS 16
+#define SDL3D_NETWORK_GLOBAL_BROADCAST "255.255.255.255"
+
 typedef enum sdl3d_network_packet_kind
 {
     SDL3D_NETWORK_PACKET_HELLO = 1,
@@ -99,15 +112,16 @@ struct sdl3d_network_discovery_session
     sdl3d_network_discovery_session_desc desc;
     char status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     NET_DatagramSocket *socket;
-    NET_Address *target_address;
-    char target_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    NET_Address *target_addresses[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS];
+    char target_hosts[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS][SDL3D_NETWORK_MAX_HOST_LENGTH];
+    bool target_probe_sent[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS];
+    int target_count;
     Uint16 target_port;
     sdl3d_network_discovery_result results[SDL3D_NETWORK_MAX_DISCOVERY_RESULTS];
     int result_count;
     float elapsed;
     float refresh_elapsed;
     bool scanning;
-    bool probe_sent;
 };
 
 #if SDL3D_NETWORKING_ENABLED
@@ -191,11 +205,17 @@ static void sdl3d_network_discovery_destroy_target_address(sdl3d_network_discove
         return;
     }
 
-    if (session->target_address != NULL)
+    for (int i = 0; i < session->target_count; ++i)
     {
-        NET_UnrefAddress(session->target_address);
-        session->target_address = NULL;
+        if (session->target_addresses[i] != NULL)
+        {
+            NET_UnrefAddress(session->target_addresses[i]);
+            session->target_addresses[i] = NULL;
+        }
+        SDL_zeroa(session->target_hosts[i]);
+        session->target_probe_sent[i] = false;
     }
+    session->target_count = 0;
 }
 
 #if SDL3D_NETWORKING_ENABLED
@@ -251,6 +271,177 @@ static const char *sdl3d_network_session_advertised_name(const sdl3d_network_ses
         return "SDL3D Session";
     }
     return session->session_name;
+}
+
+static bool sdl3d_network_discovery_target_exists(const sdl3d_network_discovery_session *session, const char *host)
+{
+    if (session == NULL || host == NULL || host[0] == '\0')
+    {
+        return false;
+    }
+
+    for (int i = 0; i < session->target_count; ++i)
+    {
+        if (SDL_strcmp(session->target_hosts[i], host) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool sdl3d_network_discovery_add_target(sdl3d_network_discovery_session *session, const char *host)
+{
+    if (session == NULL || host == NULL || host[0] == '\0')
+    {
+        return false;
+    }
+
+    if (sdl3d_network_discovery_target_exists(session, host))
+    {
+        return true;
+    }
+
+    if (session->target_count >= SDL3D_NETWORK_MAX_DISCOVERY_TARGETS)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target dropped: list full host=%s", host);
+        return false;
+    }
+
+    NET_Address *address = NET_ResolveHostname(host);
+    if (address == NULL)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target resolution create failed: host=%s error=%s",
+                    host, SDL_GetError());
+        return false;
+    }
+
+    const int index = session->target_count++;
+    session->target_addresses[index] = address;
+    SDL_snprintf(session->target_hosts[index], sizeof(session->target_hosts[index]), "%s", host);
+    session->target_probe_sent[index] = false;
+    return true;
+}
+
+static bool sdl3d_network_discovery_host_list_contains(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int count,
+                                                       const char *host)
+{
+    if (hosts == NULL || host == NULL || host[0] == '\0')
+    {
+        return false;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        if (SDL_strcmp(hosts[i], host) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool sdl3d_network_discovery_add_host_to_list(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int *count, int max,
+                                                     const char *host)
+{
+    if (hosts == NULL || count == NULL || max <= 0 || *count >= max || host == NULL || host[0] == '\0' ||
+        sdl3d_network_discovery_host_list_contains(hosts, *count, host))
+    {
+        return false;
+    }
+
+    SDL_snprintf(hosts[*count], SDL3D_NETWORK_MAX_HOST_LENGTH, "%s", host);
+    (*count)++;
+    return true;
+}
+
+#if SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS
+static int sdl3d_network_collect_directed_broadcast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
+{
+    struct ifaddrs *interfaces = NULL;
+    int count = 0;
+
+    if (hosts == NULL || max <= 0)
+    {
+        return 0;
+    }
+
+    if (getifaddrs(&interfaces) != 0)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery interface enumeration failed");
+        return 0;
+    }
+
+    for (const struct ifaddrs *iface = interfaces; iface != NULL && count < max; iface = iface->ifa_next)
+    {
+        if (iface->ifa_addr == NULL || iface->ifa_addr->sa_family != AF_INET || (iface->ifa_flags & IFF_UP) == 0 ||
+            (iface->ifa_flags & IFF_LOOPBACK) != 0)
+        {
+            continue;
+        }
+
+        const struct sockaddr_in *addr = (const struct sockaddr_in *)iface->ifa_addr;
+        Uint32 broadcast_ipv4 = 0;
+
+        if ((iface->ifa_flags & IFF_BROADCAST) != 0 && iface->ifa_broadaddr != NULL &&
+            iface->ifa_broadaddr->sa_family == AF_INET)
+        {
+            const struct sockaddr_in *broadcast = (const struct sockaddr_in *)iface->ifa_broadaddr;
+            broadcast_ipv4 = ntohl(broadcast->sin_addr.s_addr);
+        }
+        else if (iface->ifa_netmask != NULL && iface->ifa_netmask->sa_family == AF_INET)
+        {
+            const struct sockaddr_in *netmask = (const struct sockaddr_in *)iface->ifa_netmask;
+            const Uint32 address_ipv4 = ntohl(addr->sin_addr.s_addr);
+            const Uint32 mask_ipv4 = ntohl(netmask->sin_addr.s_addr);
+            broadcast_ipv4 = address_ipv4 | ~mask_ipv4;
+        }
+
+        if (broadcast_ipv4 == 0)
+        {
+            continue;
+        }
+
+        struct in_addr broadcast_addr;
+        char host[INET_ADDRSTRLEN];
+        broadcast_addr.s_addr = htonl(broadcast_ipv4);
+        if (inet_ntop(AF_INET, &broadcast_addr, host, sizeof(host)) == NULL)
+        {
+            continue;
+        }
+
+        (void)sdl3d_network_discovery_add_host_to_list(hosts, &count, max, host);
+    }
+
+    freeifaddrs(interfaces);
+    return count;
+}
+#else
+static int sdl3d_network_collect_directed_broadcast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
+{
+    (void)hosts;
+    (void)max;
+    return 0;
+}
+#endif
+
+static void sdl3d_network_discovery_add_default_targets(sdl3d_network_discovery_session *session)
+{
+    char hosts[SDL3D_NETWORK_MAX_DISCOVERY_TARGETS][SDL3D_NETWORK_MAX_HOST_LENGTH];
+    int host_count = 0;
+
+    if (session == NULL)
+    {
+        return;
+    }
+
+    host_count = sdl3d_network_collect_directed_broadcast_hosts(hosts, SDL3D_NETWORK_MAX_DISCOVERY_TARGETS - 1);
+    for (int i = 0; i < host_count; ++i)
+    {
+        (void)sdl3d_network_discovery_add_target(session, hosts[i]);
+    }
+
+    (void)sdl3d_network_discovery_add_target(session, SDL3D_NETWORK_GLOBAL_BROADCAST);
 }
 
 static void sdl3d_network_discovery_clear_results(sdl3d_network_discovery_session *session)
@@ -329,27 +520,68 @@ static bool sdl3d_network_discovery_send_packet_to(sdl3d_network_discovery_sessi
 
 static bool sdl3d_network_discovery_send_probe(sdl3d_network_discovery_session *session)
 {
+    bool any_sent = false;
+    bool any_pending = false;
+
     if (session == NULL || session->socket == NULL)
     {
         return false;
     }
 
-    if (session->target_address == NULL)
+    if (session->target_count <= 0)
     {
         return false;
     }
 
     SDL_snprintf(session->status, sizeof(session->status), "Scanning for local matches");
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
-                session->target_host[0] != '\0' ? session->target_host : "<unknown>",
-                (unsigned int)session->target_port);
-    if (!sdl3d_network_discovery_send_packet_to(session, session->target_address, session->target_port,
-                                                SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0))
+    for (int i = 0; i < session->target_count; ++i)
     {
-        return false;
+        NET_Status target_status;
+        if (session->target_addresses[i] == NULL || session->target_probe_sent[i])
+        {
+            continue;
+        }
+
+        target_status = NET_GetAddressStatus(session->target_addresses[i]);
+        if (target_status != NET_SUCCESS)
+        {
+            (void)NET_WaitUntilResolved(session->target_addresses[i], 0);
+            target_status = NET_GetAddressStatus(session->target_addresses[i]);
+        }
+        if (target_status == NET_FAILURE)
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target resolution failed: target=%s error=%s",
+                        session->target_hosts[i], SDL_GetError());
+            session->target_probe_sent[i] = true;
+            continue;
+        }
+        if (target_status != NET_SUCCESS)
+        {
+            any_pending = true;
+            continue;
+        }
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send: target=%s port=%u",
+                    session->target_hosts[i][0] != '\0' ? session->target_hosts[i] : "<unknown>",
+                    (unsigned int)session->target_port);
+        if (sdl3d_network_discovery_send_packet_to(session, session->target_addresses[i], session->target_port,
+                                                   SDL3D_NETWORK_PACKET_DISCOVERY_QUERY, NULL, 0))
+        {
+            any_sent = true;
+        }
+        else
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery probe send failed: target=%s error=%s",
+                        session->target_hosts[i], SDL_GetError());
+        }
+        session->target_probe_sent[i] = true;
     }
-    session->probe_sent = true;
-    return true;
+
+    if (any_pending)
+    {
+        SDL_snprintf(session->status, sizeof(session->status), "Resolving discovery targets");
+    }
+    return any_sent || any_pending;
 }
 
 typedef struct sdl3d_network_discovery_reply_payload
@@ -1108,8 +1340,7 @@ bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_sessio
     session->desc = *effective;
     session->target_port = effective->port;
     SDL_zero(session->status);
-    SDL_zero(session->target_host);
-    session->probe_sent = false;
+    session->target_count = 0;
 
     if (!sdl3d_network_library_acquire())
     {
@@ -1128,19 +1359,21 @@ bool sdl3d_network_discovery_session_create(const sdl3d_network_discovery_sessio
 
     if (effective->host != NULL && effective->host[0] != '\0')
     {
-        SDL_snprintf(session->target_host, sizeof(session->target_host), "%s", effective->host);
+        if (!sdl3d_network_discovery_add_target(session, effective->host))
+        {
+            sdl3d_network_discovery_session_destroy(session);
+            return false;
+        }
     }
     else
     {
-        SDL_snprintf(session->target_host, sizeof(session->target_host), "%s", "255.255.255.255");
-    }
-
-    session->target_address = NET_ResolveHostname(session->target_host);
-    if (session->target_address == NULL)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery hostname resolution failed: %s", SDL_GetError());
-        sdl3d_network_discovery_session_destroy(session);
-        return false;
+        sdl3d_network_discovery_add_default_targets(session);
+        if (session->target_count <= 0)
+        {
+            SDL_SetError("Discovery session has no usable probe targets.");
+            sdl3d_network_discovery_session_destroy(session);
+            return false;
+        }
     }
 
     SDL_snprintf(session->status, sizeof(session->status), "Ready to scan");
@@ -1178,33 +1411,12 @@ bool sdl3d_network_discovery_session_refresh(sdl3d_network_discovery_session *se
     session->elapsed = 0.0f;
     session->refresh_elapsed = 0.0f;
     session->scanning = true;
-    session->probe_sent = false;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery refresh: target=%s port=%u",
-                session->target_host[0] != '\0' ? session->target_host : "<unknown>",
-                (unsigned int)session->target_port);
-
-#if SDL3D_NETWORKING_ENABLED
-    if (session->target_address != NULL)
+    for (int i = 0; i < session->target_count; ++i)
     {
-        NET_Status target_status = NET_GetAddressStatus(session->target_address);
-        if (target_status != NET_SUCCESS)
-        {
-            (void)NET_WaitUntilResolved(session->target_address, 0);
-            target_status = NET_GetAddressStatus(session->target_address);
-        }
-        if (target_status == NET_FAILURE)
-        {
-            SDL_snprintf(session->status, sizeof(session->status), "Discovery target resolution failed");
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery target resolution failed: %s", SDL_GetError());
-            return false;
-        }
-        if (target_status != NET_SUCCESS)
-        {
-            SDL_snprintf(session->status, sizeof(session->status), "Resolving discovery target");
-            return true;
-        }
+        session->target_probe_sent[i] = false;
     }
-#endif
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D discovery refresh: targets=%d port=%u", session->target_count,
+                (unsigned int)session->target_port);
     return sdl3d_network_discovery_send_probe(session);
 }
 
@@ -1224,14 +1436,18 @@ bool sdl3d_network_discovery_session_update(sdl3d_network_discovery_session *ses
     session->elapsed += SDL_max(dt, 0.0f);
     session->refresh_elapsed += SDL_max(dt, 0.0f);
 
-    if (session->scanning && session->target_address != NULL)
+    if (session->scanning)
     {
-        const NET_Status target_status = NET_GetAddressStatus(session->target_address);
-        if (target_status != NET_SUCCESS)
+        bool has_pending_probe = false;
+        for (int i = 0; i < session->target_count; ++i)
         {
-            (void)NET_WaitUntilResolved(session->target_address, 0);
+            if (!session->target_probe_sent[i])
+            {
+                has_pending_probe = true;
+                break;
+            }
         }
-        if (NET_GetAddressStatus(session->target_address) == NET_SUCCESS && !session->probe_sent)
+        if (has_pending_probe)
         {
             (void)sdl3d_network_discovery_send_probe(session);
         }
@@ -1307,6 +1523,101 @@ const char *sdl3d_network_discovery_session_status(const sdl3d_network_discovery
     return session != NULL ? session->status : NULL;
 }
 #else
+void sdl3d_network_session_desc_init(sdl3d_network_session_desc *desc)
+{
+    if (desc == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*desc);
+    desc->role = SDL3D_NETWORK_ROLE_CLIENT;
+    desc->port = SDL3D_NETWORK_DEFAULT_PORT;
+    desc->local_port = 0;
+    desc->handshake_timeout = 5.0f;
+    desc->idle_timeout = 10.0f;
+}
+
+bool sdl3d_network_session_create(const sdl3d_network_session_desc *desc, sdl3d_network_session **out_session)
+{
+    (void)desc;
+    if (out_session != NULL)
+    {
+        *out_session = NULL;
+    }
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return false;
+}
+
+void sdl3d_network_session_destroy(sdl3d_network_session *session)
+{
+    (void)session;
+}
+
+bool sdl3d_network_session_update(sdl3d_network_session *session, float dt)
+{
+    (void)session;
+    (void)dt;
+    return false;
+}
+
+bool sdl3d_network_session_send(sdl3d_network_session *session, const void *data, int data_size)
+{
+    (void)session;
+    (void)data;
+    (void)data_size;
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return false;
+}
+
+int sdl3d_network_session_receive(sdl3d_network_session *session, void *buffer, int buffer_size)
+{
+    (void)session;
+    (void)buffer;
+    (void)buffer_size;
+    SDL_SetError("SDL3D networking is disabled at build time.");
+    return -1;
+}
+
+void sdl3d_network_session_disconnect(sdl3d_network_session *session)
+{
+    (void)session;
+}
+
+sdl3d_network_state sdl3d_network_session_state(const sdl3d_network_session *session)
+{
+    (void)session;
+    return SDL3D_NETWORK_STATE_DISCONNECTED;
+}
+
+const char *sdl3d_network_session_status(const sdl3d_network_session *session)
+{
+    (void)session;
+    return "Networking disabled";
+}
+
+bool sdl3d_network_session_is_connected(const sdl3d_network_session *session)
+{
+    (void)session;
+    return false;
+}
+
+Uint16 sdl3d_network_session_port(const sdl3d_network_session *session)
+{
+    (void)session;
+    return 0;
+}
+
+bool sdl3d_network_session_get_peer_endpoint(const sdl3d_network_session *session, char *host_buffer,
+                                             int host_buffer_size, Uint16 *out_port)
+{
+    (void)session;
+    (void)host_buffer;
+    (void)host_buffer_size;
+    (void)out_port;
+    return false;
+}
+
 void sdl3d_network_discovery_session_desc_init(sdl3d_network_discovery_session_desc *desc)
 {
     if (desc == NULL)

--- a/src/network.c
+++ b/src/network.c
@@ -11,7 +11,11 @@
 #if (defined(__APPLE__) || defined(__linux__)) && !defined(__ANDROID__)
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#if defined(__linux__)
+#include <linux/if.h>
+#else
 #include <net/if.h>
+#endif
 #include <netinet/in.h>
 #define SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS 1
 #else
@@ -323,6 +327,7 @@ static bool sdl3d_network_discovery_add_target(sdl3d_network_discovery_session *
     return true;
 }
 
+#if SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS
 static bool sdl3d_network_discovery_host_list_contains(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int count,
                                                        const char *host)
 {
@@ -355,7 +360,6 @@ static bool sdl3d_network_discovery_add_host_to_list(char hosts[][SDL3D_NETWORK_
     return true;
 }
 
-#if SDL3D_NETWORK_CAN_ENUMERATE_BROADCAST_TARGETS
 static int sdl3d_network_collect_directed_broadcast_hosts(char hosts[][SDL3D_NETWORK_MAX_HOST_LENGTH], int max)
 {
     struct ifaddrs *interfaces = NULL;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1497,7 +1497,7 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     const int lobby_start_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.lobby.start");
     ASSERT_GE(lobby_start_signal, 0);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
-    EXPECT_STREQ(item.label, "Start Game");
+    EXPECT_STREQ(item.label, "Start Selected Match");
     EXPECT_EQ(item.signal_id, lobby_start_signal);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
     EXPECT_STREQ(item.label, "Back");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1492,12 +1492,19 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.lobby"));
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
-    EXPECT_STREQ(menu.name, "menu.multiplayer.lobby");
-    EXPECT_EQ(menu.item_count, 2);
+    EXPECT_STREQ(menu.name, "menu.multiplayer.lobby.waiting");
+    EXPECT_EQ(menu.item_count, 1);
     const int lobby_start_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.lobby.start");
     ASSERT_GE(lobby_start_signal, 0);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
-    EXPECT_STREQ(item.label, "Start Selected Match");
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.lan");
+    sdl3d_properties_set_bool(sdl3d_game_data_mutable_scene_state(runtime), "multiplayer_host_connected", true);
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.lobby.connected");
+    EXPECT_EQ(menu.item_count, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Client 1");
     EXPECT_EQ(item.signal_id, lobby_start_signal);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
     EXPECT_STREQ(item.label, "Back");

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -235,6 +235,51 @@ TEST(NetworkSession, LanDiscoveryFindsWaitingHost)
     destroy_discovery_pair(&pair);
 }
 
+TEST(NetworkSession, ClientCanConnectToDiscoveredHost)
+{
+    DiscoveryPair pair{};
+    ASSERT_TRUE(create_discovery_pair(&pair));
+
+    sdl3d_network_discovery_result result{};
+    ASSERT_TRUE(pump_until_discovered(&pair, &result));
+
+    sdl3d_network_session_desc client_desc{};
+    sdl3d_network_session_desc_init(&client_desc);
+    client_desc.role = SDL3D_NETWORK_ROLE_CLIENT;
+    client_desc.host = result.host;
+    client_desc.port = result.port;
+    client_desc.handshake_timeout = 2.0f;
+    client_desc.idle_timeout = 2.0f;
+
+    sdl3d_network_session *client = nullptr;
+    ASSERT_TRUE(sdl3d_network_session_create(&client_desc, &client));
+
+    bool connected = false;
+    for (int i = 0; i < kPumpLimit; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(pair.host, 0.016f));
+        EXPECT_TRUE(sdl3d_network_session_update(client, 0.016f));
+        if (sdl3d_network_session_is_connected(pair.host) && sdl3d_network_session_is_connected(client))
+        {
+            connected = true;
+            break;
+        }
+        if (sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_REJECTED ||
+            sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_TIMED_OUT ||
+            sdl3d_network_session_state(client) == SDL3D_NETWORK_STATE_ERROR)
+        {
+            break;
+        }
+    }
+
+    EXPECT_TRUE(connected);
+    EXPECT_TRUE(sdl3d_network_session_is_connected(pair.host));
+    EXPECT_TRUE(sdl3d_network_session_is_connected(client));
+
+    sdl3d_network_session_destroy(client);
+    destroy_discovery_pair(&pair);
+}
+
 TEST(NetworkSession, HostRejectsSecondClient)
 {
     NetworkPair pair{};

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -647,11 +647,27 @@ TEST_F(PongHeadlessMultiplayerTest, NetworkPauseMenuOmitsOptions)
     metrics.paused = true;
 
     sdl3d_game_data_menu menu{};
+    sdl3d_game_data_menu_item item{};
+
+    set_multiplayer_scene_state(host_runtime, "single", "client", "direct");
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(host_runtime, &metrics, &menu));
+    ASSERT_STREQ(menu.name, "menu.pause");
+    ASSERT_EQ(menu.item_count, 3);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
+    ASSERT_STREQ(item.label, "Options");
+
+    set_multiplayer_scene_state(host_runtime, "local", "host", "host");
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(host_runtime, &metrics, &menu));
+    ASSERT_STREQ(menu.name, "menu.pause");
+    ASSERT_EQ(menu.item_count, 3);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
+    ASSERT_STREQ(item.label, "Options");
+
+    set_multiplayer_scene_state(host_runtime, "lan", "host", "host");
     ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(host_runtime, &metrics, &menu));
     ASSERT_STREQ(menu.name, "menu.pause.network");
     ASSERT_EQ(menu.item_count, 2);
 
-    sdl3d_game_data_menu_item item{};
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 0, &item));
     ASSERT_STREQ(item.label, "Resume");
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
@@ -663,6 +679,21 @@ TEST_F(PongHeadlessMultiplayerTest, NetworkPauseMenuOmitsOptions)
     ASSERT_EQ(menu.item_count, 3);
     ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
     ASSERT_STREQ(item.label, "Options");
+}
+
+TEST_F(PongHeadlessMultiplayerTest, OnlyLanClientDisablesLocalSimulation)
+{
+    set_multiplayer_scene_state(host_runtime, "single", "client", "direct");
+    EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(host_runtime, "simulation", false));
+
+    set_multiplayer_scene_state(host_runtime, "local", "client", "direct");
+    EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(host_runtime, "simulation", false));
+
+    set_multiplayer_scene_state(host_runtime, "lan", "host", "host");
+    EXPECT_TRUE(sdl3d_game_data_active_scene_update_phase(host_runtime, "simulation", false));
+
+    set_multiplayer_scene_state(host_runtime, "lan", "client", "direct");
+    EXPECT_FALSE(sdl3d_game_data_active_scene_update_phase(host_runtime, "simulation", false));
 }
 
 } // namespace

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -618,6 +618,17 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
     ASSERT_GT(received, 0);
     ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
 
+    ASSERT_TRUE(send_control_packet(client_network, PONG_NETWORK_MESSAGE_DISCONNECT));
+    received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(host_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+
     ASSERT_TRUE(send_control_packet(host_network, PONG_NETWORK_MESSAGE_DISCONNECT));
     received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
@@ -628,6 +639,30 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
     }
     ASSERT_GT(received, 0);
     ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+}
+
+TEST_F(PongHeadlessMultiplayerTest, NetworkPauseMenuOmitsOptions)
+{
+    sdl3d_game_data_ui_metrics metrics{};
+    metrics.paused = true;
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(host_runtime, &metrics, &menu));
+    ASSERT_STREQ(menu.name, "menu.pause.network");
+    ASSERT_EQ(menu.item_count, 2);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 0, &item));
+    ASSERT_STREQ(item.label, "Resume");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
+    ASSERT_STREQ(item.label, "Title");
+
+    set_multiplayer_scene_state(host_runtime, "single", "none", "none");
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu_for_metrics(host_runtime, &metrics, &menu));
+    ASSERT_STREQ(menu.name, "menu.pause");
+    ASSERT_EQ(menu.item_count, 3);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(host_runtime, menu.name, 1, &item));
+    ASSERT_STREQ(item.label, "Options");
 }
 
 } // namespace

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -21,12 +21,17 @@ namespace
 constexpr Uint32 kPongNetworkPacketMagic = 0x474E4F50u;
 constexpr Uint8 kPongNetworkPacketVersion = 1U;
 constexpr size_t kPongNetworkInputPacketSize = 20U;
-constexpr size_t kPongNetworkStatePacketSize = 108U;
+constexpr size_t kPongNetworkControlPacketSize = 12U;
+constexpr size_t kPongNetworkStatePacketSize = 112U;
 
 enum PongNetworkMessageKind : Uint8
 {
     PONG_NETWORK_MESSAGE_INPUT = 1,
     PONG_NETWORK_MESSAGE_STATE = 2,
+    PONG_NETWORK_MESSAGE_START_GAME = 3,
+    PONG_NETWORK_MESSAGE_PAUSE_REQUEST = 4,
+    PONG_NETWORK_MESSAGE_RESUME_REQUEST = 5,
+    PONG_NETWORK_MESSAGE_DISCONNECT = 6,
 };
 
 static bool write_u8(Uint8 **cursor, Uint8 *end, Uint8 value)
@@ -274,8 +279,37 @@ static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_ga
     return true;
 }
 
+static bool send_control_packet(sdl3d_network_session *net_session, PongNetworkMessageKind kind)
+{
+    Uint8 packet[32];
+    Uint8 *cursor = packet;
+    Uint8 *end = packet + sizeof(packet);
+
+    return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
+           write_u8(&cursor, end, kind) && write_u8(&cursor, end, 0U) && write_u8(&cursor, end, 0U) &&
+           write_u32(&cursor, end, 1234U) && (size_t)(cursor - packet) == kPongNetworkControlPacketSize &&
+           sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
+}
+
+static bool read_control_packet(const Uint8 *packet, int packet_size, PongNetworkMessageKind expected)
+{
+    const Uint8 *cursor = packet;
+    const Uint8 *end = packet + packet_size;
+    Uint32 magic = 0U;
+    Uint8 version = 0U;
+    Uint8 kind = 0U;
+    Uint8 reserved = 0U;
+    Uint32 tick = 0U;
+
+    return packet != nullptr && (size_t)packet_size == kPongNetworkControlPacketSize &&
+           read_u32(&cursor, end, &magic) && magic == kPongNetworkPacketMagic && read_u8(&cursor, end, &version) &&
+           version == kPongNetworkPacketVersion && read_u8(&cursor, end, &kind) && kind == (Uint8)expected &&
+           read_u8(&cursor, end, &reserved) && read_u8(&cursor, end, &reserved) && read_u32(&cursor, end, &tick) &&
+           tick == 1234U && cursor == end;
+}
+
 static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
-                                   sdl3d_network_session *net_session)
+                                   sdl3d_network_session *net_session, bool paused)
 {
     const sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.paddle.player");
     const sdl3d_registered_actor *cpu = sdl3d_game_data_find_actor(runtime, "entity.paddle.cpu");
@@ -312,6 +346,7 @@ static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_
            write_f32(&cursor, end, sdl3d_properties_get_float(presentation->props, "paddle_flash", 0.0f)) &&
            write_i32(&cursor, end, sdl3d_properties_get_int(score_player_actor->props, "value", 0)) &&
            write_i32(&cursor, end, sdl3d_properties_get_int(score_cpu_actor->props, "value", 0)) &&
+           write_i32(&cursor, end, paused ? 1 : 0) &&
            write_i32(&cursor, end, sdl3d_properties_get_bool(match->props, "finished", false) ? 1 : 0) &&
            write_i32(&cursor, end,
                      SDL_strcmp(sdl3d_properties_get_string(match->props, "winner", "none"), "player") == 0 ? 1
@@ -325,7 +360,8 @@ static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_
            sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
 }
 
-static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const Uint8 *packet, int packet_size)
+static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const Uint8 *packet, int packet_size,
+                                        bool *out_paused)
 {
     const Uint8 *cursor = packet;
     const Uint8 *end = packet + packet_size;
@@ -344,6 +380,7 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
     float paddle_flash = 0.0f;
     int score_player = 0;
     int score_cpu = 0;
+    int paused = 0;
     int finished = 0;
     int winner = 0;
     int active_motion = 0;
@@ -371,9 +408,10 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
         !read_vec3(&cursor, end, &cpu_position) || !read_vec3(&cursor, end, &ball_position) ||
         !read_vec3(&cursor, end, &ball_velocity) || !read_f32(&cursor, end, &border_flash) ||
         !read_f32(&cursor, end, &paddle_flash) || !read_i32(&cursor, end, &score_player) ||
-        !read_i32(&cursor, end, &score_cpu) || !read_i32(&cursor, end, &finished) || !read_i32(&cursor, end, &winner) ||
-        !read_i32(&cursor, end, &active_motion) || !read_i32(&cursor, end, &has_last_reflect_y) ||
-        !read_f32(&cursor, end, &last_reflect_y) || !read_i32(&cursor, end, &stagnant_reflect_count))
+        !read_i32(&cursor, end, &score_cpu) || !read_i32(&cursor, end, &paused) || !read_i32(&cursor, end, &finished) ||
+        !read_i32(&cursor, end, &winner) || !read_i32(&cursor, end, &active_motion) ||
+        !read_i32(&cursor, end, &has_last_reflect_y) || !read_f32(&cursor, end, &last_reflect_y) ||
+        !read_i32(&cursor, end, &stagnant_reflect_count))
     {
         return false;
     }
@@ -408,6 +446,10 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
     sdl3d_properties_set_int(ball->props, "stagnant_reflect_count", stagnant_reflect_count);
     sdl3d_properties_set_int(score_player_actor->props, "value", score_player);
     sdl3d_properties_set_int(score_cpu_actor->props, "value", score_cpu);
+    if (out_paused != nullptr)
+    {
+        *out_paused = paused != 0;
+    }
     sdl3d_properties_set_bool(match->props, "finished", finished != 0);
     sdl3d_properties_set_string(match->props, "winner", winner == 1 ? "player" : winner == 2 ? "cpu" : "none");
     sdl3d_properties_set_float(presentation->props, "border_flash", border_flash);
@@ -530,7 +572,7 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
 
     EXPECT_NE(host_cpu->position.y, initial_host_cpu_y);
 
-    ASSERT_TRUE(send_host_state_packet(host_runtime, host_session, host_network));
+    ASSERT_TRUE(send_host_state_packet(host_runtime, host_session, host_network, true));
     received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
     {
@@ -539,13 +581,53 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
         received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
     }
     ASSERT_GT(received, 0);
-    ASSERT_TRUE(process_client_state_packet(client_runtime, packet.data(), received));
+    bool client_paused = false;
+    ASSERT_TRUE(process_client_state_packet(client_runtime, packet.data(), received, &client_paused));
 
     EXPECT_NEAR(client_cpu->position.y, host_cpu->position.y, 0.0001f);
+    EXPECT_TRUE(client_paused);
     EXPECT_STREQ(
         sdl3d_properties_get_string(sdl3d_game_data_find_actor(client_runtime, "entity.match")->props, "winner",
                                     "none"),
         sdl3d_properties_get_string(sdl3d_game_data_find_actor(host_runtime, "entity.match")->props, "winner", "none"));
+}
+
+TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
+{
+    std::array<Uint8, SDL3D_NETWORK_MAX_PACKET_SIZE> packet{};
+
+    ASSERT_TRUE(send_control_packet(client_network, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
+    int received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(host_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
+
+    ASSERT_TRUE(send_control_packet(host_network, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
+    received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
+
+    ASSERT_TRUE(send_control_packet(host_network, PONG_NETWORK_MESSAGE_DISCONNECT));
+    received = 0;
+    for (int i = 0; i < 120 && received <= 0; ++i)
+    {
+        EXPECT_TRUE(sdl3d_network_session_update(host_network, 0.01f));
+        EXPECT_TRUE(sdl3d_network_session_update(client_network, 0.01f));
+        received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
+    }
+    ASSERT_GT(received, 0);
+    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- improve Pong LAN discovery by probing subnet-directed IPv4 broadcasts first, retaining `255.255.255.255` as a fallback, and adding a same-/24 UDP sweep in controlled batches
- make discovered-match clients auto-connect and wait for the host to start the match, while keeping direct-connect/manual host entry intact
- restore the authored lobby client list and remove the immediate-mode lobby overlay that obscured scene UI
- make network play host-authoritative by removing client paddle prediction and treating host state as the source of truth
- add resilient network start handoff so the first authoritative state packet can implicitly enter play if the start packet was missed
- replicate network pause state and allow either peer to request pause/resume
- add graceful disconnect control packets, timeout handling, and a termination notice for the remaining peer
- keep termination notices paused until the player presses Enter to return to title
- isolate LAN-only behavior from single-player and local multiplayer so stale network scene state cannot disable simulation or hide the normal pause menu
- remove Options from the LAN pause menu while preserving Resume/Options/Title for single-player and local multiplayer
- preserve client ball-camera controls while client simulation is disabled
- package the Pong splash shader asset in embedded and disk packs
- add disabled-networking direct-session stubs so the public network API links and reports disabled consistently

## Verification
- `clang-format -i demos/pong/main.c tests/test_pong_multiplayer.cpp src/network.c include/sdl3d/network.h`
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/debug --target pong_demo sdl3d_network_test sdl3d_game_data_test sdl3d_pong_multiplayer_test -j 8`
- `./build/debug/tests/sdl3d_network_test`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -R "(NetworkSession|PongHeadlessMultiplayerTest|GameDataRuntime.ValidatesPongDataWithoutDiagnostics|GameDataJson.PongDataParsesAsStrictJson|GameDataRuntime.PongClientDoesNotStartServeTimer|GameDataRuntime.LuaControllerMovesCpuPaddleTowardBall)"`
- `cmake --build build/no_network --target pong_demo -j 8`

## CI
- GitHub CI is green for Linux, macOS, Windows, Emscripten, Android, iOS, sanitizers, clang-format, and profile checks.