### PR TITLE
Author haptics feedback policies

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1760,6 +1760,33 @@
       }
     }
   ],
+  "haptics": {
+    "policies": [
+      {
+        "name": "haptics.gamepad.vibration_test",
+        "signal": "signal.settings.vibration",
+        "low_frequency": 0.30,
+        "high_frequency": 0.70,
+        "duration_ms": 100
+      },
+      {
+        "name": "haptics.gamepad.paddle_hit",
+        "signal": "signal.ball.hit_paddle",
+        "enabled_if": { "type": "property.compare", "target": "entity.settings", "key": "vibration", "op": "==", "value": true },
+        "low_frequency": 0.45,
+        "high_frequency": 0.75,
+        "duration_ms": 120,
+        "payload_actor_filters": [
+          { "key": "other_actor_name", "tags": ["paddle", "player"] },
+          {
+            "key": "other_actor_name",
+            "tags": ["paddle", "cpu"],
+            "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" }
+          }
+        ]
+      }
+    ]
+  },
   "signals": [
     "signal.game.start",
     "signal.ball.serve",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -43,13 +43,12 @@ typedef struct pong_state
     char direct_connect_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
     char direct_connect_port[16];
     char direct_connect_status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
-    int paddle_hit_connection;
-    int vibration_connection;
+    int *haptics_signal_ids;
+    int *haptics_connections;
+    int haptics_connection_count;
     int lobby_start_connection;
     int host_start_signal_id;
     int camera_toggle_signal_id;
-    int ball_hit_signal_id;
-    int vibration_signal_id;
     int discovery_refresh_signal_id;
     int discovery_refresh_connection;
     sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
@@ -1723,42 +1722,96 @@ static void refresh_local_play_input(pong_state *state)
 static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
     pong_state *state = (pong_state *)userdata;
-    const sdl3d_registered_actor *settings =
-        state != NULL ? sdl3d_game_data_find_actor(state->data, "entity.settings") : NULL;
-    const bool vibration_enabled = settings != NULL && sdl3d_properties_get_bool(settings->props, "vibration", false);
-    const char *other_actor_name =
-        payload != NULL ? sdl3d_properties_get_string(payload, "other_actor_name", NULL) : NULL;
-
-    if (state == NULL || state->input == NULL)
+    if (state == NULL || state->data == NULL || state->input == NULL)
     {
         return;
     }
 
-    if (signal_id == state->vibration_signal_id)
+    const int policy_count = sdl3d_game_data_haptics_policy_count(state->data);
+    for (int i = 0; i < policy_count; ++i)
     {
-        if (!sdl3d_input_rumble_all_gamepads(state->input, 0.30f, 0.70f, 100))
+        sdl3d_game_data_haptics_policy policy;
+        if (!sdl3d_game_data_match_haptics_policy(state->data, i, signal_id, payload, &policy))
+            continue;
+        if (!sdl3d_input_rumble_all_gamepads(state->input, policy.low_frequency, policy.high_frequency,
+                                             policy.duration_ms))
         {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Pong vibration feedback requested but no rumble-capable gamepad accepted it");
+                        "Pong haptics policy '%s' requested rumble but no gamepad accepted it",
+                        policy.name != NULL ? policy.name : "<unnamed>");
         }
+    }
+}
+
+static bool pong_haptics_signal_connected(const pong_state *state, int signal_id)
+{
+    if (state == NULL || signal_id < 0)
+        return true;
+    for (int i = 0; i < state->haptics_connection_count; ++i)
+    {
+        if (state->haptics_signal_ids != NULL && state->haptics_signal_ids[i] == signal_id)
+            return true;
+    }
+    return false;
+}
+
+static void connect_haptics_policies(sdl3d_game_context *ctx, pong_state *state)
+{
+    if (ctx == NULL || state == NULL || state->data == NULL || state->input == NULL)
+        return;
+
+    const int policy_count = sdl3d_game_data_haptics_policy_count(state->data);
+    if (policy_count <= 0)
+        return;
+
+    state->haptics_signal_ids = SDL_calloc((size_t)policy_count, sizeof(*state->haptics_signal_ids));
+    state->haptics_connections = SDL_calloc((size_t)policy_count, sizeof(*state->haptics_connections));
+    if (state->haptics_signal_ids == NULL || state->haptics_connections == NULL)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong failed to allocate haptics signal connections");
+        SDL_free(state->haptics_signal_ids);
+        SDL_free(state->haptics_connections);
+        state->haptics_signal_ids = NULL;
+        state->haptics_connections = NULL;
         return;
     }
 
