### PR TITLE
Refine Pong title wake input and shared lamp

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -726,32 +726,54 @@
     ],
     "lights": [
       {
-        "name": "light.left_red",
+        "name": "light.left_red.top",
         "type": "point",
-        "position": [-5.7, 0.35, 2.4],
+        "position": [-5.7, 2.55, 2.4],
         "color": [1.0, 0.10, 0.08],
-        "intensity": 2.6,
-        "range": 5.8,
+        "intensity": 2.0,
+        "range": 4.8,
         "effects": [
           { "type": "pulse", "rate": 1.2, "phase": 0.5, "color": [1.0, 0.18, 0.12], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
         ]
       },
       {
-        "name": "light.right_blue",
+        "name": "light.left_red.bottom",
         "type": "point",
-        "position": [5.7, 0.35, 2.4],
+        "position": [-5.7, -2.55, 2.4],
+        "color": [1.0, 0.10, 0.08],
+        "intensity": 2.0,
+        "range": 4.8,
+        "effects": [
+          { "type": "pulse", "rate": 1.2, "phase": 2.2, "color": [1.0, 0.18, 0.12], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
+        ]
+      },
+      {
+        "name": "light.right_blue.top",
+        "type": "point",
+        "position": [5.7, 2.55, 2.4],
         "color": [0.12, 0.34, 1.0],
-        "intensity": 2.6,
-        "range": 5.8,
+        "intensity": 2.0,
+        "range": 4.8,
         "effects": [
           { "type": "pulse", "rate": 1.25, "phase": 2.0, "color": [0.28, 0.54, 1.0], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
         ]
       },
       {
+        "name": "light.right_blue.bottom",
+        "type": "point",
+        "position": [5.7, -2.55, 2.4],
+        "color": [0.12, 0.34, 1.0],
+        "intensity": 2.0,
+        "range": 4.8,
+        "effects": [
+          { "type": "pulse", "rate": 1.25, "phase": 3.7, "color": [0.28, 0.54, 1.0], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
+        ]
+      },
+      {
         "name": "light.gameplay_lamp",
         "type": "point",
-        "target_entity": "entity.light.lamp",
-        "offset": [0.0, 0.0, 2.8],
+        "target_entities": ["entity.ball", "entity.ball.attract"],
+        "offset": [0.0, 0.0, 2.4],
         "color": [1.0, 0.82, 0.42],
         "intensity": 3.0,
         "range": 6.4,
@@ -1035,19 +1057,6 @@
       "properties": {
         "value": { "type": "int", "value": 0 }
       }
-    },
-    {
-      "name": "entity.light.lamp",
-      "active": true,
-      "tags": ["light", "lamp", "presentation"],
-      "transform": { "position": [-6.8, 3.8, 0.34] },
-      "properties": {
-        "active_motion": { "type": "bool", "value": true },
-        "motion_time": { "type": "float", "value": 0.0 }
-      },
-      "components": [
-        { "type": "motion.oscillate", "origin": [0.0, 3.8, 0.34], "amplitude": [6.8, 0.0, 0.0], "rate": 0.45, "phase": -1.5707963 }
-      ]
     },
     {
       "name": "entity.score.cpu",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -728,13 +728,13 @@
       {
         "name": "light.left_red_spot",
         "type": "spot",
-        "position": [-6.2, 0.0, 3.2],
-        "direction": [1.0, 0.0, -0.46],
+        "position": [-8.15, 0.0, 3.35],
+        "direction": [0.0, 0.0, -1.0],
         "color": [1.0, 0.06, 0.04],
-        "intensity": 9.5,
-        "range": 7.2,
-        "inner_cutoff": 0.90,
-        "outer_cutoff": 0.54
+        "intensity": 11.0,
+        "range": 6.2,
+        "inner_cutoff": 0.86,
+        "outer_cutoff": 0.48
       },
       {
         "name": "light.gold_ball_spot",
@@ -756,13 +756,13 @@
       {
         "name": "light.right_blue_spot",
         "type": "spot",
-        "position": [6.2, 0.0, 3.2],
-        "direction": [-1.0, 0.0, -0.46],
+        "position": [8.15, 0.0, 3.35],
+        "direction": [0.0, 0.0, -1.0],
         "color": [0.08, 0.28, 1.0],
-        "intensity": 9.5,
-        "range": 7.2,
-        "inner_cutoff": 0.90,
-        "outer_cutoff": 0.54
+        "intensity": 11.0,
+        "range": 6.2,
+        "inner_cutoff": 0.86,
+        "outer_cutoff": 0.48
       }
     ]
   },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -726,62 +726,43 @@
     ],
     "lights": [
       {
-        "name": "light.left_red.top",
-        "type": "point",
-        "position": [-5.7, 2.55, 2.4],
-        "color": [1.0, 0.10, 0.08],
-        "intensity": 2.0,
-        "range": 4.8,
-        "effects": [
-          { "type": "pulse", "rate": 1.2, "phase": 0.5, "color": [1.0, 0.18, 0.12], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
-        ]
+        "name": "light.left_red_spot",
+        "type": "spot",
+        "position": [-6.2, 0.0, 3.2],
+        "direction": [1.0, 0.0, -0.46],
+        "color": [1.0, 0.06, 0.04],
+        "intensity": 9.5,
+        "range": 7.2,
+        "inner_cutoff": 0.90,
+        "outer_cutoff": 0.54
       },
       {
-        "name": "light.left_red.bottom",
-        "type": "point",
-        "position": [-5.7, -2.55, 2.4],
-        "color": [1.0, 0.10, 0.08],
-        "intensity": 2.0,
-        "range": 4.8,
-        "effects": [
-          { "type": "pulse", "rate": 1.2, "phase": 2.2, "color": [1.0, 0.18, 0.12], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
-        ]
-      },
-      {
-        "name": "light.right_blue.top",
-        "type": "point",
-        "position": [5.7, 2.55, 2.4],
-        "color": [0.12, 0.34, 1.0],
-        "intensity": 2.0,
-        "range": 4.8,
-        "effects": [
-          { "type": "pulse", "rate": 1.25, "phase": 2.0, "color": [0.28, 0.54, 1.0], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
-        ]
-      },
-      {
-        "name": "light.right_blue.bottom",
-        "type": "point",
-        "position": [5.7, -2.55, 2.4],
-        "color": [0.12, 0.34, 1.0],
-        "intensity": 2.0,
-        "range": 4.8,
-        "effects": [
-          { "type": "pulse", "rate": 1.25, "phase": 3.7, "color": [0.28, 0.54, 1.0], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
-        ]
-      },
-      {
-        "name": "light.gameplay_lamp",
-        "type": "point",
+        "name": "light.gold_ball_spot",
+        "type": "spot",
         "target_entities": ["entity.ball", "entity.ball.attract"],
-        "offset": [0.0, 0.0, 2.4],
+        "offset": [0.0, 0.0, 2.8],
+        "direction": [0.0, 0.0, -1.0],
         "color": [1.0, 0.82, 0.42],
-        "intensity": 3.0,
-        "range": 6.4,
+        "intensity": 8.0,
+        "range": 5.8,
+        "inner_cutoff": 0.92,
+        "outer_cutoff": 0.58,
         "effects": [
-          { "type": "pulse", "rate": 1.7, "color": [1.0, 0.92, 0.58], "color_blend": 0.22, "intensity_add": 0.35, "range_add": 0.35 },
+          { "type": "pulse", "rate": 1.7, "color": [1.0, 0.92, 0.58], "color_blend": 0.22, "intensity_add": 0.55, "range_add": 0.35 },
           { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [0.65, 0.78, 1.0], "color_blend": 0.45, "intensity_add": 1.3, "range_add": 1.0 },
           { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [1.0, 1.0, 1.0], "color_blend": 0.35, "intensity_add": 1.1, "range_add": 0.8 }
         ]
+      },
+      {
+        "name": "light.right_blue_spot",
+        "type": "spot",
+        "position": [6.2, 0.0, 3.2],
+        "direction": [-1.0, 0.0, -0.46],
+        "color": [0.08, 0.28, 1.0],
+        "intensity": 9.5,
+        "range": 7.2,
+        "inner_cutoff": 0.90,
+        "outer_cutoff": 0.54
       }
     ]
   },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -734,7 +734,10 @@
         "intensity": 12.5,
         "range": 8.4,
         "inner_cutoff": 0.86,
-        "outer_cutoff": 0.48
+        "outer_cutoff": 0.48,
+        "effects": [
+          { "type": "pulse", "rate": 0.45, "phase": 0.4, "color": [1.0, 0.34, 0.08], "color_blend": 0.55, "intensity_add": 0.35, "range_add": 0.25 }
+        ]
       },
       {
         "name": "light.gold_ball_spot",
@@ -762,7 +765,10 @@
         "intensity": 12.5,
         "range": 8.4,
         "inner_cutoff": 0.86,
-        "outer_cutoff": 0.48
+        "outer_cutoff": 0.48,
+        "effects": [
+          { "type": "pulse", "rate": 0.50, "phase": 1.7, "color": [0.12, 0.72, 1.0], "color_blend": 0.55, "intensity_add": 0.35, "range_add": 0.25 }
+        ]
       }
     ]
   },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -726,49 +726,17 @@
     ],
     "lights": [
       {
-        "name": "light.red",
+        "name": "light.gameplay_lamp",
         "type": "point",
-        "position": [-7.0, 4.4, 3.2],
-        "color": [1.0, 0.1, 0.08],
-        "intensity": 2.8,
-        "range": 12.0,
+        "target_entity": "entity.light.lamp",
+        "offset": [0.0, 0.0, 2.8],
+        "color": [1.0, 0.82, 0.42],
+        "intensity": 3.0,
+        "range": 6.4,
         "effects": [
-          { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [0.65, 0.78, 1.0], "color_blend": 0.55, "intensity_add": 1.6, "range_add": 1.8 }
-        ]
-      },
-      {
-        "name": "light.green",
-        "type": "point",
-        "position": [7.0, 4.4, 3.2],
-        "color": [0.08, 1.0, 0.18],
-        "intensity": 2.7,
-        "range": 12.0,
-        "effects": [
-          { "type": "pulse", "rate": 3.8, "color": [0.18, 1.0, 0.50], "color_blend": 0.20, "intensity_add": 0.45, "range_add": 0.8 }
-        ]
-      },
-      {
-        "name": "light.blue",
-        "type": "point",
-        "position": [0.0, -4.2, 3.5],
-        "color": [0.14, 0.34, 1.0],
-        "intensity": 2.9,
-        "range": 12.0,
-        "effects": [
-          { "type": "pulse", "rate": 2.5, "phase": 1.2, "color": [0.28, 0.48, 1.0], "color_blend": 0.20, "intensity_add": 0.35, "range_add": 0.7 }
-        ]
-      },
-      {
-        "name": "light.ball",
-        "type": "point",
-        "target_entity": "entity.ball",
-        "offset": [0.0, 0.0, 1.2],
-        "color": [1.0, 0.86, 0.34],
-        "intensity": 3.1,
-        "range": 5.0,
-        "effects": [
-          { "type": "pulse", "rate": 9.0, "color": [1.0, 0.96, 0.54], "color_blend": 0.35, "intensity_add": 0.9, "range_add": 0.6 },
-          { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [1.0, 1.0, 1.0], "color_blend": 0.45, "intensity_add": 1.5, "range_add": 1.1 }
+          { "type": "pulse", "rate": 1.7, "color": [1.0, 0.92, 0.58], "color_blend": 0.22, "intensity_add": 0.35, "range_add": 0.35 },
+          { "type": "flash", "source": "entity.presentation", "property": "border_flash", "color": [0.65, 0.78, 1.0], "color_blend": 0.45, "intensity_add": 1.3, "range_add": 1.0 },
+          { "type": "flash", "source": "entity.presentation", "property": "paddle_flash", "color": [1.0, 1.0, 1.0], "color_blend": 0.35, "intensity_add": 1.1, "range_add": 0.8 }
         ]
       }
     ]
@@ -1045,6 +1013,30 @@
       "properties": {
         "value": { "type": "int", "value": 0 }
       }
+    },
+    {
+      "name": "entity.light.lamp",
+      "active": true,
+      "tags": ["light", "lamp", "presentation"],
+      "transform": { "position": [-6.8, 3.8, 0.34] },
+      "properties": {
+        "active_motion": { "type": "bool", "value": true },
+        "motion_time": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 0.11,
+          "rings": 10,
+          "slices": 14,
+          "color": [255, 218, 122, 255],
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "rate": 1.7, "color": [255, 238, 164, 255], "emissive_base": [0.55, 0.32, 0.05], "emissive_add": [0.35, 0.22, 0.05] }
+          ]
+        },
+        { "type": "motion.oscillate", "origin": [0.0, 3.8, 0.34], "amplitude": [6.8, 0.0, 0.0], "rate": 0.45, "phase": -1.5707963 }
+      ]
     },
     {
       "name": "entity.score.cpu",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -731,8 +731,8 @@
         "position": [-8.15, 0.0, 3.35],
         "direction": [0.0, 0.0, -1.0],
         "color": [1.0, 0.06, 0.04],
-        "intensity": 11.0,
-        "range": 6.2,
+        "intensity": 12.5,
+        "range": 8.4,
         "inner_cutoff": 0.86,
         "outer_cutoff": 0.48
       },
