### PR TITLE
Add schema-driven network snapshot diagnostics

### DIFF
--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -79,52 +79,20 @@ static Uint64 pong_log_timestamp_ms(void)
 static void pong_log_multiplayer_state(const char *prefix, const pong_state *state, Uint32 packet_tick,
                                        const char *extra)
 {
-    const sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
-    const sdl3d_registered_actor *player =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.paddle.player") : NULL;
-    const sdl3d_registered_actor *cpu =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.paddle.cpu") : NULL;
-    const sdl3d_registered_actor *ball =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.ball") : NULL;
-    const sdl3d_registered_actor *match =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.match") : NULL;
-    const sdl3d_registered_actor *score_player_actor =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.score.player") : NULL;
-    const sdl3d_registered_actor *score_cpu_actor =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.score.cpu") : NULL;
-    const sdl3d_vec3 player_position = player != NULL ? player->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const sdl3d_vec3 cpu_position = cpu != NULL ? cpu->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const sdl3d_vec3 ball_position = ball != NULL ? ball->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const sdl3d_vec3 ball_velocity =
-        ball != NULL ? sdl3d_properties_get_vec3(ball->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f))
-                     : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const int score_player =
-        score_player_actor != NULL ? sdl3d_properties_get_int(score_player_actor->props, "value", 0) : 0;
-    const int score_cpu = score_cpu_actor != NULL ? sdl3d_properties_get_int(score_cpu_actor->props, "value", 0) : 0;
-    const bool finished = match != NULL && sdl3d_properties_get_bool(match->props, "finished", false);
-    const char *winner = match != NULL ? sdl3d_properties_get_string(match->props, "winner", "none") : "none";
-    const char *match_mode =
-        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "match_mode", "none") : "none";
-    const char *network_role =
-        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_role", "none") : "none";
-    const char *network_flow =
-        scene_state != NULL ? sdl3d_properties_get_string(scene_state, "network_flow", "none") : "none";
+    char description[4096] = {0};
+    char error[256] = {0};
+    if (state == NULL || state->data == NULL ||
+        !sdl3d_game_data_describe_network_snapshot(state->data, "play_state", packet_tick, description,
+                                                   sizeof(description), error, sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong multiplayer state diagnostic failed: %s",
+                    error[0] != '\0' ? error : "runtime unavailable");
+        return;
+    }
 
-    SDL_LogInfo(
-        SDL_LOG_CATEGORY_APPLICATION,
-        "[%llu ms] Pong %s tick=%u scene=%s match_mode=%s network_role=%s network_flow=%s "
-        "scores=%d:%d finished=%d winner=%s player=(%.2f,%.2f,%.2f) cpu=(%.2f,%.2f,%.2f) "
-        "ball=(%.2f,%.2f,%.2f) vel=(%.2f,%.2f)%s%s",
-        (unsigned long long)pong_log_timestamp_ms(), prefix != NULL ? prefix : "state", (unsigned int)packet_tick,
-        state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
-            ? sdl3d_game_data_active_scene(state->data)
-            : "<none>",
-        match_mode != NULL ? match_mode : "none", network_role != NULL ? network_role : "none",
-        network_flow != NULL ? network_flow : "none", score_player, score_cpu, finished ? 1 : 0,
-        winner != NULL ? winner : "none", player_position.x, player_position.y, player_position.z, cpu_position.x,
-        cpu_position.y, cpu_position.z, ball_position.x, ball_position.y, ball_position.z, ball_velocity.x,
-        ball_velocity.y, extra != NULL && extra[0] != '\0' ? " " : "", extra != NULL ? extra : "");
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong %s %s%s%s", (unsigned long long)pong_log_timestamp_ms(),
+                prefix != NULL ? prefix : "state", description, extra != NULL && extra[0] != '\0' ? " " : "",
+                extra != NULL ? extra : "");
 }
 
 static const char *active_scene_name(const pong_state *state)

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1406,6 +1406,11 @@ mismatched schema hashes, wrong field counts, wrong field tags, truncation, and
 trailing bytes. Built-in `position` fields update the actor transform; object
 paths under `properties.` update actor properties. `vec2` property replication
 is stored in SDL3D's existing vec3 property bag by updating x/y and preserving z.
