### PR TITLE
Author network disconnect flow messages

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -143,6 +143,26 @@
           "host": "host",
           "direct": "direct"
         }
+      },
+      "messages": {
+        "disconnect_reasons": {
+          "peer_disconnected": "Peer disconnected",
+          "client_disconnected": "Client disconnected",
+          "host_disconnected": "Host disconnected",
+          "client_exited": "Client exited",
+          "host_exited": "Host exited",
+          "client_timed_out": "Client timed out",
+          "host_timed_out": "Host timed out",
+          "host_rejected": "Host rejected connection",
+          "host_error": "Host connection error"
+        },
+        "disconnect_status": {
+          "disconnected": "Disconnected",
+          "returning_join": "Returning to Join Match"
+        },
+        "disconnect_prompts": {
+          "match_terminated": "Match terminated: {reason} - Press Enter to return to title screen."
+        }
       }
     },
     "runtime_bindings": {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -155,6 +155,23 @@ static const char *network_session_state_value(const pong_state *state, const ch
     return fallback;
 }
 
+static const char *network_session_message(const pong_state *state, const char *group, const char *name,
+                                           const char *fallback)
+{
+    const char *message = NULL;
+    if (state != NULL && state->data != NULL &&
+        sdl3d_game_data_get_network_session_message(state->data, group, name, &message))
+    {
+        return message;
+    }
+    return fallback;
+}
+
+static const char *network_disconnect_reason(const pong_state *state, const char *name, const char *fallback)
+{
+    return network_session_message(state, "disconnect_reasons", name, fallback);
+}
+
 static const char *network_session_state_string(const pong_state *state, const char *key_name, const char *fallback)
 {
     const sdl3d_properties *scene_state =
@@ -830,7 +847,9 @@ static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state 
     }
 
     SDL_snprintf(state->network_match_termination_reason, sizeof(state->network_match_termination_reason), "%s",
-                 reason != NULL && reason[0] != '\0' ? reason : "Peer disconnected");
+                 reason != NULL && reason[0] != '\0'
+                     ? reason
+                     : network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
     state->network_match_termination_timer = 0.0f;
     state->network_match_termination_active = true;
 
@@ -838,14 +857,18 @@ static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state 
     {
         destroy_host_session_internal(state, false);
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
-                     reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
+                     reason != NULL && reason[0] != '\0'
+                         ? reason
+                         : network_disconnect_reason(state, "client_disconnected", "Client disconnected"));
         update_host_session_scene_state(state);
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host match terminated: %s", state->host_status);
     }
     else
     {
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                     reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
+                     reason != NULL && reason[0] != '\0'
+                         ? reason
+                         : network_disconnect_reason(state, "host_disconnected", "Host disconnected"));
         destroy_direct_connect_session_internal(state, false);
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client match terminated: %s", state->direct_connect_status);
     }
@@ -874,7 +897,9 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
     if (local_host)
     {
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
-                     reason != NULL && reason[0] != '\0' ? reason : "Client disconnected");
+                     reason != NULL && reason[0] != '\0'
+                         ? reason
+                         : network_disconnect_reason(state, "client_disconnected", "Client disconnected"));
         destroy_host_session_internal(state, false);
         update_host_session_scene_state(state);
         (void)sdl3d_game_data_set_active_scene(state->data,
@@ -883,7 +908,9 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
     else
     {
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                     reason != NULL && reason[0] != '\0' ? reason : "Host disconnected");
+                     reason != NULL && reason[0] != '\0'
+                         ? reason
+                         : network_disconnect_reason(state, "host_disconnected", "Host disconnected"));
         destroy_direct_connect_session_internal(state, false);
         (void)sdl3d_game_data_set_active_scene(state->data,
                                                network_session_scene(state, "join", "scene.multiplayer.join"));
@@ -912,7 +939,9 @@ static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong
         }
         return true;
     case PONG_NETWORK_MESSAGE_DISCONNECT:
-        return_to_multiplayer_after_disconnect(ctx, state, is_network_role_host(state), "Peer disconnected");
+        return_to_multiplayer_after_disconnect(
+            ctx, state, is_network_role_host(state),
+            network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
         return true;
     default:
         return false;
@@ -1034,7 +1063,8 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
                             (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                return_to_multiplayer_after_disconnect(ctx, state, false, "Host exited");
+                return_to_multiplayer_after_disconnect(ctx, state, false,
+                                                       network_disconnect_reason(state, "host_exited", "Host exited"));
                 break;
             }
             if (!is_multiplayer_play_scene(state))
@@ -1066,9 +1096,11 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             session_state == SDL3D_NETWORK_STATE_ERROR)
         {
             const bool was_playing = is_multiplayer_play_scene(state);
-            const char *reason = session_state == SDL3D_NETWORK_STATE_TIMED_OUT  ? "Host timed out"
-                                 : session_state == SDL3D_NETWORK_STATE_REJECTED ? "Host rejected connection"
-                                                                                 : "Host connection error";
+            const char *reason = session_state == SDL3D_NETWORK_STATE_TIMED_OUT
+                                     ? network_disconnect_reason(state, "host_timed_out", "Host timed out")
+                                 : session_state == SDL3D_NETWORK_STATE_REJECTED
+                                     ? network_disconnect_reason(state, "host_rejected", "Host rejected connection")
+                                     : network_disconnect_reason(state, "host_error", "Host connection error");
             if (was_playing)
             {
                 return_to_multiplayer_after_disconnect(ctx, state, false, reason);
@@ -1407,7 +1439,8 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
                             (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                return_to_multiplayer_after_disconnect(ctx, state, true, "Client exited");
+                return_to_multiplayer_after_disconnect(
+                    ctx, state, true, network_disconnect_reason(state, "client_exited", "Client exited"));
                 break;
             }
             if (is_multiplayer_play_scene(state) &&
@@ -1443,7 +1476,8 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         else if (is_multiplayer_play_scene(state) && state->host_session != NULL &&
                  sdl3d_network_session_state(state->host_session) != SDL3D_NETWORK_STATE_CONNECTED)
         {
-            begin_network_match_termination(ctx, state, true, "Client timed out");
+            begin_network_match_termination(ctx, state, true,
+                                            network_disconnect_reason(state, "client_timed_out", "Client timed out"));
         }
         return;
     }
@@ -1582,7 +1616,8 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
         if (state->direct_connect_session != NULL)
         {
             destroy_direct_connect_session(state);
-            SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Disconnected");
+            SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
+                         network_session_message(state, "disconnect_status", "disconnected", "Disconnected"));
         }
         else
         {
@@ -1593,7 +1628,8 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
     if (sdl3d_ui_layout_button(state->direct_connect_ui, "Back"))
     {
         destroy_direct_connect_session(state);
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Returning to Join Match");
+        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
+                     network_session_message(state, "disconnect_status", "returning_join", "Returning to Join Match"));
         (void)sdl3d_game_data_set_active_scene(state->data,
                                                network_session_scene(state, "join", "scene.multiplayer.join"));
     }
@@ -1603,6 +1639,29 @@ static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *sta
 
     sdl3d_ui_end_vbox(state->direct_connect_ui);
     sdl3d_ui_end_panel(state->direct_connect_ui);
+}
+
+static void format_network_termination_prompt(const pong_state *state, char *buffer, size_t buffer_size,
+                                              const char *reason)
+{
+    const char *template =
+        network_session_message(state, "disconnect_prompts", "match_terminated",
+                                "Match terminated: {reason} - Press Enter to return to title screen.");
+    const char *placeholder = template != NULL ? SDL_strstr(template, "{reason}") : NULL;
+
+    if (buffer == NULL || buffer_size == 0)
+    {
+        return;
+    }
+    if (placeholder == NULL)
+    {
+        SDL_snprintf(buffer, buffer_size, "%s", template != NULL ? template : "");
+        return;
+    }
+
+    const size_t prefix_len = (size_t)(placeholder - template);
+    SDL_snprintf(buffer, buffer_size, "%.*s%s%s", (int)prefix_len, template, reason != NULL ? reason : "",
+                 placeholder + SDL_strlen("{reason}"));
 }
 
 static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong_state *state)
@@ -1618,9 +1677,10 @@ static void draw_network_match_termination_overlay(sdl3d_game_context *ctx, pong
         return;
     }
 