@@ -759,8 +759,8 @@
         "position": [8.15, 0.0, 3.35],
         "direction": [0.0, 0.0, -1.0],
         "color": [0.08, 0.28, 1.0],
-        "intensity": 11.0,
-        "range": 6.2,
+        "intensity": 12.5,
+        "range": 8.4,
         "inner_cutoff": 0.86,
         "outer_cutoff": 0.48
       }

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -737,25 +737,14 @@
         ]
       },
       {
-        "name": "light.center_cycle",
-        "type": "point",
-        "position": [0.0, 0.0, 2.8],
-        "color": [0.18, 0.42, 1.0],
-        "intensity": 2.8,
-        "range": 6.2,
-        "effects": [
-          { "type": "color_cycle", "rate": 0.55, "colors": [[1.0, 0.18, 0.16], [1.0, 0.65, 0.12], [1.0, 0.95, 0.22], [0.18, 1.0, 0.36], [0.12, 0.90, 1.0], [0.36, 0.26, 1.0], [0.95, 0.18, 1.0]], "color_blend": 1.0, "intensity_add": 0.25, "range_add": 0.2 }
-        ]
-      },
-      {
-        "name": "light.right_green",
+        "name": "light.right_blue",
         "type": "point",
         "position": [5.7, 0.35, 2.4],
-        "color": [0.08, 1.0, 0.22],
+        "color": [0.12, 0.34, 1.0],
         "intensity": 2.6,
         "range": 5.8,
         "effects": [
-          { "type": "pulse", "rate": 1.25, "phase": 2.0, "color": [0.24, 1.0, 0.48], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
+          { "type": "pulse", "rate": 1.25, "phase": 2.0, "color": [0.28, 0.54, 1.0], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
         ]
       },
       {
@@ -1057,17 +1046,6 @@
         "motion_time": { "type": "float", "value": 0.0 }
       },
       "components": [
-        {
-          "type": "render.sphere",
-          "radius": 0.11,
-          "rings": 10,
-          "slices": 14,
-          "color": [255, 218, 122, 255],
-          "emissive": true,
-          "effects": [
-            { "type": "pulse", "rate": 1.7, "color": [255, 238, 164, 255], "emissive_base": [0.55, 0.32, 0.05], "emissive_add": [0.35, 0.22, 0.05] }
-          ]
-        },
         { "type": "motion.oscillate", "origin": [0.0, 3.8, 0.34], "amplitude": [6.8, 0.0, 0.0], "rate": 0.45, "phase": -1.5707963 }
       ]
     },

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -726,6 +726,39 @@
     ],
     "lights": [
       {
+        "name": "light.left_red",
+        "type": "point",
+        "position": [-5.7, 0.35, 2.4],
+        "color": [1.0, 0.10, 0.08],
+        "intensity": 2.6,
+        "range": 5.8,
+        "effects": [
+          { "type": "pulse", "rate": 1.2, "phase": 0.5, "color": [1.0, 0.18, 0.12], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
+        ]
+      },
+      {
+        "name": "light.center_cycle",
+        "type": "point",
+        "position": [0.0, 0.0, 2.8],
+        "color": [0.18, 0.42, 1.0],
+        "intensity": 2.8,
+        "range": 6.2,
+        "effects": [
+          { "type": "color_cycle", "rate": 0.55, "colors": [[1.0, 0.18, 0.16], [1.0, 0.65, 0.12], [1.0, 0.95, 0.22], [0.18, 1.0, 0.36], [0.12, 0.90, 1.0], [0.36, 0.26, 1.0], [0.95, 0.18, 1.0]], "color_blend": 1.0, "intensity_add": 0.25, "range_add": 0.2 }
+        ]
+      },
+      {
+        "name": "light.right_green",
+        "type": "point",
+        "position": [5.7, 0.35, 2.4],
+        "color": [0.08, 1.0, 0.22],
+        "intensity": 2.6,
+        "range": 5.8,
+        "effects": [
+          { "type": "pulse", "rate": 1.25, "phase": 2.0, "color": [0.24, 1.0, 0.48], "color_blend": 0.22, "intensity_add": 0.25, "range_add": 0.25 }
+        ]
+      },
+      {
         "name": "light.gameplay_lamp",
         "type": "point",
         "target_entity": "entity.light.lamp",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -736,7 +736,7 @@
         "inner_cutoff": 0.86,
         "outer_cutoff": 0.48,
         "effects": [
-          { "type": "pulse", "rate": 0.45, "phase": 0.4, "color": [1.0, 0.34, 0.08], "color_blend": 0.55, "intensity_add": 0.35, "range_add": 0.25 }
+          { "type": "color_cycle", "duration": 8.0, "phase": 0.05, "colors": [[1.0, 0.06, 0.04], [1.0, 0.34, 0.08], [1.0, 0.12, 0.34]], "color_blend": 1.0 }
         ]
       },
       {
@@ -767,7 +767,7 @@
         "inner_cutoff": 0.86,
         "outer_cutoff": 0.48,
         "effects": [
-          { "type": "pulse", "rate": 0.50, "phase": 1.7, "color": [0.12, 0.72, 1.0], "color_blend": 0.55, "intensity_add": 0.35, "range_add": 0.25 }
+          { "type": "color_cycle", "duration": 8.5, "phase": 0.35, "colors": [[0.08, 0.28, 1.0], [0.12, 0.72, 1.0], [0.34, 0.18, 1.0]], "color_blend": 1.0 }
         ]
       }
     ]

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -15,7 +15,6 @@
     "entity.paddle.player",
     "entity.paddle.cpu",
     "entity.ball",
-    "entity.light.lamp",
     "entity.score.player",
     "entity.score.cpu",
     "entity.match",

--- a/demos/pong/data/scenes/play.scene.json
+++ b/demos/pong/data/scenes/play.scene.json
@@ -15,6 +15,7 @@
     "entity.paddle.player",
     "entity.paddle.cpu",
     "entity.ball",
+    "entity.light.lamp",
     "entity.score.player",
     "entity.score.cpu",
     "entity.match",

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -14,7 +14,6 @@
     "entity.paddle.attract_left",
     "entity.paddle.attract_right",
     "entity.ball.attract",
-    "entity.light.lamp",
     "entity.presentation",
     "entity.effect.ambient_particles"
   ],

--- a/demos/pong/data/scenes/title.scene.json
+++ b/demos/pong/data/scenes/title.scene.json
@@ -14,6 +14,7 @@
     "entity.paddle.attract_left",
     "entity.paddle.attract_right",
     "entity.ball.attract",
