### PR TITLE
Author network session flow config

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -114,6 +114,37 @@
         "connected": "multiplayer_host_connected"
       }
     },
+    "session_flow": {
+      "scenes": {
+        "play": "scene.play",
+        "host_lobby": "scene.multiplayer.lobby",
+        "join": "scene.multiplayer.join",
+        "direct_connect": "scene.multiplayer.direct_connect",
+        "discovery": "scene.multiplayer.discovery",
+        "title": "scene.title"
+      },
+      "state_keys": {
+        "match_mode": "match_mode",
+        "network_role": "network_role",
+        "network_flow": "network_flow"
+      },
+      "state_values": {
+        "match_mode": {
+          "local": "local",
+          "network": "lan"
+        },
+        "network_role": {
+          "none": "none",
+          "host": "host",
+          "client": "client"
+        },
+        "network_flow": {
+          "none": "none",
+          "host": "host",
+          "direct": "direct"
+        }
+      }
+    },
     "replication": [
       {
         "name": "play_state",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -132,83 +132,122 @@ static const char *active_scene_name(const pong_state *state)
     return state != NULL && state->data != NULL ? sdl3d_game_data_active_scene(state->data) : NULL;
 }
 
-static bool is_direct_connect_scene(const pong_state *state)
+static const char *network_session_scene(const pong_state *state, const char *name, const char *fallback)
+{
+    const char *scene = NULL;
+    if (state != NULL && state->data != NULL && sdl3d_game_data_get_network_session_scene(state->data, name, &scene))
+    {
+        return scene;
+    }
+    return fallback;
+}
+
+static const char *network_session_state_key(const pong_state *state, const char *name, const char *fallback)
+{
+    const char *key = NULL;
+    if (state != NULL && state->data != NULL && sdl3d_game_data_get_network_session_state_key(state->data, name, &key))
+    {
+        return key;
+    }
+    return fallback;
+}
+
+static const char *network_session_state_value(const pong_state *state, const char *group, const char *name,
+                                               const char *fallback)
+{
+    const char *value = NULL;
+    if (state != NULL && state->data != NULL &&
+        sdl3d_game_data_get_network_session_state_value(state->data, group, name, &value))
+    {
+        return value;
+    }
+    return fallback;
+}
+
+static const char *network_session_state_string(const pong_state *state, const char *key_name, const char *fallback)
+{
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    const char *key = network_session_state_key(state, key_name, key_name);
+    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
+}
+
+static bool active_scene_is(const pong_state *state, const char *scene_name, const char *fallback)
 {
     const char *active_scene = active_scene_name(state);
-    return active_scene != NULL && SDL_strcmp(active_scene, "scene.multiplayer.direct_connect") == 0;
+    const char *expected_scene = network_session_scene(state, scene_name, fallback);
+    return active_scene != NULL && expected_scene != NULL && SDL_strcmp(active_scene, expected_scene) == 0;
+}
+
+static bool is_direct_connect_scene(const pong_state *state)
+{
+    return active_scene_is(state, "direct_connect", "scene.multiplayer.direct_connect");
 }
 
 static bool is_multiplayer_lobby_scene(const pong_state *state)
 {
-    const char *active_scene = active_scene_name(state);
-    return active_scene != NULL && SDL_strcmp(active_scene, "scene.multiplayer.lobby") == 0;
+    return active_scene_is(state, "host_lobby", "scene.multiplayer.lobby");
 }
 
 static bool is_multiplayer_discovery_scene(const pong_state *state)
 {
-    const char *active_scene = active_scene_name(state);
-    return active_scene != NULL && SDL_strcmp(active_scene, "scene.multiplayer.discovery") == 0;
+    return active_scene_is(state, "discovery", "scene.multiplayer.discovery");
 }
 
 static bool is_multiplayer_play_scene(const pong_state *state)
 {
-    const char *active_scene = active_scene_name(state);
-    return active_scene != NULL && SDL_strcmp(active_scene, "scene.play") == 0;
+    return active_scene_is(state, "play", "scene.play");
 }
 
 static bool is_local_match_mode(const pong_state *state)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", NULL) : NULL;
-    return match_mode != NULL && SDL_strcmp(match_mode, "local") == 0;
+    const char *match_mode = network_session_state_string(state, "match_mode", NULL);
+    return match_mode != NULL &&
+           SDL_strcmp(match_mode, network_session_state_value(state, "match_mode", "local", "local")) == 0;
 }
 
 static bool is_network_match_mode(const pong_state *state)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    const char *match_mode = scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", NULL) : NULL;
