### PR TITLE
Add data-driven network snapshot replication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ target_sources(
         src/obj_loader.c
         src/network.c
         src/network_replication.c
+        src/network_replication_schema.c
         src/properties.c
         src/rasterizer.c
         src/render_context.c

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -99,6 +99,72 @@
       "reset_menu_input_on_request": true
     }
   },
+  "network": {
+    "protocol": {
+      "id": "sdl3d.pong.v1",
+      "version": 1,
+      "transport": "udp",
+      "tick_rate": 60
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.paddle.player",
+            "fields": ["position"]
+          },
+          {
+            "entity": "entity.paddle.cpu",
+            "fields": ["position"]
+          },
+          {
+            "entity": "entity.ball",
+            "fields": [
+              "position",
+              { "path": "properties.velocity", "type": "vec2" },
+              { "path": "properties.active_motion", "type": "bool" },
+              { "path": "properties.has_last_reflect_y", "type": "bool" },
+              { "path": "properties.last_reflect_y", "type": "float32" },
+              { "path": "properties.stagnant_reflect_count", "type": "int32" }
+            ]
+          },
+          {
+            "entity": "entity.score.player",
+            "fields": [
+              { "path": "properties.value", "type": "int32" }
+            ]
+          },
+          {
+            "entity": "entity.score.cpu",
+            "fields": [
+              { "path": "properties.value", "type": "int32" }
+            ]
+          },
+          {
+            "entity": "entity.match",
+            "fields": [
+              { "path": "properties.finished", "type": "bool" }
+            ]
+          },
+          {
+            "entity": "entity.presentation",
+            "fields": [
+              { "path": "properties.border_flash", "type": "float32" },
+              { "path": "properties.paddle_flash", "type": "float32" }
+            ]
+          }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "start_game", "direction": "host_to_client", "signal": "signal.network.start_game" },
+      { "name": "terminate_match", "direction": "bidirectional", "signal": "signal.network.terminate_match" },
+      { "name": "pause_changed", "direction": "bidirectional", "signal": "signal.network.pause_changed" }
+    ]
+  },
   "scenes": {
     "initial": "scene.splash",
     "files": [
@@ -982,7 +1048,10 @@
         "stagnant_reflect_epsilon": { "type": "float", "value": 0.08 },
         "stagnant_reflect_limit": { "type": "int", "value": 2 },
         "reflect_jitter_angle": { "type": "float", "value": 0.24 },
-        "active_motion": { "type": "bool", "value": false }
+        "active_motion": { "type": "bool", "value": false },
+        "has_last_reflect_y": { "type": "bool", "value": false },
+        "last_reflect_y": { "type": "float", "value": 0.0 },
+        "stagnant_reflect_count": { "type": "int", "value": 0 }
       },
       "components": [
         {
@@ -1458,6 +1527,9 @@
     "signal.settings.reset_mouse",
     "signal.settings.reset_gamepad",
     "signal.settings.reset_audio",
+    "signal.network.start_game",
+    "signal.network.terminate_match",
+    "signal.network.pause_changed",
     "signal.multiplayer.lobby.start",
     "signal.multiplayer.discovery.refresh",
     "signal.ui.menu.move",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1170,9 +1170,8 @@ Games that support network play can author a top-level `network` block. The
 block is optional; local-only games can omit it entirely and no networking
 schema hash is produced.
 
-The current schema validation slice supports protocol metadata, host/client
-replication channels, typed actor fields, replicated input actions, and control
-messages:
+The network schema supports protocol metadata, host/client replication channels,
+typed actor fields, replicated input actions, and control messages:
 
 ```json
 {
@@ -1193,7 +1192,7 @@ messages:
             "entity": "entity.ball",
             "fields": [
               "position",
-              { "path": "properties.velocity", "type": "vec3" },
+              { "path": "properties.velocity", "type": "vec2" },
               { "path": "properties.active_motion", "type": "bool" }
             ]
           }
@@ -1238,13 +1237,24 @@ Control message directions are `host_to_client`, `client_to_host`, or
 `bidirectional`. Each control message must have a unique `name` and reference
 an existing `signal`.
 
+Host-to-client actor channels can be encoded into strict snapshot packets with
+`sdl3d_game_data_encode_network_snapshot()` and applied with
+`sdl3d_game_data_apply_network_snapshot()`. Snapshot packets include the schema
+hash, channel index, authoritative tick, field count, field type tags, and field
+values in authored order. Decoders reject unsupported packet versions,
+mismatched schema hashes, wrong field counts, wrong field tags, truncation, and
+trailing bytes. Built-in `position` fields update the actor transform; object
+paths under `properties.` update actor properties. `vec2` property replication
+is stored in SDL3D's existing vec3 property bag by updating x/y and preserving z.
+
 When a runtime loads game data with a valid `network` block, it computes a
 deterministic schema hash over protocol, replication, input, and control-message
 shape. Runtime callers can query it with
 `sdl3d_game_data_has_network_schema()` and
 `sdl3d_game_data_get_network_schema_hash()`. The hash intentionally ignores
-unrelated metadata and presentation data. Later network handshakes should use
-it to reject clients with incompatible authored schemas before gameplay starts.
+unrelated metadata and presentation data. Network handshakes should use it to
+reject clients with incompatible authored schemas before gameplay starts, and
+snapshot application enforces the same hash on every packet.
 
 ## Validation
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1227,8 +1227,10 @@ built-in transform fields with known types (`position`, `rotation`, `scale`,
 all encoded as `vec3`). Property fields should use object form with an explicit
 `path` and `type`. Supported field types are `bool`, `int32`, `float32`,
 `enum_id`, `vec2`, and `vec3`; aliases `boolean`, `int`, `float`, and
-`string_id` are accepted where obvious. Duplicate actor entries and duplicate
-fields within an actor are rejected.
+`string_id` are accepted where obvious. The generic JSON type name `number` is
+not accepted for network fields; authors should choose `int32` or `float32`
+explicitly. Duplicate actor entries and duplicate fields within an actor are
+rejected.
 
 Client-to-host channels author `inputs`; each input must reference an existing
 input action. Duplicate input actions within a channel are rejected.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -824,6 +824,50 @@ extern "C"
                                                  Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE]);
 
     /**
+     * @brief Encode an authored host-to-client replication snapshot.
+     *
+     * The named replication channel must exist in the loaded `network`
+     * schema and have `direction: "host_to_client"`. The packet includes a
+     * deterministic header, schema hash, channel index, tick, typed field
+     * tags, and field values in authored schema order. Callers provide the
+     * destination buffer; no allocation is performed.
+     *
+     * @param runtime Runtime whose actor state should be serialized.
+     * @param replication_name Authored replication channel name.
+     * @param tick Authoritative simulation tick to include in the snapshot.
+     * @param buffer Destination packet buffer.
+     * @param buffer_size Destination buffer size in bytes.
+     * @param out_size Receives written packet size in bytes.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the full snapshot was encoded.
+     */
+    bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                                 Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                                 char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Decode and apply an authored host-to-client replication snapshot.
+     *
+     * The packet must match the runtime schema hash and reference a
+     * host-to-client channel in the loaded `network` schema. Field tags and
+     * payload sizes are checked strictly. On failure, the function returns
+     * false and reports a best-effort error; callers should discard the
+     * packet. Successfully decoded values are applied directly to actors.
+     *
+     * @param runtime Runtime whose actor state should be updated.
+     * @param packet Source packet buffer.
+     * @param packet_size Source packet size in bytes.
+     * @param out_tick Receives the authoritative snapshot tick, if non-NULL.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the snapshot was decoded and applied completely.
+     */
+    bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, const void *packet,
+                                                size_t packet_size, Uint32 *out_tick, char *error_buffer,
+                                                int error_buffer_size);
+
+    /**
      * @brief Validate a JSON game data file without instantiating runtime state.
      *
      * Validation checks schema, authored names, references, supported generic

--- a/include/sdl3d/network_replication.h
+++ b/include/sdl3d/network_replication.h
@@ -75,11 +75,24 @@ extern "C"
     /** @brief Write a one-byte replication field type tag. */
     bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_replication_field_type type);
 
+    /**
+     * @brief Write raw bytes without transformation.
+     *
+     * This is intended for packet headers, hashes, and other schema-level
+     * payloads around typed field values. Passing NULL for @p bytes is valid
+     * only when @p byte_count is zero. On failure, the writer offset is
+     * unchanged.
+     */
+    bool sdl3d_replication_write_bytes(sdl3d_replication_writer *writer, const void *bytes, size_t byte_count);
+
     /** @brief Write a one-byte boolean. */
     bool sdl3d_replication_write_bool(sdl3d_replication_writer *writer, bool value);
 
     /** @brief Write a signed 32-bit integer. */
     bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 value);
+
+    /** @brief Write an unsigned 32-bit integer. */
+    bool sdl3d_replication_write_uint32(sdl3d_replication_writer *writer, Uint32 value);
 
     /** @brief Write a 32-bit float. */
     bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value);
@@ -110,6 +123,16 @@ extern "C"
     bool sdl3d_replication_read_field_type(sdl3d_replication_reader *reader, sdl3d_replication_field_type *out_type);
 
     /**
+     * @brief Read raw bytes without transformation.
+     *
+     * This is intended for packet headers, hashes, and other schema-level
+     * payloads around typed field values. Passing NULL for @p out_bytes is
+     * valid only when @p byte_count is zero. On failure, the reader offset is
+     * unchanged.
+     */
+    bool sdl3d_replication_read_bytes(sdl3d_replication_reader *reader, void *out_bytes, size_t byte_count);
+
+    /**
      * @brief Read a one-byte boolean.
      *
      * Values other than 0 and 1 fail and leave the reader offset unchanged.
@@ -118,6 +141,9 @@ extern "C"
 
     /** @brief Read a signed 32-bit integer. */
     bool sdl3d_replication_read_int32(sdl3d_replication_reader *reader, Sint32 *out_value);
+
+    /** @brief Read an unsigned 32-bit integer. */
+    bool sdl3d_replication_read_uint32(sdl3d_replication_reader *reader, Uint32 *out_value);
 
     /** @brief Read a 32-bit float. */
     bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out_value);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -15,6 +15,7 @@
 #include "game_data_validation.h"
 #include "lauxlib.h"
 #include "lua.h"
+#include "network_replication_schema.h"
 #include "script_internal.h"
 #include "sdl3d/asset.h"
 #include "sdl3d/input.h"
@@ -24,6 +25,8 @@
 #include "sdl3d/timer_pool.h"
 #include "yyjson.h"
 
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #define SDL3D_GAME_DATA_SIGNAL_BASE 20000
@@ -300,6 +303,17 @@ static void set_error(char *buffer, int buffer_size, const char *message)
     {
         SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown game data error");
     }
+}
+
+static void set_errorf(char *buffer, int buffer_size, const char *format, ...)
+{
+    if (buffer == NULL || buffer_size <= 0)
+        return;
+
+    va_list args;
+    va_start(args, format);
+    SDL_vsnprintf(buffer, (size_t)buffer_size, format != NULL ? format : "unknown game data error", args);
+    va_end(args);
 }
 
 static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
@@ -1763,12 +1777,6 @@ static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 positio
     sdl3d_properties_set_vec3(actor->props, "origin", position);
 }
 
-typedef struct game_data_replication_field
-{
-    const char *path;
-    sdl3d_replication_field_type type;
-} game_data_replication_field;
-
 typedef struct game_data_snapshot_value
 {
     sdl3d_replication_field_type type;
@@ -1780,91 +1788,6 @@ typedef struct game_data_snapshot_value
         sdl3d_vec3 as_vec3;
     } value;
 } game_data_snapshot_value;
-
-static bool game_data_replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type)
-{
-    if (type == NULL || type[0] == '\0')
-        return false;
-    if (SDL_strcmp(type, "bool") == 0 || SDL_strcmp(type, "boolean") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
-        return true;
-    }
-    if (SDL_strcmp(type, "int32") == 0 || SDL_strcmp(type, "int") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_INT32;
-        return true;
-    }
-    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
-        return true;
-    }
-    if (SDL_strcmp(type, "enum_id") == 0 || SDL_strcmp(type, "string_id") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_ENUM_ID;
-        return true;
-    }
-    if (SDL_strcmp(type, "vec2") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_VEC2;
-        return true;
-    }
-    if (SDL_strcmp(type, "vec3") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
-        return true;
-    }
-    return false;
-}
-
-static bool game_data_replication_field_descriptor(yyjson_val *field, game_data_replication_field *out_field)
-{
-    if (out_field != NULL)
-    {
-        out_field->path = NULL;
-        out_field->type = SDL3D_REPLICATION_FIELD_BOOL;
-    }
-    if (yyjson_is_str(field))
-    {
-        const char *path = yyjson_get_str(field);
-        if (path == NULL ||
-            (SDL_strcmp(path, "position") != 0 && SDL_strcmp(path, "rotation") != 0 && SDL_strcmp(path, "scale") != 0))
-        {
-            return false;
-        }
-        if (out_field != NULL)
-        {
-            out_field->path = path;
-            out_field->type = SDL3D_REPLICATION_FIELD_VEC3;
-        }
-        return true;
-    }
-    if (!yyjson_is_obj(field))
-        return false;
-
-    const char *path = json_string(field, "path", NULL);
-    if (path == NULL)
-        path = json_string(field, "field", NULL);
-    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
-    if (path == NULL || path[0] == '\0' ||
-        !game_data_replication_field_type_from_string(json_string(field, "type", NULL), &type))
-    {
-        return false;
-    }
-    if (out_field != NULL)
-    {
-        out_field->path = path;
-        out_field->type = type;
-    }
-    return true;
-}
 
 static yyjson_val *game_data_find_replication_channel_by_name(const sdl3d_game_data_runtime *runtime,
                                                               const char *replication_name, int *out_index)
@@ -1908,6 +1831,35 @@ static size_t game_data_replication_channel_field_count(yyjson_val *channel)
     return count;
 }
 
+static bool game_data_replication_channel_packet_size(yyjson_val *channel, size_t *out_size)
+{
+    if (out_size != NULL)
+        *out_size = 0U;
+    if (channel == NULL)
+        return false;
+
+    size_t size = 4U + 4U + 4U + 4U + SDL3D_REPLICATION_SCHEMA_HASH_SIZE + 4U;
+    yyjson_val *actors = obj_get(channel, "actors");
+    for (size_t actor_index = 0U; yyjson_is_arr(actors) && actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *fields = obj_get(yyjson_arr_get(actors, actor_index), "fields");
+        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+        {
+            sdl3d_replication_field_descriptor field;
+            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field))
+                return false;
+            const size_t field_size = sdl3d_replication_field_wire_size(field.type);
+            if (field_size == 0U || size > SIZE_MAX - 1U - field_size)
+                return false;
+            size += 1U + field_size;
+        }
+    }
+
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
 static const char *game_data_replication_property_key(const char *path)
 {
     static const char prefix[] = "properties.";
@@ -1916,7 +1868,7 @@ static const char *game_data_replication_property_key(const char *path)
 }
 
 static bool game_data_read_actor_replication_field(const sdl3d_registered_actor *actor,
-                                                   const game_data_replication_field *field,
+                                                   const sdl3d_replication_field_descriptor *field,
                                                    game_data_snapshot_value *out_value)
 {
     if (actor == NULL || field == NULL || out_value == NULL || field->path == NULL)
@@ -2032,7 +1984,7 @@ static bool game_data_read_snapshot_value(sdl3d_replication_reader *reader, sdl3
 }
 
 static bool game_data_apply_actor_replication_field(sdl3d_registered_actor *actor,
-                                                    const game_data_replication_field *field,
+                                                    const sdl3d_replication_field_descriptor *field,
                                                     const game_data_snapshot_value *value)
 {
     if (actor == NULL || field == NULL || value == NULL || field->path == NULL || field->type != value->type)
@@ -9261,6 +9213,18 @@ bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runt
         set_error(error_buffer, error_buffer_size, "network snapshot channel is too large");
         return false;
     }
+    size_t required_size = 0U;
+    if (!game_data_replication_channel_packet_size(channel, &required_size))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot channel contains unsupported field data");
+        return false;
+    }
+    if (buffer_size < required_size)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network snapshot requires %zu bytes, buffer has %zu bytes",
+                   required_size, buffer_size);
+        return false;
+    }
 
     sdl3d_replication_writer writer;
     sdl3d_replication_writer_init(&writer, buffer, buffer_size);
@@ -9283,19 +9247,21 @@ bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runt
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
         if (actor == NULL)
         {
-            set_error(error_buffer, error_buffer_size, "network snapshot actor not found");
+            set_errorf(error_buffer, error_buffer_size, "network snapshot actor '%s' not found",
+                       entity_name != NULL ? entity_name : "<null>");
             return false;
         }
 
         yyjson_val *fields = obj_get(actor_schema, "fields");
         for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
         {
-            game_data_replication_field field;
+            sdl3d_replication_field_descriptor field;
             game_data_snapshot_value value;
-            if (!game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) ||
+            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
                 !game_data_read_actor_replication_field(actor, &field, &value))
             {
-                set_error(error_buffer, error_buffer_size, "network snapshot failed to read authored field");
+                set_errorf(error_buffer, error_buffer_size, "network snapshot failed to read field '%s' on actor '%s'",
+                           field.path != NULL ? field.path : "<invalid>", entity_name != NULL ? entity_name : "<null>");
                 return false;
             }
             if (!game_data_write_snapshot_value(&writer, &value))
@@ -9386,8 +9352,8 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
         for (size_t field_index = 0U; ok && yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields);
              ++field_index)
         {
-            game_data_replication_field field;
-            ok = game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) &&
+            sdl3d_replication_field_descriptor field;
+            ok = sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) &&
                  decoded_index < field_count &&
                  game_data_read_snapshot_value(&reader, field.type, &values[decoded_index]);
             ++decoded_index;
@@ -9404,38 +9370,57 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
         return false;
     }
 
-    for (size_t actor_index = 0U; actor_index < yyjson_arr_size(actors); ++actor_index)
+    const size_t actor_count = yyjson_is_arr(actors) ? yyjson_arr_size(actors) : 0U;
+    sdl3d_registered_actor **resolved_actors =
+        actor_count > 0U ? (sdl3d_registered_actor **)SDL_calloc(actor_count, sizeof(*resolved_actors)) : NULL;
+    if (resolved_actors == NULL && actor_count > 0U)
+    {
+        SDL_free(values);
+        set_error(error_buffer, error_buffer_size, "network snapshot failed to allocate actor lookup storage");
+        return false;
+    }
+
+    /* Resolve every actor before applying any field so a malformed runtime cannot produce a partial snapshot apply. */
+    for (size_t actor_index = 0U; actor_index < actor_count; ++actor_index)
     {
         yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
-        if (sdl3d_game_data_find_actor(runtime, json_string(actor_schema, "entity", NULL)) == NULL)
+        const char *entity_name = json_string(actor_schema, "entity", NULL);
+        resolved_actors[actor_index] = sdl3d_game_data_find_actor(runtime, entity_name);
+        if (resolved_actors[actor_index] == NULL)
         {
+            SDL_free(resolved_actors);
             SDL_free(values);
-            set_error(error_buffer, error_buffer_size, "network snapshot actor not found");
+            set_errorf(error_buffer, error_buffer_size, "network snapshot actor '%s' not found",
+                       entity_name != NULL ? entity_name : "<null>");
             return false;
         }
     }
 
     size_t apply_index = 0U;
-    for (size_t actor_index = 0U; actor_index < yyjson_arr_size(actors); ++actor_index)
+    for (size_t actor_index = 0U; actor_index < actor_count; ++actor_index)
     {
         yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(actor_schema, "entity", NULL));
+        sdl3d_registered_actor *actor = resolved_actors[actor_index];
         yyjson_val *fields = obj_get(actor_schema, "fields");
         for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
         {
-            game_data_replication_field field;
-            if (actor == NULL || !game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) ||
+            sdl3d_replication_field_descriptor field;
+            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
                 apply_index >= field_count ||
                 !game_data_apply_actor_replication_field(actor, &field, &values[apply_index]))
             {
+                SDL_free(resolved_actors);
                 SDL_free(values);
-                set_error(error_buffer, error_buffer_size, "network snapshot failed to apply authored field");
+                set_errorf(error_buffer, error_buffer_size, "network snapshot failed to apply field '%s' on actor '%s'",
+                           field.path != NULL ? field.path : "<invalid>",
+                           actor_schema != NULL ? json_string(actor_schema, "entity", "<null>") : "<null>");
                 return false;
             }
             ++apply_index;
         }
     }
 
+    SDL_free(resolved_actors);
     SDL_free(values);
     if (out_tick != NULL)
         *out_tick = tick;

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 
 #define SDL3D_GAME_DATA_SIGNAL_BASE 20000
+#define SDL3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC 0x53335253u /* "S3RS" */
+#define SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION 1u
 
 typedef enum game_data_sensor_type
 {
@@ -1759,6 +1761,326 @@ static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 positio
         return;
     actor->position = position;
     sdl3d_properties_set_vec3(actor->props, "origin", position);
+}
+
+typedef struct game_data_replication_field
+{
+    const char *path;
+    sdl3d_replication_field_type type;
+} game_data_replication_field;
+
+typedef struct game_data_snapshot_value
+{
+    sdl3d_replication_field_type type;
+    union {
+        bool as_bool;
+        Sint32 as_int32;
+        float as_float32;
+        sdl3d_vec2 as_vec2;
+        sdl3d_vec3 as_vec3;
+    } value;
+} game_data_snapshot_value;
+
+static bool game_data_replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type)
+{
+    if (type == NULL || type[0] == '\0')
+        return false;
+    if (SDL_strcmp(type, "bool") == 0 || SDL_strcmp(type, "boolean") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
+        return true;
+    }
+    if (SDL_strcmp(type, "int32") == 0 || SDL_strcmp(type, "int") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_INT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "enum_id") == 0 || SDL_strcmp(type, "string_id") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_ENUM_ID;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec2") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC2;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec3") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
+        return true;
+    }
+    return false;
+}
+
+static bool game_data_replication_field_descriptor(yyjson_val *field, game_data_replication_field *out_field)
+{
+    if (out_field != NULL)
+    {
+        out_field->path = NULL;
+        out_field->type = SDL3D_REPLICATION_FIELD_BOOL;
+    }
+    if (yyjson_is_str(field))
+    {
+        const char *path = yyjson_get_str(field);
+        if (path == NULL ||
+            (SDL_strcmp(path, "position") != 0 && SDL_strcmp(path, "rotation") != 0 && SDL_strcmp(path, "scale") != 0))
+        {
+            return false;
+        }
+        if (out_field != NULL)
+        {
+            out_field->path = path;
+            out_field->type = SDL3D_REPLICATION_FIELD_VEC3;
+        }
+        return true;
+    }
+    if (!yyjson_is_obj(field))
+        return false;
+
+    const char *path = json_string(field, "path", NULL);
+    if (path == NULL)
+        path = json_string(field, "field", NULL);
+    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+    if (path == NULL || path[0] == '\0' ||
+        !game_data_replication_field_type_from_string(json_string(field, "type", NULL), &type))
+    {
+        return false;
+    }
+    if (out_field != NULL)
+    {
+        out_field->path = path;
+        out_field->type = type;
+    }
+    return true;
+}
+
+static yyjson_val *game_data_find_replication_channel_by_name(const sdl3d_game_data_runtime *runtime,
+                                                              const char *replication_name, int *out_index)
+{
+    yyjson_val *replication = obj_get(obj_get(runtime_root(runtime), "network"), "replication");
+    for (size_t i = 0; yyjson_is_arr(replication) && i < yyjson_arr_size(replication); ++i)
+    {
+        yyjson_val *channel = yyjson_arr_get(replication, i);
+        if (SDL_strcmp(json_string(channel, "name", ""), replication_name != NULL ? replication_name : "") == 0)
+        {
+            if (out_index != NULL)
+                *out_index = (int)i;
+            return channel;
+        }
+    }
+    return NULL;
+}
+
+static yyjson_val *game_data_find_replication_channel_by_index(const sdl3d_game_data_runtime *runtime, Uint32 index)
+{
+    yyjson_val *replication = obj_get(obj_get(runtime_root(runtime), "network"), "replication");
+    return yyjson_is_arr(replication) && index < yyjson_arr_size(replication) ? yyjson_arr_get(replication, index)
+                                                                              : NULL;
+}
+
+static bool game_data_replication_channel_is_host_to_client(yyjson_val *channel)
+{
+    return SDL_strcmp(json_string(channel, "direction", ""), "host_to_client") == 0;
+}
+
+static size_t game_data_replication_channel_field_count(yyjson_val *channel)
+{
+    size_t count = 0U;
+    yyjson_val *actors = obj_get(channel, "actors");
+    for (size_t i = 0; yyjson_is_arr(actors) && i < yyjson_arr_size(actors); ++i)
+    {
+        yyjson_val *fields = obj_get(yyjson_arr_get(actors, i), "fields");
+        if (yyjson_is_arr(fields))
+            count += yyjson_arr_size(fields);
+    }
+    return count;
+}
+
+static const char *game_data_replication_property_key(const char *path)
+{
+    static const char prefix[] = "properties.";
+    const size_t prefix_len = sizeof(prefix) - 1U;
+    return path != NULL && SDL_strncmp(path, prefix, prefix_len) == 0 ? path + prefix_len : NULL;
+}
+
+static bool game_data_read_actor_replication_field(const sdl3d_registered_actor *actor,
+                                                   const game_data_replication_field *field,
+                                                   game_data_snapshot_value *out_value)
+{
+    if (actor == NULL || field == NULL || out_value == NULL || field->path == NULL)
+        return false;
+
+    out_value->type = field->type;
+    if (SDL_strcmp(field->path, "position") == 0)
+    {
+        if (field->type != SDL3D_REPLICATION_FIELD_VEC3)
+            return false;
+        out_value->value.as_vec3 = actor->position;
+        return true;
+    }
+    if (SDL_strcmp(field->path, "rotation") == 0 || SDL_strcmp(field->path, "scale") == 0)
+    {
+        if (field->type != SDL3D_REPLICATION_FIELD_VEC3)
+            return false;
+        out_value->value.as_vec3 =
+            sdl3d_properties_get_vec3(actor->props, field->path, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        return true;
+    }
+
+    const char *key = game_data_replication_property_key(field->path);
+    const sdl3d_value *property = key != NULL ? sdl3d_properties_get_value(actor->props, key) : NULL;
+    if (property == NULL)
+        return false;
+
+    switch (field->type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        if (property->type != SDL3D_VALUE_BOOL)
+            return false;
+        out_value->value.as_bool = property->as_bool;
+        return true;
+    case SDL3D_REPLICATION_FIELD_INT32:
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        if (property->type != SDL3D_VALUE_INT)
+            return false;
+        out_value->value.as_int32 = (Sint32)property->as_int;
+        return true;
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        if (property->type != SDL3D_VALUE_FLOAT)
+            return false;
+        out_value->value.as_float32 = property->as_float;
+        return true;
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        if (property->type != SDL3D_VALUE_VEC3)
+            return false;
+        out_value->value.as_vec2 = (sdl3d_vec2){property->as_vec3.x, property->as_vec3.y};
+        return true;
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        if (property->type != SDL3D_VALUE_VEC3)
+            return false;
+        out_value->value.as_vec3 = property->as_vec3;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool game_data_write_snapshot_value(sdl3d_replication_writer *writer, const game_data_snapshot_value *value)
+{
+    if (writer == NULL || value == NULL || !sdl3d_replication_write_field_type(writer, value->type))
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return sdl3d_replication_write_bool(writer, value->value.as_bool);
+    case SDL3D_REPLICATION_FIELD_INT32:
+        return sdl3d_replication_write_int32(writer, value->value.as_int32);
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        return sdl3d_replication_write_float32(writer, value->value.as_float32);
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return sdl3d_replication_write_enum_id(writer, value->value.as_int32);
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return sdl3d_replication_write_vec2(writer, value->value.as_vec2);
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return sdl3d_replication_write_vec3(writer, value->value.as_vec3);
+    default:
+        return false;
+    }
+}
+
+static bool game_data_read_snapshot_value(sdl3d_replication_reader *reader, sdl3d_replication_field_type expected_type,
+                                          game_data_snapshot_value *out_value)
+{
+    if (reader == NULL || out_value == NULL)
+        return false;
+
+    sdl3d_replication_field_type packet_type = SDL3D_REPLICATION_FIELD_BOOL;
+    if (!sdl3d_replication_read_field_type(reader, &packet_type) || packet_type != expected_type)
+        return false;
+
+    out_value->type = expected_type;
+    switch (expected_type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return sdl3d_replication_read_bool(reader, &out_value->value.as_bool);
+    case SDL3D_REPLICATION_FIELD_INT32:
+        return sdl3d_replication_read_int32(reader, &out_value->value.as_int32);
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        return sdl3d_replication_read_float32(reader, &out_value->value.as_float32);
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return sdl3d_replication_read_enum_id(reader, &out_value->value.as_int32);
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return sdl3d_replication_read_vec2(reader, &out_value->value.as_vec2);
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return sdl3d_replication_read_vec3(reader, &out_value->value.as_vec3);
+    default:
+        return false;
+    }
+}
+
+static bool game_data_apply_actor_replication_field(sdl3d_registered_actor *actor,
+                                                    const game_data_replication_field *field,
+                                                    const game_data_snapshot_value *value)
+{
+    if (actor == NULL || field == NULL || value == NULL || field->path == NULL || field->type != value->type)
+        return false;
+
+    if (SDL_strcmp(field->path, "position") == 0)
+    {
+        if (value->type != SDL3D_REPLICATION_FIELD_VEC3)
+            return false;
+        actor_set_position(actor, value->value.as_vec3);
+        return true;
+    }
+    if (SDL_strcmp(field->path, "rotation") == 0 || SDL_strcmp(field->path, "scale") == 0)
+    {
+        if (value->type != SDL3D_REPLICATION_FIELD_VEC3)
+            return false;
+        sdl3d_properties_set_vec3(actor->props, field->path, value->value.as_vec3);
+        return true;
+    }
+
+    const char *key = game_data_replication_property_key(field->path);
+    if (key == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        sdl3d_properties_set_bool(actor->props, key, value->value.as_bool);
+        return true;
+    case SDL3D_REPLICATION_FIELD_INT32:
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        sdl3d_properties_set_int(actor->props, key, value->value.as_int32);
+        return true;
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        sdl3d_properties_set_float(actor->props, key, value->value.as_float32);
+        return true;
+    case SDL3D_REPLICATION_FIELD_VEC2: {
+        const sdl3d_vec3 current = sdl3d_properties_get_vec3(actor->props, key, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        sdl3d_properties_set_vec3(actor->props, key,
+                                  sdl3d_vec3_make(value->value.as_vec2.x, value->value.as_vec2.y, current.z));
+        return true;
+    }
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        sdl3d_properties_set_vec3(actor->props, key, value->value.as_vec3);
+        return true;
+    default:
+        return false;
+    }
 }
 
 static void copy_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value)
@@ -8899,6 +9221,224 @@ bool sdl3d_game_data_get_network_schema_hash(const sdl3d_game_data_runtime *runt
         return false;
 
     SDL_memcpy(out_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE);
+    return true;
+}
+
+bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                             Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                             char *error_buffer, int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0U;
+    if (runtime == NULL || replication_name == NULL || replication_name[0] == '\0' || buffer == NULL ||
+        buffer_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot encode requires runtime, channel, and buffer");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot encode requires an authored network schema");
+        return false;
+    }
+
+    int channel_index = -1;
+    yyjson_val *channel = game_data_find_replication_channel_by_name(runtime, replication_name, &channel_index);
+    if (channel == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot replication channel not found");
+        return false;
+    }
+    if (!game_data_replication_channel_is_host_to_client(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot channel must be host_to_client");
+        return false;
+    }
+
+    const size_t field_count = game_data_replication_channel_field_count(channel);
+    if (field_count > SDL_MAX_UINT32 || channel_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot channel is too large");
+        return false;
+    }
+
+    sdl3d_replication_writer writer;
+    sdl3d_replication_writer_init(&writer, buffer, buffer_size);
+    if (!sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC) ||
+        !sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION) ||
+        !sdl3d_replication_write_uint32(&writer, tick) ||
+        !sdl3d_replication_write_uint32(&writer, (Uint32)channel_index) ||
+        !sdl3d_replication_write_bytes(&writer, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) ||
+        !sdl3d_replication_write_uint32(&writer, (Uint32)field_count))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot buffer is too small for header");
+        return false;
+    }
+
+    yyjson_val *actors = obj_get(channel, "actors");
+    for (size_t actor_index = 0U; yyjson_is_arr(actors) && actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
+        const char *entity_name = json_string(actor_schema, "entity", NULL);
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        if (actor == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "network snapshot actor not found");
+            return false;
+        }
+
+        yyjson_val *fields = obj_get(actor_schema, "fields");
+        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+        {
+            game_data_replication_field field;
+            game_data_snapshot_value value;
+            if (!game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) ||
+                !game_data_read_actor_replication_field(actor, &field, &value))
+            {
+                set_error(error_buffer, error_buffer_size, "network snapshot failed to read authored field");
+                return false;
+            }
+            if (!game_data_write_snapshot_value(&writer, &value))
+            {
+                set_error(error_buffer, error_buffer_size, "network snapshot buffer is too small for field data");
+                return false;
+            }
+        }
+    }
+
+    if (out_size != NULL)
+        *out_size = sdl3d_replication_writer_offset(&writer);
+    return true;
+}
+
+bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, const void *packet, size_t packet_size,
+                                            Uint32 *out_tick, char *error_buffer, int error_buffer_size)
+{
+    if (out_tick != NULL)
+        *out_tick = 0U;
+    if (runtime == NULL || packet == NULL || packet_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot apply requires runtime and packet");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot apply requires an authored network schema");
+        return false;
+    }
+
+    sdl3d_replication_reader reader;
+    sdl3d_replication_reader_init(&reader, packet, packet_size);
+
+    Uint32 magic = 0U;
+    Uint32 version = 0U;
+    Uint32 tick = 0U;
+    Uint32 channel_index = 0U;
+    Uint8 schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
+    Uint32 packet_field_count = 0U;
+    if (!sdl3d_replication_read_uint32(&reader, &magic) || !sdl3d_replication_read_uint32(&reader, &version) ||
+        !sdl3d_replication_read_uint32(&reader, &tick) || !sdl3d_replication_read_uint32(&reader, &channel_index) ||
+        !sdl3d_replication_read_bytes(&reader, schema_hash, sizeof(schema_hash)) ||
+        !sdl3d_replication_read_uint32(&reader, &packet_field_count))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot packet is too small for header");
+        return false;
+    }
+    if (magic != SDL3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC || version != SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot packet has unsupported header");
+        return false;
+    }
+    if (SDL_memcmp(schema_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot schema hash does not match runtime");
+        return false;
+    }
+
+    yyjson_val *channel = game_data_find_replication_channel_by_index(runtime, channel_index);
+    if (channel == NULL || !game_data_replication_channel_is_host_to_client(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot channel is invalid for this runtime");
+        return false;
+    }
+
+    const size_t field_count = game_data_replication_channel_field_count(channel);
+    if ((Uint32)field_count != packet_field_count)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot field count does not match schema");
+        return false;
+    }
+
+    game_data_snapshot_value *values =
+        field_count > 0U ? (game_data_snapshot_value *)SDL_calloc(field_count, sizeof(*values)) : NULL;
+    if (values == NULL && field_count > 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot failed to allocate decoded field storage");
+        return false;
+    }
+
+    size_t decoded_index = 0U;
+    bool ok = true;
+    yyjson_val *actors = obj_get(channel, "actors");
+    for (size_t actor_index = 0U; ok && yyjson_is_arr(actors) && actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *fields = obj_get(yyjson_arr_get(actors, actor_index), "fields");
+        for (size_t field_index = 0U; ok && yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields);
+             ++field_index)
+        {
+            game_data_replication_field field;
+            ok = game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) &&
+                 decoded_index < field_count &&
+                 game_data_read_snapshot_value(&reader, field.type, &values[decoded_index]);
+            ++decoded_index;
+        }
+    }
+    if (ok && decoded_index != field_count)
+        ok = false;
+    if (ok && sdl3d_replication_reader_remaining(&reader) != 0U)
+        ok = false;
+    if (!ok)
+    {
+        SDL_free(values);
+        set_error(error_buffer, error_buffer_size, "network snapshot field data does not match schema");
+        return false;
+    }
+
+    for (size_t actor_index = 0U; actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
+        if (sdl3d_game_data_find_actor(runtime, json_string(actor_schema, "entity", NULL)) == NULL)
+        {
+            SDL_free(values);
+            set_error(error_buffer, error_buffer_size, "network snapshot actor not found");
+            return false;
+        }
+    }
+
+    size_t apply_index = 0U;
+    for (size_t actor_index = 0U; actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(actor_schema, "entity", NULL));
+        yyjson_val *fields = obj_get(actor_schema, "fields");
+        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+        {
+            game_data_replication_field field;
+            if (actor == NULL || !game_data_replication_field_descriptor(yyjson_arr_get(fields, field_index), &field) ||
+                apply_index >= field_count ||
+                !game_data_apply_actor_replication_field(actor, &field, &values[apply_index]))
+            {
+                SDL_free(values);
+                set_error(error_buffer, error_buffer_size, "network snapshot failed to apply authored field");
+                return false;
+            }
+            ++apply_index;
+        }
+    }
+
+    SDL_free(values);
+    if (out_tick != NULL)
+        *out_tick = tick;
     return true;
 }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -11,6 +11,7 @@
 #include <SDL3/SDL_stdinc.h>
 
 #include "game_data_standard_options.h"
+#include "network_replication_schema.h"
 #include "sdl3d/input.h"
 #include "sdl3d_crypto.h"
 
@@ -397,82 +398,6 @@ static bool is_replication_direction(const char *direction, bool allow_bidirecti
             (allow_bidirectional && SDL_strcmp(direction, "bidirectional") == 0));
 }
 
-static bool replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type)
-{
-    if (type == NULL || type[0] == '\0')
-        return false;
-    if (SDL_strcmp(type, "bool") == 0 || SDL_strcmp(type, "boolean") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
-        return true;
-    }
-    if (SDL_strcmp(type, "int32") == 0 || SDL_strcmp(type, "int") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_INT32;
-        return true;
-    }
-    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
-        return true;
-    }
-    if (SDL_strcmp(type, "enum_id") == 0 || SDL_strcmp(type, "string_id") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_ENUM_ID;
-        return true;
-    }
-    if (SDL_strcmp(type, "vec2") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_VEC2;
-        return true;
-    }
-    if (SDL_strcmp(type, "vec3") == 0)
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
-        return true;
-    }
-    return false;
-}
-
-static const char *replication_field_type_name(sdl3d_replication_field_type type)
-{
-    switch (type)
-    {
-    case SDL3D_REPLICATION_FIELD_BOOL:
-        return "bool";
-    case SDL3D_REPLICATION_FIELD_INT32:
-        return "int32";
-    case SDL3D_REPLICATION_FIELD_FLOAT32:
-        return "float32";
-    case SDL3D_REPLICATION_FIELD_ENUM_ID:
-        return "enum_id";
-    case SDL3D_REPLICATION_FIELD_VEC2:
-        return "vec2";
-    case SDL3D_REPLICATION_FIELD_VEC3:
-        return "vec3";
-    default:
-        return "invalid";
-    }
-}
-
-static bool replication_builtin_field_type(const char *field, sdl3d_replication_field_type *out_type)
-{
-    if (field != NULL &&
-        (SDL_strcmp(field, "position") == 0 || SDL_strcmp(field, "rotation") == 0 || SDL_strcmp(field, "scale") == 0))
-    {
-        if (out_type != NULL)
-            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
-        return true;
-    }
-    return false;
-}
-
 static bool is_replication_property_path(const char *path)
 {
     if (path == NULL || path[0] == '\0' || path[0] == '.' || path[SDL_strlen(path) - 1u] == '.')
@@ -517,38 +442,6 @@ static void network_hash_update_int(sdl3d_crypto_hash32_state *state, const char
     network_hash_update(state, label, buffer);
 }
 
-static bool replication_field_descriptor(yyjson_val *field, const char **out_path,
-                                         sdl3d_replication_field_type *out_type)
-{
-    if (yyjson_is_str(field))
-    {
-        const char *path = yyjson_get_str(field);
-        sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_VEC3;
-        if (!replication_builtin_field_type(path, &type))
-            return false;
-        if (out_path != NULL)
-            *out_path = path;
-        if (out_type != NULL)
-            *out_type = type;
-        return true;
-    }
-
-    if (!yyjson_is_obj(field))
-        return false;
-
-    const char *path = json_string(field, "path");
-    if (path == NULL)
-        path = json_string(field, "field");
-    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
-    if (!replication_field_type_from_string(json_string(field, "type"), &type))
-        return false;
-    if (out_path != NULL)
-        *out_path = path;
-    if (out_type != NULL)
-        *out_type = type;
-    return path != NULL && path[0] != '\0';
-}
-
 static bool validate_network_actor_fields(validation_context *ctx, yyjson_val *fields, const char *json_path)
 {
     if (!yyjson_is_arr(fields) || yyjson_arr_size(fields) == 0)
@@ -562,25 +455,24 @@ static bool validate_network_actor_fields(validation_context *ctx, yyjson_val *f
         char path[PATH_BUFFER_SIZE];
         format_path(path, sizeof(path), "%s[%zu]", json_path, i);
         yyjson_val *field = yyjson_arr_get(fields, i);
-        const char *field_path = NULL;
-        sdl3d_replication_field_type field_type = SDL3D_REPLICATION_FIELD_BOOL;
-        if (!replication_field_descriptor(field, &field_path, &field_type))
+        sdl3d_replication_field_descriptor descriptor;
+        if (!sdl3d_replication_field_descriptor_from_json(field, &descriptor))
         {
             ok = validation_error(ctx, path,
                                   "network actor field must be a built-in field string or object with path and type");
             break;
         }
-        if (!is_replication_property_path(field_path))
+        if (!is_replication_property_path(descriptor.path))
         {
-            ok = validation_error(ctx, path, "network actor field path '%s' is invalid", field_path);
+            ok = validation_error(ctx, path, "network actor field path '%s' is invalid", descriptor.path);
             break;
         }
-        if (sdl3d_replication_field_wire_size(field_type) == 0U)
+        if (sdl3d_replication_field_wire_size(descriptor.type) == 0U)
         {
             ok = validation_error(ctx, path, "unsupported network actor field type");
             break;
         }
-        if (!require_unique_name(ctx, &field_names, "network actor field", field_path, path))
+        if (!require_unique_name(ctx, &field_names, "network actor field", descriptor.path, path))
         {
             ok = false;
             break;
@@ -798,12 +690,11 @@ static void hash_network_actor_fields(sdl3d_crypto_hash32_state *state, yyjson_v
     network_hash_update_int(state, "field_count", (Sint64)yyjson_arr_size(fields));
     for (size_t i = 0; yyjson_is_arr(fields) && i < yyjson_arr_size(fields); ++i)
     {
-        const char *field_path = NULL;
-        sdl3d_replication_field_type field_type = SDL3D_REPLICATION_FIELD_BOOL;
-        if (replication_field_descriptor(yyjson_arr_get(fields, i), &field_path, &field_type))
+        sdl3d_replication_field_descriptor descriptor;
+        if (sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, i), &descriptor))
         {
-            network_hash_update(state, "field.path", field_path);
-            network_hash_update(state, "field.type", replication_field_type_name(field_type));
+            network_hash_update(state, "field.path", descriptor.path);
+            network_hash_update(state, "field.type", sdl3d_replication_field_type_name(descriptor.type));
         }
     }
 }

--- a/src/network_replication.c
+++ b/src/network_replication.c
@@ -137,6 +137,22 @@ bool sdl3d_replication_write_field_type(sdl3d_replication_writer *writer, sdl3d_
     return sdl3d_replication_write_u8(writer, (Uint8)type);
 }
 
+bool sdl3d_replication_write_bytes(sdl3d_replication_writer *writer, const void *bytes, size_t byte_count)
+{
+    if (byte_count == 0U)
+    {
+        return writer != NULL;
+    }
+    if (bytes == NULL || !sdl3d_replication_can_write(writer, byte_count))
+    {
+        return false;
+    }
+
+    memcpy(&writer->buffer[writer->offset], bytes, byte_count);
+    writer->offset += byte_count;
+    return true;
+}
+
 bool sdl3d_replication_write_bool(sdl3d_replication_writer *writer, bool value)
 {
     return sdl3d_replication_write_u8(writer, value ? 1U : 0U);
@@ -147,6 +163,11 @@ bool sdl3d_replication_write_int32(sdl3d_replication_writer *writer, Sint32 valu
     Uint32 bits = 0U;
     memcpy(&bits, &value, sizeof(bits));
     return sdl3d_replication_write_u32(writer, bits);
+}
+
+bool sdl3d_replication_write_uint32(sdl3d_replication_writer *writer, Uint32 value)
+{
+    return sdl3d_replication_write_u32(writer, value);
 }
 
 bool sdl3d_replication_write_float32(sdl3d_replication_writer *writer, float value)
@@ -243,6 +264,22 @@ bool sdl3d_replication_read_field_type(sdl3d_replication_reader *reader, sdl3d_r
     return true;
 }
 
+bool sdl3d_replication_read_bytes(sdl3d_replication_reader *reader, void *out_bytes, size_t byte_count)
+{
+    if (byte_count == 0U)
+    {
+        return reader != NULL;
+    }
+    if (out_bytes == NULL || !sdl3d_replication_can_read(reader, byte_count))
+    {
+        return false;
+    }
+
+    memcpy(out_bytes, &reader->buffer[reader->offset], byte_count);
+    reader->offset += byte_count;
+    return true;
+}
+
 bool sdl3d_replication_read_bool(sdl3d_replication_reader *reader, bool *out_value)
 {
     if (out_value == NULL || !sdl3d_replication_can_read(reader, 1U))
@@ -281,6 +318,11 @@ bool sdl3d_replication_read_int32(sdl3d_replication_reader *reader, Sint32 *out_
 
     memcpy(out_value, &value, sizeof(value));
     return true;
+}
+
+bool sdl3d_replication_read_uint32(sdl3d_replication_reader *reader, Uint32 *out_value)
+{
+    return sdl3d_replication_read_u32(reader, out_value);
 }
 
 bool sdl3d_replication_read_float32(sdl3d_replication_reader *reader, float *out_value)

--- a/src/network_replication_schema.c
+++ b/src/network_replication_schema.c
@@ -1,0 +1,133 @@
+#include "network_replication_schema.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+bool sdl3d_replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type)
+{
+    if (type == NULL || type[0] == '\0')
+        return false;
+    if (SDL_strcmp(type, "bool") == 0 || SDL_strcmp(type, "boolean") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
+        return true;
+    }
+    if (SDL_strcmp(type, "int32") == 0 || SDL_strcmp(type, "int") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_INT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "float32") == 0 || SDL_strcmp(type, "float") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_FLOAT32;
+        return true;
+    }
+    if (SDL_strcmp(type, "enum_id") == 0 || SDL_strcmp(type, "string_id") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_ENUM_ID;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec2") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC2;
+        return true;
+    }
+    if (SDL_strcmp(type, "vec3") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
+        return true;
+    }
+    return false;
+}
+
+const char *sdl3d_replication_field_type_name(sdl3d_replication_field_type type)
+{
+    switch (type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return "bool";
+    case SDL3D_REPLICATION_FIELD_INT32:
+        return "int32";
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        return "float32";
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return "enum_id";
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return "vec2";
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return "vec3";
+    default:
+        return "invalid";
+    }
+}
+
+bool sdl3d_replication_builtin_field_type(const char *field, sdl3d_replication_field_type *out_type)
+{
+    if (field != NULL &&
+        (SDL_strcmp(field, "position") == 0 || SDL_strcmp(field, "rotation") == 0 || SDL_strcmp(field, "scale") == 0))
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_VEC3;
+        return true;
+    }
+    return false;
+}
+
+static yyjson_val *schema_obj_get(yyjson_val *object, const char *key)
+{
+    return yyjson_is_obj(object) ? yyjson_obj_get(object, key) : NULL;
+}
+
+static const char *schema_json_string(yyjson_val *object, const char *key)
+{
+    yyjson_val *value = schema_obj_get(object, key);
+    return yyjson_is_str(value) ? yyjson_get_str(value) : NULL;
+}
+
+bool sdl3d_replication_field_descriptor_from_json(yyjson_val *field, sdl3d_replication_field_descriptor *out_descriptor)
+{
+    if (out_descriptor != NULL)
+    {
+        out_descriptor->path = NULL;
+        out_descriptor->type = SDL3D_REPLICATION_FIELD_BOOL;
+    }
+
+    if (yyjson_is_str(field))
+    {
+        const char *path = yyjson_get_str(field);
+        sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_VEC3;
+        if (!sdl3d_replication_builtin_field_type(path, &type))
+            return false;
+        if (out_descriptor != NULL)
+        {
+            out_descriptor->path = path;
+            out_descriptor->type = type;
+        }
+        return true;
+    }
+
+    if (!yyjson_is_obj(field))
+        return false;
+
+    const char *path = schema_json_string(field, "path");
+    if (path == NULL)
+        path = schema_json_string(field, "field");
+    sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+    if (path == NULL || path[0] == '\0' ||
+        !sdl3d_replication_field_type_from_string(schema_json_string(field, "type"), &type))
+    {
+        return false;
+    }
+
+    if (out_descriptor != NULL)
+    {
+        out_descriptor->path = path;
+        out_descriptor->type = type;
+    }
+    return true;
+}

--- a/src/network_replication_schema.h
+++ b/src/network_replication_schema.h
@@ -1,0 +1,21 @@
+#ifndef SDL3D_NETWORK_REPLICATION_SCHEMA_H
+#define SDL3D_NETWORK_REPLICATION_SCHEMA_H
+
+#include <stdbool.h>
+
+#include "sdl3d/network_replication.h"
+#include "yyjson.h"
+
+typedef struct sdl3d_replication_field_descriptor
+{
+    const char *path;
+    sdl3d_replication_field_type type;
+} sdl3d_replication_field_descriptor;
+
+bool sdl3d_replication_field_type_from_string(const char *type, sdl3d_replication_field_type *out_type);
+const char *sdl3d_replication_field_type_name(sdl3d_replication_field_type type);
+bool sdl3d_replication_builtin_field_type(const char *field, sdl3d_replication_field_type *out_type);
+bool sdl3d_replication_field_descriptor_from_json(yyjson_val *field,
+                                                  sdl3d_replication_field_descriptor *out_descriptor);
+
+#endif

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -319,6 +319,33 @@ std::array<Uint8, SDL3D_REPLICATION_SCHEMA_HASH_SIZE> load_network_schema_hash(c
     return hash;
 }
 
+void load_pong_runtime(sdl3d_game_session **out_session, sdl3d_game_data_runtime **out_runtime)
+{
+    ASSERT_NE(out_session, nullptr);
+    ASSERT_NE(out_runtime, nullptr);
+    *out_session = nullptr;
+    *out_runtime = nullptr;
+
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, out_session));
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, *out_session, out_runtime, error, sizeof(error)))
+        << error;
+    ASSERT_NE(*out_runtime, nullptr);
+}
+
+void destroy_runtime_session(sdl3d_game_session *session, sdl3d_game_data_runtime *runtime)
+{
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+void expect_vec3_near(sdl3d_vec3 actual, sdl3d_vec3 expected, float tolerance = 0.0001f)
+{
+    EXPECT_NEAR(actual.x, expected.x, tolerance);
+    EXPECT_NEAR(actual.y, expected.y, tolerance);
+    EXPECT_NEAR(actual.z, expected.z, tolerance);
+}
+
 std::filesystem::path copy_pong_data_with_storage_overrides(const std::filesystem::path &dir,
                                                             const std::filesystem::path &user_root,
                                                             const std::filesystem::path &cache_root)
@@ -4361,6 +4388,123 @@ TEST(GameDataRuntime, LocalOnlyGameHasNoNetworkSchemaHash)
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
     remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema)
+{
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_data_runtime *host = nullptr;
+    load_pong_runtime(&host_session, &host);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(host));
+
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *client = nullptr;
+    load_pong_runtime(&client_session, &client);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(client));
+
+    sdl3d_registered_actor *host_player = sdl3d_game_data_find_actor(host, "entity.paddle.player");
+    sdl3d_registered_actor *host_cpu = sdl3d_game_data_find_actor(host, "entity.paddle.cpu");
+    sdl3d_registered_actor *host_ball = sdl3d_game_data_find_actor(host, "entity.ball");
+    sdl3d_registered_actor *host_player_score = sdl3d_game_data_find_actor(host, "entity.score.player");
+    sdl3d_registered_actor *host_cpu_score = sdl3d_game_data_find_actor(host, "entity.score.cpu");
+    sdl3d_registered_actor *host_match = sdl3d_game_data_find_actor(host, "entity.match");
+    sdl3d_registered_actor *host_presentation = sdl3d_game_data_find_actor(host, "entity.presentation");
+    ASSERT_NE(host_player, nullptr);
+    ASSERT_NE(host_cpu, nullptr);
+    ASSERT_NE(host_ball, nullptr);
+    ASSERT_NE(host_player_score, nullptr);
+    ASSERT_NE(host_cpu_score, nullptr);
+    ASSERT_NE(host_match, nullptr);
+    ASSERT_NE(host_presentation, nullptr);
+
+    host_player->position = {-7.5f, 1.25f, 0.0f};
+    host_cpu->position = {7.5f, -2.0f, 0.0f};
+    host_ball->position = {1.5f, 2.5f, 0.12f};
+    sdl3d_properties_set_vec3(host_ball->props, "velocity", {3.25f, -1.75f, 9.0f});
+    sdl3d_properties_set_bool(host_ball->props, "active_motion", true);
+    sdl3d_properties_set_bool(host_ball->props, "has_last_reflect_y", true);
+    sdl3d_properties_set_float(host_ball->props, "last_reflect_y", 1.5f);
+    sdl3d_properties_set_int(host_ball->props, "stagnant_reflect_count", 2);
+    sdl3d_properties_set_int(host_player_score->props, "value", 4);
+    sdl3d_properties_set_int(host_cpu_score->props, "value", 6);
+    sdl3d_properties_set_bool(host_match->props, "finished", true);
+    sdl3d_properties_set_float(host_presentation->props, "border_flash", 0.75f);
+    sdl3d_properties_set_float(host_presentation->props, "paddle_flash", 0.5f);
+
+    sdl3d_registered_actor *client_ball = sdl3d_game_data_find_actor(client, "entity.ball");
+    ASSERT_NE(client_ball, nullptr);
+    sdl3d_properties_set_vec3(client_ball->props, "velocity", {0.0f, 0.0f, 42.0f});
+
+    std::array<Uint8, 512> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_snapshot(host, "play_state", 12345U, packet.data(), packet.size(),
+                                                        &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 0U);
+
+    Uint32 tick = 0U;
+    ASSERT_TRUE(sdl3d_game_data_apply_network_snapshot(client, packet.data(), packet_size, &tick, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(tick, 12345U);
+
+    expect_vec3_near(sdl3d_game_data_find_actor(client, "entity.paddle.player")->position, host_player->position);
+    expect_vec3_near(sdl3d_game_data_find_actor(client, "entity.paddle.cpu")->position, host_cpu->position);
+    expect_vec3_near(client_ball->position, host_ball->position);
+    const sdl3d_vec3 client_velocity =
+        sdl3d_properties_get_vec3(client_ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(client_velocity.x, 3.25f, 0.0001f);
+    EXPECT_NEAR(client_velocity.y, -1.75f, 0.0001f);
+    EXPECT_NEAR(client_velocity.z, 42.0f, 0.0001f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(client_ball->props, "active_motion", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(client_ball->props, "has_last_reflect_y", false));
+    EXPECT_NEAR(sdl3d_properties_get_float(client_ball->props, "last_reflect_y", 0.0f), 1.5f, 0.0001f);
+    EXPECT_EQ(sdl3d_properties_get_int(client_ball->props, "stagnant_reflect_count", 0), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_find_actor(client, "entity.score.player")->props, "value", 0),
+              4);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_find_actor(client, "entity.score.cpu")->props, "value", 0), 6);
+    EXPECT_TRUE(
+        sdl3d_properties_get_bool(sdl3d_game_data_find_actor(client, "entity.match")->props, "finished", false));
+    EXPECT_NEAR(sdl3d_properties_get_float(sdl3d_game_data_find_actor(client, "entity.presentation")->props,
+                                           "border_flash", 0.0f),
+                0.75f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(sdl3d_game_data_find_actor(client, "entity.presentation")->props,
+                                           "paddle_flash", 0.0f),
+                0.5f, 0.0001f);
+
+    destroy_runtime_session(host_session, host);
+    destroy_runtime_session(client_session, client);
+}
+
+TEST(GameDataRuntime, RejectsPongNetworkSnapshotsWithMismatchedSchemaOrTruncation)
+{
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_data_runtime *host = nullptr;
+    load_pong_runtime(&host_session, &host);
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *client = nullptr;
+    load_pong_runtime(&client_session, &client);
+
+    std::array<Uint8, 512> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_snapshot(host, "play_state", 10U, packet.data(), packet.size(),
+                                                        &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 24U);
+
+    std::array<Uint8, 512> corrupted = packet;
+    corrupted[16] ^= 0xffU;
+    EXPECT_FALSE(
+        sdl3d_game_data_apply_network_snapshot(client, corrupted.data(), packet_size, nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("schema hash"), std::string::npos) << error;
+
+    EXPECT_FALSE(
+        sdl3d_game_data_apply_network_snapshot(client, packet.data(), packet_size - 1U, nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("field data"), std::string::npos) << error;
+
+    destroy_runtime_session(host_session, host);
+    destroy_runtime_session(client_session, client);
 }
 
 TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4493,6 +4493,13 @@ TEST(GameDataRuntime, RejectsPongNetworkSnapshotsWithMismatchedSchemaOrTruncatio
         << error;
     ASSERT_GT(packet_size, 24U);
 
+    std::array<Uint8, 8> too_small{};
+    size_t too_small_size = 0U;
+    EXPECT_FALSE(sdl3d_game_data_encode_network_snapshot(host, "play_state", 10U, too_small.data(), too_small.size(),
+                                                         &too_small_size, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires"), std::string::npos) << error;
+    EXPECT_EQ(too_small_size, 0U);
+
     std::array<Uint8, 512> corrupted = packet;
     corrupted[16] ^= 0xffU;
     EXPECT_FALSE(

--- a/tests/test_network_replication.cpp
+++ b/tests/test_network_replication.cpp
@@ -73,6 +73,7 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
     ASSERT_TRUE(sdl3d_replication_write_bool(&writer, true));
     ASSERT_TRUE(sdl3d_replication_write_bool(&writer, false));
     ASSERT_TRUE(sdl3d_replication_write_int32(&writer, -42));
+    ASSERT_TRUE(sdl3d_replication_write_uint32(&writer, 0xfedcba98U));
     ASSERT_TRUE(sdl3d_replication_write_float32(&writer, 3.5f));
     ASSERT_TRUE(sdl3d_replication_write_enum_id(&writer, 17));
     ASSERT_TRUE(sdl3d_replication_write_vec2(&writer, expected_vec2));
@@ -85,6 +86,7 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
     bool bool_value = false;
     bool false_value = true;
     Sint32 int_value = 0;
+    Uint32 uint_value = 0U;
     float float_value = 0.0f;
     Sint32 enum_id_value = 0;
     sdl3d_vec2 vec2_value = {};
@@ -98,6 +100,8 @@ TEST(SDL3DNetworkReplication, RoundTripsSupportedFieldValues)
     EXPECT_FALSE(false_value);
     ASSERT_TRUE(sdl3d_replication_read_int32(&reader, &int_value));
     EXPECT_EQ(int_value, -42);
+    ASSERT_TRUE(sdl3d_replication_read_uint32(&reader, &uint_value));
+    EXPECT_EQ(uint_value, 0xfedcba98U);
     ASSERT_TRUE(sdl3d_replication_read_float32(&reader, &float_value));
     EXPECT_NEAR(float_value, 3.5f, kTolerance);
     ASSERT_TRUE(sdl3d_replication_read_enum_id(&reader, &enum_id_value));
@@ -181,16 +185,38 @@ TEST(SDL3DNetworkReplication, UsesDeterministicLittleEndianEncoding)
     sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
 
     ASSERT_TRUE(sdl3d_replication_write_int32(&writer, 0x01020304));
-    ASSERT_TRUE(sdl3d_replication_write_float32(&writer, 1.0f));
+    ASSERT_TRUE(sdl3d_replication_write_uint32(&writer, 0x0a0b0c0dU));
 
     EXPECT_EQ(buffer[0], 0x04);
     EXPECT_EQ(buffer[1], 0x03);
     EXPECT_EQ(buffer[2], 0x02);
     EXPECT_EQ(buffer[3], 0x01);
-    EXPECT_EQ(buffer[4], 0x00);
-    EXPECT_EQ(buffer[5], 0x00);
-    EXPECT_EQ(buffer[6], 0x80);
-    EXPECT_EQ(buffer[7], 0x3f);
+    EXPECT_EQ(buffer[4], 0x0d);
+    EXPECT_EQ(buffer[5], 0x0c);
+    EXPECT_EQ(buffer[6], 0x0b);
+    EXPECT_EQ(buffer[7], 0x0a);
+}
+
+TEST(SDL3DNetworkReplication, RoundTripsRawBytes)
+{
+    std::array<Uint8, 8> buffer{};
+    constexpr std::array<Uint8, 4> expected{{0xde, 0xad, 0xbe, 0xef}};
+
+    sdl3d_replication_writer writer{};
+    sdl3d_replication_writer_init(&writer, buffer.data(), buffer.size());
+    ASSERT_TRUE(sdl3d_replication_write_bytes(&writer, expected.data(), expected.size()));
+    ASSERT_TRUE(sdl3d_replication_write_uint32(&writer, 0x01020304U));
+
+    std::array<Uint8, 4> actual{};
+    Uint32 marker = 0U;
+    sdl3d_replication_reader reader{};
+    sdl3d_replication_reader_init(&reader, buffer.data(), sdl3d_replication_writer_offset(&writer));
+    ASSERT_TRUE(sdl3d_replication_read_bytes(&reader, actual.data(), actual.size()));
+    ASSERT_TRUE(sdl3d_replication_read_uint32(&reader, &marker));
+
+    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(marker, 0x01020304U);
+    EXPECT_EQ(sdl3d_replication_reader_remaining(&reader), 0U);
 }
 
 TEST(SDL3DNetworkReplication, RejectsTruncatedWritesWithoutAdvancing)
@@ -219,6 +245,7 @@ TEST(SDL3DNetworkReplication, RejectsZeroCapacityWrites)
     EXPECT_FALSE(sdl3d_replication_write_enum_id(&writer, 1));
     EXPECT_FALSE(sdl3d_replication_write_vec2(&writer, {1.0f, 2.0f}));
     EXPECT_FALSE(sdl3d_replication_write_vec3(&writer, {1.0f, 2.0f, 3.0f}));
+    EXPECT_FALSE(sdl3d_replication_write_bytes(&writer, "x", 1U));
     EXPECT_EQ(sdl3d_replication_writer_offset(&writer), 0U);
 }
 


### PR DESCRIPTION
## Summary

- Add generic host-to-client network snapshot encode/apply APIs driven by authored `network.replication` schemas.
- Extend the replication codec with raw byte and unsigned 32-bit helpers for packet headers and schema hashes.
- Share replication field parsing between validation and runtime so accepted field aliases and built-in fields cannot drift.
- Author Pong's `play_state` replication channel in JSON and cover it with headless snapshot round-trip tests.
- Pre-compute snapshot packet sizes, report clearer actor/field encode/apply errors, and document strict decode behavior plus vec2 property handling.

## Verification

- `clang-format -i src/game_data.c src/game_data_validation.c src/network_replication_schema.c src/network_replication_schema.h tests/test_game_data.cpp`
- `cmake --build build/debug --target sdl3d_network_replication_test sdl3d_game_data_test pong_demo -j 8`
- `./build/debug/tests/sdl3d_network_replication_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.*Network*'`
- `cmake --build build/debug -j 8`
- `ctest --test-dir build/debug --output-on-failure -j 8` passes 1041/1041; one OpenGL availability test is skipped by environment.

Closes part of #179.