### PR TITLE
Add network replication field codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ target_sources(
         src/model.c
         src/obj_loader.c
         src/network.c
+        src/network_replication.c
         src/properties.c
         src/rasterizer.c
         src/render_context.c

--- a/include/sdl3d/network_replication.h
+++ b/include/sdl3d/network_replication.h
@@ -1,0 +1,129 @@
+/**
+ * @file network_replication.h
+ * @brief Deterministic field codec for data-driven network replication.
+ *
+ * The replication codec is transport independent. It writes and reads scalar
+ * and vector field values using a strict little-endian wire format so higher
+ * layers can build authored replication schemas without embedding per-game
+ * serialization code in C.
+ */
+
+#ifndef SDL3D_NETWORK_REPLICATION_H
+#define SDL3D_NETWORK_REPLICATION_H
+
+#include <SDL3/SDL_stdinc.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "sdl3d/types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Primitive field types supported by the replication codec. */
+    typedef enum sdl3d_replication_field_type
+    {
+        SDL3D_REPLICATION_FIELD_BOOL = 1,    /**< One-byte boolean, only 0 or 1 are valid. */
+        SDL3D_REPLICATION_FIELD_INT32 = 2,   /**< Signed 32-bit integer. */
+        SDL3D_REPLICATION_FIELD_FLOAT32 = 3, /**< IEEE-754 32-bit float. */
+        SDL3D_REPLICATION_FIELD_ENUM = 4,    /**< Signed 32-bit enum or stable string-id value. */
+        SDL3D_REPLICATION_FIELD_VEC2 = 5,    /**< Two float32 values: x, y. */
+        SDL3D_REPLICATION_FIELD_VEC3 = 6,    /**< Three float32 values: x, y, z. */
+    } sdl3d_replication_field_type;
+
+    /** @brief Bounded writer for replication packets. */
+    typedef struct sdl3d_replication_writer
+    {
+        Uint8 *buffer;   /**< Destination byte buffer. */
+        size_t capacity; /**< Destination capacity in bytes. */
+        size_t offset;   /**< Current write offset in bytes. */
+    } sdl3d_replication_writer;
+
+    /** @brief Bounded reader for replication packets. */
+    typedef struct sdl3d_replication_reader
+    {
+        const Uint8 *buffer; /**< Source byte buffer. */
+        size_t size;         /**< Source size in bytes. */
+        size_t offset;       /**< Current read offset in bytes. */
+    } sdl3d_replication_reader;
+
+    /**
+     * @brief Initialize a packet writer.
+     *
+     * Passing NULL for @p buffer is valid only when @p capacity is zero.
+     */
+    void sdl3d_replication_writer_init(sdl3d_replication_writer *writer, void *buffer, size_t capacity);
+
+    /** @brief Return the current writer byte offset, or zero for NULL. */
+    size_t sdl3d_replication_writer_offset(const sdl3d_replication_writer *writer);
+
+    /** @brief Return remaining writer capacity in bytes, or zero for NULL/invalid state. */
+    size_t sdl3d_replication_writer_remaining(const sdl3d_replication_writer *writer);
+
+    /** @brief Write a one-byte replication field type tag. */
+    bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_replication_field_type type);
+
+    /** @brief Write a one-byte boolean. */
+    bool sdl3d_replication_write_bool(sdl3d_replication_writer *writer, bool value);
+
+    /** @brief Write a signed 32-bit integer. */
+    bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 value);
+
+    /** @brief Write a 32-bit float. */
+    bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value);
+
+    /** @brief Write a signed 32-bit enum or stable string-id value. */
+    bool sdl3d_replication_write_enum(sdl3d_replication_writer *writer, Sint32 value);
+
+    /** @brief Write a vec2 as two 32-bit floats. */
+    bool sdl3d_replication_write_vec2(sdl3d_replication_writer *writer, sdl3d_vec2 value);
+
+    /** @brief Write a vec3 as three 32-bit floats. */
+    bool sdl3d_replication_write_vec3(sdl3d_replication_writer *writer, sdl3d_vec3 value);
+
+    /** @brief Initialize a packet reader. */
+    void sdl3d_replication_reader_init(sdl3d_replication_reader *reader, const void *buffer, size_t size);
+
+    /** @brief Return the current reader byte offset, or zero for NULL. */
+    size_t sdl3d_replication_reader_offset(const sdl3d_replication_reader *reader);
+
+    /** @brief Return unread byte count, or zero for NULL/invalid state. */
+    size_t sdl3d_replication_reader_remaining(const sdl3d_replication_reader *reader);
+
+    /**
+     * @brief Read and validate a one-byte replication field type tag.
+     *
+     * Invalid or unknown tags fail and leave the reader offset unchanged.
+     */
+    bool sdl3d_replication_read_field_type(sdl3d_replication_reader *reader, sdl3d_replication_field_type *out_type);
+
+    /**
+     * @brief Read a one-byte boolean.
+     *
+     * Values other than 0 and 1 fail and leave the reader offset unchanged.
+     */
+    bool sdl3d_replication_read_bool(sdl3d_replication_reader *reader, bool *out_value);
+
+    /** @brief Read a signed 32-bit integer. */
+    bool sdl3d_replication_read_int32(sdl3d_replication_reader *reader, Sint32 *out_value);
+
+    /** @brief Read a 32-bit float. */
+    bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out_value);
+
+    /** @brief Read a signed 32-bit enum or stable string-id value. */
+    bool sdl3d_replication_read_enum(sdl3d_replication_reader *reader, Sint32 *out_value);
+
+    /** @brief Read a vec2 encoded as two 32-bit floats. */
+    bool sdl3d_replication_read_vec2(sdl3d_replication_reader *reader, sdl3d_vec2 *out_value);
+
+    /** @brief Read a vec3 encoded as three 32-bit floats. */
+    bool sdl3d_replication_read_vec3(sdl3d_replication_reader *reader, sdl3d_vec3 *out_value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sdl3d/network_replication.h
+++ b/include/sdl3d/network_replication.h
@@ -29,7 +29,7 @@ extern "C"
         SDL3D_REPLICATION_FIELD_BOOL = 1,    /**< One-byte boolean, only 0 or 1 are valid. */
         SDL3D_REPLICATION_FIELD_INT32 = 2,   /**< Signed 32-bit integer. */
         SDL3D_REPLICATION_FIELD_FLOAT32 = 3, /**< IEEE-754 32-bit float. */
-        SDL3D_REPLICATION_FIELD_ENUM = 4,    /**< Signed 32-bit enum or stable string-id value. */
+        SDL3D_REPLICATION_FIELD_ENUM_ID = 4, /**< Signed 32-bit enum or stable string-id value. */
         SDL3D_REPLICATION_FIELD_VEC2 = 5,    /**< Two float32 values: x, y. */
         SDL3D_REPLICATION_FIELD_VEC3 = 6,    /**< Three float32 values: x, y, z. */
     } sdl3d_replication_field_type;