+    "entity.light.lamp",
     "entity.presentation",
     "entity.effect.ambient_particles"
   ],
@@ -31,6 +32,9 @@
   "activity": {
     "enabled": true,
     "input": "any",
+    "consume_wake_input": true,
+    "block_menus_on_wake": true,
+    "block_scene_shortcuts_on_wake": true,
     "idle_after": 5.0,
     "on_enter": [
       { "type": "camera.set", "camera": "camera.overhead" },

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -866,9 +866,10 @@ Supported primitive effects are:
 Particle emitters may include `draw_emissive` for host renderers that draw particles through emissive lighting.
 
 World lights may also declare `effects`. `pulse` effects can blend color and
-add intensity/range over time; `flash` effects read a float actor property and
-use it as the effect weight. This lets data tune glows, brightness, color
-shifts, and transient flashes without host code.
+add intensity/range over time; `color_cycle` effects smoothly interpolate
+through an authored palette; `flash` effects read a float actor property and use
+it as the effect weight. This lets data tune glows, brightness, color shifts,
+and transient flashes without host code.
 
 ```json
 {
@@ -881,6 +882,7 @@ shifts, and transient flashes without host code.
                                                   "effects"
         : [
             {"type" : "pulse", "rate" : 9.0, "color" : [ 1.0, 0.96, 0.54 ], "intensity_add" : 0.9},
+            {"type" : "color_cycle", "duration" : 8.0, "colors" : [[1.0, 0.1, 0.1], [1.0, 0.45, 0.1], [0.9, 0.1, 0.5]]},
             {"type" : "flash", "source" : "entity.presentation", "property" : "paddle_flash", "intensity_add" : 1.5}
         ]
 }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -867,8 +867,7 @@ Particle emitters may include `draw_emissive` for host renderers that draw parti
 
 World lights may also declare `effects`. `pulse` effects can blend color and
 add intensity/range over time; `flash` effects read a float actor property and
-use it as the effect weight; `color_cycle` effects interpolate through an
-authored color palette over time. This lets data tune glows, brightness, color
+use it as the effect weight. This lets data tune glows, brightness, color
 shifts, and transient flashes without host code.
 
 ```json
@@ -882,7 +881,6 @@ shifts, and transient flashes without host code.
                                                   "effects"
         : [
             {"type" : "pulse", "rate" : 9.0, "color" : [ 1.0, 0.96, 0.54 ], "intensity_add" : 0.9},
-            {"type" : "color_cycle", "rate" : 0.6, "colors" : [ [1.0, 0.1, 0.1], [0.1, 1.0, 0.4], [0.2, 0.4, 1.0] ]},
             {"type" : "flash", "source" : "entity.presentation", "property" : "paddle_flash", "intensity_add" : 1.5}
         ]
 }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -866,10 +866,10 @@ Supported primitive effects are:
 Particle emitters may include `draw_emissive` for host renderers that draw particles through emissive lighting.
 
 World lights may also declare `effects`. `pulse` effects can blend color and
-add intensity/range over time;
-`flash` effects read a float actor property and use it as the effect weight.This lets data tune glows, brightness,
-    color shifts,
-    and transient flashes without host code.
+add intensity/range over time; `flash` effects read a float actor property and
+use it as the effect weight; `color_cycle` effects interpolate through an
+authored color palette over time. This lets data tune glows, brightness, color
+shifts, and transient flashes without host code.
 
 ```json
 {
@@ -882,6 +882,7 @@ add intensity/range over time;
                                                   "effects"
         : [
             {"type" : "pulse", "rate" : 9.0, "color" : [ 1.0, 0.96, 0.54 ], "intensity_add" : 0.9},
+            {"type" : "color_cycle", "rate" : 0.6, "colors" : [ [1.0, 0.1, 0.1], [0.1, 1.0, 0.4], [0.2, 0.4, 1.0] ]},
             {"type" : "flash", "source" : "entity.presentation", "property" : "paddle_flash", "intensity_add" : 1.5}
         ]
 }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -774,6 +774,31 @@ selected-item resolution, then returns a data command for the host or app-flow
 controller to apply. This keeps title screens, options screens, and simple scene
 menus from growing bespoke per-game input code.
 
+Scenes may author an `activity` block for attract-mode and kiosk-style
+behavior. The activity controller emits `on_enter`, `on_idle`, `on_active`, and
+`periodic` action arrays. Set `consume_wake_input` to `true` when the first
+input after an idle fade should only reveal the UI instead of also activating
+menus, scene shortcuts, or pause:
+
+```json
+{
+    "activity": {
+        "enabled": true,
+        "input": "any",
+        "idle_after": 5.0,
+        "consume_wake_input": true,
+        "block_menus_on_wake": true,
+        "block_scene_shortcuts_on_wake": true,
+        "on_idle": [
+            {"type": "ui.animate", "target": "ui.title.menu", "property": "alpha", "to": 0.0, "duration": 0.65}
+        ],
+        "on_active": [
+            {"type": "ui.animate", "target": "ui.title.menu", "property": "alpha", "to": 1.0, "duration": 0.20}
+        ]
+    }
+}
+```
+
 ## Entities
 
 Entities are the data form of actor registry entries plus optional component ownership.
@@ -978,6 +1003,25 @@ add intensity/range over time;
                             } ]
 }
 ```
+
+`motion.velocity_2d` integrates an actor's vec2/vec3 velocity property into
+its transform each update. `motion.oscillate` moves an actor along an authored
+sinusoid and is useful for data-authored lamps, platforms, attract-mode props,
+and other looping presentation motion:
+
+```json
+{
+    "type": "motion.oscillate",
+    "origin": [0.0, 3.8, 0.34],
+    "amplitude": [6.8, 0.0, 0.0],
+    "rate": 0.45,
+    "phase": -1.5707963
+}
+```
+
+The runtime stores oscillator time on the actor property named by
+`time_property`, defaulting to `motion_time`. Set the actor's `active_motion`
+property to `false` to pause generic motion components.
 
     ## #Conditions
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1093,7 +1093,9 @@ extern "C"
     /**
      * @brief Read an authored world light by zero-based index.
      *
-     * The returned light is suitable for passing to sdl3d_add_light().
+     * The returned light is suitable for passing to sdl3d_add_light(). Lights
+     * may target one entity with `target_entity`, or the first active-scene
+     * entity in an ordered `target_entities` fallback list.
      */
     bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int index, sdl3d_light *out_light);
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1100,10 +1100,10 @@ extern "C"
     /**
      * @brief Read an authored world light with generic visual effects evaluated.
      *
-     * Supported light effects include `pulse` and `flash`, allowing data to
-     * drive color blends, intensity changes, and range changes over time or
-     * from actor properties. Passing NULL for @p eval uses a zeroed evaluation
-     * context.
+     * Supported light effects include `pulse`, `flash`, and `color_cycle`,
+     * allowing data to drive color blends, intensity changes, and range changes
+     * over time or from actor properties. Passing NULL for @p eval uses a
+     * zeroed evaluation context.
      */
     bool sdl3d_game_data_get_world_light_evaluated(const sdl3d_game_data_runtime *runtime, int index,
                                                    const sdl3d_game_data_render_eval *eval, sdl3d_light *out_light);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -973,6 +973,24 @@ extern "C"
                                                float dt);
 
     /**
+     * @brief Return whether the active scene activity should consume wake input.
+     *
+     * This is a query-only helper for app-flow/menu controllers. When a scene
+     * has entered its authored idle state and matching input is pressed, data
+     * may request that the current input be used only to wake the scene's
+     * activity controller. The next scene-activity update will run `on_active`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param input Current input manager.
+     * @param out_block_menus Optional output set when menu input should be blocked.
+     * @param out_block_scene_shortcuts Optional output set when scene shortcuts should be blocked.
+     * @return true when the matching wake input should be consumed for this frame.
+     */
+    bool sdl3d_game_data_scene_activity_consumes_wake_input(const sdl3d_game_data_runtime *runtime,
+                                                            const sdl3d_input_manager *input, bool *out_block_menus,
+                                                            bool *out_block_scene_shortcuts);
+
+    /**
      * @brief Read the authored UI pulse phase.
      *
      * Returns @p fallback when no `presentation.ui_pulse_clock` is authored or

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1100,10 +1100,10 @@ extern "C"
     /**
      * @brief Read an authored world light with generic visual effects evaluated.
      *
-     * Supported light effects include `pulse`, `flash`, and `color_cycle`,
-     * allowing data to drive color blends, intensity changes, and range changes
-     * over time or from actor properties. Passing NULL for @p eval uses a
-     * zeroed evaluation context.
+     * Supported light effects include `pulse` and `flash`, allowing data to
+     * drive color blends, intensity changes, and range changes over time or
+     * from actor properties. Passing NULL for @p eval uses a zeroed evaluation
+     * context.
      */
     bool sdl3d_game_data_get_world_light_evaluated(const sdl3d_game_data_runtime *runtime, int index,
                                                    const sdl3d_game_data_render_eval *eval, sdl3d_light *out_light);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1102,10 +1102,10 @@ extern "C"
     /**
      * @brief Read an authored world light with generic visual effects evaluated.
      *
-     * Supported light effects include `pulse` and `flash`, allowing data to
-     * drive color blends, intensity changes, and range changes over time or
-     * from actor properties. Passing NULL for @p eval uses a zeroed evaluation
-     * context.
+     * Supported light effects include `pulse`, `color_cycle`, and `flash`,
+     * allowing data to drive color blends, intensity changes, and range changes
+     * over time or from actor properties. Passing NULL for @p eval uses a zeroed
+     * evaluation context.
      */
     bool sdl3d_game_data_get_world_light_evaluated(const sdl3d_game_data_runtime *runtime, int index,
                                                    const sdl3d_game_data_render_eval *eval, sdl3d_light *out_light);

--- a/include/sdl3d/lighting.h
+++ b/include/sdl3d/lighting.h
@@ -43,7 +43,8 @@ extern "C"
      * Unified light descriptor. Fields used depend on `type`:
      *
      * DIRECTIONAL: direction, color, intensity.
