### PR TITLE
Add data-driven input profiles

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -836,6 +836,7 @@
       {
         "name": "profile.pong.play.local.two_gamepads",
         "min_gamepads": 2,
+        "max_gamepads": 4,
         "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" },
         "unbind": [
           "action.paddle.up",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -747,6 +747,139 @@
           }
         ]
       }
+    ],
+    "profiles": [
+      {
+        "name": "profile.pong.play.lan.host",
+        "active_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "host" }
+          ]
+        },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
+          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
+          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
+          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
+          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        ]
+      },
+      {
+        "name": "profile.pong.play.lan.client",
+        "active_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+          ]
+        },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.local.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.local.down", "device": "keyboard", "key": "DOWN" },
+          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
+          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        ]
+      },
+      {
+        "name": "profile.pong.play.local.keyboard_only",
+        "min_gamepads": 0,
+        "max_gamepads": 0,
+        "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" }
+        ]
+      },
+      {
+        "name": "profile.pong.play.local.one_gamepad",
+        "min_gamepads": 1,
+        "max_gamepads": 1,
+        "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
+          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
+          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        ]
+      },
+      {
+        "name": "profile.pong.play.local.two_gamepads",
+        "min_gamepads": 2,
+        "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
+          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
+          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
+          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
+          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 },
+          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 1 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 1 },
+          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 1 },
+          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 1 }
+        ]
+      },
+      {
+        "name": "profile.pong.play.single",
+        "active_if": {
+          "type": "scene_state.compare",
+          "key": "match_mode",
+          "op": "==",
+          "value": "single",
+          "default": "single"
+        },
+        "unbind": [
+          "action.paddle.up",
+          "action.paddle.down",
+          "action.paddle.local.up",
+          "action.paddle.local.down"
+        ],
+        "bindings": [
+          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
+          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP" },
+          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN" },
+          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0 },
+          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0 }
+        ]
+      }
     ]
   },
   "world": {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -362,89 +362,28 @@ static void destroy_host_session(pong_state *state)
     destroy_host_session_internal(state, true);
 }
 