@@ -63,6 +63,13 @@ extern "C"
     /** @brief Return remaining writer capacity in bytes, or zero for NULL/invalid state. */
     size_t sdl3d_replication_writer_remaining(const sdl3d_replication_writer *writer);
 
+    /**
+     * @brief Return the wire size in bytes for a supported field type.
+     *
+     * Returns zero for invalid or unknown field types.
+     */
+    size_t sdl3d_replication_field_wire_size(sdl3d_replication_field_type type);
+
     /** @brief Write a one-byte replication field type tag. */
     bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_replication_field_type type);
 
@@ -76,7 +83,7 @@ extern "C"
     bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value);
 
     /** @brief Write a signed 32-bit enum or stable string-id value. */
-    bool sdl3d_replication_write_enum(sdl3d_replication_writer *writer, Sint32 value);
+    bool sdl3d_replication_write_enum_id(sdl3d_replication_writer *writer, Sint32 value);
 
     /** @brief Write a vec2 as two 32-bit floats. */
     bool sdl3d_replication_write_vec2(sdl3d_replication_writer *writer, sdl3d_vec2 value);
@@ -114,7 +121,7 @@ extern "C"
     bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out_value);
 
     /** @brief Read a signed 32-bit enum or stable string-id value. */
-    bool sdl3d_replication_read_enum(sdl3d_replication_reader *reader, Sint32 *out_value);
+    bool sdl3d_replication_read_enum_id(sdl3d_replication_reader *reader, Sint32 *out_value);
 
     /** @brief Read a vec2 encoded as two 32-bit floats. */
     bool sdl3d_replication_read_vec2(sdl3d_replication_reader *reader, sdl3d_vec2 *out_value);

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -25,6 +25,7 @@
 #include "sdl3d/math.h"
 #include "sdl3d/model.h"
 #include "sdl3d/network.h"
+#include "sdl3d/network_replication.h"
 #include "sdl3d/render_context.h"
 #include "sdl3d/scene.h"
 #include "sdl3d/script.h"

--- a/src/network_replication.c
+++ b/src/network_replication.c
@@ -2,10 +2,13 @@
 
 #include <string.h>
 
+_Static_assert(sizeof(Sint32) == sizeof(Uint32), "SDL3D replication requires 32-bit signed integers");
+_Static_assert(sizeof(float) == sizeof(Uint32), "SDL3D replication requires 32-bit floats");
+
 static bool sdl3d_replication_field_type_is_valid(sdl3d_replication_field_type type)
 {
     return type == SDL3D_REPLICATION_FIELD_BOOL || type == SDL3D_REPLICATION_FIELD_INT32 ||
-           type == SDL3D_REPLICATION_FIELD_FLOAT32 || type == SDL3D_REPLICATION_FIELD_ENUM ||
+           type == SDL3D_REPLICATION_FIELD_FLOAT32 || type == SDL3D_REPLICATION_FIELD_ENUM_ID ||
            type == SDL3D_REPLICATION_FIELD_VEC2 || type == SDL3D_REPLICATION_FIELD_VEC3;
 }
 
