### PR TITLE
Author network pause bindings

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -155,6 +155,10 @@
         "pause_request": "pause_request",
         "resume_request": "resume_request",
         "disconnect": "disconnect"
+      },
+      "pause": {
+        "action": "action.pause",
+        "state": { "actor": "entity.match", "property": "paused" }
       }
     },
     "replication": [

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -704,10 +704,17 @@ static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_s
     int pause_action = -1;
     pong_network_message_kind request_kind;
 
-    if (ctx == NULL || state == NULL || state->input == NULL || state->direct_connect_session == NULL ||
-        state->data == NULL || !sdl3d_game_data_get_network_runtime_pause_action(state->data, &pause_action) ||
-        pause_action < 0 || !is_multiplayer_play_scene(state) || !is_network_role_client(state) ||
-        !sdl3d_network_session_is_connected(state->direct_connect_session) ||
+    if (ctx == NULL || state == NULL || state->input == NULL || state->data == NULL ||
+        state->direct_connect_session == NULL)
+    {
+        return;
+    }
+    if (!is_multiplayer_play_scene(state) || !is_network_role_client(state) ||
+        !sdl3d_network_session_is_connected(state->direct_connect_session))
+    {
+        return;
+    }
+    if (!sdl3d_game_data_get_network_runtime_pause_action(state->data, &pause_action) ||
         !sdl3d_input_is_pressed(state->input, pause_action))
     {
         return;

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -701,11 +701,11 @@ static bool send_client_input_packet(pong_state *state)
 
 static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_state *state)
 {
-    const int pause_action =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.pause") : -1;
+    int pause_action = -1;
     pong_network_message_kind request_kind;
 
     if (ctx == NULL || state == NULL || state->input == NULL || state->direct_connect_session == NULL ||
+        state->data == NULL || !sdl3d_game_data_get_network_runtime_pause_action(state->data, &pause_action) ||
         pause_action < 0 || !is_multiplayer_play_scene(state) || !is_network_role_client(state) ||
         !sdl3d_network_session_is_connected(state->direct_connect_session) ||
         !sdl3d_input_is_pressed(state->input, pause_action))
@@ -721,27 +721,34 @@ static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_s
 
 static bool sync_match_pause_from_context(sdl3d_game_context *ctx, pong_state *state)
 {
-    sdl3d_registered_actor *match =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.match") : NULL;
-    if (ctx == NULL || match == NULL)
+    char error[160] = {0};
+    if (ctx == NULL || state == NULL || state->data == NULL)
     {
         return false;
     }
 
-    sdl3d_properties_set_bool(match->props, "paused", ctx->paused);
+    if (!sdl3d_game_data_set_network_runtime_pause_state(state->data, ctx->paused, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network pause state write failed: %s", error);
+        return false;
+    }
     return true;
 }
 
 static bool sync_context_pause_from_match(sdl3d_game_context *ctx, pong_state *state)
 {
-    const sdl3d_registered_actor *match =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_actor(state->data, "entity.match") : NULL;
-    const bool paused = match != NULL && sdl3d_properties_get_bool(match->props, "paused", false);
-    if (ctx == NULL || match == NULL)
+    bool paused = false;
+    char error[160] = {0};
+    if (ctx == NULL || state == NULL || state->data == NULL)
     {
         return false;
     }
 
+    if (!sdl3d_game_data_get_network_runtime_pause_state(state->data, &paused, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network pause state read failed: %s", error);
+        return false;
+    }
     if (ctx->paused != paused)
     {
         ctx->paused = paused;

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1393,7 +1393,36 @@ names into game host code. `replication` maps semantic names to entries in
 `network.replication`, and `controls` maps semantic names to entries in
 `network.control_messages`. Values are validated as references. Callers resolve
 them with `sdl3d_game_data_get_network_runtime_replication()` and
-`sdl3d_game_data_get_network_runtime_control()`. These maps are runtime
+`sdl3d_game_data_get_network_runtime_control()`. `pause` can additionally bind a
+network pause action and the bool actor property that mirrors pause state into
+replicated game data:
+
+```json
+"runtime_bindings": {
+  "replication": {
+    "state_snapshot": "play_state",
+    "client_input": "client_input"
+  },
+  "controls": {
+    "pause_request": "pause_request",
+    "resume_request": "resume_request"
+  },
+  "pause": {
+    "action": "action.pause",
+    "state": {
+      "actor": "entity.match",
+      "property": "paused"
+    }
+  }
+}
+```
+
+The `pause.action` value must reference an input action. `pause.state.actor`
+must reference an entity, and `pause.state.property` must name a bool property at
+runtime. Host code can resolve these bindings with
+`sdl3d_game_data_get_network_runtime_pause_action()`,
+`sdl3d_game_data_get_network_runtime_pause_state()`, and
+`sdl3d_game_data_set_network_runtime_pause_state()`. These maps are runtime
 orchestration metadata and are not part of the replication schema hash.
 
 Replication channel directions are `host_to_client` or `client_to_host`, and

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1419,7 +1419,9 @@ replicated game data:
 
 The `pause.action` value must reference an input action. `pause.state.actor`
 must reference an entity, and `pause.state.property` must name a bool property at
-runtime. Host code can resolve these bindings with
+runtime. The referenced property should be declared on the actor with a bool type
+and a sane default value, usually `false`, so network pause reads have a defined
+state before the first replicated snapshot. Host code can resolve these bindings with
 `sdl3d_game_data_get_network_runtime_pause_action()`,
 `sdl3d_game_data_get_network_runtime_pause_state()`, and
 `sdl3d_game_data_set_network_runtime_pause_state()`. These maps are runtime

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -955,6 +955,52 @@ extern "C"
                                                      const char **out_control);
 
     /**
+     * @brief Resolve the authored network pause input action id.
+     *
+     * The pause binding is authored under `network.runtime_bindings.pause`.
+     * The `action` value references an input action that should request
+     * pause/resume in network play.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param out_action_id Receives the runtime input action id.
+     * @return true when the pause action binding exists and resolves.
+     */
+    bool sdl3d_game_data_get_network_runtime_pause_action(const sdl3d_game_data_runtime *runtime, int *out_action_id);
+
+    /**
+     * @brief Read the authored network pause state property.
+     *
+     * The pause state is authored under `network.runtime_bindings.pause.state`
+     * as an actor reference and bool property name. This lets host code mirror
+     * pause state into replicated game state without knowing concrete actor ids
+     * or property keys.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param out_paused Receives the current pause state.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the pause state binding exists and resolves to a bool.
+     */
+    bool sdl3d_game_data_get_network_runtime_pause_state(const sdl3d_game_data_runtime *runtime, bool *out_paused,
+                                                         char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Write the authored network pause state property.
+     *
+     * The pause state is authored under `network.runtime_bindings.pause.state`
+     * as an actor reference and bool property name. This helper sets that
+     * property to @p paused.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param paused New pause state.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the pause state binding exists and was written.
+     */
+    bool sdl3d_game_data_set_network_runtime_pause_state(sdl3d_game_data_runtime *runtime, bool paused,
+                                                         char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Format a diagnostic summary for an authored network snapshot channel.
      *
      * The helper walks the named host-to-client replication channel in authored

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9958,6 +9958,13 @@ bool sdl3d_game_data_set_network_runtime_pause_state(sdl3d_game_data_runtime *ru
     if (!network_runtime_pause_state_binding(runtime, &actor, &property, error_buffer, error_buffer_size))
         return false;
 
+    const sdl3d_value *existing = sdl3d_properties_get_value(actor->props, property);
+    if (existing != NULL && existing->type != SDL3D_VALUE_BOOL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network pause property '%s' must be bool", property);
+        return false;
+    }
+
     sdl3d_properties_set_bool(actor->props, property, paused);
     return true;
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9859,6 +9859,109 @@ bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *
     return game_data_get_network_runtime_binding(runtime, "controls", name, out_control);
 }
 
+static yyjson_val *network_runtime_pause_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(network_runtime_bindings_json(runtime), "pause");
+}
+
+static bool network_runtime_pause_state_binding(const sdl3d_game_data_runtime *runtime,
+                                                sdl3d_registered_actor **out_actor, const char **out_property,
+                                                char *error_buffer, int error_buffer_size)
+{
+    if (out_actor != NULL)
+        *out_actor = NULL;
+    if (out_property != NULL)
+        *out_property = NULL;
+    if (runtime == NULL || out_actor == NULL || out_property == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network pause state requires a runtime");
+        return false;
+    }
+
+    yyjson_val *state = obj_get(network_runtime_pause_json(runtime), "state");
+    const char *actor_name = json_string(state, "actor", NULL);
+    const char *property = json_string(state, "property", NULL);
+    if (actor_name == NULL || actor_name[0] == '\0' || property == NULL || property[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "network pause state binding is not authored");
+        return false;
+    }
+
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, actor_name);
+    if (actor == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network pause actor '%s' not found", actor_name);
+        return false;
+    }
+
+    *out_actor = actor;
+    *out_property = property;
+    return true;
+}
+
+bool sdl3d_game_data_get_network_runtime_pause_action(const sdl3d_game_data_runtime *runtime, int *out_action_id)
+{
+    if (out_action_id != NULL)
+        *out_action_id = -1;
+    if (runtime == NULL || out_action_id == NULL)
+        return false;
+
+    const char *action = json_string(network_runtime_pause_json(runtime), "action", NULL);
+    if (action == NULL || action[0] == '\0')
+        return false;
+
+    const int action_id = sdl3d_game_data_find_action(runtime, action);
+    if (action_id < 0)
+        return false;
+
+    *out_action_id = action_id;
+    return true;
+}
+
+bool sdl3d_game_data_get_network_runtime_pause_state(const sdl3d_game_data_runtime *runtime, bool *out_paused,
+                                                     char *error_buffer, int error_buffer_size)
+{
+    if (out_paused != NULL)
+        *out_paused = false;
+    if (out_paused == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network pause state output is required");
+        return false;
+    }
+
+    sdl3d_registered_actor *actor = NULL;
+    const char *property = NULL;
+    if (!network_runtime_pause_state_binding(runtime, &actor, &property, error_buffer, error_buffer_size))
+        return false;
+
+    const sdl3d_value *value = sdl3d_properties_get_value(actor->props, property);
+    if (value == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network pause property '%s' not found", property);
+        return false;
+    }
+    if (value->type != SDL3D_VALUE_BOOL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network pause property '%s' must be bool", property);
+        return false;
+    }
+
+    *out_paused = value->as_bool;
+    return true;
+}
+
+bool sdl3d_game_data_set_network_runtime_pause_state(sdl3d_game_data_runtime *runtime, bool paused, char *error_buffer,
+                                                     int error_buffer_size)
+{
+    sdl3d_registered_actor *actor = NULL;
+    const char *property = NULL;
+    if (!network_runtime_pause_state_binding(runtime, &actor, &property, error_buffer, error_buffer_size))
+        return false;
+
+    sdl3d_properties_set_bool(actor->props, property, paused);
+    return true;
+}
+
 static bool game_data_append_snapshot_value(char *buffer, size_t buffer_size, size_t *offset,
                                             const game_data_snapshot_value *value)
 {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -746,8 +746,39 @@ static bool validate_network_runtime_binding_map(validation_context *ctx, yyjson
     return true;
 }
 
+static bool validate_network_runtime_pause_binding(validation_context *ctx, yyjson_val *pause, validation_names *names)
+{
+    if (pause == NULL)
+        return true;
+    if (!yyjson_is_obj(pause))
+        return validation_error(ctx, "$.network.runtime_bindings.pause",
+                                "network runtime_bindings pause must be an object");
+
+    if (!require_ref(ctx, &names->actions, "input action", json_string(pause, "action"),
+                     "$.network.runtime_bindings.pause.action"))
+    {
+        return false;
+    }
+
+    yyjson_val *state = obj_get(pause, "state");
+    if (!yyjson_is_obj(state))
+        return validation_error(ctx, "$.network.runtime_bindings.pause.state",
+                                "network runtime_bindings pause state must be an object");
+    if (!require_ref(ctx, &names->entities, "entity", json_string(state, "actor"),
+                     "$.network.runtime_bindings.pause.state.actor"))
+    {
+        return false;
+    }
+    if (!is_non_empty_string(state, "property"))
+        return validation_error(ctx, "$.network.runtime_bindings.pause.state.property",
+                                "network runtime_bindings pause state property must be a non-empty string");
+
+    return true;
+}
+
 static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_val *network,
-                                              const name_table *replication_names, const name_table *control_names)
+                                              const name_table *replication_names, const name_table *control_names,
+                                              validation_names *names)
 {
     yyjson_val *bindings = obj_get(network, "runtime_bindings");
     if (bindings == NULL)
@@ -760,7 +791,8 @@ static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_va
                                                 replication_names) &&
            validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"),
                                                 "$.network.runtime_bindings.controls", "network control message",
-                                                control_names);
+                                                control_names) &&
+           validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names);
 }
 
 static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
@@ -905,7 +937,7 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
         }
     }
     if (ok)
