### PR TITLE
Validate authored network replication schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ This file gives working guidance for AI agents maintaining SDL_3D.
 ## Suggested workflow
 
 - Read the existing code and docs before editing.
-- Make the smallest correct change that addresses the root cause.
+- Make the most architecturally correct change that addresses the root cause.
 - Add focused tests for the changed behavior.
 - Run the relevant build/test targets before finishing.
 - Update documentation or sample data if the public behavior changed.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1227,9 +1227,9 @@ entity and declare a non-empty `fields` array. Field strings are allowed for
 built-in transform fields with known types (`position`, `rotation`, `scale`,
 all encoded as `vec3`). Property fields should use object form with an explicit
 `path` and `type`. Supported field types are `bool`, `int32`, `float32`,
-`enum_id`, `vec2`, and `vec3`; aliases `boolean`, `int`, `float`, `number`,
-and `string_id` are accepted where obvious. Duplicate actor entries and
-duplicate fields within an actor are rejected.
+`enum_id`, `vec2`, and `vec3`; aliases `boolean`, `int`, `float`, and
+`string_id` are accepted where obvious. Duplicate actor entries and duplicate
+fields within an actor are rejected.
 
 Client-to-host channels author `inputs`; each input must reference an existing
 input action. Duplicate input actions within a channel are rejected.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1164,6 +1164,88 @@ Bad Pong adapters:
 
 Those are generic actions and should remain data.
 
+## Network Replication
+
+Games that support network play can author a top-level `network` block. The
+block is optional; local-only games can omit it entirely and no networking
+schema hash is produced.
+
+The current schema validation slice supports protocol metadata, host/client
+replication channels, typed actor fields, replicated input actions, and control
+messages:
+
+```json
+{
+  "network": {
+    "protocol": {
+      "id": "sdl3d.pong.v1",
+      "version": 1,
+      "transport": "udp",
+      "tick_rate": 60
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": [
+              "position",
+              { "path": "properties.velocity", "type": "vec3" },
+              { "path": "properties.active_motion", "type": "bool" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "client_input",
+        "direction": "client_to_host",
+        "rate": 60,
+        "inputs": [
+          { "action": "action.paddle.remote.up" },
+          { "action": "action.paddle.remote.down" }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" }
+    ]
+  }
+}
+```
+
+`protocol.id` must be a non-empty string. `protocol.version` and
+`protocol.tick_rate` must be positive integers. `protocol.transport` currently
+supports `udp`.
+
+Replication channel directions are `host_to_client` or `client_to_host`, and
+`rate` must be a positive integer.
+Host-to-client channels author `actors`; each actor must reference an existing
+entity and declare a non-empty `fields` array. Field strings are allowed for
+built-in transform fields with known types (`position`, `rotation`, `scale`,
+all encoded as `vec3`). Property fields should use object form with an explicit
+`path` and `type`. Supported field types are `bool`, `int32`, `float32`,
+`enum_id`, `vec2`, and `vec3`; aliases `boolean`, `int`, `float`, `number`,
+and `string_id` are accepted where obvious. Duplicate actor entries and
+duplicate fields within an actor are rejected.
+
+Client-to-host channels author `inputs`; each input must reference an existing
+input action. Duplicate input actions within a channel are rejected.
+
+Control message directions are `host_to_client`, `client_to_host`, or
+`bidirectional`. Each control message must have a unique `name` and reference
+an existing `signal`.
+
+When a runtime loads game data with a valid `network` block, it computes a
+deterministic schema hash over protocol, replication, input, and control-message
+shape. Runtime callers can query it with
+`sdl3d_game_data_has_network_schema()` and
+`sdl3d_game_data_get_network_schema_hash()`. The hash intentionally ignores
+unrelated metadata and presentation data. Later network handshakes should use
+it to reject clients with incompatible authored schemas before gameplay starts.
+
 ## Validation
 
 Game data is validated before runtime state is instantiated. Host tools can call `sdl3d_game_data_validate_file()` directly to collect diagnostics without creating actors, input bindings, timers, or signal handlers. `sdl3d_game_data_load_file()` runs the same validation pass before loading scripts and wiring logic.
@@ -1174,6 +1256,7 @@ Diagnostics are designed for authored content. Errors include the source file, a
 - duplicate names within entity, signal, script, adapter, input action, timer, camera, font, and sensor namespaces
 - script ids, modules, dependencies, dependency cycles, and script file existence
 - input binding structure
