### PR TITLE
Finish Pong C host audit

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -112,6 +112,18 @@
         "endpoint": "multiplayer_host_endpoint",
         "peer": "multiplayer_host_client",
         "connected": "multiplayer_host_connected"
+      },
+      "discovery": {
+        "count": "multiplayer_discovery_count",
+        "status": "multiplayer_discovery_status",
+        "result_0": "session_0",
+        "result_1": "session_1",
+        "result_2": "session_2",
+        "result_3": "session_3",
+        "result_4": "session_4",
+        "result_5": "session_5",
+        "result_6": "session_6",
+        "result_7": "session_7"
       }
     },
     "session_flow": {
@@ -175,6 +187,19 @@
         "pause_request": "pause_request",
         "resume_request": "resume_request",
         "disconnect": "disconnect"
+      },
+      "actions": {
+        "client_up": "action.paddle.local.up",
+        "client_down": "action.paddle.local.down",
+        "menu_select": "action.menu.select",
+        "menu_back": "action.menu.back",
+        "camera_toggle": "action.camera.ball.toggle"
+      },
+      "signals": {
+        "lobby_start": "signal.multiplayer.lobby.start",
+        "camera_toggle": "signal.camera.ball.toggle",
+        "discovery_refresh": "signal.multiplayer.discovery.refresh",
+        "ui_select": "signal.ui.menu.select"
       },
       "pause": {
         "action": "action.pause",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -76,6 +76,14 @@ static const char PONG_NETWORK_BINDING_START_GAME[] = "start_game";
 static const char PONG_NETWORK_BINDING_PAUSE_REQUEST[] = "pause_request";
 static const char PONG_NETWORK_BINDING_RESUME_REQUEST[] = "resume_request";
 static const char PONG_NETWORK_BINDING_DISCONNECT[] = "disconnect";
+static const char PONG_NETWORK_BINDING_CLIENT_UP[] = "client_up";
+static const char PONG_NETWORK_BINDING_CLIENT_DOWN[] = "client_down";
+static const char PONG_NETWORK_BINDING_MENU_SELECT[] = "menu_select";
+static const char PONG_NETWORK_BINDING_MENU_BACK[] = "menu_back";
+static const char PONG_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
+static const char PONG_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
+static const char PONG_NETWORK_BINDING_DISCOVERY_REFRESH[] = "discovery_refresh";
+static const char PONG_NETWORK_BINDING_UI_SELECT[] = "ui_select";
 
 typedef struct pong_network_control_binding
 {
@@ -164,6 +172,28 @@ static const char *network_session_message(const pong_state *state, const char *
         return message;
     }
     return fallback;
+}
+
+static int network_runtime_action_id(const pong_state *state, const char *name)
+{
+    int action_id = -1;
+    if (state != NULL && state->data != NULL &&
+        sdl3d_game_data_get_network_runtime_action(state->data, name, &action_id))
+    {
+        return action_id;
+    }
+    return -1;
+}
+
+static int network_runtime_signal_id(const pong_state *state, const char *name)
+{
+    int signal_id = -1;
+    if (state != NULL && state->data != NULL &&
+        sdl3d_game_data_get_network_runtime_signal(state->data, name, &signal_id))
+    {
+        return signal_id;
+    }
+    return -1;
 }
 
 static const char *network_disconnect_reason(const pong_state *state, const char *name, const char *fallback)
@@ -669,8 +699,8 @@ static bool send_client_input_packet(pong_state *state)
     size_t packet_size = 0U;
     char error[160] = {0};
     const char *client_input_channel = NULL;
-    const int p2_up = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.up");
-    const int p2_down = sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.paddle.local.down");
+    const int p2_up = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_UP);
+    const int p2_down = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_DOWN);
 
     if (state == NULL || state->direct_connect_session == NULL || state->input == NULL || p2_up < 0 || p2_down < 0 ||
         !sdl3d_network_session_is_connected(state->direct_connect_session))