+Callers that need diagnostic logging can use
+`sdl3d_game_data_describe_network_snapshot()` to format the active scene,
+authored `session_flow` state values, and every replicated actor field in schema
+order. This keeps debug output tied to the authored replication channel instead
+of hard-coding game actor ids or property paths in host C.
 
 Client-to-host input channels can be encoded with
 `sdl3d_game_data_encode_network_input()` and applied with

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -923,6 +923,29 @@ extern "C"
                                                          const char *name, const char **out_value);
 
     /**
+     * @brief Format a diagnostic summary for an authored network snapshot channel.
+     *
+     * The helper walks the named host-to-client replication channel in authored
+     * schema order and appends every replicated actor field to @p buffer. It
+     * also includes the active scene and authored `network.session_flow`
+     * scene-state key values when present. This is intended for lightweight
+     * host/client diagnostics without hard-coding game actor ids or property
+     * paths in the host program.
+     *
+     * @param runtime Runtime whose current state should be described.
+     * @param replication_name Authored host-to-client replication channel name.
+     * @param tick Simulation or packet tick to include in the description.
+     * @param buffer Destination text buffer.
+     * @param buffer_size Destination text buffer size in bytes.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when @p buffer contains a complete, null-terminated summary.
+     */
+    bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                                   Uint32 tick, char *buffer, size_t buffer_size, char *error_buffer,
+                                                   int error_buffer_size);
+
+    /**
      * @brief Encode an authored host-to-client replication snapshot.
      *
      * The named replication channel must exist in the loaded `network`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -320,6 +320,25 @@ static void set_errorf(char *buffer, int buffer_size, const char *format, ...)
     va_end(args);
 }
 
+static bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char *format, ...)
+{
+    if (buffer == NULL || buffer_size == 0U || offset == NULL || *offset >= buffer_size || format == NULL)
+        return false;
+
+    va_list args;
+    va_start(args, format);
+    const int written = SDL_vsnprintf(buffer + *offset, buffer_size - *offset, format, args);
+    va_end(args);
+    if (written < 0 || (size_t)written >= buffer_size - *offset)
+    {
+        buffer[buffer_size - 1U] = '\0';
+        return false;
+    }
+
+    *offset += (size_t)written;
+    return true;
+}
+
 static bool set_action_keyboard_binding(sdl3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
 static bool set_action_mouse_button_binding(sdl3d_game_data_runtime *runtime, const char *action, Uint8 button);
 static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, const char *action,
@@ -9801,6 +9820,131 @@ bool sdl3d_game_data_get_network_session_state_value(const sdl3d_game_data_runti
         return false;
 
     *out_value = value;
+    return true;
+}
+
+static bool game_data_append_snapshot_value(char *buffer, size_t buffer_size, size_t *offset,
+                                            const game_data_snapshot_value *value)
+{
+    if (value == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_REPLICATION_FIELD_BOOL:
+        return append_format(buffer, buffer_size, offset, "%s", value->value.as_bool ? "true" : "false");
+    case SDL3D_REPLICATION_FIELD_INT32:
+    case SDL3D_REPLICATION_FIELD_ENUM_ID:
+        return append_format(buffer, buffer_size, offset, "%d", (int)value->value.as_int32);
+    case SDL3D_REPLICATION_FIELD_FLOAT32:
+        return append_format(buffer, buffer_size, offset, "%.3f", value->value.as_float32);
+    case SDL3D_REPLICATION_FIELD_VEC2:
+        return append_format(buffer, buffer_size, offset, "(%.3f,%.3f)", value->value.as_vec2.x,
+                             value->value.as_vec2.y);
+    case SDL3D_REPLICATION_FIELD_VEC3:
+        return append_format(buffer, buffer_size, offset, "(%.3f,%.3f,%.3f)", value->value.as_vec3.x,
+                             value->value.as_vec3.y, value->value.as_vec3.z);
+    default:
+        return false;
+    }
+}
+
+bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                               Uint32 tick, char *buffer, size_t buffer_size, char *error_buffer,
+                                               int error_buffer_size)
+{
+    if (buffer != NULL && buffer_size > 0U)
+        buffer[0] = '\0';
+    if (runtime == NULL || replication_name == NULL || replication_name[0] == '\0' || buffer == NULL ||
+        buffer_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot describe requires runtime, channel, and buffer");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot describe requires an authored network schema");
+        return false;
+    }
+
+    yyjson_val *channel = game_data_find_replication_channel_by_name(runtime, replication_name, NULL);
+    if (channel == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot describe channel not found");
+        return false;
+    }
+    if (!game_data_replication_channel_is_host_to_client(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot describe channel must be host_to_client");
+        return false;
+    }
+
+    size_t offset = 0U;
+    const char *active_scene = sdl3d_game_data_active_scene(runtime);
+    if (!append_format(buffer, buffer_size, &offset, "tick=%u scene=%s channel=%s", (unsigned int)tick,
+                       active_scene != NULL ? active_scene : "<none>", replication_name))
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot describe buffer is too small");
+        return false;
+    }
+
+    yyjson_val *state_keys = obj_get(network_session_flow_json(runtime), "state_keys");
+    if (yyjson_is_obj(state_keys))
+    {
+        yyjson_val *state_key = NULL;
+        yyjson_val *state_value_key = NULL;
+        size_t state_index = 0U;
+        size_t state_max = 0U;
+        yyjson_obj_foreach(state_keys, state_index, state_max, state_key, state_value_key)
+        {
+            const char *semantic = yyjson_get_str(state_key);
+            const char *key = yyjson_is_str(state_value_key) ? yyjson_get_str(state_value_key) : NULL;
+            const char *value = sdl3d_properties_get_string(runtime->scene_state, key, "none");
+            if (semantic != NULL && key != NULL &&
+                !append_format(buffer, buffer_size, &offset, " %s=%s", semantic, value != NULL ? value : "none"))
+            {
+                set_error(error_buffer, error_buffer_size, "network snapshot describe buffer is too small");
+                return false;
+            }
+        }
+    }
+
+    yyjson_val *actors = obj_get(channel, "actors");
+    for (size_t actor_index = 0U; yyjson_is_arr(actors) && actor_index < yyjson_arr_size(actors); ++actor_index)
+    {
+        yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
+        const char *entity_name = json_string(actor_schema, "entity", NULL);
+        const sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        if (actor == NULL)
+        {
+            set_errorf(error_buffer, error_buffer_size, "network snapshot describe actor '%s' not found",
+                       entity_name != NULL ? entity_name : "<null>");
+            return false;
+        }
+
+        yyjson_val *fields = obj_get(actor_schema, "fields");
+        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+        {
+            sdl3d_replication_field_descriptor field;
+            game_data_snapshot_value value;
+            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
+                !game_data_read_actor_replication_field(actor, &field, &value))
+            {
+                set_errorf(error_buffer, error_buffer_size,
+                           "network snapshot describe failed to read field '%s' on actor '%s'",
+                           field.path != NULL ? field.path : "<invalid>", entity_name != NULL ? entity_name : "<null>");
+                return false;
+            }
+            if (!append_format(buffer, buffer_size, &offset, " %s.%s=", entity_name != NULL ? entity_name : "<null>",
+                               field.path != NULL ? field.path : "<invalid>") ||
+                !game_data_append_snapshot_value(buffer, buffer_size, &offset, &value))
+            {
+                set_error(error_buffer, error_buffer_size, "network snapshot describe buffer is too small");
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -5073,6 +5073,28 @@ TEST(GameDataRuntime, EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema)
                                            "paddle_flash", 0.0f),
                 0.5f, 0.0001f);
 
+    sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(host), "match_mode", "lan");
+    sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(host), "network_role", "host");
+    sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(host), "network_flow", "direct");
+    char description[4096]{};
+    ASSERT_TRUE(sdl3d_game_data_describe_network_snapshot(host, "play_state", 12345U, description, sizeof(description),
+                                                          error, sizeof(error)))
+        << error;
+    const std::string text(description);
+    EXPECT_NE(text.find("tick=12345"), std::string::npos);
+    EXPECT_NE(text.find("scene=scene.splash"), std::string::npos);
+    EXPECT_NE(text.find("match_mode=lan"), std::string::npos);
+    EXPECT_NE(text.find("network_role=host"), std::string::npos);
+    EXPECT_NE(text.find("network_flow=direct"), std::string::npos);
+    EXPECT_NE(text.find("entity.paddle.player.position=(-7.500,1.250,0.000)"), std::string::npos);
+    EXPECT_NE(text.find("entity.ball.properties.velocity=(3.250,-1.750)"), std::string::npos);
+    EXPECT_NE(text.find("entity.match.properties.paused=true"), std::string::npos);
+
+    char tiny_description[16]{};
+    EXPECT_FALSE(sdl3d_game_data_describe_network_snapshot(host, "play_state", 12345U, tiny_description,
+                                                           sizeof(tiny_description), error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("buffer is too small"), std::string::npos);
+
     destroy_runtime_session(host_session, host);
     destroy_runtime_session(client_session, client);
 }


### PR DESCRIPTION
## Summary

- Add `sdl3d_game_data_describe_network_snapshot()` to format active scene, authored `network.session_flow` state values, and host-to-client replication fields in schema order.
- Replace Pong's hard-coded multiplayer state diagnostic reads with the generic snapshot formatter.
- Document the diagnostic helper and extend game-data coverage for formatted output and small-buffer failure.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c demos/pong/main.c tests/test_game_data.cpp`
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema:GameDataRuntime.LoadsPongDataIntoGenericSessionServices'`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `ctest --test-dir build/debug --output-on-failure -L unit`
- `git diff --check`

Continues #186.
