### PR TITLE
Add data-driven network input replication

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -157,6 +157,15 @@
             ]
           }
         ]
+      },
+      {
+        "name": "client_input",
+        "direction": "client_to_host",
+        "rate": 60,
+        "inputs": [
+          { "action": "action.paddle.local.up" },
+          { "action": "action.paddle.local.down" }
+        ]
       }
     ],
     "control_messages": [

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -70,7 +70,6 @@ typedef enum pong_network_message_kind
 
 static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
 static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
-static const size_t PONG_NETWORK_INPUT_PACKET_SIZE = 20U;
 static const size_t PONG_NETWORK_CONTROL_PACKET_SIZE = 12U;
 static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 112U;
 
@@ -388,6 +387,7 @@ static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mo
 
 static void clear_network_action_overrides(pong_state *state)
 {
+    char error[128] = {0};
     if (state == NULL || state->input == NULL || state->data == NULL)
     {
         return;
@@ -405,13 +405,17 @@ static void clear_network_action_overrides(pong_state *state)
     {
         sdl3d_input_clear_action_override(state->input, p1_down);
     }
-    if (p2_up >= 0)
+    if (!sdl3d_game_data_clear_network_input_overrides(state->data, "client_input", state->input, error,
+                                                       (int)sizeof(error)))
     {
-        sdl3d_input_clear_action_override(state->input, p2_up);
-    }
-    if (p2_down >= 0)
-    {
-        sdl3d_input_clear_action_override(state->input, p2_down);
+        if (p2_up >= 0)
+        {
+            sdl3d_input_clear_action_override(state->input, p2_up);
+        }
+        if (p2_down >= 0)
+        {
+            sdl3d_input_clear_action_override(state->input, p2_down);
+        }
     }
 }
 
@@ -908,9 +912,9 @@ static bool start_selected_lobby_match(pong_state *state)
 
 static bool send_client_input_packet(pong_state *state)
 {
-    Uint8 packet[32];
-    Uint8 *cursor = packet;
-    Uint8 *end = packet + sizeof(packet);
+    Uint8 packet[128];
+    size_t packet_size = 0U;
+    char error[160] = {0};
     const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
     const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
 
@@ -923,34 +927,23 @@ static bool send_client_input_packet(pong_state *state)
     const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(state->input);
     const float up_value = snapshot != NULL ? snapshot->actions[p2_up].value : 0.0f;
     const float down_value = snapshot != NULL ? snapshot->actions[p2_down].value : 0.0f;
+    const Uint32 tick = snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U;
 
-    if (!pong_network_write_u32(&cursor, end, PONG_NETWORK_PACKET_MAGIC) ||
-        !pong_network_write_u8(&cursor, end, PONG_NETWORK_PACKET_VERSION) ||
-        !pong_network_write_u8(&cursor, end, (Uint8)PONG_NETWORK_MESSAGE_INPUT) ||
-        !pong_network_write_u8(&cursor, end, 0U) || !pong_network_write_u8(&cursor, end, 0U) ||
-        !pong_network_write_u32(&cursor, end, snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U) ||
-        !pong_network_write_f32(&cursor, end, up_value) || !pong_network_write_f32(&cursor, end, down_value))
+    if (!sdl3d_game_data_encode_network_input(state->data, "client_input", state->input, tick, packet, sizeof(packet),
+                                              &packet_size, error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet encode failed");
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet encode failed: %s", error);
         return false;
     }
 
-    if ((size_t)(cursor - packet) != PONG_NETWORK_INPUT_PACKET_SIZE)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet size mismatch: expected=%zu actual=%zu",
-                    PONG_NETWORK_INPUT_PACKET_SIZE, (size_t)(cursor - packet));
-        return false;
-    }
-
-    if (!sdl3d_network_session_send(state->direct_connect_session, packet, (int)(cursor - packet)))
+    if (!sdl3d_network_session_send(state->direct_connect_session, packet, (int)packet_size))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", SDL_GetError());
         return false;
     }
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client->host input tick=%u up=%.3f down=%.3f scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(),
-                snapshot != NULL ? (unsigned int)SDL_max(snapshot->tick, 0) : 0U, up_value, down_value,
+                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, up_value, down_value,
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
                     : "<none>");
