### PR TITLE
Add data-authored dynamic list menus

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -448,6 +448,19 @@ row moves. `scene_state.value_from` may be `value`, `label`, or `index` and is
 applied when a populated row is accepted. UI menu presenters may author
 `visible_count` to show a scrolling window around the selected row instead of
 rendering every row.
+`label_key_format` and `value_key_format` must each contain exactly one `%d`
+token and no other printf-style specifiers; the runtime replaces that token
+with the zero-based row index. `label_format` is not a printf string: use the
+literal `{label}` token where the row label should appear.
+
+Dynamic-list label and value pointers returned by
+`sdl3d_game_data_get_menu_item()` are copied into storage on the returned
+`sdl3d_game_data_menu_item`, so they remain valid until that struct is
+overwritten. Static menu item strings remain runtime-owned. If a dynamic list
+shrinks while selected, the highlighted flattened menu index is clamped to the
+new flattened item range; this can move selection from a removed row to a
+following static item such as `Back`. `visible_count` is likewise applied to
+the flattened menu, including both dynamic rows and static items.
 
 `input_binding` controls capture the next keyboard key, mouse button, or
 gamepad button and immediately rebind all authored actions for that device. This is how games can

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -413,6 +413,42 @@ and `:` so it can store hostnames, IPv4 addresses, IPv6-style text, and ports.
 Restricted charsets reject non-ASCII UTF-8 input. `max_length` is measured in
 UTF-8 bytes and must be 255 or fewer.
 
+Menus can also include a data-authored dynamic list item. A dynamic list expands
+one authored menu row into zero or more selectable rows at runtime. The first
+source type is `scene_state_indexed`, which reads a count and indexed label /
+value keys from scene state. This is useful for server browsers, save-slot
+lists, profile selectors, inventory rows, and similar UI where the row count is
+not known when the scene JSON is authored:
+
+```json
+{
+    "type" : "dynamic_list",
+    "name" : "list.local_matches",
+    "source" : {
+        "type" : "scene_state_indexed",
+        "count_key" : "local_match_count",
+        "label_key_format" : "local_match_%d_label",
+        "value_key_format" : "local_match_%d_endpoint"
+    },
+    "empty_label" : "No local matches found",
+    "label_format" : "Join {label}",
+    "selected_index_key" : "selected_local_match_index",
+    "selected_value_key" : "selected_local_match_endpoint",
+    "scene_state" : { "key" : "selected_local_match", "value_from" : "value" },
+    "signal" : "signal.multiplayer.join_selected"
+}
+```
+
+The menu controller treats expanded rows like normal menu items: Up/Down moves
+through them, Back still resolves the authored back item, and Accept selects the
+current row. If the source count is zero, `empty_label` renders one inert row
+with no signal, scene change, or scene-state mutation. `selected_index_key` and
+`selected_value_key` are optional scene-state outputs updated as the highlighted
+row moves. `scene_state.value_from` may be `value`, `label`, or `index` and is
+applied when a populated row is accepted. UI menu presenters may author
+`visible_count` to show a scrolling window around the selected row instead of
+rendering every row.
+
 `input_binding` controls capture the next keyboard key, mouse button, or
 gamepad button and immediately rebind all authored actions for that device. This is how games can
 expose one player-facing input such as `Up` while updating both gameplay and

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -43,6 +43,9 @@ extern "C"
      */
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE (16U + SDL3D_REPLICATION_SCHEMA_HASH_SIZE)
 
+    /** @brief Maximum bytes stored for one dynamic menu row label or value, including room for terminator. */
+#define SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY 256U
+
     /** @brief Opaque runtime created from one game JSON document. */
     typedef struct sdl3d_game_data_runtime sdl3d_game_data_runtime;
 
@@ -694,6 +697,12 @@ extern "C"
         int dynamic_list_index;
         /** @brief Runtime-owned value associated with the dynamic row, or NULL. */
         const char *dynamic_list_value;
+        /** @brief Storage backing label for dynamic-list rows. */
+        char dynamic_list_label_storage[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
+        /** @brief Storage backing scene_state_value for dynamic-list rows. */
+        char dynamic_list_scene_state_value_storage[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
+        /** @brief Storage backing dynamic_list_value. */
+        char dynamic_list_value_storage[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
     } sdl3d_game_data_menu_item;
 
     /** @brief Authored scene transition behavior policy. */
@@ -1846,9 +1855,20 @@ extern "C"
     bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *menu_name, int delta);
 
     /**
+     * @brief Publish side effects for the currently selected menu item without moving selection.
+     *
+     * Dynamic-list rows may author selected-index or selected-value scene-state
+     * outputs. This helper refreshes those outputs for the current highlighted
+     * item. It does not emit signals, select the item, or change scenes.
+     */
+    bool sdl3d_game_data_publish_menu_selection(sdl3d_game_data_runtime *runtime, const char *menu_name);
+
+    /**
      * @brief Read one item from an authored menu.
      *
-     * @p index is zero based. The returned strings remain owned by the runtime.
+     * @p index is zero based. Static returned strings remain owned by the
+     * runtime. Dynamic-list label/value strings are copied into storage fields
+     * on @p out_item and remain valid until @p out_item is overwritten.
      */
     bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const char *menu_name, int index,
                                        sdl3d_game_data_menu_item *out_item);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -686,6 +686,14 @@ extern "C"
         int choice_count;
         /** @brief Number of action bindings affected by an input-binding control. */
         int input_binding_count;
+        /** @brief True when this item was expanded from an authored dynamic list. */
+        bool dynamic_list_item;
+        /** @brief Authored dynamic list name, or NULL for static menu items. */
+        const char *dynamic_list_name;
+        /** @brief Zero-based row index inside the dynamic list, or -1 for static/empty rows. */
+        int dynamic_list_index;
+        /** @brief Runtime-owned value associated with the dynamic row, or NULL. */
+        const char *dynamic_list_value;
     } sdl3d_game_data_menu_item;
 
     /** @brief Authored scene transition behavior policy. */

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -126,10 +126,12 @@ extern "C"
         const char *return_to;         /**< Runtime-owned scene to store as return target, or NULL. */
         const char *scene_state_key;   /**< Runtime-owned scene-state key to set, or NULL. */
         const char *scene_state_value; /**< Runtime-owned scene-state string value to assign, or NULL. */
