### PR TITLE
Add data-driven network control messages

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -170,8 +170,9 @@
     ],
     "control_messages": [
       { "name": "start_game", "direction": "host_to_client", "signal": "signal.network.start_game" },
-      { "name": "terminate_match", "direction": "bidirectional", "signal": "signal.network.terminate_match" },
-      { "name": "pause_changed", "direction": "bidirectional", "signal": "signal.network.pause_changed" }
+      { "name": "pause_request", "direction": "bidirectional", "signal": "signal.network.pause_changed" },
+      { "name": "resume_request", "direction": "bidirectional", "signal": "signal.network.pause_changed" },
+      { "name": "disconnect", "direction": "bidirectional", "signal": "signal.network.terminate_match" }
     ]
   },
   "scenes": {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -70,13 +70,12 @@ typedef enum pong_network_message_kind
 
 static const Uint32 PONG_NETWORK_PACKET_MAGIC = 0x474E4F50u; /* "PONG" little-endian */
 static const Uint8 PONG_NETWORK_PACKET_VERSION = 1U;
-static const size_t PONG_NETWORK_CONTROL_PACKET_SIZE = 12U;
 static const size_t PONG_NETWORK_STATE_PACKET_SIZE = 112U;
 
-static bool send_network_control_packet(sdl3d_network_session *session, pong_network_message_kind kind,
-                                        const char *label);
-static bool send_network_control_packet_repeated(sdl3d_network_session *session, pong_network_message_kind kind,
-                                                 const char *label, int count);
+static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session,
+                                        pong_network_message_kind kind, const char *label);
+static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session,
+                                                 pong_network_message_kind kind, const char *label, int count);
 
 static Uint64 pong_log_timestamp_ms(void)
 {
@@ -480,7 +479,7 @@ static void destroy_host_session_internal(pong_state *state, bool notify_peer)
     {
         if (notify_peer)
         {
-            (void)send_network_control_packet_repeated(state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT,
+            (void)send_network_control_packet_repeated(state, state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT,
                                                        "host disconnect", 5);
         }
         sdl3d_network_session_destroy(state->host_session);
@@ -698,8 +697,8 @@ static void destroy_direct_connect_session_internal(pong_state *state, bool noti
     {
         if (notify_peer)
         {
-            (void)send_network_control_packet_repeated(state->direct_connect_session, PONG_NETWORK_MESSAGE_DISCONNECT,
-                                                       "client disconnect", 5);
+            (void)send_network_control_packet_repeated(state, state->direct_connect_session,
+                                                       PONG_NETWORK_MESSAGE_DISCONNECT, "client disconnect", 5);
         }
         sdl3d_network_session_destroy(state->direct_connect_session);
         state->direct_connect_session = NULL;
@@ -761,37 +760,79 @@ static void reset_direct_connect_defaults(pong_state *state)
     SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Ready to connect");
 }
 
-static bool send_network_control_packet(sdl3d_network_session *session, pong_network_message_kind kind,
-                                        const char *label)
+static const char *network_control_name_for_kind(pong_network_message_kind kind)
+{
+    switch (kind)
+    {
+    case PONG_NETWORK_MESSAGE_START_GAME:
+        return "start_game";
+    case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
+        return "pause_request";
+    case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
+        return "resume_request";
+    case PONG_NETWORK_MESSAGE_DISCONNECT:
+        return "disconnect";
+    default:
+        return NULL;
+    }
+}
+
+static bool network_control_kind_from_name(const char *name, pong_network_message_kind *out_kind)
+{
+    if (name == NULL)
+    {
+        return false;
+    }
+    if (SDL_strcmp(name, "start_game") == 0)
+    {
+        if (out_kind != NULL)
+            *out_kind = PONG_NETWORK_MESSAGE_START_GAME;
+        return true;
+    }
+    if (SDL_strcmp(name, "pause_request") == 0)
+    {
+        if (out_kind != NULL)
+            *out_kind = PONG_NETWORK_MESSAGE_PAUSE_REQUEST;
+        return true;
+    }
+    if (SDL_strcmp(name, "resume_request") == 0)
+    {
+        if (out_kind != NULL)
+            *out_kind = PONG_NETWORK_MESSAGE_RESUME_REQUEST;
+        return true;
+    }
+    if (SDL_strcmp(name, "disconnect") == 0)
+    {
+        if (out_kind != NULL)
+            *out_kind = PONG_NETWORK_MESSAGE_DISCONNECT;
+        return true;
+    }
+    return false;
+}
+
+static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session,
+                                        pong_network_message_kind kind, const char *label)
 {
     Uint8 packet[32];
-    Uint8 *cursor = packet;
-    Uint8 *end = packet + sizeof(packet);
+    size_t packet_size = 0U;
+    char error[160] = {0};
     const Uint32 tick = (Uint32)SDL_GetTicks();
+    const char *control_name = network_control_name_for_kind(kind);
 
-    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    if (state == NULL || state->data == NULL || session == NULL || !sdl3d_network_session_is_connected(session) ||
+        control_name == NULL)
     {
         return false;
     }
 
-    if (!pong_network_write_u32(&cursor, end, PONG_NETWORK_PACKET_MAGIC) ||
-        !pong_network_write_u8(&cursor, end, PONG_NETWORK_PACKET_VERSION) ||
-        !pong_network_write_u8(&cursor, end, (Uint8)kind) || !pong_network_write_u8(&cursor, end, 0U) ||
-        !pong_network_write_u8(&cursor, end, 0U) || !pong_network_write_u32(&cursor, end, tick))
+    if (!sdl3d_game_data_encode_network_control(state->data, control_name, tick, packet, sizeof(packet), &packet_size,
+                                                error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet encode failed: kind=%u",
-                    (unsigned int)kind);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet encode failed: %s", error);
         return false;
     }
 
-    if ((size_t)(cursor - packet) != PONG_NETWORK_CONTROL_PACKET_SIZE)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet size mismatch: expected=%zu actual=%zu",
-                    PONG_NETWORK_CONTROL_PACKET_SIZE, (size_t)(cursor - packet));
-        return false;
-    }
-
-    if (!sdl3d_network_session_send(session, packet, (int)(cursor - packet)))
+    if (!sdl3d_network_session_send(session, packet, (int)packet_size))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet send failed: %s", SDL_GetError());
         return false;
@@ -802,15 +843,15 @@ static bool send_network_control_packet(sdl3d_network_session *session, pong_net
     return true;
 }
 
-static bool send_network_control_packet_repeated(sdl3d_network_session *session, pong_network_message_kind kind,
-                                                 const char *label, int count)
+static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session,
+                                                 pong_network_message_kind kind, const char *label, int count)
 {
     bool sent_any = false;
     const int attempts = SDL_max(count, 1);
 
     for (int i = 0; i < attempts; ++i)
     {
-        if (send_network_control_packet(session, kind, label))
+        if (send_network_control_packet(state, session, kind, label))
         {
             sent_any = true;
         }
@@ -823,34 +864,28 @@ static bool send_network_control_packet_repeated(sdl3d_network_session *session,
     return sent_any;
 }
 
-static bool read_network_control_packet(const Uint8 *packet, int packet_size, pong_network_message_kind expected,
-                                        Uint32 *out_tick)
+static bool read_network_control_packet(pong_state *state, const Uint8 *packet, int packet_size,
+                                        pong_network_message_kind expected, Uint32 *out_tick)
 {
-    const Uint8 *cursor = packet;
-    const Uint8 *end = packet + packet_size;
-    Uint32 magic = 0U;
-    Uint8 version = 0U;
-    Uint8 kind = 0U;
-    Uint8 reserved = 0U;
-    Uint32 tick = 0U;
+    sdl3d_game_data_network_control control;
+    pong_network_message_kind actual = 0;
+    char error[160] = {0};
 
-    if (packet == NULL || (size_t)packet_size != PONG_NETWORK_CONTROL_PACKET_SIZE)
+    if (state == NULL || state->data == NULL || packet == NULL || packet_size <= 0)
     {
         return false;
     }
 
-    if (!pong_network_read_u32(&cursor, end, &magic) || magic != PONG_NETWORK_PACKET_MAGIC ||
-        !pong_network_read_u8(&cursor, end, &version) || version != PONG_NETWORK_PACKET_VERSION ||
-        !pong_network_read_u8(&cursor, end, &kind) || kind != (Uint8)expected ||
-        !pong_network_read_u8(&cursor, end, &reserved) || !pong_network_read_u8(&cursor, end, &reserved) ||
-        !pong_network_read_u32(&cursor, end, &tick) || cursor != end)
+    if (!sdl3d_game_data_decode_network_control(state->data, packet, (size_t)packet_size, &control, error,
+                                                (int)sizeof(error)) ||
+        !network_control_kind_from_name(control.name, &actual) || actual != expected)
     {
         return false;
     }
 
     if (out_tick != NULL)
     {
-        *out_tick = tick;
+        *out_tick = control.tick;
     }
     return true;
 }
@@ -869,7 +904,7 @@ static bool send_host_start_packet(pong_state *state)
         return false;
     }
 
-    if (!send_network_control_packet(state->host_session, PONG_NETWORK_MESSAGE_START_GAME, "start game"))
+    if (!send_network_control_packet(state, state->host_session, PONG_NETWORK_MESSAGE_START_GAME, "start game"))
     {
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s", SDL_GetError());
         update_host_session_scene_state(state);
@@ -972,7 +1007,7 @@ static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_s
     }
 
     request_kind = ctx->paused ? PONG_NETWORK_MESSAGE_RESUME_REQUEST : PONG_NETWORK_MESSAGE_PAUSE_REQUEST;
-    (void)send_network_control_packet(state->direct_connect_session, request_kind,
+    (void)send_network_control_packet(state, state->direct_connect_session, request_kind,
                                       request_kind == PONG_NETWORK_MESSAGE_PAUSE_REQUEST ? "pause request"
                                                                                          : "resume request");
 }
@@ -1212,7 +1247,7 @@ static bool process_network_control_packet(sdl3d_game_context *ctx, pong_state *
                                            int packet_size, pong_network_message_kind kind)
 {
     Uint32 tick = 0U;
-    if (!read_network_control_packet(packet, packet_size, kind, &tick))
+    if (!read_network_control_packet(state, packet, packet_size, kind, &tick))
     {
         return false;
     }
@@ -1391,7 +1426,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
         while ((packet_size =
                     sdl3d_network_session_receive(state->direct_connect_session, packet, (int)sizeof(packet))) > 0)
         {
-            if (packet_size >= 1 && packet[0] == (Uint8)PONG_NETWORK_MESSAGE_START_GAME)
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_START_GAME, NULL))
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
                 clear_network_action_overrides(state);
@@ -1402,21 +1437,10 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                 }
                 continue;
             }