-static void bind_local_play_controls(pong_state *state)
+static bool apply_active_play_input_profile(pong_state *state)
 {
+    char error[192];
+    const char *profile_name = NULL;
     if (state == NULL || state->data == NULL || state->input == NULL)
     {
-        return;
+        return false;
     }
 
-    const int gamepad_count = sdl3d_input_gamepad_count(state->input);
-    const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
-    const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
-    const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
-    const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
-
-    if (p1_up < 0 || p1_down < 0 || p2_up < 0 || p2_down < 0)
+    error[0] = '\0';
+    if (!sdl3d_game_data_apply_active_input_profile(state->data, state->input, &profile_name, error, sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong local input rebinding skipped: required paddle actions were not registered");
-        return;
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile apply failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+        return false;
     }
 
-    sdl3d_input_unbind_action(state->input, p1_up);
-    sdl3d_input_unbind_action(state->input, p1_down);
-    sdl3d_input_unbind_action(state->input, p2_up);
-    sdl3d_input_unbind_action(state->input, p2_down);
-
-    sdl3d_input_bind_key(state->input, p1_up, SDL_SCANCODE_UP);
-    sdl3d_input_bind_key(state->input, p1_down, SDL_SCANCODE_DOWN);
-
-    if (gamepad_count >= 2)
-    {
-        sdl3d_input_bind_gamepad_button_at(state->input, p1_up, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
-        sdl3d_input_bind_gamepad_button_at(state->input, p1_down, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p1_up, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p1_down, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
-
-        sdl3d_input_bind_gamepad_button_at(state->input, p2_up, 1, SDL_GAMEPAD_BUTTON_DPAD_UP);
-        sdl3d_input_bind_gamepad_button_at(state->input, p2_down, 1, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p2_up, 1, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p2_down, 1, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
-    }
-    else if (gamepad_count == 1)
-    {
-        sdl3d_input_bind_gamepad_button_at(state->input, p2_up, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
-        sdl3d_input_bind_gamepad_button_at(state->input, p2_down, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p2_up, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
-        sdl3d_input_bind_gamepad_axis_at(state->input, p2_down, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
-    }
-
-    state->local_input_gamepad_count = gamepad_count;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong local input configured: gamepads=%d", gamepad_count);
-}
-
-static void bind_network_play_controls(pong_state *state, const char *up_action_name, const char *down_action_name)
-{
-    if (state == NULL || state->data == NULL || state->input == NULL)
-    {
-        return;
-    }
-
-    const int up_action = sdl3d_game_data_find_action(state->data, up_action_name);
-    const int down_action = sdl3d_game_data_find_action(state->data, down_action_name);
-    if (up_action < 0 || down_action < 0)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Pong network input rebinding skipped: required paddle actions were not registered");
-        return;
-    }
-
-    sdl3d_input_unbind_action(state->input, up_action);
-    sdl3d_input_unbind_action(state->input, down_action);
-    sdl3d_input_bind_key(state->input, up_action, SDL_SCANCODE_UP);
-    sdl3d_input_bind_key(state->input, down_action, SDL_SCANCODE_DOWN);
-
-    if (sdl3d_input_gamepad_count(state->input) > 0)
-    {
-        sdl3d_input_bind_gamepad_button_at(state->input, up_action, 0, SDL_GAMEPAD_BUTTON_DPAD_UP);
-        sdl3d_input_bind_gamepad_button_at(state->input, down_action, 0, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        sdl3d_input_bind_gamepad_axis_at(state->input, up_action, 0, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
-        sdl3d_input_bind_gamepad_axis_at(state->input, down_action, 0, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
-    }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong network input configured: role=%s actions=%s/%s gamepads=%d",
-                network_role_name(state), up_action_name, down_action_name, sdl3d_input_gamepad_count(state->input));
+    state->local_input_gamepad_count = sdl3d_input_gamepad_count(state->input);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile applied: profile=%s role=%s gamepads=%d",
+                profile_name != NULL ? profile_name : "<none>", network_role_name(state),
+                state->local_input_gamepad_count);
+    return true;
 }
 
 static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
@@ -488,69 +427,7 @@ static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtim
         sdl3d_properties_set_string(mutable_scene_state, "network_flow", network_flow != NULL ? network_flow : "none");
     }
 
-    if (SDL_strcmp(match_mode != NULL ? match_mode : "single", "local") == 0)
-    {
-        bind_local_play_controls(state);
-    }
-    else if (SDL_strcmp(network_role != NULL ? network_role : "none", "host") == 0)
-    {
-        bind_network_play_controls(state, "action.paddle.up", "action.paddle.down");
-        const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
-        const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
-        if (p2_up >= 0)
-        {
-            sdl3d_input_unbind_action(state->input, p2_up);
-        }
-        if (p2_down >= 0)
-        {
-            sdl3d_input_unbind_action(state->input, p2_down);
-        }
-    }
-    else if (SDL_strcmp(network_role != NULL ? network_role : "none", "client") == 0)
-    {
-        const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
-        const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
-        if (p1_up >= 0)
-        {
-            sdl3d_input_unbind_action(state->input, p1_up);
-        }
-        if (p1_down >= 0)
-        {
-            sdl3d_input_unbind_action(state->input, p1_down);
-        }
-
-        bind_network_play_controls(state, "action.paddle.local.up", "action.paddle.local.down");
-    }
-    else
-    {
-        const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
-        const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
-        if (p1_up < 0 || p1_down < 0)
-        {
-            return false;
-        }
-
-        sdl3d_input_unbind_action(state->input, p1_up);
-        sdl3d_input_unbind_action(state->input, p1_down);
-        sdl3d_input_bind_key(state->input, p1_up, SDL_SCANCODE_UP);
-        sdl3d_input_bind_key(state->input, p1_down, SDL_SCANCODE_DOWN);
-        sdl3d_input_bind_gamepad_button(state->input, p1_up, SDL_GAMEPAD_BUTTON_DPAD_UP);
-        sdl3d_input_bind_gamepad_button(state->input, p1_down, SDL_GAMEPAD_BUTTON_DPAD_DOWN);
-        sdl3d_input_bind_gamepad_axis(state->input, p1_up, SDL_GAMEPAD_AXIS_LEFTY, -1.0f);
-        sdl3d_input_bind_gamepad_axis(state->input, p1_down, SDL_GAMEPAD_AXIS_LEFTY, 1.0f);
-
-        const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
-        const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
-        if (p2_up >= 0)
-            sdl3d_input_unbind_action(state->input, p2_up);
-        if (p2_down >= 0)
-            sdl3d_input_unbind_action(state->input, p2_down);
-        state->local_input_gamepad_count = sdl3d_input_gamepad_count(state->input);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong single-player input configured: gamepads=%d",
-                    state->local_input_gamepad_count);
-    }
-
-    return true;
+    return apply_active_play_input_profile(state);
 }
 
 static void destroy_direct_connect_session_internal(pong_state *state, bool notify_peer)
@@ -1765,8 +1642,7 @@ static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong
 static void refresh_local_play_input(pong_state *state)
 {
     const char *active_scene = state != NULL && state->data != NULL ? sdl3d_game_data_active_scene(state->data) : NULL;
-    if (state == NULL || state->input == NULL || active_scene == NULL || SDL_strcmp(active_scene, "scene.play") != 0 ||
-        !is_local_match_mode(state))
+    if (state == NULL || state->input == NULL || active_scene == NULL || SDL_strcmp(active_scene, "scene.play") != 0)
     {
         return;
     }
@@ -1774,7 +1650,7 @@ static void refresh_local_play_input(pong_state *state)
     const int gamepad_count = sdl3d_input_gamepad_count(state->input);
     if (gamepad_count != state->local_input_gamepad_count)
     {
-        bind_local_play_controls(state);
+        (void)apply_active_play_input_profile(state);
     }
 }
 

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -364,7 +364,7 @@ static void destroy_host_session(pong_state *state)
 
 static bool apply_active_play_input_profile(pong_state *state)
 {
-    char error[192];
+    char error[256];
     const char *profile_name = NULL;
     if (state == NULL || state->data == NULL || state->input == NULL)
     {
@@ -1650,7 +1650,10 @@ static void refresh_local_play_input(pong_state *state)
     const int gamepad_count = sdl3d_input_gamepad_count(state->input);
     if (gamepad_count != state->local_input_gamepad_count)
     {
-        (void)apply_active_play_input_profile(state);
+        if (!apply_active_play_input_profile(state))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile hotplug refresh failed");
+        }
     }
 }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -286,6 +286,8 @@ Supported UI binding sources are `metric` (`fps`, `frame`, `paused`), `property`
 and `scene_state`.
 Supported UI conditions include `always`, `app.paused`, `camera.active`, `property.compare`,
 `property.bool`, `scene_state.compare`, `all`, `any`, and `not`.
+`scene_state.compare` may author `default` as a fallback scalar when the
+requested scene-state key has not been set yet.
 
 Scene UI can also declare data-driven menu presenters. A presenter turns a
 scene `menus[]` controller into a visible stack with authored alignment, colors,
@@ -513,13 +515,15 @@ action named in `unbind`, then applies each authored binding in order.
 }
 ```
 
-`active_if` uses the standard data condition language. `min_gamepads` and
-`max_gamepads` are optional gates evaluated against the live input manager.
-Gamepad bindings may omit `slot` or use `-1` to accept any connected gamepad;
-otherwise `slot` pins the binding to a local player index. Authors should keep
-profile predicates mutually exclusive or order them from most specific to most
-general, because `sdl3d_game_data_apply_active_input_profile()` applies the
-first matching profile.
+`active_if` uses the standard data condition language. If omitted, the profile
+matches any scene state and can act as an explicit fallback. `min_gamepads` and
+`max_gamepads` are optional gates evaluated against the live input manager; an
+omitted `max_gamepads` means no upper bound. Gamepad bindings may omit `slot` or
+use `-1` to accept any connected gamepad; otherwise `slot` pins the binding to a
+local player index. Authors should keep profile predicates mutually exclusive or
+order them from most specific to most general, because
+`sdl3d_game_data_apply_active_input_profile()` applies the first matching
+profile.
 
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -478,6 +478,49 @@ Gameplay input bindings may also use authored mouse axes and gamepad axes. The
 standard rebinding UI captures button-like inputs; analog axis rebinding needs
 game-specific policy for threshold, direction, and conflict behavior.
 
+Runtime input role/device policy can be authored under `input.profiles`.
+Profiles let a scene or adapter select a complete binding overlay without
+hard-coding device assignment in host C. Applying a profile first unbinds every
+action named in `unbind`, then applies each authored binding in order.
+
+```json
+{
+  "input": {
+    "profiles": [
+      {
+        "name": "profile.play.lan.client",
+        "active_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "lan" },
+            { "type": "scene_state.compare", "key": "network_role", "op": "==", "value": "client" }
+          ]
+        },
+        "min_gamepads": 0,
+        "max_gamepads": 4,
+        "unbind": [
+          "action.player1.up",
+          "action.player2.up"
+        ],
+        "bindings": [
+          { "action": "action.player2.up", "device": "keyboard", "key": "UP" },
+          { "action": "action.player2.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
+          { "action": "action.player2.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`active_if` uses the standard data condition language. `min_gamepads` and
+`max_gamepads` are optional gates evaluated against the live input manager.
+Gamepad bindings may omit `slot` or use `-1` to accept any connected gamepad;
+otherwise `slot` pins the binding to a local player index. Authors should keep
+profile predicates mutually exclusive or order them from most specific to most
+general, because `sdl3d_game_data_apply_active_input_profile()` applies the
+first matching profile.
+
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for
 screens that intentionally stage changes before committing them.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1606,6 +1606,41 @@ extern "C"
     bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
 
     /**
+     * @brief Apply one authored input profile to an input manager.
+     *
+     * Profiles are authored under `input.profiles`. Applying a profile first
+     * unbinds every action listed in its `unbind` array, then applies each
+     * authored keyboard, mouse, or gamepad binding in profile order.
+     *
+     * @param runtime Runtime containing authored profile data and action ids.
+     * @param input Input manager to mutate.
+     * @param profile_name Authored profile name.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the profile exists and all authored bindings were applied.
+     */
+    bool sdl3d_game_data_apply_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                             const char *profile_name, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Apply the first input profile whose authored conditions match.
+     *
+     * Profiles are evaluated in authored order. `active_if` uses the same
+     * condition language as scene UI/menu rules, and optional `min_gamepads`
+     * / `max_gamepads` gates use the current input manager device count.
+     *
+     * @param runtime Runtime containing authored profile data and action ids.
+     * @param input Input manager to mutate.
+     * @param out_profile_name Receives the applied runtime-owned profile name, if non-NULL.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when a matching profile was found and applied.
+     */
+    bool sdl3d_game_data_apply_active_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                                    const char **out_profile_name, char *error_buffer,
+                                                    int error_buffer_size);
+
+    /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.
      */
     int sdl3d_game_data_scene_shortcut_count(const sdl3d_game_data_runtime *runtime);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -324,6 +324,8 @@ static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const 
 static bool set_action_mouse_button_binding(sdl3d_game_data_runtime *runtime, const char *action, Uint8 button);
 static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
                                               SDL_GamepadButton button);
+static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
+                                const sdl3d_game_data_ui_metrics *metrics);
 
 static bool path_is_absolute(const char *path)
 {
@@ -5891,6 +5893,204 @@ static bool load_input(sdl3d_game_data_runtime *runtime, yyjson_val *root, char 
         }
     }
     return true;
+}
+
+static yyjson_val *find_input_profile_json(const sdl3d_game_data_runtime *runtime, const char *profile_name)
+{
+    yyjson_val *profiles = obj_get(obj_get(runtime_root(runtime), "input"), "profiles");
+    for (size_t i = 0; profile_name != NULL && yyjson_is_arr(profiles) && i < yyjson_arr_size(profiles); ++i)
+    {
+        yyjson_val *profile = yyjson_arr_get(profiles, i);
+        const char *name = json_string(profile, "name", NULL);
+        if (name != NULL && SDL_strcmp(name, profile_name) == 0)
+            return profile;
+    }
+    return NULL;
+}
+
+static bool input_profile_binding_to_spec(const sdl3d_game_data_runtime *runtime, yyjson_val *binding,
+                                          input_binding_spec *out_spec, char *error_buffer, int error_buffer_size)
+{
+    const char *action = json_string(binding, "action", NULL);
+    const char *device = json_string(binding, "device", "");
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    const float scale = json_float(binding, "scale", 1.0f);
+    if (binding == NULL || out_spec == NULL || action == NULL || action_id < 0)
+    {
+        set_errorf(error_buffer, error_buffer_size, "input profile binding references unknown action '%s'",
+                   action != NULL ? action : "<missing>");
+        return false;
+    }
+
+    SDL_zero(*out_spec);
+    out_spec->action = action;
+    out_spec->action_id = action_id;
+    out_spec->gamepad_index = -1;
+    out_spec->scale = scale;
+
+    if (SDL_strcmp(device, "keyboard") == 0)
+    {
+        const SDL_Scancode code = scancode_from_json(json_string(binding, "key", NULL));
+        if (code == SDL_SCANCODE_UNKNOWN)
+        {
+            set_error(error_buffer, error_buffer_size, "input profile keyboard binding has an invalid key");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_KEYBOARD;
+        out_spec->scancode = code;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+    if (SDL_strcmp(device, "mouse") == 0)
+    {
+        const char *axis = json_string(binding, "axis", NULL);
+        const char *button = json_string(binding, "button", NULL);
+        if (axis != NULL)
+        {
+            bool valid_axis = false;
+            out_spec->mouse_axis = mouse_axis_from_json(axis, &valid_axis);
+            if (!valid_axis)
+            {
+                set_error(error_buffer, error_buffer_size, "input profile mouse binding has an invalid axis");
+                return false;
+            }
+            out_spec->source = SDL3D_INPUT_MOUSE_AXIS;
+            return true;
+        }
+        out_spec->mouse_button = mouse_button_from_json(button);
+        if (out_spec->mouse_button == 0)
+        {
+            set_error(error_buffer, error_buffer_size, "input profile mouse binding has an invalid button");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_MOUSE_BUTTON;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+    if (SDL_strcmp(device, "gamepad") == 0)
+    {
+        const char *axis = json_string(binding, "axis", NULL);
+        const char *button = json_string(binding, "button", NULL);
+        out_spec->gamepad_index = json_int(binding, "slot", -1);
+        if (axis != NULL)
+        {
+            out_spec->gamepad_axis = gamepad_axis_from_json(axis);
+            if (out_spec->gamepad_axis == SDL_GAMEPAD_AXIS_INVALID)
+            {
+                set_error(error_buffer, error_buffer_size, "input profile gamepad binding has an invalid axis");
+                return false;
+            }
+            out_spec->source = SDL3D_INPUT_GAMEPAD_AXIS;
+            return true;
+        }
+        out_spec->gamepad_button = gamepad_button_from_json(button);
+        if (out_spec->gamepad_button == SDL_GAMEPAD_BUTTON_INVALID)
+        {
+            set_error(error_buffer, error_buffer_size, "input profile gamepad binding has an invalid button");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_GAMEPAD_BUTTON;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+
+    set_errorf(error_buffer, error_buffer_size, "input profile binding uses unsupported device '%s'",
+               device != NULL ? device : "<missing>");
+    return false;
+}
+
+static bool apply_input_profile_json(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input, yyjson_val *profile,
+                                     char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *unbind = obj_get(profile, "unbind");
+    yyjson_val *bindings = obj_get(profile, "bindings");
+    if (runtime == NULL || input == NULL || profile == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "input profile apply requires runtime, input, and profile");
+        return false;
+    }
+
+    for (size_t i = 0; yyjson_is_arr(unbind) && i < yyjson_arr_size(unbind); ++i)
+    {
+        const char *action = yyjson_get_str(yyjson_arr_get(unbind, i));
+        const int action_id = sdl3d_game_data_find_action(runtime, action);
+        if (action_id < 0)
+        {
+            set_errorf(error_buffer, error_buffer_size, "input profile unbind references unknown action '%s'",
+                       action != NULL ? action : "<invalid>");
+            return false;
+        }
+        sdl3d_input_unbind_action(input, action_id);
+    }
+
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        input_binding_spec spec;
+        if (!input_profile_binding_to_spec(runtime, yyjson_arr_get(bindings, i), &spec, error_buffer,
+                                           error_buffer_size))
+        {
+            return false;
+        }
+        bind_input_spec(input, &spec);
+    }
+    return true;
+}
+
+static bool input_profile_matches(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                  yyjson_val *profile)
+{
+    const int gamepads = sdl3d_input_gamepad_count(input);
+    yyjson_val *min_gamepads = obj_get(profile, "min_gamepads");
+    yyjson_val *max_gamepads = obj_get(profile, "max_gamepads");
+    if (yyjson_is_num(min_gamepads) && gamepads < (int)yyjson_get_sint(min_gamepads))
+        return false;
+    if (yyjson_is_num(max_gamepads) && gamepads > (int)yyjson_get_sint(max_gamepads))
+        return false;
+    return eval_data_condition(runtime, obj_get(profile, "active_if"), NULL);
+}
+
+bool sdl3d_game_data_apply_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                         const char *profile_name, char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *profile = find_input_profile_json(runtime, profile_name);
+    if (profile == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "input profile '%s' was not found",
+                   profile_name != NULL ? profile_name : "<null>");
+        return false;
+    }
+    return apply_input_profile_json(runtime, input, profile, error_buffer, error_buffer_size);
+}
+
+bool sdl3d_game_data_apply_active_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                                const char **out_profile_name, char *error_buffer,
+                                                int error_buffer_size)
+{
+    if (out_profile_name != NULL)
+        *out_profile_name = NULL;
+    if (runtime == NULL || input == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "active input profile apply requires runtime and input");
+        return false;
+    }
+
+    yyjson_val *profiles = obj_get(obj_get(runtime_root(runtime), "input"), "profiles");
+    for (size_t i = 0; yyjson_is_arr(profiles) && i < yyjson_arr_size(profiles); ++i)
+    {
+        yyjson_val *profile = yyjson_arr_get(profiles, i);
+        if (input_profile_matches(runtime, input, profile))
+        {
+            const char *name = json_string(profile, "name", NULL);
+            if (!apply_input_profile_json(runtime, input, profile, error_buffer, error_buffer_size))
+                return false;
+            if (out_profile_name != NULL)
+                *out_profile_name = name;
+            return true;
+        }
+    }
+
+    set_error(error_buffer, error_buffer_size, "no authored input profile matched the current state");
+    return false;
 }
 
 static bool load_timers(sdl3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -113,6 +113,55 @@ static bool is_virtual_storage_path(const char *value)
     return value != NULL && (SDL_strncmp(value, "user://", 7) == 0 || SDL_strncmp(value, "cache://", 8) == 0);
 }
 
+static bool validation_key_name_valid(const char *name)
+{
+    if (name == NULL || name[0] == '\0')
+        return false;
+    if (SDL_strcmp(name, "UP") == 0 || SDL_strcmp(name, "DOWN") == 0 || SDL_strcmp(name, "LEFT") == 0 ||
+        SDL_strcmp(name, "RIGHT") == 0 || SDL_strcmp(name, "RETURN") == 0 || SDL_strcmp(name, "ESCAPE") == 0 ||
+        SDL_strcmp(name, "BACKSPACE") == 0 || SDL_strcmp(name, "DELETE") == 0)
+    {
+        return true;
+    }
+    if (SDL_strlen(name) == 1)
+        return SDL_GetScancodeFromKey(SDL_GetKeyFromName(name), NULL) != SDL_SCANCODE_UNKNOWN;
+    return SDL_GetScancodeFromName(name) != SDL_SCANCODE_UNKNOWN;
+}
+
+static bool validation_mouse_button_name_valid(const char *name)
+{
+    return name != NULL &&
+           (SDL_strcmp(name, "LEFT") == 0 || SDL_strcmp(name, "MIDDLE") == 0 || SDL_strcmp(name, "RIGHT") == 0 ||
+            SDL_strcmp(name, "X1") == 0 || SDL_strcmp(name, "X2") == 0);
+}
+
+static bool validation_mouse_axis_name_valid(const char *name)
+{
+    return name != NULL && (SDL_strcmp(name, "x") == 0 || SDL_strcmp(name, "y") == 0 ||
+                            SDL_strcmp(name, "wheel") == 0 || SDL_strcmp(name, "wheel_x") == 0);
+}
+
+static bool validation_gamepad_axis_name_valid(const char *name)
+{
+    return name != NULL && (SDL_strcmp(name, "left_x") == 0 || SDL_strcmp(name, "left_y") == 0 ||
+                            SDL_strcmp(name, "right_x") == 0 || SDL_strcmp(name, "right_y") == 0 ||
+                            SDL_strcmp(name, "left_trigger") == 0 || SDL_strcmp(name, "right_trigger") == 0);
+}
+
+static bool validation_gamepad_button_name_valid(const char *name)
+{
+    static const char *const valid[] = {
+        "START",       "BACK",          "SOUTH",          "NORTH",        "EAST",          "WEST",         "LEFT_STICK",
+        "RIGHT_STICK", "LEFT_SHOULDER", "RIGHT_SHOULDER", "DPAD_UP",      "DPAD_DOWN",     "DPAD_LEFT",    "DPAD_RIGHT",
+        "GUIDE",       "MISC1",         "RIGHT_PADDLE1",  "LEFT_PADDLE1", "RIGHT_PADDLE2", "LEFT_PADDLE2", "TOUCHPAD"};
+    for (size_t i = 0; name != NULL && i < SDL_arraysize(valid); ++i)
+    {
+        if (SDL_strcmp(name, valid[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
 static void set_first_error(validation_context *ctx, const char *json_path, const char *message)
 {
     if (ctx->error_buffer == NULL || ctx->error_buffer_size <= 0 || ctx->error_buffer[0] != '\0')
@@ -1422,6 +1471,131 @@ static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
         }
     }
     return true;
+}
+
+static bool validate_input_profile_binding(validation_context *ctx, yyjson_val *binding, const char *path,
+                                           validation_names *names)
+{
+    if (!yyjson_is_obj(binding))
+        return validation_error(ctx, path, "input profile bindings must be objects");
+    const char *action = json_string(binding, "action");
+    const char *device = json_string(binding, "device");
+    if (!require_ref(ctx, &names->actions, "input action", action, path))
+        return false;
+
+    if (SDL_strcmp(device != NULL ? device : "", "keyboard") == 0)
+    {
+        const char *key = json_string(binding, "key");
+        if (!validation_key_name_valid(key))
+            return validation_error(ctx, path, "keyboard input profile binding requires a valid key");
+    }
+    else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
+    {
+        const char *axis = json_string(binding, "axis");
+        const char *button = json_string(binding, "button");
+        if (axis == NULL && button == NULL)
+            return validation_error(ctx, path, "gamepad input profile binding requires an axis or button");
+        if (axis != NULL && !validation_gamepad_axis_name_valid(axis))
+            return validation_error(ctx, path, "gamepad input profile binding requires a valid axis");
+        if (button != NULL && !validation_gamepad_button_name_valid(button))
+            return validation_error(ctx, path, "gamepad input profile binding requires a valid button");
+        yyjson_val *slot = obj_get(binding, "slot");
+        if (slot != NULL &&
+            (!yyjson_is_num(slot) || yyjson_get_sint(slot) < -1 || yyjson_get_sint(slot) >= SDL3D_INPUT_MAX_GAMEPADS))
+        {
+            return validation_error(ctx, path, "gamepad input profile binding slot must be -1 or a valid slot index");
+        }
+    }
+    else if (SDL_strcmp(device != NULL ? device : "", "mouse") == 0)
+    {
+        const char *axis = json_string(binding, "axis");
+        const char *button = json_string(binding, "button");
+        if (axis == NULL && button == NULL)
+            return validation_error(ctx, path, "mouse input profile binding requires an axis or button");
+        if (axis != NULL && !validation_mouse_axis_name_valid(axis))
+            return validation_error(ctx, path, "mouse input profile binding requires a valid axis");
+        if (button != NULL && !validation_mouse_button_name_valid(button))
+            return validation_error(ctx, path, "mouse input profile binding requires a valid button");
+    }
+    else
+    {
+        return validation_error(ctx, path, "unsupported input profile binding device '%s'",
+                                device != NULL ? device : "<missing>");
+    }
+    return true;
+}
+
+static bool validate_input_profiles(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *profiles = obj_get(obj_get(root, "input"), "profiles");
+    if (profiles == NULL)
+        return true;
+    if (!yyjson_is_arr(profiles))
+        return validation_error(ctx, "$.input.profiles", "input profiles must be an array");
+
+    name_table profile_names = {0};
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(profiles); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        yyjson_val *profile = yyjson_arr_get(profiles, i);
+        format_path(path, sizeof(path), "$.input.profiles[%zu]", i);
+        if (!yyjson_is_obj(profile))
+        {
+            ok = validation_error(ctx, path, "input profiles must be objects");
+            break;
+        }
+        ok = require_unique_name(ctx, &profile_names, "input profile", json_string(profile, "name"), path);
+
+        yyjson_val *min_gamepads = obj_get(profile, "min_gamepads");
+        yyjson_val *max_gamepads = obj_get(profile, "max_gamepads");
+        if (ok && min_gamepads != NULL &&
+            (!yyjson_is_num(min_gamepads) || yyjson_get_sint(min_gamepads) < 0 ||
+             yyjson_get_sint(min_gamepads) > SDL3D_INPUT_MAX_GAMEPADS))
+        {
+            ok = validation_error(ctx, path, "input profile min_gamepads must be a valid gamepad count");
+        }
+        if (ok && max_gamepads != NULL &&
+            (!yyjson_is_num(max_gamepads) || yyjson_get_sint(max_gamepads) < 0 ||
+             yyjson_get_sint(max_gamepads) > SDL3D_INPUT_MAX_GAMEPADS))
+        {
+            ok = validation_error(ctx, path, "input profile max_gamepads must be a valid gamepad count");
+        }
+        if (ok && yyjson_is_num(min_gamepads) && yyjson_is_num(max_gamepads) &&
+            yyjson_get_sint(min_gamepads) > yyjson_get_sint(max_gamepads))
+        {
+            ok = validation_error(ctx, path, "input profile min_gamepads cannot exceed max_gamepads");
+        }
+        if (ok && obj_get(profile, "active_if") != NULL)
+        {
+            char condition_path[PATH_BUFFER_SIZE];
+            format_path(condition_path, sizeof(condition_path), "%s.active_if", path);
+            ok = validate_data_condition(ctx, obj_get(profile, "active_if"), condition_path, names);
+        }
+
+        yyjson_val *unbind = obj_get(profile, "unbind");
+        if (ok && unbind != NULL && !yyjson_is_arr(unbind))
+            ok = validation_error(ctx, path, "input profile unbind must be an array");
+        for (size_t u = 0; ok && yyjson_is_arr(unbind) && u < yyjson_arr_size(unbind); ++u)
+        {
+            char item_path[PATH_BUFFER_SIZE];
+            format_path(item_path, sizeof(item_path), "%s.unbind[%zu]", path, u);
+            ok =
+                require_ref(ctx, &names->actions, "input action", yyjson_get_str(yyjson_arr_get(unbind, u)), item_path);
+        }
+
+        yyjson_val *bindings = obj_get(profile, "bindings");
+        if (ok && bindings != NULL && !yyjson_is_arr(bindings))
+            ok = validation_error(ctx, path, "input profile bindings must be an array");
+        for (size_t b = 0; ok && yyjson_is_arr(bindings) && b < yyjson_arr_size(bindings); ++b)
+        {
+            char binding_path[PATH_BUFFER_SIZE];
+            format_path(binding_path, sizeof(binding_path), "%s.bindings[%zu]", path, b);
+            ok = validate_input_profile_binding(ctx, yyjson_arr_get(bindings, b), binding_path, names);
+        }
+    }
+    name_table_destroy(&profile_names);
+    return ok;
 }
 
 static bool validate_components(validation_context *ctx, yyjson_val *root, validation_names *names)
@@ -3129,7 +3303,8 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
-           validate_input_bindings(ctx, root) && validate_components(ctx, root, names) &&
+           validate_input_bindings(ctx, root) && validate_input_profiles(ctx, root, names) &&
+           validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2180,6 +2180,14 @@ TEST(GameDataRuntime, AppliesAuthoredPongPlayInputProfiles)
     ASSERT_GE(p1_up, 0);
     ASSERT_GE(p2_up, 0);
 
+    ASSERT_TRUE(sdl3d_game_data_apply_input_profile(runtime, input, "profile.pong.play.single", error, sizeof(error)))
+        << error;
+    error[0] = '\0';
+    EXPECT_FALSE(
+        sdl3d_game_data_apply_input_profile(runtime, input, "profile.pong.play.missing", error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("profile.pong.play.missing"), std::string::npos);
+    error[0] = '\0';
+
     const char *profile_name = nullptr;
     ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
         << error;
@@ -2233,6 +2241,79 @@ TEST(GameDataRuntime, AppliesAuthoredPongPlayInputProfiles)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AppliesFallbackAndMouseInputProfiles)
+{
+    const std::filesystem::path dir = unique_test_dir("input_profile_mouse");
+    write_text(dir / "mouse_profile.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Mouse Profile", "id": "test.mouse_profile", "version": "0.1.0" },
+  "world": { "name": "world.mouse_profile", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.pointer.primary" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.requires_gamepad",
+        "min_gamepads": 1,
+        "bindings": [
+          { "action": "action.pointer.primary", "device": "keyboard", "key": "SPACE" }
+        ]
+      },
+      {
+        "name": "profile.fallback.mouse",
+        "unbind": [ "action.pointer.primary" ],
+        "bindings": [
+          { "action": "action.pointer.primary", "device": "mouse", "button": "LEFT" }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "mouse_profile.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int action = sdl3d_game_data_find_action(runtime, "action.pointer.primary");
+    ASSERT_GE(action, 0);
+
+    const char *profile_name = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(profile_name, "profile.fallback.mouse");
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 1);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, action), 1.0f);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    sdl3d_input_process_event(input, &mouse);
+    sdl3d_input_update(input, 2);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, action), 0.0f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2164,6 +2164,77 @@ TEST(GameDataRuntime, DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, AppliesAuthoredPongPlayInputProfiles)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int p1_up = sdl3d_game_data_find_action(runtime, "action.paddle.up");
+    const int p2_up = sdl3d_game_data_find_action(runtime, "action.paddle.local.up");
+    ASSERT_GE(p1_up, 0);
+    ASSERT_GE(p2_up, 0);
+
+    const char *profile_name = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    ASSERT_STREQ(profile_name, "profile.pong.play.single");
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 1.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 0.0f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "match_mode", "lan");
+    sdl3d_properties_set_string(scene_state, "network_role", "client");
+    sdl3d_properties_set_string(scene_state, "network_flow", "direct");
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    ASSERT_STREQ(profile_name, "profile.pong.play.lan.client");
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 1.0f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+
+    sdl3d_properties_set_string(scene_state, "match_mode", "local");
+    sdl3d_properties_set_string(scene_state, "network_role", "none");
+    sdl3d_properties_set_string(scene_state, "network_flow", "none");
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    ASSERT_STREQ(profile_name, "profile.pong.play.local.keyboard_only");
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 1.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 0.0f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)
 {
     sdl3d_game_session *session = nullptr;
@@ -4240,6 +4311,44 @@ TEST(GameDataRuntime, ValidatesPongDataWithoutDiagnostics)
     EXPECT_TRUE(sdl3d_game_data_validate_file(SDL3D_PONG_DATA_PATH, &options, error, sizeof(error))) << error;
     EXPECT_TRUE(capture.diagnostics.empty());
     EXPECT_EQ(error[0], '\0');
+}
+
+TEST(GameDataRuntime, RejectsInvalidInputProfiles)
+{
+    const std::filesystem::path dir = unique_test_dir("input_profiles");
+    write_text(dir / "bad_input_profile.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Input Profile", "id": "test.bad_input_profile", "version": "0.1.0" },
+  "world": { "name": "world.bad_input_profile", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.up" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.bad",
+        "min_gamepads": 2,
+        "max_gamepads": 1,
+        "bindings": [
+          { "action": "action.up", "device": "gamepad", "button": "DPAD_UP", "slot": -2 }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_input_profile.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.input.profiles[0]"), std::string::npos);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, StandardOptionsAdoptionFixtureLoadsReusablePackage)


### PR DESCRIPTION
## Summary
- add reusable `input.profiles` support for applying authored input binding overlays at runtime
- move Pong play input role/device binding policy out of host-side C and into `pong.game.json` profiles
- validate authored input profiles and document the JSON schema shape
- add tests for Pong profile selection/application and invalid profile validation

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `ctest --test-dir build/debug --output-on-failure -R "GameDataRuntime\.|GameDataJson\."`
- `ctest --test-dir build/debug --output-on-failure -L unit`

Closes first slice of #186.