### PR TITLE
Author network scene state bindings

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -106,6 +106,14 @@
       "transport": "udp",
       "tick_rate": 60
     },
+    "scene_state": {
+      "host": {
+        "status": "multiplayer_host_status",
+        "endpoint": "multiplayer_host_endpoint",
+        "peer": "multiplayer_host_client",
+        "connected": "multiplayer_host_connected"
+      }
+    },
     "replication": [
       {
         "name": "play_state",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -242,6 +242,18 @@ static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mo
     return ok;
 }
 
+static const char *network_scene_state_key(const pong_state *state, const char *scope, const char *name,
+                                           const char *fallback)
+{
+    const char *key = NULL;
+    if (state != NULL && state->data != NULL &&
+        sdl3d_game_data_get_network_scene_state_key(state->data, scope, name, &key))
+    {
+        return key;
+    }
+    return fallback;
+}
+
 static void clear_network_action_overrides(pong_state *state)
 {
     char error[160] = {0};
@@ -295,10 +307,16 @@ static void update_host_session_scene_state(pong_state *state)
         SDL_snprintf(client_label, sizeof(client_label), "Client 1 - Connected");
     }
 
-    sdl3d_properties_set_string(scene_state, "multiplayer_host_status", state->host_status);
-    sdl3d_properties_set_string(scene_state, "multiplayer_host_endpoint", state->host_endpoint);
-    sdl3d_properties_set_string(scene_state, "multiplayer_host_client", client_label);
-    sdl3d_properties_set_bool(scene_state, "multiplayer_host_connected", client_connected);
+    sdl3d_properties_set_string(
+        scene_state, network_scene_state_key(state, "host", "status", "multiplayer_host_status"), state->host_status);
+    sdl3d_properties_set_string(scene_state,
+                                network_scene_state_key(state, "host", "endpoint", "multiplayer_host_endpoint"),
+                                state->host_endpoint);
+    sdl3d_properties_set_string(scene_state, network_scene_state_key(state, "host", "peer", "multiplayer_host_client"),
+                                client_label);
+    sdl3d_properties_set_bool(scene_state,
+                              network_scene_state_key(state, "host", "connected", "multiplayer_host_connected"),
+                              client_connected);
 }
 
 static void destroy_host_session_internal(pong_state *state, bool notify_peer)

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1284,6 +1284,14 @@ typed actor fields, replicated input actions, and control messages:
       "transport": "udp",
       "tick_rate": 60
     },