@@ -106,6 +109,25 @@ size_t sdl3d_replication_writer_remaining(const sdl3d_replication_writer *writer
     return writer->capacity - writer->offset;
 }
 
+size_t sdl3d_replication_field_wire_size(sdl3d_replication_field_type type)
+{
+    switch (type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return 1U;
+    case SDL3D_REPLICATION_FIELD_INT32:
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return 4U;
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return 8U;
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return 12U;
+    default:
+        return 0U;
+    }
+}
+
 bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_replication_field_type type)
 {
     if (!sdl3d_replication_field_type_is_valid(type))
@@ -122,11 +144,6 @@ bool sdl3d_replication_write_bool(sdl3d_replication_writer *writer, bool value)
 
 bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 value)
 {
-    if (sizeof(value) != sizeof(Uint32))
-    {
-        return false;
-    }
-
     Uint32 bits = 0U;
     memcpy(&bits, &value, sizeof(bits));
     return sdl3d_replication_write_u32(writer, bits);
@@ -134,17 +151,12 @@ bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 valu
 
 bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value)
 {
-    if (sizeof(value) != sizeof(Uint32))
-    {
-        return false;
-    }
-
     Uint32 bits = 0U;
     memcpy(&bits, &value, sizeof(bits));
     return sdl3d_replication_write_u32(writer, bits);
 }
 
-bool sdl3d_replication_write_enum(sdl3d_replication_writer *writer, Sint32 value)
+bool sdl3d_replication_write_enum_id(sdl3d_replication_writer *writer, Sint32 value)
 {
     return sdl3d_replication_write_int32(writer, value);
 }
@@ -260,10 +272,6 @@ bool sdl3d_replication_read_int32(sdl3d_replication_reader *reader, Sint32 *out_
     {
         return false;
     }
-    if (sizeof(*out_value) != sizeof(Uint32))
-    {
-        return false;
-    }
 
     Uint32 value = 0U;
     if (!sdl3d_replication_read_u32(reader, &value))
@@ -281,10 +289,6 @@ bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out
     {
         return false;
     }
-    if (sizeof(*out_value) != sizeof(Uint32))
-    {
-        return false;
-    }
 
     Uint32 bits = 0U;
     if (!sdl3d_replication_read_u32(reader, &bits))
@@ -296,7 +300,7 @@ bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out
     return true;
 }
 
-bool sdl3d_replication_read_enum(sdl3d_replication_reader *reader, Sint32 *out_value)
+bool sdl3d_replication_read_enum_id(sdl3d_replication_reader *reader, Sint32 *out_value)
 {
     return sdl3d_replication_read_int32(reader, out_value);
 }