@@ -1115,8 +1145,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
 
 static void update_network_match_termination(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
-    const int select_action =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_action(state->data, "action.menu.select") : -1;
+    const int select_action = network_runtime_action_id(state, PONG_NETWORK_BINDING_MENU_SELECT);
 
     if (state == NULL || !state->network_match_termination_active)
     {
@@ -1209,51 +1238,21 @@ static void update_discovery_scene_state(pong_state *state)
         return;
     }
 
-    sdl3d_properties_set_int(scene_state, "multiplayer_discovery_count", result_count);
+    sdl3d_properties_set_int(
+        scene_state, network_scene_state_key(state, "discovery", "count", "multiplayer_discovery_count"), result_count);
     sdl3d_properties_set_string(
-        scene_state, "multiplayer_discovery_status",
+        scene_state, network_scene_state_key(state, "discovery", "status", "multiplayer_discovery_status"),
         state->discovery_session != NULL ? sdl3d_network_discovery_session_status(state->discovery_session) : "Idle");
     for (int i = 0; i < SDL3D_NETWORK_MAX_DISCOVERY_RESULTS; ++i)
     {
-        const char *key = NULL;
+        char key_name[16];
+        char fallback_key[16];
         sdl3d_network_discovery_result result;
         char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
         SDL_zero(result);
         label[0] = '\0';
-        switch (i)
-        {
-        case 0:
-            key = "session_0";
-            break;
-        case 1:
-            key = "session_1";
-            break;
-        case 2:
-            key = "session_2";
-            break;
-        case 3:
-            key = "session_3";
-            break;
-        case 4:
-            key = "session_4";
-            break;
-        case 5:
-            key = "session_5";
-            break;
-        case 6:
-            key = "session_6";
-            break;
-        case 7:
-            key = "session_7";
-            break;
-        default:
-            break;
-        }
-
-        if (key == NULL)
-        {
-            continue;
-        }
+        SDL_snprintf(key_name, sizeof(key_name), "result_%d", i);
+        SDL_snprintf(fallback_key, sizeof(fallback_key), "session_%d", i);
 
         if (i < result_count && sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
         {
@@ -1262,7 +1261,8 @@ static void update_discovery_scene_state(pong_state *state)
                          (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
                          result.status[0] != '\0' ? result.status : "");
         }
-        sdl3d_properties_set_string(scene_state, key, label);
+        sdl3d_properties_set_string(scene_state, network_scene_state_key(state, "discovery", key_name, fallback_key),
+                                    label);
     }
 }
 
@@ -1313,10 +1313,9 @@ static bool start_discovered_match_connection(pong_state *state, int index)
     return true;
 }
 