+    "scene_state": {
+      "host": {
+        "status": "multiplayer_host_status",
+        "endpoint": "multiplayer_host_endpoint",
+        "peer": "multiplayer_host_client",
+        "connected": "multiplayer_host_connected"
+      }
+    },
     "replication": [
       {
         "name": "play_state",
@@ -1321,6 +1329,15 @@ typed actor fields, replicated input actions, and control messages:
 `protocol.id` must be a non-empty string. `protocol.version` and
 `protocol.tick_rate` must be positive integers. `protocol.transport` currently
 supports `udp`.
+
+`scene_state` is optional. It is a game-authored map of named network/session
+UI state keys, grouped by scope. Host integration code can resolve entries with
+`sdl3d_game_data_get_network_scene_state_key()` and write status values into
+`sdl3d_game_data_mutable_scene_state()` without hard-coding the property names
+used by lobby or connection scenes. All scopes and values must be objects of
+non-empty string keys to non-empty string scene-state property names. These keys
+are presentation/orchestration metadata and are intentionally not part of the
+network schema hash.
 
 Replication channel directions are `host_to_client` or `client_to_host`, and
 `rate` must be a positive integer.
@@ -1393,7 +1410,7 @@ Diagnostics are designed for authored content. Errors include the source file, a
 - duplicate names within entity, signal, script, adapter, input action, timer, camera, font, and sensor namespaces
 - script ids, modules, dependencies, dependency cycles, and script file existence
 - input binding structure
-- network protocol, replication directions, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
+- network protocol, replication directions, scene-state key maps, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
 - app lifecycle, UI, render effect, sensor, timer, binding, action, component, adapter, light, and camera references
 - supported generic logic action types and required action payloads
 - warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -858,6 +858,26 @@ extern "C"
                                                  Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE]);
 
     /**
+     * @brief Resolve an authored scene-state key used by network UI/session flows.
+     *
+     * Games may place arbitrary string key maps under `network.scene_state`.
+     * Host integration code can use this helper to avoid hard-coding the
+     * `scene_state` property names that authored lobby, discovery, or direct
+     * connect scenes display.
+     *
+     * For example, `network.scene_state.host.status` can resolve to
+     * `multiplayer_host_status`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param scope Authored scene-state group, such as `host`.
+     * @param name Authored key name within the group, such as `status`.
+     * @param out_key Receives a string owned by @p runtime.
+     * @return true when the key exists and @p out_key was filled.
+     */
+    bool sdl3d_game_data_get_network_scene_state_key(const sdl3d_game_data_runtime *runtime, const char *scope,
+                                                     const char *name, const char **out_key);
+
+    /**
      * @brief Encode an authored host-to-client replication snapshot.
      *
      * The named replication channel must exist in the loaded `network`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9690,13 +9690,12 @@ bool sdl3d_game_data_get_network_scene_state_key(const sdl3d_game_data_runtime *
 {
     if (out_key != NULL)
         *out_key = NULL;
-    if (runtime == NULL || runtime->doc == NULL || scope == NULL || scope[0] == '\0' || name == NULL ||
-        name[0] == '\0' || out_key == NULL)
+    if (runtime == NULL || scope == NULL || scope[0] == '\0' || name == NULL || name[0] == '\0' || out_key == NULL)
     {
         return false;
     }
 
-    yyjson_val *root = yyjson_doc_get_root(runtime->doc);
+    yyjson_val *root = runtime_root(runtime);
     yyjson_val *scene_state = obj_get(obj_get(root, "network"), "scene_state");
     yyjson_val *group = obj_get(scene_state, scope);
     const char *key = json_string(group, name, NULL);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9685,6 +9685,28 @@ bool sdl3d_game_data_get_network_schema_hash(const sdl3d_game_data_runtime *runt
     return true;
 }
 
+bool sdl3d_game_data_get_network_scene_state_key(const sdl3d_game_data_runtime *runtime, const char *scope,
+                                                 const char *name, const char **out_key)
+{
+    if (out_key != NULL)
+        *out_key = NULL;
+    if (runtime == NULL || runtime->doc == NULL || scope == NULL || scope[0] == '\0' || name == NULL ||
+        name[0] == '\0' || out_key == NULL)
+    {
+        return false;
+    }
+
+    yyjson_val *root = yyjson_doc_get_root(runtime->doc);
+    yyjson_val *scene_state = obj_get(obj_get(root, "network"), "scene_state");
+    yyjson_val *group = obj_get(scene_state, scope);
+    const char *key = json_string(group, name, NULL);
+    if (key == NULL || key[0] == '\0')
+        return false;
+
+    *out_key = key;
+    return true;
+}
+
 bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
                                              Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
                                              char *error_buffer, int error_buffer_size)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -606,6 +606,48 @@ static bool validate_network_inputs(validation_context *ctx, yyjson_val *inputs,
     return ok;
 }
 
+static bool validate_network_scene_state(validation_context *ctx, yyjson_val *network)
+{
+    yyjson_val *scene_state = obj_get(network, "scene_state");
+    if (scene_state == NULL)
+        return true;
+    if (!yyjson_is_obj(scene_state))
+        return validation_error(ctx, "$.network.scene_state", "network scene_state must be an object");
+
+    yyjson_val *scope_key;
+    yyjson_obj_iter scope_iter;
+    yyjson_obj_iter_init(scene_state, &scope_iter);
+    while ((scope_key = yyjson_obj_iter_next(&scope_iter)) != NULL)
+    {
+        const char *scope_name = yyjson_get_str(scope_key);
+        yyjson_val *scope = yyjson_obj_iter_get_val(scope_key);
+        char scope_path[PATH_BUFFER_SIZE];
+        format_path(scope_path, sizeof(scope_path), "$.network.scene_state.%s",
+                    scope_name != NULL ? scope_name : "<invalid>");
+        if (scope_name == NULL || scope_name[0] == '\0')
+            return validation_error(ctx, scope_path, "network scene_state scope must have a non-empty name");
+        if (!yyjson_is_obj(scope))
+            return validation_error(ctx, scope_path, "network scene_state scope must be an object");
+
+        yyjson_val *key;
+        yyjson_obj_iter key_iter;
+        yyjson_obj_iter_init(scope, &key_iter);
+        while ((key = yyjson_obj_iter_next(&key_iter)) != NULL)
+        {
+            const char *name = yyjson_get_str(key);
+            yyjson_val *value = yyjson_obj_iter_get_val(key);
+            char key_path[PATH_BUFFER_SIZE];
+            format_path(key_path, sizeof(key_path), "%s.%s", scope_path, name != NULL ? name : "<invalid>");
+            if (name == NULL || name[0] == '\0')
+                return validation_error(ctx, key_path, "network scene_state key name must be non-empty");
+            if (!yyjson_is_str(value) || yyjson_get_len(value) == 0)
+                return validation_error(ctx, key_path, "network scene_state key value must be a non-empty string");
+        }
+    }
+
+    return true;
+}
+
 static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *network = obj_get(root, "network");
@@ -630,6 +672,8 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
     if (!yyjson_is_int(tick_rate) || yyjson_get_sint(tick_rate) <= 0)
         return validation_error(ctx, "$.network.protocol.tick_rate",
                                 "network protocol tick_rate must be a positive integer");
+    if (!validate_network_scene_state(ctx, network))
+        return false;
 
     yyjson_val *replication = obj_get(network, "replication");
     if (!yyjson_is_arr(replication) || yyjson_arr_size(replication) == 0)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1192,6 +1192,13 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.title"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.options"), 0);
     EXPECT_GE(sdl3d_game_data_find_action(runtime, "action.scene.play"), 0);
+    const char *network_scene_state_key = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "status", &network_scene_state_key));
+    EXPECT_STREQ(network_scene_state_key, "multiplayer_host_status");
+    ASSERT_TRUE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "connected", &network_scene_state_key));
+    EXPECT_STREQ(network_scene_state_key, "multiplayer_host_connected");
+    EXPECT_FALSE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "missing", &network_scene_state_key));
+    EXPECT_EQ(network_scene_state_key, nullptr);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
     EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
@@ -5397,6 +5404,31 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "client_to_host network replication must declare inputs",
+        },
+        {
+            "bad_scene_state_key",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "scene_state": {
+      "host": {
+        "status": ""
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network scene_state key value must be a non-empty string",
         },
     };
 


### PR DESCRIPTION
## Summary

- Add `network.scene_state` as authored key maps for network/session UI state
- Add `sdl3d_game_data_get_network_scene_state_key()` plus validation and docs
- Move Pong lobby host status scene-state key names into `pong.game.json` and resolve them through the engine helper

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target sdl3d_pong_multiplayer_test -j4 && ./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -L unit`