--- a/src/network_replication.c
+++ b/src/network_replication.c
@@ -1,0 +1,341 @@
+#include "sdl3d/network_replication.h"
+
+#include <string.h>
+
+static bool sdl3d_replication_field_type_is_valid(sdl3d_replication_field_type type)
+{
+    return type == SDL3D_REPLICATION_FIELD_BOOL || type == SDL3D_REPLICATION_FIELD_INT32 ||
+           type == SDL3D_REPLICATION_FIELD_FLOAT32 || type == SDL3D_REPLICATION_FIELD_ENUM ||
+           type == SDL3D_REPLICATION_FIELD_VEC2 || type == SDL3D_REPLICATION_FIELD_VEC3;
+}
+
+static bool sdl3d_replication_can_write(const sdl3d_replication_writer *writer, size_t byte_count)
+{
+    if (writer == NULL || (writer->buffer == NULL && writer->capacity > 0) || writer->offset > writer->capacity)
+    {
+        return false;
+    }
+    return byte_count <= writer->capacity - writer->offset;
+}
+
+static bool sdl3d_replication_can_read(const sdl3d_replication_reader *reader, size_t byte_count)
+{
+    if (reader == NULL || (reader->buffer == NULL && reader->size > 0) || reader->offset > reader->size)
+    {
+        return false;
+    }
+    return byte_count <= reader->size - reader->offset;
+}
+
+static bool sdl3d_replication_write_u8(sdl3d_replication_writer *writer, Uint8 value)
+{
+    if (!sdl3d_replication_can_write(writer, 1U))
+    {
+        return false;
+    }
+
+    writer->buffer[writer->offset] = value;
+    writer->offset += 1U;
+    return true;
+}
+
+static bool sdl3d_replication_read_u8(sdl3d_replication_reader *reader, Uint8 *out_value)
+{
+    if (out_value == NULL || !sdl3d_replication_can_read(reader, 1U))
+    {
+        return false;
+    }
+
+    *out_value = reader->buffer[reader->offset];
+    reader->offset += 1U;
+    return true;
+}
+
+static bool sdl3d_replication_write_u32(sdl3d_replication_writer *writer, Uint32 value)
+{
+    if (!sdl3d_replication_can_write(writer, 4U))
+    {
+        return false;
+    }
+
+    writer->buffer[writer->offset + 0U] = (Uint8)(value & 0xFFU);
+    writer->buffer[writer->offset + 1U] = (Uint8)((value >> 8U) & 0xFFU);
+    writer->buffer[writer->offset + 2U] = (Uint8)((value >> 16U) & 0xFFU);
+    writer->buffer[writer->offset + 3U] = (Uint8)((value >> 24U) & 0xFFU);
+    writer->offset += 4U;
+    return true;
+}
+
+static bool sdl3d_replication_read_u32(sdl3d_replication_reader *reader, Uint32 *out_value)
+{
+    if (out_value == NULL || !sdl3d_replication_can_read(reader, 4U))
+    {
+        return false;
+    }
+
+    *out_value = (Uint32)reader->buffer[reader->offset + 0U] | ((Uint32)reader->buffer[reader->offset + 1U] << 8U) |
+                 ((Uint32)reader->buffer[reader->offset + 2U] << 16U) |
+                 ((Uint32)reader->buffer[reader->offset + 3U] << 24U);
+    reader->offset += 4U;
+    return true;
+}
+
+void sdl3d_replication_writer_init(sdl3d_replication_writer *writer, void *buffer, size_t capacity)
+{
+    if (writer == NULL)
+    {
+        return;
+    }
+
+    writer->buffer = (Uint8 *)buffer;
+    writer->capacity = capacity;
+    writer->offset = 0U;
+}
+
+size_t sdl3d_replication_writer_offset(const sdl3d_replication_writer *writer)
+{
+    return writer != NULL ? writer->offset : 0U;
+}
+
+size_t sdl3d_replication_writer_remaining(const sdl3d_replication_writer *writer)
+{
+    if (writer == NULL || writer->offset > writer->capacity)
+    {
+        return 0U;
+    }
+    return writer->capacity - writer->offset;
+}
+
+bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_replication_field_type type)
+{
+    if (!sdl3d_replication_field_type_is_valid(type))
+    {
+        return false;
+    }
+    return sdl3d_replication_write_u8(writer, (Uint8)type);
+}
+
+bool sdl3d_replication_write_bool(sdl3d_replication_writer *writer, bool value)
+{
+    return sdl3d_replication_write_u8(writer, value ? 1U : 0U);
+}
+
+bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 value)
+{
+    if (sizeof(value) != sizeof(Uint32))
+    {
+        return false;
+    }
+
+    Uint32 bits = 0U;
+    memcpy(&bits, &value, sizeof(bits));
+    return sdl3d_replication_write_u32(writer, bits);
+}
+
+bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value)
+{
+    if (sizeof(value) != sizeof(Uint32))
+    {
+        return false;
+    }
+
+    Uint32 bits = 0U;
+    memcpy(&bits, &value, sizeof(bits));
+    return sdl3d_replication_write_u32(writer, bits);
+}
+
+bool sdl3d_replication_write_enum(sdl3d_replication_writer *writer, Sint32 value)
+{
+    return sdl3d_replication_write_int32(writer, value);
+}
+
+bool sdl3d_replication_write_vec2(sdl3d_replication_writer *writer, sdl3d_vec2 value)
+{
+    const size_t offset = writer != NULL ? writer->offset : 0U;
+    if (!sdl3d_replication_can_write(writer, 8U))
+    {
+        return false;
+    }
+    if (!sdl3d_replication_write_float32(writer, value.x) || !sdl3d_replication_write_float32(writer, value.y))
+    {
+        writer->offset = offset;
+        return false;
+    }
+    return true;
+}
+
+bool sdl3d_replication_write_vec3(sdl3d_replication_writer *writer, sdl3d_vec3 value)
+{
+    const size_t offset = writer != NULL ? writer->offset : 0U;
+    if (!sdl3d_replication_can_write(writer, 12U))
+    {
+        return false;
+    }
+    if (!sdl3d_replication_write_float32(writer, value.x) || !sdl3d_replication_write_float32(writer, value.y) ||
+        !sdl3d_replication_write_float32(writer, value.z))
+    {
+        writer->offset = offset;
+        return false;
+    }
+    return true;
+}
+
+void sdl3d_replication_reader_init(sdl3d_replication_reader *reader, const void *buffer, size_t size)
+{
+    if (reader == NULL)
+    {
+        return;
+    }
+
+    reader->buffer = (const Uint8 *)buffer;
+    reader->size = size;
+    reader->offset = 0U;
+}
+
+size_t sdl3d_replication_reader_offset(const sdl3d_replication_reader *reader)
+{
+    return reader != NULL ? reader->offset : 0U;
+}
+
+size_t sdl3d_replication_reader_remaining(const sdl3d_replication_reader *reader)
+{
+    if (reader == NULL || reader->offset > reader->size)
+    {
+        return 0U;
+    }
+    return reader->size - reader->offset;
+}
+
+bool sdl3d_replication_read_field_type(sdl3d_replication_reader *reader, sdl3d_replication_field_type *out_type)
+{
+    if (out_type == NULL || !sdl3d_replication_can_read(reader, 1U))
+    {
+        return false;
+    }
+
+    const size_t offset = reader->offset;
+    Uint8 value = 0U;
+    if (!sdl3d_replication_read_u8(reader, &value))
+    {
+        return false;
+    }
+
+    const sdl3d_replication_field_type type = (sdl3d_replication_field_type)value;
+    if (!sdl3d_replication_field_type_is_valid(type))
+    {
+        reader->offset = offset;
+        return false;
+    }
+
+    *out_type = type;
+    return true;
+}
+
+bool sdl3d_replication_read_bool(sdl3d_replication_reader *reader, bool *out_value)
+{
+    if (out_value == NULL || !sdl3d_replication_can_read(reader, 1U))
+    {
+        return false;
+    }
+
+    const size_t offset = reader->offset;
+    Uint8 value = 0U;
+    if (!sdl3d_replication_read_u8(reader, &value))
+    {
+        return false;
+    }
+    if (value > 1U)
+    {
+        reader->offset = offset;
+        return false;
+    }
+
+    *out_value = value != 0U;
+    return true;
+}
+
+bool sdl3d_replication_read_int32(sdl3d_replication_reader *reader, Sint32 *out_value)
+{
+    if (out_value == NULL)
+    {
+        return false;
+    }
+    if (sizeof(*out_value) != sizeof(Uint32))
+    {
+        return false;
+    }
+
+    Uint32 value = 0U;
+    if (!sdl3d_replication_read_u32(reader, &value))
+    {
+        return false;
+    }
+
+    memcpy(out_value, &value, sizeof(value));
+    return true;
+}
+
+bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out_value)
+{
+    if (out_value == NULL)
+    {
+        return false;
+    }
+    if (sizeof(*out_value) != sizeof(Uint32))
+    {
+        return false;
+    }
+
+    Uint32 bits = 0U;
+    if (!sdl3d_replication_read_u32(reader, &bits))
+    {
+        return false;
+    }
+
+    memcpy(out_value, &bits, sizeof(bits));
+    return true;
+}
+
+bool sdl3d_replication_read_enum(sdl3d_replication_reader *reader, Sint32 *out_value)
+{
+    return sdl3d_replication_read_int32(reader, out_value);
+}
+
+bool sdl3d_replication_read_vec2(sdl3d_replication_reader *reader, sdl3d_vec2 *out_value)
+{
+    if (out_value == NULL || !sdl3d_replication_can_read(reader, 8U))
+    {
+        return false;
+    }
+
+    const size_t offset = reader->offset;
+    sdl3d_vec2 value = {0.0f, 0.0f};
+    if (!sdl3d_replication_read_float32(reader, &value.x) || !sdl3d_replication_read_float32(reader, &value.y))
+    {
+        reader->offset = offset;
+        return false;
+    }
+
+    *out_value = value;
+    return true;
+}
+
+bool sdl3d_replication_read_vec3(sdl3d_replication_reader *reader, sdl3d_vec3 *out_value)
+{
+    if (out_value == NULL || !sdl3d_replication_can_read(reader, 12U))
+    {
+        return false;
+    }
+
+    const size_t offset = reader->offset;
+    sdl3d_vec3 value = {0.0f, 0.0f, 0.0f};
+    if (!sdl3d_replication_read_float32(reader, &value.x) || !sdl3d_replication_read_float32(reader, &value.y) ||
+        !sdl3d_replication_read_float32(reader, &value.z))
+    {
+        reader->offset = offset;
+        return false;
+    }
+
+    *out_value = value;
+    return true;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,6 +216,7 @@ else()
     if(SDL3D_ENABLE_NETWORKING AND NOT EMSCRIPTEN AND NOT ANDROID AND NOT IOS)
         sdl3d_add_test(sdl3d_network_test test_network.cpp unit)
     endif()
+    sdl3d_add_test(sdl3d_network_replication_test test_network_replication.cpp unit)
     sdl3d_add_test(sdl3d_game_data_test test_game_data.cpp unit)
     if(EMSCRIPTEN)
         target_compile_definitions(

--- a/tests/test_network_replication.cpp
+++ b/tests/test_network_replication.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <limits>
 
 extern "C"
 {
@@ -12,6 +13,14 @@ extern "C"
 namespace
 {
 constexpr float kTolerance = 1e-6f;
+
+Uint32 float_bits(float value)
+{
+    Uint32 bits = 0;
+    static_assert(sizeof(bits) == sizeof(value), "float test helper requires 32-bit floats");
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
 
 void expect_vec2_near(sdl3d_vec2 actual, sdl3d_vec2 expected)
 {
@@ -62,9 +71,10 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
     const sdl3d_vec3 expected_vec3 = {3.0f, -4.0f, 5.5f};
     ASSERT_TRUE(sdl3d_replication_write_field_type(&writer, SDL3D_REPLICATION_FIELD_VEC3));
     ASSERT_TRUE(sdl3d_replication_write_bool(&writer, true));
+    ASSERT_TRUE(sdl3d_replication_write_bool(&writer, false));
     ASSERT_TRUE(sdl3d_replication_write_int32(&writer, -42));
     ASSERT_TRUE(sdl3d_replication_write_float32(&writer, 3.5f));
-    ASSERT_TRUE(sdl3d_replication_write_enum(&writer, 17));
+    ASSERT_TRUE(sdl3d_replication_write_enum_id(&writer, 17));
     ASSERT_TRUE(sdl3d_replication_write_vec2(&writer, expected_vec2));
     ASSERT_TRUE(sdl3d_replication_write_vec3(&writer, expected_vec3));
 
@@ -73,9 +83,10 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
 
     sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
     bool bool_value = false;
+    bool false_value = true;
     Sint32 int_value = 0;
     float float_value = 0.0f;
-    Sint32 enum_value = 0;
+    Sint32 enum_id_value = 0;
     sdl3d_vec2 vec2_value = {};
     sdl3d_vec3 vec3_value = {};
 
@@ -83,17 +94,84 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
     EXPECT_EQ(type, SDL3D_REPLICATION_FIELD_VEC3);
     ASSERT_TRUE(sdl3d_replication_read_bool(&reader, &bool_value));
     EXPECT_TRUE(bool_value);
+    ASSERT_TRUE(sdl3d_replication_read_bool(&reader, &false_value));
+    EXPECT_FALSE(false_value);
     ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &int_value));
     EXPECT_EQ(int_value, -42);
     ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &float_value));
     EXPECT_NEAR(float_value, 3.5f, kTolerance);
-    ASSERT_TRUE(sdl3d_replication_read_enum(&reader, &enum_value));
-    EXPECT_EQ(enum_value, 17);
+    ASSERT_TRUE(sdl3d_replication_read_enum_id(&reader, &enum_id_value));
+    EXPECT_EQ(enum_id_value, 17);
     ASSERT_TRUE(sdl3d_replication_read_vec2(&reader, &vec2_value));
     expect_vec2_near(vec2_value, expected_vec2);
     ASSERT_TRUE(sdl3d_replication_read_vec3(&reader, &vec3_value));
     expect_vec3_near(vec3_value, expected_vec3);
     EXPECT_EQ(sdl3d_replication_reader_remaining(&reader), 0U);
+}
+
+TEST(SDL3DNetworkReplication, ReportsFieldWireSizes)
+{
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_BOOL), 1U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_INT32), 4U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_FLOAT32), 4U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_ENUM_ID), 4U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_VEC2), 8U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_VEC3), 12U);
+    EXPECT_EQ(sdl3d_replication_field_wire_size((sdl3d_replication_field_type)255), 0U);
+}
+
+TEST(SDL3DNetworkReplication, RoundTripsBoundaryIntegers)
+{
+    std::array<Uint8, 8> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+
+    ASSERT_TRUE(sdl3d_replication_write_int32(&writer, std::numeric_limits<Sint32>::min()));
+    ASSERT_TRUE(sdl3d_replication_write_int32(&writer, std::numeric_limits<Sint32>::max()));
+
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), sdl3d_replication_writer_offset(&writer));
+
+    Sint32 min_value = 0;
+    Sint32 max_value = 0;
+    ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &min_value));
+    ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &max_value));
+    EXPECT_EQ(min_value, std::numeric_limits<Sint32>::min());
+    EXPECT_EQ(max_value, std::numeric_limits<Sint32>::max());
+}
+
+TEST(SDL3DNetworkReplication, PreservesFloatBitPatterns)
+{
+    std::array<Uint8, 16> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+
+    const float negative_zero = -0.0f;
+    const float infinity = std::numeric_limits<float>::infinity();
+    const float quiet_nan = std::numeric_limits<float>::quiet_NaN();
+    const float negative_value = -123.5f;
+
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, negative_zero));
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, infinity));
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, quiet_nan));
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, negative_value));
+
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), sdl3d_replication_writer_offset(&writer));
+
+    float out_negative_zero = 1.0f;
+    float out_infinity = 0.0f;
+    float out_nan = 0.0f;
+    float out_negative_value = 0.0f;
+    ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &out_negative_zero));
+    ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &out_infinity));
+    ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &out_nan));
+    ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &out_negative_value));
+
+    EXPECT_EQ(float_bits(out_negative_zero), float_bits(negative_zero));
+    EXPECT_EQ(float_bits(out_infinity), float_bits(infinity));
+    EXPECT_EQ(float_bits(out_nan), float_bits(quiet_nan));
+    EXPECT_EQ(float_bits(out_negative_value), float_bits(negative_value));
 }
 
 TEST(SDL3DNetworkReplication, UsesDeterministicLittleEndianEncoding)
