### PR TITLE
Generalize input profile hotplug refresh

### DIFF
--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -52,7 +52,7 @@ typedef struct pong_state
     int vibration_signal_id;
     int discovery_refresh_signal_id;
     int discovery_refresh_connection;
-    int local_input_gamepad_count;
+    sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
     bool network_match_termination_active;
     float network_match_termination_timer;
     char network_match_termination_reason[96];
@@ -344,30 +344,6 @@ static void destroy_host_session_internal(pong_state *state, bool notify_peer)
 static void destroy_host_session(pong_state *state)
 {
     destroy_host_session_internal(state, true);
-}
-
-static bool apply_active_play_input_profile(pong_state *state)
-{
-    char error[256];
-    const char *profile_name = NULL;
-    if (state == NULL || state->data == NULL || state->input == NULL)
-    {
-        return false;
-    }
-
-    error[0] = '\0';
-    if (!sdl3d_game_data_apply_active_input_profile(state->data, state->input, &profile_name, error, sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile apply failed: %s",
-                    error[0] != '\0' ? error : "unknown error");
-        return false;
-    }
-
-    state->local_input_gamepad_count = sdl3d_input_gamepad_count(state->input);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile applied: profile=%s role=%s gamepads=%d",
-                profile_name != NULL ? profile_name : "<none>", network_role_name(state),
-                state->local_input_gamepad_count);
-    return true;
 }
 
 static void destroy_direct_connect_session_internal(pong_state *state, bool notify_peer)
@@ -1587,13 +1563,20 @@ static void refresh_local_play_input(pong_state *state)
         return;
     }
 
-    const int gamepad_count = sdl3d_input_gamepad_count(state->input);
-    if (gamepad_count != state->local_input_gamepad_count)
+    char error[256] = {0};
+    const char *profile_name = NULL;
+    bool applied = false;
+    if (!sdl3d_game_data_apply_active_input_profile_on_device_change(
+            state->data, state->input, &state->input_profile_refresh, &profile_name, &applied, error, sizeof(error)))
     {
-        if (!apply_active_play_input_profile(state))
-        {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile hotplug refresh failed");
-        }
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile hotplug refresh failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+    }
+    else if (applied)
+    {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile refreshed: profile=%s role=%s gamepads=%d",
+                    profile_name != NULL ? profile_name : "<none>", network_role_name(state),
+                    state->input_profile_refresh.gamepad_count);
     }
 }
 
@@ -1815,7 +1798,7 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
     state->discovery_refresh_signal_id =
         sdl3d_game_data_find_signal(state->data, "signal.multiplayer.discovery.refresh");