-    if (!vibration_enabled)
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
+    for (int i = 0; i < policy_count; ++i)
     {
-        return;
-    }
-
-    if (signal_id == state->ball_hit_signal_id && other_actor_name != NULL &&
-        (SDL_strcmp(other_actor_name, "entity.paddle.player") == 0 ||
-         (is_local_match_mode(state) && SDL_strcmp(other_actor_name, "entity.paddle.cpu") == 0)))
-    {
-        if (!sdl3d_input_rumble_all_gamepads(state->input, 0.45f, 0.75f, 120))
+        sdl3d_game_data_haptics_policy policy;
+        if (!sdl3d_game_data_get_haptics_policy_at(state->data, i, &policy) ||
+            pong_haptics_signal_connected(state, policy.signal_id))
         {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Pong paddle hit rumble requested but no rumble-capable gamepad accepted it");
+            continue;
+        }
+
+        const int connection = sdl3d_signal_connect(bus, policy.signal_id, on_gamepad_feedback, state);
+        if (connection > 0)
+        {
+            state->haptics_signal_ids[state->haptics_connection_count] = policy.signal_id;
+            state->haptics_connections[state->haptics_connection_count] = connection;
+            ++state->haptics_connection_count;
         }
     }
+}
+
+static void disconnect_haptics_policies(sdl3d_game_context *ctx, pong_state *state)
+{
+    if (ctx == NULL || state == NULL)
+        return;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
+    for (int i = 0; i < state->haptics_connection_count; ++i)
+    {
+        if (state->haptics_connections != NULL && state->haptics_connections[i] > 0)
+            sdl3d_signal_disconnect(bus, state->haptics_connections[i]);
+    }
+    SDL_free(state->haptics_signal_ids);
+    SDL_free(state->haptics_connections);
+    state->haptics_signal_ids = NULL;
+    state->haptics_connections = NULL;
+    state->haptics_connection_count = 0;
 }
 
 static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -1928,14 +1981,11 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong gamepad slot: slot=%d id=%d connected=%d", i,
                     sdl3d_input_gamepad_id_at(state->input, i), sdl3d_input_gamepad_is_connected(state->input, i));
     }
-    state->paddle_hit_connection = 0;
-    state->vibration_connection = 0;
+    state->haptics_connection_count = 0;
     state->lobby_start_connection = 0;
     state->discovery_refresh_connection = 0;
     state->host_start_signal_id = sdl3d_game_data_find_signal(state->data, "signal.multiplayer.lobby.start");
     state->camera_toggle_signal_id = sdl3d_game_data_find_signal(state->data, "signal.camera.ball.toggle");
-    state->ball_hit_signal_id = sdl3d_game_data_find_signal(state->data, "signal.ball.hit_paddle");
-    state->vibration_signal_id = sdl3d_game_data_find_signal(state->data, "signal.settings.vibration");
     state->discovery_refresh_signal_id =
         sdl3d_game_data_find_signal(state->data, "signal.multiplayer.discovery.refresh");
     sdl3d_game_data_input_profile_refresh_state_init(&state->input_profile_refresh);