-            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_START_GAME))
-            {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
-                clear_network_action_overrides(state);
-                if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
-                {
-                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
-                                SDL_GetError());
-                }
-                continue;
-            }
-            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT))
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, NULL))
             {
                 Uint32 tick = 0U;
-                if (read_network_control_packet(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+                if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
                 {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
                                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
@@ -1790,10 +1814,10 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         int packet_size = 0;
         while ((packet_size = sdl3d_network_session_receive(state->host_session, packet, (int)sizeof(packet))) > 0)
         {
-            if (pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT))
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, NULL))
             {
                 Uint32 tick = 0U;
-                if (read_network_control_packet(packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+                if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
                 {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
                                 (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
@@ -1802,14 +1826,14 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
                 break;
             }
             if (is_multiplayer_play_scene(state) &&
-                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_PAUSE_REQUEST))
+                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_PAUSE_REQUEST, NULL))
             {
                 (void)process_network_control_packet(ctx, state, packet, packet_size,
                                                      PONG_NETWORK_MESSAGE_PAUSE_REQUEST);
                 continue;
             }
             if (is_multiplayer_play_scene(state) &&
-                pong_network_packet_is_kind(packet, packet_size, PONG_NETWORK_MESSAGE_RESUME_REQUEST))
+                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_RESUME_REQUEST, NULL))
             {
                 (void)process_network_control_packet(ctx, state, packet, packet_size,
                                                      PONG_NETWORK_MESSAGE_RESUME_REQUEST);

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1209,7 +1209,8 @@ typed actor fields, replicated input actions, and control messages:
       }
     ],
     "control_messages": [
-      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" }
+      { "name": "pause_request", "direction": "client_to_host", "signal": "signal.network.pause" },
+      { "name": "disconnect", "direction": "bidirectional", "signal": "signal.network.disconnect" }
     ]
   }
 }