-     * POINT:       position, color, intensity, range.
+     * POINT:       position, color, intensity, range. Range is a soft falloff
+     *              scale, not a hard cutoff.
      * SPOT:        position, direction, color, intensity, range,
      *              inner_cutoff, outer_cutoff (cosines of half-angles).
      */

--- a/include/sdl3d/lighting.h
+++ b/include/sdl3d/lighting.h
@@ -46,7 +46,8 @@ extern "C"
      * POINT:       position, color, intensity, range. Range is a soft falloff
      *              scale, not a hard cutoff.
      * SPOT:        position, direction, color, intensity, range,
-     *              inner_cutoff, outer_cutoff (cosines of half-angles).
+     *              inner_cutoff, outer_cutoff (cosines of half-angles). The
+     *              cone edge is smoothly blended between the cutoffs.
      */
     typedef struct sdl3d_light
     {

--- a/shaders/pbr_frag.glsl
+++ b/shaders/pbr_frag.glsl
@@ -93,7 +93,8 @@ void main() {
             if (uLights[i].type == 2) {
                 float cosA = dot(-L, normalize(uLights[i].direction));
                 float eps = uLights[i].innerCutoff - uLights[i].outerCutoff;
-                attenuation *= clamp((cosA - uLights[i].outerCutoff) / max(eps, 0.0001), 0.0, 1.0);
+                float spotIntensity = clamp((cosA - uLights[i].outerCutoff) / max(eps, 0.0001), 0.0, 1.0);
+                attenuation *= spotIntensity * spotIntensity * (3.0 - 2.0 * spotIntensity);
             }
         }
 

--- a/shaders/pbr_frag.glsl
+++ b/shaders/pbr_frag.glsl
@@ -88,8 +88,7 @@ void main() {
             L = toLight / max(dist, 0.0001);
             if (uLights[i].range > 0.0) {
                 float r = dist / uLights[i].range;
-                attenuation = max(1.0 - r * r, 0.0);
-                attenuation *= attenuation;
+                attenuation = exp(-2.8 * r * r);
             }
             if (uLights[i].type == 2) {
                 float cosA = dot(-L, normalize(uLights[i].direction));

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -665,8 +665,7 @@ static sdl3d_vec4 sdl3d_shade_point_retro(const sdl3d_lighting_params *lp, sdl3d
             if (light->range > 0.0f)
             {
                 float ratio = dist / light->range;
-                attenuation = SDL_max(1.0f - ratio * ratio, 0.0f);
-                attenuation *= attenuation;
+                attenuation = SDL_expf(-2.8f * ratio * ratio);
             }
             else
             {

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -683,7 +683,9 @@ static sdl3d_vec4 sdl3d_shade_point_retro(const sdl3d_lighting_params *lp, sdl3d
                 }
                 else
                 {
-                    attenuation *= sdl3d_clamp01((cos_angle - light->outer_cutoff) / epsilon);
+                    float spot_intensity = sdl3d_clamp01((cos_angle - light->outer_cutoff) / epsilon);
+                    spot_intensity = spot_intensity * spot_intensity * (3.0f - 2.0f * spot_intensity);
+                    attenuation *= spot_intensity;
                 }
             }
         }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2708,32 +2708,6 @@ static void light_color_lerp(float color[3], const sdl3d_vec3 target, float t)
     color[2] = color[2] + (target.z - color[2]) * t;
 }
 
-static bool light_effect_palette_color(yyjson_val *colors, float position, sdl3d_vec3 *out_color)
-{
-    const size_t count = yyjson_is_arr(colors) ? yyjson_arr_size(colors) : 0;
-    if (out_color == NULL || count == 0)
-        return false;
-
-    if (count == 1)
-    {
-        *out_color = json_vec3_value(yyjson_arr_get(colors, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
-        return true;
-    }
-
-    const float wrapped = SDL_fmodf(position, (float)count);
-    const float index_float = wrapped < 0.0f ? wrapped + (float)count : wrapped;
-    const int index0 = (int)SDL_floorf(index_float);
-    const int index1 = (index0 + 1) % (int)count;
-    const float t = index_float - (float)index0;
-    const sdl3d_vec3 color0 =
-        json_vec3_value(yyjson_arr_get(colors, (size_t)index0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
-    const sdl3d_vec3 color1 = json_vec3_value(yyjson_arr_get(colors, (size_t)index1), color0);
-
-    *out_color = sdl3d_vec3_make(color0.x + (color1.x - color0.x) * t, color0.y + (color1.y - color0.y) * t,
-                                 color0.z + (color1.z - color0.z) * t);
-    return true;
-}
-
 static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_val *light_json,
                                 const sdl3d_game_data_render_eval *eval, sdl3d_light *light)
 {
@@ -2760,17 +2734,6 @@ static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_v
             value =
                 source != NULL && property != NULL ? sdl3d_properties_get_float(source->props, property, 0.0f) : 0.0f;
             value = game_data_clampf(value, 0.0f, 1.0f);
-        }
-        else if (SDL_strcmp(type, "color_cycle") == 0)
-        {
-            const float time = eval != NULL ? eval->time : 0.0f;
-            const float rate = json_float(effect, "rate", 1.0f);
-            const float phase = json_float(effect, "phase", 0.0f);
-            sdl3d_vec3 target;
-            if (!light_effect_palette_color(obj_get(effect, "colors"), time * rate + phase, &target))
-                continue;
-            light_color_lerp(light->color, target, json_float(effect, "color_blend", 1.0f));
-            value = 1.0f;
         }
         else
         {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7546,6 +7546,34 @@ static bool activity_input_matches(const sdl3d_game_data_runtime *runtime, yyjso
     return sdl3d_input_any_pressed(input);
 }
 
+bool sdl3d_game_data_scene_activity_consumes_wake_input(const sdl3d_game_data_runtime *runtime,
+                                                        const sdl3d_input_manager *input, bool *out_block_menus,
+                                                        bool *out_block_scene_shortcuts)
+{
+    if (out_block_menus != NULL)
+        *out_block_menus = false;
+    if (out_block_scene_shortcuts != NULL)
+        *out_block_scene_shortcuts = false;
+    if (runtime == NULL || input == NULL)
+        return false;
+
+    yyjson_val *activity = active_scene_activity_json(runtime);
+    const char *active_scene = sdl3d_game_data_active_scene(runtime);
+    const scene_activity_state *state = &runtime->activity;
+    if (activity == NULL || state->scene != active_scene || !state->idle ||
+        !activity_input_matches(runtime, activity, input))
+    {
+        return false;
+    }
+
+    const bool consume = json_bool(activity, "consume_wake_input", false);
+    if (out_block_menus != NULL)
+        *out_block_menus = json_bool(activity, "block_menus_on_wake", consume);
+    if (out_block_scene_shortcuts != NULL)
+        *out_block_scene_shortcuts = json_bool(activity, "block_scene_shortcuts_on_wake", consume);
+    return consume;
+}
+
 bool sdl3d_game_data_update_scene_activity(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input, float dt)
 {
     if (runtime == NULL)
@@ -8090,16 +8118,34 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
         for (size_t c = 0; c < yyjson_arr_size(components); ++c)
         {
             yyjson_val *component = yyjson_arr_get(components, c);
-            if (SDL_strcmp(json_string(component, "type", ""), "motion.velocity_2d") != 0 ||
-                !sdl3d_properties_get_bool(actor->props, "active_motion", true))
+            const char *type = json_string(component, "type", "");
+            if (!sdl3d_properties_get_bool(actor->props, "active_motion", true))
             {
                 continue;
             }
 
-            const char *property = json_string(component, "property", "velocity");
-            const sdl3d_vec3 velocity = actor_vec_property(actor, property);
-            actor_set_position(actor, sdl3d_vec3_make(actor->position.x + velocity.x * dt,
-                                                      actor->position.y + velocity.y * dt, actor->position.z));
+            if (SDL_strcmp(type, "motion.velocity_2d") == 0)
+            {
+                const char *property = json_string(component, "property", "velocity");
+                const sdl3d_vec3 velocity = actor_vec_property(actor, property);
+                actor_set_position(actor, sdl3d_vec3_make(actor->position.x + velocity.x * dt,
+                                                          actor->position.y + velocity.y * dt, actor->position.z));
+            }
+            else if (SDL_strcmp(type, "motion.oscillate") == 0)
+            {
+                const char *time_property = json_string(component, "time_property", "motion_time");
+                const float time = sdl3d_properties_get_float(actor->props, time_property, 0.0f) + dt;
+                sdl3d_properties_set_float(actor->props, time_property, time);
+
+                const sdl3d_vec3 origin = json_vec3_value(obj_get(component, "origin"), actor->position);
+                const sdl3d_vec3 amplitude =
+                    json_vec3_value(obj_get(component, "amplitude"), sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+                const float rate = json_float(component, "rate", 1.0f);
+                const float phase = json_float(component, "phase", 0.0f);
+                const float wave = SDL_sinf(time * rate + phase);
+                actor_set_position(actor, sdl3d_vec3_make(origin.x + amplitude.x * wave, origin.y + amplitude.y * wave,
+                                                          origin.z + amplitude.z * wave));
+            }
         }
     }
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2672,6 +2672,19 @@ bool sdl3d_game_data_get_world_light(const sdl3d_game_data_runtime *runtime, int
     out_light->position = json_vec3(light_json, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
     const char *target_entity = json_string(light_json, "target_entity", NULL);
     sdl3d_registered_actor *target = sdl3d_game_data_find_actor(runtime, target_entity);
+    yyjson_val *target_entities = obj_get(light_json, "target_entities");
+    for (size_t i = 0; target == NULL && yyjson_is_arr(target_entities) && i < yyjson_arr_size(target_entities); ++i)
+    {
+        const char *candidate = yyjson_get_str(yyjson_arr_get(target_entities, i));
+        if (candidate != NULL && active_scene_has_entity_internal(runtime, candidate))
+            target = sdl3d_game_data_find_actor(runtime, candidate);
+    }
+    for (size_t i = 0; target == NULL && yyjson_is_arr(target_entities) && i < yyjson_arr_size(target_entities); ++i)
+    {
+        const char *candidate = yyjson_get_str(yyjson_arr_get(target_entities, i));
+        if (candidate != NULL)
+            target = sdl3d_game_data_find_actor(runtime, candidate);
+    }
     if (target != NULL)
     {
         const sdl3d_vec3 offset = json_vec3(light_json, "offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2708,6 +2708,32 @@ static void light_color_lerp(float color[3], const sdl3d_vec3 target, float t)
     color[2] = color[2] + (target.z - color[2]) * t;
 }
 
+static bool light_effect_palette_color(yyjson_val *colors, float position, sdl3d_vec3 *out_color)
+{
+    const size_t count = yyjson_is_arr(colors) ? yyjson_arr_size(colors) : 0;
+    if (out_color == NULL || count == 0)
+        return false;
+
+    if (count == 1)
+    {
+        *out_color = json_vec3_value(yyjson_arr_get(colors, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+        return true;
+    }
+
+    const float wrapped = SDL_fmodf(position, (float)count);
+    const float index_float = wrapped < 0.0f ? wrapped + (float)count : wrapped;
+    const int index0 = (int)SDL_floorf(index_float);
+    const int index1 = (index0 + 1) % (int)count;
+    const float t = index_float - (float)index0;
+    const sdl3d_vec3 color0 =
+        json_vec3_value(yyjson_arr_get(colors, (size_t)index0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+    const sdl3d_vec3 color1 = json_vec3_value(yyjson_arr_get(colors, (size_t)index1), color0);
+
+    *out_color = sdl3d_vec3_make(color0.x + (color1.x - color0.x) * t, color0.y + (color1.y - color0.y) * t,
+                                 color0.z + (color1.z - color0.z) * t);
+    return true;
+}
+
 static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_val *light_json,
                                 const sdl3d_game_data_render_eval *eval, sdl3d_light *light)
 {
@@ -2734,6 +2760,17 @@ static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_v
             value =
                 source != NULL && property != NULL ? sdl3d_properties_get_float(source->props, property, 0.0f) : 0.0f;
             value = game_data_clampf(value, 0.0f, 1.0f);
+        }
+        else if (SDL_strcmp(type, "color_cycle") == 0)
+        {
+            const float time = eval != NULL ? eval->time : 0.0f;
+            const float rate = json_float(effect, "rate", 1.0f);
+            const float phase = json_float(effect, "phase", 0.0f);
+            sdl3d_vec3 target;
+            if (!light_effect_palette_color(obj_get(effect, "colors"), time * rate + phase, &target))
+                continue;
+            light_color_lerp(light->color, target, json_float(effect, "color_blend", 1.0f));
+            value = 1.0f;
         }
         else
         {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2721,6 +2721,41 @@ static void light_color_lerp(float color[3], const sdl3d_vec3 target, float t)
     color[2] = color[2] + (target.z - color[2]) * t;
 }
 
+static bool light_effect_sample_color_cycle(yyjson_val *effect, float time, sdl3d_vec3 fallback, sdl3d_vec3 *out_color)
+{
+    yyjson_val *colors = obj_get(effect, "colors");
+    if (out_color == NULL || !yyjson_is_arr(colors) || yyjson_arr_size(colors) == 0)
+        return false;
+
+    const size_t count = yyjson_arr_size(colors);
+    if (count == 1)
+    {
+        *out_color = json_vec3_value(yyjson_arr_get(colors, 0), fallback);
+        return true;
+    }
+
+    const float duration = SDL_max(json_float(effect, "duration", 4.0f), 0.001f);
+    float phase = json_float(effect, "phase", 0.0f);
+    float cycle = SDL_fmodf(time / duration + phase, 1.0f);
+    if (cycle < 0.0f)
+        cycle += 1.0f;
+
+    const float scaled = cycle * (float)count;
+    size_t index = (size_t)SDL_floorf(scaled);
+    if (index >= count)
+        index = count - 1;
+    const size_t next_index = (index + 1U) % count;
+
+    float t = scaled - (float)index;
+    if (json_bool(effect, "smooth", true))
+        t = t * t * (3.0f - 2.0f * t);
+
+    const sdl3d_vec3 a = json_vec3_value(yyjson_arr_get(colors, index), fallback);
+    const sdl3d_vec3 b = json_vec3_value(yyjson_arr_get(colors, next_index), a);
+    *out_color = sdl3d_vec3_make(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t);
+    return true;
+}
+
 static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_val *light_json,
                                 const sdl3d_game_data_render_eval *eval, sdl3d_light *light)
 {
@@ -2739,6 +2774,17 @@ static void apply_light_effects(const sdl3d_game_data_runtime *runtime, yyjson_v
             const float rate = json_float(effect, "rate", 1.0f);
             const float phase = json_float(effect, "phase", 0.0f);
             value = 0.5f + 0.5f * SDL_sinf(time * rate + phase);
+        }
+        else if (SDL_strcmp(type, "color_cycle") == 0)
+        {
+            const float time = eval != NULL ? eval->time : 0.0f;
+            sdl3d_vec3 target;
+            if (light_effect_sample_color_cycle(
+                    effect, time, sdl3d_vec3_make(light->color[0], light->color[1], light->color[2]), &target))
+            {
+                light_color_lerp(light->color, target, json_float(effect, "color_blend", 1.0f));
+            }
+            continue;
         }
         else if (SDL_strcmp(type, "flash") == 0)
         {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2103,6 +2103,17 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
                 if (!is_non_empty_string(effect, "property"))
                     return validation_error(ctx, effect_path, "light flash effect requires a non-empty property");
             }
+            else if (SDL_strcmp(type != NULL ? type : "", "color_cycle") == 0)
+            {
+                yyjson_val *colors = obj_get(effect, "colors");
+                if (!yyjson_is_arr(colors) || yyjson_arr_size(colors) < 2)
+                    return validation_error(ctx, effect_path, "light color_cycle effect requires at least two colors");
+                for (size_t color_index = 0; color_index < yyjson_arr_size(colors); ++color_index)
+                {
+                    if (!is_vec_array(yyjson_arr_get(colors, color_index), 3))
+                        return validation_error(ctx, effect_path, "light color_cycle colors must be vec3 arrays");
+                }
+            }
             else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0)
             {
                 return validation_error(ctx, effect_path, "unsupported light effect type '%s'",

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -514,8 +514,8 @@ static bool is_vec_array(yyjson_val *value, size_t min_count)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb", "collision.circle", "control.axis_1d", "motion.velocity_2d",
-        "particles.emitter",  "property.decay", "render.cube",      "render.sphere",
+        "adapter.controller", "collision.aabb",    "collision.circle", "control.axis_1d", "motion.oscillate",
+        "motion.velocity_2d", "particles.emitter", "property.decay",   "render.cube",     "render.sphere",
     };
 
     if (type == NULL)
@@ -1099,6 +1099,21 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (json_string(component, "rate_property") == NULL && !yyjson_is_num(obj_get(component, "rate")))
                     return validation_error(ctx, path, "property.decay requires rate or rate_property");
             }
+            else if (SDL_strcmp(type, "motion.oscillate") == 0)
+            {
+                yyjson_val *origin = obj_get(component, "origin");
+                yyjson_val *amplitude = obj_get(component, "amplitude");
+                yyjson_val *rate = obj_get(component, "rate");
+                yyjson_val *phase = obj_get(component, "phase");
+                if (origin != NULL && !is_vec_array(origin, 3))
+                    return validation_error(ctx, path, "motion.oscillate origin must be a vec3");
+                if (amplitude != NULL && !is_vec_array(amplitude, 3))
+                    return validation_error(ctx, path, "motion.oscillate amplitude must be a vec3");
+                if (rate != NULL && !yyjson_is_num(rate))
+                    return validation_error(ctx, path, "motion.oscillate rate must be a number");
+                if (phase != NULL && !yyjson_is_num(phase))
+                    return validation_error(ctx, path, "motion.oscillate phase must be a number");
+            }
             else if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0)
             {
                 yyjson_val *lighting = obj_get(component, "lighting");
@@ -1482,6 +1497,15 @@ static bool validate_scene_activity(validation_context *ctx, yyjson_val *activit
     yyjson_val *reset_periodic = obj_get(activity, "reset_periodic_on_input");
     if (reset_periodic != NULL && !yyjson_is_bool(reset_periodic))
         return validation_error(ctx, json_path, "scene activity reset_periodic_on_input must be a boolean");
+    yyjson_val *consume_wake = obj_get(activity, "consume_wake_input");
+    if (consume_wake != NULL && !yyjson_is_bool(consume_wake))
+        return validation_error(ctx, json_path, "scene activity consume_wake_input must be a boolean");
+    yyjson_val *block_menus = obj_get(activity, "block_menus_on_wake");
+    if (block_menus != NULL && !yyjson_is_bool(block_menus))
+        return validation_error(ctx, json_path, "scene activity block_menus_on_wake must be a boolean");
+    yyjson_val *block_shortcuts = obj_get(activity, "block_scene_shortcuts_on_wake");
+    if (block_shortcuts != NULL && !yyjson_is_bool(block_shortcuts))
+        return validation_error(ctx, json_path, "scene activity block_scene_shortcuts_on_wake must be a boolean");
 
     const char *input = json_string(activity, "input");
     if (input != NULL && SDL_strcmp(input, "any") != 0 && SDL_strcmp(input, "action") != 0 &&

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2076,6 +2076,18 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
         const char *target_entity = json_string(light, "target_entity");
         if (target_entity != NULL && !require_ref(ctx, &names->entities, "entity", target_entity, path))
             return false;
+        yyjson_val *target_entities = obj_get(light, "target_entities");
+        if (target_entities != NULL && !yyjson_is_arr(target_entities))
+            return validation_error(ctx, path, "light target_entities must be an array");
+        for (size_t target_index = 0; yyjson_is_arr(target_entities) && target_index < yyjson_arr_size(target_entities);
+             ++target_index)
+        {
+            yyjson_val *target = yyjson_arr_get(target_entities, target_index);
+            if (!yyjson_is_str(target))
+                return validation_error(ctx, path, "light target_entities entries must be entity names");
+            if (!require_ref(ctx, &names->entities, "entity", yyjson_get_str(target), path))
+                return false;
+        }
 
         yyjson_val *effects = obj_get(light, "effects");
         for (size_t e = 0; yyjson_is_arr(effects) && e < yyjson_arr_size(effects); ++e)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2091,18 +2091,6 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
                 if (!is_non_empty_string(effect, "property"))
                     return validation_error(ctx, effect_path, "light flash effect requires a non-empty property");
             }
-            else if (SDL_strcmp(type != NULL ? type : "", "color_cycle") == 0)
-            {
-                yyjson_val *colors = obj_get(effect, "colors");
-                if (!yyjson_is_arr(colors) || yyjson_arr_size(colors) == 0)
-                    return validation_error(ctx, effect_path, "light color_cycle effect requires a colors array");
-                for (size_t color_index = 0; color_index < yyjson_arr_size(colors); ++color_index)
-                {
-                    if (!is_vec_array(yyjson_arr_get(colors, color_index), 3))
-                        return validation_error(ctx, effect_path,
-                                                "light color_cycle effect colors must be vec3 values");
-                }
-            }
             else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0)
             {
                 return validation_error(ctx, effect_path, "unsupported light effect type '%s'",

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2091,6 +2091,18 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
                 if (!is_non_empty_string(effect, "property"))
                     return validation_error(ctx, effect_path, "light flash effect requires a non-empty property");
             }
+            else if (SDL_strcmp(type != NULL ? type : "", "color_cycle") == 0)
+            {
+                yyjson_val *colors = obj_get(effect, "colors");
+                if (!yyjson_is_arr(colors) || yyjson_arr_size(colors) == 0)
+                    return validation_error(ctx, effect_path, "light color_cycle effect requires a colors array");
+                for (size_t color_index = 0; color_index < yyjson_arr_size(colors); ++color_index)
+                {
+                    if (!is_vec_array(yyjson_arr_get(colors, color_index), 3))
+                        return validation_error(ctx, effect_path,
+                                                "light color_cycle effect colors must be vec3 values");
+                }
+            }
             else if (SDL_strcmp(type != NULL ? type : "", "pulse") != 0)
             {
                 return validation_error(ctx, effect_path, "unsupported light effect type '%s'",

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1644,17 +1644,22 @@ bool sdl3d_game_data_app_flow_update(sdl3d_game_data_app_flow *flow, sdl3d_game_
     bool timeline_blocks_scene_shortcuts = false;
     app_flow_timeline_blocks(flow, runtime, &timeline_blocks_menus, &timeline_blocks_scene_shortcuts);
 
-    if (!skip_consumed)
+    bool activity_blocks_menus = false;
+    bool activity_blocks_scene_shortcuts = false;
+    const bool activity_wake_consumed = sdl3d_game_data_scene_activity_consumes_wake_input(
+        runtime, input, &activity_blocks_menus, &activity_blocks_scene_shortcuts);
+
+    if (!skip_consumed && !activity_wake_consumed)
     {
         if (flow->app.quit_action_id >= 0 &&
             sdl3d_game_data_active_scene_allows_action(runtime, flow->app.quit_action_id) &&
             sdl3d_input_is_pressed(input, flow->app.quit_action_id))
             app_flow_request_quit(flow, ctx, runtime);
 
-        if (!skip_blocks_scene_shortcuts && !timeline_blocks_scene_shortcuts)
+        if (!skip_blocks_scene_shortcuts && !timeline_blocks_scene_shortcuts && !activity_blocks_scene_shortcuts)
             app_flow_consume_scene_shortcuts(flow, runtime, input);
         bool menu_consumed = false;
-        if (!skip_blocks_menus && !timeline_blocks_menus)
+        if (!skip_blocks_menus && !timeline_blocks_menus && !activity_blocks_menus)
             menu_consumed = app_flow_consume_menu(flow, ctx, runtime, input, bus);
 
         if (!menu_consumed && flow->app.pause_action_id >= 0 &&

--- a/src/shading.c
+++ b/src/shading.c
@@ -146,6 +146,7 @@ static bool sdl3d_compute_light_contribution(const sdl3d_light *light, float px,
             else
             {
                 float spot_intensity = sdl3d_clampf((cos_angle - light->outer_cutoff) / epsilon, 0.0f, 1.0f);
+                spot_intensity = spot_intensity * spot_intensity * (3.0f - 2.0f * spot_intensity);
                 attenuation *= spot_intensity;
             }
         }

--- a/src/shading.c
+++ b/src/shading.c
@@ -118,8 +118,7 @@ static bool sdl3d_compute_light_contribution(const sdl3d_light *light, float px,
         if (light->range > 0.0f)
         {
             float ratio = dist / light->range;
-            attenuation = sdl3d_maxf(1.0f - ratio * ratio, 0.0f);
-            attenuation *= attenuation;
+            attenuation = SDL_expf(-2.8f * ratio * ratio);
         }
         else
         {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -569,6 +569,33 @@ void write_scene_activity_json(const std::filesystem::path &dir)
                R"json({
   "schema": "sdl3d.game.v0",
   "metadata": { "name": "Activity", "id": "test.activity", "version": "0.1.0" },
+  "input": {
+    "contexts": [
+      {
+        "name": "menu",
+        "actions": [
+          {
+            "name": "action.menu.select",
+            "bindings": [
+              { "device": "keyboard", "key": "RETURN" }
+            ]
+          },
+          {
+            "name": "action.menu.up",
+            "bindings": [
+              { "device": "keyboard", "key": "UP" }
+            ]
+          },
+          {
+            "name": "action.menu.down",
+            "bindings": [
+              { "device": "keyboard", "key": "DOWN" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "world": {
     "cameras": [
       {
@@ -600,11 +627,19 @@ void write_scene_activity_json(const std::filesystem::path &dir)
         "idle": { "type": "bool", "value": false },
         "periodic": { "type": "int", "value": 0 }
       }
+    },
+    {
+      "name": "entity.lamp",
+      "active": true,
+      "transform": { "position": [2.0, 0.0, 0.0] },
+      "components": [
+        { "type": "motion.oscillate", "origin": [2.0, 0.0, 0.0], "amplitude": [3.0, 0.0, 0.0], "rate": 1.0 }
+      ]
     }
   ],
   "scenes": {
     "initial": "scene.title",
-    "files": ["scenes/title.scene.json"]
+    "files": ["scenes/title.scene.json", "scenes/play.scene.json"]
   }
 })json");
     write_text(dir / "scenes" / "title.scene.json",
@@ -614,10 +649,14 @@ void write_scene_activity_json(const std::filesystem::path &dir)
   "updates_game": false,
   "renders_world": false,
   "camera": "camera.overhead",
-  "entities": ["entity.state"],
+  "entities": ["entity.state", "entity.lamp"],
+  "input": { "actions": ["action.menu.select", "action.menu.up", "action.menu.down"] },
   "activity": {
     "enabled": true,
     "input": "any",
+    "consume_wake_input": true,
+    "block_menus_on_wake": true,
+    "block_scene_shortcuts_on_wake": true,
     "idle_after": 1.0,
     "on_enter": [
       { "type": "property.set", "target": "entity.state", "key": "entered", "value": true },
@@ -639,7 +678,26 @@ void write_scene_activity_json(const std::filesystem::path &dir)
         ]
       }
     ]
-  }
+  },
+  "menus": [
+    {
+      "name": "menu.title",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        { "label": "Play", "scene": "scene.play" }
+      ]
+    }
+  ]
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": false,
+  "entities": []
 })json");
 }
 
@@ -1142,13 +1200,14 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
     EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
 
-    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 4);
-    sdl3d_light ball_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 3, &ball_light));
-    EXPECT_EQ(ball_light.type, SDL3D_LIGHT_POINT);
-    EXPECT_NEAR(ball_light.position.x, 0.0f, 0.0001f);
-    EXPECT_NEAR(ball_light.position.y, 0.0f, 0.0001f);
-    EXPECT_NEAR(ball_light.position.z, 1.32f, 0.0001f);
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 1);
+    sdl3d_light lamp_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &lamp_light));
+    EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_POINT);
+    EXPECT_NEAR(lamp_light.position.x, -6.8f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.y, 3.8f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.z, 3.14f, 0.0001f);
+    EXPECT_NEAR(lamp_light.range, 6.4f, 0.0001f);
 
     sdl3d_particle_config particles{};
     ASSERT_TRUE(sdl3d_game_data_get_particle_emitter(runtime, "entity.effect.ambient_particles", &particles));
@@ -1210,7 +1269,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     RenderPrimitiveCapture capture{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &capture));
     EXPECT_EQ(capture.cubes, 16);
-    EXPECT_EQ(capture.spheres, 1);
+    EXPECT_EQ(capture.spheres, 2);
     EXPECT_TRUE(capture.saw_player_paddle);
     EXPECT_TRUE(capture.saw_ball);
 
@@ -3215,6 +3274,11 @@ TEST(GameDataRuntime, SceneActivityDrivesIdleWakeAndPeriodicActions)
     key.key.scancode = SDL_SCANCODE_SPACE;
     sdl3d_input_process_event(input, &key);
     sdl3d_input_update(input, 1);
+    bool block_menus = false;
+    bool block_shortcuts = false;
+    EXPECT_TRUE(sdl3d_game_data_scene_activity_consumes_wake_input(runtime, input, &block_menus, &block_shortcuts));
+    EXPECT_TRUE(block_menus);
+    EXPECT_TRUE(block_shortcuts);
     ASSERT_TRUE(sdl3d_game_data_update_scene_activity(runtime, input, 0.0f));
     EXPECT_FALSE(sdl3d_properties_get_bool(state->props, "idle", true));
 
@@ -3227,6 +3291,97 @@ TEST(GameDataRuntime, SceneActivityDrivesIdleWakeAndPeriodicActions)
 
     ASSERT_TRUE(sdl3d_game_data_update_scene_activity(runtime, input, 1.1f));
     EXPECT_TRUE(sdl3d_properties_get_bool(state->props, "idle", false));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, AppFlowConsumesActivityWakeInputBeforeMenus)
+{
+    const std::filesystem::path dir = unique_test_dir("scene_activity_app_flow");
+    write_scene_activity_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "activity.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    sdl3d_registered_actor *state = sdl3d_game_data_find_actor(runtime, "entity.state");
+    ASSERT_NE(state, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_update_scene_activity(runtime, input, 0.0f));
+    ASSERT_TRUE(sdl3d_game_data_update_scene_activity(runtime, input, 1.1f));
+    ASSERT_TRUE(sdl3d_properties_get_bool(state->props, "idle", false));
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+    EXPECT_FALSE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+
+    ASSERT_TRUE(sdl3d_game_data_update_scene_activity(runtime, input, 0.0f));
+    EXPECT_FALSE(sdl3d_properties_get_bool(state->props, "idle", true));
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.title");
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.play");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, MotionOscillateMovesActiveSceneActors)
+{
+    const std::filesystem::path dir = unique_test_dir("motion_oscillate");
+    write_scene_activity_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "activity.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_registered_actor *lamp = sdl3d_game_data_find_actor(runtime, "entity.lamp");
+    ASSERT_NE(lamp, nullptr);
+    EXPECT_NEAR(lamp->position.x, 2.0f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
+    EXPECT_NEAR(lamp->position.x, 2.0f + 3.0f * SDL_sinf(1.0f), 0.0001f);
+    EXPECT_NEAR(lamp->position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(lamp->position.z, 0.0f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
+    EXPECT_NEAR(lamp->position.x, 2.0f + 3.0f * SDL_sinf(2.0f), 0.0001f);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1210,6 +1210,11 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(red_light.direction.z, -1.0f, 0.0001f);
     EXPECT_NEAR(red_light.color[0], 1.0f, 0.0001f);
     EXPECT_NEAR(red_light.color[1], 0.06f, 0.0001f);
+    sdl3d_light red_eval{};
+    sdl3d_game_data_render_eval red_light_eval{};
+    red_light_eval.time = 1.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 0, &red_light_eval, &red_eval));
+    EXPECT_GT(red_eval.color[1], red_light.color[1]);
 
     sdl3d_light blue_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &blue_light));
@@ -1222,6 +1227,11 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(blue_light.color[0], 0.08f, 0.0001f);
     EXPECT_NEAR(blue_light.color[1], 0.28f, 0.0001f);
     EXPECT_NEAR(blue_light.color[2], 1.0f, 0.0001f);
+    sdl3d_light blue_eval{};
+    sdl3d_game_data_render_eval blue_light_eval{};
+    blue_light_eval.time = 1.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 2, &blue_light_eval, &blue_eval));
+    EXPECT_GT(blue_eval.color[1], blue_light.color[1]);
 
     sdl3d_light lamp_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &lamp_light));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1200,9 +1200,16 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
     EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
 
-    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 1);
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 4);
+    sdl3d_light center_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &center_light));
+    EXPECT_EQ(center_light.type, SDL3D_LIGHT_POINT);
+    EXPECT_NEAR(center_light.position.x, 0.0f, 0.0001f);
+    EXPECT_NEAR(center_light.position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(center_light.position.z, 2.8f, 0.0001f);
+
     sdl3d_light lamp_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &lamp_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 3, &lamp_light));
     EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_POINT);
     EXPECT_NEAR(lamp_light.position.x, -6.8f, 0.0001f);
     EXPECT_NEAR(lamp_light.position.y, 3.8f, 0.0001f);
@@ -1288,6 +1295,17 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 0, &light_eval, &flashed_light));
     EXPECT_GT(flashed_light.intensity, base_light.intensity);
     EXPECT_GT(flashed_light.range, base_light.range);