-        int selected_index;            /**< Selected item index after this update, or -1. */
-        int signal_id;                 /**< Selected item signal id, including data-bound controls, or -1. */
-        int move_signal_id;            /**< Menu navigation signal id emitted by the host, or -1. */
-        int select_signal_id;          /**< Menu activation signal id emitted by the host, or -1. */
+        /** @brief Storage backing scene_state_value when it is produced from a dynamic row. */
+        char scene_state_value_storage[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
+        int selected_index;   /**< Selected item index after this update, or -1. */
+        int signal_id;        /**< Selected item signal id, including data-bound controls, or -1. */
+        int move_signal_id;   /**< Menu navigation signal id emitted by the host, or -1. */
+        int select_signal_id; /**< Menu activation signal id emitted by the host, or -1. */
         sdl3d_game_data_menu_pause_command pause_command; /**< Pause command requested by selected item. */
         bool handled_input;                               /**< True when a menu action was consumed. */
         bool selected;                                    /**< True when the selected item was activated. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -37,7 +37,6 @@
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
 #define SDL3D_GAME_DATA_MENU_TEXT_MAX_BYTES 255
-#define SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES 255
 
 typedef enum game_data_sensor_type
 {
@@ -310,9 +309,6 @@ typedef struct sdl3d_game_data_runtime
     scene_activity_state activity;
     float current_dt;
     unsigned int rng_state;
-    char dynamic_menu_label[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
-    char dynamic_menu_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
-    char dynamic_menu_scene_state_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
 } sdl3d_game_data_runtime;
 
 static void set_error(char *buffer, int buffer_size, const char *message)
@@ -4523,6 +4519,18 @@ bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *men
     return true;
 }
 
+bool sdl3d_game_data_publish_menu_selection(sdl3d_game_data_runtime *runtime, const char *menu_name)
+{
+    scene_menu_state *menu = find_scene_menu(active_scene_entry(runtime), menu_name);
+    const int item_count = menu_runtime_item_count(runtime, menu);
+    if (menu == NULL || item_count <= 0)
+        return false;
+
+    menu->selected_index = SDL_clamp(menu->selected_index, 0, item_count - 1);
+    update_dynamic_list_selection_state(runtime, menu);
+    return true;
+}
+
 static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *type)
 {
     if (type == NULL)
@@ -4634,7 +4642,29 @@ static bool menu_dynamic_list_format_key(yyjson_val *source, const char *field, 
     const char *format = json_string(source, field, NULL);
     if (format == NULL || buffer == NULL || buffer_size == 0U)
         return false;
-    SDL_snprintf(buffer, buffer_size, format, index);
+
+    const char *placeholder = SDL_strstr(format, "%d");
+    if (placeholder == NULL)
+        return false;
+    if (SDL_strstr(placeholder + 2, "%") != NULL)
+        return false;
+    for (const char *scan = format; scan < placeholder; ++scan)
+    {
+        if (*scan == '%')
+            return false;
+    }
+
+    char index_text[32];
+    SDL_snprintf(index_text, sizeof(index_text), "%d", index);
+    const size_t prefix_len = (size_t)(placeholder - format);
+    const size_t suffix_len = SDL_strlen(placeholder + 2);
+    const size_t required = prefix_len + SDL_strlen(index_text) + suffix_len + 1U;
+    if (required > buffer_size)
+        return false;
+    SDL_memcpy(buffer, format, prefix_len);
+    SDL_strlcpy(buffer + prefix_len, index_text, buffer_size - prefix_len);
+    SDL_strlcpy(buffer + prefix_len + SDL_strlen(index_text), placeholder + 2,
+                buffer_size - prefix_len - SDL_strlen(index_text));
     return true;
 }
 
@@ -4688,14 +4718,17 @@ static void menu_dynamic_list_apply_label_template(const char *format, const cha
 }
 
 static const char *menu_dynamic_list_label(const sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index,
-                                           bool dynamic_empty)
+                                           bool dynamic_empty, char *buffer, size_t buffer_size)
 {
-    if (runtime == NULL || item == NULL)
+    if (runtime == NULL || item == NULL || buffer == NULL || buffer_size == 0U)
         return NULL;
     if (dynamic_empty)
-        return json_string(item, "empty_label", "No entries");
+    {
+        SDL_strlcpy(buffer, json_string(item, "empty_label", "No entries"), buffer_size);
+        return buffer;
+    }
 
-    char raw_label[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    char raw_label[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
     const char *label =
         menu_dynamic_list_entry_string(runtime, item, dynamic_index, "label_key_format", raw_label, sizeof(raw_label));
     if (label == NULL)
@@ -4707,20 +4740,20 @@ static const char *menu_dynamic_list_label(const sdl3d_game_data_runtime *runtim
     const char *label_format = json_string(item, "label_format", NULL);
     if (label_format != NULL)
     {
-        sdl3d_game_data_runtime *mutable_runtime = (sdl3d_game_data_runtime *)runtime;
-        menu_dynamic_list_apply_label_template(label_format, label, mutable_runtime->dynamic_menu_label,
-                                               sizeof(mutable_runtime->dynamic_menu_label));
-        return mutable_runtime->dynamic_menu_label;
+        menu_dynamic_list_apply_label_template(label_format, label, buffer, buffer_size);
+        return buffer;
     }
-    return label;
+    SDL_strlcpy(buffer, label, buffer_size);
+    return buffer;
 }
 
-static const char *menu_dynamic_list_value(const sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index)
+static const char *menu_dynamic_list_value(const sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index,
+                                           char *buffer, size_t buffer_size)
 {
-    if (runtime == NULL || item == NULL || dynamic_index < 0)
+    if (runtime == NULL || item == NULL || dynamic_index < 0 || buffer == NULL || buffer_size == 0U)
         return NULL;
 
-    char raw_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    char raw_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
     const char *value =
         menu_dynamic_list_entry_string(runtime, item, dynamic_index, "value_key_format", raw_value, sizeof(raw_value));
     if (value == NULL)
@@ -4729,30 +4762,24 @@ static const char *menu_dynamic_list_value(const sdl3d_game_data_runtime *runtim
     if (value == NULL)
         return NULL;
 
-    SDL_strlcpy(((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value, value,
-                sizeof(((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value));
-    return ((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value;
+    SDL_strlcpy(buffer, value, buffer_size);
+    return buffer;
 }
 
-static const char *menu_dynamic_scene_state_value(sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index,
-                                                  const char *value_from)
+static const char *menu_dynamic_scene_state_value(const sdl3d_game_data_runtime *runtime, yyjson_val *item,
+                                                  int dynamic_index, const char *value_from, char *buffer,
+                                                  size_t buffer_size)
 {
-    if (runtime == NULL || item == NULL || dynamic_index < 0)
+    if (runtime == NULL || item == NULL || dynamic_index < 0 || buffer == NULL || buffer_size == 0U)
         return NULL;
     if (value_from == NULL || SDL_strcmp(value_from, "value") == 0)
-        return menu_dynamic_list_value(runtime, item, dynamic_index);
+        return menu_dynamic_list_value(runtime, item, dynamic_index, buffer, buffer_size);
     if (SDL_strcmp(value_from, "label") == 0)
-    {
-        SDL_strlcpy(runtime->dynamic_menu_scene_state_value,
-                    menu_dynamic_list_label(runtime, item, dynamic_index, false),
-                    sizeof(runtime->dynamic_menu_scene_state_value));
-        return runtime->dynamic_menu_scene_state_value;
-    }
+        return menu_dynamic_list_label(runtime, item, dynamic_index, false, buffer, buffer_size);
     if (SDL_strcmp(value_from, "index") == 0)
     {
-        SDL_snprintf(runtime->dynamic_menu_scene_state_value, sizeof(runtime->dynamic_menu_scene_state_value), "%d",
-                     dynamic_index);
-        return runtime->dynamic_menu_scene_state_value;
+        SDL_snprintf(buffer, buffer_size, "%d", dynamic_index);
+        return buffer;
     }
     return NULL;
 }
@@ -4771,7 +4798,9 @@ static void update_dynamic_list_selection_state(sdl3d_game_data_runtime *runtime
     if (selected_index_key != NULL)
         sdl3d_properties_set_int(runtime->scene_state, selected_index_key, dynamic_index);
     const char *selected_value_key = json_string(item, "selected_value_key", NULL);
-    const char *selected_value = menu_dynamic_list_value(runtime, item, dynamic_index);
+    char selected_value_buffer[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
+    const char *selected_value =
+        menu_dynamic_list_value(runtime, item, dynamic_index, selected_value_buffer, sizeof(selected_value_buffer));
     if (selected_value_key != NULL && selected_value != NULL)
         sdl3d_properties_set_string(runtime->scene_state, selected_value_key, selected_value);
 }
@@ -4811,18 +4840,24 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
 
     if (menu_item_is_dynamic_list(item))
     {
-        out_item->label = menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty);
+        out_item->label =
+            menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty, out_item->dynamic_list_label_storage,
+                                    sizeof(out_item->dynamic_list_label_storage));
         out_item->scene = dynamic_empty ? NULL : json_string(item, "scene", NULL);
         out_item->return_to = dynamic_empty ? NULL : json_string(item, "return_to", NULL);
         yyjson_val *scene_state = obj_get(item, "scene_state");
         out_item->scene_state_key = dynamic_empty ? NULL : json_string(scene_state, "key", NULL);
-        out_item->scene_state_value =
-            dynamic_empty || out_item->scene_state_key == NULL
-                ? NULL
-                : (json_string(scene_state, "value", NULL) != NULL
-                       ? json_string(scene_state, "value", NULL)
-                       : menu_dynamic_scene_state_value((sdl3d_game_data_runtime *)runtime, item, dynamic_index,
-                                                        json_string(scene_state, "value_from", "value")));
+        if (!dynamic_empty && out_item->scene_state_key != NULL)
+        {
+            const char *static_scene_state_value = json_string(scene_state, "value", NULL);
+            out_item->scene_state_value =
+                static_scene_state_value != NULL
+                    ? static_scene_state_value
+                    : menu_dynamic_scene_state_value(runtime, item, dynamic_index,
+                                                     json_string(scene_state, "value_from", "value"),
+                                                     out_item->dynamic_list_scene_state_value_storage,
+                                                     sizeof(out_item->dynamic_list_scene_state_value_storage));
+        }
         out_item->return_scene = !dynamic_empty && json_bool(item, "return_scene", false);
         out_item->quit = !dynamic_empty && json_bool(item, "quit", false);
         out_item->signal_id =
@@ -4834,7 +4869,10 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
         out_item->dynamic_list_item = true;
         out_item->dynamic_list_name = json_string(item, "name", NULL);
         out_item->dynamic_list_index = dynamic_index;
-        out_item->dynamic_list_value = dynamic_empty ? NULL : menu_dynamic_list_value(runtime, item, dynamic_index);
+        out_item->dynamic_list_value =
+            dynamic_empty ? NULL
+                          : menu_dynamic_list_value(runtime, item, dynamic_index, out_item->dynamic_list_value_storage,
+                                                    sizeof(out_item->dynamic_list_value_storage));
         return out_item->label != NULL;
     }
 
@@ -5987,7 +6025,7 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
         sdl3d_game_data_ui_text text;
         char label[128];
         if (menu_item_is_dynamic_list(item))
-            SDL_strlcpy(label, menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty), sizeof(label));
+            (void)menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty, label, sizeof(label));
         else
             format_menu_item_label(runtime, item, label, sizeof(label));
         SDL_zero(text);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -37,6 +37,7 @@
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
 #define SDL3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
 #define SDL3D_GAME_DATA_MENU_TEXT_MAX_BYTES 255
+#define SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES 255
 
 typedef enum game_data_sensor_type
 {
@@ -309,6 +310,9 @@ typedef struct sdl3d_game_data_runtime
     scene_activity_state activity;
     float current_dt;
     unsigned int rng_state;
+    char dynamic_menu_label[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    char dynamic_menu_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    char dynamic_menu_scene_state_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
 } sdl3d_game_data_runtime;
 
 static void set_error(char *buffer, int buffer_size, const char *message)
@@ -367,6 +371,8 @@ static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, 
                                               SDL_GamepadButton button);
 static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
                                 const sdl3d_game_data_ui_metrics *metrics);
+static int menu_runtime_item_count(const sdl3d_game_data_runtime *runtime, const scene_menu_state *menu);
+static void update_dynamic_list_selection_state(sdl3d_game_data_runtime *runtime, scene_menu_state *menu);
 
 static bool path_is_absolute(const char *path)
 {
@@ -4490,8 +4496,9 @@ bool sdl3d_game_data_get_active_menu_for_metrics(const sdl3d_game_data_runtime *
     out_menu->back_action_id = sdl3d_game_data_find_action(runtime, json_string(menu, "back_action", NULL));
     out_menu->move_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "move_signal", NULL));
     out_menu->select_signal_id = sdl3d_game_data_find_signal(runtime, json_string(menu, "select_signal", NULL));
-    out_menu->selected_index = state->selected_index;
-    out_menu->item_count = state->item_count;
+    out_menu->item_count = menu_runtime_item_count(runtime, state);
+    out_menu->selected_index =
+        out_menu->item_count > 0 ? SDL_clamp(state->selected_index, 0, out_menu->item_count - 1) : -1;
     return out_menu->name != NULL && out_menu->item_count > 0;
 }
 
@@ -4503,13 +4510,16 @@ bool sdl3d_game_data_get_active_menu(const sdl3d_game_data_runtime *runtime, sdl
 bool sdl3d_game_data_menu_move(sdl3d_game_data_runtime *runtime, const char *menu_name, int delta)
 {
     scene_menu_state *menu = find_scene_menu(active_scene_entry(runtime), menu_name);
-    if (menu == NULL || menu->item_count <= 0)
+    const int item_count = menu_runtime_item_count(runtime, menu);
+    if (menu == NULL || item_count <= 0)
         return false;
 
-    int next = (menu->selected_index + delta) % menu->item_count;
+    menu->selected_index = SDL_clamp(menu->selected_index, 0, item_count - 1);
+    int next = (menu->selected_index + delta) % item_count;
     if (next < 0)
-        next += menu->item_count;
+        next += item_count;
     menu->selected_index = next;
+    update_dynamic_list_selection_state(runtime, menu);
     return true;
 }
 
@@ -4528,6 +4538,242 @@ static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *typ
     if (SDL_strcmp(type, "text") == 0)
         return SDL3D_GAME_DATA_MENU_CONTROL_TEXT;
     return SDL3D_GAME_DATA_MENU_CONTROL_NONE;
+}
+
+static bool menu_item_is_dynamic_list(yyjson_val *item)
+{
+    return yyjson_is_obj(item) && SDL_strcmp(json_string(item, "type", ""), "dynamic_list") == 0;
+}
+
+static yyjson_val *menu_dynamic_list_source(yyjson_val *item)
+{
+    return menu_item_is_dynamic_list(item) ? obj_get(item, "source") : NULL;
+}
+
+static int menu_dynamic_list_count(const sdl3d_game_data_runtime *runtime, yyjson_val *item)
+{
+    yyjson_val *source = menu_dynamic_list_source(item);
+    if (runtime == NULL || !yyjson_is_obj(source) ||
+        SDL_strcmp(json_string(source, "type", ""), "scene_state_indexed") != 0)
+        return 0;
+
+    const char *count_key = json_string(source, "count_key", NULL);
+    if (count_key == NULL)
+        return 0;
+    return SDL_max(0, sdl3d_properties_get_int(runtime->scene_state, count_key, 0));
+}
+
+static int menu_dynamic_list_row_count(const sdl3d_game_data_runtime *runtime, yyjson_val *item)
+{
+    const int count = menu_dynamic_list_count(runtime, item);
+    if (count > 0)
+        return count;
+    return json_string(item, "empty_label", NULL) != NULL ? 1 : 0;
+}
+
+static int menu_authored_item_row_count(const sdl3d_game_data_runtime *runtime, yyjson_val *item)
+{
+    return menu_item_is_dynamic_list(item) ? menu_dynamic_list_row_count(runtime, item) : 1;
+}
+
+static int menu_runtime_item_count(const sdl3d_game_data_runtime *runtime, const scene_menu_state *menu)
+{
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    int count = 0;
+    for (size_t i = 0; yyjson_is_arr(items) && i < yyjson_arr_size(items); ++i)
+        count += menu_authored_item_row_count(runtime, yyjson_arr_get(items, i));
+    return count;
+}
+
+static bool resolve_menu_item_at(const sdl3d_game_data_runtime *runtime, const scene_menu_state *menu, int item_index,
+                                 yyjson_val **out_item, int *out_dynamic_index, bool *out_dynamic_empty)
+{
+    if (out_item != NULL)
+        *out_item = NULL;
+    if (out_dynamic_index != NULL)
+        *out_dynamic_index = -1;
+    if (out_dynamic_empty != NULL)
+        *out_dynamic_empty = false;
+    yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
+    if (!yyjson_is_arr(items) || item_index < 0)
+        return false;
+
+    int cursor = 0;
+    for (size_t i = 0; i < yyjson_arr_size(items); ++i)
+    {
+        yyjson_val *item = yyjson_arr_get(items, i);
+        const int rows = menu_authored_item_row_count(runtime, item);
+        if (item_index < cursor + rows)
+        {
+            if (out_item != NULL)
+                *out_item = item;
+            if (menu_item_is_dynamic_list(item))
+            {
+                const int source_count = menu_dynamic_list_count(runtime, item);
+                if (source_count > 0)
+                {
+                    if (out_dynamic_index != NULL)
+                        *out_dynamic_index = item_index - cursor;
+                }
+                else
+                {
+                    if (out_dynamic_empty != NULL)
+                        *out_dynamic_empty = true;
+                }
+            }
+            return true;
+        }
+        cursor += rows;
+    }
+    return false;
+}
+
+static bool menu_dynamic_list_format_key(yyjson_val *source, const char *field, int index, char *buffer,
+                                         size_t buffer_size)
+{
+    const char *format = json_string(source, field, NULL);
+    if (format == NULL || buffer == NULL || buffer_size == 0U)
+        return false;
+    SDL_snprintf(buffer, buffer_size, format, index);
+    return true;
+}
+
+static const char *menu_dynamic_list_entry_string(const sdl3d_game_data_runtime *runtime, yyjson_val *item,
+                                                  int dynamic_index, const char *format_field, char *buffer,
+                                                  size_t buffer_size)
+{
+    yyjson_val *source = menu_dynamic_list_source(item);
+    char key[128];
+    if (runtime == NULL || dynamic_index < 0 || buffer == NULL || buffer_size == 0U ||
+        !menu_dynamic_list_format_key(source, format_field, dynamic_index, key, sizeof(key)))
+        return NULL;
+    return sdl3d_properties_get_string(runtime->scene_state, key, NULL);
+}
+
+static void menu_dynamic_list_apply_label_template(const char *format, const char *label, char *buffer,
+                                                   size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0U)
+        return;
+    if (format == NULL)
+    {
+        SDL_strlcpy(buffer, label != NULL ? label : "", buffer_size);
+        return;
+    }
+
+    const char *cursor = format;
+    size_t offset = 0U;
+    buffer[0] = '\0';
+    while (*cursor != '\0' && offset + 1U < buffer_size)
+    {
+        const char *marker = SDL_strstr(cursor, "{label}");
+        if (marker == NULL)
+        {
+            SDL_strlcpy(buffer + offset, cursor, buffer_size - offset);
+            return;
+        }
+        const size_t prefix_len = (size_t)(marker - cursor);
+        const size_t writable_prefix = SDL_min(prefix_len, buffer_size - offset - 1U);
+        SDL_memcpy(buffer + offset, cursor, writable_prefix);
+        offset += writable_prefix;
+        buffer[offset] = '\0';
+        const char *value = label != NULL ? label : "";
+        const size_t value_len = SDL_strlen(value);
+        const size_t writable_value = SDL_min(value_len, buffer_size - offset - 1U);
+        SDL_memcpy(buffer + offset, value, writable_value);
+        offset += writable_value;
+        buffer[offset] = '\0';
+        cursor = marker + SDL_strlen("{label}");
+    }
+}
+
+static const char *menu_dynamic_list_label(const sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index,
+                                           bool dynamic_empty)
+{
+    if (runtime == NULL || item == NULL)
+        return NULL;
+    if (dynamic_empty)
+        return json_string(item, "empty_label", "No entries");
+
+    char raw_label[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    const char *label =
+        menu_dynamic_list_entry_string(runtime, item, dynamic_index, "label_key_format", raw_label, sizeof(raw_label));
+    if (label == NULL)
+        label = menu_dynamic_list_entry_string(runtime, item, dynamic_index, "value_key_format", raw_label,
+                                               sizeof(raw_label));
+    if (label == NULL)
+        label = "";
+
+    const char *label_format = json_string(item, "label_format", NULL);
+    if (label_format != NULL)
+    {
+        sdl3d_game_data_runtime *mutable_runtime = (sdl3d_game_data_runtime *)runtime;
+        menu_dynamic_list_apply_label_template(label_format, label, mutable_runtime->dynamic_menu_label,
+                                               sizeof(mutable_runtime->dynamic_menu_label));
+        return mutable_runtime->dynamic_menu_label;
+    }
+    return label;
+}
+
+static const char *menu_dynamic_list_value(const sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index)
+{
+    if (runtime == NULL || item == NULL || dynamic_index < 0)
+        return NULL;
+
+    char raw_value[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_MAX_BYTES + 1U];
+    const char *value =
+        menu_dynamic_list_entry_string(runtime, item, dynamic_index, "value_key_format", raw_value, sizeof(raw_value));
+    if (value == NULL)
+        value = menu_dynamic_list_entry_string(runtime, item, dynamic_index, "label_key_format", raw_value,
+                                               sizeof(raw_value));
+    if (value == NULL)
+        return NULL;
+
+    SDL_strlcpy(((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value, value,
+                sizeof(((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value));
+    return ((sdl3d_game_data_runtime *)runtime)->dynamic_menu_value;
+}
+
+static const char *menu_dynamic_scene_state_value(sdl3d_game_data_runtime *runtime, yyjson_val *item, int dynamic_index,
+                                                  const char *value_from)
+{
+    if (runtime == NULL || item == NULL || dynamic_index < 0)
+        return NULL;
+    if (value_from == NULL || SDL_strcmp(value_from, "value") == 0)
+        return menu_dynamic_list_value(runtime, item, dynamic_index);
+    if (SDL_strcmp(value_from, "label") == 0)
+    {
+        SDL_strlcpy(runtime->dynamic_menu_scene_state_value,
+                    menu_dynamic_list_label(runtime, item, dynamic_index, false),
+                    sizeof(runtime->dynamic_menu_scene_state_value));
+        return runtime->dynamic_menu_scene_state_value;
+    }
+    if (SDL_strcmp(value_from, "index") == 0)
+    {
+        SDL_snprintf(runtime->dynamic_menu_scene_state_value, sizeof(runtime->dynamic_menu_scene_state_value), "%d",
+                     dynamic_index);
+        return runtime->dynamic_menu_scene_state_value;
+    }
+    return NULL;
+}
+
+static void update_dynamic_list_selection_state(sdl3d_game_data_runtime *runtime, scene_menu_state *menu)
+{
+    yyjson_val *item = NULL;
+    int dynamic_index = -1;
+    bool dynamic_empty = false;
+    if (runtime == NULL || menu == NULL ||
+        !resolve_menu_item_at(runtime, menu, menu->selected_index, &item, &dynamic_index, &dynamic_empty) ||
+        !menu_item_is_dynamic_list(item) || dynamic_empty)
+        return;
+
+    const char *selected_index_key = json_string(item, "selected_index_key", NULL);
+    if (selected_index_key != NULL)
+        sdl3d_properties_set_int(runtime->scene_state, selected_index_key, dynamic_index);
+    const char *selected_value_key = json_string(item, "selected_value_key", NULL);
+    const char *selected_value = menu_dynamic_list_value(runtime, item, dynamic_index);
+    if (selected_value_key != NULL && selected_value != NULL)
+        sdl3d_properties_set_string(runtime->scene_state, selected_value_key, selected_value);
 }
 
 static bool json_value_matches_property(yyjson_val *value, const sdl3d_value *property);
@@ -4553,10 +4799,45 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
         out_item->signal_id = -1;
     }
     const scene_menu_state *menu = find_scene_menu_const(active_scene_entry_const(runtime), menu_name);
-    if (runtime == NULL || menu == NULL || out_item == NULL || index < 0 || index >= menu->item_count)
+    const int item_count = menu_runtime_item_count(runtime, menu);
+    if (runtime == NULL || menu == NULL || out_item == NULL || index < 0 || index >= item_count)
         return false;
 
-    yyjson_val *item = yyjson_arr_get(obj_get(menu->menu, "items"), (size_t)index);
+    yyjson_val *item = NULL;
+    int dynamic_index = -1;
+    bool dynamic_empty = false;
+    if (!resolve_menu_item_at(runtime, menu, index, &item, &dynamic_index, &dynamic_empty))
+        return false;
+
+    if (menu_item_is_dynamic_list(item))
+    {
+        out_item->label = menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty);
+        out_item->scene = dynamic_empty ? NULL : json_string(item, "scene", NULL);
+        out_item->return_to = dynamic_empty ? NULL : json_string(item, "return_to", NULL);
+        yyjson_val *scene_state = obj_get(item, "scene_state");
+        out_item->scene_state_key = dynamic_empty ? NULL : json_string(scene_state, "key", NULL);
+        out_item->scene_state_value =
+            dynamic_empty || out_item->scene_state_key == NULL
+                ? NULL
+                : (json_string(scene_state, "value", NULL) != NULL
+                       ? json_string(scene_state, "value", NULL)
+                       : menu_dynamic_scene_state_value((sdl3d_game_data_runtime *)runtime, item, dynamic_index,
+                                                        json_string(scene_state, "value_from", "value")));
+        out_item->return_scene = !dynamic_empty && json_bool(item, "return_scene", false);
+        out_item->quit = !dynamic_empty && json_bool(item, "quit", false);
+        out_item->signal_id =
+            dynamic_empty ? -1 : sdl3d_game_data_find_signal(runtime, json_string(item, "signal", NULL));
+        out_item->pause_command = dynamic_empty ? SDL3D_GAME_DATA_MENU_PAUSE_NONE
+                                                : parse_menu_pause_command(json_string(item, "pause", NULL));
+        out_item->has_return_paused = !dynamic_empty && obj_get(item, "return_paused") != NULL;
+        out_item->return_paused = !dynamic_empty && json_bool(item, "return_paused", false);
+        out_item->dynamic_list_item = true;
+        out_item->dynamic_list_name = json_string(item, "name", NULL);
+        out_item->dynamic_list_index = dynamic_index;
+        out_item->dynamic_list_value = dynamic_empty ? NULL : menu_dynamic_list_value(runtime, item, dynamic_index);
+        return out_item->label != NULL;
+    }
+
     yyjson_val *control = obj_get(item, "control");
     out_item->label = json_string(item, "label", NULL);
     out_item->scene = json_string(item, "scene", NULL);
@@ -4577,6 +4858,7 @@ bool sdl3d_game_data_get_menu_item(const sdl3d_game_data_runtime *runtime, const
         yyjson_is_arr(obj_get(control, "choices")) ? (int)yyjson_arr_size(obj_get(control, "choices")) : 0;
     out_item->input_binding_count =
         yyjson_is_arr(obj_get(control, "bindings")) ? (int)yyjson_arr_size(obj_get(control, "bindings")) : 0;
+    out_item->dynamic_list_index = -1;
     return yyjson_is_obj(item) && out_item->label != NULL;
 }
 
@@ -5659,8 +5941,10 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
         return true;
 
     const scene_menu_state *menu_state = find_scene_menu_const(scene, json_string(presenter, "menu", NULL));
-    yyjson_val *items = menu_state != NULL ? obj_get(menu_state->menu, "items") : NULL;
-    if (menu_state == NULL || !yyjson_is_arr(items))
+    if (menu_state == NULL)
+        return true;
+    const int item_count = menu_runtime_item_count(runtime, menu_state);
+    if (item_count <= 0)
         return true;
 
     yyjson_val *presenter_active_if = obj_get(presenter, "active_if");
@@ -5676,19 +5960,36 @@ static bool for_each_ui_menu_presenter(const sdl3d_game_data_runtime *runtime, c
     const bool normalized = json_bool(presenter, "normalized", false);
     const sdl3d_game_data_ui_align align =
         parse_ui_align(json_string(presenter, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_CENTER);
-
-    for (int i = 0; i < menu_state->item_count; ++i)
+    const int selected_index = SDL_clamp(menu_state->selected_index, 0, item_count - 1);
+    const int visible_count = json_int(presenter, "visible_count", item_count);
+    int first_index = 0;
+    int last_index = item_count;
+    if (visible_count > 0 && visible_count < item_count)
     {
-        yyjson_val *item = yyjson_arr_get(items, (size_t)i);
-        const bool selected = i == menu_state->selected_index;
-        const float row_y = y + gap * (float)i;
+        first_index = selected_index - visible_count / 2;
+        first_index = SDL_clamp(first_index, 0, item_count - visible_count);
+        last_index = first_index + visible_count;
+    }
+
+    for (int i = first_index; i < last_index; ++i)
+    {
+        yyjson_val *item = NULL;
+        int dynamic_index = -1;
+        bool dynamic_empty = false;
+        if (!resolve_menu_item_at(runtime, menu_state, i, &item, &dynamic_index, &dynamic_empty))
+            continue;
+        const bool selected = i == selected_index;
+        const float row_y = y + gap * (float)(i - first_index);
 
         if (selected && !emit_ui_menu_cursor(presenter, row_y, callback, userdata))
             return false;
 
         sdl3d_game_data_ui_text text;
         char label[128];
-        format_menu_item_label(runtime, item, label, sizeof(label));
+        if (menu_item_is_dynamic_list(item))
+            SDL_strlcpy(label, menu_dynamic_list_label(runtime, item, dynamic_index, dynamic_empty), sizeof(label));
+        else
+            format_menu_item_label(runtime, item, label, sizeof(label));
         SDL_zero(text);
         text.name = json_string(presenter, "name", NULL);
         text.font = json_string(presenter, "font", NULL);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3565,6 +3565,28 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
     return true;
 }
 
+static bool dynamic_list_key_format_valid(const char *format)
+{
+    if (format == NULL || format[0] == '\0')
+        return false;
+
+    const char *placeholder = SDL_strstr(format, "%d");
+    if (placeholder == NULL)
+        return false;
+    for (const char *scan = format; *scan != '\0'; ++scan)
+    {
+        if (*scan != '%')
+            continue;
+        if (scan == placeholder)
+        {
+            ++scan;
+            continue;
+        }
+        return false;
+    }
+    return SDL_strstr(placeholder + 2, "%d") == NULL;
+}
+
 static bool validate_dynamic_menu_list_source(validation_context *ctx, yyjson_val *source, const char *path)
 {
     if (!yyjson_is_obj(source))
@@ -3576,9 +3598,13 @@ static bool validate_dynamic_menu_list_source(validation_context *ctx, yyjson_va
         return validation_error(ctx, path, "dynamic_list source requires a non-empty count_key");
     if (!is_non_empty_string(source, "label_key_format"))
         return validation_error(ctx, path, "dynamic_list source requires a non-empty label_key_format");
+    if (!dynamic_list_key_format_valid(json_string(source, "label_key_format")))
+        return validation_error(ctx, path, "dynamic_list source label_key_format must contain exactly one %%d token");
     yyjson_val *value_format = obj_get(source, "value_key_format");
     if (value_format != NULL && (!yyjson_is_str(value_format) || yyjson_get_str(value_format)[0] == '\0'))
         return validation_error(ctx, path, "dynamic_list source value_key_format must be a non-empty string");
+    if (value_format != NULL && !dynamic_list_key_format_valid(yyjson_get_str(value_format)))
+        return validation_error(ctx, path, "dynamic_list source value_key_format must contain exactly one %%d token");
     return true;
 }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3565,6 +3565,89 @@ static bool validate_menu_item_control(validation_context *ctx, yyjson_val *cont
     return true;
 }
 
+static bool validate_dynamic_menu_list_source(validation_context *ctx, yyjson_val *source, const char *path)
+{
+    if (!yyjson_is_obj(source))
+        return validation_error(ctx, path, "dynamic_list menu item requires a source object");
+    const char *type = json_string(source, "type");
+    if (type == NULL || SDL_strcmp(type, "scene_state_indexed") != 0)
+        return validation_error(ctx, path, "dynamic_list source type must be scene_state_indexed");
+    if (!is_non_empty_string(source, "count_key"))
+        return validation_error(ctx, path, "dynamic_list source requires a non-empty count_key");
+    if (!is_non_empty_string(source, "label_key_format"))
+        return validation_error(ctx, path, "dynamic_list source requires a non-empty label_key_format");
+    yyjson_val *value_format = obj_get(source, "value_key_format");
+    if (value_format != NULL && (!yyjson_is_str(value_format) || yyjson_get_str(value_format)[0] == '\0'))
+        return validation_error(ctx, path, "dynamic_list source value_key_format must be a non-empty string");
+    return true;
+}
+
+static bool validate_dynamic_menu_list_item(validation_context *ctx, yyjson_val *item, const char *path,
+                                            validation_names *names)
+{
+    if (!is_non_empty_string(item, "name"))
+        return validation_error(ctx, path, "dynamic_list menu item requires a non-empty name");
+    char source_path[PATH_BUFFER_SIZE];
+    format_path(source_path, sizeof(source_path), "%s.source", path);
+    if (!validate_dynamic_menu_list_source(ctx, obj_get(item, "source"), source_path))
+        return false;
+
+    yyjson_val *empty_label = obj_get(item, "empty_label");
+    if (empty_label != NULL && !yyjson_is_str(empty_label))
+        return validation_error(ctx, path, "dynamic_list empty_label must be a string");
+    yyjson_val *label_format = obj_get(item, "label_format");
+    if (label_format != NULL && !yyjson_is_str(label_format))
+        return validation_error(ctx, path, "dynamic_list label_format must be a string");
+    yyjson_val *selected_index_key = obj_get(item, "selected_index_key");
+    if (selected_index_key != NULL &&
+        (!yyjson_is_str(selected_index_key) || yyjson_get_str(selected_index_key)[0] == '\0'))
+        return validation_error(ctx, path, "dynamic_list selected_index_key must be a non-empty string");
+    yyjson_val *selected_value_key = obj_get(item, "selected_value_key");
+    if (selected_value_key != NULL &&
+        (!yyjson_is_str(selected_value_key) || yyjson_get_str(selected_value_key)[0] == '\0'))
+        return validation_error(ctx, path, "dynamic_list selected_value_key must be a non-empty string");
+
+    const char *scene = json_string(item, "scene");
+    if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, path))
+        return false;
+    const char *return_to = json_string(item, "return_to");
+    if (return_to != NULL && !require_ref(ctx, &names->scenes, "scene", return_to, path))
+        return false;
+    const char *signal = json_string(item, "signal");
+    if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+        return false;
+    yyjson_val *scene_state = obj_get(item, "scene_state");
+    if (scene_state != NULL)
+    {
+        if (!yyjson_is_obj(scene_state))
+            return validation_error(ctx, path, "dynamic_list scene_state must be an object");
+        if (!is_non_empty_string(scene_state, "key"))
+            return validation_error(ctx, path, "dynamic_list scene_state requires a non-empty key");
+        const char *value = json_string(scene_state, "value");
+        const char *value_from = json_string(scene_state, "value_from");
+        if (value != NULL && value_from != NULL)
+            return validation_error(ctx, path, "dynamic_list scene_state may use value or value_from, not both");
+        if (value == NULL && value_from == NULL)
+            return validation_error(ctx, path, "dynamic_list scene_state requires value or value_from");
+        if (value != NULL && value[0] == '\0')
+            return validation_error(ctx, path, "dynamic_list scene_state value must be non-empty");
+        if (value_from != NULL && SDL_strcmp(value_from, "value") != 0 && SDL_strcmp(value_from, "label") != 0 &&
+            SDL_strcmp(value_from, "index") != 0)
+            return validation_error(ctx, path, "dynamic_list scene_state value_from must be value, label, or index");
+    }
+    yyjson_val *return_scene = obj_get(item, "return_scene");
+    if (return_scene != NULL && !yyjson_is_bool(return_scene))
+        return validation_error(ctx, path, "dynamic_list return_scene must be a boolean");
+    yyjson_val *return_paused = obj_get(item, "return_paused");
+    if (return_paused != NULL && !yyjson_is_bool(return_paused))
+        return validation_error(ctx, path, "dynamic_list return_paused must be a boolean");
+    const char *pause = json_string(item, "pause");
+    if (pause != NULL && SDL_strcmp(pause, "pause") != 0 && SDL_strcmp(pause, "resume") != 0 &&
+        SDL_strcmp(pause, "unpause") != 0 && SDL_strcmp(pause, "toggle") != 0)
+        return validation_error(ctx, path, "dynamic_list pause must be pause, resume, unpause, or toggle");
+    return true;
+}
+
 static bool scene_has_menu_name(yyjson_val *scene_root, const char *name)
 {
     yyjson_val *menus = obj_get(scene_root, "menus");
@@ -3738,6 +3821,15 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
             char item_path[PATH_BUFFER_SIZE];
             format_path(item_path, sizeof(item_path), "%s.items[%zu]", menu_path, i);
             yyjson_val *item = yyjson_arr_get(items, i);
+            const char *item_type = json_string(item, "type");
+            if (item_type != NULL)
+            {
+                if (SDL_strcmp(item_type, "dynamic_list") != 0)
+                    return validation_error(ctx, item_path, "scene menu item type must be dynamic_list when present");
+                if (!validate_dynamic_menu_list_item(ctx, item, item_path, names))
+                    return false;
+                continue;
+            }
             if (!is_non_empty_string(item, "label"))
                 return validation_error(ctx, item_path, "scene menu item requires a label");
             const char *scene = json_string(item, "scene");
@@ -3796,6 +3888,9 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         if (!scene_has_menu_name(root, menu_name))
             return validation_error(ctx, menu_path, "scene UI menu presenter references unknown menu '%s'",
                                     menu_name != NULL ? menu_name : "<missing>");
+        yyjson_val *visible_count = obj_get(presenter, "visible_count");
+        if (visible_count != NULL && (!yyjson_is_int(visible_count) || yyjson_get_sint(visible_count) <= 0))
+            return validation_error(ctx, menu_path, "scene UI menu presenter visible_count must be a positive integer");
         if (!require_ref(ctx, &names->fonts, "font asset", json_string(presenter, "font"), menu_path))
             return false;
         yyjson_val *cursor = obj_get(presenter, "cursor");

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1037,6 +1037,8 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
             return true;
 
         sdl3d_game_data_menu_item item;
+        /* Selecting the initially highlighted dynamic-list row should publish its selected outputs. */
+        (void)sdl3d_game_data_menu_move(runtime, refreshed.name, 0);
         if (!sdl3d_game_data_get_menu_item(runtime, refreshed.name, refreshed.selected_index, &item))
             return true;
 

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -887,6 +887,21 @@ static bool menu_input_is_idle(const sdl3d_game_data_runtime *runtime, const sdl
            !menu_action_held(runtime, input, menu->back_action_id, "ui_back");
 }
 
+static void menu_result_set_scene_state(sdl3d_game_data_menu_update_result *result,
+                                        const sdl3d_game_data_menu_item *item)
+{
+    if (result == NULL || item == NULL)
+        return;
+    result->scene_state_key = item->scene_state_key;
+    result->scene_state_value = item->scene_state_value;
+    if (item->dynamic_list_item && item->scene_state_value != NULL)
+    {
+        SDL_strlcpy(result->scene_state_value_storage, item->scene_state_value,
+                    sizeof(result->scene_state_value_storage));
+        result->scene_state_value = result->scene_state_value_storage;
+    }
+}
+
 bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
                                               bool *input_armed, const sdl3d_game_data_ui_metrics *metrics,
                                               sdl3d_game_data_menu_update_result *out_result)