@@ -126,6 +204,22 @@ TEST(SDL3DNetworkReplication, RejectsTruncatedWritesWithoutAdvancing)
     const sdl3d_vec3 value = {1.0f, 2.0f, 3.0f};
     EXPECT_FALSE(sdl3d_replication_write_vec3(&writer, value));
     EXPECT_EQ(sdl3d_replication_writer_offset(&writer), offset);
+}
+
+TEST(SDL3DNetworkReplication, RejectsZeroCapacityWrites)
+{
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, nullptr, 0U);
+
+    EXPECT_EQ(sdl3d_replication_writer_offset(&writer), 0U);
+    EXPECT_EQ(sdl3d_replication_writer_remaining(&writer), 0U);
+    EXPECT_FALSE(sdl3d_replication_write_bool(&writer, false));
+    EXPECT_FALSE(sdl3d_replication_write_int32(&writer, 1));
+    EXPECT_FALSE(sdl3d_replication_write_float32(&writer, 1.0f));
+    EXPECT_FALSE(sdl3d_replication_write_enum_id(&writer, 1));
+    EXPECT_FALSE(sdl3d_replication_write_vec2(&writer, {1.0f, 2.0f}));
+    EXPECT_FALSE(sdl3d_replication_write_vec3(&writer, {1.0f, 2.0f, 3.0f}));
+    EXPECT_EQ(sdl3d_replication_writer_offset(&writer), 0U);
 }
 
 TEST(SDL3DNetworkReplication, RejectsTruncatedReadsWithoutAdvancing)

