### PR TITLE
Add input device assignment policies

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -748,6 +748,26 @@
         ]
       }
     ],
+    "device_assignment_sets": [
+      {
+        "name": "input.assignment.keyboard.vertical_arrows",
+        "device": "keyboard",
+        "bindings": [
+          { "semantic": "up", "key": "UP" },
+          { "semantic": "down", "key": "DOWN" }
+        ]
+      },
+      {
+        "name": "input.assignment.gamepad.vertical_dpad_left_stick",
+        "device": "gamepad",
+        "bindings": [
+          { "semantic": "up", "button": "DPAD_UP" },
+          { "semantic": "down", "button": "DPAD_DOWN" },
+          { "semantic": "up", "axis": "left_y", "scale": -1.0 },
+          { "semantic": "down", "axis": "left_y", "scale": 1.0 }
+        ]
+      }
+    ],
     "profiles": [
       {
         "name": "profile.pong.play.lan.host",
@@ -764,13 +784,16 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
-          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
-          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
-          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
-          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 0,
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          }
         ]
       },
       {
@@ -788,13 +811,16 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.local.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.local.down", "device": "keyboard", "key": "DOWN" },
-          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
-          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.local.up", "down": "action.paddle.local.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 0,
+            "actions": { "up": "action.paddle.local.up", "down": "action.paddle.local.down" }
+          }
         ]
       },
       {
@@ -808,9 +834,11 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          }
         ]
       },
       {
@@ -824,13 +852,16 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
-          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
-          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 0,
+            "actions": { "up": "action.paddle.local.up", "down": "action.paddle.local.down" }
+          }
         ]
       },
       {
@@ -844,17 +875,21 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
-          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
-          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 0 },
-          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 },
-          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 0 },
-          { "action": "action.paddle.local.up", "device": "gamepad", "button": "DPAD_UP", "slot": 1 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "button": "DPAD_DOWN", "slot": 1 },
-          { "action": "action.paddle.local.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 1 },
-          { "action": "action.paddle.local.down", "device": "gamepad", "axis": "left_y", "scale": 1.0, "slot": 1 }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 0,
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 1,
+            "actions": { "up": "action.paddle.local.up", "down": "action.paddle.local.down" }
+          }
         ]
       },
       {
@@ -872,13 +907,15 @@
           "action.paddle.local.up",
           "action.paddle.local.down"
         ],
