### PR TITLE
Move Pong play input setup into data actions

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1912,6 +1912,7 @@
         "signal": "signal.game.start",
         "actions": [
           { "type": "adapter.invoke", "adapter": "adapter.pong.configure_play_input" },
+          { "type": "input.clear_network_input_overrides", "channel": "client_input" },
           { "type": "input.apply_active_profile" },
           {
             "type": "branch",

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1912,6 +1912,7 @@
         "signal": "signal.game.start",
         "actions": [
           { "type": "adapter.invoke", "adapter": "adapter.pong.configure_play_input" },
+          { "type": "input.apply_active_profile" },
           {
             "type": "branch",
             "if": {
@@ -2135,7 +2136,7 @@
       "kind": "action",
       "script": "script.pong",
       "function": "configure_play_input",
-      "description": "Configure Pong paddle bindings for single-player or local multiplayer layouts."
+      "description": "Normalize Pong play scene input role state before the authored active input profile applies."
     },
     {
       "name": "adapter.pong.load_persistence",

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -117,7 +117,33 @@ function pong.cpu_track_ball(paddle, payload, ctx)
     return true
 end
 
-function pong.configure_play_input(_, _, _)
+local function context_string(payload, ctx, key, fallback)
+    local value = payload ~= nil and payload[key] or nil
+    if value ~= nil and value ~= "" then
+        return value
+    end
+    return ctx:state_get(key, fallback)
+end
+
+function pong.configure_play_input(_, payload, ctx)
+    local requested_match_mode = context_string(payload, ctx, "match_mode", "single")
+    local requested_lan = requested_match_mode == "lan"
+    local requested_network_role = requested_lan and context_string(payload, ctx, "network_role", "none") or "none"
+    local requested_network_flow = requested_lan and context_string(payload, ctx, "network_flow", "none") or "none"
+    local valid_network_role = requested_network_role == "host" or requested_network_role == "client"
+    local match_mode = requested_lan and not valid_network_role and "single" or requested_match_mode
+    local network_role = requested_lan and valid_network_role and requested_network_role or "none"
+    local network_flow = requested_lan and valid_network_role and requested_network_flow or "none"
+
+    ctx:state_set("match_mode", match_mode or "single")
+    ctx:state_set("network_role", network_role or "none")
+    ctx:state_set("network_flow", network_flow or "none")
+    ctx:log(string.format(
+        "Pong play input context: requested_match_mode=%s match_mode=%s network_role=%s network_flow=%s",
+        requested_match_mode or "none",
+        match_mode or "none",
+        network_role or "none",
+        network_flow or "none"))
     return true
 end
 

--- a/demos/pong/data/scripts/pong.lua
+++ b/demos/pong/data/scripts/pong.lua
@@ -118,9 +118,11 @@ function pong.cpu_track_ball(paddle, payload, ctx)
 end
 
 local function context_string(payload, ctx, key, fallback)
-    local value = payload ~= nil and payload[key] or nil
-    if value ~= nil and value ~= "" then
-        return value
+    if payload ~= nil then
+        local value = payload[key]
+        if type(value) == "string" and value ~= "" then
+            return value
+        end
     end
     return ctx:state_get(key, fallback)
 end

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -207,22 +207,6 @@ static bool is_network_role_client(const pong_state *state)
     return is_network_match_mode(state) && SDL_strcmp(network_role_name(state), "client") == 0;
 }
 
-static const char *scene_payload_string(const sdl3d_properties *payload, const char *key)
-{
-    return payload != NULL ? sdl3d_properties_get_string(payload, key, NULL) : NULL;
-}
-
-static const char *scene_context_string(const sdl3d_properties *payload, const sdl3d_properties *scene_state,
-                                        const char *key, const char *fallback)
-{
-    const char *value = scene_payload_string(payload, key);
-    if (value != NULL)
-    {
-        return value;
-    }
-    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
-}
-
 static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode, const char *network_role,
                                          const char *network_flow)
 {
@@ -260,35 +244,17 @@ static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mo
 
 static void clear_network_action_overrides(pong_state *state)
 {
-    char error[128] = {0};
+    char error[160] = {0};
     if (state == NULL || state->input == NULL || state->data == NULL)
     {
         return;
     }
 
-    const int p1_up = sdl3d_game_data_find_action(state->data, "action.paddle.up");
-    const int p1_down = sdl3d_game_data_find_action(state->data, "action.paddle.down");
-    const int p2_up = sdl3d_game_data_find_action(state->data, "action.paddle.local.up");
-    const int p2_down = sdl3d_game_data_find_action(state->data, "action.paddle.local.down");
-    if (p1_up >= 0)
-    {
-        sdl3d_input_clear_action_override(state->input, p1_up);
-    }
-    if (p1_down >= 0)
-    {
-        sdl3d_input_clear_action_override(state->input, p1_down);
-    }
     if (!sdl3d_game_data_clear_network_input_overrides(state->data, "client_input", state->input, error,
                                                        (int)sizeof(error)))
     {
-        if (p2_up >= 0)
-        {
-            sdl3d_input_clear_action_override(state->input, p2_up);
-        }
-        if (p2_down >= 0)
-        {
-            sdl3d_input_clear_action_override(state->input, p2_down);
-        }
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network input override clear failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
     }
 }
 
@@ -384,50 +350,6 @@ static bool apply_active_play_input_profile(pong_state *state)
                 profile_name != NULL ? profile_name : "<none>", network_role_name(state),
                 state->local_input_gamepad_count);
     return true;
-}
-
-static bool configure_play_input(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
-                                 sdl3d_registered_actor *target, const sdl3d_properties *payload)
-{
-    pong_state *state = (pong_state *)userdata;
-    (void)runtime;
-    (void)adapter_name;
-    (void)target;
-
-    if (state == NULL || state->data == NULL || state->input == NULL)
-    {
-        return false;
-    }
-
-    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(state->data);
-    sdl3d_properties *mutable_scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-    const char *requested_match_mode = scene_context_string(payload, scene_state, "match_mode", "single");
-    const bool requested_lan = requested_match_mode != NULL && SDL_strcmp(requested_match_mode, "lan") == 0;
-    const char *requested_network_role =
-        requested_lan ? scene_context_string(payload, scene_state, "network_role", "none") : "none";
-    const char *requested_network_flow =
-        requested_lan ? scene_context_string(payload, scene_state, "network_flow", "none") : "none";
-    const bool valid_network_role =
-        requested_network_role != NULL &&
-        (SDL_strcmp(requested_network_role, "host") == 0 || SDL_strcmp(requested_network_role, "client") == 0);
-    const char *match_mode = requested_lan && !valid_network_role ? "single" : requested_match_mode;
-    const char *network_role = requested_lan && valid_network_role ? requested_network_role : "none";
-    const char *network_flow = requested_lan && valid_network_role ? requested_network_flow : "none";
-
-    clear_network_action_overrides(state);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "Pong play input context: requested_match_mode=%s match_mode=%s network_role=%s network_flow=%s",
-                requested_match_mode != NULL ? requested_match_mode : "none", match_mode != NULL ? match_mode : "none",
-                network_role != NULL ? network_role : "none", network_flow != NULL ? network_flow : "none");
-
-    if (mutable_scene_state != NULL)
-    {
-        sdl3d_properties_set_string(mutable_scene_state, "match_mode", match_mode != NULL ? match_mode : "single");
-        sdl3d_properties_set_string(mutable_scene_state, "network_role", network_role != NULL ? network_role : "none");
-        sdl3d_properties_set_string(mutable_scene_state, "network_flow", network_flow != NULL ? network_flow : "none");
-    }
-
-    return apply_active_play_input_profile(state);
 }
 
 static void destroy_direct_connect_session_internal(pong_state *state, bool notify_peer)
@@ -1771,16 +1693,6 @@ static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
                 sdl3d_game_data_active_scene(state->data) != NULL ? sdl3d_game_data_active_scene(state->data)
                                                                   : "<none>");
 