--- a/tests/test_network_replication.cpp
+++ b/tests/test_network_replication.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <cstring>
+
+extern "C"
+{
+#include "sdl3d/network_replication.h"
+}
+
+namespace
+{
+constexpr float kTolerance = 1e-6f;
+
+void expect_vec2_near(sdl3d_vec2 actual, sdl3d_vec2 expected)
+{
+    EXPECT_NEAR(actual.x, expected.x, kTolerance);
+    EXPECT_NEAR(actual.y, expected.y, kTolerance);
+}
+
+void expect_vec3_near(sdl3d_vec3 actual, sdl3d_vec3 expected)
+{
+    EXPECT_NEAR(actual.x, expected.x, kTolerance);
+    EXPECT_NEAR(actual.y, expected.y, kTolerance);
+    EXPECT_NEAR(actual.z, expected.z, kTolerance);
+}
+} // namespace
+
+TEST(SDL3DNetworkReplication, WriterAndReaderTrackSize)
+{
+    std::array<Uint8, 16> buffer{};
+
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+    EXPECT_EQ(sdl3d_replication_writer_offset(&writer), 0U);
+    EXPECT_EQ(sdl3d_replication_writer_remaining(&writer), buffer.size());
+
+    ASSERT_TRUE(sdl3d_replication_write_bool(&writer, true));
+    EXPECT_EQ(sdl3d_replication_writer_offset(&writer), 1U);
+    EXPECT_EQ(sdl3d_replication_writer_remaining(&writer), buffer.size() - 1U);
+
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), sdl3d_replication_writer_offset(&writer));
+    EXPECT_EQ(sdl3d_replication_reader_offset(&reader), 0U);
+    EXPECT_EQ(sdl3d_replication_reader_remaining(&reader), 1U);
+
+    bool value = false;
+    ASSERT_TRUE(sdl3d_replication_read_bool(&reader, &value));
+    EXPECT_TRUE(value);
+    EXPECT_EQ(sdl3d_replication_reader_offset(&reader), 1U);
+    EXPECT_EQ(sdl3d_replication_reader_remaining(&reader), 0U);
+}
+
+TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
+{
+    std::array<Uint8, 128> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+
+    const sdl3d_vec2 expected_vec2 = {1.25f, -2.5f};
+    const sdl3d_vec3 expected_vec3 = {3.0f, -4.0f, 5.5f};
+    ASSERT_TRUE(sdl3d_replication_write_field_type(&writer, SDL3D_REPLICATION_FIELD_VEC3));
+    ASSERT_TRUE(sdl3d_replication_write_bool(&writer, true));
+    ASSERT_TRUE(sdl3d_replication_write_int32(&writer, -42));
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, 3.5f));
+    ASSERT_TRUE(sdl3d_replication_write_enum(&writer, 17));
+    ASSERT_TRUE(sdl3d_replication_write_vec2(&writer, expected_vec2));
+    ASSERT_TRUE(sdl3d_replication_write_vec3(&writer, expected_vec3));
+
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), sdl3d_replication_writer_offset(&writer));
+
+    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+    bool bool_value = false;
+    Sint32 int_value = 0;
+    float float_value = 0.0f;
+    Sint32 enum_value = 0;
+    sdl3d_vec2 vec2_value = {};
+    sdl3d_vec3 vec3_value = {};
+
+    ASSERT_TRUE(sdl3d_replication_read_field_type(&reader, &type));
+    EXPECT_EQ(type, SDL3D_REPLICATION_FIELD_VEC3);
+    ASSERT_TRUE(sdl3d_replication_read_bool(&reader, &bool_value));
+    EXPECT_TRUE(bool_value);
+    ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &int_value));
+    EXPECT_EQ(int_value, -42);
+    ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &float_value));
+    EXPECT_NEAR(float_value, 3.5f, kTolerance);
+    ASSERT_TRUE(sdl3d_replication_read_enum(&reader, &enum_value));
+    EXPECT_EQ(enum_value, 17);
+    ASSERT_TRUE(sdl3d_replication_read_vec2(&reader, &vec2_value));
+    expect_vec2_near(vec2_value, expected_vec2);
+    ASSERT_TRUE(sdl3d_replication_read_vec3(&reader, &vec3_value));
+    expect_vec3_near(vec3_value, expected_vec3);
+    EXPECT_EQ(sdl3d_replication_reader_remaining(&reader), 0U);
+}
+
+TEST(SDL3DNetworkReplication, UsesDeterministicLittleEndianEncoding)
+{
+    std::array<Uint8, 8> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+
+    ASSERT_TRUE(sdl3d_replication_write_int32(&writer, 0x01020304));
+    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, 1.0f));
+
+    EXPECT_EQ(buffer[0], 0x04);
+    EXPECT_EQ(buffer[1], 0x03);
+    EXPECT_EQ(buffer[2], 0x02);
+    EXPECT_EQ(buffer[3], 0x01);
+    EXPECT_EQ(buffer[4], 0x00);
+    EXPECT_EQ(buffer[5], 0x00);
+    EXPECT_EQ(buffer[6], 0x80);
+    EXPECT_EQ(buffer[7], 0x3f);
+}
+
+TEST(SDL3DNetworkReplication, RejectsTruncatedWritesWithoutAdvancing)
+{
+    std::array<Uint8, 8> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+
+    ASSERT_TRUE(sdl3d_replication_write_int32(&writer, 1234));
+    const size_t offset = sdl3d_replication_writer_offset(&writer);
+    const sdl3d_vec3 value = {1.0f, 2.0f, 3.0f};
+    EXPECT_FALSE(sdl3d_replication_write_vec3(&writer, value));
+    EXPECT_EQ(sdl3d_replication_writer_offset(&writer), offset);
+}
+
+TEST(SDL3DNetworkReplication, RejectsTruncatedReadsWithoutAdvancing)
+{
+    const std::array<Uint8, 7> buffer = {0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00};
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), buffer.size());
+
+    Sint32 first = 0;
+    ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &first));
+    EXPECT_EQ(first, 1);
+    const size_t offset = sdl3d_replication_reader_offset(&reader);
+
+    Sint32 second = 0;
+    EXPECT_FALSE(sdl3d_replication_read_int32(&reader, &second));
+    EXPECT_EQ(sdl3d_replication_reader_offset(&reader), offset);
+}
+
+TEST(SDL3DNetworkReplication, RejectsInvalidBoolAndFieldTypeWithoutAdvancing)
+{
+    const std::array<Uint8, 2> buffer = {2U, 255U};
+
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), buffer.size());
+
+    bool bool_value = false;
+    EXPECT_FALSE(sdl3d_replication_read_bool(&reader, &bool_value));
+    EXPECT_EQ(sdl3d_replication_reader_offset(&reader), 0U);
+
+    reader.offset = 1U;
+    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+    EXPECT_FALSE(sdl3d_replication_read_field_type(&reader, &type));
+    EXPECT_EQ(sdl3d_replication_reader_offset(&reader), 1U);
+}
+
+TEST(SDL3DNetworkReplication, RejectsInvalidArguments)
+{
+    std::array<Uint8, 4> buffer{};
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), buffer.size());
+
+    EXPECT_FALSE(sdl3d_replication_write_bool(nullptr, true));
+    EXPECT_FALSE(sdl3d_replication_write_field_type(&writer, (sdl3d_replication_field_type)255));
+
+    EXPECT_FALSE(sdl3d_replication_read_bool(nullptr, nullptr));
+    EXPECT_FALSE(sdl3d_replication_read_bool(&reader, nullptr));
+}


### PR DESCRIPTION
## Summary

- Adds a transport-independent `sdl3d/network_replication.h` field codec for future data-authored network replication schemas.
- Supports bool, int32, float32, enum-id/string-id integer values, vec2, vec3, and field type tags.
- Uses deterministic little-endian encoding and strict bounded readers/writers that do not advance offsets on decode/encode failure.
- Adds `sdl3d_replication_field_wire_size(...)` so schema layers can size packets without duplicating wire-size constants.
- Adds focused unit coverage for round trips, byte order, truncation handling, invalid values, null arguments, zero-capacity writers, boundary integers, and float bit-pattern preservation.

## Verification

- `cmake --build build/debug --target sdl3d_network_replication_test -j 8`
- `./build/debug/tests/sdl3d_network_replication_test`
- `git diff --check`

Refs #179