+    sdl3d_light cycle_light_start{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 1, &light_eval, &cycle_light_start));
+    EXPECT_NEAR(cycle_light_start.color[0], 1.0f, 0.0001f);
+    EXPECT_NEAR(cycle_light_start.color[1], 0.18f, 0.0001f);
+    EXPECT_NEAR(cycle_light_start.color[2], 0.16f, 0.0001f);
+    light_eval.time = 1.0f / 0.55f;
+    sdl3d_light cycle_light_next{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 1, &light_eval, &cycle_light_next));
+    EXPECT_NEAR(cycle_light_next.color[0], 1.0f, 0.0001f);
+    EXPECT_NEAR(cycle_light_next.color[1], 0.65f, 0.0001f);
+    EXPECT_NEAR(cycle_light_next.color[2], 0.12f, 0.0001f);
 
     sdl3d_game_data_render_eval render_eval{};
     render_eval.time = 0.25f;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1200,23 +1200,31 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
     EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
 
-    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 3);
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 5);
+    sdl3d_light red_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &red_light));
+    EXPECT_EQ(red_light.type, SDL3D_LIGHT_POINT);
+    EXPECT_NEAR(red_light.position.x, -5.7f, 0.0001f);
+    EXPECT_NEAR(red_light.position.y, 2.55f, 0.0001f);
+    EXPECT_NEAR(red_light.color[0], 1.0f, 0.0001f);
+    EXPECT_NEAR(red_light.color[1], 0.10f, 0.0001f);
+
     sdl3d_light blue_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &blue_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &blue_light));
     EXPECT_EQ(blue_light.type, SDL3D_LIGHT_POINT);
     EXPECT_NEAR(blue_light.position.x, 5.7f, 0.0001f);