@@ -1260,6 +1261,16 @@ normal action snapshot APIs. Malformed packets are rejected before any override
 is changed. When a peer disconnects or a network scene exits, callers should
 use `sdl3d_game_data_clear_network_input_overrides()` for the same channel so
 remote input cannot leak into later local play.
+
+Control messages can be encoded with
+`sdl3d_game_data_encode_network_control()`, decoded with
+`sdl3d_game_data_decode_network_control()`, and emitted through the runtime
+signal bus with `sdl3d_game_data_apply_network_control()`. Control packets
+carry the schema hash, authored control-message index, and tick; decoders
+reject unsupported versions, mismatched schema hashes, invalid control indexes,
+truncation, and trailing bytes. Applying a valid control message emits the
+authored signal with a payload containing `network_control`,
+`network_direction`, and `network_tick`.
 
 When a runtime loads game data with a valid `network` block, it computes a
 deterministic schema hash over protocol, replication, input, and control-message

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -65,6 +65,32 @@ extern "C"
         const char *window_vsync_key;
     } sdl3d_game_data_app_control;
 
+    /** @brief Direction for an authored network replication or control message. */
+    typedef enum sdl3d_game_data_network_direction
+    {
+        /** @brief Invalid or unknown network direction. */
+        SDL3D_GAME_DATA_NETWORK_DIRECTION_INVALID = 0,
+        /** @brief Message flows from the authoritative host to a client. */
+        SDL3D_GAME_DATA_NETWORK_DIRECTION_HOST_TO_CLIENT = 1,
+        /** @brief Message flows from a client to the authoritative host. */
+        SDL3D_GAME_DATA_NETWORK_DIRECTION_CLIENT_TO_HOST = 2,
+        /** @brief Message may flow in either direction. */
+        SDL3D_GAME_DATA_NETWORK_DIRECTION_BIDIRECTIONAL = 3,
+    } sdl3d_game_data_network_direction;
+
+    /** @brief Decoded authored network control message descriptor. */
+    typedef struct sdl3d_game_data_network_control
+    {
+        /** @brief Authored control message name, owned by the runtime. */
+        const char *name;
+        /** @brief Authored message direction. */
+        sdl3d_game_data_network_direction direction;
+        /** @brief Signal referenced by the control message, or -1. */
+        int signal_id;
+        /** @brief Tick carried by the control packet. */
+        Uint32 tick;
+    } sdl3d_game_data_network_control;
+
     /** @brief Authored font asset descriptor. */
     typedef struct sdl3d_game_data_font_asset
     {
@@ -929,6 +955,67 @@ extern "C"
     bool sdl3d_game_data_clear_network_input_overrides(const sdl3d_game_data_runtime *runtime,
                                                        const char *replication_name, sdl3d_input_manager *input,
                                                        char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Encode an authored network control message packet.
+     *
+     * The named control message must exist in the loaded `network`
+     * `control_messages` array. The packet includes a deterministic header,
+     * schema hash, control-message index, and tick. Callers provide the
+     * destination buffer; no allocation is performed.
+     *
+     * @param runtime Runtime containing the authored network schema.
+     * @param control_name Authored control message name.
+     * @param tick Simulation or wall-clock tick to include in the packet.
+     * @param buffer Destination packet buffer.
+     * @param buffer_size Destination buffer size in bytes.
+     * @param out_size Receives written packet size in bytes.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the control packet was encoded.
+     */
+    bool sdl3d_game_data_encode_network_control(const sdl3d_game_data_runtime *runtime, const char *control_name,
+                                                Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                                char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Decode an authored network control message packet.
+     *
+     * The packet must match the runtime schema hash and reference an authored
+     * control message in the loaded `network` schema. On success @p out_control
+     * receives runtime-owned descriptor strings and the packet tick.
+     *
+     * @param runtime Runtime containing the authored network schema.
+     * @param packet Source packet buffer.
+     * @param packet_size Source packet size in bytes.
+     * @param out_control Receives decoded control metadata.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the packet was decoded completely.
+     */
+    bool sdl3d_game_data_decode_network_control(const sdl3d_game_data_runtime *runtime, const void *packet,
+                                                size_t packet_size, sdl3d_game_data_network_control *out_control,
+                                                char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Decode and emit an authored network control message signal.
+     *
+     * This validates the packet with sdl3d_game_data_decode_network_control()
+     * and emits the control message's authored signal on the runtime session
+     * bus. The signal payload includes `network_control`, `network_direction`,
+     * and `network_tick` fields.
+     *
+     * @param runtime Runtime containing the authored network schema and session bus.
+     * @param packet Source packet buffer.
+     * @param packet_size Source packet size in bytes.
+     * @param out_control Receives decoded control metadata, if non-NULL.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the packet was decoded and the signal emitted.
+     */
+    bool sdl3d_game_data_apply_network_control(sdl3d_game_data_runtime *runtime, const void *packet, size_t packet_size,
+                                               sdl3d_game_data_network_control *out_control, char *error_buffer,
+                                               int error_buffer_size);
 
     /**
      * @brief Validate a JSON game data file without instantiating runtime state.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -34,6 +34,8 @@
 #define SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION 1u
 #define SDL3D_GAME_DATA_NETWORK_INPUT_MAGIC 0x49335253u /* "S3RI" */
 #define SDL3D_GAME_DATA_NETWORK_INPUT_VERSION 1u
+#define SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
+#define SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
 
 typedef enum game_data_sensor_type
 {
@@ -1906,6 +1908,70 @@ static const char *game_data_replication_input_action(yyjson_val *input)
 static int game_data_replication_action_id(const sdl3d_game_data_runtime *runtime, yyjson_val *input)
 {
     return sdl3d_game_data_find_action(runtime, game_data_replication_input_action(input));
+}
+
+static sdl3d_game_data_network_direction game_data_network_direction_from_string(const char *direction)
+{
+    if (direction == NULL)
+        return SDL3D_GAME_DATA_NETWORK_DIRECTION_INVALID;
+    if (SDL_strcmp(direction, "host_to_client") == 0)
+        return SDL3D_GAME_DATA_NETWORK_DIRECTION_HOST_TO_CLIENT;
+    if (SDL_strcmp(direction, "client_to_host") == 0)
+        return SDL3D_GAME_DATA_NETWORK_DIRECTION_CLIENT_TO_HOST;
+    if (SDL_strcmp(direction, "bidirectional") == 0)
+        return SDL3D_GAME_DATA_NETWORK_DIRECTION_BIDIRECTIONAL;
+    return SDL3D_GAME_DATA_NETWORK_DIRECTION_INVALID;
+}
+
+static const char *game_data_network_direction_name(sdl3d_game_data_network_direction direction)
+{
+    switch (direction)
+    {
+    case SDL3D_GAME_DATA_NETWORK_DIRECTION_HOST_TO_CLIENT:
+        return "host_to_client";
+    case SDL3D_GAME_DATA_NETWORK_DIRECTION_CLIENT_TO_HOST:
+        return "client_to_host";
+    case SDL3D_GAME_DATA_NETWORK_DIRECTION_BIDIRECTIONAL:
+        return "bidirectional";
+    default:
+        return "invalid";
+    }
+}
+
+static yyjson_val *game_data_find_network_control_by_name(const sdl3d_game_data_runtime *runtime,
+                                                          const char *control_name, int *out_index)
+{
+    yyjson_val *controls = obj_get(obj_get(runtime_root(runtime), "network"), "control_messages");
+    for (size_t i = 0; yyjson_is_arr(controls) && i < yyjson_arr_size(controls); ++i)
+    {
+        yyjson_val *control = yyjson_arr_get(controls, i);
+        if (SDL_strcmp(json_string(control, "name", ""), control_name != NULL ? control_name : "") == 0)
+        {
+            if (out_index != NULL)
+                *out_index = (int)i;
+            return control;
+        }
+    }
+    return NULL;
+}
+
+static yyjson_val *game_data_find_network_control_by_index(const sdl3d_game_data_runtime *runtime, Uint32 index)
+{
+    yyjson_val *controls = obj_get(obj_get(runtime_root(runtime), "network"), "control_messages");
+    return yyjson_is_arr(controls) && index < yyjson_arr_size(controls) ? yyjson_arr_get(controls, index) : NULL;
+}
+
+static bool game_data_network_control_packet_size(size_t *out_size)
+{
+    const size_t size = 4U + 4U + 4U + 4U + SDL3D_REPLICATION_SCHEMA_HASH_SIZE;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+static int game_data_network_control_signal_id(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    return sdl3d_game_data_find_signal(runtime, json_string(control, "signal", NULL));
 }
 
 static const char *game_data_replication_property_key(const char *path)
@@ -9705,6 +9771,173 @@ bool sdl3d_game_data_clear_network_input_overrides(const sdl3d_game_data_runtime
         sdl3d_input_clear_action_override(input, action_id);
     }
 
+    return true;
+}
+
+bool sdl3d_game_data_encode_network_control(const sdl3d_game_data_runtime *runtime, const char *control_name,
+                                            Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                            char *error_buffer, int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0U;
+    if (runtime == NULL || control_name == NULL || control_name[0] == '\0' || buffer == NULL || buffer_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network control encode requires runtime, control, and buffer");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network control encode requires an authored network schema");
+        return false;
+    }
+
+    int control_index = -1;
+    yyjson_val *control = game_data_find_network_control_by_name(runtime, control_name, &control_index);
+    if (control == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network control message not found");
+        return false;
+    }
+    if (control_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network control message index is invalid");
+        return false;
+    }
+
+    size_t required_size = 0U;
+    (void)game_data_network_control_packet_size(&required_size);
+    if (buffer_size < required_size)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network control requires %zu bytes, buffer has %zu bytes",
+                   required_size, buffer_size);
+        return false;
+    }
+
+    sdl3d_replication_writer writer;
+    sdl3d_replication_writer_init(&writer, buffer, buffer_size);
+    if (!sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC) ||
+        !sdl3d_replication_write_uint32(&writer, SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION) ||
+        !sdl3d_replication_write_uint32(&writer, tick) ||
+        !sdl3d_replication_write_uint32(&writer, (Uint32)control_index) ||
+        !sdl3d_replication_write_bytes(&writer, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE))
+    {
+        set_error(error_buffer, error_buffer_size, "network control buffer is too small for packet");
+        return false;
+    }
+
+    if (out_size != NULL)
+        *out_size = sdl3d_replication_writer_offset(&writer);
+    return true;
+}
+
+bool sdl3d_game_data_decode_network_control(const sdl3d_game_data_runtime *runtime, const void *packet,
+                                            size_t packet_size, sdl3d_game_data_network_control *out_control,
+                                            char *error_buffer, int error_buffer_size)
+{
+    if (out_control != NULL)
+    {
+        out_control->name = NULL;
+        out_control->direction = SDL3D_GAME_DATA_NETWORK_DIRECTION_INVALID;
+        out_control->signal_id = -1;
+        out_control->tick = 0U;
+    }
+    if (runtime == NULL || packet == NULL || packet_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network control decode requires runtime and packet");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network control decode requires an authored network schema");
+        return false;
+    }
+
+    size_t required_size = 0U;
+    (void)game_data_network_control_packet_size(&required_size);
+    if (packet_size != required_size)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network control packet requires %zu bytes, packet has %zu bytes",
+                   required_size, packet_size);
+        return false;
+    }
+
+    sdl3d_replication_reader reader;
+    sdl3d_replication_reader_init(&reader, packet, packet_size);
+
+    Uint32 magic = 0U;
+    Uint32 version = 0U;
+    Uint32 tick = 0U;
+    Uint32 control_index = 0U;
+    Uint8 schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
+    if (!sdl3d_replication_read_uint32(&reader, &magic) || !sdl3d_replication_read_uint32(&reader, &version) ||
+        !sdl3d_replication_read_uint32(&reader, &tick) || !sdl3d_replication_read_uint32(&reader, &control_index) ||
+        !sdl3d_replication_read_bytes(&reader, schema_hash, sizeof(schema_hash)) ||
+        sdl3d_replication_reader_remaining(&reader) != 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network control packet is malformed");
+        return false;
+    }
+    if (magic != SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC || version != SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION)
+    {
+        set_error(error_buffer, error_buffer_size, "network control packet has unsupported header");
+        return false;
+    }
+    if (SDL_memcmp(schema_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network control schema hash does not match runtime");
+        return false;
+    }
+
+    yyjson_val *control = game_data_find_network_control_by_index(runtime, control_index);
+    if (control == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network control message index is invalid for this runtime");
+        return false;
+    }
+
+    const sdl3d_game_data_network_direction direction =
+        game_data_network_direction_from_string(json_string(control, "direction", NULL));
+    const int signal_id = game_data_network_control_signal_id(runtime, control);
+    if (direction == SDL3D_GAME_DATA_NETWORK_DIRECTION_INVALID || signal_id < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network control message metadata is invalid for this runtime");
+        return false;
+    }
+
+    if (out_control != NULL)
+    {
+        out_control->name = json_string(control, "name", NULL);
+        out_control->direction = direction;
+        out_control->signal_id = signal_id;
+        out_control->tick = tick;
+    }
+    return true;
+}
+
+bool sdl3d_game_data_apply_network_control(sdl3d_game_data_runtime *runtime, const void *packet, size_t packet_size,
+                                           sdl3d_game_data_network_control *out_control, char *error_buffer,
+                                           int error_buffer_size)
+{
+    sdl3d_game_data_network_control control;
+    if (!sdl3d_game_data_decode_network_control(runtime, packet, packet_size, &control, error_buffer,
+                                                error_buffer_size))
+        return false;
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network control failed to allocate signal payload");
+        return false;
+    }
+
+    sdl3d_properties_set_string(payload, "network_control", control.name != NULL ? control.name : "");
+    sdl3d_properties_set_string(payload, "network_direction", game_data_network_direction_name(control.direction));
+    sdl3d_properties_set_int(payload, "network_tick", (int)SDL_min(control.tick, (Uint32)SDL_MAX_SINT32));
+    sdl3d_signal_emit(runtime_bus(runtime), control.signal_id, payload);
+    sdl3d_properties_destroy(payload);
+
+    if (out_control != NULL)
+        *out_control = control;
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -46,6 +46,15 @@ struct DiagnosticCapture
     std::vector<CapturedDiagnostic> diagnostics;
 };
 