-    return match_mode != NULL && SDL_strcmp(match_mode, "lan") == 0;
+    const char *match_mode = network_session_state_string(state, "match_mode", NULL);
+    return match_mode != NULL &&
+           SDL_strcmp(match_mode, network_session_state_value(state, "match_mode", "network", "lan")) == 0;
 }
 
 static bool is_network_flow_host(const pong_state *state)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    const char *network_flow =
-        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", NULL) : NULL;
-    return network_flow != NULL && SDL_strcmp(network_flow, "host") == 0;
+    const char *network_flow = network_session_state_string(state, "network_flow", NULL);
+    return network_flow != NULL &&
+           SDL_strcmp(network_flow, network_session_state_value(state, "network_flow", "host", "host")) == 0;
 }
 
 static bool is_network_flow_direct(const pong_state *state)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    const char *network_flow =
-        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", NULL) : NULL;
-    return network_flow != NULL && SDL_strcmp(network_flow, "direct") == 0;
+    const char *network_flow = network_session_state_string(state, "network_flow", NULL);
+    return network_flow != NULL &&
+           SDL_strcmp(network_flow, network_session_state_value(state, "network_flow", "direct", "direct")) == 0;
 }
 
 static const char *network_role_name(const pong_state *state)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
+    return network_session_state_string(state, "network_role", "none");
 }
 
 static bool is_network_role_host(const pong_state *state)
 {
-    return is_network_match_mode(state) && SDL_strcmp(network_role_name(state), "host") == 0;
+    return is_network_match_mode(state) &&
+           SDL_strcmp(network_role_name(state), network_session_state_value(state, "network_role", "host", "host")) ==
+               0;
 }
 
 static bool is_network_role_client(const pong_state *state)
 {
-    return is_network_match_mode(state) && SDL_strcmp(network_role_name(state), "client") == 0;
+    return is_network_match_mode(state) &&
+           SDL_strcmp(network_role_name(state),
+                      network_session_state_value(state, "network_role", "client", "client")) == 0;
 }
 
-static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode, const char *network_role,
-                                         const char *network_flow)
+static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode_value,
+                                         const char *network_role_value, const char *network_flow_value)
 {
     sdl3d_properties *payload = NULL;
     bool ok = false;
@@ -224,22 +263,33 @@ static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mo
         return false;
     }
 
-    if (match_mode != NULL)
+    if (match_mode_value != NULL)
     {
-        sdl3d_properties_set_string(payload, "match_mode", match_mode);
+        sdl3d_properties_set_string(payload, network_session_state_key(state, "match_mode", "match_mode"),
+                                    match_mode_value);
     }
-    if (network_role != NULL)
+    if (network_role_value != NULL)
     {
-        sdl3d_properties_set_string(payload, "network_role", network_role);
+        sdl3d_properties_set_string(payload, network_session_state_key(state, "network_role", "network_role"),
+                                    network_role_value);
     }
-    if (network_flow != NULL)
+    if (network_flow_value != NULL)
     {
-        sdl3d_properties_set_string(payload, "network_flow", network_flow);
+        sdl3d_properties_set_string(payload, network_session_state_key(state, "network_flow", "network_flow"),
+                                    network_flow_value);
     }
 
-    ok = sdl3d_game_data_set_active_scene_with_payload(state->data, "scene.play", payload);
+    ok = sdl3d_game_data_set_active_scene_with_payload(state->data, network_session_scene(state, "play", "scene.play"),
+                                                       payload);
     sdl3d_properties_destroy(payload);
     return ok;
+}
+
+static bool enter_network_multiplayer_play_scene(pong_state *state, const char *role_name, const char *flow_name)
+{
+    return enter_multiplayer_play_scene(state, network_session_state_value(state, "match_mode", "network", "lan"),
+                                        network_session_state_value(state, "network_role", role_name, role_name),
+                                        network_session_state_value(state, "network_flow", flow_name, flow_name));
 }
 
 static const char *network_scene_state_key(const pong_state *state, const char *scope, const char *name,
@@ -590,7 +640,7 @@ static bool start_selected_lobby_match(pong_state *state)
     }
 
     clear_network_action_overrides(state);
-    if (!enter_multiplayer_play_scene(state, "lan", "host", "host"))
+    if (!enter_network_multiplayer_play_scene(state, "host", "host"))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to enter multiplayer play scene: %s",
                     SDL_GetError());