+- network protocol, replication directions, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
 - app lifecycle, UI, render effect, sensor, timer, binding, action, component, adapter, light, and camera references
 - supported generic logic action types and required action payloads
 - warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -24,6 +24,7 @@
 #include "sdl3d/font.h"
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
+#include "sdl3d/network_replication.h"
 #include "sdl3d/properties.h"
 #include "sdl3d/sprite_asset.h"
 #include "sdl3d/storage.h"
@@ -800,6 +801,27 @@ extern "C"
      * @return true when @p out_config was filled.
      */
     bool sdl3d_game_data_get_storage_config(const sdl3d_game_data_runtime *runtime, sdl3d_storage_config *out_config);
+
+    /**
+     * @brief Return whether the game data authored a network replication schema.
+     *
+     * Local-only games can omit the `network` block entirely. In that case
+     * there is no schema hash to exchange during multiplayer handshakes.
+     */
+    bool sdl3d_game_data_has_network_schema(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Copy the deterministic network replication schema hash.
+     *
+     * The hash covers the authored protocol, replication channels, fields,
+     * inputs, and control messages, but ignores unrelated game data. It is
+     * intended for host/client compatibility checks before gameplay begins.
+     *
+     * @return true when @p runtime has an authored network schema and
+     * @p out_hash was filled with SDL3D_REPLICATION_SCHEMA_HASH_SIZE bytes.
+     */
+    bool sdl3d_game_data_get_network_schema_hash(const sdl3d_game_data_runtime *runtime,
+                                                 Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE]);
 
     /**
      * @brief Validate a JSON game data file without instantiating runtime state.

--- a/include/sdl3d/network_replication.h
+++ b/include/sdl3d/network_replication.h
@@ -18,6 +18,8 @@
 
 #include "sdl3d/types.h"
 
+#define SDL3D_REPLICATION_SCHEMA_HASH_SIZE 32
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -284,6 +284,8 @@ typedef struct sdl3d_game_data_runtime
     int property_snapshot_count;
     int property_snapshot_capacity;
     sdl3d_storage *storage;
+    bool has_network_schema;
+    Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
     const char *active_camera;
     scene_activity_state activity;
     float current_dt;
@@ -8773,6 +8775,12 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
         sdl3d_game_data_destroy(runtime);
         return false;
     }
+    if (!sdl3d_game_data_network_schema_hash(root, runtime->network_schema_hash, &runtime->has_network_schema))
+    {
+        sdl3d_game_data_destroy(runtime);
+        set_error(error_buffer, error_buffer_size, "failed to compute network schema hash");
+        return false;
+    }
     load_storage_config(runtime, root);
 
     yyjson_val *logic = obj_get(root, "logic");
@@ -8876,6 +8884,21 @@ bool sdl3d_game_data_get_storage_config(const sdl3d_game_data_runtime *runtime, 
         return false;
 
     *out_config = runtime->storage_config;
+    return true;
+}
+
+bool sdl3d_game_data_has_network_schema(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->has_network_schema;
+}
+
+bool sdl3d_game_data_get_network_schema_hash(const sdl3d_game_data_runtime *runtime,
+                                             Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE])
+{
+    if (runtime == NULL || out_hash == NULL || !runtime->has_network_schema)
+        return false;
+
+    SDL_memcpy(out_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE);
     return true;
 }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -413,7 +413,7 @@ static bool replication_field_type_from_string(const char *type, sdl3d_replicati
             *out_type = SDL3D_REPLICATION_FIELD_INT32;
         return true;
     }
-    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0 || SDL_strcmp(type, "number") == 0)
+    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0)
     {
         if (out_type != NULL)
             *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
@@ -496,10 +496,17 @@ static bool is_replication_property_path(const char *path)
 static void network_hash_update(sdl3d_crypto_hash32_state *state, const char *label, const char *value)
 {
     static const char sep = '\0';
+    static const char null_marker = '\1';
     sdl3d_crypto_hash32_update(state, label, SDL_strlen(label));
     sdl3d_crypto_hash32_update(state, &sep, 1u);
     if (value != NULL)
+    {
         sdl3d_crypto_hash32_update(state, value, SDL_strlen(value));
+    }
+    else
+    {
+        sdl3d_crypto_hash32_update(state, &null_marker, 1u);
+    }
     sdl3d_crypto_hash32_update(state, &sep, 1u);
 }
 
@@ -711,6 +718,11 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
         yyjson_val *inputs = obj_get(entry, "inputs");
         if (SDL_strcmp(direction, "host_to_client") == 0)
         {
+            if (actors == NULL)
+            {
+                ok = validation_error(ctx, path, "host_to_client network replication must declare actors");
+                break;
+            }
             if (inputs != NULL)
             {
                 ok = validation_error(ctx, path, "host_to_client network replication must not declare inputs");
@@ -722,6 +734,11 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
         }
         else
         {
+            if (inputs == NULL)
+            {
+                ok = validation_error(ctx, path, "client_to_host network replication must declare inputs");
+                break;
+            }
             if (actors != NULL)
             {
                 ok = validation_error(ctx, path, "client_to_host network replication must not declare actors");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -12,6 +12,7 @@
 
 #include "game_data_standard_options.h"
 #include "sdl3d/input.h"
+#include "sdl3d_crypto.h"
 
 #define PATH_BUFFER_SIZE 256
 
@@ -387,6 +388,477 @@ static bool note_name(name_table *table, const char *name, const char *json_path
     if (name == NULL || name[0] == '\0' || name_table_contains(table, name))
         return true;
     return name_table_add(table, name, json_path);
+}
+
+static bool is_replication_direction(const char *direction, bool allow_bidirectional)
+{
+    return direction != NULL &&
+           (SDL_strcmp(direction, "host_to_client") == 0 || SDL_strcmp(direction, "client_to_host") == 0 ||
+            (allow_bidirectional && SDL_strcmp(direction, "bidirectional") == 0));
+}
+
+static bool replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type)
+{
+    if (type == NULL || type[0] == '\0')
+        return false;
+    if (SDL_strcmp(type, "bool") == 0 || SDL_strcmp(type, "boolean") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
+        return true;
+    }
+    if (SDL_strcmp(type, "int32") == 0 || SDL_strcmp(type, "int") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_INT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0 || SDL_strcmp(type, "number") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "enum_id") == 0 || SDL_strcmp(type, "string_id") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_ENUM_ID;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec2") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC2;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec3") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
+        return true;
+    }
+    return false;
+}
+
+static const char *replication_field_type_name(sdl3d_replication_field_type type)
+{
+    switch (type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return "bool";
+    case SDL3D_REPLICATION_FIELD_INT32:
+        return "int32";
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        return "float32";
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return "enum_id";
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return "vec2";
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return "vec3";
+    default:
+        return "invalid";
+    }
+}
+
+static bool replication_builtin_field_type(const char *field, sdl3d_replication_field_type *out_type)
+{
+    if (field != NULL &&
+        (SDL_strcmp(field, "position") == 0 || SDL_strcmp(field, "rotation") == 0 || SDL_strcmp(field, "scale") == 0))
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
+        return true;
+    }
+    return false;
+}
+
+static bool is_replication_property_path(const char *path)
+{
+    if (path == NULL || path[0] == '\0' || path[0] == '.' || path[SDL_strlen(path) - 1u] == '.')
+        return false;
+
+    bool previous_dot = false;
+    for (const char *p = path; *p != '\0'; ++p)
+    {
+        const char c = *p;
+        const bool valid =
+            (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.';
+        if (!valid)
+            return false;
+        if (c == '.' && previous_dot)
+            return false;
+        previous_dot = c == '.';
+    }
+    return true;
+}
+
+static void network_hash_update(sdl3d_crypto_hash32_state *state, const char *label, const char *value)
+{
+    static const char sep = '\0';
+    sdl3d_crypto_hash32_update(state, label, SDL_strlen(label));
+    sdl3d_crypto_hash32_update(state, &sep, 1u);
+    if (value != NULL)
+        sdl3d_crypto_hash32_update(state, value, SDL_strlen(value));
+    sdl3d_crypto_hash32_update(state, &sep, 1u);
+}
+
+static void network_hash_update_int(sdl3d_crypto_hash32_state *state, const char *label, Sint64 value)
+{
+    char buffer[32];
+    SDL_snprintf(buffer, sizeof(buffer), "%lld", (long long)value);
+    network_hash_update(state, label, buffer);
+}
+
+static bool replication_field_descriptor(yyjson_val *field, const char **out_path,
+                                         sdl3d_replication_field_type *out_type)
+{
+    if (yyjson_is_str(field))
+    {
+        const char *path = yyjson_get_str(field);
+        sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_VEC3;
+        if (!replication_builtin_field_type(path, &type))
+            return false;
+        if (out_path != NULL)
+            *out_path = path;
+        if (out_type != NULL)
+            *out_type = type;
+        return true;
+    }
+
+    if (!yyjson_is_obj(field))
+        return false;
+
+    const char *path = json_string(field, "path");
+    if (path == NULL)
+        path = json_string(field, "field");
+    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+    if (!replication_field_type_from_string(json_string(field, "type"), &type))
+        return false;
+    if (out_path != NULL)
+        *out_path = path;
+    if (out_type != NULL)
+        *out_type = type;
+    return path != NULL && path[0] != '\0';
+}
+
+static bool validate_network_actor_fields(validation_context *ctx, yyjson_val *fields, const char *json_path)
+{
+    if (!yyjson_is_arr(fields) || yyjson_arr_size(fields) == 0)
+        return validation_error(ctx, json_path, "network actor fields must be a non-empty array");
+
+    name_table field_names;
+    SDL_zero(field_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(fields); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *field = yyjson_arr_get(fields, i);
+        const char *field_path = NULL;
+        sdl3d_replication_field_type field_type = SDL3D_REPLICATION_FIELD_BOOL;
+        if (!replication_field_descriptor(field, &field_path, &field_type))
+        {
+            ok = validation_error(ctx, path,
+                                  "network actor field must be a built-in field string or object with path and type");
+            break;
+        }
+        if (!is_replication_property_path(field_path))
+        {
+            ok = validation_error(ctx, path, "network actor field path '%s' is invalid", field_path);
+            break;
+        }
+        if (sdl3d_replication_field_wire_size(field_type) == 0U)
+        {
+            ok = validation_error(ctx, path, "unsupported network actor field type");
+            break;
+        }
+        if (!require_unique_name(ctx, &field_names, "network actor field", field_path, path))
+        {
+            ok = false;
+            break;
+        }
+    }
+    name_table_destroy(&field_names);
+    return ok;
+}
+
+static bool validate_network_actors(validation_context *ctx, yyjson_val *actors, const char *json_path,
+                                    validation_names *names)
+{
+    if (!yyjson_is_arr(actors) || yyjson_arr_size(actors) == 0)
+        return validation_error(ctx, json_path, "network actors must be a non-empty array");
+
+    name_table actor_names;
+    SDL_zero(actor_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(actors); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *actor = yyjson_arr_get(actors, i);
+        if (!yyjson_is_obj(actor))
+        {
+            ok = validation_error(ctx, path, "network actor entry must be an object");
+            break;
+        }
+        const char *entity = json_string(actor, "entity");
+        if (!require_ref(ctx, &names->entities, "entity", entity, path) ||
+            !require_unique_name(ctx, &actor_names, "network actor", entity, path))
+        {
+            ok = false;
+            break;
+        }
+        char fields_path[PATH_BUFFER_SIZE];
+        format_path(fields_path, sizeof(fields_path), "%s.fields", path);
+        ok = validate_network_actor_fields(ctx, obj_get(actor, "fields"), fields_path);
+    }
+    name_table_destroy(&actor_names);
+    return ok;
+}
+
+static bool validate_network_inputs(validation_context *ctx, yyjson_val *inputs, const char *json_path,
+                                    validation_names *names)
+{
+    if (!yyjson_is_arr(inputs) || yyjson_arr_size(inputs) == 0)
+        return validation_error(ctx, json_path, "network inputs must be a non-empty array");
+
+    name_table input_names;
+    SDL_zero(input_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(inputs); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *input = yyjson_arr_get(inputs, i);
+        if (!yyjson_is_obj(input))
+        {
+            ok = validation_error(ctx, path, "network input entry must be an object");
+            break;
+        }
+        const char *action = json_string(input, "action");
+        if (!require_ref(ctx, &names->actions, "input action", action, path) ||
+            !require_unique_name(ctx, &input_names, "network input action", action, path))
+        {
+            ok = false;
+            break;
+        }
+    }
+    name_table_destroy(&input_names);
+    return ok;
+}
+
+static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *network = obj_get(root, "network");
+    if (network == NULL)
+        return true;
+    if (!yyjson_is_obj(network))
+        return validation_error(ctx, "$.network", "network must be an object");
+
+    yyjson_val *protocol = obj_get(network, "protocol");
+    if (!yyjson_is_obj(protocol))
+        return validation_error(ctx, "$.network.protocol", "network protocol must be an object");
+    if (!is_non_empty_string(protocol, "id"))
+        return validation_error(ctx, "$.network.protocol.id", "network protocol id must be a non-empty string");
+    yyjson_val *version = obj_get(protocol, "version");
+    if (!yyjson_is_int(version) || yyjson_get_sint(version) < 1)
+        return validation_error(ctx, "$.network.protocol.version",
+                                "network protocol version must be a positive integer");
+    const char *transport = json_string(protocol, "transport");
+    if (transport == NULL || SDL_strcmp(transport, "udp") != 0)
+        return validation_error(ctx, "$.network.protocol.transport", "network protocol transport must be udp");
+    yyjson_val *tick_rate = obj_get(protocol, "tick_rate");
+    if (!yyjson_is_int(tick_rate) || yyjson_get_sint(tick_rate) <= 0)
+        return validation_error(ctx, "$.network.protocol.tick_rate",
+                                "network protocol tick_rate must be a positive integer");
+
+    yyjson_val *replication = obj_get(network, "replication");
+    if (!yyjson_is_arr(replication) || yyjson_arr_size(replication) == 0)
+        return validation_error(ctx, "$.network.replication", "network replication must be a non-empty array");
+
+    name_table replication_names;
+    SDL_zero(replication_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(replication); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.network.replication[%zu]", i);
+        yyjson_val *entry = yyjson_arr_get(replication, i);
+        if (!yyjson_is_obj(entry))
+        {
+            ok = validation_error(ctx, path, "network replication entry must be an object");
+            break;
+        }
+        if (!require_unique_name(ctx, &replication_names, "network replication", json_string(entry, "name"), path))
+        {
+            ok = false;
+            break;
+        }
+        const char *direction = json_string(entry, "direction");
+        if (!is_replication_direction(direction, false))
+        {
+            ok = validation_error(ctx, path, "network replication direction must be host_to_client or client_to_host");
+            break;
+        }
+        yyjson_val *rate = obj_get(entry, "rate");
+        if (!yyjson_is_int(rate) || yyjson_get_sint(rate) <= 0)
+        {
+            ok = validation_error(ctx, path, "network replication rate must be a positive integer");
+            break;
+        }
+        yyjson_val *actors = obj_get(entry, "actors");
+        yyjson_val *inputs = obj_get(entry, "inputs");
+        if (SDL_strcmp(direction, "host_to_client") == 0)
+        {
+            if (inputs != NULL)
+            {
+                ok = validation_error(ctx, path, "host_to_client network replication must not declare inputs");
+                break;
+            }
+            char actors_path[PATH_BUFFER_SIZE];
+            format_path(actors_path, sizeof(actors_path), "%s.actors", path);
+            ok = validate_network_actors(ctx, actors, actors_path, names);
+        }
+        else
+        {
+            if (actors != NULL)
+            {
+                ok = validation_error(ctx, path, "client_to_host network replication must not declare actors");
+                break;
+            }
+            char inputs_path[PATH_BUFFER_SIZE];
+            format_path(inputs_path, sizeof(inputs_path), "%s.inputs", path);
+            ok = validate_network_inputs(ctx, inputs, inputs_path, names);
+        }
+    }
+    name_table_destroy(&replication_names);
+    if (!ok)
+        return false;
+
+    yyjson_val *controls = obj_get(network, "control_messages");
+    if (controls == NULL)
+        return true;
+    if (!yyjson_is_arr(controls))
+        return validation_error(ctx, "$.network.control_messages", "network control_messages must be an array");
+
+    name_table control_names;
+    SDL_zero(control_names);
+    for (size_t i = 0; ok && i < yyjson_arr_size(controls); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.network.control_messages[%zu]", i);
+        yyjson_val *control = yyjson_arr_get(controls, i);
+        if (!yyjson_is_obj(control))
+        {
+            ok = validation_error(ctx, path, "network control message must be an object");
+            break;
+        }
+        if (!require_unique_name(ctx, &control_names, "network control message", json_string(control, "name"), path))
+        {
+            ok = false;
+            break;
+        }
+        if (!is_replication_direction(json_string(control, "direction"), true))
+        {
+            ok = validation_error(ctx, path,
+                                  "network control message direction must be host_to_client, client_to_host, or "
+                                  "bidirectional");
+            break;
+        }
+        if (!require_ref(ctx, &names->signals, "signal", json_string(control, "signal"), path))
+        {
+            ok = false;
+            break;
+        }
+    }
+    name_table_destroy(&control_names);
+    return ok;
+}
+
+static void hash_network_actor_fields(sdl3d_crypto_hash32_state *state, yyjson_val *fields)
+{
+    network_hash_update_int(state, "field_count", (Sint64)yyjson_arr_size(fields));
+    for (size_t i = 0; yyjson_is_arr(fields) && i < yyjson_arr_size(fields); ++i)
+    {
+        const char *field_path = NULL;
+        sdl3d_replication_field_type field_type = SDL3D_REPLICATION_FIELD_BOOL;
+        if (replication_field_descriptor(yyjson_arr_get(fields, i), &field_path, &field_type))
+        {
+            network_hash_update(state, "field.path", field_path);
+            network_hash_update(state, "field.type", replication_field_type_name(field_type));
+        }
+    }
+}
+
+bool sdl3d_game_data_network_schema_hash(yyjson_val *root, Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE],
+                                         bool *out_present)
+{
+    if (out_present != NULL)
+        *out_present = false;
+    if (out_hash != NULL)
+        SDL_memset(out_hash, 0, SDL3D_REPLICATION_SCHEMA_HASH_SIZE);
+    if (!yyjson_is_obj(root))
+        return false;
+
+    yyjson_val *network = obj_get(root, "network");
+    if (network == NULL)
+        return true;
+    if (!yyjson_is_obj(network) || out_hash == NULL)
+        return false;
+
+    if (out_present != NULL)
+        *out_present = true;
+
+    sdl3d_crypto_hash32_state state;
+    sdl3d_crypto_hash32_init(&state);
+    network_hash_update(&state, "schema", "sdl3d.network.replication.v0");
+
+    yyjson_val *protocol = obj_get(network, "protocol");
+    network_hash_update(&state, "protocol.id", json_string(protocol, "id"));
+    network_hash_update_int(&state, "protocol.version", yyjson_get_sint(obj_get(protocol, "version")));
+    network_hash_update(&state, "protocol.transport", json_string(protocol, "transport"));
+    network_hash_update_int(&state, "protocol.tick_rate", yyjson_get_sint(obj_get(protocol, "tick_rate")));
+
+    yyjson_val *replication = obj_get(network, "replication");
+    network_hash_update_int(&state, "replication_count", (Sint64)yyjson_arr_size(replication));
+    for (size_t i = 0; yyjson_is_arr(replication) && i < yyjson_arr_size(replication); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(replication, i);
+        network_hash_update(&state, "replication.name", json_string(entry, "name"));
+        network_hash_update(&state, "replication.direction", json_string(entry, "direction"));
+        network_hash_update_int(&state, "replication.rate", yyjson_get_sint(obj_get(entry, "rate")));
+
+        yyjson_val *actors = obj_get(entry, "actors");
+        network_hash_update_int(&state, "actor_count", (Sint64)yyjson_arr_size(actors));
+        for (size_t a = 0; yyjson_is_arr(actors) && a < yyjson_arr_size(actors); ++a)
+        {
+            yyjson_val *actor = yyjson_arr_get(actors, a);
+            network_hash_update(&state, "actor.entity", json_string(actor, "entity"));
+            hash_network_actor_fields(&state, obj_get(actor, "fields"));
+        }
+
+        yyjson_val *inputs = obj_get(entry, "inputs");
+        network_hash_update_int(&state, "input_count", (Sint64)yyjson_arr_size(inputs));
+        for (size_t input_index = 0; yyjson_is_arr(inputs) && input_index < yyjson_arr_size(inputs); ++input_index)
+        {
+            yyjson_val *input = yyjson_arr_get(inputs, input_index);
+            network_hash_update(&state, "input.action", json_string(input, "action"));
+        }
+    }
+
+    yyjson_val *controls = obj_get(network, "control_messages");
+    network_hash_update_int(&state, "control_count", (Sint64)yyjson_arr_size(controls));
+    for (size_t i = 0; yyjson_is_arr(controls) && i < yyjson_arr_size(controls); ++i)
+    {
+        yyjson_val *control = yyjson_arr_get(controls, i);
+        network_hash_update(&state, "control.name", json_string(control, "name"));
+        network_hash_update(&state, "control.direction", json_string(control, "direction"));
+        network_hash_update(&state, "control.signal", json_string(control, "signal"));
+    }
+
+    sdl3d_crypto_hash32_final(&state, out_hash);
+    return true;
 }
 
 static bool path_is_absolute(const char *path)
@@ -2752,7 +3224,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
-           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
+           validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
            validate_lights(ctx, root, names) && validate_logic(ctx, root, names) &&
            validate_adapters(ctx, root, names) &&

--- a/src/game_data_validation.h
+++ b/src/game_data_validation.h
@@ -8,11 +8,15 @@
 
 #include "sdl3d/asset.h"
 #include "sdl3d/game_data.h"
+#include "sdl3d/network_replication.h"
 #include "yyjson.h"
 
 bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path, const char *base_dir,
                                        const sdl3d_asset_resolver *assets,
                                        const sdl3d_game_data_validation_options *options, char *error_buffer,
                                        int error_buffer_size);
+
+bool sdl3d_game_data_network_schema_hash(yyjson_val *root, Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE],
+                                         bool *out_present);
 
 #endif /* SDL3D_GAME_DATA_VALIDATION_H */

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -216,6 +217,106 @@ void write_text(const std::filesystem::path &path, const char *text)
     std::filesystem::create_directories(path.parent_path());
     std::ofstream out(path, std::ios::binary);
     out << text;