-    EXPECT_NEAR(blue_light.position.y, 0.35f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.y, 2.55f, 0.0001f);
     EXPECT_NEAR(blue_light.position.z, 2.4f, 0.0001f);
     EXPECT_NEAR(blue_light.color[0], 0.12f, 0.0001f);
     EXPECT_NEAR(blue_light.color[1], 0.34f, 0.0001f);
     EXPECT_NEAR(blue_light.color[2], 1.0f, 0.0001f);
 
     sdl3d_light lamp_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &lamp_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 4, &lamp_light));
     EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_POINT);
-    EXPECT_NEAR(lamp_light.position.x, -6.8f, 0.0001f);
-    EXPECT_NEAR(lamp_light.position.y, 3.8f, 0.0001f);
-    EXPECT_NEAR(lamp_light.position.z, 3.14f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.x, 0.0f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.z, 2.52f, 0.0001f);
     EXPECT_NEAR(lamp_light.range, 6.4f, 0.0001f);
 
     sdl3d_particle_config particles{};
@@ -1293,9 +1301,9 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     sdl3d_light base_light{};
     sdl3d_light flashed_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &base_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 4, &base_light));
     sdl3d_game_data_render_eval light_eval{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 0, &light_eval, &flashed_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 4, &light_eval, &flashed_light));
     EXPECT_GT(flashed_light.intensity, base_light.intensity);
     EXPECT_GT(flashed_light.range, base_light.range);
     sdl3d_game_data_render_eval render_eval{};

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1200,16 +1200,19 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
     EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
 