@@ -1945,16 +1995,7 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     update_host_session_scene_state(state);
     if (state->input != NULL)
     {
-        if (state->ball_hit_signal_id >= 0)
-        {
-            state->paddle_hit_connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
-                                                                state->ball_hit_signal_id, on_gamepad_feedback, state);
-        }
-        if (state->vibration_signal_id >= 0)
-        {
-            state->vibration_connection = sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
-                                                               state->vibration_signal_id, on_gamepad_feedback, state);
-        }
+        connect_haptics_policies(ctx, state);
         if (state->host_start_signal_id >= 0)
         {
             state->lobby_start_connection =
@@ -2094,16 +2135,7 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     sdl3d_game_data_particle_cache_free(&state->particle_cache);
     sdl3d_game_data_image_cache_free(&state->image_cache);
     sdl3d_game_data_font_cache_free(&state->font_cache);
-    if (state->paddle_hit_connection > 0)
-    {
-        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->paddle_hit_connection);
-        state->paddle_hit_connection = 0;
-    }
-    if (state->vibration_connection > 0)
-    {
-        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->vibration_connection);
-        state->vibration_connection = 0;
-    }
+    disconnect_haptics_policies(ctx, state);
     if (state->lobby_start_connection > 0)
     {
         sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->lobby_start_connection);

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -737,6 +737,47 @@ child menu selections set `menu_state_key` in scene state instead of requesting 
 }
 ```
 
+Haptics policies can be authored under `haptics.policies`. Each policy names the
+trigger signal, rumble intensity, and duration. Hosts can enumerate policies
+with `sdl3d_game_data_haptics_policy_count()` and
+`sdl3d_game_data_get_haptics_policy_at()`, subscribe to the referenced signals,
+then call `sdl3d_game_data_match_haptics_policy()` for each signal payload before
+starting rumble.
+
+```json
+{
+  "haptics": {
+    "policies": [
+      {
+        "name": "haptics.player_hit",
+        "signal": "signal.player.hit",
+        "enabled_if": {
+          "type": "property.compare",
+          "target": "entity.settings",
+          "key": "vibration",
+          "op": "==",
+          "value": true
+        },
+        "low_frequency": 0.45,
+        "high_frequency": 0.75,
+        "duration_ms": 120,
+        "payload_actor_filters": [
+          { "key": "other_actor_name", "tags": ["player"] }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`enabled_if` is optional and uses the same condition syntax as UI visibility and
+profile activation. `payload_actor_filters` is optional; when present, at least
+one filter must match. A filter reads an actor name from the signal payload field
+named by `key`, then matches either a concrete `actor` reference or all authored
+`tags` on that actor. Filters may also have their own `active_if` condition.
+Intensities must be numbers from 0 to 1, and `duration_ms` must be a positive
+integer.
+
     Sprite assets can be authored under `assets.sprites`:
 
 ```json

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -99,6 +99,21 @@ extern "C"
         Uint32 tick;
     } sdl3d_game_data_network_control;
 
+    /** @brief Authored haptics/rumble policy selected by a signal payload. */
+    typedef struct sdl3d_game_data_haptics_policy
+    {
+        /** @brief Stable authored policy name, owned by the runtime. */
+        const char *name;
+        /** @brief Signal that triggers the policy, or -1. */
+        int signal_id;
+        /** @brief Low-frequency rumble intensity in the range [0, 1]. */
+        float low_frequency;
+        /** @brief High-frequency rumble intensity in the range [0, 1]. */
+        float high_frequency;
+        /** @brief Rumble duration in milliseconds. */
+        Uint32 duration_ms;
+    } sdl3d_game_data_haptics_policy;
+
     /** @brief Authored font asset descriptor. */
     typedef struct sdl3d_game_data_font_asset
     {
@@ -970,6 +985,50 @@ extern "C"
      */
     bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *runtime, const char *name,
                                                      const char **out_control);
+
+    /**
+     * @brief Return the number of authored haptics policies.
+     *
+     * Policies are authored under `haptics.policies`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @return Number of authored policies, or 0 when none are authored.
+     */
+    int sdl3d_game_data_haptics_policy_count(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Read an authored haptics policy descriptor by index.
+     *
+     * This exposes the policy's signal and rumble parameters so hosts can
+     * subscribe to the necessary signals. Use
+     * `sdl3d_game_data_match_haptics_policy()` before playing rumble.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param index Zero-based policy index.
+     * @param out_policy Receives the policy descriptor.
+     * @return true when @p index exists and @p out_policy was filled.
+     */
+    bool sdl3d_game_data_get_haptics_policy_at(const sdl3d_game_data_runtime *runtime, int index,
+                                               sdl3d_game_data_haptics_policy *out_policy);
+
+    /**
+     * @brief Test whether an authored haptics policy matches a signal event.
+     *
+     * The helper checks the policy signal, optional `enabled_if` condition, and
+     * optional payload actor filters. Payload actor filters read actor names
+     * from the signal payload and may match by concrete actor name or authored
+     * entity tags.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param index Zero-based policy index.
+     * @param signal_id Emitted signal id.
+     * @param payload Optional signal payload.
+     * @param out_policy Receives the matching policy descriptor.
+     * @return true when the policy exists and matches this event.
+     */
+    bool sdl3d_game_data_match_haptics_policy(const sdl3d_game_data_runtime *runtime, int index, int signal_id,
+                                              const sdl3d_properties *payload,
+                                              sdl3d_game_data_haptics_policy *out_policy);
 
     /**
      * @brief Resolve the authored network pause input action id.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -1534,6 +1534,20 @@ static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, in
     return true;
 }
 
+static bool entity_json_has_all_tags_from_json(yyjson_val *entity, yyjson_val *tags)
+{
+    if (!yyjson_is_arr(tags) || yyjson_arr_size(tags) == 0)
+        return false;
+
+    for (size_t i = 0; i < yyjson_arr_size(tags); ++i)
+    {
+        yyjson_val *tag = yyjson_arr_get(tags, i);
+        if (!yyjson_is_str(tag) || !entity_json_has_tag(entity, yyjson_get_str(tag)))
+            return false;
+    }
+    return true;
+}
+
 static yyjson_val *find_component_json(yyjson_val *entity, const char *type)
 {
     yyjson_val *components = obj_get(entity, "components");
@@ -9876,6 +9890,109 @@ bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *
                                                  const char **out_control)
 {
     return game_data_get_network_runtime_binding(runtime, "controls", name, out_control);
+}
+
+static yyjson_val *haptics_policies_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(obj_get(runtime_root(runtime), "haptics"), "policies");
+}
+
+static yyjson_val *haptics_policy_json(const sdl3d_game_data_runtime *runtime, int index)
+{
+    yyjson_val *policies = haptics_policies_json(runtime);
+    if (!yyjson_is_arr(policies) || index < 0 || (size_t)index >= yyjson_arr_size(policies))
+        return NULL;
+    return yyjson_arr_get(policies, (size_t)index);
+}
+
+int sdl3d_game_data_haptics_policy_count(const sdl3d_game_data_runtime *runtime)
+{
+    yyjson_val *policies = haptics_policies_json(runtime);
+    return yyjson_is_arr(policies) ? (int)yyjson_arr_size(policies) : 0;
+}
+
+bool sdl3d_game_data_get_haptics_policy_at(const sdl3d_game_data_runtime *runtime, int index,
+                                           sdl3d_game_data_haptics_policy *out_policy)
+{
+    if (out_policy != NULL)
+        SDL_zero(*out_policy);
+    if (runtime == NULL || out_policy == NULL)
+        return false;
+
+    yyjson_val *policy = haptics_policy_json(runtime, index);
+    if (!yyjson_is_obj(policy))
+        return false;
+
+    const char *signal = json_string(policy, "signal", NULL);
+    out_policy->name = json_string(policy, "name", NULL);
+    out_policy->signal_id = sdl3d_game_data_find_signal(runtime, signal);
+    out_policy->low_frequency = json_float(policy, "low_frequency", json_float(policy, "low", 0.0f));
+    out_policy->high_frequency = json_float(policy, "high_frequency", json_float(policy, "high", 0.0f));
+    out_policy->duration_ms = (Uint32)SDL_max(json_int(policy, "duration_ms", 0), 0);
+    return out_policy->name != NULL && out_policy->signal_id >= 0 && out_policy->duration_ms > 0U;
+}
+
+static bool haptics_payload_actor_filter_matches(const sdl3d_game_data_runtime *runtime, yyjson_val *filter,
+                                                 const sdl3d_properties *payload)
+{
+    if (runtime == NULL || !yyjson_is_obj(filter) || payload == NULL)
+        return false;
+    if (!eval_data_condition(runtime, obj_get(filter, "active_if"), NULL))
+        return false;
+
+    const char *key = json_string(filter, "key", NULL);
+    const char *payload_actor_name = key != NULL ? sdl3d_properties_get_string(payload, key, NULL) : NULL;
+    if (payload_actor_name == NULL || payload_actor_name[0] == '\0')
+        return false;
+
+    const char *actor_name = json_string(filter, "actor", NULL);
+    if (actor_name != NULL && SDL_strcmp(actor_name, payload_actor_name) == 0)
+        return true;
+
+    yyjson_val *tags = obj_get(filter, "tags");
+    if (yyjson_is_arr(tags))
+    {
+        yyjson_val *entity = find_entity_json(runtime, payload_actor_name);
+        return entity != NULL && entity_json_has_all_tags_from_json(entity, tags);
+    }
+
+    return false;
+}
+
+static bool haptics_policy_payload_matches(const sdl3d_game_data_runtime *runtime, yyjson_val *policy,
+                                           const sdl3d_properties *payload)
+{
+    yyjson_val *filters = obj_get(policy, "payload_actor_filters");
+    if (filters == NULL)
+        return true;
+    if (!yyjson_is_arr(filters) || yyjson_arr_size(filters) == 0)
+        return false;
+
+    for (size_t i = 0; i < yyjson_arr_size(filters); ++i)
+    {
+        if (haptics_payload_actor_filter_matches(runtime, yyjson_arr_get(filters, i), payload))
+            return true;
+    }
+    return false;
+}
+
+bool sdl3d_game_data_match_haptics_policy(const sdl3d_game_data_runtime *runtime, int index, int signal_id,
+                                          const sdl3d_properties *payload, sdl3d_game_data_haptics_policy *out_policy)
+{
+    yyjson_val *policy = haptics_policy_json(runtime, index);
+    sdl3d_game_data_haptics_policy candidate;
+    if (!sdl3d_game_data_get_haptics_policy_at(runtime, index, &candidate))
+        return false;
+    if (candidate.signal_id != signal_id)
+        return false;
+    if (!eval_data_condition(runtime, obj_get(policy, "enabled_if"), NULL))
+        return false;
+    if (!haptics_policy_payload_matches(runtime, policy, payload))
+        return false;
+
+    if (out_policy != NULL)
+        *out_policy = candidate;
+    return true;
 }
 
 static yyjson_val *network_runtime_pause_json(const sdl3d_game_data_runtime *runtime)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -958,6 +958,122 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
     return ok;
 }
 
+static bool validate_haptics_actor_filter(validation_context *ctx, yyjson_val *filter, const char *path,
+                                          validation_names *names)
+{
+    if (!yyjson_is_obj(filter))
+        return validation_error(ctx, path, "haptics payload actor filter must be an object");
+    if (!is_non_empty_string(filter, "key"))
+        return validation_error(ctx, path, "haptics payload actor filter requires a non-empty key");
+
+    const char *actor = json_string(filter, "actor");
+    yyjson_val *tags = obj_get(filter, "tags");
+    if (actor == NULL && tags == NULL)
+        return validation_error(ctx, path, "haptics payload actor filter requires actor or tags");
+    if (actor != NULL && !require_ref(ctx, &names->entities, "entity", actor, path))
+        return false;
+    if (tags != NULL)
+    {
+        if (!yyjson_is_arr(tags) || yyjson_arr_size(tags) == 0)
+            return validation_error(ctx, path, "haptics payload actor filter tags must be a non-empty array");
+        for (size_t i = 0; i < yyjson_arr_size(tags); ++i)
+        {
+            yyjson_val *tag = yyjson_arr_get(tags, i);
+            if (!yyjson_is_str(tag) || yyjson_get_len(tag) == 0)
+                return validation_error(ctx, path, "haptics payload actor filter tags must be non-empty strings");
+        }
+    }
+
+    char condition_path[PATH_BUFFER_SIZE];
+    format_path(condition_path, sizeof(condition_path), "%s.active_if", path);
+    return validate_data_condition(ctx, obj_get(filter, "active_if"), condition_path, names);
+}
+
+static bool validate_haptics(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *haptics = obj_get(root, "haptics");
+    if (haptics == NULL)
+        return true;
+    if (!yyjson_is_obj(haptics))
+        return validation_error(ctx, "$.haptics", "haptics must be an object");
+
+    yyjson_val *policies = obj_get(haptics, "policies");
+    if (policies == NULL)
+        return true;
+    if (!yyjson_is_arr(policies))
+        return validation_error(ctx, "$.haptics.policies", "haptics policies must be an array");
+
+    name_table policy_names;
+    SDL_zero(policy_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(policies); ++i)
+    {
+        yyjson_val *policy = yyjson_arr_get(policies, i);
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.haptics.policies[%zu]", i);
+        if (!yyjson_is_obj(policy))
+        {
+            ok = validation_error(ctx, path, "haptics policy must be an object");
+            break;
+        }
+        if (!require_unique_name(ctx, &policy_names, "haptics policy", json_string(policy, "name"), path) ||
+            !require_ref(ctx, &names->signals, "signal", json_string(policy, "signal"), path))
+        {
+            ok = false;
+            break;
+        }
+
+        yyjson_val *low = obj_get(policy, "low_frequency");
+        yyjson_val *high = obj_get(policy, "high_frequency");
+        yyjson_val *duration = obj_get(policy, "duration_ms");
+        if (!yyjson_is_num(low) || yyjson_get_num(low) < 0.0 || yyjson_get_num(low) > 1.0)
+        {
+            ok = validation_error(ctx, path, "haptics low_frequency must be a number from 0 to 1");
+            break;
+        }
+        if (!yyjson_is_num(high) || yyjson_get_num(high) < 0.0 || yyjson_get_num(high) > 1.0)
+        {
+            ok = validation_error(ctx, path, "haptics high_frequency must be a number from 0 to 1");
+            break;
+        }
+        if (!yyjson_is_int(duration) || yyjson_get_sint(duration) <= 0)
+        {
+            ok = validation_error(ctx, path, "haptics duration_ms must be a positive integer");
+            break;
+        }
+
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.enabled_if", path);
+        if (!validate_data_condition(ctx, obj_get(policy, "enabled_if"), condition_path, names))
+        {
+            ok = false;
+            break;
+        }
+
+        yyjson_val *filters = obj_get(policy, "payload_actor_filters");
+        if (filters == NULL)
+            continue;
+        if (!yyjson_is_arr(filters) || yyjson_arr_size(filters) == 0)
+        {
+            ok = validation_error(ctx, path, "haptics payload_actor_filters must be a non-empty array");
+            break;
+        }
+        for (size_t filter_index = 0; filter_index < yyjson_arr_size(filters); ++filter_index)
+        {
+            char filter_path[PATH_BUFFER_SIZE];
+            format_path(filter_path, sizeof(filter_path), "%s.payload_actor_filters[%zu]", path, filter_index);
+            if (!validate_haptics_actor_filter(ctx, yyjson_arr_get(filters, filter_index), filter_path, names))
+            {
+                ok = false;
+                break;
+            }
+        }
+    }
+
+    name_table_destroy(&policy_names);
+    return ok;
+}
+
 static void hash_network_actor_fields(sdl3d_crypto_hash32_state *state, yyjson_val *fields)
 {
     network_hash_update_int(state, "field_count", (Sint64)yyjson_arr_size(fields));
@@ -3804,8 +3920,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
            validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
-           validate_lights(ctx, root, names) && validate_logic(ctx, root, names) &&
-           validate_adapters(ctx, root, names) &&
+           validate_lights(ctx, root, names) && validate_haptics(ctx, root, names) &&
+           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1245,6 +1245,35 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     ASSERT_TRUE(sdl3d_game_data_get_network_runtime_pause_state(runtime, &network_paused, error, sizeof(error)))
         << error;
     EXPECT_TRUE(network_paused);
+    ASSERT_EQ(sdl3d_game_data_haptics_policy_count(runtime), 2);
+    sdl3d_game_data_haptics_policy haptics_policy{};
+    ASSERT_TRUE(sdl3d_game_data_get_haptics_policy_at(runtime, 0, &haptics_policy));
+    EXPECT_STREQ(haptics_policy.name, "haptics.gamepad.vibration_test");
+    EXPECT_EQ(haptics_policy.signal_id, sdl3d_game_data_find_signal(runtime, "signal.settings.vibration"));
+    EXPECT_FLOAT_EQ(haptics_policy.low_frequency, 0.30f);
+    EXPECT_FLOAT_EQ(haptics_policy.high_frequency, 0.70f);
+    EXPECT_EQ(haptics_policy.duration_ms, 100U);
+    ASSERT_TRUE(sdl3d_game_data_get_haptics_policy_at(runtime, 1, &haptics_policy));
+    EXPECT_STREQ(haptics_policy.name, "haptics.gamepad.paddle_hit");
+    EXPECT_EQ(haptics_policy.signal_id, sdl3d_game_data_find_signal(runtime, "signal.ball.hit_paddle"));
+
+    sdl3d_properties *haptics_payload = sdl3d_properties_create();
+    ASSERT_NE(haptics_payload, nullptr);
+    const int paddle_hit_signal = sdl3d_game_data_find_signal(runtime, "signal.ball.hit_paddle");
+    sdl3d_properties_set_string(haptics_payload, "other_actor_name", "entity.paddle.player");
+    EXPECT_TRUE(sdl3d_game_data_match_haptics_policy(runtime, 1, paddle_hit_signal, haptics_payload, &haptics_policy));
+    sdl3d_properties_set_string(haptics_payload, "other_actor_name", "entity.paddle.cpu");
+    EXPECT_FALSE(sdl3d_game_data_match_haptics_policy(runtime, 1, paddle_hit_signal, haptics_payload, &haptics_policy));
+    sdl3d_properties_set_string(sdl3d_game_data_mutable_scene_state(runtime), "match_mode", "local");
+    EXPECT_TRUE(sdl3d_game_data_match_haptics_policy(runtime, 1, paddle_hit_signal, haptics_payload, &haptics_policy));
+    sdl3d_properties_set_string(haptics_payload, "other_actor_name", "entity.paddle.attract_left");
+    EXPECT_FALSE(sdl3d_game_data_match_haptics_policy(runtime, 1, paddle_hit_signal, haptics_payload, &haptics_policy));
+    sdl3d_registered_actor *settings_for_haptics = sdl3d_game_data_find_actor(runtime, "entity.settings");
+    ASSERT_NE(settings_for_haptics, nullptr);
+    sdl3d_properties_set_bool(settings_for_haptics->props, "vibration", false);
+    sdl3d_properties_set_string(haptics_payload, "other_actor_name", "entity.paddle.player");
+    EXPECT_FALSE(sdl3d_game_data_match_haptics_policy(runtime, 1, paddle_hit_signal, haptics_payload, &haptics_policy));
+    sdl3d_properties_destroy(haptics_payload);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.overhead");
     EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.splash");
     EXPECT_EQ(sdl3d_game_data_scene_count(runtime), 15);
@@ -4627,6 +4656,44 @@ TEST(GameDataRuntime, ValidatesPongDataWithoutDiagnostics)
     EXPECT_TRUE(sdl3d_game_data_validate_file(SDL3D_PONG_DATA_PATH, &options, error, sizeof(error))) << error;
     EXPECT_TRUE(capture.diagnostics.empty());
     EXPECT_EQ(error[0], '\0');
+}
+
+TEST(GameDataRuntime, RejectsInvalidHapticsPolicies)
+{
+    const std::filesystem::path dir = unique_test_dir("haptics_policy_validation");
+    write_text(dir / "bad_haptics.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Haptics", "id": "test.bad_haptics", "version": "0.1.0" },
+  "world": { "name": "world.bad_haptics", "kind": "fixed_screen" },
+  "entities": [
+    { "name": "entity.player", "tags": ["player"] }
+  ],
+  "signals": [
+    "signal.hit"
+  ],
+  "haptics": {
+    "policies": [
+      {
+        "name": "haptics.bad",
+        "signal": "signal.hit",
+        "low_frequency": 1.5,
+        "high_frequency": 0.5,
+        "duration_ms": 100,
+        "payload_actor_filters": [
+          { "key": "other_actor_name", "tags": [] }
+        ]
+      }
+    ]
+  }
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "bad_haptics.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("haptics low_frequency must be a number from 0 to 1"), std::string::npos)
+        << error;
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, RejectsInvalidInputProfiles)


### PR DESCRIPTION
## Summary

- add authored `haptics.policies` with signal, enabled condition, payload actor filters, and rumble parameters
- expose generic haptics policy enumeration/matching helpers in game data
- migrate Pong gamepad feedback to authored policies so C no longer hard-codes settings or paddle actor names
- document haptics policies and add validation/runtime tests

Continues #194.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`

## Next slice

Next should be issue #194 slice 5: final Pong C audit. Re-scan `demos/pong/main.c` for remaining `entity.*`, `action.*`, `signal.*`, replication channel, and scene id literals; categorize each as host integration, native UI limitation, or JSON/Lua migration candidate, then remove or document the remaining acceptable literals.