-    if (!sdl3d_game_data_register_adapter(state->data, "adapter.pong.configure_play_input", configure_play_input,
-                                          state))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong play input adapter registration failed");
-        sdl3d_game_data_destroy(state->data);
-        state->data = NULL;
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
-        return false;
-    }
     return true;
 }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -572,6 +572,10 @@ Logic bindings can apply profiles directly:
   authored conditions and gamepad gates match the current scene state.
 - `{ "type": "input.apply_profile", "profile": "profile.name" }` applies one
   named profile.
+- `{ "type": "input.clear_network_input_overrides", "channel":
+  "client_input" }` clears action overrides written by an authored
+  `client_to_host` network input channel, preventing stale remote input from
+  leaking into later local play.
 
 Use an adapter or data actions before `input.apply_active_profile` when a game
 needs to normalize scene-state values that choose the active profile.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -566,6 +566,16 @@ referenced set, and every semantic in the set must be mapped to an action.
 keyboard and mouse sets are global device policies and reject slot-specific
 assignments.
 
+Logic bindings can apply profiles directly:
+
+- `{ "type": "input.apply_active_profile" }` applies the first profile whose
+  authored conditions and gamepad gates match the current scene state.
+- `{ "type": "input.apply_profile", "profile": "profile.name" }` applies one
+  named profile.
+
+Use an adapter or data actions before `input.apply_active_profile` when a game
+needs to normalize scene-state values that choose the active profile.
+
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for
 screens that intentionally stage changes before committing them.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1609,9 +1609,9 @@ extern "C"
      * @brief Apply one authored input profile to an input manager.
      *
      * Profiles are authored under `input.profiles`. Applying a profile first