@@ -640,10 +690,7 @@ static bool send_client_input_packet(pong_state *state)
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "[%llu ms] Pong client input packet queued: role=%s flow=%s p2_up=%.3f p2_down=%.3f",
                 (unsigned long long)pong_log_timestamp_ms(), network_role_name(state),
-                state != NULL && state->data != NULL && sdl3d_game_data_scene_state(state->data) != NULL
-                    ? sdl3d_properties_get_string(sdl3d_game_data_scene_state(state->data), "network_flow", "none")
-                    : "none",
-                up_value, down_value);
+                network_session_state_string(state, "network_flow", "none"), up_value, down_value);
     return true;
 }
 
@@ -811,14 +858,16 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
                      reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
         destroy_host_session_internal(state, false);
         update_host_session_scene_state(state);
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.lobby");
+        (void)sdl3d_game_data_set_active_scene(state->data,
+                                               network_session_scene(state, "host_lobby", "scene.multiplayer.lobby"));
     }
     else
     {
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
                      reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
         destroy_direct_connect_session_internal(state, false);
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+        (void)sdl3d_game_data_set_active_scene(state->data,
+                                               network_session_scene(state, "join", "scene.multiplayer.join"));
     }
 }
 
@@ -946,7 +995,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
                 clear_network_action_overrides(state);
-                if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
+                if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
                 {
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
                                 SDL_GetError());
@@ -966,7 +1015,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                             "Pong client received authoritative state before start command; entering play scene");
                 clear_network_action_overrides(state);
-                if (!enter_multiplayer_play_scene(state, "lan", "client", "direct"))
+                if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
                 {
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                                 "Pong client failed to enter multiplayer play scene from state packet: %s",
@@ -1041,7 +1090,7 @@ static void update_network_match_termination(sdl3d_game_context *ctx, pong_state
     }
     if (state->data != NULL)
     {
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.title");
+        (void)sdl3d_game_data_set_active_scene(state->data, network_session_scene(state, "title", "scene.title"));
     }
 }
 
@@ -1232,7 +1281,8 @@ static void update_discovery_controls(sdl3d_game_context *ctx, pong_state *state
         emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
         destroy_discovery_session(state);
         destroy_direct_connect_session(state);
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+        (void)sdl3d_game_data_set_active_scene(state->data,
+                                               network_session_scene(state, "join", "scene.multiplayer.join"));
     }
 }
 
@@ -1299,7 +1349,8 @@ static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
     {
         destroy_discovery_session(state);
         destroy_direct_connect_session(state);
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+        (void)sdl3d_game_data_set_active_scene(state->data,
+                                               network_session_scene(state, "join", "scene.multiplayer.join"));
     }
 
     sdl3d_ui_end_vbox(state->discovery_ui);
@@ -1516,7 +1567,8 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
     {
         destroy_direct_connect_session(state);
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Returning to Join Match");
-        (void)sdl3d_game_data_set_active_scene(state->data, "scene.multiplayer.join");
+        (void)sdl3d_game_data_set_active_scene(state->data,
+                                               network_session_scene(state, "join", "scene.multiplayer.join"));
     }
 
     sdl3d_ui_layout_label(state->direct_connect_ui, "Status");
@@ -1558,7 +1610,8 @@ static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong
 static void refresh_local_play_input(pong_state *state)
 {
     const char *active_scene = state != NULL && state->data != NULL ? sdl3d_game_data_active_scene(state->data) : NULL;
-    if (state == NULL || state->input == NULL || active_scene == NULL || SDL_strcmp(active_scene, "scene.play") != 0)
+    if (state == NULL || state->input == NULL || active_scene == NULL ||
+        SDL_strcmp(active_scene, network_session_scene(state, "play", "scene.play")) != 0)
     {
         return;
     }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1298,6 +1298,26 @@ typed actor fields, replicated input actions, and control messages:
         "connected": "multiplayer_host_connected"
       }
     },