+}
+
+std::string network_schema_game_json(const std::string &network_json, const char *metadata_name = "Network Schema")
+{
+    return std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": ")json") +
+           metadata_name + R"json(", "id": "test.network_schema", "version": "0.1.0" },
+  "world": { "name": "world.network_schema", "kind": "fixed_screen" },
+  "entities": [
+    { "name": "entity.paddle.player" },
+    { "name": "entity.ball" }
+  ],
+  "signals": [
+    "signal.network.start",
+    "signal.network.pause"
+  ],
+  "input": {
+    "contexts": [
+      {
+        "name": "gameplay",
+        "actions": [
+          { "name": "action.remote.up" },
+          { "name": "action.remote.down" }
+        ]
+      }
+    ]
+  },
+  "network": )json" +
+           network_json +
+           R"json(
+})json";
+}
+
+std::string valid_network_schema_json(const char *ball_velocity_type = "vec3")
+{
+    return std::string(R"json({
+    "protocol": {
+      "id": "sdl3d.test.network.v1",
+      "version": 1,
+      "transport": "udp",
+      "tick_rate": 60
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.paddle.player",
+            "fields": [
+              "position",
+              { "path": "properties.active", "type": "bool" }
+            ]
+          },
+          {
+            "entity": "entity.ball",
+            "fields": [
+              "position",
+              { "path": "properties.velocity", "type": ")json") +
+           ball_velocity_type + R"json(" }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "client_input",
+        "direction": "client_to_host",
+        "rate": 60,
+        "inputs": [
+          { "action": "action.remote.up" },
+          { "action": "action.remote.down" }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "start_game", "direction": "host_to_client", "signal": "signal.network.start" },
+      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" }
+    ]
+  })json";
+}
+
+std::array<Uint8, SDL3D_REPLICATION_SCHEMA_HASH_SIZE> load_network_schema_hash(const std::filesystem::path &path)
+{
+    sdl3d_game_session *session = nullptr;
+    EXPECT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_TRUE(sdl3d_game_data_load_file(path.string().c_str(), session, &runtime, error, sizeof(error))) << error;
+    EXPECT_NE(runtime, nullptr);
+    EXPECT_TRUE(sdl3d_game_data_has_network_schema(runtime));
+
+    std::array<Uint8, SDL3D_REPLICATION_SCHEMA_HASH_SIZE> hash{};
+    EXPECT_TRUE(sdl3d_game_data_get_network_schema_hash(runtime, hash.data()));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    return hash;
 }
 
 std::filesystem::path copy_pong_data_with_storage_overrides(const std::filesystem::path &dir,
@@ -4204,6 +4305,153 @@ TEST(GameDataRuntime, ValidatesAuthoredStorageConfig)
         sdl3d_game_data_validate_file((dir / "good_storage.game.json").string().c_str(), nullptr, error, sizeof(error)))
         << error;
     EXPECT_EQ(error[0], '\0');
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
+{
+    const std::filesystem::path dir = unique_test_dir("network_schema");
+    const std::string network_json = valid_network_schema_json();
+
+    write_text(dir / "network_a.game.json", network_schema_game_json(network_json, "Network Schema A").c_str());
+    write_text(dir / "network_b.game.json", network_schema_game_json(network_json, "Different Metadata").c_str());
+    write_text(dir / "network_changed.game.json",
+               network_schema_game_json(valid_network_schema_json("vec2"), "Network Schema A").c_str());
+
+    char error[512]{};
+    ASSERT_TRUE(
+        sdl3d_game_data_validate_file((dir / "network_a.game.json").string().c_str(), nullptr, error, sizeof(error)))
+        << error;
+
+    const auto hash_a = load_network_schema_hash(dir / "network_a.game.json");
+    const auto hash_b = load_network_schema_hash(dir / "network_b.game.json");
+    const auto hash_changed = load_network_schema_hash(dir / "network_changed.game.json");
+
+    EXPECT_EQ(hash_a, hash_b);
+    EXPECT_NE(hash_a, hash_changed);
+
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
+{
+    struct Case
+    {
+        const char *name;
+        std::string network_json;
+        const char *expected_error;
+    };
+
+    const Case cases[] = {
+        {
+            "unknown_entity",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          { "entity": "entity.missing", "fields": [ "position" ] }
+        ]
+      }
+    ]
+  })json",
+            "unknown entity reference",
+        },
+        {
+            "duplicate_field",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": [
+              { "path": "properties.velocity", "type": "vec3" },
+              { "path": "properties.velocity", "type": "vec3" }
+            ]
+          }
+        ]
+      }
+    ]
+  })json",
+            "duplicate network actor field",
+        },
+        {
+            "unsupported_field_type",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": [
+              { "path": "properties.transform", "type": "mat4" }
+            ]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network actor field must",
+        },
+        {
+            "unknown_action",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "client_input",
+        "direction": "client_to_host",
+        "rate": 60,
+        "inputs": [
+          { "action": "action.missing" }
+        ]
+      }
+    ]
+  })json",
+            "unknown input action reference",
+        },
+        {
+            "bad_direction",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "sideways",
+        "rate": 60,
+        "actors": [
+          { "entity": "entity.ball", "fields": [ "position" ] }
+        ]
+      }
+    ]
+  })json",
+            "network replication direction",
+        },
+    };
+
+    const std::filesystem::path dir = unique_test_dir("bad_network_schema");
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path path = dir / (std::string(test_case.name) + ".game.json");
+        write_text(path, network_schema_game_json(test_case.network_json, test_case.name).c_str());
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
     remove_test_dir(dir);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4333,6 +4333,36 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, LocalOnlyGameHasNoNetworkSchemaHash)