+struct NetworkSignalCapture
+{
+    int calls = 0;
+    int signal_id = -1;
+    std::string network_control;
+    std::string network_direction;
+    int network_tick = 0;
+};
+
 struct RenderPrimitiveCapture
 {
     int cubes = 0;
@@ -55,6 +64,21 @@ struct RenderPrimitiveCapture
     bool saw_options_background = false;
     bool saw_options_glow = false;
 };
+
+void capture_signal_payload(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    auto *capture = static_cast<NetworkSignalCapture *>(userdata);
+    if (capture == nullptr)
+    {
+        return;
+    }
+
+    capture->calls++;
+    capture->signal_id = signal_id;
+    capture->network_control = sdl3d_properties_get_string(payload, "network_control", "");
+    capture->network_direction = sdl3d_properties_get_string(payload, "network_direction", "");
+    capture->network_tick = sdl3d_properties_get_int(payload, "network_tick", 0);
+}
 
 struct UiTextCapture
 {
@@ -4614,6 +4638,93 @@ TEST(GameDataRuntime, RejectsPongNetworkInputWithMismatchedSchemaOrTruncation)
 
     destroy_runtime_session(client_session, client);
     destroy_runtime_session(host_session, host);
+}
+
+TEST(GameDataRuntime, EncodesDecodesAndAppliesPongNetworkControlFromAuthoredSchema)
+{
+    sdl3d_game_session *sender_session = nullptr;
+    sdl3d_game_data_runtime *sender = nullptr;
+    load_pong_runtime(&sender_session, &sender);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(sender));
+
+    sdl3d_game_session *receiver_session = nullptr;
+    sdl3d_game_data_runtime *receiver = nullptr;
+    load_pong_runtime(&receiver_session, &receiver);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(receiver));
+
+    std::array<Uint8, 128> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_control(sender, "pause_request", 77U, packet.data(), packet.size(),
+                                                       &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 0U);
+
+    sdl3d_game_data_network_control control{};
+    ASSERT_TRUE(
+        sdl3d_game_data_decode_network_control(receiver, packet.data(), packet_size, &control, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(control.name, "pause_request");
+    EXPECT_EQ(control.direction, SDL3D_GAME_DATA_NETWORK_DIRECTION_BIDIRECTIONAL);
+    EXPECT_EQ(control.signal_id, sdl3d_game_data_find_signal(receiver, "signal.network.pause_changed"));
+    EXPECT_EQ(control.tick, 77U);
+
+    NetworkSignalCapture capture;
+    const int connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(receiver_session), control.signal_id,
+                                                capture_signal_payload, &capture);
+    ASSERT_GT(connection, 0);
+    sdl3d_game_data_network_control applied{};
+    ASSERT_TRUE(
+        sdl3d_game_data_apply_network_control(receiver, packet.data(), packet_size, &applied, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(applied.name, "pause_request");
+    EXPECT_EQ(capture.calls, 1);
+    EXPECT_EQ(capture.signal_id, control.signal_id);
+    EXPECT_EQ(capture.network_control, "pause_request");
+    EXPECT_EQ(capture.network_direction, "bidirectional");
+    EXPECT_EQ(capture.network_tick, 77);
+    sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(receiver_session), connection);
+
+    destroy_runtime_session(sender_session, sender);
+    destroy_runtime_session(receiver_session, receiver);
+}
+
+TEST(GameDataRuntime, RejectsPongNetworkControlWithMismatchedSchemaOrBadSize)
+{
+    sdl3d_game_session *sender_session = nullptr;
+    sdl3d_game_data_runtime *sender = nullptr;
+    load_pong_runtime(&sender_session, &sender);
+    sdl3d_game_session *receiver_session = nullptr;
+    sdl3d_game_data_runtime *receiver = nullptr;
+    load_pong_runtime(&receiver_session, &receiver);
+
+    std::array<Uint8, 128> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_control(sender, "disconnect", 88U, packet.data(), packet.size(),
+                                                       &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_GT(packet_size, 24U);
+
+    std::array<Uint8, 8> too_small{};
+    size_t too_small_size = 0U;
+    EXPECT_FALSE(sdl3d_game_data_encode_network_control(sender, "disconnect", 88U, too_small.data(), too_small.size(),
+                                                        &too_small_size, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires"), std::string::npos) << error;
+    EXPECT_EQ(too_small_size, 0U);
+
+    std::array<Uint8, 128> corrupted = packet;
+    corrupted[16] ^= 0xffU;
+    EXPECT_FALSE(
+        sdl3d_game_data_decode_network_control(receiver, corrupted.data(), packet_size, nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("schema hash"), std::string::npos) << error;
+
+    EXPECT_FALSE(sdl3d_game_data_decode_network_control(receiver, packet.data(), packet_size - 1U, nullptr, error,
+                                                        sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires"), std::string::npos) << error;
+
+    destroy_runtime_session(sender_session, sender);
+    destroy_runtime_session(receiver_session, receiver);
 }
 
 TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <string>
 
 extern "C"
 {
@@ -20,7 +22,6 @@ namespace
 {
 constexpr Uint32 kPongNetworkPacketMagic = 0x474E4F50u;
 constexpr Uint8 kPongNetworkPacketVersion = 1U;
-constexpr size_t kPongNetworkControlPacketSize = 12U;
 constexpr size_t kPongNetworkStatePacketSize = 112U;
 
 enum PongNetworkMessageKind : Uint8
@@ -242,33 +243,47 @@ static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_ga
                                                (size_t)packet_size, &tick, error, sizeof(error));
 }
 
-static bool send_control_packet(sdl3d_network_session *net_session, PongNetworkMessageKind kind)
+static const char *control_name_for_kind(PongNetworkMessageKind kind)
 {
-    Uint8 packet[32];
-    Uint8 *cursor = packet;
-    Uint8 *end = packet + sizeof(packet);
-
-    return write_u32(&cursor, end, kPongNetworkPacketMagic) && write_u8(&cursor, end, kPongNetworkPacketVersion) &&
-           write_u8(&cursor, end, kind) && write_u8(&cursor, end, 0U) && write_u8(&cursor, end, 0U) &&
-           write_u32(&cursor, end, 1234U) && (size_t)(cursor - packet) == kPongNetworkControlPacketSize &&
-           sdl3d_network_session_send(net_session, packet, (int)(cursor - packet));
+    switch (kind)
+    {
+    case PONG_NETWORK_MESSAGE_START_GAME:
+        return "start_game";
+    case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
+        return "pause_request";
+    case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
+        return "resume_request";
+    case PONG_NETWORK_MESSAGE_DISCONNECT:
+        return "disconnect";
+    default:
+        return nullptr;
+    }
 }
 
-static bool read_control_packet(const Uint8 *packet, int packet_size, PongNetworkMessageKind expected)
+static bool send_control_packet(sdl3d_game_data_runtime *runtime, sdl3d_network_session *net_session,
+                                PongNetworkMessageKind kind)
 {
-    const Uint8 *cursor = packet;
-    const Uint8 *end = packet + packet_size;
-    Uint32 magic = 0U;
-    Uint8 version = 0U;
-    Uint8 kind = 0U;
-    Uint8 reserved = 0U;
-    Uint32 tick = 0U;
+    Uint8 packet[128];
+    size_t packet_size = 0U;
+    char error[160]{};
+    const char *control_name = control_name_for_kind(kind);
 
-    return packet != nullptr && (size_t)packet_size == kPongNetworkControlPacketSize &&
-           read_u32(&cursor, end, &magic) && magic == kPongNetworkPacketMagic && read_u8(&cursor, end, &version) &&
-           version == kPongNetworkPacketVersion && read_u8(&cursor, end, &kind) && kind == (Uint8)expected &&
-           read_u8(&cursor, end, &reserved) && read_u8(&cursor, end, &reserved) && read_u32(&cursor, end, &tick) &&
-           tick == 1234U && cursor == end;
+    return control_name != nullptr &&
+           sdl3d_game_data_encode_network_control(runtime, control_name, 1234U, packet, sizeof(packet), &packet_size,
+                                                  error, sizeof(error)) &&
+           sdl3d_network_session_send(net_session, packet, (int)packet_size);
+}
+
+static bool read_control_packet(sdl3d_game_data_runtime *runtime, const Uint8 *packet, int packet_size,
+                                PongNetworkMessageKind expected)
+{
+    sdl3d_game_data_network_control control{};
+    char error[160]{};
+
+    return runtime != nullptr && packet != nullptr &&
+           sdl3d_game_data_decode_network_control(runtime, packet, (size_t)packet_size, &control, error,
+                                                  sizeof(error)) &&
+           SDL_strcmp(control.name, control_name_for_kind(expected)) == 0 && control.tick == 1234U;
 }
 
 static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
@@ -439,10 +454,15 @@ class PongHeadlessMultiplayerTest : public ::testing::Test
         set_multiplayer_scene_state(host_runtime, "lan", "host", "host");
         set_multiplayer_scene_state(client_runtime, "lan", "client", "direct");
 
+        const ::testing::TestInfo *test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        const std::string test_name =
+            test_info != nullptr ? std::string(test_info->test_suite_name()) + "." + test_info->name() : "pong";
+        network_port = (Uint16)(30000U + (Uint32)(std::hash<std::string>{}(test_name) % 20000U));
+
         sdl3d_network_session_desc host_desc{};
         sdl3d_network_session_desc_init(&host_desc);
         host_desc.role = SDL3D_NETWORK_ROLE_HOST;
-        host_desc.port = SDL3D_NETWORK_DEFAULT_PORT;
+        host_desc.port = network_port;
         host_desc.handshake_timeout = 2.0f;
         host_desc.idle_timeout = 2.0f;
         ASSERT_TRUE(sdl3d_network_session_create(&host_desc, &host_network));
@@ -451,7 +471,7 @@ class PongHeadlessMultiplayerTest : public ::testing::Test
         sdl3d_network_session_desc_init(&client_desc);
         client_desc.role = SDL3D_NETWORK_ROLE_CLIENT;
         client_desc.host = "127.0.0.1";
-        client_desc.port = SDL3D_NETWORK_DEFAULT_PORT;
+        client_desc.port = network_port;
         client_desc.handshake_timeout = 2.0f;
         client_desc.idle_timeout = 2.0f;
         ASSERT_TRUE(sdl3d_network_session_create(&client_desc, &client_network));
@@ -484,6 +504,7 @@ class PongHeadlessMultiplayerTest : public ::testing::Test
     sdl3d_game_data_runtime *client_runtime = nullptr;
     sdl3d_network_session *host_network = nullptr;
     sdl3d_network_session *client_network = nullptr;
+    Uint16 network_port = SDL3D_NETWORK_DEFAULT_PORT;
     int p1_up = -1;
     int p1_down = -1;
     int p2_up = -1;
@@ -559,7 +580,7 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
 {
     std::array<Uint8, SDL3D_NETWORK_MAX_PACKET_SIZE> packet{};
 
-    ASSERT_TRUE(send_control_packet(client_network, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
+    ASSERT_TRUE(send_control_packet(client_runtime, client_network, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
     int received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
     {
@@ -568,9 +589,9 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
         received = sdl3d_network_session_receive(host_network, packet.data(), (int)packet.size());
     }
     ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
+    ASSERT_TRUE(read_control_packet(host_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
 
-    ASSERT_TRUE(send_control_packet(host_network, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
+    ASSERT_TRUE(send_control_packet(host_runtime, host_network, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
     received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
     {
@@ -579,9 +600,9 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
         received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
     }
     ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
+    ASSERT_TRUE(read_control_packet(client_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
 
-    ASSERT_TRUE(send_control_packet(client_network, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(send_control_packet(client_runtime, client_network, PONG_NETWORK_MESSAGE_DISCONNECT));
     received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
     {
@@ -590,9 +611,9 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
         received = sdl3d_network_session_receive(host_network, packet.data(), (int)packet.size());
     }
     ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(read_control_packet(host_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
 
-    ASSERT_TRUE(send_control_packet(host_network, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(send_control_packet(host_runtime, host_network, PONG_NETWORK_MESSAGE_DISCONNECT));
     received = 0;
     for (int i = 0; i < 120 && received <= 0; ++i)
     {
@@ -601,7 +622,7 @@ TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
         received = sdl3d_network_session_receive(client_network, packet.data(), (int)packet.size());
     }
     ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(read_control_packet(client_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
 }
 
 TEST_F(PongHeadlessMultiplayerTest, NetworkPauseMenuOmitsOptions)


### PR DESCRIPTION
## Summary

- add generic authored network control-message encode/decode/apply APIs with schema-hash validation
- move Pong network start, pause, resume, and disconnect controls onto authored control messages
- update Pong multiplayer tests to use engine control APIs and isolate UDP ports per test case
- document network control message packet behavior and signal payloads

## Verification

- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.*Network*'`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -j 8`
- `git diff --check`

Closes part of #179.