+    "session_flow": {
+      "scenes": {
+        "play": "scene.play",
+        "host_lobby": "scene.multiplayer.lobby",
+        "join": "scene.multiplayer.join",
+        "direct_connect": "scene.multiplayer.direct_connect",
+        "discovery": "scene.multiplayer.discovery",
+        "title": "scene.title"
+      },
+      "state_keys": {
+        "match_mode": "match_mode",
+        "network_role": "network_role",
+        "network_flow": "network_flow"
+      },
+      "state_values": {
+        "match_mode": { "network": "lan" },
+        "network_role": { "host": "host", "client": "client" },
+        "network_flow": { "host": "host", "direct": "direct" }
+      }
+    },
     "replication": [
       {
         "name": "play_state",
@@ -1344,6 +1364,18 @@ used by lobby or connection scenes. All scopes and values must be objects of
 non-empty string keys to non-empty string scene-state property names. These keys
 are presentation/orchestration metadata and are intentionally not part of the
 network schema hash.
+
+`session_flow` is optional. It gives host integration code semantic names for
+network scene orchestration without baking a particular demo's scene ids or
+scene-state strings into C. `scenes` maps semantic names such as `play`,
+`host_lobby`, `join`, `direct_connect`, `discovery`, or `title` to validated
+scene ids. `state_keys` maps semantic state names to scene-state property keys.
+`state_values` maps semantic values inside each state group to concrete strings
+stored in scene state. Callers resolve these values with
+`sdl3d_game_data_get_network_session_scene()`,
+`sdl3d_game_data_get_network_session_state_key()`, and
+`sdl3d_game_data_get_network_session_state_value()`. Like `scene_state`, these
+orchestration maps are not part of the replication schema hash.
 
 Replication channel directions are `host_to_client` or `client_to_host`, and
 `rate` must be a positive integer.
@@ -1416,7 +1448,7 @@ Diagnostics are designed for authored content. Errors include the source file, a
 - duplicate names within entity, signal, script, adapter, input action, timer, camera, font, and sensor namespaces
 - script ids, modules, dependencies, dependency cycles, and script file existence
 - input binding structure
-- network protocol, replication directions, scene-state key maps, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
+- network protocol, replication directions, scene-state key maps, session-flow maps, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
 - app lifecycle, UI, render effect, sensor, timer, binding, action, component, adapter, light, and camera references
 - supported generic logic action types and required action payloads
 - warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -878,6 +878,51 @@ extern "C"
                                                      const char *name, const char **out_key);
 
     /**
+     * @brief Resolve an authored network session scene id.
+     *
+     * Games may author reusable scene ids under `network.session_flow.scenes`,
+     * such as `play`, `host_lobby`, `join`, `direct_connect`, or `title`.
+     * Host integration code can use this helper to avoid hard-coding scene ids
+     * while still owning transport/session objects.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored scene semantic name.
+     * @param out_scene Receives a scene id owned by @p runtime.
+     * @return true when the scene semantic exists and @p out_scene was filled.
+     */
+    bool sdl3d_game_data_get_network_session_scene(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                   const char **out_scene);
+
+    /**
+     * @brief Resolve an authored network session scene-state key.
+     *
+     * Keys are authored under `network.session_flow.state_keys`, such as
+     * `match_mode`, `network_role`, or `network_flow`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored key semantic name.
+     * @param out_key Receives a scene-state key owned by @p runtime.
+     * @return true when the key semantic exists and @p out_key was filled.
+     */
+    bool sdl3d_game_data_get_network_session_state_key(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                       const char **out_key);
+
+    /**
+     * @brief Resolve an authored network session scene-state value.
+     *
+     * Values are authored under `network.session_flow.state_values.<group>`.
+     * For example, `state_values.network_role.host` may resolve to `host`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param group Authored value group, usually a state key semantic.
+     * @param name Authored value semantic name.
+     * @param out_value Receives a value string owned by @p runtime.
+     * @return true when the value semantic exists and @p out_value was filled.
+     */
+    bool sdl3d_game_data_get_network_session_state_value(const sdl3d_game_data_runtime *runtime, const char *group,
+                                                         const char *name, const char **out_value);
+
+    /**
      * @brief Encode an authored host-to-client replication snapshot.
      *
      * The named replication channel must exist in the loaded `network`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9749,6 +9749,61 @@ bool sdl3d_game_data_get_network_scene_state_key(const sdl3d_game_data_runtime *
     return true;
 }
 
+static yyjson_val *network_session_flow_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(obj_get(runtime_root(runtime), "network"), "session_flow");
+}
+
+static bool game_data_get_network_session_string(const sdl3d_game_data_runtime *runtime, const char *section,
+                                                 const char *name, const char **out_value)
+{
+    if (out_value != NULL)
+        *out_value = NULL;
+    if (runtime == NULL || section == NULL || section[0] == '\0' || name == NULL || name[0] == '\0' ||
+        out_value == NULL)
+    {
+        return false;
+    }
+
+    const char *value = json_string(obj_get(network_session_flow_json(runtime), section), name, NULL);
+    if (value == NULL || value[0] == '\0')
+        return false;
+
+    *out_value = value;
+    return true;
+}
+
+bool sdl3d_game_data_get_network_session_scene(const sdl3d_game_data_runtime *runtime, const char *name,
+                                               const char **out_scene)
+{
+    return game_data_get_network_session_string(runtime, "scenes", name, out_scene);
+}
+
+bool sdl3d_game_data_get_network_session_state_key(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                   const char **out_key)
+{
+    return game_data_get_network_session_string(runtime, "state_keys", name, out_key);
+}
+
+bool sdl3d_game_data_get_network_session_state_value(const sdl3d_game_data_runtime *runtime, const char *group,
+                                                     const char *name, const char **out_value)
+{
+    if (out_value != NULL)
+        *out_value = NULL;
+    if (runtime == NULL || group == NULL || group[0] == '\0' || name == NULL || name[0] == '\0' || out_value == NULL)
+    {
+        return false;
+    }
+
+    yyjson_val *groups = obj_get(network_session_flow_json(runtime), "state_values");
+    const char *value = json_string(obj_get(groups, group), name, NULL);
+    if (value == NULL || value[0] == '\0')
+        return false;
+
+    *out_value = value;
+    return true;
+}
+
 bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
                                              Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
                                              char *error_buffer, int error_buffer_size)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -648,6 +648,76 @@ static bool validate_network_scene_state(validation_context *ctx, yyjson_val *ne
     return true;
 }
 
+static bool validate_network_session_string_map(validation_context *ctx, yyjson_val *map, const char *json_path,
+                                                const char *label, const name_table *scene_names)
+{
+    if (map == NULL)
+        return true;
+    if (!yyjson_is_obj(map))
+        return validation_error(ctx, json_path, "network session_flow %s must be an object", label);
+
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(map, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        yyjson_val *value = yyjson_obj_iter_get_val(key);
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s.%s", json_path, name != NULL ? name : "<invalid>");
+        if (name == NULL || name[0] == '\0')
+            return validation_error(ctx, path, "network session_flow %s key must be non-empty", label);
+        if (!yyjson_is_str(value) || yyjson_get_len(value) == 0)
+            return validation_error(ctx, path, "network session_flow %s value must be a non-empty string", label);
+        if (scene_names != NULL && !require_ref(ctx, scene_names, "scene", yyjson_get_str(value), path))
+            return false;
+    }
+
+    return true;
+}
+
+static bool validate_network_session_flow(validation_context *ctx, yyjson_val *network, validation_names *names)
+{
+    yyjson_val *flow = obj_get(network, "session_flow");
+    if (flow == NULL)
+        return true;
+    if (!yyjson_is_obj(flow))
+        return validation_error(ctx, "$.network.session_flow", "network session_flow must be an object");
+
+    if (!validate_network_session_string_map(ctx, obj_get(flow, "scenes"), "$.network.session_flow.scenes", "scenes",
+                                             &names->scenes) ||
+        !validate_network_session_string_map(ctx, obj_get(flow, "state_keys"), "$.network.session_flow.state_keys",
+                                             "state_keys", NULL))
+    {
+        return false;
+    }
+
+    yyjson_val *state_values = obj_get(flow, "state_values");
+    if (state_values == NULL)
+        return true;
+    if (!yyjson_is_obj(state_values))
+        return validation_error(ctx, "$.network.session_flow.state_values",
+                                "network session_flow state_values must be an object");
+
+    yyjson_val *group_key;
+    yyjson_obj_iter group_iter;
+    yyjson_obj_iter_init(state_values, &group_iter);
+    while ((group_key = yyjson_obj_iter_next(&group_iter)) != NULL)
+    {
+        const char *group_name = yyjson_get_str(group_key);
+        yyjson_val *group = yyjson_obj_iter_get_val(group_key);
+        char group_path[PATH_BUFFER_SIZE];
+        format_path(group_path, sizeof(group_path), "$.network.session_flow.state_values.%s",
+                    group_name != NULL ? group_name : "<invalid>");
+        if (group_name == NULL || group_name[0] == '\0')
+            return validation_error(ctx, group_path, "network session_flow state_values group must be non-empty");
+        if (!validate_network_session_string_map(ctx, group, group_path, "state_values", NULL))
+            return false;
+    }
+
+    return true;
+}
+
 static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *network = obj_get(root, "network");
@@ -673,6 +743,8 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
         return validation_error(ctx, "$.network.protocol.tick_rate",
                                 "network protocol tick_rate must be a positive integer");
     if (!validate_network_scene_state(ctx, network))
+        return false;
+    if (!validate_network_session_flow(ctx, network, names))
         return false;
 
     yyjson_val *replication = obj_get(network, "replication");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1199,6 +1199,19 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_STREQ(network_scene_state_key, "multiplayer_host_connected");
     EXPECT_FALSE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "missing", &network_scene_state_key));
     EXPECT_EQ(network_scene_state_key, nullptr);
+    const char *network_session_value = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_get_network_session_scene(runtime, "play", &network_session_value));
+    EXPECT_STREQ(network_session_value, "scene.play");
+    ASSERT_TRUE(sdl3d_game_data_get_network_session_scene(runtime, "join", &network_session_value));
+    EXPECT_STREQ(network_session_value, "scene.multiplayer.join");
+    ASSERT_TRUE(sdl3d_game_data_get_network_session_state_key(runtime, "match_mode", &network_session_value));
+    EXPECT_STREQ(network_session_value, "match_mode");
+    ASSERT_TRUE(
+        sdl3d_game_data_get_network_session_state_value(runtime, "match_mode", "network", &network_session_value));
+    EXPECT_STREQ(network_session_value, "lan");
+    ASSERT_TRUE(
+        sdl3d_game_data_get_network_session_state_value(runtime, "network_role", "client", &network_session_value));
+    EXPECT_STREQ(network_session_value, "client");
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
     EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
@@ -4905,9 +4918,25 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
 {
     const std::filesystem::path dir = unique_test_dir("network_schema");
     const std::string network_json = valid_network_schema_json();
+    std::string network_with_session_flow = network_json;
+    const size_t session_flow_insert = network_with_session_flow.rfind("\n  }");
+    ASSERT_NE(session_flow_insert, std::string::npos);
+    network_with_session_flow.insert(session_flow_insert, R"json(,
+    "session_flow": {
+      "state_keys": {
+        "match_mode": "match_mode"
+      },
+      "state_values": {
+        "match_mode": {
+          "network": "lan"
+        }
+      }
+    })json");
 
     write_text(dir / "network_a.game.json", network_schema_game_json(network_json, "Network Schema A").c_str());
     write_text(dir / "network_b.game.json", network_schema_game_json(network_json, "Different Metadata").c_str());
+    write_text(dir / "network_session_flow.game.json",
+               network_schema_game_json(network_with_session_flow, "Network Schema A").c_str());
     write_text(dir / "network_changed.game.json",
                network_schema_game_json(valid_network_schema_json("vec2"), "Network Schema A").c_str());
 
@@ -4918,9 +4947,11 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
 
     const auto hash_a = load_network_schema_hash(dir / "network_a.game.json");
     const auto hash_b = load_network_schema_hash(dir / "network_b.game.json");
+    const auto hash_with_session_flow = load_network_schema_hash(dir / "network_session_flow.game.json");
     const auto hash_changed = load_network_schema_hash(dir / "network_changed.game.json");
 
     EXPECT_EQ(hash_a, hash_b);
+    EXPECT_EQ(hash_a, hash_with_session_flow);
     EXPECT_NE(hash_a, hash_changed);
 
     remove_test_dir(dir);
@@ -5500,6 +5531,31 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "network scene_state key value must be a non-empty string",
+        },
+        {
+            "bad_session_flow_state_key",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "session_flow": {
+      "state_keys": {
+        "match_mode": ""
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network session_flow state_keys value must be a non-empty string",
         },
     };
 


### PR DESCRIPTION
## Summary

- Add `network.session_flow` for authored network scene ids, scene-state keys, and semantic state values
- Add runtime accessors and validation for session-flow orchestration metadata
- Migrate Pong network play/lobby/join/title scene transitions and network payload keys through the authored flow config
- Keep session-flow metadata out of the replication schema hash

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LoadsPongDataIntoGenericSessionServices:GameDataRuntime.ValidatesNetworkReplicationSchemaAndComputesStableHash:GameDataRuntime.RejectsInvalidNetworkReplicationSchemas:GameDataRuntime.ExposesDataDrivenScenesAndMenus'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target sdl3d_pong_multiplayer_test -j4 && ./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -L unit`