@@ -1011,8 +1026,7 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
                 out_result->quit = item.quit;
                 out_result->scene = item.scene;
                 out_result->return_to = item.return_to;
-                out_result->scene_state_key = item.scene_state_key;
-                out_result->scene_state_value = item.scene_state_value;
+                menu_result_set_scene_state(out_result, &item);
                 out_result->return_scene = item.return_scene;
                 out_result->signal_id = item.signal_id;
                 out_result->pause_command = item.pause_command;
@@ -1038,7 +1052,7 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
 
         sdl3d_game_data_menu_item item;
         /* Selecting the initially highlighted dynamic-list row should publish its selected outputs. */
-        (void)sdl3d_game_data_menu_move(runtime, refreshed.name, 0);
+        (void)sdl3d_game_data_publish_menu_selection(runtime, refreshed.name);
         if (!sdl3d_game_data_get_menu_item(runtime, refreshed.name, refreshed.selected_index, &item))
             return true;
 
@@ -1096,10 +1110,13 @@ bool sdl3d_game_data_update_menus_for_metrics(sdl3d_game_data_runtime *runtime, 
             out_result->quit = !control_adjust_input && !out_result->control_changed && item.quit;
             out_result->scene = !control_adjust_input && !out_result->control_changed ? item.scene : NULL;
             out_result->return_to = !control_adjust_input && !out_result->control_changed ? item.return_to : NULL;
-            out_result->scene_state_key =
-                !control_adjust_input && !out_result->control_changed ? item.scene_state_key : NULL;
-            out_result->scene_state_value =
-                !control_adjust_input && !out_result->control_changed ? item.scene_state_value : NULL;
+            if (!control_adjust_input && !out_result->control_changed)
+                menu_result_set_scene_state(out_result, &item);
+            else
+            {
+                out_result->scene_state_key = NULL;
+                out_result->scene_state_value = NULL;
+            }
             out_result->return_scene = !control_adjust_input && !out_result->control_changed && item.return_scene;
             out_result->signal_id = out_result->selected ? item.signal_id : -1;
             out_result->pause_command = !control_adjust_input && !out_result->control_changed

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -2946,6 +2946,250 @@ TEST(GameDataRuntime, RejectsInvalidMenuTextControlSchema)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, DynamicListMenuUsesIndexedSceneStateEntries)
+{
+    const std::filesystem::path dir = unique_test_dir("menu_dynamic_list");
+    write_text(dir / "dynamic_list.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Dynamic List", "id": "test.dynamic_list", "version": "0.1.0" },
+  "world": { "name": "world.dynamic_list", "kind": "fixed_screen" },
+  "assets": { "fonts": [{ "id": "font.hud", "builtin": "Inter", "size": 18 }] },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.ui",
+        "actions": [
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] },
+          { "name": "action.menu.back", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] }
+        ]
+      }
+    ]
+  },
+  "signals": ["signal.session.join"],
+  "entities": [],
+  "scenes": { "initial": "scene.browser", "files": ["scenes/browser.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "browser.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.browser",
+  "input": {
+    "actions": ["action.menu.select", "action.menu.back", "action.menu.up", "action.menu.down"]
+  },
+  "menus": [
+    {
+      "name": "menu.sessions",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "items": [
+        {
+          "type": "dynamic_list",
+          "name": "list.sessions",
+          "source": {
+            "type": "scene_state_indexed",
+            "count_key": "session_count",
+            "label_key_format": "session_%d_label",
+            "value_key_format": "session_%d_value"
+          },
+          "empty_label": "No sessions discovered",
+          "label_format": "Join {label}",
+          "selected_index_key": "selected_session_index",
+          "selected_value_key": "selected_session_live",
+          "scene_state": { "key": "selected_session", "value_from": "value" },
+          "signal": "signal.session.join"
+        },
+        { "label": "Back", "return_scene": true }
+      ]
+    }
+  ],
+  "ui": {
+    "menus": [
+      {
+        "name": "ui.sessions",
+        "menu": "menu.sessions",
+        "font": "font.hud",
+        "x": 0.5,
+        "y": 0.2,
+        "gap": 0.1,
+        "normalized": true,
+        "visible_count": 2
+      }
+    ]
+  }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "dynamic_list.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.sessions");
+    EXPECT_EQ(menu.item_count, 2);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_TRUE(item.dynamic_list_item);
+    EXPECT_EQ(item.dynamic_list_index, -1);
+    EXPECT_STREQ(item.label, "No sessions discovered");
+    EXPECT_EQ(item.signal_id, -1);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_int(scene_state, "session_count", 4);
+    sdl3d_properties_set_string(scene_state, "session_0_label", "Alpha");
+    sdl3d_properties_set_string(scene_state, "session_0_value", "10.0.0.1:27183");
+    sdl3d_properties_set_string(scene_state, "session_1_label", "Beta");
+    sdl3d_properties_set_string(scene_state, "session_1_value", "10.0.0.2:27183");
+    sdl3d_properties_set_string(scene_state, "session_2_label", "Gamma");
+    sdl3d_properties_set_string(scene_state, "session_2_value", "10.0.0.3:27183");
+    sdl3d_properties_set_string(scene_state, "session_3_label", "Delta");
+    sdl3d_properties_set_string(scene_state, "session_3_value", "10.0.0.4:27183");
+
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.item_count, 5);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_TRUE(item.dynamic_list_item);
+    EXPECT_STREQ(item.dynamic_list_name, "list.sessions");
+    EXPECT_EQ(item.dynamic_list_index, 1);
+    EXPECT_STREQ(item.dynamic_list_value, "10.0.0.2:27183");
+    EXPECT_STREQ(item.label, "Join Beta");
+
+    struct MenuLabels
+    {
+        std::vector<std::string> labels;
+    } labels;
+    auto collect_menu_labels = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *capture = static_cast<MenuLabels *>(userdata);
+        if (std::string(text->name) == "ui.sessions")
+            capture->labels.emplace_back(text->text);
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, collect_menu_labels, &labels));
+    ASSERT_EQ(labels.labels.size(), 2U);
+    EXPECT_EQ(labels.labels[0], "Join Alpha");
+    EXPECT_EQ(labels.labels[1], "Join Beta");
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event event{};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_DOWN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_FALSE(result.selected);
+    EXPECT_EQ(result.selected_index, 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "selected_session_index", -1), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "selected_session_live", ""), "10.0.0.2:27183");
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.handled_input);
+    EXPECT_TRUE(result.selected);
+    EXPECT_EQ(result.signal_id, sdl3d_game_data_find_signal(runtime, "signal.session.join"));
+    EXPECT_STREQ(result.scene_state_key, "selected_session");
+    EXPECT_STREQ(result.scene_state_value, "10.0.0.2:27183");
+
+    sdl3d_properties_set_int(scene_state, "session_count", 1);
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.item_count, 2);
+    EXPECT_EQ(menu.selected_index, 1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidDynamicListMenuSchema)
+{
+    const std::filesystem::path dir = unique_test_dir("menu_dynamic_list_validation");
+    const auto write_case = [&](const char *name, const char *item_json) {
+        write_text(dir / (std::string(name) + ".game.json"),
+                   R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Dynamic List Validation", "id": "test.dynamic_list_validation", "version": "0.1.0" },
+  "world": { "name": "world.dynamic_list_validation", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.ui",
+        "actions": [
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] }
+        ]
+      }
+    ]
+  },
+  "signals": ["signal.session.join"],
+  "entities": [],
+  "scenes": { "initial": "scene.browser", "files": ["scenes/browser.scene.json"] }
+})json");
+        write_text(dir / "scenes" / "browser.scene.json", (std::string(R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.browser",
+  "input": { "actions": ["action.menu.select", "action.menu.up", "action.menu.down"] },
+  "menus": [
+    {
+      "name": "menu.browser",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [)json") + item_json +
+                                                           R"json(]
+    }
+  ]
+})json")
+                                                              .c_str());
+    };
+
+    char error[512]{};
+    write_case("missing_source", R"json({ "type": "dynamic_list", "name": "list.sessions" })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "missing_source.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires a source object"), std::string::npos) << error;
+
+    error[0] = '\0';
+    write_case("bad_value_from",
+               R"json({
+      "type": "dynamic_list",
+      "name": "list.sessions",
+      "source": {
+        "type": "scene_state_indexed",
+        "count_key": "session_count",
+        "label_key_format": "session_%d_label"
+      },
+      "scene_state": { "key": "selected_session", "value_from": "endpoint" }
+    })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_value_from.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("value_from must be value, label, or index"), std::string::npos) << error;
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, PlaySceneMenusAreSelectedByAuthoredConditions)
 {
     sdl3d_game_session *session = nullptr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3063,6 +3063,14 @@ TEST(GameDataRuntime, DynamicListMenuUsesIndexedSceneStateEntries)
     EXPECT_EQ(item.dynamic_list_index, 1);
     EXPECT_STREQ(item.dynamic_list_value, "10.0.0.2:27183");
     EXPECT_STREQ(item.label, "Join Beta");
+    sdl3d_game_data_menu_item first_dynamic_item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &first_dynamic_item));
+    sdl3d_game_data_menu_item second_dynamic_item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &second_dynamic_item));
+    EXPECT_STREQ(first_dynamic_item.label, "Join Alpha");
+    EXPECT_STREQ(second_dynamic_item.label, "Join Beta");
+    EXPECT_STREQ(first_dynamic_item.dynamic_list_value, "10.0.0.1:27183");
+    EXPECT_STREQ(second_dynamic_item.dynamic_list_value, "10.0.0.2:27183");
 
     struct MenuLabels
     {
@@ -3186,6 +3194,39 @@ TEST(GameDataRuntime, RejectsInvalidDynamicListMenuSchema)
     EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_value_from.game.json").string().c_str(), nullptr, error,
                                                sizeof(error)));
     EXPECT_NE(std::string(error).find("value_from must be value, label, or index"), std::string::npos) << error;