-static void emit_pong_signal_by_name(sdl3d_game_context *ctx, pong_state *state, const char *signal_name)
+static void emit_network_runtime_signal(sdl3d_game_context *ctx, pong_state *state, const char *name)
 {
-    const int signal_id =
-        state != NULL && state->data != NULL ? sdl3d_game_data_find_signal(state->data, signal_name) : -1;
+    const int signal_id = network_runtime_signal_id(state, name);
     if (ctx == NULL || state == NULL || signal_id < 0)
     {
         return;
@@ -1332,11 +1331,11 @@ static void update_discovery_controls(sdl3d_game_context *ctx, pong_state *state
         return;
     }
 
-    const int back_action = sdl3d_game_data_find_action(state->data, "action.menu.back");
+    const int back_action = network_runtime_action_id(state, PONG_NETWORK_BINDING_MENU_BACK);
 
     if (back_action >= 0 && sdl3d_input_is_pressed(state->input, back_action))
     {
-        emit_pong_signal_by_name(ctx, state, "signal.ui.menu.select");
+        emit_network_runtime_signal(ctx, state, PONG_NETWORK_BINDING_UI_SELECT);
         destroy_discovery_session(state);
         destroy_direct_connect_session(state);
         (void)sdl3d_game_data_set_active_scene(state->data,
@@ -1567,8 +1566,7 @@ static void publish_multiplayer_state(sdl3d_game_context *ctx, pong_state *state
 
 static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_state *state)
 {
-    const int camera_toggle_action =
-        sdl3d_game_data_find_action(state != NULL ? state->data : NULL, "action.camera.ball.toggle");
+    const int camera_toggle_action = network_runtime_action_id(state, PONG_NETWORK_BINDING_CAMERA_TOGGLE);
 
     if (ctx == NULL || state == NULL || state->input == NULL || state->data == NULL ||
         state->camera_toggle_signal_id < 0 || camera_toggle_action < 0 || !is_multiplayer_play_scene(state) ||
@@ -1984,10 +1982,9 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     state->haptics_connection_count = 0;
     state->lobby_start_connection = 0;
     state->discovery_refresh_connection = 0;
-    state->host_start_signal_id = sdl3d_game_data_find_signal(state->data, "signal.multiplayer.lobby.start");
-    state->camera_toggle_signal_id = sdl3d_game_data_find_signal(state->data, "signal.camera.ball.toggle");
-    state->discovery_refresh_signal_id =
-        sdl3d_game_data_find_signal(state->data, "signal.multiplayer.discovery.refresh");
+    state->host_start_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_LOBBY_START);
+    state->camera_toggle_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_CAMERA_TOGGLE);
+    state->discovery_refresh_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_DISCOVERY_REFRESH);
     sdl3d_game_data_input_profile_refresh_state_init(&state->input_profile_refresh);
     SDL_snprintf(state->host_status, sizeof(state->host_status), "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1436,10 +1436,13 @@ orchestration maps are not part of the replication schema hash.
 authored replication channels and control messages without baking those schema
 names into game host code. `replication` maps semantic names to entries in
 `network.replication`, and `controls` maps semantic names to entries in
-`network.control_messages`. Values are validated as references. Callers resolve
-them with `sdl3d_game_data_get_network_runtime_replication()` and
-`sdl3d_game_data_get_network_runtime_control()`. `pause` can additionally bind a
-network pause action and the bool actor property that mirrors pause state into
+`network.control_messages`. `actions` maps semantic names to input actions, and
+`signals` maps semantic names to signals. Values are validated as references.
+Callers resolve them with `sdl3d_game_data_get_network_runtime_replication()`,
+`sdl3d_game_data_get_network_runtime_control()`,
+`sdl3d_game_data_get_network_runtime_action()`, and
+`sdl3d_game_data_get_network_runtime_signal()`. `pause` can additionally bind
+a network pause action and the bool actor property that mirrors pause state into
 replicated game data:
 
 ```json
@@ -1451,6 +1454,14 @@ replicated game data:
   "controls": {
     "pause_request": "pause_request",
     "resume_request": "resume_request"
+  },
+  "actions": {
+    "menu_back": "action.menu.back",
+    "camera_toggle": "action.camera.ball.toggle"
+  },
+  "signals": {
+    "lobby_start": "signal.multiplayer.lobby.start",
+    "ui_select": "signal.ui.menu.select"
   },
   "pause": {
     "action": "action.pause",
@@ -1467,6 +1478,8 @@ must reference an entity, and `pause.state.property` must name a bool property a
 runtime. The referenced property should be declared on the actor with a bool type
 and a sane default value, usually `false`, so network pause reads have a defined
 state before the first replicated snapshot. Host code can resolve these bindings with
+`sdl3d_game_data_get_network_runtime_action()`,
+`sdl3d_game_data_get_network_runtime_signal()`,
 `sdl3d_game_data_get_network_runtime_pause_action()`,
 `sdl3d_game_data_get_network_runtime_pause_state()`, and
 `sdl3d_game_data_set_network_runtime_pause_state()`. These maps are runtime

--- a/docs/pong-c-audit.md
+++ b/docs/pong-c-audit.md
@@ -1,0 +1,37 @@
+# Pong C Host Audit
+
+This audit tracks the remaining authored-data literals in `demos/pong/main.c`
+after the Pong data-driven migration. The demo host should own SDL process
+integration, native UI surfaces, and UDP session lifetime. Gameplay rules and
+reusable schema decisions should live in JSON or Lua.
+
+## Migrated in this pass
+
+- Discovery overlay scene-state keys now resolve through
+  `network.scene_state.discovery`.
+- Network host actions now resolve through `network.runtime_bindings.actions`.
+- Network host signals now resolve through `network.runtime_bindings.signals`.
+
+## Remaining accepted host integration
+
+- `network.session_flow` semantic names such as `play`, `join`, `host_lobby`,
+  `match_mode`, and `network_role` are host orchestration concepts. The C host
+  passes semantic names to generic resolver APIs and uses authored fallbacks only
+  as defensive defaults.
+- `network.runtime_bindings` semantic names such as `state_snapshot`,
+  `client_input`, and `disconnect` are not game schema names. They are stable
+  host integration roles that resolve to authored replication channels and
+  control messages.
+- Direct-connect text entry and discovery panels are still native UI overlays.
+  They remain in C until the engine has data-authored text entry/list widgets
+  capable of replacing those temporary surfaces.
+- UDP socket/session lifecycle, timeout handling, and app shutdown remain C
+  responsibilities because they bridge platform/runtime services to game data.
+
+## Follow-up Candidates
+
+- Replace the native direct-connect and discovery overlays with generalized
+  data-authored UI widgets once editable text boxes and dynamic list controls
+  exist.
+- Consider caching resolved network/session binding strings if profiling ever
+  shows repeated JSON lookup overhead in host orchestration.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -987,6 +987,36 @@ extern "C"
                                                      const char **out_control);
 
     /**
+     * @brief Resolve an authored network runtime input action binding.
+     *
+     * Runtime action bindings are authored under
+     * `network.runtime_bindings.actions` and map host integration semantics,
+     * such as `menu_back` or `camera_toggle`, to concrete input action names.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored binding semantic name.
+     * @param out_action Receives the resolved action id.
+     * @return true when the binding exists and resolves to an input action.
+     */
+    bool sdl3d_game_data_get_network_runtime_action(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                    int *out_action);
+
+    /**
+     * @brief Resolve an authored network runtime signal binding.
+     *
+     * Runtime signal bindings are authored under
+     * `network.runtime_bindings.signals` and map host integration semantics,
+     * such as `lobby_start` or `ui_select`, to concrete signal names.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored binding semantic name.
+     * @param out_signal Receives the resolved signal id.
+     * @return true when the binding exists and resolves to a signal.
+     */
+    bool sdl3d_game_data_get_network_runtime_signal(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                    int *out_signal);
+
+    /**
      * @brief Return the number of authored haptics policies.
      *
      * Policies are authored under `haptics.policies`.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9892,6 +9892,40 @@ bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *
     return game_data_get_network_runtime_binding(runtime, "controls", name, out_control);
 }
 
+bool sdl3d_game_data_get_network_runtime_action(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                int *out_action)
+{
+    const char *action_name = NULL;
+    if (out_action != NULL)
+        *out_action = -1;
+    if (out_action == NULL || !game_data_get_network_runtime_binding(runtime, "actions", name, &action_name))
+        return false;
+
+    const int action_id = sdl3d_game_data_find_action(runtime, action_name);
+    if (action_id < 0)
+        return false;
+
+    *out_action = action_id;
+    return true;
+}
+
+bool sdl3d_game_data_get_network_runtime_signal(const sdl3d_game_data_runtime *runtime, const char *name,
+                                                int *out_signal)
+{
+    const char *signal_name = NULL;
+    if (out_signal != NULL)
+        *out_signal = -1;
+    if (out_signal == NULL || !game_data_get_network_runtime_binding(runtime, "signals", name, &signal_name))
+        return false;
+
+    const int signal_id = sdl3d_game_data_find_signal(runtime, signal_name);
+    if (signal_id < 0)
+        return false;
+
+    *out_signal = signal_id;
+    return true;
+}
+
 static yyjson_val *haptics_policies_json(const sdl3d_game_data_runtime *runtime)
 {
     return obj_get(obj_get(runtime_root(runtime), "haptics"), "policies");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -807,6 +807,10 @@ static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_va
            validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"),
                                                 "$.network.runtime_bindings.controls", "network control message",
                                                 control_names) &&
+           validate_network_runtime_binding_map(ctx, obj_get(bindings, "actions"), "$.network.runtime_bindings.actions",
+                                                "input action", &names->actions) &&
+           validate_network_runtime_binding_map(ctx, obj_get(bindings, "signals"), "$.network.runtime_bindings.signals",
+                                                "signal", &names->signals) &&
            validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1199,6 +1199,11 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_STREQ(network_scene_state_key, "multiplayer_host_status");
     ASSERT_TRUE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "connected", &network_scene_state_key));
     EXPECT_STREQ(network_scene_state_key, "multiplayer_host_connected");
+    ASSERT_TRUE(sdl3d_game_data_get_network_scene_state_key(runtime, "discovery", "count", &network_scene_state_key));
+    EXPECT_STREQ(network_scene_state_key, "multiplayer_discovery_count");
+    ASSERT_TRUE(
+        sdl3d_game_data_get_network_scene_state_key(runtime, "discovery", "result_0", &network_scene_state_key));
+    EXPECT_STREQ(network_scene_state_key, "session_0");
     EXPECT_FALSE(sdl3d_game_data_get_network_scene_state_key(runtime, "host", "missing", &network_scene_state_key));
     EXPECT_EQ(network_scene_state_key, nullptr);
     const char *network_session_value = nullptr;
@@ -1234,6 +1239,15 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_STREQ(network_runtime_value, "disconnect");
     EXPECT_FALSE(sdl3d_game_data_get_network_runtime_control(runtime, "missing", &network_runtime_value));
     EXPECT_EQ(network_runtime_value, nullptr);
+    int network_runtime_id = -1;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_action(runtime, "client_up", &network_runtime_id));
+    EXPECT_EQ(network_runtime_id, sdl3d_game_data_find_action(runtime, "action.paddle.local.up"));
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_action(runtime, "menu_back", &network_runtime_id));
+    EXPECT_EQ(network_runtime_id, sdl3d_game_data_find_action(runtime, "action.menu.back"));
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_signal(runtime, "lobby_start", &network_runtime_id));
+    EXPECT_EQ(network_runtime_id, sdl3d_game_data_find_signal(runtime, "signal.multiplayer.lobby.start"));
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_signal(runtime, "ui_select", &network_runtime_id));
+    EXPECT_EQ(network_runtime_id, sdl3d_game_data_find_signal(runtime, "signal.ui.menu.select"));
     int network_pause_action = -1;
     ASSERT_TRUE(sdl3d_game_data_get_network_runtime_pause_action(runtime, &network_pause_action));
     EXPECT_EQ(network_pause_action, sdl3d_game_data_find_action(runtime, "action.pause"));
@@ -5053,6 +5067,12 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
         "start_game": "start_game",
         "pause_request": "pause"
       },
+      "actions": {
+        "menu_select": "action.pause"
+      },
+      "signals": {
+        "pause_changed": "signal.network.pause"
+      },
       "pause": {
         "action": "action.pause",
         "state": { "actor": "entity.match", "property": "paused" }
@@ -5788,6 +5808,56 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "unknown network control message reference",
+        },
+        {
+            "bad_runtime_action_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "actions": {
+        "menu_select": "action.missing"
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown input action reference",
+        },
+        {
+            "bad_runtime_signal_binding",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "signals": {
+        "ui_select": "signal.missing"
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown signal reference",
         },
         {
             "bad_runtime_pause_action_binding",


### PR DESCRIPTION
## Summary

- add runtime action/signal binding helpers under `network.runtime_bindings.actions` and `network.runtime_bindings.signals`
- migrate remaining Pong network host action/signal lookups and discovery scene-state keys to authored bindings
- document the final Pong C host audit and the remaining accepted host integration points
- extend validation/docs/tests for runtime action and signal bindings

Closes final slice of #194.

## Verification

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c demos/pong/main.c tests/test_game_data.cpp`
- `python3 -m json.tool demos/pong/data/pong.game.json >/dev/null`
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`

## Next slice

After this merges, issue #194 should be complete. The next practical slice should be replacing the remaining native direct-connect/discovery overlays with generalized data-authored text-entry and dynamic-list UI widgets, because those are now the largest remaining Pong-specific C surfaces.