-    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 4);
-    sdl3d_light center_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &center_light));
-    EXPECT_EQ(center_light.type, SDL3D_LIGHT_POINT);
-    EXPECT_NEAR(center_light.position.x, 0.0f, 0.0001f);
-    EXPECT_NEAR(center_light.position.y, 0.0f, 0.0001f);
-    EXPECT_NEAR(center_light.position.z, 2.8f, 0.0001f);
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 3);
+    sdl3d_light blue_light{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &blue_light));
+    EXPECT_EQ(blue_light.type, SDL3D_LIGHT_POINT);
+    EXPECT_NEAR(blue_light.position.x, 5.7f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.y, 0.35f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.z, 2.4f, 0.0001f);
+    EXPECT_NEAR(blue_light.color[0], 0.12f, 0.0001f);
+    EXPECT_NEAR(blue_light.color[1], 0.34f, 0.0001f);
+    EXPECT_NEAR(blue_light.color[2], 1.0f, 0.0001f);
 
     sdl3d_light lamp_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 3, &lamp_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &lamp_light));
     EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_POINT);
     EXPECT_NEAR(lamp_light.position.x, -6.8f, 0.0001f);
     EXPECT_NEAR(lamp_light.position.y, 3.8f, 0.0001f);
@@ -1276,7 +1279,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     RenderPrimitiveCapture capture{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &capture));
     EXPECT_EQ(capture.cubes, 16);
-    EXPECT_EQ(capture.spheres, 2);
+    EXPECT_EQ(capture.spheres, 1);
     EXPECT_TRUE(capture.saw_player_paddle);
     EXPECT_TRUE(capture.saw_ball);
 
@@ -1295,18 +1298,6 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 0, &light_eval, &flashed_light));
     EXPECT_GT(flashed_light.intensity, base_light.intensity);
     EXPECT_GT(flashed_light.range, base_light.range);
-    sdl3d_light cycle_light_start{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 1, &light_eval, &cycle_light_start));
-    EXPECT_NEAR(cycle_light_start.color[0], 1.0f, 0.0001f);
-    EXPECT_NEAR(cycle_light_start.color[1], 0.18f, 0.0001f);
-    EXPECT_NEAR(cycle_light_start.color[2], 0.16f, 0.0001f);
-    light_eval.time = 1.0f / 0.55f;
-    sdl3d_light cycle_light_next{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 1, &light_eval, &cycle_light_next));
-    EXPECT_NEAR(cycle_light_next.color[0], 1.0f, 0.0001f);
-    EXPECT_NEAR(cycle_light_next.color[1], 0.65f, 0.0001f);
-    EXPECT_NEAR(cycle_light_next.color[2], 0.12f, 0.0001f);
-
     sdl3d_game_data_render_eval render_eval{};
     render_eval.time = 0.25f;
     EvaluatedPrimitiveCapture evaluated{};

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1204,21 +1204,21 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     sdl3d_light red_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &red_light));
     EXPECT_EQ(red_light.type, SDL3D_LIGHT_SPOT);