-    SDL_snprintf(message, sizeof(message), "Match terminated: %s - Press Enter to return to title screen.",
-                 state->network_match_termination_reason[0] != '\0' ? state->network_match_termination_reason
-                                                                    : "Peer disconnected");
+    format_network_termination_prompt(state, message, sizeof(message),
+                                      state->network_match_termination_reason[0] != '\0'
+                                          ? state->network_match_termination_reason
+                                          : network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
 
     panel_w = 880.0f;
     panel_h = 150.0f;

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1381,10 +1381,14 @@ scene-state strings into C. `scenes` maps semantic names such as `play`,
 `host_lobby`, `join`, `direct_connect`, `discovery`, or `title` to validated
 scene ids. `state_keys` maps semantic state names to scene-state property keys.
 `state_values` maps semantic values inside each state group to concrete strings
-stored in scene state. Callers resolve these values with
+stored in scene state. `messages` maps semantic text groups to non-empty strings
+for host-owned network UI flows, such as disconnect reasons or termination
+prompts. Prompt strings may use host-specific placeholders such as `{reason}`
+when the caller documents and substitutes them. Callers resolve these values with
 `sdl3d_game_data_get_network_session_scene()`,
 `sdl3d_game_data_get_network_session_state_key()`, and
-`sdl3d_game_data_get_network_session_state_value()`. Like `scene_state`, these
+`sdl3d_game_data_get_network_session_state_value()`, and
+`sdl3d_game_data_get_network_session_message()`. Like `scene_state`, these
 orchestration maps are not part of the replication schema hash.
 
 `runtime_bindings` is optional. It maps host integration semantics to concrete

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -923,6 +923,23 @@ extern "C"
                                                          const char *name, const char **out_value);
 
     /**
+     * @brief Resolve an authored network session message.
+     *
+     * Messages are authored under `network.session_flow.messages.<group>`.
+     * Host integration code can use this for player-facing network flow text
+     * such as disconnect reasons or termination prompts without hard-coding
+     * those strings in C.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param group Authored message group.
+     * @param name Authored message semantic name.
+     * @param out_message Receives a message string owned by @p runtime.
+     * @return true when the message semantic exists and @p out_message was filled.
+     */
+    bool sdl3d_game_data_get_network_session_message(const sdl3d_game_data_runtime *runtime, const char *group,
+                                                     const char *name, const char **out_message);
+
+    /**
      * @brief Resolve an authored network runtime replication channel binding.
      *
      * Runtime bindings are authored under `network.runtime_bindings.replication`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9823,6 +9823,25 @@ bool sdl3d_game_data_get_network_session_state_value(const sdl3d_game_data_runti
     return true;
 }
 
+bool sdl3d_game_data_get_network_session_message(const sdl3d_game_data_runtime *runtime, const char *group,
+                                                 const char *name, const char **out_message)
+{
+    if (out_message != NULL)
+        *out_message = NULL;
+    if (runtime == NULL || group == NULL || group[0] == '\0' || name == NULL || name[0] == '\0' || out_message == NULL)
+    {
+        return false;
+    }
+
+    yyjson_val *groups = obj_get(network_session_flow_json(runtime), "messages");
+    const char *value = json_string(obj_get(groups, group), name, NULL);
+    if (value == NULL || value[0] == '\0')
+        return false;
+
+    *out_message = value;
+    return true;
+}
+
 static yyjson_val *network_runtime_bindings_json(const sdl3d_game_data_runtime *runtime)
 {
     return obj_get(obj_get(runtime_root(runtime), "network"), "runtime_bindings");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -693,26 +693,41 @@ static bool validate_network_session_flow(validation_context *ctx, yyjson_val *n
     }
 
     yyjson_val *state_values = obj_get(flow, "state_values");
-    if (state_values == NULL)
-        return true;
-    if (!yyjson_is_obj(state_values))
-        return validation_error(ctx, "$.network.session_flow.state_values",
-                                "network session_flow state_values must be an object");
-
-    yyjson_val *group_key;
-    yyjson_obj_iter group_iter;
-    yyjson_obj_iter_init(state_values, &group_iter);
-    while ((group_key = yyjson_obj_iter_next(&group_iter)) != NULL)
+    yyjson_val *messages = obj_get(flow, "messages");
+    const struct
     {
-        const char *group_name = yyjson_get_str(group_key);
-        yyjson_val *group = yyjson_obj_iter_get_val(group_key);
-        char group_path[PATH_BUFFER_SIZE];
-        format_path(group_path, sizeof(group_path), "$.network.session_flow.state_values.%s",
-                    group_name != NULL ? group_name : "<invalid>");
-        if (group_name == NULL || group_name[0] == '\0')
-            return validation_error(ctx, group_path, "network session_flow state_values group must be non-empty");
-        if (!validate_network_session_string_map(ctx, group, group_path, "state_values", NULL))
-            return false;
+        yyjson_val *root;
+        const char *path;
+        const char *label;
+    } grouped_maps[] = {
+        {state_values, "$.network.session_flow.state_values", "state_values"},
+        {messages, "$.network.session_flow.messages", "messages"},
+    };
+
+    for (size_t map_index = 0; map_index < SDL_arraysize(grouped_maps); ++map_index)
+    {
+        if (grouped_maps[map_index].root == NULL)
+            continue;
+        if (!yyjson_is_obj(grouped_maps[map_index].root))
+            return validation_error(ctx, grouped_maps[map_index].path, "network session_flow %s must be an object",
+                                    grouped_maps[map_index].label);
+
+        yyjson_val *group_key;
+        yyjson_obj_iter group_iter;
+        yyjson_obj_iter_init(grouped_maps[map_index].root, &group_iter);
+        while ((group_key = yyjson_obj_iter_next(&group_iter)) != NULL)
+        {
+            const char *group_name = yyjson_get_str(group_key);
+            yyjson_val *group = yyjson_obj_iter_get_val(group_key);
+            char group_path[PATH_BUFFER_SIZE];
+            format_path(group_path, sizeof(group_path), "%s.%s", grouped_maps[map_index].path,
+                        group_name != NULL ? group_name : "<invalid>");
+            if (group_name == NULL || group_name[0] == '\0')
+                return validation_error(ctx, group_path, "network session_flow %s group must be non-empty",
+                                        grouped_maps[map_index].label);
+            if (!validate_network_session_string_map(ctx, group, group_path, grouped_maps[map_index].label, NULL))
+                return false;
+        }
     }
 
     return true;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1214,6 +1214,15 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     ASSERT_TRUE(
         sdl3d_game_data_get_network_session_state_value(runtime, "network_role", "client", &network_session_value));
     EXPECT_STREQ(network_session_value, "client");
+    ASSERT_TRUE(sdl3d_game_data_get_network_session_message(runtime, "disconnect_reasons", "host_exited",
+                                                            &network_session_value));
+    EXPECT_STREQ(network_session_value, "Host exited");
+    ASSERT_TRUE(sdl3d_game_data_get_network_session_message(runtime, "disconnect_prompts", "match_terminated",
+                                                            &network_session_value));
+    EXPECT_STREQ(network_session_value, "Match terminated: {reason} - Press Enter to return to title screen.");
+    EXPECT_FALSE(
+        sdl3d_game_data_get_network_session_message(runtime, "disconnect_reasons", "missing", &network_session_value));
+    EXPECT_EQ(network_session_value, nullptr);
     const char *network_runtime_value = nullptr;
     ASSERT_TRUE(sdl3d_game_data_get_network_runtime_replication(runtime, "state_snapshot", &network_runtime_value));
     EXPECT_STREQ(network_runtime_value, "play_state");
@@ -4954,6 +4963,14 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
         "match_mode": {
           "network": "lan"
         }
+      },
+      "messages": {
+        "disconnect_reasons": {
+          "host_exited": "Host exited"
+        },
+        "disconnect_prompts": {
+          "match_terminated": "Match terminated: {reason}"
+        }
       }
     })json");
     std::string network_with_runtime_bindings = network_json;
@@ -5624,6 +5641,33 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "network session_flow state_keys value must be a non-empty string",
+        },
+        {
+            "bad_session_flow_message",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "session_flow": {
+      "messages": {
+        "disconnect_reasons": {
+          "host_exited": ""
+        }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network session_flow messages value must be a non-empty string",
         },
         {
             "bad_runtime_replication_binding",


### PR DESCRIPTION
## Summary

- add `network.session_flow.messages` for authored network flow text such as disconnect reasons and termination prompts
- expose `sdl3d_game_data_get_network_session_message()` with validation for grouped non-empty message maps
- move Pong network disconnect/status/prompt text through authored message lookups while keeping session teardown in C
- document the new session message map and cover it in game-data tests

Continues #194.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`

## Next slice

Next should be issue #194 slice 4: author/generalize haptics actor filters so Pong paddle-hit rumble no longer depends on hard-coded actor names in C.