@@ -1072,49 +1065,28 @@ static bool apply_play_state_snapshot(sdl3d_game_context *ctx, pong_state *state
 
 static bool process_host_input_packet(pong_state *state, const Uint8 *packet, int packet_size)
 {
-    const Uint8 *cursor = packet;
-    const Uint8 *end = packet + packet_size;
-    Uint32 magic = 0U;
-    Uint8 version = 0U;
-    Uint8 kind = 0U;
-    Uint8 reserved = 0U;
     Uint32 tick = 0U;
-    float up_value = 0.0f;
-    float down_value = 0.0f;
+    char error[160] = {0};
 
-    if (state == NULL || packet == NULL || packet_size < 12)
+    if (state == NULL || state->data == NULL || state->input == NULL || packet == NULL || packet_size <= 0)
     {
         return false;
     }
 
-    if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
-        !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
-        !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT ||
-        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
-        !pong_network_read_u32(&cursor, end, &tick) || !pong_network_read_f32(&cursor, end, &up_value) ||
-        !pong_network_read_f32(&cursor, end, &down_value))
+    if (!sdl3d_game_data_apply_network_input(state->data, state->input, packet, (size_t)packet_size, &tick, error,
+                                             (int)sizeof(error)))
     {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host input packet apply failed: %s", error);
         return false;
     }
 
-    if ((size_t)packet_size != PONG_NETWORK_INPUT_PACKET_SIZE)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host input packet size mismatch: expected=%zu actual=%d",
-                    PONG_NETWORK_INPUT_PACKET_SIZE, packet_size);
-        return false;
-    }
-
-    (void)tick;
-    set_network_action_override(state, "action.paddle.local.up", up_value);
-    set_network_action_override(state, "action.paddle.local.down", down_value);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host<-client input tick=%u up=%.3f down=%.3f scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, up_value, down_value,
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host<-client input tick=%u scene=%s",
+                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick,
                 state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
                     ? sdl3d_game_data_active_scene(state->data)
                     : "<none>");
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong host applied remote paddle input: p2_up=%.3f p2_down=%.3f",
-                (unsigned long long)pong_log_timestamp_ms(), up_value, down_value);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host queued remote paddle input overrides",
+                (unsigned long long)pong_log_timestamp_ms());
     return true;
 }
 
@@ -1843,8 +1815,7 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
                                                      PONG_NETWORK_MESSAGE_RESUME_REQUEST);
                 continue;
             }