-        "bindings": [
-          { "action": "action.paddle.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.paddle.down", "device": "keyboard", "key": "DOWN" },
-          { "action": "action.paddle.up", "device": "gamepad", "button": "DPAD_UP" },
-          { "action": "action.paddle.down", "device": "gamepad", "button": "DPAD_DOWN" },
-          { "action": "action.paddle.up", "device": "gamepad", "axis": "left_y", "scale": -1.0 },
-          { "action": "action.paddle.down", "device": "gamepad", "axis": "left_y", "scale": 1.0 }
+        "assignments": [
+          {
+            "set": "input.assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          },
+          {
+            "set": "input.assignment.gamepad.vertical_dpad_left_stick",
+            "actions": { "up": "action.paddle.up", "down": "action.paddle.down" }
+          }
         ]
       }
     ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -483,8 +483,10 @@ game-specific policy for threshold, direction, and conflict behavior.
 Runtime input role/device policy can be authored under `input.profiles`.
 Profiles let a scene or adapter select a complete binding overlay without
 hard-coding device assignment in host C. Applying a profile first unbinds every
-action named in `unbind`, then applies each authored binding and reusable device
-assignment in order.
+action named in `unbind`, then applies either raw authored bindings or reusable
+device assignments. A single profile may use `bindings` or `assignments`, but
+not both; keeping those styles separate avoids ambiguous ordering and keeps
+profiles easy to audit.
 
 ```json
 {
@@ -558,6 +560,11 @@ maps those semantics to concrete game actions and may pin gamepad bindings to a
 slot. This supports common policies like keyboard-as-player-1,
 first-gamepad-as-player-2, first-two-gamepads-as-player-1/player-2, and
 LAN-client controls without duplicating key/button/axis rows in every profile.
+Every key in an assignment `actions` map must match a semantic declared by the
+referenced set, and every semantic in the set must be mapped to an action.
+`slot` is valid only when the referenced assignment set has `"device": "gamepad"`;
+keyboard and mouse sets are global device policies and reject slot-specific
+assignments.
 
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -483,11 +483,32 @@ game-specific policy for threshold, direction, and conflict behavior.
 Runtime input role/device policy can be authored under `input.profiles`.
 Profiles let a scene or adapter select a complete binding overlay without
 hard-coding device assignment in host C. Applying a profile first unbinds every
-action named in `unbind`, then applies each authored binding in order.
+action named in `unbind`, then applies each authored binding and reusable device
+assignment in order.
 
 ```json
 {
   "input": {
+    "device_assignment_sets": [
+      {
+        "name": "assignment.keyboard.vertical_arrows",
+        "device": "keyboard",
+        "bindings": [
+          { "semantic": "up", "key": "UP" },
+          { "semantic": "down", "key": "DOWN" }
+        ]
+      },
+      {
+        "name": "assignment.gamepad.vertical_dpad_left_stick",
+        "device": "gamepad",
+        "bindings": [
+          { "semantic": "up", "button": "DPAD_UP" },
+          { "semantic": "down", "button": "DPAD_DOWN" },
+          { "semantic": "up", "axis": "left_y", "scale": -1.0 },
+          { "semantic": "down", "axis": "left_y", "scale": 1.0 }
+        ]
+      }
+    ],
     "profiles": [
       {
         "name": "profile.play.lan.client",
@@ -504,10 +525,16 @@ action named in `unbind`, then applies each authored binding in order.
           "action.player1.up",
           "action.player2.up"
         ],
-        "bindings": [
-          { "action": "action.player2.up", "device": "keyboard", "key": "UP" },
-          { "action": "action.player2.up", "device": "gamepad", "button": "DPAD_UP", "slot": 0 },
-          { "action": "action.player2.up", "device": "gamepad", "axis": "left_y", "scale": -1.0, "slot": 0 }
+        "assignments": [
+          {
+            "set": "assignment.keyboard.vertical_arrows",
+            "actions": { "up": "action.player2.up", "down": "action.player2.down" }
+          },
+          {
+            "set": "assignment.gamepad.vertical_dpad_left_stick",
+            "slot": 0,
+            "actions": { "up": "action.player2.up", "down": "action.player2.down" }
+          }
         ]
       }
     ]
@@ -524,6 +551,13 @@ local player index. Authors should keep profile predicates mutually exclusive or
 order them from most specific to most general, because
 `sdl3d_game_data_apply_active_input_profile()` applies the first matching
 profile.
+
+Device assignment sets define reusable device-specific bindings once, using
+semantic names such as `up`, `down`, `accept`, or `fire`. A profile assignment
+maps those semantics to concrete game actions and may pin gamepad bindings to a
+slot. This supports common policies like keyboard-as-player-1,
+first-gamepad-as-player-2, first-two-gamepads-as-player-1/player-2, and
+LAN-client controls without duplicating key/button/axis rows in every profile.
 
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1610,7 +1610,8 @@ extern "C"
      *
      * Profiles are authored under `input.profiles`. Applying a profile first
      * unbinds every action listed in its `unbind` array, then applies each
-     * authored keyboard, mouse, or gamepad binding in profile order.
+     * authored keyboard, mouse, or gamepad binding and each reusable
+     * `input.device_assignment_sets` assignment in profile order.
      *
      * @param runtime Runtime containing authored profile data and action ids.
      * @param input Input manager to mutate.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5908,6 +5908,19 @@ static yyjson_val *find_input_profile_json(const sdl3d_game_data_runtime *runtim
     return NULL;
 }
 
+static yyjson_val *find_input_assignment_set_json(const sdl3d_game_data_runtime *runtime, const char *set_name)
+{
+    yyjson_val *sets = obj_get(obj_get(runtime_root(runtime), "input"), "device_assignment_sets");
+    for (size_t i = 0; set_name != NULL && yyjson_is_arr(sets) && i < yyjson_arr_size(sets); ++i)
+    {
+        yyjson_val *set = yyjson_arr_get(sets, i);
+        const char *name = json_string(set, "name", NULL);
+        if (name != NULL && SDL_strcmp(name, set_name) == 0)
+            return set;
+    }
+    return NULL;
+}
+
 static bool input_profile_binding_to_spec(const sdl3d_game_data_runtime *runtime, yyjson_val *binding,
                                           input_binding_spec *out_spec, char *error_buffer, int error_buffer_size)
 {
@@ -5999,11 +6012,148 @@ static bool input_profile_binding_to_spec(const sdl3d_game_data_runtime *runtime
     return false;
 }
 
+static bool input_assignment_binding_to_spec(const sdl3d_game_data_runtime *runtime, const char *device,
+                                             yyjson_val *binding, const char *action, int gamepad_slot,
+                                             input_binding_spec *out_spec, char *error_buffer, int error_buffer_size)
+{
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    const float scale = json_float(binding, "scale", 1.0f);
+    if (runtime == NULL || binding == NULL || out_spec == NULL || action == NULL || action_id < 0)
+    {
+        set_errorf(error_buffer, error_buffer_size, "input assignment references unknown action '%s'",
+                   action != NULL ? action : "<missing>");
+        return false;
+    }
+
+    SDL_zero(*out_spec);
+    out_spec->action = action;
+    out_spec->action_id = action_id;
+    out_spec->gamepad_index = -1;
+    out_spec->scale = scale;
+
+    if (SDL_strcmp(device != NULL ? device : "", "keyboard") == 0)
+    {
+        const SDL_Scancode code = scancode_from_json(json_string(binding, "key", NULL));
+        if (code == SDL_SCANCODE_UNKNOWN)
+        {
+            set_error(error_buffer, error_buffer_size, "input assignment keyboard binding has an invalid key");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_KEYBOARD;
+        out_spec->scancode = code;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+
+    if (SDL_strcmp(device != NULL ? device : "", "mouse") == 0)
+    {
+        const char *axis = json_string(binding, "axis", NULL);
+        const char *button = json_string(binding, "button", NULL);
+        if (axis != NULL)
+        {
+            bool valid_axis = false;
+            out_spec->mouse_axis = mouse_axis_from_json(axis, &valid_axis);
+            if (!valid_axis)
+            {
+                set_error(error_buffer, error_buffer_size, "input assignment mouse binding has an invalid axis");
+                return false;
+            }
+            out_spec->source = SDL3D_INPUT_MOUSE_AXIS;
+            return true;
+        }
+        out_spec->mouse_button = mouse_button_from_json(button);
+        if (out_spec->mouse_button == 0)
+        {
+            set_error(error_buffer, error_buffer_size, "input assignment mouse binding has an invalid button");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_MOUSE_BUTTON;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+
+    if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
+    {
+        const char *axis = json_string(binding, "axis", NULL);
+        const char *button = json_string(binding, "button", NULL);
+        out_spec->gamepad_index = gamepad_slot;
+        if (axis != NULL)
+        {
+            out_spec->gamepad_axis = gamepad_axis_from_json(axis);
+            if (out_spec->gamepad_axis == SDL_GAMEPAD_AXIS_INVALID)
+            {
+                set_error(error_buffer, error_buffer_size, "input assignment gamepad binding has an invalid axis");
+                return false;
+            }
+            out_spec->source = SDL3D_INPUT_GAMEPAD_AXIS;
+            return true;
+        }
+        out_spec->gamepad_button = gamepad_button_from_json(button);
+        if (out_spec->gamepad_button == SDL_GAMEPAD_BUTTON_INVALID)
+        {
+            set_error(error_buffer, error_buffer_size, "input assignment gamepad binding has an invalid button");
+            return false;
+        }
+        out_spec->source = SDL3D_INPUT_GAMEPAD_BUTTON;
+        out_spec->scale = 1.0f;
+        return true;
+    }
+
+    set_errorf(error_buffer, error_buffer_size, "input assignment set uses unsupported device '%s'",
+               device != NULL ? device : "<missing>");
+    return false;
+}
+
+static bool apply_input_assignment_json(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
+                                        yyjson_val *assignment, char *error_buffer, int error_buffer_size)
+{
+    const char *set_name = json_string(assignment, "set", NULL);
+    yyjson_val *set = find_input_assignment_set_json(runtime, set_name);
+    yyjson_val *actions = obj_get(assignment, "actions");
+    yyjson_val *bindings = obj_get(set, "bindings");
+    const char *device = json_string(set, "device", NULL);
+    const int gamepad_slot = json_int(assignment, "slot", -1);
+    if (runtime == NULL || input == NULL || assignment == NULL || set == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "input assignment set '%s' was not found",
+                   set_name != NULL ? set_name : "<missing>");
+        return false;
+    }
+    if (!yyjson_is_obj(actions))
+    {
+        set_errorf(error_buffer, error_buffer_size, "input assignment '%s' requires an actions object",
+                   set_name != NULL ? set_name : "<missing>");
+        return false;
+    }
+
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        const char *semantic = json_string(binding, "semantic", NULL);
+        const char *action = semantic != NULL ? json_string(actions, semantic, NULL) : NULL;
+        input_binding_spec spec;
+        if (semantic == NULL || action == NULL)
+        {
+            set_errorf(error_buffer, error_buffer_size, "input assignment '%s' is missing action for semantic '%s'",
+                       set_name != NULL ? set_name : "<missing>", semantic != NULL ? semantic : "<missing>");
+            return false;
+        }
+        if (!input_assignment_binding_to_spec(runtime, device, binding, action, gamepad_slot, &spec, error_buffer,
+                                              error_buffer_size))
+        {
+            return false;
+        }
+        bind_input_spec(input, &spec);
+    }
+    return true;
+}
+
 static bool apply_input_profile_json(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input, yyjson_val *profile,
                                      char *error_buffer, int error_buffer_size)
 {
     yyjson_val *unbind = obj_get(profile, "unbind");
     yyjson_val *bindings = obj_get(profile, "bindings");
+    yyjson_val *assignments = obj_get(profile, "assignments");
     if (runtime == NULL || input == NULL || profile == NULL)
     {
         set_error(error_buffer, error_buffer_size, "input profile apply requires runtime, input, and profile");
@@ -6032,6 +6182,15 @@ static bool apply_input_profile_json(sdl3d_game_data_runtime *runtime, sdl3d_inp
             return false;
         }
         bind_input_spec(input, &spec);
+    }
+
+    for (size_t i = 0; yyjson_is_arr(assignments) && i < yyjson_arr_size(assignments); ++i)
+    {
+        if (!apply_input_assignment_json(runtime, input, yyjson_arr_get(assignments, i), error_buffer,
+                                         error_buffer_size))
+        {
+            return false;
+        }
     }
     return true;
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5908,19 +5908,6 @@ static yyjson_val *find_input_profile_json(const sdl3d_game_data_runtime *runtim
     return NULL;
 }
 
-static yyjson_val *find_input_assignment_set_json(const sdl3d_game_data_runtime *runtime, const char *set_name)
-{
-    yyjson_val *sets = obj_get(obj_get(runtime_root(runtime), "input"), "device_assignment_sets");
-    for (size_t i = 0; set_name != NULL && yyjson_is_arr(sets) && i < yyjson_arr_size(sets); ++i)
-    {
-        yyjson_val *set = yyjson_arr_get(sets, i);
-        const char *name = json_string(set, "name", NULL);
-        if (name != NULL && SDL_strcmp(name, set_name) == 0)
-            return set;
-    }
-    return NULL;
-}
-
 static bool input_profile_binding_to_spec(const sdl3d_game_data_runtime *runtime, yyjson_val *binding,
                                           input_binding_spec *out_spec, char *error_buffer, int error_buffer_size)
 {
@@ -6108,7 +6095,7 @@ static bool apply_input_assignment_json(sdl3d_game_data_runtime *runtime, sdl3d_
                                         yyjson_val *assignment, char *error_buffer, int error_buffer_size)
 {
     const char *set_name = json_string(assignment, "set", NULL);
-    yyjson_val *set = find_input_assignment_set_json(runtime, set_name);
+    yyjson_val *set = sdl3d_game_data_find_input_assignment_set_json(runtime_root(runtime), set_name);
     yyjson_val *actions = obj_get(assignment, "actions");
     yyjson_val *bindings = obj_get(set, "bindings");
     const char *device = json_string(set, "device", NULL);
@@ -6157,6 +6144,11 @@ static bool apply_input_profile_json(sdl3d_game_data_runtime *runtime, sdl3d_inp
     if (runtime == NULL || input == NULL || profile == NULL)
     {
         set_error(error_buffer, error_buffer_size, "input profile apply requires runtime, input, and profile");
+        return false;
+    }
+    if (bindings != NULL && assignments != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "input profile cannot mix bindings and assignments");
         return false;
     }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1559,7 +1559,7 @@ static bool validate_input_profile_binding(validation_context *ctx, yyjson_val *
     return true;
 }
 
-static yyjson_val *find_input_assignment_set_json(yyjson_val *root, const char *set_name)
+yyjson_val *sdl3d_game_data_find_input_assignment_set_json(yyjson_val *root, const char *set_name)
 {
     yyjson_val *sets = obj_get(obj_get(root, "input"), "device_assignment_sets");
     for (size_t i = 0; set_name != NULL && yyjson_is_arr(sets) && i < yyjson_arr_size(sets); ++i)
@@ -1570,6 +1570,19 @@ static yyjson_val *find_input_assignment_set_json(yyjson_val *root, const char *
             return set;
     }
     return NULL;
+}
+
+static bool input_assignment_set_has_semantic(yyjson_val *set, const char *semantic)
+{
+    yyjson_val *bindings = obj_get(set, "bindings");
+    for (size_t i = 0; semantic != NULL && yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        const char *binding_semantic = json_string(binding, "semantic");
+        if (binding_semantic != NULL && SDL_strcmp(binding_semantic, semantic) == 0)
+            return true;
+    }
+    return false;
 }
 
 static bool validate_input_assignment_set_binding(validation_context *ctx, yyjson_val *binding, const char *device,
@@ -1660,7 +1673,13 @@ static bool validate_input_profile_assignment(validation_context *ctx, yyjson_va
     if (!require_ref(ctx, &names->input_assignment_sets, "input device assignment set", set_name, path))
         return false;
 
+    yyjson_val *set = sdl3d_game_data_find_input_assignment_set_json(root, set_name);
+    const char *device = json_string(set, "device");
     yyjson_val *slot = obj_get(assignment, "slot");
+    if (slot != NULL && SDL_strcmp(device != NULL ? device : "", "gamepad") != 0)
+    {
+        return validation_error(ctx, path, "input profile assignment slot is only valid for gamepad assignment sets");
+    }
     if (slot != NULL &&
         (!yyjson_is_num(slot) || yyjson_get_sint(slot) < -1 || yyjson_get_sint(slot) >= SDL3D_INPUT_MAX_GAMEPADS))
     {
@@ -1671,7 +1690,6 @@ static bool validate_input_profile_assignment(validation_context *ctx, yyjson_va
     if (!yyjson_is_obj(actions))
         return validation_error(ctx, path, "input profile assignment requires an actions object");
 
-    yyjson_val *set = find_input_assignment_set_json(root, set_name);
     yyjson_val *bindings = obj_get(set, "bindings");
     for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
     {
@@ -1680,6 +1698,21 @@ static bool validate_input_profile_assignment(validation_context *ctx, yyjson_va
         const char *semantic = json_string(binding, "semantic");
         const char *action = semantic != NULL ? json_string(actions, semantic) : NULL;
         format_path(action_path, sizeof(action_path), "%s.actions.%s", path, semantic != NULL ? semantic : "<missing>");
+        if (!require_ref(ctx, &names->actions, "input action", action, action_path))
+            return false;
+    }
+    size_t idx, max;
+    yyjson_val *key;
+    yyjson_val *value;
+    yyjson_obj_foreach(actions, idx, max, key, value)
+    {
+        char action_path[PATH_BUFFER_SIZE];
+        const char *semantic = yyjson_is_str(key) ? yyjson_get_str(key) : NULL;
+        const char *action = yyjson_is_str(value) ? yyjson_get_str(value) : NULL;
+        format_path(action_path, sizeof(action_path), "%s.actions.%s", path, semantic != NULL ? semantic : "<invalid>");
+        if (!input_assignment_set_has_semantic(set, semantic))
+            return validation_error(ctx, action_path, "input profile assignment maps unknown semantic '%s'",
+                                    semantic != NULL ? semantic : "<invalid>");
         if (!require_ref(ctx, &names->actions, "input action", action, action_path))
             return false;
     }
@@ -1756,6 +1789,8 @@ static bool validate_input_profiles(validation_context *ctx, yyjson_val *root, v
         }
 
         yyjson_val *assignments = obj_get(profile, "assignments");
+        if (ok && bindings != NULL && assignments != NULL)
+            ok = validation_error(ctx, path, "input profile cannot mix bindings and assignments");
         if (ok && assignments != NULL && !yyjson_is_arr(assignments))
             ok = validation_error(ctx, path, "input profile assignments must be an array");
         for (size_t a = 0; ok && yyjson_is_arr(assignments) && a < yyjson_arr_size(assignments); ++a)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -55,6 +55,7 @@ typedef struct validation_names
     name_table script_modules;
     name_table adapters;
     name_table actions;
+    name_table input_assignment_sets;
     name_table timers;
     name_table cameras;
     name_table fonts;
@@ -160,6 +161,13 @@ static bool validation_gamepad_button_name_valid(const char *name)
             return true;
     }
     return false;
+}
+
+static bool input_device_name_valid(const char *device)
+{
+    return SDL_strcmp(device != NULL ? device : "", "keyboard") == 0 ||
+           SDL_strcmp(device != NULL ? device : "", "gamepad") == 0 ||
+           SDL_strcmp(device != NULL ? device : "", "mouse") == 0;
 }
 
 static void set_first_error(validation_context *ctx, const char *json_path, const char *message)
@@ -1408,14 +1416,40 @@ static bool collect_sensors(validation_context *ctx, yyjson_val *root, validatio
     return true;
 }
 
+static bool collect_input_assignment_sets(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *sets = obj_get(obj_get(root, "input"), "device_assignment_sets");
+    if (sets == NULL)
+        return true;
+    if (!yyjson_is_arr(sets))
+        return validation_error(ctx, "$.input.device_assignment_sets", "input device assignment sets must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(sets); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        yyjson_val *set = yyjson_arr_get(sets, i);
+        format_path(path, sizeof(path), "$.input.device_assignment_sets[%zu]", i);
+        if (!yyjson_is_obj(set))
+            return validation_error(ctx, path, "input device assignment sets must be objects");
+        const char *name = json_string(set, "name");
+        if (name != NULL && name[0] != '\0' &&
+            !require_unique_name(ctx, &names->input_assignment_sets, "input device assignment set", name, path))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool collect_names(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
-           collect_input_actions(ctx, root, names) && collect_cameras(ctx, root, names) &&
-           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
-           collect_images(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
-           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
+           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
+           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
+           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
+           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
+           collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -1525,6 +1559,133 @@ static bool validate_input_profile_binding(validation_context *ctx, yyjson_val *
     return true;
 }
 
+static yyjson_val *find_input_assignment_set_json(yyjson_val *root, const char *set_name)
+{
+    yyjson_val *sets = obj_get(obj_get(root, "input"), "device_assignment_sets");
+    for (size_t i = 0; set_name != NULL && yyjson_is_arr(sets) && i < yyjson_arr_size(sets); ++i)
+    {
+        yyjson_val *set = yyjson_arr_get(sets, i);
+        const char *name = json_string(set, "name");
+        if (name != NULL && SDL_strcmp(name, set_name) == 0)
+            return set;
+    }
+    return NULL;
+}
+
+static bool validate_input_assignment_set_binding(validation_context *ctx, yyjson_val *binding, const char *device,
+                                                  const char *path)
+{
+    if (!yyjson_is_obj(binding))
+        return validation_error(ctx, path, "input device assignment bindings must be objects");
+    if (!is_non_empty_string(binding, "semantic"))
+        return validation_error(ctx, path, "input device assignment binding requires a non-empty semantic");
+
+    if (SDL_strcmp(device != NULL ? device : "", "keyboard") == 0)
+    {
+        if (!validation_key_name_valid(json_string(binding, "key")))
+            return validation_error(ctx, path, "keyboard input device assignment binding requires a valid key");
+    }
+    else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
+    {
+        const char *axis = json_string(binding, "axis");
+        const char *button = json_string(binding, "button");
+        if (axis == NULL && button == NULL)
+            return validation_error(ctx, path, "gamepad input device assignment binding requires an axis or button");
+        if (axis != NULL && !validation_gamepad_axis_name_valid(axis))
+            return validation_error(ctx, path, "gamepad input device assignment binding requires a valid axis");
+        if (button != NULL && !validation_gamepad_button_name_valid(button))
+            return validation_error(ctx, path, "gamepad input device assignment binding requires a valid button");
+    }
+    else if (SDL_strcmp(device != NULL ? device : "", "mouse") == 0)
+    {
+        const char *axis = json_string(binding, "axis");
+        const char *button = json_string(binding, "button");
+        if (axis == NULL && button == NULL)
+            return validation_error(ctx, path, "mouse input device assignment binding requires an axis or button");
+        if (axis != NULL && !validation_mouse_axis_name_valid(axis))
+            return validation_error(ctx, path, "mouse input device assignment binding requires a valid axis");
+        if (button != NULL && !validation_mouse_button_name_valid(button))
+            return validation_error(ctx, path, "mouse input device assignment binding requires a valid button");
+    }
+    else
+    {
+        return validation_error(ctx, path, "unsupported input device assignment device '%s'",
+                                device != NULL ? device : "<missing>");
+    }
+    return true;
+}
+
+static bool validate_input_assignment_sets(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *sets = obj_get(obj_get(root, "input"), "device_assignment_sets");
+    if (sets == NULL)
+        return true;
+    if (!yyjson_is_arr(sets))
+        return validation_error(ctx, "$.input.device_assignment_sets", "input device assignment sets must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(sets); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        yyjson_val *set = yyjson_arr_get(sets, i);
+        format_path(path, sizeof(path), "$.input.device_assignment_sets[%zu]", i);
+        if (!yyjson_is_obj(set))
+            return validation_error(ctx, path, "input device assignment sets must be objects");
+        const char *device = json_string(set, "device");
+        if (!is_non_empty_string(set, "name"))
+            return validation_error(ctx, path, "input device assignment set requires a non-empty name");
+        if (!input_device_name_valid(device))
+            return validation_error(ctx, path, "input device assignment set has unsupported device '%s'",
+                                    device != NULL ? device : "<missing>");
+
+        yyjson_val *bindings = obj_get(set, "bindings");
+        if (!yyjson_is_arr(bindings) || yyjson_arr_size(bindings) == 0)
+            return validation_error(ctx, path, "input device assignment set requires non-empty bindings");
+        for (size_t b = 0; b < yyjson_arr_size(bindings); ++b)
+        {
+            char binding_path[PATH_BUFFER_SIZE];
+            format_path(binding_path, sizeof(binding_path), "%s.bindings[%zu]", path, b);
+            if (!validate_input_assignment_set_binding(ctx, yyjson_arr_get(bindings, b), device, binding_path))
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool validate_input_profile_assignment(validation_context *ctx, yyjson_val *root, yyjson_val *assignment,
+                                              const char *path, validation_names *names)
+{
+    if (!yyjson_is_obj(assignment))
+        return validation_error(ctx, path, "input profile assignments must be objects");
+    const char *set_name = json_string(assignment, "set");
+    if (!require_ref(ctx, &names->input_assignment_sets, "input device assignment set", set_name, path))
+        return false;
+
+    yyjson_val *slot = obj_get(assignment, "slot");
+    if (slot != NULL &&
+        (!yyjson_is_num(slot) || yyjson_get_sint(slot) < -1 || yyjson_get_sint(slot) >= SDL3D_INPUT_MAX_GAMEPADS))
+    {
+        return validation_error(ctx, path, "input profile assignment slot must be -1 or a valid slot index");
+    }
+
+    yyjson_val *actions = obj_get(assignment, "actions");
+    if (!yyjson_is_obj(actions))
+        return validation_error(ctx, path, "input profile assignment requires an actions object");
+
+    yyjson_val *set = find_input_assignment_set_json(root, set_name);
+    yyjson_val *bindings = obj_get(set, "bindings");
+    for (size_t i = 0; yyjson_is_arr(bindings) && i < yyjson_arr_size(bindings); ++i)
+    {
+        char action_path[PATH_BUFFER_SIZE];
+        yyjson_val *binding = yyjson_arr_get(bindings, i);
+        const char *semantic = json_string(binding, "semantic");
+        const char *action = semantic != NULL ? json_string(actions, semantic) : NULL;
+        format_path(action_path, sizeof(action_path), "%s.actions.%s", path, semantic != NULL ? semantic : "<missing>");
+        if (!require_ref(ctx, &names->actions, "input action", action, action_path))
+            return false;
+    }
+    return true;
+}
+
 static bool validate_input_profiles(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *profiles = obj_get(obj_get(root, "input"), "profiles");
@@ -1592,6 +1753,16 @@ static bool validate_input_profiles(validation_context *ctx, yyjson_val *root, v
             char binding_path[PATH_BUFFER_SIZE];
             format_path(binding_path, sizeof(binding_path), "%s.bindings[%zu]", path, b);
             ok = validate_input_profile_binding(ctx, yyjson_arr_get(bindings, b), binding_path, names);
+        }
+
+        yyjson_val *assignments = obj_get(profile, "assignments");
+        if (ok && assignments != NULL && !yyjson_is_arr(assignments))
+            ok = validation_error(ctx, path, "input profile assignments must be an array");
+        for (size_t a = 0; ok && yyjson_is_arr(assignments) && a < yyjson_arr_size(assignments); ++a)
+        {
+            char assignment_path[PATH_BUFFER_SIZE];
+            format_path(assignment_path, sizeof(assignment_path), "%s.assignments[%zu]", path, a);
+            ok = validate_input_profile_assignment(ctx, root, yyjson_arr_get(assignments, a), assignment_path, names);
         }
     }
     name_table_destroy(&profile_names);
@@ -3303,8 +3474,8 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
-           validate_input_bindings(ctx, root) && validate_input_profiles(ctx, root, names) &&
-           validate_components(ctx, root, names) &&
+           validate_input_bindings(ctx, root) && validate_input_assignment_sets(ctx, root) &&
+           validate_input_profiles(ctx, root, names) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
@@ -3329,6 +3500,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->script_modules);
     name_table_destroy(&names->adapters);
     name_table_destroy(&names->actions);
+    name_table_destroy(&names->input_assignment_sets);
     name_table_destroy(&names->timers);
     name_table_destroy(&names->cameras);
     name_table_destroy(&names->fonts);

--- a/src/game_data_validation.h
+++ b/src/game_data_validation.h
@@ -19,4 +19,6 @@ bool sdl3d_game_data_validate_document(yyjson_val *root, const char *source_path
 bool sdl3d_game_data_network_schema_hash(yyjson_val *root, Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE],
                                          bool *out_present);
 
+yyjson_val *sdl3d_game_data_find_input_assignment_set_json(yyjson_val *root, const char *set_name);
+
 #endif /* SDL3D_GAME_DATA_VALIDATION_H */

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2239,6 +2239,92 @@ TEST(GameDataRuntime, AppliesAuthoredPongPlayInputProfiles)
     EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 1.0f);
     EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 0.0f);
 
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 6);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, AppliesAuthoredPongGamepadAssignmentPolicies)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    if (sdl3d_input_gamepad_count(input) != 0)
+    {
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+
+    const int p1_up = sdl3d_game_data_find_action(runtime, "action.paddle.up");
+    const int p2_up = sdl3d_game_data_find_action(runtime, "action.paddle.local.up");
+    ASSERT_GE(p1_up, 0);
+    ASSERT_GE(p2_up, 0);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "match_mode", "local");
+    sdl3d_properties_set_string(scene_state, "network_role", "none");
+    sdl3d_properties_set_string(scene_state, "network_flow", "none");
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7101;
+    sdl3d_input_process_event(input, &event);
+
+    const char *profile_name = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(profile_name, "profile.pong.play.local.one_gamepad");
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 7101;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 1.0f);
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7102;
+    sdl3d_input_process_event(input, &event);
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(profile_name, "profile.pong.play.local.two_gamepads");
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 7101;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 1.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 0.0f);
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 4);
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 7102;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 5);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 1.0f);
+
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
 }
@@ -4429,6 +4515,46 @@ TEST(GameDataRuntime, RejectsInvalidInputProfiles)
     EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_input_profile.game.json").string().c_str(), nullptr, error,
                                                sizeof(error)));
     EXPECT_NE(std::string(error).find("$.input.profiles[0]"), std::string::npos);
+
+    write_text(dir / "bad_input_assignment.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Input Assignment", "id": "test.bad_input_assignment", "version": "0.1.0" },
+  "world": { "name": "world.bad_input_assignment", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.up" }
+        ]
+      }
+    ],
+    "device_assignment_sets": [
+      {
+        "name": "assignment.bad",
+        "device": "gamepad",
+        "bindings": [
+          { "semantic": "up", "button": "NOT_A_BUTTON" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.bad",
+        "assignments": [
+          { "set": "assignment.bad", "actions": { "up": "action.up" } }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    error[0] = '\0';
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_input_assignment.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.input.device_assignment_sets[0].bindings[0]"), std::string::npos);
     remove_test_dir(dir);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4555,6 +4555,129 @@ TEST(GameDataRuntime, RejectsInvalidInputProfiles)
     EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_input_assignment.game.json").string().c_str(), nullptr,
                                                error, sizeof(error)));
     EXPECT_NE(std::string(error).find("$.input.device_assignment_sets[0].bindings[0]"), std::string::npos);
+
+    write_text(dir / "mixed_input_profile.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Mixed Input Profile", "id": "test.mixed_input_profile", "version": "0.1.0" },
+  "world": { "name": "world.mixed_input_profile", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.up" }
+        ]
+      }
+    ],
+    "device_assignment_sets": [
+      {
+        "name": "assignment.keyboard",
+        "device": "keyboard",
+        "bindings": [
+          { "semantic": "up", "key": "UP" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.mixed",
+        "bindings": [
+          { "action": "action.up", "device": "keyboard", "key": "UP" }
+        ],
+        "assignments": [
+          { "set": "assignment.keyboard", "actions": { "up": "action.up" } }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    error[0] = '\0';
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "mixed_input_profile.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.input.profiles[0]"), std::string::npos);
+
+    write_text(dir / "extra_assignment_semantic.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Extra Assignment Semantic", "id": "test.extra_assignment_semantic", "version": "0.1.0" },
+  "world": { "name": "world.extra_assignment_semantic", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.up" }
+        ]
+      }
+    ],
+    "device_assignment_sets": [
+      {
+        "name": "assignment.keyboard",
+        "device": "keyboard",
+        "bindings": [
+          { "semantic": "up", "key": "UP" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.extra",
+        "assignments": [
+          { "set": "assignment.keyboard", "actions": { "up": "action.up", "fire": "action.up" } }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    error[0] = '\0';
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "extra_assignment_semantic.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.input.profiles[0].assignments[0].actions.fire"), std::string::npos);
+
+    write_text(dir / "nongamepad_assignment_slot.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Nongamepad Assignment Slot", "id": "test.nongamepad_assignment_slot", "version": "0.1.0" },
+  "world": { "name": "world.nongamepad_assignment_slot", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.gameplay",
+        "actions": [
+          { "name": "action.up" }
+        ]
+      }
+    ],
+    "device_assignment_sets": [
+      {
+        "name": "assignment.keyboard",
+        "device": "keyboard",
+        "bindings": [
+          { "semantic": "up", "key": "UP" }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "name": "profile.slot",
+        "assignments": [
+          { "set": "assignment.keyboard", "slot": 0, "actions": { "up": "action.up" } }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    error[0] = '\0';
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "nongamepad_assignment_slot.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.input.profiles[0].assignments[0]"), std::string::npos);
     remove_test_dir(dir);
 }
 


### PR DESCRIPTION
## Summary
- add reusable `input.device_assignment_sets` that expand semantic device bindings into concrete profile actions
- validate assignment set names, devices, semantics, slots, and action references
- migrate Pong play profiles to keyboard/gamepad assignment sets for single-player, local multiplayer, LAN host, and LAN client modes
- add tests for zero/one/two-gamepad profile behavior and invalid assignment validation

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `ctest --test-dir build/debug --output-on-failure -R "GameDataRuntime\.(AppliesAuthoredPongPlayInputProfiles|AppliesAuthoredPongGamepadAssignmentPolicies|AppliesFallbackAndMouseInputProfiles|RejectsInvalidInputProfiles|ValidatesPongDataWithoutDiagnostics)|GameDataJson\.PongDataParsesAsStrictJson"`
- `ctest --test-dir build/debug --output-on-failure -L unit`

Continues #186.