-        ok = validate_network_runtime_bindings(ctx, network, &replication_names, &control_names);
+        ok = validate_network_runtime_bindings(ctx, network, &replication_names, &control_names, names);
     name_table_destroy(&control_names);
     name_table_destroy(&replication_names);
     return ok;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -252,7 +252,8 @@ std::string network_schema_game_json(const std::string &network_json, const char
   "world": { "name": "world.network_schema", "kind": "fixed_screen" },
   "entities": [
     { "name": "entity.paddle.player" },
-    { "name": "entity.ball" }
+    { "name": "entity.ball" },
+    { "name": "entity.match", "properties": { "paused": { "type": "bool", "value": false } } }
   ],
   "signals": [
     "signal.network.start",
@@ -264,7 +265,8 @@ std::string network_schema_game_json(const std::string &network_json, const char
         "name": "gameplay",
         "actions": [
           { "name": "action.remote.up" },
-          { "name": "action.remote.down" }
+          { "name": "action.remote.down" },
+          { "name": "action.pause" }
         ]
       }
     ]
@@ -1223,6 +1225,17 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_STREQ(network_runtime_value, "disconnect");
     EXPECT_FALSE(sdl3d_game_data_get_network_runtime_control(runtime, "missing", &network_runtime_value));
     EXPECT_EQ(network_runtime_value, nullptr);
+    int network_pause_action = -1;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_pause_action(runtime, &network_pause_action));
+    EXPECT_EQ(network_pause_action, sdl3d_game_data_find_action(runtime, "action.pause"));
+    bool network_paused = true;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_pause_state(runtime, &network_paused, error, sizeof(error)))
+        << error;
+    EXPECT_FALSE(network_paused);
+    ASSERT_TRUE(sdl3d_game_data_set_network_runtime_pause_state(runtime, true, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_pause_state(runtime, &network_paused, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(network_paused);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
     EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
@@ -4955,6 +4968,10 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
       "controls": {
         "start_game": "start_game",
         "pause_request": "pause"
+      },
+      "pause": {
+        "action": "action.pause",
+        "state": { "actor": "entity.match", "property": "paused" }
       }
     })json");
 
@@ -5660,6 +5677,84 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "unknown network control message reference",
+        },
+        {
+            "bad_runtime_pause_action_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "pause": {
+        "action": "action.missing.pause",
+        "state": { "actor": "entity.match", "property": "paused" }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown input action reference",
+        },
+        {
+            "bad_runtime_pause_state_actor_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "pause": {
+        "action": "action.pause",
+        "state": { "actor": "entity.missing.match", "property": "paused" }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown entity reference",
+        },
+        {
+            "bad_runtime_pause_state_property_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "pause": {
+        "action": "action.pause",
+        "state": { "actor": "entity.match", "property": "" }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network runtime_bindings pause state property must be a non-empty string",
         },
     };
 

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -202,20 +202,22 @@ static bool read_control_packet(sdl3d_game_data_runtime *runtime, const Uint8 *p
 static bool send_host_state_packet(sdl3d_game_data_runtime *runtime, sdl3d_game_session *session,
                                    sdl3d_network_session *net_session, bool paused)
 {
-    sdl3d_registered_actor *match = sdl3d_game_data_find_actor(runtime, "entity.match");
     const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(sdl3d_game_session_get_input(session));
     Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
     size_t packet_size = 0U;
     char error[160]{};
     const char *state_channel = nullptr;
 
-    if (runtime == nullptr || session == nullptr || net_session == nullptr || match == nullptr ||
+    if (runtime == nullptr || session == nullptr || net_session == nullptr ||
         !sdl3d_game_data_get_network_runtime_replication(runtime, PONG_NETWORK_BINDING_STATE_SNAPSHOT, &state_channel))
     {
         return false;
     }
 
-    sdl3d_properties_set_bool(match->props, "paused", paused);
+    if (!sdl3d_game_data_set_network_runtime_pause_state(runtime, paused, error, sizeof(error)))
+    {
+        return false;
+    }
     return sdl3d_game_data_encode_network_snapshot(runtime, state_channel,
                                                    (Uint32)SDL_max(snapshot != nullptr ? snapshot->tick : 0, 0), packet,
                                                    sizeof(packet), &packet_size, error, sizeof(error)) &&
@@ -226,7 +228,6 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
                                         bool *out_paused)
 {
     Uint32 tick = 0U;
-    sdl3d_registered_actor *match = nullptr;
     char error[160]{};
 
     if (runtime == nullptr || packet == nullptr || packet_size <= 0)
@@ -240,15 +241,9 @@ static bool process_client_state_packet(sdl3d_game_data_runtime *runtime, const 
     }
 
     (void)tick;
-    match = sdl3d_game_data_find_actor(runtime, "entity.match");
-    if (match == nullptr)
-    {
-        return false;
-    }
-
     if (out_paused != nullptr)
     {
-        *out_paused = sdl3d_properties_get_bool(match->props, "paused", false);
+        return sdl3d_game_data_get_network_runtime_pause_state(runtime, out_paused, error, sizeof(error));
     }
     return true;
 }


### PR DESCRIPTION
## Summary

- add `network.runtime_bindings.pause` for authored pause action and replicated pause-state actor/property bindings
- expose engine helpers to resolve, read, and write network pause bindings without Pong-specific actor/action names
- migrate Pong network pause sync and headless multiplayer tests to the authored bindings
- document and validate the new runtime binding shape

Continues #194.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp tests/test_pong_multiplayer.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`