### PR TITLE
Add runtime collections for dynamic menus

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -439,6 +439,41 @@ not known when the scene JSON is authored:
 }
 ```
 
+Dynamic lists can also read host-published runtime collections. This is the
+preferred source when an engine subsystem owns the rows, such as LAN discovery,
+save-game enumeration, profiles, rebindable devices, or downloadable content:
+
+```json
+{
+    "type" : "dynamic_list",
+    "name" : "list.local_matches",
+    "source" : {
+        "type" : "runtime_collection",
+        "collection" : "local_matches",
+        "label_field" : "name",
+        "value_field" : "endpoint"
+    },
+    "empty_label" : "No local matches found",
+    "label_format" : "Join {label}",
+    "selected_index_key" : "selected_local_match_index",
+    "selected_value_key" : "selected_local_match_endpoint",
+    "scene_state" : { "key" : "selected_local_match", "value_from" : "value" },
+    "signal" : "signal.multiplayer.join_selected"
+}
+```
+
+Host code publishes runtime collection rows through
+`sdl3d_game_data_runtime_collection_set_string()`,
+`sdl3d_game_data_runtime_collection_set_int()`,
+`sdl3d_game_data_runtime_collection_set_float()`, and
+`sdl3d_game_data_runtime_collection_set_bool()`. Collections are runtime-owned
+and read-only from UI; clear a collection before republishing a shorter result
+set. Dynamic-list labels and values are formatted from the authored
+`label_field` and optional `value_field`; string, integer, float, and boolean
+fields are supported. Floats are formatted with three fractional digits for
+stable UI output. If `value_field` is omitted, accepting a row can still use
+`value_from: "label"` or `value_from: "index"`.
+
 The menu controller treats expanded rows like normal menu items: Up/Down moves
 through them, Back still resolves the authored back item, and Accept selects the
 current row. If the source count is zero, `empty_label` renders one inert row

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1864,6 +1864,44 @@ extern "C"
     bool sdl3d_game_data_publish_menu_selection(sdl3d_game_data_runtime *runtime, const char *menu_name);
 
     /**
+     * @brief Remove every row from a runtime collection.
+     *
+     * Runtime collections are named, host-populated row sets that authored UI
+     * can read through dynamic-list menu sources. Clearing an unknown
+     * collection is a successful no-op.
+     */
+    bool sdl3d_game_data_runtime_collection_clear(sdl3d_game_data_runtime *runtime, const char *collection_name);
+
+    /**
+     * @brief Return the number of rows currently published in a runtime collection.
+     *
+     * Unknown collections have a count of zero.
+     */
+    int sdl3d_game_data_runtime_collection_count(const sdl3d_game_data_runtime *runtime, const char *collection_name);
+
+    /**
+     * @brief Publish a string field on one runtime collection row.
+     *
+     * Rows are zero-based and created on demand. Host systems should publish
+     * contiguous rows and then clear the collection before republishing a
+     * shorter result set.
+     */
+    bool sdl3d_game_data_runtime_collection_set_string(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                       int row_index, const char *field_name, const char *value);
+
+    /** @brief Publish an integer field on one runtime collection row. */
+    bool sdl3d_game_data_runtime_collection_set_int(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                    int row_index, const char *field_name, int value);
+
+    /** @brief Publish a floating-point field on one runtime collection row. */
+    bool sdl3d_game_data_runtime_collection_set_float(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                      int row_index, const char *field_name, float value);
+
+    /** @brief Publish a boolean field on one runtime collection row. */
+    bool sdl3d_game_data_runtime_collection_set_bool(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                     int row_index, const char *field_name, bool value);
+
+    /**
      * @brief Read one item from an authored menu.
      *
      * @p index is zero based. Static returned strings remain owned by the

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -234,6 +234,14 @@ typedef struct property_snapshot
     sdl3d_properties *properties;
 } property_snapshot;
 
+typedef struct runtime_collection
+{
+    char *name;
+    sdl3d_properties **rows;
+    int row_count;
+    int row_capacity;
+} runtime_collection;
+
 typedef struct scene_activity_state
 {
     const char *scene;
@@ -302,6 +310,9 @@ typedef struct sdl3d_game_data_runtime
     property_snapshot *property_snapshots;
     int property_snapshot_count;
     int property_snapshot_capacity;
+    runtime_collection *collections;
+    int collection_count;
+    int collection_capacity;
     sdl3d_storage *storage;
     bool has_network_schema;
     Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
@@ -4531,6 +4542,198 @@ bool sdl3d_game_data_publish_menu_selection(sdl3d_game_data_runtime *runtime, co
     return true;
 }
 
+static runtime_collection *find_runtime_collection(sdl3d_game_data_runtime *runtime, const char *collection_name)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->collection_count; ++i)
+    {
+        if (SDL_strcmp(runtime->collections[i].name, collection_name) == 0)
+            return &runtime->collections[i];
+    }
+    return NULL;
+}
+
+static const runtime_collection *find_runtime_collection_const(const sdl3d_game_data_runtime *runtime,
+                                                               const char *collection_name)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->collection_count; ++i)
+    {
+        if (SDL_strcmp(runtime->collections[i].name, collection_name) == 0)
+            return &runtime->collections[i];
+    }
+    return NULL;
+}
+
+static runtime_collection *get_or_create_runtime_collection(sdl3d_game_data_runtime *runtime,
+                                                            const char *collection_name)
+{
+    runtime_collection *existing = find_runtime_collection(runtime, collection_name);
+    if (existing != NULL)
+        return existing;
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0')
+        return NULL;
+
+    if (runtime->collection_count >= runtime->collection_capacity)
+    {
+        const int next_capacity = runtime->collection_capacity > 0 ? runtime->collection_capacity * 2 : 4;
+        runtime_collection *next = (runtime_collection *)SDL_realloc(
+            runtime->collections, (size_t)next_capacity * sizeof(*runtime->collections));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + runtime->collection_capacity, 0,
+                   (size_t)(next_capacity - runtime->collection_capacity) * sizeof(*runtime->collections));
+        runtime->collections = next;
+        runtime->collection_capacity = next_capacity;
+    }
+
+    runtime_collection *collection = &runtime->collections[runtime->collection_count];
+    SDL_zero(*collection);
+    collection->name = SDL_strdup(collection_name);
+    if (collection->name == NULL)
+        return NULL;
+    ++runtime->collection_count;
+    return collection;
+}
+
+static sdl3d_properties *runtime_collection_ensure_row(runtime_collection *collection, int row_index)
+{
+    if (collection == NULL || row_index < 0)
+        return NULL;
+    if (row_index >= collection->row_capacity)
+    {
+        int next_capacity = collection->row_capacity > 0 ? collection->row_capacity : 4;
+        while (next_capacity <= row_index)
+            next_capacity *= 2;
+        sdl3d_properties **next =
+            (sdl3d_properties **)SDL_realloc(collection->rows, (size_t)next_capacity * sizeof(*collection->rows));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + collection->row_capacity, 0,
+                   (size_t)(next_capacity - collection->row_capacity) * sizeof(*collection->rows));
+        collection->rows = next;
+        collection->row_capacity = next_capacity;
+    }
+    if (collection->rows[row_index] == NULL)
+    {
+        collection->rows[row_index] = sdl3d_properties_create();
+        if (collection->rows[row_index] == NULL)
+            return NULL;
+    }
+    if (row_index >= collection->row_count)
+        collection->row_count = row_index + 1;
+    return collection->rows[row_index];
+}
+
+static bool runtime_collection_field_to_string(const runtime_collection *collection, int row_index,
+                                               const char *field_name, char *buffer, size_t buffer_size)
+{
+    if (collection == NULL || row_index < 0 || row_index >= collection->row_count || field_name == NULL ||
+        field_name[0] == '\0' || buffer == NULL || buffer_size == 0U || collection->rows[row_index] == NULL)
+        return false;
+
+    const sdl3d_value *value = sdl3d_properties_get_value(collection->rows[row_index], field_name);
+    if (value == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_INT:
+        SDL_snprintf(buffer, buffer_size, "%d", value->as_int);
+        return true;
+    case SDL3D_VALUE_FLOAT:
+        SDL_snprintf(buffer, buffer_size, "%.3f", (double)value->as_float);
+        return true;
+    case SDL3D_VALUE_BOOL:
+        SDL_strlcpy(buffer, value->as_bool ? "true" : "false", buffer_size);
+        return true;
+    case SDL3D_VALUE_STRING:
+        SDL_strlcpy(buffer, value->as_string != NULL ? value->as_string : "", buffer_size);
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool sdl3d_game_data_runtime_collection_clear(sdl3d_game_data_runtime *runtime, const char *collection_name)
+{
+    runtime_collection *collection = find_runtime_collection(runtime, collection_name);
+    if (collection == NULL)
+        return runtime != NULL && collection_name != NULL && collection_name[0] != '\0';
+
+    for (int i = 0; i < collection->row_count; ++i)
+    {
+        sdl3d_properties_destroy(collection->rows[i]);
+        collection->rows[i] = NULL;
+    }
+    collection->row_count = 0;
+    return true;
+}
+
+int sdl3d_game_data_runtime_collection_count(const sdl3d_game_data_runtime *runtime, const char *collection_name)
+{
+    const runtime_collection *collection = find_runtime_collection_const(runtime, collection_name);
+    return collection != NULL ? collection->row_count : 0;
+}
+
+bool sdl3d_game_data_runtime_collection_set_string(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                   int row_index, const char *field_name, const char *value)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0' || row_index < 0 ||
+        field_name == NULL || field_name[0] == '\0')
+        return false;
+    runtime_collection *collection = get_or_create_runtime_collection(runtime, collection_name);
+    sdl3d_properties *row = runtime_collection_ensure_row(collection, row_index);
+    if (row == NULL)
+        return false;
+    sdl3d_properties_set_string(row, field_name, value != NULL ? value : "");
+    return true;
+}
+
+bool sdl3d_game_data_runtime_collection_set_int(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                int row_index, const char *field_name, int value)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0' || row_index < 0 ||
+        field_name == NULL || field_name[0] == '\0')
+        return false;
+    runtime_collection *collection = get_or_create_runtime_collection(runtime, collection_name);
+    sdl3d_properties *row = runtime_collection_ensure_row(collection, row_index);
+    if (row == NULL)
+        return false;
+    sdl3d_properties_set_int(row, field_name, value);
+    return true;
+}
+
+bool sdl3d_game_data_runtime_collection_set_float(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                  int row_index, const char *field_name, float value)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0' || row_index < 0 ||
+        field_name == NULL || field_name[0] == '\0')
+        return false;
+    runtime_collection *collection = get_or_create_runtime_collection(runtime, collection_name);
+    sdl3d_properties *row = runtime_collection_ensure_row(collection, row_index);
+    if (row == NULL)
+        return false;
+    sdl3d_properties_set_float(row, field_name, value);
+    return true;
+}
+
+bool sdl3d_game_data_runtime_collection_set_bool(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                                 int row_index, const char *field_name, bool value)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0' || row_index < 0 ||
+        field_name == NULL || field_name[0] == '\0')
+        return false;
+    runtime_collection *collection = get_or_create_runtime_collection(runtime, collection_name);
+    sdl3d_properties *row = runtime_collection_ensure_row(collection, row_index);
+    if (row == NULL)
+        return false;
+    sdl3d_properties_set_bool(row, field_name, value);
+    return true;
+}
+
 static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *type)
 {
     if (type == NULL)
@@ -4561,14 +4764,20 @@ static yyjson_val *menu_dynamic_list_source(yyjson_val *item)
 static int menu_dynamic_list_count(const sdl3d_game_data_runtime *runtime, yyjson_val *item)
 {
     yyjson_val *source = menu_dynamic_list_source(item);
-    if (runtime == NULL || !yyjson_is_obj(source) ||
-        SDL_strcmp(json_string(source, "type", ""), "scene_state_indexed") != 0)
+    if (runtime == NULL || !yyjson_is_obj(source))
         return 0;
 
-    const char *count_key = json_string(source, "count_key", NULL);
-    if (count_key == NULL)
-        return 0;
-    return SDL_max(0, sdl3d_properties_get_int(runtime->scene_state, count_key, 0));
+    const char *type = json_string(source, "type", "");
+    if (SDL_strcmp(type, "scene_state_indexed") == 0)
+    {
+        const char *count_key = json_string(source, "count_key", NULL);
+        if (count_key == NULL)
+            return 0;
+        return SDL_max(0, sdl3d_properties_get_int(runtime->scene_state, count_key, 0));
+    }
+    if (SDL_strcmp(type, "runtime_collection") == 0)
+        return sdl3d_game_data_runtime_collection_count(runtime, json_string(source, "collection", NULL));
+    return 0;
 }
 
 static int menu_dynamic_list_row_count(const sdl3d_game_data_runtime *runtime, yyjson_val *item)
@@ -4673,11 +4882,33 @@ static const char *menu_dynamic_list_entry_string(const sdl3d_game_data_runtime 
                                                   size_t buffer_size)
 {
     yyjson_val *source = menu_dynamic_list_source(item);
-    char key[128];
-    if (runtime == NULL || dynamic_index < 0 || buffer == NULL || buffer_size == 0U ||
-        !menu_dynamic_list_format_key(source, format_field, dynamic_index, key, sizeof(key)))
+    if (runtime == NULL || !yyjson_is_obj(source) || dynamic_index < 0 || buffer == NULL || buffer_size == 0U)
         return NULL;
-    return sdl3d_properties_get_string(runtime->scene_state, key, NULL);
+
+    const char *type = json_string(source, "type", "");
+    if (SDL_strcmp(type, "scene_state_indexed") == 0)
+    {
+        char key[SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY];
+        if (!menu_dynamic_list_format_key(source, format_field, dynamic_index, key, sizeof(key)))
+            return NULL;
+        return sdl3d_properties_get_string(runtime->scene_state, key, NULL);
+    }
+    if (SDL_strcmp(type, "runtime_collection") == 0)
+    {
+        const char *field = NULL;
+        if (SDL_strcmp(format_field, "label_key_format") == 0)
+            field = json_string(source, "label_field", NULL);
+        else if (SDL_strcmp(format_field, "value_key_format") == 0)
+            field = json_string(source, "value_field", NULL);
+        if (field == NULL)
+            return NULL;
+
+        const runtime_collection *collection =
+            find_runtime_collection_const(runtime, json_string(source, "collection", NULL));
+        return runtime_collection_field_to_string(collection, dynamic_index, field, buffer, buffer_size) ? buffer
+                                                                                                         : NULL;
+    }
+    return NULL;
 }
 
 static void menu_dynamic_list_apply_label_template(const char *format, const char *label, char *buffer,
@@ -11605,6 +11836,13 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->property_snapshots[i].target);
         sdl3d_properties_destroy(runtime->property_snapshots[i].properties);
     }
+    for (int i = 0; i < runtime->collection_count; ++i)
+    {
+        SDL_free(runtime->collections[i].name);
+        for (int row = 0; row < runtime->collections[i].row_count; ++row)
+            sdl3d_properties_destroy(runtime->collections[i].rows[row]);
+        SDL_free(runtime->collections[i].rows);
+    }
 
     clear_menu_text_entry_capture(runtime);
     sdl3d_script_engine_destroy(runtime->scripts);
@@ -11626,6 +11864,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->animations);
     SDL_free(runtime->audio_files);
     SDL_free(runtime->property_snapshots);
+    SDL_free(runtime->collections);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -4602,6 +4602,8 @@ static sdl3d_properties *runtime_collection_ensure_row(runtime_collection *colle
 {
     if (collection == NULL || row_index < 0)
         return NULL;
+    if (row_index > collection->row_count)
+        return NULL;
     if (row_index >= collection->row_capacity)
     {
         int next_capacity = collection->row_capacity > 0 ? collection->row_capacity : 4;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3592,20 +3592,37 @@ static bool validate_dynamic_menu_list_source(validation_context *ctx, yyjson_va
     if (!yyjson_is_obj(source))
         return validation_error(ctx, path, "dynamic_list menu item requires a source object");
     const char *type = json_string(source, "type");
-    if (type == NULL || SDL_strcmp(type, "scene_state_indexed") != 0)
-        return validation_error(ctx, path, "dynamic_list source type must be scene_state_indexed");
-    if (!is_non_empty_string(source, "count_key"))
-        return validation_error(ctx, path, "dynamic_list source requires a non-empty count_key");
-    if (!is_non_empty_string(source, "label_key_format"))
-        return validation_error(ctx, path, "dynamic_list source requires a non-empty label_key_format");
-    if (!dynamic_list_key_format_valid(json_string(source, "label_key_format")))
-        return validation_error(ctx, path, "dynamic_list source label_key_format must contain exactly one %%d token");
-    yyjson_val *value_format = obj_get(source, "value_key_format");
-    if (value_format != NULL && (!yyjson_is_str(value_format) || yyjson_get_str(value_format)[0] == '\0'))
-        return validation_error(ctx, path, "dynamic_list source value_key_format must be a non-empty string");
-    if (value_format != NULL && !dynamic_list_key_format_valid(yyjson_get_str(value_format)))
-        return validation_error(ctx, path, "dynamic_list source value_key_format must contain exactly one %%d token");
-    return true;
+    if (type != NULL && SDL_strcmp(type, "scene_state_indexed") == 0)
+    {
+        if (!is_non_empty_string(source, "count_key"))
+            return validation_error(ctx, path, "dynamic_list source requires a non-empty count_key");
+        if (!is_non_empty_string(source, "label_key_format"))
+            return validation_error(ctx, path, "dynamic_list source requires a non-empty label_key_format");
+        if (!dynamic_list_key_format_valid(json_string(source, "label_key_format")))
+            return validation_error(ctx, path,
+                                    "dynamic_list source label_key_format must contain exactly one %%d token");
+        yyjson_val *value_format = obj_get(source, "value_key_format");
+        if (value_format != NULL && (!yyjson_is_str(value_format) || yyjson_get_str(value_format)[0] == '\0'))
+            return validation_error(ctx, path, "dynamic_list source value_key_format must be a non-empty string");
+        if (value_format != NULL && !dynamic_list_key_format_valid(yyjson_get_str(value_format)))
+            return validation_error(ctx, path,
+                                    "dynamic_list source value_key_format must contain exactly one %%d token");
+        return true;
+    }
+    if (type != NULL && SDL_strcmp(type, "runtime_collection") == 0)
+    {
+        if (!is_non_empty_string(source, "collection"))
+            return validation_error(ctx, path,
+                                    "dynamic_list runtime_collection source requires a non-empty collection");
+        if (!is_non_empty_string(source, "label_field"))
+            return validation_error(ctx, path,
+                                    "dynamic_list runtime_collection source requires a non-empty label_field");
+        yyjson_val *value_field = obj_get(source, "value_field");
+        if (value_field != NULL && (!yyjson_is_str(value_field) || yyjson_get_str(value_field)[0] == '\0'))
+            return validation_error(ctx, path, "dynamic_list runtime_collection source value_field must be non-empty");
+        return true;
+    }
+    return validation_error(ctx, path, "dynamic_list source type must be scene_state_indexed or runtime_collection");
 }
 
 static bool validate_dynamic_menu_list_item(validation_context *ctx, yyjson_val *item, const char *path,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3197,6 +3197,9 @@ TEST(GameDataRuntime, DynamicListMenuReadsRuntimeCollections)
                                           error, sizeof(error)))
         << error;
 
+    EXPECT_FALSE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 2, "name", "Sparse"));
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
+
     sdl3d_game_data_menu menu{};
     ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
     EXPECT_EQ(menu.item_count, 2);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3130,6 +3130,142 @@ TEST(GameDataRuntime, DynamicListMenuUsesIndexedSceneStateEntries)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, DynamicListMenuReadsRuntimeCollections)
+{
+    const std::filesystem::path dir = unique_test_dir("menu_dynamic_runtime_collection");
+    write_text(dir / "dynamic_collection.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Dynamic Runtime Collection", "id": "test.dynamic_runtime_collection", "version": "0.1.0" },
+  "world": { "name": "world.dynamic_runtime_collection", "kind": "fixed_screen" },
+  "assets": { "fonts": [{ "id": "font.hud", "builtin": "Inter", "size": 18 }] },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.ui",
+        "actions": [
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] }
+        ]
+      }
+    ]
+  },
+  "signals": ["signal.session.inspect"],
+  "entities": [],
+  "scenes": { "initial": "scene.browser", "files": ["scenes/browser.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "browser.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.browser",
+  "input": { "actions": ["action.menu.select", "action.menu.up", "action.menu.down"] },
+  "menus": [
+    {
+      "name": "menu.sessions",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "items": [
+        {
+          "type": "dynamic_list",
+          "name": "list.sessions",
+          "source": {
+            "type": "runtime_collection",
+            "collection": "local_matches",
+            "label_field": "name",
+            "value_field": "latency_ms"
+          },
+          "empty_label": "No runtime rows",
+          "label_format": "{label}",
+          "selected_index_key": "selected_runtime_index",
+          "selected_value_key": "selected_runtime_latency",
+          "scene_state": { "key": "selected_runtime_latency_on_accept", "value_from": "value" },
+          "signal": "signal.session.inspect"
+        },
+        { "label": "Back", "return_scene": true }
+      ]
+    }
+  ]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "dynamic_collection.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_game_data_menu menu{};
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.item_count, 2);
+
+    sdl3d_game_data_menu_item item{};
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_TRUE(item.dynamic_list_item);
+    EXPECT_EQ(item.dynamic_list_index, -1);
+    EXPECT_STREQ(item.label, "No runtime rows");
+
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "name", "Alpha"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_int(runtime, "local_matches", 0, "latency_ms", 42));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 1, "name", "Beta"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_float(runtime, "local_matches", 1, "latency_ms", 19.5f));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_bool(runtime, "local_matches", 1, "secure", true));
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 2);
+
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.item_count, 3);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Alpha");
+    EXPECT_STREQ(item.dynamic_list_value, "42");
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Beta");
+    EXPECT_STREQ(item.dynamic_list_value, "19.500");
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    bool armed = true;
+    sdl3d_game_data_menu_update_result result{};
+    SDL_Event event{};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_DOWN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_EQ(result.selected_index, 1);
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "selected_runtime_index", -1), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "selected_runtime_latency", ""), "19.500");
+
+    event.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 2);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+
+    event = {};
+    event.type = SDL_EVENT_KEY_DOWN;
+    event.key.scancode = SDL_SCANCODE_RETURN;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_update_menus(runtime, input, &armed, &result));
+    EXPECT_TRUE(result.selected);
+    EXPECT_STREQ(result.scene_state_key, "selected_runtime_latency_on_accept");
+    EXPECT_STREQ(result.scene_state_value, "19.500");
+
+    EXPECT_TRUE(sdl3d_game_data_runtime_collection_clear(runtime, "local_matches"));
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_EQ(menu.item_count, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "No runtime rows");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidDynamicListMenuSchema)
 {
     const std::filesystem::path dir = unique_test_dir("menu_dynamic_list_validation");
@@ -3226,6 +3362,36 @@ TEST(GameDataRuntime, RejectsInvalidDynamicListMenuSchema)
     EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_value_format.game.json").string().c_str(), nullptr, error,
                                                sizeof(error)));
     EXPECT_NE(std::string(error).find("value_key_format must contain exactly one %d token"), std::string::npos)
+        << error;
+
+    error[0] = '\0';
+    write_case("missing_runtime_collection",
+               R"json({
+      "type": "dynamic_list",
+      "name": "list.sessions",
+      "source": {
+        "type": "runtime_collection",
+        "label_field": "name"
+      }
+    })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "missing_runtime_collection.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("runtime_collection source requires a non-empty collection"), std::string::npos)
+        << error;
+
+    error[0] = '\0';
+    write_case("missing_runtime_label_field",
+               R"json({
+      "type": "dynamic_list",
+      "name": "list.sessions",
+      "source": {
+        "type": "runtime_collection",
+        "collection": "local_matches"
+      }
+    })json");
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "missing_runtime_label_field.game.json").string().c_str(),
+                                               nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("runtime_collection source requires a non-empty label_field"), std::string::npos)
         << error;
 
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary

Implements slice 3 of #201 by adding a generic runtime collection bridge for data-authored dynamic-list menus.

- Adds runtime-owned named collections with typed row fields published by host systems.
- Adds public collection APIs for string, int, float, and bool row fields, plus count and clear helpers.
- Extends dynamic-list `source.type` with `runtime_collection` so UI can read host-published rows without indexed scene-state keys.
- Keeps existing `scene_state_indexed` dynamic-list sources working unchanged.
- Validates runtime collection dynamic-list sources and documents the schema/API contract.
- Adds focused runtime tests for populated/empty collections, typed value formatting, selected outputs, accept behavior, clearing, and invalid schema.

## Validation

- `clang-format` on touched C/C++ files
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_input_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DynamicListMenuReadsRuntimeCollections:GameDataRuntime.DynamicListMenuUsesIndexedSceneStateEntries:GameDataRuntime.RejectsInvalidDynamicListMenuSchema'`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_input_test`

## Next slice

The next slice should start data actions for the direct-connect flow: authored host/port sources, start/cancel/observe actions, status propagation, and removal of Pong-specific direct-connect form handling from `demos/pong/main.c`.