+
+    error[0] = '\0';
+    write_case("bad_label_format",
+               R"json({
+      "type": "dynamic_list",
+      "name": "list.sessions",
+      "source": {
+        "type": "scene_state_indexed",
+        "count_key": "session_count",
+        "label_key_format": "session_%s_label"
+      }
+    })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_label_format.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("label_key_format must contain exactly one %d token"), std::string::npos)
+        << error;
+
+    error[0] = '\0';
+    write_case("bad_value_format",
+               R"json({
+      "type": "dynamic_list",
+      "name": "list.sessions",
+      "source": {
+        "type": "scene_state_indexed",
+        "count_key": "session_count",
+        "label_key_format": "session_%d_label",
+        "value_key_format": "session_%d_%d_value"
+      }
+    })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_value_format.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("value_key_format must contain exactly one %d token"), std::string::npos)
+        << error;
 
     remove_test_dir(dir);
 }


### PR DESCRIPTION
## Summary

Implements slice 2 of #201 by adding a reusable data-authored dynamic list primitive for menus.

- Adds `type: "dynamic_list"` menu items backed by indexed scene-state rows.
- Expands dynamic rows into normal selectable menu items at runtime, including inert empty-state rows.
- Supports selected index/value scene-state outputs and per-row selection metadata.
- Adds `visible_count` windowing for UI menu presenters so long lists can scroll around the selected row.
- Copies dynamic row label/value text into caller-owned result storage so concurrent menu item reads do not share mutable runtime buffers.
- Adds a dedicated selection-publish helper instead of using zero-delta menu movement for dynamic-list side effects.
- Validates dynamic-list key formats and expands the single `%d` token without treating authored data as a printf format string.
- Documents flattened-menu selection clamping and `visible_count` behavior.

## Validation

- `clang-format` on touched C/C++ files
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_input_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DynamicListMenuUsesIndexedSceneStateEntries:GameDataRuntime.RejectsInvalidDynamicListMenuSchema'`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_input_test`

## Next slice

The next practical slice for #201 should be the generic runtime collection bridge. That lets host systems like LAN discovery expose typed rows directly to dynamic lists instead of relying only on indexed scene-state keys.