-     * unbinds every action listed in its `unbind` array, then applies each
-     * authored keyboard, mouse, or gamepad binding and each reusable
-     * `input.device_assignment_sets` assignment in profile order.
+     * unbinds every action listed in its `unbind` array, then applies either
+     * raw keyboard, mouse, or gamepad bindings or reusable
+     * `input.device_assignment_sets` assignments.
      *
      * @param runtime Runtime containing authored profile data and action ids.
      * @param input Input manager to mutate.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -8185,6 +8185,36 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
     if (SDL_strcmp(type, "input.reset_bindings") == 0)
         return sdl3d_game_data_reset_menu_input_bindings(runtime, json_string(action, "menu", NULL));
 
+    if (SDL_strcmp(type, "input.apply_profile") == 0)
+    {
+        char error[256] = {0};
+        sdl3d_input_manager *input = runtime_input(runtime);
+        const char *profile = json_string(action, "profile", NULL);
+        if (!sdl3d_game_data_apply_input_profile(runtime, input, profile, error, (int)sizeof(error)))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "game data input profile apply failed: %s",
+                        error[0] != '\0' ? error : "unknown error");
+            return false;
+        }
+        return true;
+    }
+
+    if (SDL_strcmp(type, "input.apply_active_profile") == 0)
+    {
+        char error[256] = {0};
+        const char *profile = NULL;
+        sdl3d_input_manager *input = runtime_input(runtime);
+        if (!sdl3d_game_data_apply_active_input_profile(runtime, input, &profile, error, (int)sizeof(error)))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "game data active input profile apply failed: %s",
+                        error[0] != '\0' ? error : "unknown error");
+            return false;
+        }
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "game data active input profile applied: profile=%s",
+                    profile != NULL ? profile : "<none>");
+        return true;
+    }
+
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -8215,6 +8215,20 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return true;
     }
 
+    if (SDL_strcmp(type, "input.clear_network_input_overrides") == 0)
+    {
+        char error[256] = {0};
+        sdl3d_input_manager *input = runtime_input(runtime);
+        const char *channel = json_string(action, "channel", NULL);
+        if (!sdl3d_game_data_clear_network_input_overrides(runtime, channel, input, error, (int)sizeof(error)))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "game data network input override clear failed: %s",
+                        error[0] != '\0' ? error : "unknown error");
+            return false;
+        }
+        return true;
+    }
+
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -56,6 +56,7 @@ typedef struct validation_names
     name_table adapters;
     name_table actions;
     name_table input_assignment_sets;