-    state->local_input_gamepad_count = -1;
+    sdl3d_game_data_input_profile_refresh_state_init(&state->input_profile_refresh);
     SDL_snprintf(state->host_status, sizeof(state->host_status), "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",
                  (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -579,6 +579,12 @@ Logic bindings can apply profiles directly:
 
 Use an adapter or data actions before `input.apply_active_profile` when a game
 needs to normalize scene-state values that choose the active profile.
+For hotplug support, hosts can keep a
+`sdl3d_game_data_input_profile_refresh_state` and call
+`sdl3d_game_data_apply_active_input_profile_on_device_change()` from their
+frame loop while a profile-managed scene is active. The helper applies the
+active profile on first use and after the connected gamepad count changes,
+leaving scene-entry profile application in authored data actions.
 
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1626,6 +1626,26 @@ extern "C"
     bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
 
     /**
+     * @brief Device-count state for active input profile refresh.
+     *
+     * Initialize with sdl3d_game_data_input_profile_refresh_state_init() before
+     * the first refresh. Callers may reset the state when entering a new scene
+     * if they want to force one active-profile application on the next frame.
+     */
+    typedef struct sdl3d_game_data_input_profile_refresh_state
+    {
+        /** @brief Last observed gamepad count. */
+        int gamepad_count;
+        /** @brief Whether gamepad_count has been sampled at least once. */
+        bool initialized;
+    } sdl3d_game_data_input_profile_refresh_state;
+
+    /**
+     * @brief Initialize active input profile refresh state.
+     */
+    void sdl3d_game_data_input_profile_refresh_state_init(sdl3d_game_data_input_profile_refresh_state *state);
+
+    /**
      * @brief Apply one authored input profile to an input manager.
      *
      * Profiles are authored under `input.profiles`. Applying a profile first
@@ -1660,6 +1680,30 @@ extern "C"
     bool sdl3d_game_data_apply_active_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
                                                     const char **out_profile_name, char *error_buffer,
                                                     int error_buffer_size);
+
+    /**
+     * @brief Apply the active input profile when connected gamepad count changes.
+     *
+     * This helper centralizes the common hotplug policy for data-authored input
+     * profiles. It applies the active profile on first use, then applies again
+     * only when sdl3d_input_gamepad_count() changes. Scene changes that should
+     * always rebind controls should still use authored `input.apply_active_profile`
+     * actions on scene entry.
+     *
+     * @param runtime Runtime containing authored profile data and action ids.
+     * @param input Input manager to inspect and mutate.
+     * @param state Persistent refresh state owned by the caller.
+     * @param out_profile_name Receives the applied runtime-owned profile name, if non-NULL and applied.
+     * @param out_applied Receives whether a profile was applied this call, if non-NULL.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when no refresh was needed or the matching profile was applied.
+     */
+    bool sdl3d_game_data_apply_active_input_profile_on_device_change(sdl3d_game_data_runtime *runtime,
+                                                                     sdl3d_input_manager *input,
+                                                                     sdl3d_game_data_input_profile_refresh_state *state,
+                                                                     const char **out_profile_name, bool *out_applied,
+                                                                     char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Return the number of scene shortcuts authored under `app.scene_shortcuts`.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6244,6 +6244,49 @@ bool sdl3d_game_data_apply_active_input_profile(sdl3d_game_data_runtime *runtime
     return false;
 }
 
+void sdl3d_game_data_input_profile_refresh_state_init(sdl3d_game_data_input_profile_refresh_state *state)
+{
+    if (state == NULL)
+        return;
+
+    state->gamepad_count = -1;
+    state->initialized = false;
+}
+
+bool sdl3d_game_data_apply_active_input_profile_on_device_change(sdl3d_game_data_runtime *runtime,
+                                                                 sdl3d_input_manager *input,
+                                                                 sdl3d_game_data_input_profile_refresh_state *state,
+                                                                 const char **out_profile_name, bool *out_applied,
+                                                                 char *error_buffer, int error_buffer_size)
+{
+    if (out_profile_name != NULL)
+        *out_profile_name = NULL;
+    if (out_applied != NULL)
+        *out_applied = false;
+    if (runtime == NULL || input == NULL || state == NULL)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "active input profile device refresh requires runtime, input, and refresh state");
+        return false;
+    }
+
+    const int gamepad_count = sdl3d_input_gamepad_count(input);
+    if (state->initialized && state->gamepad_count == gamepad_count)
+        return true;
+
+    const char *profile_name = NULL;
+    if (!sdl3d_game_data_apply_active_input_profile(runtime, input, &profile_name, error_buffer, error_buffer_size))
+        return false;
+
+    state->gamepad_count = gamepad_count;
+    state->initialized = true;
+    if (out_profile_name != NULL)
+        *out_profile_name = profile_name;
+    if (out_applied != NULL)
+        *out_applied = true;
+    return true;
+}
+
 static bool load_timers(sdl3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *timers = obj_get(logic, "timers");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2361,6 +2361,77 @@ TEST(GameDataRuntime, AppliesAuthoredPongGamepadAssignmentPolicies)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, RefreshesActiveInputProfileWhenGamepadCountChanges)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    if (sdl3d_input_gamepad_count(input) != 0)
+    {
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "match_mode", "local");
+    sdl3d_properties_set_string(scene_state, "network_role", "none");
+    sdl3d_properties_set_string(scene_state, "network_flow", "none");
+
+    sdl3d_game_data_input_profile_refresh_state refresh{};
+    sdl3d_game_data_input_profile_refresh_state_init(&refresh);
+
+    const char *profile_name = nullptr;
+    bool applied = false;
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile_on_device_change(runtime, input, &refresh, &profile_name,
+                                                                            &applied, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(applied);
+    EXPECT_STREQ(profile_name, "profile.pong.play.local.keyboard_only");
+    EXPECT_EQ(refresh.gamepad_count, 0);
+
+    profile_name = "unchanged";
+    applied = true;
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile_on_device_change(runtime, input, &refresh, &profile_name,
+                                                                            &applied, error, sizeof(error)))
+        << error;
+    EXPECT_FALSE(applied);
+    EXPECT_EQ(profile_name, nullptr);
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7201;
+    sdl3d_input_process_event(input, &event);
+
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile_on_device_change(runtime, input, &refresh, &profile_name,
+                                                                            &applied, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(applied);
+    EXPECT_STREQ(profile_name, "profile.pong.play.local.one_gamepad");
+    EXPECT_EQ(refresh.gamepad_count, 1);
+
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7202;
+    sdl3d_input_process_event(input, &event);
+
+    ASSERT_TRUE(sdl3d_game_data_apply_active_input_profile_on_device_change(runtime, input, &refresh, &profile_name,
+                                                                            &applied, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(applied);
+    EXPECT_STREQ(profile_name, "profile.pong.play.local.two_gamepads");
+    EXPECT_EQ(refresh.gamepad_count, 2);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AppliesFallbackAndMouseInputProfiles)
 {
     const std::filesystem::path dir = unique_test_dir("input_profile_mouse");


### PR DESCRIPTION
## Summary

- Add reusable game-data state and helper for active input profile refresh on gamepad count changes
- Replace Pong-specific gamepad count tracking/profile reapply logic with the generic helper
- Document profile hotplug refresh and add focused runtime coverage for zero/one/two gamepad transitions

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c demos/pong/main.c tests/test_game_data.cpp`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.RefreshesActiveInputProfileWhenGamepadCountChanges:GameDataRuntime.AppliesAuthoredPongGamepadAssignmentPolicies:GameDataRuntime.AppliesAuthoredPongPlayInputProfiles'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target sdl3d_pong_multiplayer_test -j4 && ./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -L unit`