-            if (is_multiplayer_play_scene(state) &&
-                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_INPUT))
+            if (is_multiplayer_play_scene(state))
             {
                 if (process_host_input_packet(state, packet, packet_size))
                 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1249,6 +1249,18 @@ trailing bytes. Built-in `position` fields update the actor transform; object
 paths under `properties.` update actor properties. `vec2` property replication
 is stored in SDL3D's existing vec3 property bag by updating x/y and preserving z.
 
+Client-to-host input channels can be encoded with
+`sdl3d_game_data_encode_network_input()` and applied with
+`sdl3d_game_data_apply_network_input()`. Input packets use the same strict
+schema-hash and channel-index checks as snapshots, then store each authored
+action value as a tagged `float32` in schema order. Applying a packet writes
+the decoded values into the destination `sdl3d_input_manager` as action
+overrides, so the next input update exposes the remote actions through the
+normal action snapshot APIs. Malformed packets are rejected before any override
+is changed. When a peer disconnects or a network scene exits, callers should
+use `sdl3d_game_data_clear_network_input_overrides()` for the same channel so
+remote input cannot leak into later local play.
+
 When a runtime loads game data with a valid `network` block, it computes a
 deterministic schema hash over protocol, replication, input, and control-message
 shape. Runtime callers can query it with

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -868,6 +868,69 @@ extern "C"
                                                 int error_buffer_size);
 
     /**
+     * @brief Encode an authored client-to-host input replication packet.
+     *
+     * The named replication channel must exist in the loaded `network`
+     * schema and have `direction: "client_to_host"`. Each authored input
+     * action is sampled from @p input as a float value and written in schema
+     * order with strict field type tags. Callers provide the destination
+     * buffer; no allocation is performed.
+     *
+     * @param runtime Runtime containing the authored network schema and actions.
+     * @param replication_name Authored replication channel name.
+     * @param input Input manager whose current snapshot should be serialized.
+     * @param tick Client simulation/input tick to include in the packet.
+     * @param buffer Destination packet buffer.
+     * @param buffer_size Destination buffer size in bytes.
+     * @param out_size Receives written packet size in bytes.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the full input packet was encoded.
+     */
+    bool sdl3d_game_data_encode_network_input(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                              const sdl3d_input_manager *input, Uint32 tick, void *buffer,
+                                              size_t buffer_size, size_t *out_size, char *error_buffer,
+                                              int error_buffer_size);
+
+    /**
+     * @brief Decode and apply an authored client-to-host input packet.
+     *
+     * The packet must match the runtime schema hash and reference a
+     * client-to-host input channel in the loaded `network` schema. Decoded
+     * action values are applied to @p input as action overrides. On failure,
+     * no overrides are changed.
+     *
+     * @param runtime Runtime containing the authored network schema and actions.
+     * @param input Input manager that should receive replicated action overrides.
+     * @param packet Source packet buffer.
+     * @param packet_size Source packet size in bytes.
+     * @param out_tick Receives the client input tick, if non-NULL.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the packet was decoded and all action overrides were applied.
+     */
+    bool sdl3d_game_data_apply_network_input(const sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                             const void *packet, size_t packet_size, Uint32 *out_tick,
+                                             char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Clear action overrides declared by an authored input replication channel.
+     *
+     * This is useful when a peer disconnects or a networked scene exits so
+     * remote action overrides cannot leak into local play.
+     *
+     * @param runtime Runtime containing the authored network schema and actions.
+     * @param replication_name Authored client-to-host replication channel name.
+     * @param input Input manager whose replicated overrides should be cleared.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when all authored input overrides were cleared.
+     */
+    bool sdl3d_game_data_clear_network_input_overrides(const sdl3d_game_data_runtime *runtime,
+                                                       const char *replication_name, sdl3d_input_manager *input,
+                                                       char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Validate a JSON game data file without instantiating runtime state.
      *
      * Validation checks schema, authored names, references, supported generic

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -32,6 +32,8 @@
 #define SDL3D_GAME_DATA_SIGNAL_BASE 20000
 #define SDL3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC 0x53335253u /* "S3RS" */
 #define SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION 1u
+#define SDL3D_GAME_DATA_NETWORK_INPUT_MAGIC 0x49335253u /* "S3RI" */
+#define SDL3D_GAME_DATA_NETWORK_INPUT_VERSION 1u
 
 typedef enum game_data_sensor_type
 {
@@ -1789,6 +1791,12 @@ typedef struct game_data_snapshot_value
     } value;
 } game_data_snapshot_value;
 
+typedef struct game_data_input_value
+{
+    int action_id;
+    float value;
+} game_data_input_value;
+
 static yyjson_val *game_data_find_replication_channel_by_name(const sdl3d_game_data_runtime *runtime,
                                                               const char *replication_name, int *out_index)
 {
@@ -1816,6 +1824,11 @@ static yyjson_val *game_data_find_replication_channel_by_index(const sdl3d_game_
 static bool game_data_replication_channel_is_host_to_client(yyjson_val *channel)
 {
     return SDL_strcmp(json_string(channel, "direction", ""), "host_to_client") == 0;
+}
+
+static bool game_data_replication_channel_is_client_to_host(yyjson_val *channel)
+{
+    return SDL_strcmp(json_string(channel, "direction", ""), "client_to_host") == 0;
 }
 
 static size_t game_data_replication_channel_field_count(yyjson_val *channel)
@@ -1858,6 +1871,41 @@ static bool game_data_replication_channel_packet_size(yyjson_val *channel, size_
     if (out_size != NULL)
         *out_size = size;
     return true;
+}
+
+static size_t game_data_replication_channel_input_count(yyjson_val *channel)
+{
+    yyjson_val *inputs = obj_get(channel, "inputs");
+    return yyjson_is_arr(inputs) ? yyjson_arr_size(inputs) : 0U;
+}
+
+static bool game_data_replication_input_packet_size(yyjson_val *channel, size_t *out_size)
+{
+    if (out_size != NULL)
+        *out_size = 0U;
+    if (channel == NULL)
+        return false;
+
+    const size_t input_count = game_data_replication_channel_input_count(channel);
+    const size_t input_value_size = 1U + sdl3d_replication_field_wire_size(SDL3D_REPLICATION_FIELD_FLOAT32);
+    size_t size = 4U + 4U + 4U + 4U + SDL3D_REPLICATION_SCHEMA_HASH_SIZE + 4U;
+    if (input_value_size == 1U || input_count > (SIZE_MAX - size) / input_value_size)
+        return false;
+    size += input_count * input_value_size;
+
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+static const char *game_data_replication_input_action(yyjson_val *input)
+{
+    return json_string(input, "action", NULL);
+}
+
+static int game_data_replication_action_id(const sdl3d_game_data_runtime *runtime, yyjson_val *input)
+{
+    return sdl3d_game_data_find_action(runtime, game_data_replication_input_action(input));
 }
 
 static const char *game_data_replication_property_key(const char *path)
@@ -9424,6 +9472,239 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
     SDL_free(values);
     if (out_tick != NULL)
         *out_tick = tick;
+    return true;
+}
+
+bool sdl3d_game_data_encode_network_input(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                          const sdl3d_input_manager *input, Uint32 tick, void *buffer,
+                                          size_t buffer_size, size_t *out_size, char *error_buffer,
+                                          int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0U;
+    if (runtime == NULL || replication_name == NULL || replication_name[0] == '\0' || input == NULL || buffer == NULL ||
+        buffer_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network input encode requires runtime, channel, input, and buffer");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network input encode requires an authored network schema");
+        return false;
+    }
+
+    int channel_index = -1;
+    yyjson_val *channel = game_data_find_replication_channel_by_name(runtime, replication_name, &channel_index);
+    if (channel == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network input replication channel not found");
+        return false;
+    }
+    if (!game_data_replication_channel_is_client_to_host(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network input channel must be client_to_host");
+        return false;
+    }
+
+    const size_t input_count = game_data_replication_channel_input_count(channel);
+    if (input_count > SDL_MAX_UINT32 || channel_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network input channel is too large");
+        return false;
+    }
+    size_t required_size = 0U;
+    if (!game_data_replication_input_packet_size(channel, &required_size))
+    {
+        set_error(error_buffer, error_buffer_size, "network input channel contains unsupported field data");
+        return false;
+    }
+    if (buffer_size < required_size)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network input requires %zu bytes, buffer has %zu bytes",
+                   required_size, buffer_size);
+        return false;
+    }
+
+    sdl3d_replication_writer writer;
+    sdl3d_replication_writer_init(&writer, buffer, buffer_size);
+    if (!sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_INPUT_MAGIC) ||
+        !sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_INPUT_VERSION) ||
+        !sdl3d_replication_write_uint32(&writer, tick) ||
+        !sdl3d_replication_write_uint32(&writer, (Uint32)channel_index) ||
+        !sdl3d_replication_write_bytes(&writer, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) ||
+        !sdl3d_replication_write_uint32(&writer, (Uint32)input_count))
+    {
+        set_error(error_buffer, error_buffer_size, "network input buffer is too small for header");
+        return false;
+    }
+
+    yyjson_val *inputs = obj_get(channel, "inputs");
+    for (size_t input_index = 0U; yyjson_is_arr(inputs) && input_index < yyjson_arr_size(inputs); ++input_index)
+    {
+        yyjson_val *input_schema = yyjson_arr_get(inputs, input_index);
+        const char *action_name = game_data_replication_input_action(input_schema);
+        const int action_id = game_data_replication_action_id(runtime, input_schema);
+        if (action_id < 0)
+        {
+            set_errorf(error_buffer, error_buffer_size, "network input action '%s' not found",
+                       action_name != NULL ? action_name : "<null>");
+            return false;
+        }
+
+        const float value = SDL_clamp(sdl3d_input_get_value(input, action_id), -1.0f, 1.0f);
+        if (!sdl3d_replication_write_field_type(&writer, SDL3D_REPLICATION_FIELD_FLOAT32) ||
+            !sdl3d_replication_write_float32(&writer, value))
+        {
+            set_error(error_buffer, error_buffer_size, "network input buffer is too small for action data");
+            return false;
+        }
+    }
+
+    if (out_size != NULL)
+        *out_size = sdl3d_replication_writer_offset(&writer);
+    return true;
+}
+
+bool sdl3d_game_data_apply_network_input(const sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                         const void *packet, size_t packet_size, Uint32 *out_tick, char *error_buffer,
+                                         int error_buffer_size)
+{
+    if (out_tick != NULL)
+        *out_tick = 0U;
+    if (runtime == NULL || input == NULL || packet == NULL || packet_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network input apply requires runtime, input, and packet");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network input apply requires an authored network schema");
+        return false;
+    }
+
+    sdl3d_replication_reader reader;
+    sdl3d_replication_reader_init(&reader, packet, packet_size);
+
+    Uint32 magic = 0U;
+    Uint32 version = 0U;
+    Uint32 tick = 0U;
+    Uint32 channel_index = 0U;
+    Uint8 schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
+    Uint32 packet_input_count = 0U;
+    if (!sdl3d_replication_read_uint32(&reader, &magic) || !sdl3d_replication_read_uint32(&reader, &version) ||
+        !sdl3d_replication_read_uint32(&reader, &tick) || !sdl3d_replication_read_uint32(&reader, &channel_index) ||
+        !sdl3d_replication_read_bytes(&reader, schema_hash, sizeof(schema_hash)) ||
+        !sdl3d_replication_read_uint32(&reader, &packet_input_count))
+    {
+        set_error(error_buffer, error_buffer_size, "network input packet is too small for header");
+        return false;
+    }
+    if (magic != SDL3D_GAME_DATA_NETWORK_INPUT_MAGIC || version != SDL3D_GAME_DATA_NETWORK_INPUT_VERSION)
+    {
+        set_error(error_buffer, error_buffer_size, "network input packet has unsupported header");
+        return false;
+    }
+    if (SDL_memcmp(schema_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network input schema hash does not match runtime");
+        return false;
+    }
+
+    yyjson_val *channel = game_data_find_replication_channel_by_index(runtime, channel_index);
+    if (channel == NULL || !game_data_replication_channel_is_client_to_host(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network input channel is invalid for this runtime");
+        return false;
+    }
+
+    const size_t input_count = game_data_replication_channel_input_count(channel);
+    if ((Uint32)input_count != packet_input_count)
+    {
+        set_error(error_buffer, error_buffer_size, "network input count does not match schema");
+        return false;
+    }
+
+    game_data_input_value *values =
+        input_count > 0U ? (game_data_input_value *)SDL_calloc(input_count, sizeof(*values)) : NULL;
+    if (values == NULL && input_count > 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network input failed to allocate decoded action storage");
+        return false;
+    }
+
+    bool ok = true;
+    yyjson_val *inputs = obj_get(channel, "inputs");
+    for (size_t input_index = 0U; ok && yyjson_is_arr(inputs) && input_index < yyjson_arr_size(inputs); ++input_index)
+    {
+        yyjson_val *input_schema = yyjson_arr_get(inputs, input_index);
+        sdl3d_replication_field_type type = SDL3D_REPLICATION_FIELD_BOOL;
+        values[input_index].action_id = game_data_replication_action_id(runtime, input_schema);
+        ok = values[input_index].action_id >= 0 && sdl3d_replication_read_field_type(&reader, &type) &&
+             type == SDL3D_REPLICATION_FIELD_FLOAT32 &&
+             sdl3d_replication_read_float32(&reader, &values[input_index].value);
+        values[input_index].value = SDL_clamp(values[input_index].value, -1.0f, 1.0f);
+    }
+    if (ok && sdl3d_replication_reader_remaining(&reader) != 0U)
+        ok = false;
+    if (!ok)
+    {
+        SDL_free(values);
+        set_error(error_buffer, error_buffer_size, "network input action data does not match schema");
+        return false;
+    }
+
+    for (size_t input_index = 0U; input_index < input_count; ++input_index)
+        sdl3d_input_set_action_override(input, values[input_index].action_id, values[input_index].value);
+
+    SDL_free(values);
+    if (out_tick != NULL)
+        *out_tick = tick;
+    return true;
+}
+
+bool sdl3d_game_data_clear_network_input_overrides(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                                   sdl3d_input_manager *input, char *error_buffer,
+                                                   int error_buffer_size)
+{
+    if (runtime == NULL || replication_name == NULL || replication_name[0] == '\0' || input == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network input override clear requires runtime, channel, and input");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network input override clear requires an authored network schema");
+        return false;
+    }
+
+    yyjson_val *channel = game_data_find_replication_channel_by_name(runtime, replication_name, NULL);
+    if (channel == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network input replication channel not found");
+        return false;
+    }
+    if (!game_data_replication_channel_is_client_to_host(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network input channel must be client_to_host");
+        return false;
+    }
+
+    yyjson_val *inputs = obj_get(channel, "inputs");
+    for (size_t input_index = 0U; yyjson_is_arr(inputs) && input_index < yyjson_arr_size(inputs); ++input_index)
+    {
+        yyjson_val *input_schema = yyjson_arr_get(inputs, input_index);
+        const char *action_name = game_data_replication_input_action(input_schema);
+        const int action_id = game_data_replication_action_id(runtime, input_schema);
+        if (action_id < 0)
+        {
+            set_errorf(error_buffer, error_buffer_size, "network input action '%s' not found",
+                       action_name != NULL ? action_name : "<null>");
+            return false;
+        }
+        sdl3d_input_clear_action_override(input, action_id);
+    }
+
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4514,6 +4514,108 @@ TEST(GameDataRuntime, RejectsPongNetworkSnapshotsWithMismatchedSchemaOrTruncatio
     destroy_runtime_session(client_session, client);
 }
 
+TEST(GameDataRuntime, EncodesAndAppliesPongNetworkInputFromAuthoredSchema)
+{
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *client = nullptr;
+    load_pong_runtime(&client_session, &client);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(client));
+
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_data_runtime *host = nullptr;
+    load_pong_runtime(&host_session, &host);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(host));
+
+    sdl3d_input_manager *client_input = sdl3d_game_session_get_input(client_session);
+    sdl3d_input_manager *host_input = sdl3d_game_session_get_input(host_session);
+    ASSERT_NE(client_input, nullptr);
+    ASSERT_NE(host_input, nullptr);
+
+    const int up_action = sdl3d_game_data_find_action(client, "action.paddle.local.up");
+    const int down_action = sdl3d_game_data_find_action(client, "action.paddle.local.down");
+    ASSERT_GE(up_action, 0);
+    ASSERT_GE(down_action, 0);
+
+    sdl3d_input_set_action_override(client_input, up_action, 0.75f);
+    sdl3d_input_set_action_override(client_input, down_action, -0.25f);
+    ASSERT_NE(sdl3d_input_update(client_input, 44), nullptr);
+
+    std::array<Uint8, 128> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_input(client, "client_input", client_input, 44U, packet.data(),
+                                                     packet.size(), &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 0U);
+
+    Uint32 tick = 0U;
+    ASSERT_TRUE(
+        sdl3d_game_data_apply_network_input(host, host_input, packet.data(), packet_size, &tick, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(tick, 44U);
+
+    ASSERT_NE(sdl3d_input_update(host_input, 45), nullptr);
+    const int host_up_action = sdl3d_game_data_find_action(host, "action.paddle.local.up");
+    const int host_down_action = sdl3d_game_data_find_action(host, "action.paddle.local.down");
+    ASSERT_GE(host_up_action, 0);
+    ASSERT_GE(host_down_action, 0);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_up_action), 0.75f, 0.0001f);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_down_action), -0.25f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_clear_network_input_overrides(host, "client_input", host_input, error, sizeof(error)))
+        << error;
+    ASSERT_NE(sdl3d_input_update(host_input, 46), nullptr);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_up_action), 0.0f, 0.0001f);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_down_action), 0.0f, 0.0001f);
+
+    destroy_runtime_session(client_session, client);
+    destroy_runtime_session(host_session, host);
+}
+
+TEST(GameDataRuntime, RejectsPongNetworkInputWithMismatchedSchemaOrTruncation)
+{
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *client = nullptr;
+    load_pong_runtime(&client_session, &client);
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_data_runtime *host = nullptr;
+    load_pong_runtime(&host_session, &host);
+
+    sdl3d_input_manager *client_input = sdl3d_game_session_get_input(client_session);
+    sdl3d_input_manager *host_input = sdl3d_game_session_get_input(host_session);
+    ASSERT_NE(client_input, nullptr);
+    ASSERT_NE(host_input, nullptr);
+    ASSERT_NE(sdl3d_input_update(client_input, 10), nullptr);
+
+    std::array<Uint8, 128> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_input(client, "client_input", client_input, 10U, packet.data(),
+                                                     packet.size(), &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 24U);
+
+    std::array<Uint8, 8> too_small{};
+    size_t too_small_size = 0U;
+    EXPECT_FALSE(sdl3d_game_data_encode_network_input(client, "client_input", client_input, 10U, too_small.data(),
+                                                      too_small.size(), &too_small_size, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires"), std::string::npos) << error;
+    EXPECT_EQ(too_small_size, 0U);
+
+    std::array<Uint8, 128> corrupted = packet;
+    corrupted[16] ^= 0xffU;
+    EXPECT_FALSE(sdl3d_game_data_apply_network_input(host, host_input, corrupted.data(), packet_size, nullptr, error,
+                                                     sizeof(error)));
+    EXPECT_NE(std::string(error).find("schema hash"), std::string::npos) << error;
+
+    EXPECT_FALSE(sdl3d_game_data_apply_network_input(host, host_input, packet.data(), packet_size - 1U, nullptr, error,
+                                                     sizeof(error)));
+    EXPECT_NE(std::string(error).find("action data"), std::string::npos) << error;
+
+    destroy_runtime_session(client_session, client);
+    destroy_runtime_session(host_session, host);
+}
+
 TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
 {
     struct Case

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -20,7 +20,6 @@ namespace
 {
 constexpr Uint32 kPongNetworkPacketMagic = 0x474E4F50u;
 constexpr Uint8 kPongNetworkPacketVersion = 1U;
-constexpr size_t kPongNetworkInputPacketSize = 20U;
 constexpr size_t kPongNetworkControlPacketSize = 12U;
 constexpr size_t kPongNetworkStatePacketSize = 112U;
 
@@ -213,70 +212,34 @@ static bool wait_for_network_pair(sdl3d_network_session *host, sdl3d_network_ses
     return false;
 }
 
-static bool send_client_input_packet(sdl3d_game_session *session, sdl3d_network_session *net_session, int p2_up,
-                                     int p2_down)
+static bool send_client_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
+                                     sdl3d_network_session *net_session)
 {
     const sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
     const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(input);
-    const float up_value = snapshot != nullptr && p2_up >= 0 ? snapshot->actions[p2_up].value : 0.0f;
-    const float down_value = snapshot != nullptr && p2_down >= 0 ? snapshot->actions[p2_down].value : 0.0f;
-    Uint8 packet[32];
-    Uint8 *cursor = packet;
-    Uint8 *end = packet + sizeof(packet);
+    Uint8 packet[128];
+    size_t packet_size = 0U;
+    char error[160]{};
 
-    return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
-           write_u8(&cursor, end, PONG_NETWORK_MESSAGE_INPUT) && write_u8(&cursor, end, 0U) &&
-           write_u8(&cursor, end, 0U) &&
-           write_u32(&cursor, end, (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0)) &&
-           write_f32(&cursor, end, up_value) && write_f32(&cursor, end, down_value) &&
-           (size_t)(cursor - packet) == kPongNetworkInputPacketSize &&
-           sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
+    return sdl3d_game_data_encode_network_input(runtime, "client_input", input,
+                                                (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0), packet,
+                                                sizeof(packet), &packet_size, error, sizeof(error)) &&
+           sdl3d_network_session_send(net_session, packet, (int)packet_size);
 }
 
 static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
                                       const Uint8 *packet, int packet_size)
 {
-    const Uint8 *cursor = packet;
-    const Uint8 *end = packet + packet_size;
-    Uint32 magic = 0U;
-    Uint8 version = 0U;
-    Uint8 kind = 0U;
-    Uint8 reserved = 0U;
     Uint32 tick = 0U;
-    float up_value = 0.0f;
-    float down_value = 0.0f;
+    char error[160]{};
 
-    if (runtime == nullptr || packet == nullptr || packet_size < 12)
+    if (runtime == nullptr || session == nullptr || packet == nullptr || packet_size <= 0)
     {
         return false;
     }
 
-    if (!read_u32(&cursor, end, &magic) || magic != kPongNetworkPacketMagic || !read_u8(&cursor, end, &version) ||
-        version != kPongNetworkPacketVersion || !read_u8(&cursor, end, &kind) ||
-        kind != (Uint8)PONG_NETWORK_MESSAGE_INPUT || !read_u8(&cursor, end, &reserved) ||
-        !read_u8(&cursor, end, &reserved) || !read_u32(&cursor, end, &tick) || !read_f32(&cursor, end, &up_value) ||
-        !read_f32(&cursor, end, &down_value))
-    {
-        return false;
-    }
-
-    if ((size_t)packet_size != kPongNetworkInputPacketSize)
-    {
-        return false;
-    }
-
-    (void)tick;
-    const int p2_up = sdl3d_game_data_find_action(runtime, "action.paddle.local.up");
-    const int p2_down = sdl3d_game_data_find_action(runtime, "action.paddle.local.down");
-    if (p2_up >= 0)
-    {
-        sdl3d_input_set_action_override(sdl3d_game_session_get_input(session), p2_up, up_value);
-    }
-    if (p2_down >= 0)
-    {
-        sdl3d_input_set_action_override(sdl3d_game_session_get_input(session), p2_down, down_value);
-    }
-    return true;
+    return sdl3d_game_data_apply_network_input(runtime, sdl3d_game_session_get_input(session), packet,
+                                               (size_t)packet_size, &tick, error, sizeof(error));
 }
 
 static bool send_control_packet(sdl3d_network_session *net_session, PongNetworkMessageKind kind)
@@ -554,7 +517,7 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
     sdl3d_input_set_action_override(sdl3d_game_session_get_input(client_session), p2_down, 0.0f);
     ASSERT_TRUE(sdl3d_game_session_tick(client_session, 0.016f));
 
-    ASSERT_TRUE(send_client_input_packet(client_session, client_network, p2_up, p2_down));
+    ASSERT_TRUE(send_client_input_packet(client_runtime, client_session, client_network));
 
     std::array<Uint8, SDL3D_NETWORK_MAX_PACKET_SIZE> packet{};
     int received = 0;


### PR DESCRIPTION
## Summary

- add generic client-to-host network input packet encode/apply APIs driven by authored replication schemas
- author Pong's `client_input` replication channel and route Pong client input through the generic engine path
- add network input documentation and focused runtime/headless multiplayer test coverage

## Verification

- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.*Network*'`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -j 8`
- `git diff --check`

Closes part of #179.