+    name_table input_profiles;
     name_table timers;
     name_table cameras;
     name_table fonts;
@@ -1441,15 +1442,40 @@ static bool collect_input_assignment_sets(validation_context *ctx, yyjson_val *r
     return true;
 }
 
+static bool collect_input_profiles(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *profiles = obj_get(obj_get(root, "input"), "profiles");
+    if (profiles == NULL)
+        return true;
+    if (!yyjson_is_arr(profiles))
+        return validation_error(ctx, "$.input.profiles", "input profiles must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(profiles); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        yyjson_val *profile = yyjson_arr_get(profiles, i);
+        format_path(path, sizeof(path), "$.input.profiles[%zu]", i);
+        if (!yyjson_is_obj(profile))
+            return validation_error(ctx, path, "input profiles must be objects");
+        const char *name = json_string(profile, "name");
+        if (name != NULL && name[0] != '\0' &&
+            !require_unique_name(ctx, &names->input_profiles, "input profile", name, path))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool collect_names(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
            collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
-           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
-           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
-           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
-           collect_sensors(ctx, root, names);
+           collect_input_profiles(ctx, root, names) && collect_cameras(ctx, root, names) &&
+           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
+           collect_images(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -2079,6 +2105,17 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     {
         if (!is_non_empty_string(action, "menu"))
             return validation_error(ctx, json_path, "input.reset_bindings requires a non-empty menu");
+        return true;
+    }
+    if (SDL_strcmp(type, "input.apply_profile") == 0)
+    {
+        const char *profile = json_string(action, "profile");
+        return require_ref(ctx, &names->input_profiles, "input profile", profile, json_path);
+    }
+    if (SDL_strcmp(type, "input.apply_active_profile") == 0)
+    {
+        if (names->input_profiles.count <= 0)
+            return validation_error(ctx, json_path, "input.apply_active_profile requires at least one input profile");
         return true;
     }
     if (SDL_strcmp(type, "ui.animate") == 0)
@@ -3536,6 +3573,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->adapters);
     name_table_destroy(&names->actions);
     name_table_destroy(&names->input_assignment_sets);
+    name_table_destroy(&names->input_profiles);
     name_table_destroy(&names->timers);
     name_table_destroy(&names->cameras);
     name_table_destroy(&names->fonts);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -57,6 +57,7 @@ typedef struct validation_names
     name_table actions;
     name_table input_assignment_sets;
     name_table input_profiles;
+    name_table network_input_channels;
     name_table timers;
     name_table cameras;
     name_table fonts;
@@ -1467,15 +1468,46 @@ static bool collect_input_profiles(validation_context *ctx, yyjson_val *root, va
     return true;
 }
 
+static bool collect_network_input_channels(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *replication = obj_get(obj_get(root, "network"), "replication");
+    if (replication == NULL)
+        return true;
+    if (!yyjson_is_arr(replication))
+        return validation_error(ctx, "$.network.replication", "network replication must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(replication); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        yyjson_val *entry = yyjson_arr_get(replication, i);
+        format_path(path, sizeof(path), "$.network.replication[%zu]", i);
+        if (!yyjson_is_obj(entry))
+            return validation_error(ctx, path, "network replication entries must be objects");
+        if (SDL_strcmp(json_string(entry, "direction") != NULL ? json_string(entry, "direction") : "",
+                       "client_to_host") != 0)
+        {
+            continue;
+        }
+        const char *name = json_string(entry, "name");
+        if (name != NULL && name[0] != '\0' &&
+            !require_unique_name(ctx, &names->network_input_channels, "network input channel", name, path))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool collect_names(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
            collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
-           collect_input_profiles(ctx, root, names) && collect_cameras(ctx, root, names) &&
-           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
-           collect_images(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
-           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
+           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
+           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
+           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
+           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
+           collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -2117,6 +2149,11 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (names->input_profiles.count <= 0)
             return validation_error(ctx, json_path, "input.apply_active_profile requires at least one input profile");
         return true;
+    }
+    if (SDL_strcmp(type, "input.clear_network_input_overrides") == 0)
+    {
+        return require_ref(ctx, &names->network_input_channels, "network input channel", json_string(action, "channel"),
+                           json_path);
     }
     if (SDL_strcmp(type, "ui.animate") == 0)
     {
@@ -3574,6 +3611,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->actions);
     name_table_destroy(&names->input_assignment_sets);
     name_table_destroy(&names->input_profiles);
+    name_table_destroy(&names->network_input_channels);
     name_table_destroy(&names->timers);
     name_table_destroy(&names->cameras);
     name_table_destroy(&names->fonts);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1975,8 +1975,17 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     ASSERT_NE(payload, nullptr);
     sdl3d_properties_set_string(payload, "from_scene", "scene.options");
     sdl3d_properties_set_string(payload, "selected_level", "level.test");
+    sdl3d_input_manager *play_input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(play_input, nullptr);
+    const int remote_up_action = sdl3d_game_data_find_action(runtime, "action.paddle.local.up");
+    ASSERT_GE(remote_up_action, 0);
+    sdl3d_input_set_action_override(play_input, remote_up_action, 1.0f);
+    ASSERT_NE(sdl3d_input_update(play_input, 10), nullptr);
+    EXPECT_NEAR(sdl3d_input_get_value(play_input, remote_up_action), 1.0f, 0.0001f);
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload));
+    ASSERT_NE(sdl3d_input_update(play_input, 11), nullptr);
+    EXPECT_NEAR(sdl3d_input_get_value(play_input, remote_up_action), 0.0f, 0.0001f);
     EXPECT_TRUE(payload_capture.called);
     EXPECT_EQ(payload_capture.from_scene, "scene.options");
     EXPECT_EQ(payload_capture.to_scene, "scene.play");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1985,6 +1985,22 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
 
     sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "match_mode", ""), "single");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_role", ""), "none");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_flow", ""), "none");
