### PR TITLE
Author network runtime bindings

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -145,6 +145,18 @@
         }
       }
     },
+    "runtime_bindings": {
+      "replication": {
+        "state_snapshot": "play_state",
+        "client_input": "client_input"
+      },
+      "controls": {
+        "start_game": "start_game",
+        "pause_request": "pause_request",
+        "resume_request": "resume_request",
+        "disconnect": "disconnect"
+      }
+    },
     "replication": [
       {
         "name": "play_state",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -71,6 +71,13 @@ static bool send_network_control_packet(pong_state *state, sdl3d_network_session
 static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session,
                                                  pong_network_message_kind kind, const char *label, int count);
 
+static const char PONG_NETWORK_BINDING_STATE_SNAPSHOT[] = "state_snapshot";
+static const char PONG_NETWORK_BINDING_CLIENT_INPUT[] = "client_input";
+static const char PONG_NETWORK_BINDING_START_GAME[] = "start_game";
+static const char PONG_NETWORK_BINDING_PAUSE_REQUEST[] = "pause_request";
+static const char PONG_NETWORK_BINDING_RESUME_REQUEST[] = "resume_request";
+static const char PONG_NETWORK_BINDING_DISCONNECT[] = "disconnect";
+
 static Uint64 pong_log_timestamp_ms(void)
 {
     return SDL_GetTicks();
@@ -81,8 +88,11 @@ static void pong_log_multiplayer_state(const char *prefix, const pong_state *sta
 {
     char description[4096] = {0};
     char error[256] = {0};
+    const char *state_channel = NULL;
     if (state == NULL || state->data == NULL ||
-        !sdl3d_game_data_describe_network_snapshot(state->data, "play_state", packet_tick, description,
+        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
+                                                         &state_channel) ||
+        !sdl3d_game_data_describe_network_snapshot(state->data, state_channel, packet_tick, description,
                                                    sizeof(description), error, sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong multiplayer state diagnostic failed: %s",
@@ -275,12 +285,15 @@ static const char *network_scene_state_key(const pong_state *state, const char *
 static void clear_network_action_overrides(pong_state *state)
 {
     char error[160] = {0};
+    const char *client_input_channel = NULL;
     if (state == NULL || state->input == NULL || state->data == NULL)
     {
         return;
     }
 
-    if (!sdl3d_game_data_clear_network_input_overrides(state->data, "client_input", state->input, error,
+    if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
+                                                         &client_input_channel) ||
+        !sdl3d_game_data_clear_network_input_overrides(state->data, client_input_channel, state->input, error,
                                                        (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network input override clear failed: %s",
@@ -433,52 +446,52 @@ static void reset_direct_connect_defaults(pong_state *state)
     SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Ready to connect");
 }
 
-static const char *network_control_name_for_kind(pong_network_message_kind kind)
+static const char *network_control_binding_for_kind(pong_network_message_kind kind)
 {
     switch (kind)
     {
     case PONG_NETWORK_MESSAGE_START_GAME:
-        return "start_game";
+        return PONG_NETWORK_BINDING_START_GAME;
     case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
-        return "pause_request";
+        return PONG_NETWORK_BINDING_PAUSE_REQUEST;
     case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
-        return "resume_request";
+        return PONG_NETWORK_BINDING_RESUME_REQUEST;
     case PONG_NETWORK_MESSAGE_DISCONNECT:
-        return "disconnect";
+        return PONG_NETWORK_BINDING_DISCONNECT;
     default:
         return NULL;
     }
 }
 
-static bool network_control_kind_from_name(const char *name, pong_network_message_kind *out_kind)
+static const char *network_control_name_for_kind(const pong_state *state, pong_network_message_kind kind)
 {
-    if (name == NULL)
+    const char *control_name = NULL;
+    const char *binding = network_control_binding_for_kind(kind);
+    if (state == NULL || state->data == NULL || binding == NULL ||
+        !sdl3d_game_data_get_network_runtime_control(state->data, binding, &control_name))
+    {
+        return NULL;
+    }
+    return control_name;
+}
+
+static bool network_control_kind_from_name(const pong_state *state, const char *name,
+                                           pong_network_message_kind *out_kind)
+{
+    if (state == NULL || state->data == NULL || name == NULL)
     {
         return false;
     }
-    if (SDL_strcmp(name, "start_game") == 0)
+    for (pong_network_message_kind kind = PONG_NETWORK_MESSAGE_START_GAME; kind <= PONG_NETWORK_MESSAGE_DISCONNECT;
+         kind = (pong_network_message_kind)(kind + 1))
     {
-        if (out_kind != NULL)
-            *out_kind = PONG_NETWORK_MESSAGE_START_GAME;
-        return true;
-    }
-    if (SDL_strcmp(name, "pause_request") == 0)
-    {
-        if (out_kind != NULL)
-            *out_kind = PONG_NETWORK_MESSAGE_PAUSE_REQUEST;
-        return true;
-    }
-    if (SDL_strcmp(name, "resume_request") == 0)
-    {
-        if (out_kind != NULL)
-            *out_kind = PONG_NETWORK_MESSAGE_RESUME_REQUEST;
-        return true;
-    }
-    if (SDL_strcmp(name, "disconnect") == 0)
-    {
-        if (out_kind != NULL)
-            *out_kind = PONG_NETWORK_MESSAGE_DISCONNECT;
-        return true;
+        const char *control_name = network_control_name_for_kind(state, kind);
+        if (control_name != NULL && SDL_strcmp(name, control_name) == 0)
+        {
+            if (out_kind != NULL)
+                *out_kind = kind;
+            return true;
+        }
     }
     return false;
 }
@@ -490,7 +503,7 @@ static bool send_network_control_packet(pong_state *state, sdl3d_network_session
     size_t packet_size = 0U;
     char error[160] = {0};
     const Uint32 tick = (Uint32)SDL_GetTicks();
-    const char *control_name = network_control_name_for_kind(kind);
+    const char *control_name = network_control_name_for_kind(state, kind);
 
     if (state == NULL || state->data == NULL || session == NULL || !sdl3d_network_session_is_connected(session) ||
         control_name == NULL)
@@ -551,7 +564,7 @@ static bool read_network_control_packet(pong_state *state, const Uint8 *packet, 
 
     if (!sdl3d_game_data_decode_network_control(state->data, packet, (size_t)packet_size, &control, error,
                                                 (int)sizeof(error)) ||
-        !network_control_kind_from_name(control.name, &actual) || actual != expected)
+        !network_control_kind_from_name(state, control.name, &actual) || actual != expected)
     {
         return false;
     }
@@ -623,10 +636,13 @@ static bool send_client_input_packet(pong_state *state)
     Uint8 packet[128];
     size_t packet_size = 0U;
     char error[160] = {0};
+    const char *client_input_channel = NULL;
     const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
     const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
 
     if (state == NULL || state->direct_connect_session == NULL || state->input == NULL || p2_up < 0 || p2_down < 0 ||
+        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
+                                                         &client_input_channel) ||
         !sdl3d_network_session_is_connected(state->direct_connect_session))
     {
         return false;
@@ -637,8 +653,8 @@ static bool send_client_input_packet(pong_state *state)
     const float down_value = snapshot != NULL ? snapshot->actions[p2_down].value : 0.0f;
     const Uint32 tick = snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U;
 
-    if (!sdl3d_game_data_encode_network_input(state->data, "client_input", state->input, tick, packet, sizeof(packet),
-                                              &packet_size, error, (int)sizeof(error)))
+    if (!sdl3d_game_data_encode_network_input(state->data, client_input_channel, state->input, tick, packet,
+                                              sizeof(packet), &packet_size, error, (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet encode failed: %s", error);
         return false;
@@ -874,16 +890,19 @@ static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
     Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
     size_t packet_size = 0U;
     char error[160] = {0};
+    const char *state_channel = NULL;
 
     if (state == NULL || state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session) ||
-        state->data == NULL || state->input == NULL)
+        state->data == NULL || state->input == NULL ||
+        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
+                                                         &state_channel))
     {
         return false;
     }
 
     snapshot = sdl3d_input_get_snapshot(state->input);
     if (snapshot == NULL || !sync_match_pause_from_context(ctx, state) ||
-        !sdl3d_game_data_encode_network_snapshot(state->data, "play_state", (Uint32)SDL_max(snapshot->tick, 0), packet,
+        !sdl3d_game_data_encode_network_snapshot(state->data, state_channel, (Uint32)SDL_max(snapshot->tick, 0), packet,
                                                  sizeof(packet), &packet_size, error, (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed: %s", error);

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -78,6 +78,19 @@ static const char PONG_NETWORK_BINDING_PAUSE_REQUEST[] = "pause_request";
 static const char PONG_NETWORK_BINDING_RESUME_REQUEST[] = "resume_request";
 static const char PONG_NETWORK_BINDING_DISCONNECT[] = "disconnect";
 
+typedef struct pong_network_control_binding
+{
+    pong_network_message_kind kind;
+    const char *binding;
+} pong_network_control_binding;
+
+static const pong_network_control_binding PONG_NETWORK_CONTROL_BINDINGS[] = {
+    {PONG_NETWORK_MESSAGE_START_GAME, PONG_NETWORK_BINDING_START_GAME},
+    {PONG_NETWORK_MESSAGE_PAUSE_REQUEST, PONG_NETWORK_BINDING_PAUSE_REQUEST},
+    {PONG_NETWORK_MESSAGE_RESUME_REQUEST, PONG_NETWORK_BINDING_RESUME_REQUEST},
+    {PONG_NETWORK_MESSAGE_DISCONNECT, PONG_NETWORK_BINDING_DISCONNECT},
+};
+
 static Uint64 pong_log_timestamp_ms(void)
 {
     return SDL_GetTicks();
@@ -292,8 +305,13 @@ static void clear_network_action_overrides(pong_state *state)
     }
 
     if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
-                                                         &client_input_channel) ||
-        !sdl3d_game_data_clear_network_input_overrides(state->data, client_input_channel, state->input, error,
+                                                         &client_input_channel))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: replication.%s",
+                    PONG_NETWORK_BINDING_CLIENT_INPUT);
+        return;
+    }
+    if (!sdl3d_game_data_clear_network_input_overrides(state->data, client_input_channel, state->input, error,
                                                        (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network input override clear failed: %s",
@@ -448,19 +466,12 @@ static void reset_direct_connect_defaults(pong_state *state)
 
 static const char *network_control_binding_for_kind(pong_network_message_kind kind)
 {
-    switch (kind)
+    for (size_t i = 0; i < SDL_arraysize(PONG_NETWORK_CONTROL_BINDINGS); ++i)
     {
-    case PONG_NETWORK_MESSAGE_START_GAME:
-        return PONG_NETWORK_BINDING_START_GAME;
-    case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
-        return PONG_NETWORK_BINDING_PAUSE_REQUEST;
-    case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
-        return PONG_NETWORK_BINDING_RESUME_REQUEST;
-    case PONG_NETWORK_MESSAGE_DISCONNECT:
-        return PONG_NETWORK_BINDING_DISCONNECT;
-    default:
-        return NULL;
+        if (PONG_NETWORK_CONTROL_BINDINGS[i].kind == kind)
+            return PONG_NETWORK_CONTROL_BINDINGS[i].binding;
     }
+    return NULL;
 }
 
 static const char *network_control_name_for_kind(const pong_state *state, pong_network_message_kind kind)
@@ -482,9 +493,9 @@ static bool network_control_kind_from_name(const pong_state *state, const char *
     {
         return false;
     }
-    for (pong_network_message_kind kind = PONG_NETWORK_MESSAGE_START_GAME; kind <= PONG_NETWORK_MESSAGE_DISCONNECT;
-         kind = (pong_network_message_kind)(kind + 1))
+    for (size_t i = 0; i < SDL_arraysize(PONG_NETWORK_CONTROL_BINDINGS); ++i)
     {
+        const pong_network_message_kind kind = PONG_NETWORK_CONTROL_BINDINGS[i].kind;
         const char *control_name = network_control_name_for_kind(state, kind);
         if (control_name != NULL && SDL_strcmp(name, control_name) == 0)
         {
@@ -503,11 +514,16 @@ static bool send_network_control_packet(pong_state *state, sdl3d_network_session
     size_t packet_size = 0U;
     char error[160] = {0};
     const Uint32 tick = (Uint32)SDL_GetTicks();
-    const char *control_name = network_control_name_for_kind(state, kind);
-
-    if (state == NULL || state->data == NULL || session == NULL || !sdl3d_network_session_is_connected(session) ||
-        control_name == NULL)
+    if (state == NULL || state->data == NULL || session == NULL || !sdl3d_network_session_is_connected(session))
     {
+        return false;
+    }
+    const char *control_name = network_control_name_for_kind(state, kind);
+    if (control_name == NULL)
+    {
+        const char *binding = network_control_binding_for_kind(kind);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: controls.%s",
+                    binding != NULL ? binding : "<unknown>");
         return false;
     }
 
@@ -641,10 +657,15 @@ static bool send_client_input_packet(pong_state *state)
     const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
 
     if (state == NULL || state->direct_connect_session == NULL || state->input == NULL || p2_up < 0 || p2_down < 0 ||
-        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
-                                                         &client_input_channel) ||
         !sdl3d_network_session_is_connected(state->direct_connect_session))
     {
+        return false;
+    }
+    if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
+                                                         &client_input_channel))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: replication.%s",
+                    PONG_NETWORK_BINDING_CLIENT_INPUT);
         return false;
     }
 
@@ -893,10 +914,15 @@ static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
     const char *state_channel = NULL;
 
     if (state == NULL || state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session) ||
-        state->data == NULL || state->input == NULL ||
-        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
+        state->data == NULL || state->input == NULL)
+    {
+        return false;
+    }
+    if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
                                                          &state_channel))
     {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: replication.%s",
+                    PONG_NETWORK_BINDING_STATE_SNAPSHOT);
         return false;
     }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1318,6 +1318,16 @@ typed actor fields, replicated input actions, and control messages:
         "network_flow": { "host": "host", "direct": "direct" }
       }
     },
+    "runtime_bindings": {
+      "replication": {
+        "state_snapshot": "play_state",
+        "client_input": "client_input"
+      },
+      "controls": {
+        "pause_request": "pause_request",
+        "disconnect": "disconnect"
+      }
+    },
     "replication": [
       {
         "name": "play_state",
@@ -1376,6 +1386,15 @@ stored in scene state. Callers resolve these values with
 `sdl3d_game_data_get_network_session_state_key()`, and
 `sdl3d_game_data_get_network_session_state_value()`. Like `scene_state`, these
 orchestration maps are not part of the replication schema hash.
+
+`runtime_bindings` is optional. It maps host integration semantics to concrete
+authored replication channels and control messages without baking those schema
+names into game host code. `replication` maps semantic names to entries in
+`network.replication`, and `controls` maps semantic names to entries in
+`network.control_messages`. Values are validated as references. Callers resolve
+them with `sdl3d_game_data_get_network_runtime_replication()` and
+`sdl3d_game_data_get_network_runtime_control()`. These maps are runtime
+orchestration metadata and are not part of the replication schema hash.
 
 Replication channel directions are `host_to_client` or `client_to_host`, and
 `rate` must be a positive integer.
@@ -1453,7 +1472,7 @@ Diagnostics are designed for authored content. Errors include the source file, a
 - duplicate names within entity, signal, script, adapter, input action, timer, camera, font, and sensor namespaces
 - script ids, modules, dependencies, dependency cycles, and script file existence
 - input binding structure
-- network protocol, replication directions, scene-state key maps, session-flow maps, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
+- network protocol, replication directions, scene-state key maps, session-flow maps, runtime binding maps, actor/property/action/signal references, supported field types, duplicate network fields, and schema hash shape
 - app lifecycle, UI, render effect, sensor, timer, binding, action, component, adapter, light, and camera references
 - supported generic logic action types and required action payloads
 - warnings for suspicious data such as unused adapters, unused scripts, or unsupported component types

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -923,6 +923,38 @@ extern "C"
                                                          const char *name, const char **out_value);
 
     /**
+     * @brief Resolve an authored network runtime replication channel binding.
+     *
+     * Runtime bindings are authored under `network.runtime_bindings.replication`
+     * and map host integration semantics, such as `state_snapshot` or
+     * `client_input`, to concrete replication channel names declared in
+     * `network.replication`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored binding semantic name.
+     * @param out_channel Receives a replication channel name owned by @p runtime.
+     * @return true when the binding exists and @p out_channel was filled.
+     */
+    bool sdl3d_game_data_get_network_runtime_replication(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                         const char **out_channel);
+
+    /**
+     * @brief Resolve an authored network runtime control-message binding.
+     *
+     * Runtime bindings are authored under `network.runtime_bindings.controls`
+     * and map host integration semantics, such as `pause_request` or
+     * `disconnect`, to concrete control-message names declared in
+     * `network.control_messages`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored binding semantic name.
+     * @param out_control Receives a control-message name owned by @p runtime.
+     * @return true when the binding exists and @p out_control was filled.
+     */
+    bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                     const char **out_control);
+
+    /**
      * @brief Format a diagnostic summary for an authored network snapshot channel.
      *
      * The helper walks the named host-to-client replication channel in authored

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9823,6 +9823,42 @@ bool sdl3d_game_data_get_network_session_state_value(const sdl3d_game_data_runti
     return true;
 }
 
+static yyjson_val *network_runtime_bindings_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(obj_get(runtime_root(runtime), "network"), "runtime_bindings");
+}
+
+static bool game_data_get_network_runtime_binding(const sdl3d_game_data_runtime *runtime, const char *section,
+                                                  const char *name, const char **out_value)
+{
+    if (out_value != NULL)
+        *out_value = NULL;
+    if (runtime == NULL || section == NULL || section[0] == '\0' || name == NULL || name[0] == '\0' ||
+        out_value == NULL)
+    {
+        return false;
+    }
+
+    const char *value = json_string(obj_get(network_runtime_bindings_json(runtime), section), name, NULL);
+    if (value == NULL || value[0] == '\0')
+        return false;
+
+    *out_value = value;
+    return true;
+}
+
+bool sdl3d_game_data_get_network_runtime_replication(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                     const char **out_channel)
+{
+    return game_data_get_network_runtime_binding(runtime, "replication", name, out_channel);
+}
+
+bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                 const char **out_control)
+{
+    return game_data_get_network_runtime_binding(runtime, "controls", name, out_control);
+}
+
 static bool game_data_append_snapshot_value(char *buffer, size_t buffer_size, size_t *offset,
                                             const game_data_snapshot_value *value)
 {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -718,6 +718,51 @@ static bool validate_network_session_flow(validation_context *ctx, yyjson_val *n
     return true;
 }
 
+static bool validate_network_runtime_binding_map(validation_context *ctx, yyjson_val *map, const char *json_path,
+                                                 const char *label, const name_table *references)
+{
+    if (map == NULL)
+        return true;
+    if (!yyjson_is_obj(map))
+        return validation_error(ctx, json_path, "network runtime_bindings %s must be an object", label);
+
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(map, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        yyjson_val *value = yyjson_obj_iter_get_val(key);
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s.%s", json_path, name != NULL ? name : "<invalid>");
+        if (name == NULL || name[0] == '\0')
+            return validation_error(ctx, path, "network runtime_bindings %s key must be non-empty", label);
+        if (!yyjson_is_str(value) || yyjson_get_len(value) == 0)
+            return validation_error(ctx, path, "network runtime_bindings %s value must be a non-empty string", label);
+        if (!require_ref(ctx, references, label, yyjson_get_str(value), path))
+            return false;
+    }
+
+    return true;
+}
+
+static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_val *network,
+                                              const name_table *replication_names, const name_table *control_names)
+{
+    yyjson_val *bindings = obj_get(network, "runtime_bindings");
+    if (bindings == NULL)
+        return true;
+    if (!yyjson_is_obj(bindings))
+        return validation_error(ctx, "$.network.runtime_bindings", "network runtime_bindings must be an object");
+
+    return validate_network_runtime_binding_map(ctx, obj_get(bindings, "replication"),
+                                                "$.network.runtime_bindings.replication", "network replication",
+                                                replication_names) &&
+           validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"),
+                                                "$.network.runtime_bindings.controls", "network control message",
+                                                control_names);
+}
+
 static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *network = obj_get(root, "network");
@@ -816,19 +861,22 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
             ok = validate_network_inputs(ctx, inputs, inputs_path, names);
         }
     }
-    name_table_destroy(&replication_names);
     if (!ok)
+    {
+        name_table_destroy(&replication_names);
         return false;
+    }
 
     yyjson_val *controls = obj_get(network, "control_messages");
-    if (controls == NULL)
-        return true;
-    if (!yyjson_is_arr(controls))
+    if (controls != NULL && !yyjson_is_arr(controls))
+    {
+        name_table_destroy(&replication_names);
         return validation_error(ctx, "$.network.control_messages", "network control_messages must be an array");
+    }
 
     name_table control_names;
     SDL_zero(control_names);
-    for (size_t i = 0; ok && i < yyjson_arr_size(controls); ++i)
+    for (size_t i = 0; ok && yyjson_is_arr(controls) && i < yyjson_arr_size(controls); ++i)
     {
         char path[PATH_BUFFER_SIZE];
         format_path(path, sizeof(path), "$.network.control_messages[%zu]", i);
@@ -856,7 +904,10 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
             break;
         }
     }
+    if (ok)
+        ok = validate_network_runtime_bindings(ctx, network, &replication_names, &control_names);
     name_table_destroy(&control_names);
+    name_table_destroy(&replication_names);
     return ok;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1212,6 +1212,17 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     ASSERT_TRUE(
         sdl3d_game_data_get_network_session_state_value(runtime, "network_role", "client", &network_session_value));
     EXPECT_STREQ(network_session_value, "client");
+    const char *network_runtime_value = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_replication(runtime, "state_snapshot", &network_runtime_value));
+    EXPECT_STREQ(network_runtime_value, "play_state");
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_replication(runtime, "client_input", &network_runtime_value));
+    EXPECT_STREQ(network_runtime_value, "client_input");
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_control(runtime, "pause_request", &network_runtime_value));
+    EXPECT_STREQ(network_runtime_value, "pause_request");
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_control(runtime, "disconnect", &network_runtime_value));
+    EXPECT_STREQ(network_runtime_value, "disconnect");
+    EXPECT_FALSE(sdl3d_game_data_get_network_runtime_control(runtime, "missing", &network_runtime_value));
+    EXPECT_EQ(network_runtime_value, nullptr);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
     EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
@@ -4932,11 +4943,27 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
         }
       }
     })json");
+    std::string network_with_runtime_bindings = network_json;
+    const size_t runtime_bindings_insert = network_with_runtime_bindings.rfind("\n  }");
+    ASSERT_NE(runtime_bindings_insert, std::string::npos);
+    network_with_runtime_bindings.insert(runtime_bindings_insert, R"json(,
+    "runtime_bindings": {
+      "replication": {
+        "state_snapshot": "play_state",
+        "client_input": "client_input"
+      },
+      "controls": {
+        "start_game": "start_game",
+        "pause_request": "pause"
+      }
+    })json");
 
     write_text(dir / "network_a.game.json", network_schema_game_json(network_json, "Network Schema A").c_str());
     write_text(dir / "network_b.game.json", network_schema_game_json(network_json, "Different Metadata").c_str());
     write_text(dir / "network_session_flow.game.json",
                network_schema_game_json(network_with_session_flow, "Network Schema A").c_str());
+    write_text(dir / "network_runtime_bindings.game.json",
+               network_schema_game_json(network_with_runtime_bindings, "Network Schema A").c_str());
     write_text(dir / "network_changed.game.json",
                network_schema_game_json(valid_network_schema_json("vec2"), "Network Schema A").c_str());
 
@@ -4948,10 +4975,12 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
     const auto hash_a = load_network_schema_hash(dir / "network_a.game.json");
     const auto hash_b = load_network_schema_hash(dir / "network_b.game.json");
     const auto hash_with_session_flow = load_network_schema_hash(dir / "network_session_flow.game.json");
+    const auto hash_with_runtime_bindings = load_network_schema_hash(dir / "network_runtime_bindings.game.json");
     const auto hash_changed = load_network_schema_hash(dir / "network_changed.game.json");
 
     EXPECT_EQ(hash_a, hash_b);
     EXPECT_EQ(hash_a, hash_with_session_flow);
+    EXPECT_EQ(hash_a, hash_with_runtime_bindings);
     EXPECT_NE(hash_a, hash_changed);
 
     remove_test_dir(dir);
@@ -5578,6 +5607,59 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "network session_flow state_keys value must be a non-empty string",
+        },
+        {
+            "bad_runtime_replication_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "replication": {
+        "state_snapshot": "missing_channel"
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown network replication reference",
+        },
+        {
+            "bad_runtime_control_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "controls": {
+        "pause_request": "missing_control"
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" }
+    ]
+  })json",
+            "unknown network control message reference",
         },
     };
 

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -28,6 +28,13 @@ enum PongNetworkMessageKind : Uint8
     PONG_NETWORK_MESSAGE_DISCONNECT,
 };
 
+constexpr const char *PONG_NETWORK_BINDING_STATE_SNAPSHOT = "state_snapshot";
+constexpr const char *PONG_NETWORK_BINDING_CLIENT_INPUT = "client_input";
+constexpr const char *PONG_NETWORK_BINDING_START_GAME = "start_game";
+constexpr const char *PONG_NETWORK_BINDING_PAUSE_REQUEST = "pause_request";
+constexpr const char *PONG_NETWORK_BINDING_RESUME_REQUEST = "resume_request";
+constexpr const char *PONG_NETWORK_BINDING_DISCONNECT = "disconnect";
+
 static sdl3d_game_session *create_session(bool include_audio = false)
 {
     sdl3d_game_session_desc desc{};
@@ -114,8 +121,11 @@ static bool send_client_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_gam
     Uint8 packet[128];
     size_t packet_size = 0U;
     char error[160]{};
+    const char *client_input_channel = nullptr;
 
-    return sdl3d_game_data_encode_network_input(runtime, "client_input", input,
+    return sdl3d_game_data_get_network_runtime_replication(runtime, PONG_NETWORK_BINDING_CLIENT_INPUT,
+                                                           &client_input_channel) &&
+           sdl3d_game_data_encode_network_input(runtime, client_input_channel, input,
                                                 (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0), packet,
                                                 sizeof(packet), &packet_size, error, sizeof(error)) &&
            sdl3d_network_session_send(net_session, packet, (int)packet_size);
@@ -136,21 +146,30 @@ static bool process_host_input_packet(sdl3d_game_data_runtime *runtime, sdl3d_ga
                                                (size_t)packet_size, &tick, error, sizeof(error));
 }
 
-static const char *control_name_for_kind(PongNetworkMessageKind kind)
+static const char *control_binding_for_kind(PongNetworkMessageKind kind)
 {
     switch (kind)
     {
     case PONG_NETWORK_MESSAGE_START_GAME:
-        return "start_game";
+        return PONG_NETWORK_BINDING_START_GAME;
     case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
-        return "pause_request";
+        return PONG_NETWORK_BINDING_PAUSE_REQUEST;
     case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
-        return "resume_request";
+        return PONG_NETWORK_BINDING_RESUME_REQUEST;
     case PONG_NETWORK_MESSAGE_DISCONNECT:
-        return "disconnect";
+        return PONG_NETWORK_BINDING_DISCONNECT;
     default:
         return nullptr;
     }
+}
+
+static const char *control_name_for_kind(sdl3d_game_data_runtime *runtime, PongNetworkMessageKind kind)
+{
+    const char *control_name = nullptr;
+    const char *binding = control_binding_for_kind(kind);
+    return binding != nullptr && sdl3d_game_data_get_network_runtime_control(runtime, binding, &control_name)
+               ? control_name
+               : nullptr;
 }
 
 static bool send_control_packet(sdl3d_game_data_runtime *runtime, sdl3d_network_session *net_session,
@@ -159,7 +178,7 @@ static bool send_control_packet(sdl3d_game_data_runtime *runtime, sdl3d_network_
     Uint8 packet[SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE];
     size_t packet_size = 0U;
     char error[160]{};
-    const char *control_name = control_name_for_kind(kind);
+    const char *control_name = control_name_for_kind(runtime, kind);
 
     return control_name != nullptr &&
            sdl3d_game_data_encode_network_control(runtime, control_name, 1234U, packet, sizeof(packet), &packet_size,
@@ -172,11 +191,12 @@ static bool read_control_packet(sdl3d_game_data_runtime *runtime, const Uint8 *p
 {
     sdl3d_game_data_network_control control{};
     char error[160]{};
+    const char *expected_name = control_name_for_kind(runtime, expected);
 
-    return runtime != nullptr && packet != nullptr &&
+    return runtime != nullptr && packet != nullptr && expected_name != nullptr &&
            sdl3d_game_data_decode_network_control(runtime, packet, (size_t)packet_size, &control, error,
                                                   sizeof(error)) &&
-           SDL_strcmp(control.name, control_name_for_kind(expected)) == 0 && control.tick == 1234U;
+           SDL_strcmp(control.name, expected_name) == 0 && control.tick == 1234U;
 }
 
 static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
@@ -187,14 +207,16 @@ static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_
     Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
     size_t packet_size = 0U;
     char error[160]{};
+    const char *state_channel = nullptr;
 
-    if (runtime == nullptr || session == nullptr || net_session == nullptr || match == nullptr)
+    if (runtime == nullptr || session == nullptr || net_session == nullptr || match == nullptr ||
+        !sdl3d_game_data_get_network_runtime_replication(runtime, PONG_NETWORK_BINDING_STATE_SNAPSHOT, &state_channel))
     {
         return false;
     }
 
     sdl3d_properties_set_bool(match->props, "paused", paused);
-    return sdl3d_game_data_encode_network_snapshot(runtime, "play_state",
+    return sdl3d_game_data_encode_network_snapshot(runtime, state_channel,
                                                    (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0), packet,
                                                    sizeof(packet), &packet_size, error, sizeof(error)) &&
            sdl3d_network_session_send(net_session, packet, (int)packet_size);


### PR DESCRIPTION
## Summary

- Add `network.runtime_bindings` for authored runtime lookup of replication channels and control messages.
- Add runtime helpers for resolving authored network replication/control bindings and validation that binding values reference existing schema entries.
- Migrate Pong and headless multiplayer helpers away from hard-coded `play_state`, `client_input`, and concrete control-message names.
- Document the new schema and expand game-data validation/hash tests.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp tests/test_pong_multiplayer.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LoadsPongDataIntoGenericSessionServices:GameDataRuntime.ValidatesNetworkReplicationSchemaAndComputesStableHash:GameDataRuntime.RejectsInvalidNetworkReplicationSchemas:GameDataRuntime.EncodesAndAppliesPongNetworkInputFromAuthoredSchema:GameDataRuntime.EncodesDecodesAndAppliesPongNetworkControlFromAuthoredSchema'`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `./build/debug/tests/sdl3d_game_data_test`
- `ctest --test-dir build/debug --output-on-failure -L unit`
- `git diff --check`

Continues #194.