-    EXPECT_NEAR(red_light.position.x, -6.2f, 0.0001f);
+    EXPECT_NEAR(red_light.position.x, -8.15f, 0.0001f);
     EXPECT_NEAR(red_light.position.y, 0.0f, 0.0001f);
-    EXPECT_NEAR(red_light.direction.x, 1.0f, 0.0001f);
-    EXPECT_NEAR(red_light.direction.z, -0.46f, 0.0001f);
+    EXPECT_NEAR(red_light.direction.x, 0.0f, 0.0001f);
+    EXPECT_NEAR(red_light.direction.z, -1.0f, 0.0001f);
     EXPECT_NEAR(red_light.color[0], 1.0f, 0.0001f);
     EXPECT_NEAR(red_light.color[1], 0.06f, 0.0001f);
 
     sdl3d_light blue_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &blue_light));
     EXPECT_EQ(blue_light.type, SDL3D_LIGHT_SPOT);
-    EXPECT_NEAR(blue_light.position.x, 6.2f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.x, 8.15f, 0.0001f);
     EXPECT_NEAR(blue_light.position.y, 0.0f, 0.0001f);
-    EXPECT_NEAR(blue_light.position.z, 3.2f, 0.0001f);
-    EXPECT_NEAR(blue_light.direction.x, -1.0f, 0.0001f);
-    EXPECT_NEAR(blue_light.direction.z, -0.46f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.z, 3.35f, 0.0001f);
+    EXPECT_NEAR(blue_light.direction.x, 0.0f, 0.0001f);
+    EXPECT_NEAR(blue_light.direction.z, -1.0f, 0.0001f);
     EXPECT_NEAR(blue_light.color[0], 0.08f, 0.0001f);
     EXPECT_NEAR(blue_light.color[1], 0.28f, 0.0001f);
     EXPECT_NEAR(blue_light.color[2], 1.0f, 0.0001f);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1200,32 +1200,37 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_NEAR(ambient[1], 0.018f, 0.0001f);
     EXPECT_NEAR(ambient[2], 0.026f, 0.0001f);
 
-    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 5);
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 3);
     sdl3d_light red_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &red_light));
-    EXPECT_EQ(red_light.type, SDL3D_LIGHT_POINT);
-    EXPECT_NEAR(red_light.position.x, -5.7f, 0.0001f);
-    EXPECT_NEAR(red_light.position.y, 2.55f, 0.0001f);
+    EXPECT_EQ(red_light.type, SDL3D_LIGHT_SPOT);
+    EXPECT_NEAR(red_light.position.x, -6.2f, 0.0001f);
+    EXPECT_NEAR(red_light.position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(red_light.direction.x, 1.0f, 0.0001f);
+    EXPECT_NEAR(red_light.direction.z, -0.46f, 0.0001f);
     EXPECT_NEAR(red_light.color[0], 1.0f, 0.0001f);
-    EXPECT_NEAR(red_light.color[1], 0.10f, 0.0001f);
+    EXPECT_NEAR(red_light.color[1], 0.06f, 0.0001f);
 
     sdl3d_light blue_light{};
     ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 2, &blue_light));
-    EXPECT_EQ(blue_light.type, SDL3D_LIGHT_POINT);
-    EXPECT_NEAR(blue_light.position.x, 5.7f, 0.0001f);
-    EXPECT_NEAR(blue_light.position.y, 2.55f, 0.0001f);
-    EXPECT_NEAR(blue_light.position.z, 2.4f, 0.0001f);
-    EXPECT_NEAR(blue_light.color[0], 0.12f, 0.0001f);
-    EXPECT_NEAR(blue_light.color[1], 0.34f, 0.0001f);
+    EXPECT_EQ(blue_light.type, SDL3D_LIGHT_SPOT);
+    EXPECT_NEAR(blue_light.position.x, 6.2f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.y, 0.0f, 0.0001f);
+    EXPECT_NEAR(blue_light.position.z, 3.2f, 0.0001f);
+    EXPECT_NEAR(blue_light.direction.x, -1.0f, 0.0001f);
+    EXPECT_NEAR(blue_light.direction.z, -0.46f, 0.0001f);
+    EXPECT_NEAR(blue_light.color[0], 0.08f, 0.0001f);
+    EXPECT_NEAR(blue_light.color[1], 0.28f, 0.0001f);
     EXPECT_NEAR(blue_light.color[2], 1.0f, 0.0001f);
 
     sdl3d_light lamp_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 4, &lamp_light));
-    EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_POINT);
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &lamp_light));
+    EXPECT_EQ(lamp_light.type, SDL3D_LIGHT_SPOT);
     EXPECT_NEAR(lamp_light.position.x, 0.0f, 0.0001f);
     EXPECT_NEAR(lamp_light.position.y, 0.0f, 0.0001f);
-    EXPECT_NEAR(lamp_light.position.z, 2.52f, 0.0001f);
-    EXPECT_NEAR(lamp_light.range, 6.4f, 0.0001f);
+    EXPECT_NEAR(lamp_light.position.z, 2.92f, 0.0001f);
+    EXPECT_NEAR(lamp_light.direction.z, -1.0f, 0.0001f);
+    EXPECT_NEAR(lamp_light.range, 5.8f, 0.0001f);
 
     sdl3d_particle_config particles{};
     ASSERT_TRUE(sdl3d_game_data_get_particle_emitter(runtime, "entity.effect.ambient_particles", &particles));
@@ -1301,9 +1306,9 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
 
     sdl3d_light base_light{};
     sdl3d_light flashed_light{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 4, &base_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 1, &base_light));
     sdl3d_game_data_render_eval light_eval{};
-    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 4, &light_eval, &flashed_light));
+    ASSERT_TRUE(sdl3d_game_data_get_world_light_evaluated(runtime, 1, &light_eval, &flashed_light));
     EXPECT_GT(flashed_light.intensity, base_light.intensity);
     EXPECT_GT(flashed_light.range, base_light.range);
     sdl3d_game_data_render_eval render_eval{};

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -263,7 +263,7 @@ TEST(SDL3DPBRShading, PointLightAttenuatesWithDistance)
     EXPECT_GT(r_near, r_far);
 }
 
-TEST(SDL3DPBRShading, PointLightOutOfRangeProducesNoLight)
+TEST(SDL3DPBRShading, PointLightBeyondRangeFallsOffSmoothly)
 {
     sdl3d_light pl = make_point(0.0f, 2.0f, 0.0f, 1.0f, 1.0f);
     sdl3d_lighting_params p = make_params(0.0f, 1.0f);
@@ -271,9 +271,14 @@ TEST(SDL3DPBRShading, PointLightOutOfRangeProducesNoLight)
     p.light_count = 1;
 
     float r, g, b;
-    /* Fragment at origin, light at y=2, range=1 → distance > range. */
+    /* Fragment at origin, light at y=2, range=1: soft falloff should be nearly black, not hard-clamped. */
     sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &r, &g, &b);
     EXPECT_NEAR(r, 0.0f, 0.01f);
+
+    float edge_r, edge_g, edge_b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, &edge_r, &edge_g, &edge_b);
+    EXPECT_GT(edge_r, 0.0f);
+    EXPECT_LT(edge_r, 0.1f);
 }
 
 TEST(SDL3DPBRShading, SpotLightInsideConeProducesLight)

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -294,6 +294,23 @@ TEST(SDL3DPBRShading, SpotLightInsideConeProducesLight)
     EXPECT_GT(r, 0.05f);
 }
 
+TEST(SDL3DPBRShading, SpotLightConeEdgeFallsOffSmoothly)
+{
+    sdl3d_light sl = make_spot(0.0f, 2.0f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 10.0f, cosf(0.3f), cosf(0.8f));
+    sdl3d_lighting_params p = make_params(0.0f, 1.0f);
+    p.lights = &sl;
+    p.light_count = 1;
+
+    float center_r, center_g, center_b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &center_r, &center_g, &center_b);
+
+    float edge_r, edge_g, edge_b;
+    sdl3d_shade_fragment_pbr(&p, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, &edge_r, &edge_g, &edge_b);
+
+    EXPECT_GT(edge_r, 0.0f);
+    EXPECT_LT(edge_r, center_r);
+}
+
 TEST(SDL3DPBRShading, SpotLightOutsideConeProducesNoLight)
 {
     /* Spot at y=2 pointing down, fragment far to the side. */


### PR DESCRIPTION
## Summary

- Prevent hidden title attract-mode wake input from immediately activating the selected menu item.
- Add reusable authored `motion.oscillate` scene behavior for future data-driven presentation motion.
- Simplify Pong title/playfield lighting to three authored spotlights: bright red above the left paddle lane, gold centered over the active ball, and bright blue above the right paddle lane.
- Add reusable authored world-light `color_cycle` effects, then use them for the left and right Pong spotlights so they gradually shift through palettes over time.
- Make the gold gameplay light follow the active ball via authored light target fallbacks, without rendering a visible lamp marker.
- Soften point-light distance falloff and spot-cone edge blending in CPU and GPU lighting paths to reduce harsh overlap boundaries.

## Validation

- `clang-format -i include/sdl3d/game_data.h include/sdl3d/lighting.h src/game_data.c src/game_data_validation.c src/drawing3d.c src/shading.c tests/test_game_data.cpp tests/test_lighting.cpp`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_lighting_test pong_demo -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ExposesAuthoredPongPresentationData:GameDataRuntime.ValidatesPongDataWithoutDiagnostics'`
- `./build/debug/tests/sdl3d_lighting_test`
- `./build/debug/tests/game_data_json_test`
- `git diff --check`
- `./build/debug/demos/pong/pong_demo` startup smoke
