### PR TITLE
Add data-authored text entry controls

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -345,7 +345,8 @@ Menu items can also author generic settings controls and emit data-authored sign
 }
 ```
 
-Supported control types are `toggle`, `choice`, `range`, and `input_binding`.
+Supported control types are `toggle`, `choice`, `range`, `input_binding`, and
+`text`.
 The generic menu controller applies property controls directly to actor
 properties and the menu UI presenter displays the current value. A menu can
 author `left_action` and `right_action` so range and choice controls can be
@@ -381,6 +382,34 @@ adjusted without activating navigation items:
     Range controls clamp to their authored min /
     max.Adding `"value_type" : "int"` stores the result as an integer property; adding `"display": "slider"` renders
 the menu value as a compact slider label.
+
+`text` controls capture editable UTF-8 text and write it to scene state or an
+actor string property. While a text control is focused, text input, Backspace,
+Delete, Return, Escape, and the menu select/back actions are consumed by the
+text editor instead of leaking into parent menu navigation. This is the
+preferred primitive for forms such as direct-connect hostnames, save names,
+profile names, and chat-style short fields:
+
+```json
+{
+    "label" : "Host",
+    "control" : {
+        "type" : "text",
+        "target" : "scene_state",
+        "key" : "direct_connect_host",
+        "default" : "127.0.0.1",
+        "placeholder" : "Host / IP",
+        "charset" : "hostname",
+        "max_length" : 64
+    }
+}
+```
+
+Omit `target` or set it to `"scene_state"` to bind the value to persistent
+scene state. Set `target` to an entity id to bind an actor string property.
+Supported `charset` values are `text`, `utf8`, `ascii`, `integer`, `digits`,
+`numeric`, and `hostname`. `hostname` accepts letters, digits, `.`, `-`, `_`,
+and `:` so it can store hostnames, IPv4 addresses, IPv6-style text, and ports.
 
 `input_binding` controls capture the next keyboard key, mouse button, or
 gamepad button and immediately rebind all authored actions for that device. This is how games can

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -410,6 +410,8 @@ scene state. Set `target` to an entity id to bind an actor string property.
 Supported `charset` values are `text`, `utf8`, `ascii`, `integer`, `digits`,
 `numeric`, and `hostname`. `hostname` accepts letters, digits, `.`, `-`, `_`,
 and `:` so it can store hostnames, IPv4 addresses, IPv6-style text, and ports.
+Restricted charsets reject non-ASCII UTF-8 input. `max_length` is measured in
+UTF-8 bytes and must be 255 or fewer.
 
 `input_binding` controls capture the next keyboard key, mouse button, or
 gamepad button and immediately rebind all authored actions for that device. This is how games can

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -597,6 +597,8 @@ extern "C"
         SDL3D_GAME_DATA_MENU_CONTROL_RANGE = 3,
         /** @brief Menu item captures a keyboard key or gamepad button and rebinds authored actions. */
         SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING = 4,
+        /** @brief Menu item captures editable text and writes it to scene state or an actor property. */
+        SDL3D_GAME_DATA_MENU_CONTROL_TEXT = 5,
     } sdl3d_game_data_menu_control_type;
 
     /** @brief App pause command authored on a menu item. */
@@ -626,6 +628,21 @@ extern "C"
         /** @brief The captured input was rejected because another binding uses it. */
         SDL3D_GAME_DATA_INPUT_BINDING_CAPTURE_CONFLICT = 4,
     } sdl3d_game_data_input_binding_capture_status;
+
+    /** @brief Result of advancing an active menu text-entry capture. */
+    typedef enum sdl3d_game_data_text_entry_capture_status
+    {
+        /** @brief No text-entry capture is active. */
+        SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_NONE = 0,
+        /** @brief Capture is active and waiting for more input. */
+        SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_WAITING = 1,
+        /** @brief Capture was canceled and the original value was restored. */
+        SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED = 2,
+        /** @brief Capture is active and edited the bound value. */
+        SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CHANGED = 3,
+        /** @brief Capture was submitted. */
+        SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_SUBMITTED = 4,
+    } sdl3d_game_data_text_entry_capture_status;
 
     /**
      * @brief Runtime descriptor for one authored menu item.
@@ -1882,6 +1899,30 @@ extern "C"
      * @brief Reset all binding controls in a menu to their authored defaults.
      */
     bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime, const char *menu_name);
+
+    /**
+     * @brief Start text capture for an authored menu text control.
+     *
+     * The menu item must author a `control` with `type: "text"`. While active,
+     * callers should call sdl3d_game_data_update_menu_text_entry_capture()
+     * before normal menu navigation so editing keys are consumed locally.
+     */
+    bool sdl3d_game_data_start_menu_text_entry_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                       int item_index);
+
+    /** @brief Return true while a menu text-entry capture is active. */
+    bool sdl3d_game_data_menu_text_entry_capture_active(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Advance active text-entry capture from current input.
+     *
+     * SDL text-input payloads append to the bound string. Backspace and Delete
+     * remove the previous UTF-8 codepoint. The menu's select action or Return
+     * submits; the menu's back action or the authored cancel key cancels and
+     * restores the original value.
+     */
+    sdl3d_game_data_text_entry_capture_status sdl3d_game_data_update_menu_text_entry_capture(
+        sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input);
 
     /**
      * @brief Device-count state for active input profile refresh.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -141,6 +141,10 @@ extern "C"
         bool input_binding_capture_started; /**< True when an input-binding item entered capture mode. */
         bool input_binding_changed;         /**< True when a captured input changed authored action bindings. */
         bool input_binding_conflict;        /**< True when a captured input was rejected as a duplicate binding. */
+        bool text_entry_capture_started;    /**< True when a text item entered capture mode. */
+        bool text_entry_changed;            /**< True when captured text edited its bound value. */
+        bool text_entry_submitted;          /**< True when text capture was submitted. */
+        bool text_entry_canceled;           /**< True when text capture was canceled and restored. */
     } sdl3d_game_data_menu_update_result;
 
     /**

--- a/include/sdl3d/input.h
+++ b/include/sdl3d/input.h
@@ -31,6 +31,7 @@ extern "C"
 #define SDL3D_INPUT_MAX_BINDINGS 128
 #define SDL3D_INPUT_ACTION_NAME_MAX 32
 #define SDL3D_INPUT_MAX_GAMEPADS 4
+#define SDL3D_INPUT_TEXT_MAX 128
 
     /**
      * @brief Physical input source kind for an action binding.
@@ -406,6 +407,16 @@ extern "C"
 
     /** @brief Return the current snapshot, or NULL for a NULL manager. */
     const sdl3d_input_snapshot *sdl3d_input_get_snapshot(const sdl3d_input_manager *input);
+
+    /**
+     * @brief Return UTF-8 text entered during the current input tick.
+     *
+     * This contains SDL text-input event payloads accumulated before the most
+     * recent sdl3d_input_update() call. The pointer is owned by @p input and
+     * remains valid until the next update. It is an empty string when no text
+     * was entered or during demo playback.
+     */
+    const char *sdl3d_input_get_text_input(const sdl3d_input_manager *input);
 
     /* ================================================================== */
     /* Default bindings                                                    */

--- a/src/game.c
+++ b/src/game.c
@@ -481,6 +481,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         SDL_Quit();
         return 1;
     }
+    SDL_StartTextInput(ctx.window);
 
     sdl3d_time_reset();
 
@@ -659,6 +660,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         callbacks->shutdown(&ctx, userdata);
     }
 
+    SDL_StopTextInput(ctx.window);
     sdl3d_game_cleanup_context(&ctx);
     SDL_Quit();
     return result;

--- a/src/game.c
+++ b/src/game.c
@@ -481,7 +481,9 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         SDL_Quit();
         return 1;
     }
+#if !defined(__ANDROID__)
     SDL_StartTextInput(ctx.window);
+#endif
 
     sdl3d_time_reset();
 
@@ -660,7 +662,9 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         callbacks->shutdown(&ctx, userdata);
     }
 
+#if !defined(__ANDROID__)
     SDL_StopTextInput(ctx.window);
+#endif
     sdl3d_game_cleanup_context(&ctx);
     SDL_Quit();
     return result;

--- a/src/game.c
+++ b/src/game.c
@@ -20,6 +20,13 @@
 #define SDL3D_GAME_DEFAULT_WINDOW_MODE SDL3D_WINDOW_MODE_WINDOWED
 #endif
 
+#if defined(__ANDROID__) || defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) ||                                 \
+    defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__)
+#define SDL3D_GAME_ENABLE_GLOBAL_TEXT_INPUT 0
+#else
+#define SDL3D_GAME_ENABLE_GLOBAL_TEXT_INPUT 1
+#endif
+
 struct sdl3d_game_session
 {
     sdl3d_actor_registry *registry;
@@ -481,7 +488,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         SDL_Quit();
         return 1;
     }
-#if !defined(__ANDROID__)
+#if SDL3D_GAME_ENABLE_GLOBAL_TEXT_INPUT
     SDL_StartTextInput(ctx.window);
 #endif
 
@@ -662,7 +669,7 @@ int sdl3d_run_game(const sdl3d_game_config *config, const sdl3d_game_callbacks *
         callbacks->shutdown(&ctx, userdata);
     }
 
-#if !defined(__ANDROID__)
+#if SDL3D_GAME_ENABLE_GLOBAL_TEXT_INPUT
     SDL_StopTextInput(ctx.window);
 #endif
     sdl3d_game_cleanup_context(&ctx);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -36,6 +36,7 @@
 #define SDL3D_GAME_DATA_NETWORK_INPUT_VERSION 1u
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
+#define SDL3D_GAME_DATA_MENU_TEXT_MAX_BYTES 255
 
 typedef enum game_data_sensor_type
 {
@@ -141,7 +142,7 @@ typedef struct menu_text_entry_capture
     bool active;
     const char *menu;
     int item_index;
-    char original[256];
+    char *original;
 } menu_text_entry_capture;
 
 typedef enum menu_binding_device
@@ -327,6 +328,18 @@ static void set_errorf(char *buffer, int buffer_size, const char *format, ...)
     va_start(args, format);
     SDL_vsnprintf(buffer, (size_t)buffer_size, format != NULL ? format : "unknown game data error", args);
     va_end(args);
+}
+
+static void clear_menu_text_entry_capture(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+
+    runtime->text_capture.active = false;
+    runtime->text_capture.menu = NULL;
+    runtime->text_capture.item_index = -1;
+    SDL_free(runtime->text_capture.original);
+    runtime->text_capture.original = NULL;
 }
 
 static bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char *format, ...)
@@ -4293,7 +4306,7 @@ bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runt
     const char *previous = sdl3d_game_data_active_scene(runtime);
     runtime->active_scene_index = (int)(scene - runtime->scenes);
     runtime->input_capture.active = false;
-    runtime->text_capture.active = false;
+    clear_menu_text_entry_capture(runtime);
     apply_scene_camera(runtime, scene);
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data scene set: %s -> %s",
                  previous != NULL ? previous : "<none>", scene->name != NULL ? scene->name : "<none>");
@@ -4512,7 +4525,7 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
         return SDL3D_GAME_DATA_MENU_CONTROL_RANGE;
     if (SDL_strcmp(type, "input_binding") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING;
-    if (SDL_strcmp(type, "text") == 0 || SDL_strcmp(type, "text_entry") == 0)
+    if (SDL_strcmp(type, "text") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_TEXT;
     return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
 }
@@ -5048,12 +5061,16 @@ static bool menu_control_set_string_value(sdl3d_game_data_runtime *runtime, yyjs
     return true;
 }
 
-static bool menu_text_allowed_char(yyjson_val *control, unsigned char ch)
+static bool menu_text_restricted_charset(const char *charset)
+{
+    return charset != NULL && SDL_strcmp(charset, "text") != 0 && SDL_strcmp(charset, "utf8") != 0;
+}
+
+static bool menu_text_allowed_ascii(const char *charset, unsigned char ch)
 {
     if (ch < 0x20U || ch == 0x7fU)
         return false;
 
-    const char *charset = json_string(control, "charset", json_string(control, "allow", "text"));
     if (charset == NULL || SDL_strcmp(charset, "text") == 0 || SDL_strcmp(charset, "utf8") == 0)
         return true;
     if (SDL_strcmp(charset, "ascii") == 0)
@@ -5070,6 +5087,43 @@ static bool menu_text_allowed_char(yyjson_val *control, unsigned char ch)
     return true;
 }
 
+static int menu_text_valid_utf8_sequence_bytes(const unsigned char *cursor, size_t remaining)
+{
+    if (cursor == NULL || remaining == 0U || cursor[0] == '\0')
+        return 0;
+
+    const unsigned char b0 = cursor[0];
+    if ((b0 & 0x80U) == 0U)
+        return 1;
+    if (remaining < 2U)
+        return 0;
+    if (b0 >= 0xc2U && b0 <= 0xdfU)
+        return (cursor[1] & 0xc0U) == 0x80U ? 2 : 0;
+    if (remaining < 3U)
+        return 0;
+    if (b0 == 0xe0U)
+        return (cursor[1] >= 0xa0U && cursor[1] <= 0xbfU && (cursor[2] & 0xc0U) == 0x80U) ? 3 : 0;
+    if ((b0 >= 0xe1U && b0 <= 0xecU) || (b0 >= 0xeeU && b0 <= 0xefU))
+        return ((cursor[1] & 0xc0U) == 0x80U && (cursor[2] & 0xc0U) == 0x80U) ? 3 : 0;
+    if (b0 == 0xedU)
+        return (cursor[1] >= 0x80U && cursor[1] <= 0x9fU && (cursor[2] & 0xc0U) == 0x80U) ? 3 : 0;
+    if (remaining < 4U)
+        return 0;
+    if (b0 == 0xf0U)
+        return (cursor[1] >= 0x90U && cursor[1] <= 0xbfU && (cursor[2] & 0xc0U) == 0x80U &&
+                (cursor[3] & 0xc0U) == 0x80U)
+                   ? 4
+                   : 0;
+    if (b0 >= 0xf1U && b0 <= 0xf3U)
+        return ((cursor[1] & 0xc0U) == 0x80U && (cursor[2] & 0xc0U) == 0x80U && (cursor[3] & 0xc0U) == 0x80U) ? 4 : 0;
+    if (b0 == 0xf4U)
+        return (cursor[1] >= 0x80U && cursor[1] <= 0x8fU && (cursor[2] & 0xc0U) == 0x80U &&
+                (cursor[3] & 0xc0U) == 0x80U)
+                   ? 4
+                   : 0;
+    return 0;
+}
+
 static bool menu_text_append_filtered(yyjson_val *control, char *buffer, size_t buffer_size, const char *text)
 {
     if (control == NULL || buffer == NULL || buffer_size == 0U || text == NULL || text[0] == '\0')
@@ -5077,34 +5131,33 @@ static bool menu_text_append_filtered(yyjson_val *control, char *buffer, size_t 
 
     bool changed = false;
     size_t used = SDL_strlen(buffer);
-    const int max_length = SDL_clamp(json_int(control, "max_length", (int)buffer_size - 1), 0, (int)buffer_size - 1);
-    for (const unsigned char *cursor = (const unsigned char *)text; *cursor != '\0' && used < (size_t)max_length;)
+    const int max_length = SDL_clamp(json_int(control, "max_length", SDL3D_GAME_DATA_MENU_TEXT_MAX_BYTES), 0,
+                                     (int)SDL_min(buffer_size - 1U, (size_t)SDL3D_GAME_DATA_MENU_TEXT_MAX_BYTES));
+    const char *charset = json_string(control, "charset", json_string(control, "allow", "text"));
+    const unsigned char *cursor = (const unsigned char *)text;
+    size_t remaining = SDL_strlen(text);
+    while (remaining > 0U && *cursor != '\0' && used < (size_t)max_length)
     {
-        const unsigned char ch = *cursor;
-        int bytes = 1;
-        if ((ch & 0x80U) == 0U)
+        int bytes = menu_text_valid_utf8_sequence_bytes(cursor, remaining);
+        if (bytes <= 0)
         {
-            if (!menu_text_allowed_char(control, ch))
+            ++cursor;
+            --remaining;
+            continue;
+        }
+        if (bytes == 1)
+        {
+            if (!menu_text_allowed_ascii(charset, *cursor))
             {
                 ++cursor;
+                --remaining;
                 continue;
             }
         }
-        else if ((ch & 0xe0U) == 0xc0U)
+        else if (menu_text_restricted_charset(charset))
         {
-            bytes = 2;
-        }
-        else if ((ch & 0xf0U) == 0xe0U)
-        {
-            bytes = 3;
-        }
-        else if ((ch & 0xf8U) == 0xf0U)
-        {
-            bytes = 4;
-        }
-        else
-        {
-            ++cursor;
+            cursor += bytes;
+            remaining -= (size_t)bytes;
             continue;
         }
 
@@ -5112,6 +5165,7 @@ static bool menu_text_append_filtered(yyjson_val *control, char *buffer, size_t 
             break;
         for (int i = 0; i < bytes; ++i)
             buffer[used++] = (char)*cursor++;
+        remaining -= (size_t)bytes;
         buffer[used] = '\0';
         changed = true;
     }
@@ -5141,11 +5195,16 @@ bool sdl3d_game_data_start_menu_text_entry_capture(sdl3d_game_data_runtime *runt
         parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
         return false;
 
+    clear_menu_text_entry_capture(runtime);
     runtime->text_capture.active = true;
     runtime->text_capture.menu = menu_name;
     runtime->text_capture.item_index = item_index;
-    SDL_strlcpy(runtime->text_capture.original, menu_control_string_value(runtime, control),
-                sizeof(runtime->text_capture.original));
+    runtime->text_capture.original = SDL_strdup(menu_control_string_value(runtime, control));
+    if (runtime->text_capture.original == NULL)
+    {
+        clear_menu_text_entry_capture(runtime);
+        return false;
+    }
     (void)menu_control_set_string_value(runtime, control, runtime->text_capture.original);
     return true;
 }
@@ -5165,7 +5224,7 @@ sdl3d_game_data_text_entry_capture_status sdl3d_game_data_update_menu_text_entry
     yyjson_val *control = obj_get(item, "control");
     if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
     {
-        runtime->text_capture.active = false;
+        clear_menu_text_entry_capture(runtime);
         return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED;
     }
 
@@ -5184,8 +5243,9 @@ sdl3d_game_data_text_entry_capture_status sdl3d_game_data_update_menu_text_entry
         (menu_desc.back_action_id >= 0 && sdl3d_input_is_pressed(input, menu_desc.back_action_id));
     if (cancel_pressed)
     {
-        (void)menu_control_set_string_value(runtime, control, runtime->text_capture.original);
-        runtime->text_capture.active = false;
+        (void)menu_control_set_string_value(
+            runtime, control, runtime->text_capture.original != NULL ? runtime->text_capture.original : "");
+        clear_menu_text_entry_capture(runtime);
         return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED;
     }
 
@@ -5194,7 +5254,7 @@ sdl3d_game_data_text_entry_capture_status sdl3d_game_data_update_menu_text_entry
         (menu_desc.select_action_id >= 0 && sdl3d_input_is_pressed(input, menu_desc.select_action_id));
     if (submit_pressed)
     {
-        runtime->text_capture.active = false;
+        clear_menu_text_entry_capture(runtime);
         return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_SUBMITTED;
     }
 
@@ -11207,6 +11267,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         sdl3d_properties_destroy(runtime->property_snapshots[i].properties);
     }
 
+    clear_menu_text_entry_capture(runtime);
     sdl3d_script_engine_destroy(runtime->scripts);
     sdl3d_properties_destroy(runtime->scene_state);
     sdl3d_storage_destroy(runtime->storage);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -136,6 +136,14 @@ typedef struct menu_input_binding_capture
     int item_index;
 } menu_input_binding_capture;
 
+typedef struct menu_text_entry_capture
+{
+    bool active;
+    const char *menu;
+    int item_index;
+    char original[256];
+} menu_text_entry_capture;
+
 typedef enum menu_binding_device
 {
     MENU_BINDING_DEVICE_KEYBOARD = 0,
@@ -268,6 +276,7 @@ typedef struct sdl3d_game_data_runtime
     int input_binding_count;
     int input_binding_capacity;
     menu_input_binding_capture input_capture;
+    menu_text_entry_capture text_capture;
     sdl3d_script_engine *scripts;
     script_entry *script_entries;
     int script_count;
@@ -4284,6 +4293,7 @@ bool sdl3d_game_data_set_active_scene_with_payload(sdl3d_game_data_runtime *runt
     const char *previous = sdl3d_game_data_active_scene(runtime);
     runtime->active_scene_index = (int)(scene - runtime->scenes);
     runtime->input_capture.active = false;
+    runtime->text_capture.active = false;
     apply_scene_camera(runtime, scene);
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data scene set: %s -> %s",
                  previous != NULL ? previous : "<none>", scene->name != NULL ? scene->name : "<none>");
@@ -4502,6 +4512,8 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
         return SDL3D_GAME_DATA_MENU_CONTROL_RANGE;
     if (SDL_strcmp(type, "input_binding") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING;
+    if (SDL_strcmp(type, "text") == 0 || SDL_strcmp(type, "text_entry") == 0)
+        return SDL3D_GAME_DATA_MENU_CONTROL_TEXT;
     return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
 }
 
@@ -4999,6 +5011,207 @@ bool sdl3d_game_data_reset_menu_input_bindings(sdl3d_game_data_runtime *runtime,
     return changed;
 }
 
+static sdl3d_properties *menu_control_properties(sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    if (runtime == NULL || control == NULL)
+        return NULL;
+
+    const char *target = json_string(control, "target", NULL);
+    if (target == NULL || SDL_strcmp(target, "scene_state") == 0)
+        return runtime->scene_state;
+
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    return actor != NULL ? actor->props : NULL;
+}
+
+static const sdl3d_properties *menu_control_properties_const(const sdl3d_game_data_runtime *runtime,
+                                                             yyjson_val *control)
+{
+    return menu_control_properties((sdl3d_game_data_runtime *)runtime, control);
+}
+
+static const char *menu_control_string_value(const sdl3d_game_data_runtime *runtime, yyjson_val *control)
+{
+    const char *key = json_string(control, "key", NULL);
+    const char *fallback = json_string(control, "default", "");
+    const sdl3d_properties *props = menu_control_properties_const(runtime, control);
+    return props != NULL && key != NULL ? sdl3d_properties_get_string(props, key, fallback) : fallback;
+}
+
+static bool menu_control_set_string_value(sdl3d_game_data_runtime *runtime, yyjson_val *control, const char *value)
+{
+    const char *key = json_string(control, "key", NULL);
+    sdl3d_properties *props = menu_control_properties(runtime, control);
+    if (props == NULL || key == NULL || value == NULL)
+        return false;
+    sdl3d_properties_set_string(props, key, value);
+    return true;
+}
+
+static bool menu_text_allowed_char(yyjson_val *control, unsigned char ch)
+{
+    if (ch < 0x20U || ch == 0x7fU)
+        return false;
+
+    const char *charset = json_string(control, "charset", json_string(control, "allow", "text"));
+    if (charset == NULL || SDL_strcmp(charset, "text") == 0 || SDL_strcmp(charset, "utf8") == 0)
+        return true;
+    if (SDL_strcmp(charset, "ascii") == 0)
+        return ch < 0x80U;
+    if (SDL_strcmp(charset, "integer") == 0 || SDL_strcmp(charset, "digits") == 0)
+        return ch >= '0' && ch <= '9';
+    if (SDL_strcmp(charset, "numeric") == 0)
+        return (ch >= '0' && ch <= '9') || ch == '.' || ch == '-';
+    if (SDL_strcmp(charset, "hostname") == 0)
+    {
+        return (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '.' ||
+               ch == '-' || ch == '_' || ch == ':';
+    }
+    return true;
+}
+
+static bool menu_text_append_filtered(yyjson_val *control, char *buffer, size_t buffer_size, const char *text)
+{
+    if (control == NULL || buffer == NULL || buffer_size == 0U || text == NULL || text[0] == '\0')
+        return false;
+
+    bool changed = false;
+    size_t used = SDL_strlen(buffer);
+    const int max_length = SDL_clamp(json_int(control, "max_length", (int)buffer_size - 1), 0, (int)buffer_size - 1);
+    for (const unsigned char *cursor = (const unsigned char *)text; *cursor != '\0' && used < (size_t)max_length;)
+    {
+        const unsigned char ch = *cursor;
+        int bytes = 1;
+        if ((ch & 0x80U) == 0U)
+        {
+            if (!menu_text_allowed_char(control, ch))
+            {
+                ++cursor;
+                continue;
+            }
+        }
+        else if ((ch & 0xe0U) == 0xc0U)
+        {
+            bytes = 2;
+        }
+        else if ((ch & 0xf0U) == 0xe0U)
+        {
+            bytes = 3;
+        }
+        else if ((ch & 0xf8U) == 0xf0U)
+        {
+            bytes = 4;
+        }
+        else
+        {
+            ++cursor;
+            continue;
+        }
+
+        if (used + (size_t)bytes > (size_t)max_length || used + (size_t)bytes + 1U > buffer_size)
+            break;
+        for (int i = 0; i < bytes; ++i)
+            buffer[used++] = (char)*cursor++;
+        buffer[used] = '\0';
+        changed = true;
+    }
+    return changed;
+}
+
+static bool menu_text_backspace(char *buffer)
+{
+    if (buffer == NULL || buffer[0] == '\0')
+        return false;
+
+    size_t len = SDL_strlen(buffer);
+    do
+    {
+        --len;
+    } while (len > 0U && (((unsigned char)buffer[len] & 0xc0U) == 0x80U));
+    buffer[len] = '\0';
+    return true;
+}
+
+bool sdl3d_game_data_start_menu_text_entry_capture(sdl3d_game_data_runtime *runtime, const char *menu_name,
+                                                   int item_index)
+{
+    yyjson_val *item = find_menu_item_at(runtime, menu_name, item_index);
+    yyjson_val *control = obj_get(item, "control");
+    if (runtime == NULL || menu_name == NULL ||
+        parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
+        return false;
+
+    runtime->text_capture.active = true;
+    runtime->text_capture.menu = menu_name;
+    runtime->text_capture.item_index = item_index;
+    SDL_strlcpy(runtime->text_capture.original, menu_control_string_value(runtime, control),
+                sizeof(runtime->text_capture.original));
+    (void)menu_control_set_string_value(runtime, control, runtime->text_capture.original);
+    return true;
+}
+
+bool sdl3d_game_data_menu_text_entry_capture_active(const sdl3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->text_capture.active;
+}
+
+sdl3d_game_data_text_entry_capture_status sdl3d_game_data_update_menu_text_entry_capture(
+    sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
+{
+    if (runtime == NULL || !runtime->text_capture.active)
+        return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_NONE;
+
+    yyjson_val *item = find_menu_item_at(runtime, runtime->text_capture.menu, runtime->text_capture.item_index);
+    yyjson_val *control = obj_get(item, "control");
+    if (parse_menu_control_type(json_string(control, "type", NULL)) != SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
+    {
+        runtime->text_capture.active = false;
+        return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED;
+    }
+
+    const scene_menu_state *menu = find_scene_menu_const(active_scene_entry_const(runtime), runtime->text_capture.menu);
+    sdl3d_game_data_menu menu_desc;
+    SDL_zero(menu_desc);
+    menu_desc.select_action_id = -1;
+    menu_desc.back_action_id = -1;
+    if (menu != NULL)
+        (void)sdl3d_game_data_get_active_menu(runtime, &menu_desc);
+
+    const SDL_Scancode scancode = sdl3d_input_get_pressed_scancode(input);
+    const SDL_Scancode cancel_key = scancode_from_json(json_string(control, "cancel_key", "ESCAPE"));
+    const bool cancel_pressed =
+        (cancel_key != SDL_SCANCODE_UNKNOWN && scancode == cancel_key) ||
+        (menu_desc.back_action_id >= 0 && sdl3d_input_is_pressed(input, menu_desc.back_action_id));
+    if (cancel_pressed)
+    {
+        (void)menu_control_set_string_value(runtime, control, runtime->text_capture.original);
+        runtime->text_capture.active = false;
+        return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED;
+    }
+
+    const bool submit_pressed =
+        scancode == SDL_SCANCODE_RETURN || scancode == SDL_SCANCODE_KP_ENTER ||
+        (menu_desc.select_action_id >= 0 && sdl3d_input_is_pressed(input, menu_desc.select_action_id));
+    if (submit_pressed)
+    {
+        runtime->text_capture.active = false;
+        return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_SUBMITTED;
+    }
+
+    char value[256];
+    SDL_strlcpy(value, menu_control_string_value(runtime, control), sizeof(value));
+    bool changed = false;
+    if (scancode == SDL_SCANCODE_BACKSPACE || scancode == SDL_SCANCODE_DELETE)
+        changed = menu_text_backspace(value) || changed;
+    changed = menu_text_append_filtered(control, value, sizeof(value), sdl3d_input_get_text_input(input)) || changed;
+    if (changed)
+    {
+        (void)menu_control_set_string_value(runtime, control, value);
+        return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CHANGED;
+    }
+    return SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_WAITING;
+}
+
 static bool set_property_from_json(sdl3d_properties *props, const char *key, yyjson_val *value)
 {
     if (props == NULL || key == NULL || value == NULL)
@@ -5127,6 +5340,7 @@ bool sdl3d_game_data_adjust_menu_item_control(sdl3d_game_data_runtime *runtime, 
     }
     case SDL3D_GAME_DATA_MENU_CONTROL_NONE:
     case SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING:
+    case SDL3D_GAME_DATA_MENU_CONTROL_TEXT:
         return false;
     }
     return false;
@@ -5166,6 +5380,8 @@ bool sdl3d_game_data_scene_shortcut_at(const sdl3d_game_data_runtime *runtime, i
 bool sdl3d_game_data_active_menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input)
 {
     if (sdl3d_game_data_menu_input_binding_capture_active(runtime))
+        return false;
+    if (sdl3d_game_data_menu_text_entry_capture_active(runtime))
         return false;
     sdl3d_game_data_menu menu;
     if (!sdl3d_game_data_get_active_menu(runtime, &menu))
@@ -5299,6 +5515,23 @@ static void format_menu_item_label(const sdl3d_game_data_runtime *runtime, yyjso
             SDL_snprintf(buffer, buffer_size, "%s: %s", label,
                          scancode_display_name(current_input_binding_control_scancode(runtime, control)));
         }
+        return;
+    }
+    if (type == SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
+    {
+        char value[256];
+        SDL_strlcpy(value, menu_control_string_value(runtime, control), sizeof(value));
+        const bool active =
+            runtime != NULL && runtime->text_capture.active &&
+            item == find_menu_item_at(runtime, runtime->text_capture.menu, runtime->text_capture.item_index);
+        const char *placeholder = json_string(control, "placeholder", "");
+        const char *cursor = json_string(control, "cursor", "|");
+        if (value[0] == '\0' && placeholder != NULL && placeholder[0] != '\0' && !active)
+            SDL_snprintf(buffer, buffer_size, "%s: %s", label, placeholder);
+        else if (active)
+            SDL_snprintf(buffer, buffer_size, "%s: %s%s", label, value, cursor != NULL ? cursor : "|");
+        else
+            SDL_snprintf(buffer, buffer_size, "%s: %s", label, value);
         return;
     }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3493,12 +3493,16 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
 
     const char *type = json_string(control, "type");
     if (type == NULL || (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 &&
-                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "input_binding") != 0))
-        return validation_error(ctx, path, "menu item control requires type toggle, choice, range, or input_binding");
+                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "input_binding") != 0 &&
+                         SDL_strcmp(type, "text") != 0 && SDL_strcmp(type, "text_entry") != 0))
+        return validation_error(ctx, path,
+                                "menu item control requires type toggle, choice, range, input_binding, or text");
 
     if (SDL_strcmp(type, "input_binding") != 0)
     {
-        if (!require_ref(ctx, &names->entities, "entity", json_string(control, "target"), path))
+        const char *target = json_string(control, "target");
+        if (target != NULL && SDL_strcmp(target, "scene_state") != 0 &&
+            !require_ref(ctx, &names->entities, "entity", target, path))
             return false;
         if (!is_non_empty_string(control, "key"))
             return validation_error(ctx, path, "menu item control requires a non-empty key");
@@ -3534,6 +3538,26 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
                 return validation_error(ctx, path,
                                         "input_binding controls support keyboard, mouse, or gamepad bindings");
         }
+    }
+    if (SDL_strcmp(type, "text") == 0 || SDL_strcmp(type, "text_entry") == 0)
+    {
+        yyjson_val *max_length = obj_get(control, "max_length");
+        if (max_length != NULL && (!yyjson_is_int(max_length) || yyjson_get_sint(max_length) < 0))
+            return validation_error(ctx, path, "text control max_length must be a non-negative integer");
+        if (obj_get(control, "default") != NULL && !yyjson_is_str(obj_get(control, "default")))
+            return validation_error(ctx, path, "text control default must be a string");
+        if (obj_get(control, "placeholder") != NULL && !yyjson_is_str(obj_get(control, "placeholder")))
+            return validation_error(ctx, path, "text control placeholder must be a string");
+        const char *charset = json_string(control, "charset");
+        if (charset == NULL)
+            charset = json_string(control, "allow");
+        if (charset != NULL && SDL_strcmp(charset, "text") != 0 && SDL_strcmp(charset, "utf8") != 0 &&
+            SDL_strcmp(charset, "ascii") != 0 && SDL_strcmp(charset, "integer") != 0 &&
+            SDL_strcmp(charset, "digits") != 0 && SDL_strcmp(charset, "numeric") != 0 &&
+            SDL_strcmp(charset, "hostname") != 0)
+            return validation_error(ctx, path,
+                                    "text control charset must be text, utf8, ascii, integer, digits, numeric, or "
+                                    "hostname");
     }
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -16,6 +16,7 @@
 #include "sdl3d_crypto.h"
 
 #define PATH_BUFFER_SIZE 256
+#define GAME_DATA_MENU_TEXT_MAX_BYTES 255
 
 typedef struct name_table
 {
@@ -3492,9 +3493,9 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
         return validation_error(ctx, path, "menu item control must be an object");
 
     const char *type = json_string(control, "type");
-    if (type == NULL || (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 &&
-                         SDL_strcmp(type, "range") != 0 && SDL_strcmp(type, "input_binding") != 0 &&
-                         SDL_strcmp(type, "text") != 0 && SDL_strcmp(type, "text_entry") != 0))
+    if (type == NULL ||
+        (SDL_strcmp(type, "toggle") != 0 && SDL_strcmp(type, "choice") != 0 && SDL_strcmp(type, "range") != 0 &&
+         SDL_strcmp(type, "input_binding") != 0 && SDL_strcmp(type, "text") != 0))
         return validation_error(ctx, path,
                                 "menu item control requires type toggle, choice, range, input_binding, or text");
 
@@ -3539,11 +3540,13 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
                                         "input_binding controls support keyboard, mouse, or gamepad bindings");
         }
     }
-    if (SDL_strcmp(type, "text") == 0 || SDL_strcmp(type, "text_entry") == 0)
+    if (SDL_strcmp(type, "text") == 0)
     {
         yyjson_val *max_length = obj_get(control, "max_length");
         if (max_length != NULL && (!yyjson_is_int(max_length) || yyjson_get_sint(max_length) < 0))
             return validation_error(ctx, path, "text control max_length must be a non-negative integer");
+        if (max_length != NULL && yyjson_get_sint(max_length) > GAME_DATA_MENU_TEXT_MAX_BYTES)
+            return validation_error(ctx, path, "text control max_length must be 255 bytes or fewer");
         if (obj_get(control, "default") != NULL && !yyjson_is_str(obj_get(control, "default")))
             return validation_error(ctx, path, "text control default must be a string");
         if (obj_get(control, "placeholder") != NULL && !yyjson_is_str(obj_get(control, "placeholder")))

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -926,6 +926,22 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
         }
         return true;
     }
+    if (sdl3d_game_data_menu_text_entry_capture_active(runtime))
+    {
+        const sdl3d_game_data_text_entry_capture_status capture_status =
+            sdl3d_game_data_update_menu_text_entry_capture(runtime, input);
+        if (out_result != NULL)
+        {
+            out_result->handled_input = true;
+            out_result->text_entry_changed = capture_status == SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CHANGED;
+            out_result->text_entry_submitted = capture_status == SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_SUBMITTED;
+            out_result->text_entry_canceled = capture_status == SDL3D_GAME_DATA_TEXT_ENTRY_CAPTURE_CANCELED;
+            out_result->control_changed = out_result->text_entry_changed;
+            out_result->selected = out_result->text_entry_submitted;
+            out_result->select_signal_id = out_result->text_entry_submitted ? menu.select_signal_id : -1;
+        }
+        return true;
+    }
 
     if (!*input_armed)
     {
@@ -1048,8 +1064,29 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
                 out_result->handled_input = true;
                 return true;
             }
+            if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
+            {
+                out_result->text_entry_capture_started =
+                    sdl3d_game_data_start_menu_text_entry_capture(runtime, refreshed.name, refreshed.selected_index);
+                out_result->selected = out_result->text_entry_capture_started;
+                out_result->select_signal_id = out_result->selected ? refreshed.select_signal_id : -1;
+                out_result->signal_id = -1;
+                out_result->quit = false;
+                out_result->scene = NULL;
+                out_result->return_to = NULL;
+                out_result->scene_state_key = NULL;
+                out_result->scene_state_value = NULL;
+                out_result->return_scene = false;
+                out_result->pause_command = SDL3D_GAME_DATA_MENU_PAUSE_NONE;
+                out_result->has_return_paused = false;
+                out_result->return_paused = false;
+                out_result->control_changed = false;
+                out_result->handled_input = true;
+                return true;
+            }
             out_result->control_changed =
-                control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING
+                control_adjust_input && (item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING ||
+                                         item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
                     ? false
                     : sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
             out_result->selected = !control_adjust_input || out_result->control_changed;
@@ -1075,7 +1112,10 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
             if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
                 (void)sdl3d_game_data_start_menu_input_binding_capture(runtime, refreshed.name,
                                                                        refreshed.selected_index);
-            else if (item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING)
+            else if (!control_adjust_input && item.control_type == SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
+                (void)sdl3d_game_data_start_menu_text_entry_capture(runtime, refreshed.name, refreshed.selected_index);
+            else if (item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_INPUT_BINDING &&
+                     item.control_type != SDL3D_GAME_DATA_MENU_CONTROL_TEXT)
                 (void)sdl3d_game_data_adjust_menu_item_control(runtime, &item, control_direction);
         }
     }

--- a/src/input.c
+++ b/src/input.c
@@ -81,6 +81,8 @@ struct sdl3d_input_manager
     SDL_Scancode pressed_scancode;
     Uint8 pressed_mouse_button;
     SDL_GamepadButton pressed_gamepad_button;
+    char pending_text_input[SDL3D_INPUT_TEXT_MAX];
+    char current_text_input[SDL3D_INPUT_TEXT_MAX];
 
     float deadzone;
 
@@ -634,6 +636,7 @@ static void sdl3d_input_reset_transients(sdl3d_input_manager *input)
     input->mouse_dy_accum = 0.0f;
     input->mouse_wheel_x_accum = 0.0f;
     input->mouse_wheel_y_accum = 0.0f;
+    input->pending_text_input[0] = '\0';
     SDL_memset(input->key_pressed_this_frame, 0, sizeof(input->key_pressed_this_frame));
     SDL_memset(input->key_released_this_frame, 0, sizeof(input->key_released_this_frame));
     SDL_memset(input->key_pressed_modifiers_this_frame, 0, sizeof(input->key_pressed_modifiers_this_frame));
@@ -647,6 +650,21 @@ static void sdl3d_input_reset_transients(sdl3d_input_manager *input)
         SDL_memset(input->gamepads[i].button_released_this_frame, 0,
                    sizeof(input->gamepads[i].button_released_this_frame));
     }
+}
+
+static void sdl3d_input_append_text(sdl3d_input_manager *input, const char *text)
+{
+    if (input == NULL || text == NULL || text[0] == '\0')
+    {
+        return;
+    }
+
+    const size_t current = SDL_strlen(input->pending_text_input);
+    if (current + 1U >= sizeof(input->pending_text_input))
+    {
+        return;
+    }
+    SDL_strlcpy(input->pending_text_input + current, text, sizeof(input->pending_text_input) - current);
 }
 
 static bool sdl3d_input_physical_any_pressed(const sdl3d_input_manager *input)
@@ -1190,6 +1208,9 @@ void sdl3d_input_process_event(sdl3d_input_manager *input, const SDL_Event *even
 
     switch (event->type)
     {
+    case SDL_EVENT_TEXT_INPUT:
+        sdl3d_input_append_text(input, event->text.text);
+        break;
     case SDL_EVENT_KEY_DOWN:
         if (event->key.scancode >= 0 && event->key.scancode < SDL_SCANCODE_COUNT && !event->key.repeat)
         {
@@ -1338,6 +1359,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
             input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
             input->pressed_mouse_button = 0;
             input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
+            input->current_text_input[0] = '\0';
             SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
             for (int i = 0; i < SDL3D_INPUT_MAX_ACTIONS; ++i)
             {
@@ -1362,6 +1384,7 @@ const sdl3d_input_snapshot *sdl3d_input_update(sdl3d_input_manager *input, int t
     input->pressed_scancode = sdl3d_input_first_pressed_scancode(input);
     input->pressed_mouse_button = sdl3d_input_first_pressed_mouse_button(input);
     input->pressed_gamepad_button = sdl3d_input_first_pressed_gamepad_button(input);
+    SDL_strlcpy(input->current_text_input, input->pending_text_input, sizeof(input->current_text_input));
 
     for (int action_id = 0; action_id < input->action_count; ++action_id)
     {
@@ -1610,6 +1633,11 @@ bool sdl3d_input_rumble_all_gamepads(sdl3d_input_manager *input, float low_frequ
 const sdl3d_input_snapshot *sdl3d_input_get_snapshot(const sdl3d_input_manager *input)
 {
     return input != NULL ? &input->snapshot : NULL;
+}
+
+const char *sdl3d_input_get_text_input(const sdl3d_input_manager *input)
+{
+    return input != NULL ? input->current_text_input : "";
 }
 
 static int sdl3d_input_ensure_action(sdl3d_input_manager *input, const char *name)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2693,6 +2693,194 @@ TEST(GameDataRuntime, MenuControllerConsumesAuthoredMenuInput)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, MenuTextEntryCapturesEditingInput)
+{
+    const std::filesystem::path dir = unique_test_dir("menu_text_entry");
+    write_text(dir / "text_entry.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Text Entry", "id": "test.text_entry", "version": "0.1.0" },
+  "world": { "name": "world.text_entry", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.ui",
+        "actions": [
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] },
+          { "name": "action.menu.back", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] }
+        ]
+      }
+    ]
+  },
+  "entities": [],
+  "scenes": { "initial": "scene.form", "files": ["scenes/form.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "form.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.form",
+  "input": { "actions": ["action.menu.select", "action.menu.back", "action.menu.up", "action.menu.down"] },
+  "menus": [
+    {
+      "name": "menu.form",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "items": [
+        {
+          "label": "Host",
+          "control": {
+            "type": "text",
+            "target": "scene_state",
+            "key": "host",
+            "default": "",
+            "placeholder": "Host / IP",
+            "charset": "hostname",
+            "max_length": 32
+          }
+        },
+        { "label": "Back", "return_scene": true }
+      ]
+    }
+  ]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "text_entry.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    ASSERT_STREQ(menu.name, "menu.form");
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_TEXT);
+
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event event{};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.text_entry_capture_started);
+    EXPECT_TRUE(sdl3d_game_data_menu_text_entry_capture_active(runtime));
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_TEXT_INPUT;
+    event.text.text = "host local@1";
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.text_entry_changed);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "host", ""), "hostlocal1");
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_DOWN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 4);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.selected_index, 0);
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 5);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_BACKSPACE;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 6);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "host", ""), "hostlocal");
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 7);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_DELETE;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 8);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "host", ""), "hostloca");
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 9);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 10);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.text_entry_canceled);
+    EXPECT_FALSE(sdl3d_game_data_menu_text_entry_capture_active(runtime));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "host", ""), "");
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 11);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 12);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.text_entry_capture_started);
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 13);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_TEXT_INPUT;
+    event.text.text = "192.168.1.20:27183";
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 14);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 15);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.text_entry_submitted);
+    EXPECT_FALSE(sdl3d_game_data_menu_text_entry_capture_active(runtime));
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "host", ""), "192.168.1.20:27183");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, PlaySceneMenusAreSelectedByAuthoredConditions)
 {
     sdl3d_game_session *session = nullptr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2783,7 +2783,13 @@ TEST(GameDataRuntime, MenuTextEntryCapturesEditingInput)
 
     event = {};
     event.type = SDL_EVENT_TEXT_INPUT;
-    event.text.text = "host local@1";
+    event.text.text = "host local@1"
+                      "\xC3"
+                      "\xA9"
+                      "\xF0"
+                      "\x9F"
+                      "\x98"
+                      "\x80";
     sdl3d_input_process_event(input, &event);
     sdl3d_input_update(input, 3);
     ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
@@ -2878,6 +2884,65 @@ TEST(GameDataRuntime, MenuTextEntryCapturesEditingInput)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidMenuTextControlSchema)
+{
+    const std::filesystem::path dir = unique_test_dir("menu_text_entry_validation");
+    const auto write_case = [&](const char *name, const char *control_json) {
+        write_text(dir / (std::string(name) + ".game.json"),
+                   R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Text Entry Validation", "id": "test.text_entry_validation", "version": "0.1.0" },
+  "world": { "name": "world.text_entry_validation", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.ui",
+        "actions": [
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] }
+        ]
+      }
+    ]
+  },
+  "entities": [],
+  "scenes": { "initial": "scene.form", "files": ["scenes/form.scene.json"] }
+})json");
+        write_text(dir / "scenes" / "form.scene.json", (std::string(R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.form",
+  "input": { "actions": ["action.menu.select", "action.menu.up", "action.menu.down"] },
+  "menus": [
+    {
+      "name": "menu.form",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        { "label": "Host", "control": )json") + control_json +
+                                                        R"json( }
+      ]
+    }
+  ]
+})json")
+                                                           .c_str());
+    };
+
+    char error[512]{};
+    write_case("alias", R"json({ "type": "text_entry", "target": "scene_state", "key": "host" })json");
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "alias.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("menu item control requires type"), std::string::npos) << error;
+
+    error[0] = '\0';
+    write_case("too_long", R"json({ "type": "text", "target": "scene_state", "key": "host", "max_length": 256 })json");
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "too_long.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("max_length must be 255 bytes or fewer"), std::string::npos) << error;
+
     remove_test_dir(dir);
 }
 

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -64,6 +64,14 @@ void push_key(sdl3d_input_manager *input, SDL_EventType type, SDL_Scancode scanc
     sdl3d_input_process_event(input, &event);
 }
 
+void push_text(sdl3d_input_manager *input, const char *text)
+{
+    SDL_Event event{};
+    event.type = SDL_EVENT_TEXT_INPUT;
+    event.text.text = text;
+    sdl3d_input_process_event(input, &event);
+}
+
 void push_key_mod(sdl3d_input_manager *input, SDL_EventType type, SDL_Scancode scancode, SDL_Keymod modifiers)
 {
     SDL_Event event{};
@@ -803,4 +811,17 @@ TEST(InputDemo, PlaybackStopPreservesPendingLiveInput)
     EXPECT_TRUE(sdl3d_input_is_held(input.input, jump));
 
     sdl3d_demo_playback_free(player);
+}
+
+TEST(InputManager, CapturesTextInputForCurrentTick)
+{
+    InputPtr input;
+
+    push_text(input.input, "abc");
+    push_text(input.input, ".42");
+    ASSERT_NE(sdl3d_input_update(input.input, 1), nullptr);
+    EXPECT_STREQ(sdl3d_input_get_text_input(input.input), "abc.42");
+
+    ASSERT_NE(sdl3d_input_update(input.input, 2), nullptr);
+    EXPECT_STREQ(sdl3d_input_get_text_input(input.input), "");
 }


### PR DESCRIPTION
## Summary
- add SDL text-input capture to the input manager and enable text input in the managed game loop
- add reusable data-authored menu text controls bound to scene state or actor string properties
- consume focused editing input locally, including typing, Backspace/Delete, submit, cancel, and menu-input isolation
- validate and document the text-control schema, including max length and charset filters

## Verification
- clang-format on touched C/C++ files
- cmake --build build/debug --target sdl3d_input_test sdl3d_game_data_test pong_demo -j4
- ./build/debug/tests/sdl3d_input_test
- ./build/debug/tests/sdl3d_game_data_test
- ctest --test-dir build/debug --output-on-failure (1054/1054 passed, one expected skipped OpenGL fixture)

First slice of #201.