+{
+    const std::filesystem::path dir = unique_test_dir("no_network_schema");
+    write_text(dir / "local_only.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Local Only", "id": "test.local_only", "version": "0.1.0" },
+  "world": { "name": "world.local_only", "kind": "fixed_screen" },
+  "entities": []
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "local_only.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    ASSERT_NE(runtime, nullptr);
+
+    std::array<Uint8, SDL3D_REPLICATION_SCHEMA_HASH_SIZE> hash{};
+    EXPECT_FALSE(sdl3d_game_data_has_network_schema(runtime));
+    EXPECT_FALSE(sdl3d_game_data_get_network_schema_hash(runtime, hash.data()));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
 {
     struct Case
@@ -4406,6 +4436,28 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
             "network actor field must",
         },
         {
+            "number_alias_is_not_a_network_field_type",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": [
+              { "path": "properties.speed", "type": "number" }
+            ]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network actor field must",
+        },
+        {
             "unknown_action",
             R"json({
     "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
@@ -4438,6 +4490,80 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "network replication direction",
+        },
+        {
+            "duplicate_replication_channel",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          { "entity": "entity.ball", "fields": [ "position" ] }
+        ]
+      },
+      {
+        "name": "play_state",
+        "direction": "client_to_host",
+        "rate": 60,
+        "inputs": [
+          { "action": "action.remote.up" }
+        ]
+      }
+    ]
+  })json",
+            "duplicate network replication",
+        },
+        {
+            "duplicate_control_message",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          { "entity": "entity.ball", "fields": [ "position" ] }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" },
+      { "name": "pause", "direction": "host_to_client", "signal": "signal.network.start" }
+    ]
+  })json",
+            "duplicate network control message",
+        },
+        {
+            "host_to_client_missing_actors",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60
+      }
+    ]
+  })json",
+            "host_to_client network replication must declare actors",
+        },
+        {
+            "client_to_host_missing_inputs",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "client_input",
+        "direction": "client_to_host",
+        "rate": 60
+      }
+    ]
+  })json",
+            "client_to_host network replication must declare inputs",
         },
     };
 


### PR DESCRIPTION
## Summary

- Adds validation for the authored top-level `network` replication schema.
- Validates protocol id/version/transport/tick rate, replication channel directions/rates, entity refs, typed actor fields, input action refs, control signal refs, and duplicate network names/fields.
- Computes and stores a deterministic network schema hash on loaded game-data runtimes for future host/client handshake compatibility checks, including distinct NULL hashing markers.
- Adds runtime APIs to query whether a network schema exists and copy its schema hash.
- Documents the authored network schema shape and hash behavior.
- Carries forward the requested `AGENTS.md` workflow wording update.

## Review Follow-up

- Added local-only runtime coverage for games without a `network` block.
- Added duplicate replication channel and duplicate control message validation coverage.
- Removed the ambiguous `number` alias for network field types.
- Added clearer diagnostics for missing `actors` on `host_to_client` channels and missing `inputs` on `client_to_host` channels.

## Verification

- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesNetworkReplicationSchemaAndComputesStableHash:GameDataRuntime.LocalOnlyGameHasNoNetworkSchemaHash:GameDataRuntime.RejectsInvalidNetworkReplicationSchemas'`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_network_replication_test`
- `cmake --build build/debug --target pong_demo -j 8`
- `git diff --check`

Refs #179