+
+    sdl3d_properties *lan_payload = sdl3d_properties_create();
+    ASSERT_NE(lan_payload, nullptr);
+    sdl3d_properties_set_string(lan_payload, "match_mode", "lan");
+    sdl3d_properties_set_string(lan_payload, "network_role", "client");
+    sdl3d_properties_set_string(lan_payload, "network_flow", "direct");
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.title"));
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", lan_payload));
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "match_mode", ""), "lan");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_role", ""), "client");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_flow", ""), "direct");
+    sdl3d_properties_destroy(lan_payload);
+
     sdl3d_properties_set_string(scene_state, "selected_level", "level.002");
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.title"));
     EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "selected_level", ""), "level.002");


### PR DESCRIPTION
## Summary

- add reusable `input.apply_profile`, `input.apply_active_profile`, and `input.clear_network_input_overrides` logic actions
- move Pong play input role normalization into Lua and apply the authored active profile from JSON
- clear authored network input override channels from data before profile application so stale remote input cannot leak into local play
- remove the Pong C adapter that hard-coded play input scene-state setup
- document profile/override input actions and extend Pong scene-entry tests

## Verification

- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `luac -p demos/pong/data/scripts/pong.lua`
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo sdl3d_pong_multiplayer_test -j4`
- `ctest --test-dir build/debug --output-on-failure -R "GameDataRuntime\.(ExposesDataDrivenScenesAndMenus|EncodesAndAppliesPongNetworkInputFromAuthoredSchema|ValidatesPongDataWithoutDiagnostics)|PongHeadlessMultiplayerTest|GameDataJson\.PongDataParsesAsStrictJson"`
- `ctest --test-dir build/debug --output-on-failure -L unit`
- `git diff --check`

Continues #186.
