### PR TITLE
Add data-authored direct-connect actions

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -199,7 +199,9 @@
         "lobby_start": "signal.multiplayer.lobby.start",
         "camera_toggle": "signal.camera.ball.toggle",
         "discovery_refresh": "signal.multiplayer.discovery.refresh",
-        "ui_select": "signal.ui.menu.select"
+        "ui_select": "signal.ui.menu.select",
+        "direct_connect": "signal.multiplayer.direct.connect",
+        "direct_disconnect": "signal.multiplayer.direct.disconnect"
       },
       "pause": {
         "action": "action.pause",
@@ -1852,6 +1854,8 @@
     "signal.network.pause_changed",
     "signal.multiplayer.lobby.start",
     "signal.multiplayer.discovery.refresh",
+    "signal.multiplayer.direct.connect",
+    "signal.multiplayer.direct.disconnect",
     "signal.ui.menu.move",
     "signal.ui.menu.select",
     "signal.app.quit_fade_done"
@@ -1972,6 +1976,35 @@
         "signal": "signal.ui.menu.select",
         "actions": [
           { "type": "audio.play_sfx", "sound": "sound.ui.select" }
+        ]
+      },
+      {
+        "signal": "signal.multiplayer.direct.connect",
+        "actions": [
+          {
+            "type": "network.direct_connect.start",
+            "name": "direct_connect",
+            "host_key": "direct_connect_host",
+            "port_key": "direct_connect_port",
+            "default_host": "127.0.0.1",
+            "default_port": 27183,
+            "status_key": "direct_connect_status",
+            "state_key": "direct_connect_state",
+            "connected_key": "direct_connect_connected"
+          }
+        ]
+      },
+      {
+        "signal": "signal.multiplayer.direct.disconnect",
+        "actions": [
+          {
+            "type": "network.direct_connect.cancel",
+            "name": "direct_connect",
+            "status": "Disconnected",
+            "status_key": "direct_connect_status",
+            "state_key": "direct_connect_state",
+            "connected_key": "direct_connect_connected"
+          }
         ]
       },
       {

--- a/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
+++ b/demos/pong/data/scenes/multiplayer_direct_connect.scene.json
@@ -23,7 +23,68 @@
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "activity": {
+    "enabled": true,
+    "reset_periodic_on_input": false,
+    "periodic": [
+      {
+        "interval": 0.1,
+        "actions": [
+          {
+            "type": "network.direct_connect.observe",
+            "name": "direct_connect",
+            "status_key": "direct_connect_status",
+            "state_key": "direct_connect_state",
+            "connected_key": "direct_connect_connected"
+          }
+        ]
+      }
+    ]
+  },
   "menus": [
+    {
+      "name": "menu.multiplayer.direct",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "items": [
+        {
+          "label": "Host",
+          "control": {
+            "type": "text",
+            "target": "scene_state",
+            "key": "direct_connect_host",
+            "default": "127.0.0.1",
+            "placeholder": "Host / IP",
+            "charset": "hostname",
+            "max_length": 96
+          }
+        },
+        {
+          "label": "Port",
+          "control": {
+            "type": "text",
+            "target": "scene_state",
+            "key": "direct_connect_port",
+            "default": "27183",
+            "placeholder": "Port",
+            "charset": "digits",
+            "max_length": 5
+          }
+        },
+        { "label": "Connect", "signal": "signal.multiplayer.direct.connect" },
+        { "label": "Disconnect", "signal": "signal.multiplayer.direct.disconnect" },
+        {
+          "label": "Back",
+          "signal": "signal.multiplayer.direct.disconnect",
+          "scene": "scene.multiplayer.join",
+          "scene_state": { "key": "network_flow", "value": "direct" }
+        }
+      ]
+    }
   ],
   "ui": {
     "text": [
@@ -36,8 +97,36 @@
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.direct.status",
+        "font": "font.hud",
+        "text": [
+          "Status: ",
+          { "type": "scene_state", "key": "direct_connect_status" }
+        ],
+        "x": 0.5,
+        "y": 0.75,
+        "normalized": true,
+        "centered": true,
+        "color": [210, 232, 255, 255]
       }
     ],
-    "menus": []
+    "menus": [
+      {
+        "name": "ui.multiplayer.direct.menu",
+        "menu": "menu.multiplayer.direct",
+        "font": "font.hud",
+        "x": 0.43,
+        "y": 0.34,
+        "gap": 0.075,
+        "normalized": true,
+        "align": "left",
+        "selected_prefix": "> ",
+        "unselected_prefix": "  ",
+        "color": [222, 236, 255, 255],
+        "selected_color": [255, 232, 128, 255]
+      }
+    ]
   }
 }

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -84,6 +84,12 @@ static const char PONG_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
 static const char PONG_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
 static const char PONG_NETWORK_BINDING_DISCOVERY_REFRESH[] = "discovery_refresh";
 static const char PONG_NETWORK_BINDING_UI_SELECT[] = "ui_select";
+static const char PONG_DIRECT_CONNECT_SESSION[] = "direct_connect";
+static const char PONG_DIRECT_CONNECT_HOST_KEY[] = "direct_connect_host";
+static const char PONG_DIRECT_CONNECT_PORT_KEY[] = "direct_connect_port";
+static const char PONG_DIRECT_CONNECT_STATUS_KEY[] = "direct_connect_status";
+static const char PONG_DIRECT_CONNECT_STATE_KEY[] = "direct_connect_state";
+static const char PONG_DIRECT_CONNECT_CONNECTED_KEY[] = "direct_connect_connected";
 
 typedef struct pong_network_control_binding
 {
@@ -443,6 +449,13 @@ static void destroy_host_session(pong_state *state)
 
 static void destroy_direct_connect_session_internal(pong_state *state, bool notify_peer)
 {
+    if (state != NULL)
+    {
+        state->direct_connect_session =
+            state->data != NULL
+                ? sdl3d_game_data_get_network_direct_connect_session(state->data, PONG_DIRECT_CONNECT_SESSION)
+                : state->direct_connect_session;
+    }
     if (state != NULL && state->direct_connect_session != NULL)
     {
         if (notify_peer)
@@ -450,7 +463,9 @@ static void destroy_direct_connect_session_internal(pong_state *state, bool noti
             (void)send_network_control_packet_repeated(state, state->direct_connect_session,
                                                        PONG_NETWORK_MESSAGE_DISCONNECT, "client disconnect", 5);
         }
-        sdl3d_network_session_destroy(state->direct_connect_session);
+        (void)sdl3d_game_data_network_direct_connect_cancel(
+            state->data, PONG_DIRECT_CONNECT_SESSION, PONG_DIRECT_CONNECT_STATUS_KEY, PONG_DIRECT_CONNECT_STATE_KEY,
+            PONG_DIRECT_CONNECT_CONNECTED_KEY, "Disconnected");
         state->direct_connect_session = NULL;
     }
 }
@@ -508,6 +523,15 @@ static void reset_direct_connect_defaults(pong_state *state)
     SDL_snprintf(state->direct_connect_port, sizeof(state->direct_connect_port), "%u",
                  (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
     SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Ready to connect");
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
+    if (scene_state != NULL)
+    {
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_HOST_KEY, state->direct_connect_host);
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_PORT_KEY, state->direct_connect_port);
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_STATUS_KEY, state->direct_connect_status);
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_STATE_KEY, "disconnected");
+        sdl3d_properties_set_bool(scene_state, PONG_DIRECT_CONNECT_CONNECTED_KEY, false);
+    }
 }
 
 static const char *network_control_binding_for_kind(pong_network_message_kind kind)
@@ -1020,41 +1044,39 @@ static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
 
 static bool start_direct_connect_session(pong_state *state)
 {
-    sdl3d_network_session_desc desc;
     int port = 0;
 
-    if (state == NULL)
+    if (state == NULL || state->data == NULL)
     {
         return false;
     }
 
-    port = SDL_atoi(state->direct_connect_port);
-    if (port <= 0 || port > 65535)
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
+    const char *host = scene_state != NULL
+                           ? sdl3d_properties_get_string(scene_state, PONG_DIRECT_CONNECT_HOST_KEY, "127.0.0.1")
+                           : "127.0.0.1";
+    const char *port_text =
+        scene_state != NULL ? sdl3d_properties_get_string(scene_state, PONG_DIRECT_CONNECT_PORT_KEY, NULL) : NULL;
+    port = port_text != NULL ? SDL_atoi(port_text) : SDL3D_NETWORK_DEFAULT_PORT;
+    if (!sdl3d_game_data_network_direct_connect_start(state->data, PONG_DIRECT_CONNECT_SESSION, host, port,
+                                                      PONG_DIRECT_CONNECT_STATUS_KEY, PONG_DIRECT_CONNECT_STATE_KEY,
+                                                      PONG_DIRECT_CONNECT_CONNECTED_KEY))
     {
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Invalid port");
+        const char *status =
+            scene_state != NULL
+                ? sdl3d_properties_get_string(scene_state, PONG_DIRECT_CONNECT_STATUS_KEY, SDL_GetError())
+                : SDL_GetError();
+        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
+                     status != NULL && status[0] != '\0' ? status : "Connect failed");
         return false;
     }
 
-    destroy_direct_connect_session(state);
-
-    sdl3d_network_session_desc_init(&desc);
-    desc.role = SDL3D_NETWORK_ROLE_CLIENT;
-    desc.host = state->direct_connect_host;
-    desc.port = (Uint16)port;
-    desc.local_port = 0;
-    desc.handshake_timeout = 5.0f;
-    desc.idle_timeout = 10.0f;
-
-    if (!sdl3d_network_session_create(&desc, &state->direct_connect_session))
-    {
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s", SDL_GetError());
-        return false;
-    }
-
-    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                 sdl3d_network_session_status(state->direct_connect_session) != NULL
-                     ? sdl3d_network_session_status(state->direct_connect_session)
-                     : "Connecting");
+    state->direct_connect_session =
+        sdl3d_game_data_get_network_direct_connect_session(state->data, PONG_DIRECT_CONNECT_SESSION);
+    const char *status = scene_state != NULL
+                             ? sdl3d_properties_get_string(scene_state, PONG_DIRECT_CONNECT_STATUS_KEY, "Connecting")
+                             : "Connecting";
+    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s", status);
     return true;
 }
 
@@ -1065,6 +1087,10 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
         return;
     }
 
+    state->direct_connect_session =
+        state->data != NULL
+            ? sdl3d_game_data_get_network_direct_connect_session(state->data, PONG_DIRECT_CONNECT_SESSION)
+            : state->direct_connect_session;
     if (state->direct_connect_session != NULL)
     {
         Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
@@ -1072,6 +1098,9 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
         const char *status = sdl3d_network_session_status(state->direct_connect_session);
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
                      status != NULL && status[0] != '\0' ? status : "Connecting");
+        (void)sdl3d_game_data_network_direct_connect_publish_status(
+            state->data, PONG_DIRECT_CONNECT_SESSION, PONG_DIRECT_CONNECT_STATUS_KEY, PONG_DIRECT_CONNECT_STATE_KEY,
+            PONG_DIRECT_CONNECT_CONNECTED_KEY);
 
         while ((packet_size =
                     sdl3d_network_session_receive(state->direct_connect_session, packet, (int)sizeof(packet))) > 0)
@@ -1301,6 +1330,12 @@ static bool start_discovered_match_connection(pong_state *state, int index)
     SDL_strlcpy(state->direct_connect_host, result.host, sizeof(state->direct_connect_host));
     SDL_snprintf(port_buffer, sizeof(port_buffer), "%u", (unsigned int)result.port);
     SDL_strlcpy(state->direct_connect_port, port_buffer, sizeof(state->direct_connect_port));
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
+    if (scene_state != NULL)
+    {
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_HOST_KEY, state->direct_connect_host);
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_PORT_KEY, state->direct_connect_port);
+    }
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery auto-connecting to result %d: %s:%u session=%s",
                 index, result.host, (unsigned int)result.port,
                 result.session_name[0] != '\0' ? result.session_name : "SDL3D Session");
@@ -1310,6 +1345,8 @@ static bool start_discovered_match_connection(pong_state *state, int index)
         return false;
     }
     SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Match found. Connecting...");
+    if (scene_state != NULL)
+        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_STATUS_KEY, state->direct_connect_status);
     return true;
 }
 
@@ -1492,6 +1529,10 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
     {
         return;
     }
+    state->direct_connect_session =
+        state->data != NULL
+            ? sdl3d_game_data_get_network_direct_connect_session(state->data, PONG_DIRECT_CONNECT_SESSION)
+            : state->direct_connect_session;
 
     update_host_session_status(ctx, state, dt);
 
@@ -1579,63 +1620,6 @@ static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_st
     {
         sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(ctx->session), state->camera_toggle_signal_id, NULL);
     }
-}
-
-static void draw_direct_connect_overlay(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (ctx == NULL || state == NULL || state->direct_connect_ui == NULL)
-    {
-        return;
-    }
-
-    const int screen_w = sdl3d_get_render_context_width(ctx->renderer);
-    const int screen_h = sdl3d_get_render_context_height(ctx->renderer);
-    const float panel_w = (float)screen_w * 0.46f;
-    const float panel_h = (float)screen_h * 0.44f;
-    const float panel_x = ((float)screen_w - panel_w) * 0.5f;
-    const float panel_y = ((float)screen_h - panel_h) * 0.5f;
-
-    sdl3d_ui_begin_panel(state->direct_connect_ui, panel_x, panel_y, panel_w, panel_h);
-    sdl3d_ui_begin_vbox(state->direct_connect_ui, panel_x + 28.0f, panel_y + 24.0f, panel_w - 56.0f, panel_h - 48.0f);
-
-    sdl3d_ui_layout_label(state->direct_connect_ui, "JOIN MATCH");
-    sdl3d_ui_layout_label(state->direct_connect_ui, "Host");
-    (void)sdl3d_ui_layout_text_field(state->direct_connect_ui, state->direct_connect_host,
-                                     (int)sizeof(state->direct_connect_host));
-    sdl3d_ui_layout_label(state->direct_connect_ui, "Port");
-    (void)sdl3d_ui_layout_text_field(state->direct_connect_ui, state->direct_connect_port,
-                                     (int)sizeof(state->direct_connect_port));
-    sdl3d_ui_separator(state->direct_connect_ui);
-
-    if (sdl3d_ui_layout_button(state->direct_connect_ui,
-                               state->direct_connect_session != NULL ? "Disconnect" : "Connect"))
-    {
-        if (state->direct_connect_session != NULL)
-        {
-            destroy_direct_connect_session(state);
-            SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                         network_session_message(state, "disconnect_status", "disconnected", "Disconnected"));
-        }
-        else
-        {
-            (void)start_direct_connect_session(state);
-        }
-    }
-
-    if (sdl3d_ui_layout_button(state->direct_connect_ui, "Back"))
-    {
-        destroy_direct_connect_session(state);
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                     network_session_message(state, "disconnect_status", "returning_join", "Returning to Join Match"));
-        (void)sdl3d_game_data_set_active_scene(state->data,
-                                               network_session_scene(state, "join", "scene.multiplayer.join"));
-    }
-
-    sdl3d_ui_layout_label(state->direct_connect_ui, "Status");
-    sdl3d_ui_layout_label(state->direct_connect_ui, state->direct_connect_status);
-
-    sdl3d_ui_end_vbox(state->direct_connect_ui);
-    sdl3d_ui_end_panel(state->direct_connect_ui);
 }
 
 static void format_network_termination_prompt(const pong_state *state, char *buffer, size_t buffer_size,
@@ -2016,20 +2000,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
 static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
 {
     pong_state *state = (pong_state *)userdata;
-    if (state != NULL && is_direct_connect_scene(state) && state->direct_connect_ui != NULL && event != NULL)
-    {
-        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
-                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
-        const bool key_event =
-            event->type == SDL_EVENT_KEY_DOWN || event->type == SDL_EVENT_KEY_UP || event->type == SDL_EVENT_TEXT_INPUT;
-
-        (void)sdl3d_ui_process_event(state->direct_connect_ui, event);
-
-        if (mouse_event || key_event)
-        {
-            ctx->input_event_consumed = true;
-        }
-    }
     if (state != NULL && is_multiplayer_discovery_scene(state) && state->discovery_ui != NULL && event != NULL)
     {
         const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
@@ -2101,10 +2071,6 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     frame.pulse_phase = state->frame_state.ui_pulse_phase;
     sdl3d_game_data_draw_frame(&frame);
 
-    if (is_direct_connect_scene(state))
-    {
-        draw_direct_connect_overlay(ctx, state);
-    }
     if (is_multiplayer_discovery_scene(state))
     {
         draw_discovery_overlay(ctx, state);

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -701,6 +701,42 @@ frame loop while a profile-managed scene is active. The helper applies the
 active profile on first use and after the connected gamepad count changes,
 leaving scene-entry profile application in authored data actions.
 
+Direct-connect multiplayer forms should use menu `text` controls for the host
+and port fields, then invoke data-authored network actions from menu signals:
+
+```json
+{
+    "signal" : "signal.multiplayer.direct.connect",
+    "actions" : [
+        {
+            "type" : "network.direct_connect.start",
+            "name" : "direct_connect",
+            "host_key" : "direct_connect_host",
+            "port_key" : "direct_connect_port",
+            "default_host" : "127.0.0.1",
+            "default_port" : 27183,
+            "status_key" : "direct_connect_status",
+            "state_key" : "direct_connect_state",
+            "connected_key" : "direct_connect_connected"
+        }
+    ]
+}
+```
+
+`network.direct_connect.start` creates or replaces a runtime-owned UDP client
+session. `name` identifies the session. `host_key` and `port_key` read editable
+scene-state strings; alternatively, authors can provide literal `host` and
+`port` values. `default_host` and `default_port` are used when scene-state
+values are absent. Ports must resolve to `1..65535`. `status_key`, `state_key`,
+and `connected_key` are optional scene-state outputs used by UI labels and
+conditions. `network.direct_connect.observe` republishes those outputs from an
+existing named session, which is useful from a scene `activity.periodic` list.
+`network.direct_connect.cancel` destroys the named session, treats unknown
+sessions as a successful no-op, and writes a disconnected status. The engine
+owns session lifetime; host code can inspect the runtime-owned pointer with
+`sdl3d_game_data_get_network_direct_connect_session()` when it needs to send or
+receive game packets.
+
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for
 screens that intentionally stage changes before committing them.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -24,6 +24,7 @@
 #include "sdl3d/font.h"
 #include "sdl3d/game.h"
 #include "sdl3d/lighting.h"
+#include "sdl3d/network.h"
 #include "sdl3d/network_replication.h"
 #include "sdl3d/properties.h"
 #include "sdl3d/sprite_asset.h"
@@ -1900,6 +1901,41 @@ extern "C"
     /** @brief Publish a boolean field on one runtime collection row. */
     bool sdl3d_game_data_runtime_collection_set_bool(sdl3d_game_data_runtime *runtime, const char *collection_name,
                                                      int row_index, const char *field_name, bool value);
+
+    /**
+     * @brief Start or replace a named runtime-owned UDP direct-connect client session.
+     *
+     * The session is owned by @p runtime and remains valid until canceled,
+     * replaced, or the runtime is destroyed. @p status_key, @p state_key, and
+     * @p connected_key are optional scene-state keys updated after creation.
+     */
+    bool sdl3d_game_data_network_direct_connect_start(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                      const char *host, int port, const char *status_key,
+                                                      const char *state_key, const char *connected_key);
+
+    /**
+     * @brief Cancel and destroy a named runtime-owned direct-connect session.
+     *
+     * Canceling an unknown session is a successful no-op.
+     */
+    bool sdl3d_game_data_network_direct_connect_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                       const char *status_key, const char *state_key,
+                                                       const char *connected_key, const char *status);
+
+    /**
+     * @brief Publish a named runtime-owned direct-connect session's status into scene state.
+     */
+    bool sdl3d_game_data_network_direct_connect_publish_status(sdl3d_game_data_runtime *runtime,
+                                                               const char *session_name, const char *status_key,
+                                                               const char *state_key, const char *connected_key);
+
+    /**
+     * @brief Return a runtime-owned direct-connect session, or NULL when absent.
+     *
+     * The caller must not destroy the returned pointer.
+     */
+    sdl3d_network_session *sdl3d_game_data_get_network_direct_connect_session(sdl3d_game_data_runtime *runtime,
+                                                                              const char *session_name);
 
     /**
      * @brief Read one item from an authored menu.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -20,6 +20,7 @@
 #include "sdl3d/asset.h"
 #include "sdl3d/input.h"
 #include "sdl3d/math.h"
+#include "sdl3d/network.h"
 #include "sdl3d/script.h"
 #include "sdl3d/signal_bus.h"
 #include "sdl3d/timer_pool.h"
@@ -242,6 +243,12 @@ typedef struct runtime_collection
     int row_capacity;
 } runtime_collection;
 
+typedef struct runtime_direct_connect_session
+{
+    char *name;
+    sdl3d_network_session *session;
+} runtime_direct_connect_session;
+
 typedef struct scene_activity_state
 {
     const char *scene;
@@ -313,6 +320,9 @@ typedef struct sdl3d_game_data_runtime
     runtime_collection *collections;
     int collection_count;
     int collection_capacity;
+    runtime_direct_connect_session *direct_connect_sessions;
+    int direct_connect_session_count;
+    int direct_connect_session_capacity;
     sdl3d_storage *storage;
     bool has_network_schema;
     Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
@@ -1355,6 +1365,16 @@ static int json_int(yyjson_val *object, const char *key, int fallback)
 {
     yyjson_val *value = obj_get(object, key);
     return yyjson_is_int(value) ? (int)yyjson_get_int(value) : fallback;
+}
+
+static int json_int_or_string(yyjson_val *object, const char *key, int fallback)
+{
+    yyjson_val *value = obj_get(object, key);
+    if (yyjson_is_int(value))
+        return (int)yyjson_get_int(value);
+    if (yyjson_is_str(value))
+        return SDL_atoi(yyjson_get_str(value));
+    return fallback;
 }
 
 static sdl3d_vec3 json_vec3_value(yyjson_val *value, sdl3d_vec3 fallback)
@@ -4733,6 +4753,197 @@ bool sdl3d_game_data_runtime_collection_set_bool(sdl3d_game_data_runtime *runtim
     if (row == NULL)
         return false;
     sdl3d_properties_set_bool(row, field_name, value);
+    return true;
+}
+
+static const char *game_data_network_state_name(sdl3d_network_state state)
+{
+    switch (state)
+    {
+    case SDL3D_NETWORK_STATE_DISCONNECTED:
+        return "disconnected";
+    case SDL3D_NETWORK_STATE_CONNECTING:
+        return "connecting";
+    case SDL3D_NETWORK_STATE_WAITING:
+        return "waiting";
+    case SDL3D_NETWORK_STATE_CONNECTED:
+        return "connected";
+    case SDL3D_NETWORK_STATE_REJECTED:
+        return "rejected";
+    case SDL3D_NETWORK_STATE_TIMED_OUT:
+        return "timed_out";
+    case SDL3D_NETWORK_STATE_ERROR:
+        return "error";
+    default:
+        return "unknown";
+    }
+}
+
+static runtime_direct_connect_session *find_direct_connect_session(sdl3d_game_data_runtime *runtime,
+                                                                   const char *session_name)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->direct_connect_session_count; ++i)
+    {
+        if (SDL_strcmp(runtime->direct_connect_sessions[i].name, session_name) == 0)
+            return &runtime->direct_connect_sessions[i];
+    }
+    return NULL;
+}
+
+static runtime_direct_connect_session *get_or_create_direct_connect_session(sdl3d_game_data_runtime *runtime,
+                                                                            const char *session_name)
+{
+    runtime_direct_connect_session *existing = find_direct_connect_session(runtime, session_name);
+    if (existing != NULL)
+        return existing;
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+
+    if (runtime->direct_connect_session_count >= runtime->direct_connect_session_capacity)
+    {
+        const int next_capacity =
+            runtime->direct_connect_session_capacity > 0 ? runtime->direct_connect_session_capacity * 2 : 2;
+        runtime_direct_connect_session *next = (runtime_direct_connect_session *)SDL_realloc(
+            runtime->direct_connect_sessions, (size_t)next_capacity * sizeof(*runtime->direct_connect_sessions));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + runtime->direct_connect_session_capacity, 0,
+                   (size_t)(next_capacity - runtime->direct_connect_session_capacity) *
+                       sizeof(*runtime->direct_connect_sessions));
+        runtime->direct_connect_sessions = next;
+        runtime->direct_connect_session_capacity = next_capacity;
+    }
+
+    runtime_direct_connect_session *entry = &runtime->direct_connect_sessions[runtime->direct_connect_session_count];
+    SDL_zero(*entry);
+    entry->name = SDL_strdup(session_name);
+    if (entry->name == NULL)
+        return NULL;
+    ++runtime->direct_connect_session_count;
+    return entry;
+}
+
+static void direct_connect_publish_status_entry(sdl3d_game_data_runtime *runtime,
+                                                const runtime_direct_connect_session *entry, const char *status_key,
+                                                const char *state_key, const char *connected_key,
+                                                const char *fallback_status)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+
+    const sdl3d_network_state state = entry != NULL && entry->session != NULL
+                                          ? sdl3d_network_session_state(entry->session)
+                                          : SDL3D_NETWORK_STATE_DISCONNECTED;
+    const char *status = entry != NULL && entry->session != NULL ? sdl3d_network_session_status(entry->session) : NULL;
+    if (status == NULL || status[0] == '\0')
+        status = fallback_status != NULL ? fallback_status : game_data_network_state_name(state);
+
+    if (status_key != NULL && status_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, status_key, status);
+    if (state_key != NULL && state_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, state_key, game_data_network_state_name(state));
+    if (connected_key != NULL && connected_key[0] != '\0')
+        sdl3d_properties_set_bool(runtime->scene_state, connected_key, state == SDL3D_NETWORK_STATE_CONNECTED);
+}
+
+static void direct_connect_publish_manual_status(sdl3d_game_data_runtime *runtime, const char *status_key,
+                                                 const char *state_key, const char *connected_key, const char *status,
+                                                 const char *state, bool connected)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    if (status_key != NULL && status_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, status_key, status != NULL ? status : "");
+    if (state_key != NULL && state_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, state_key, state != NULL ? state : "unknown");
+    if (connected_key != NULL && connected_key[0] != '\0')
+        sdl3d_properties_set_bool(runtime->scene_state, connected_key, connected);
+}
+
+sdl3d_network_session *sdl3d_game_data_get_network_direct_connect_session(sdl3d_game_data_runtime *runtime,
+                                                                          const char *session_name)
+{
+    runtime_direct_connect_session *entry = find_direct_connect_session(runtime, session_name);
+    return entry != NULL ? entry->session : NULL;
+}
+
+bool sdl3d_game_data_network_direct_connect_publish_status(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                           const char *status_key, const char *state_key,
+                                                           const char *connected_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    direct_connect_publish_status_entry(runtime, find_direct_connect_session(runtime, session_name), status_key,
+                                        state_key, connected_key, "Disconnected");
+    return true;
+}
+
+bool sdl3d_game_data_network_direct_connect_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                   const char *status_key, const char *state_key,
+                                                   const char *connected_key, const char *status)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_direct_connect_session *entry = find_direct_connect_session(runtime, session_name);
+    if (entry != NULL && entry->session != NULL)
+    {
+        sdl3d_network_session_destroy(entry->session);
+        entry->session = NULL;
+    }
+    direct_connect_publish_status_entry(runtime, entry, status_key, state_key, connected_key,
+                                        status != NULL ? status : "Disconnected");
+    return true;
+}
+
+bool sdl3d_game_data_network_direct_connect_start(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                  const char *host, int port, const char *status_key,
+                                                  const char *state_key, const char *connected_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_direct_connect_session *entry = get_or_create_direct_connect_session(runtime, session_name);
+    if (entry == NULL)
+        return false;
+
+    if (host == NULL || host[0] == '\0')
+    {
+        direct_connect_publish_manual_status(runtime, status_key, state_key, connected_key, "Invalid host", "error",
+                                             false);
+        return false;
+    }
+
+    if (port <= 0 || port > 65535)
+    {
+        direct_connect_publish_manual_status(runtime, status_key, state_key, connected_key, "Invalid port", "error",
+                                             false);
+        return false;
+    }
+
+    if (entry->session != NULL)
+    {
+        sdl3d_network_session_destroy(entry->session);
+        entry->session = NULL;
+    }
+
+    sdl3d_network_session_desc desc;
+    sdl3d_network_session_desc_init(&desc);
+    desc.role = SDL3D_NETWORK_ROLE_CLIENT;
+    desc.host = host;
+    desc.port = (Uint16)port;
+    desc.local_port = 0;
+    desc.handshake_timeout = 5.0f;
+    desc.idle_timeout = 10.0f;
+
+    if (!sdl3d_network_session_create(&desc, &entry->session))
+    {
+        direct_connect_publish_manual_status(runtime, status_key, state_key, connected_key, SDL_GetError(), "error",
+                                             false);
+        return false;
+    }
+
+    direct_connect_publish_status_entry(runtime, entry, status_key, state_key, connected_key, "Connecting");
     return true;
 }
 
@@ -9176,6 +9387,40 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return true;
     }
 
+    if (SDL_strcmp(type, "network.direct_connect.start") == 0)
+    {
+        const char *name = json_string(action, "name", NULL);
+        const char *host_key = json_string(action, "host_key", NULL);
+        const char *port_key = json_string(action, "port_key", NULL);
+        const char *host = runtime != NULL && host_key != NULL
+                               ? sdl3d_properties_get_string(runtime->scene_state, host_key,
+                                                             json_string(action, "default_host", "127.0.0.1"))
+                               : json_string(action, "host", json_string(action, "default_host", "127.0.0.1"));
+        const int default_port = json_int(action, "default_port", SDL3D_NETWORK_DEFAULT_PORT);
+        const char *port_text = runtime != NULL && port_key != NULL
+                                    ? sdl3d_properties_get_string(runtime->scene_state, port_key, NULL)
+                                    : NULL;
+        const int port = port_text != NULL ? SDL_atoi(port_text) : json_int_or_string(action, "port", default_port);
+        return sdl3d_game_data_network_direct_connect_start(
+            runtime, name, host, port, json_string(action, "status_key", NULL), json_string(action, "state_key", NULL),
+            json_string(action, "connected_key", NULL));
+    }
+
+    if (SDL_strcmp(type, "network.direct_connect.cancel") == 0)
+    {
+        return sdl3d_game_data_network_direct_connect_cancel(
+            runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL),
+            json_string(action, "status", "Disconnected"));
+    }
+
+    if (SDL_strcmp(type, "network.direct_connect.observe") == 0)
+    {
+        return sdl3d_game_data_network_direct_connect_publish_status(
+            runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL));
+    }
+
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
 
@@ -11845,6 +12090,11 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
             sdl3d_properties_destroy(runtime->collections[i].rows[row]);
         SDL_free(runtime->collections[i].rows);
     }
+    for (int i = 0; i < runtime->direct_connect_session_count; ++i)
+    {
+        SDL_free(runtime->direct_connect_sessions[i].name);
+        sdl3d_network_session_destroy(runtime->direct_connect_sessions[i].session);
+    }
 
     clear_menu_text_entry_capture(runtime);
     sdl3d_script_engine_destroy(runtime->scripts);
@@ -11867,6 +12117,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->audio_files);
     SDL_free(runtime->property_snapshots);
     SDL_free(runtime->collections);
+    SDL_free(runtime->direct_connect_sessions);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -85,6 +85,7 @@ static bool require_ref(validation_context *ctx, const name_table *table, const 
 static bool asset_path_exists(validation_context *ctx, const char *asset_path, const char *json_path,
                               const char *asset_kind);
 static void format_path(char *buffer, size_t buffer_size, const char *format, ...);
+static bool validation_error(validation_context *ctx, const char *json_path, const char *format, ...);
 
 static yyjson_val *obj_get(yyjson_val *object, const char *key)
 {
@@ -115,6 +116,24 @@ static bool is_storage_path_segment(const char *value)
 static bool is_virtual_storage_path(const char *value)
 {
     return value != NULL && (SDL_strncmp(value, "user://", 7) == 0 || SDL_strncmp(value, "cache://", 8) == 0);
+}
+
+static bool validate_network_port_value(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                        const char *label)
+{
+    if (value == NULL)
+        return true;
+    if (yyjson_is_int(value))
+    {
+        const int port = (int)yyjson_get_int(value);
+        if (port > 0 && port <= 65535)
+            return true;
+    }
+    else if (yyjson_is_str(value) && yyjson_get_str(value) != NULL && yyjson_get_str(value)[0] != '\0')
+    {
+        return true;
+    }
+    return validation_error(ctx, json_path, "%s must be a non-empty string or integer 1..65535", label);
 }
 
 static bool validation_key_name_valid(const char *name)
@@ -2517,6 +2536,34 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     {
         return require_ref(ctx, &names->network_input_channels, "network input channel", json_string(action, "channel"),
                            json_path);
+    }
+    if (SDL_strcmp(type, "network.direct_connect.start") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "network.direct_connect.start requires a non-empty name");
+        if (!is_non_empty_string(action, "host_key") && !is_non_empty_string(action, "host") &&
+            !is_non_empty_string(action, "default_host"))
+            return validation_error(ctx, json_path,
+                                    "network.direct_connect.start requires host_key, host, or default_host");
+        if (!is_non_empty_string(action, "port_key") && obj_get(action, "port") == NULL &&
+            obj_get(action, "default_port") == NULL)
+            return validation_error(ctx, json_path,
+                                    "network.direct_connect.start requires port_key, port, or default_port");
+        if (!validate_network_port_value(ctx, obj_get(action, "port"), json_path, "network.direct_connect.start port"))
+            return false;
+        yyjson_val *default_port = obj_get(action, "default_port");
+        if (default_port != NULL &&
+            (!yyjson_is_int(default_port) || yyjson_get_int(default_port) <= 0 || yyjson_get_int(default_port) > 65535))
+            return validation_error(ctx, json_path,
+                                    "network.direct_connect.start default_port must be integer 1..65535");
+        return true;
+    }
+    if (SDL_strcmp(type, "network.direct_connect.cancel") == 0 ||
+        SDL_strcmp(type, "network.direct_connect.observe") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "%s requires a non-empty name", type);
+        return true;
     }
     if (SDL_strcmp(type, "ui.animate") == 0)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1898,7 +1898,24 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(item.scene, "scene.multiplayer.lan");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.direct_connect"));
-    EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.direct");
+    EXPECT_EQ(menu.item_count, 5);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_STREQ(item.label, "Host");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_TEXT);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Port");
+    EXPECT_EQ(item.control_type, SDL3D_GAME_DATA_MENU_CONTROL_TEXT);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 2, &item));
+    EXPECT_STREQ(item.label, "Connect");
+    EXPECT_EQ(item.signal_id, sdl3d_game_data_find_signal(runtime, "signal.multiplayer.direct.connect"));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 3, &item));
+    EXPECT_STREQ(item.label, "Disconnect");
+    EXPECT_EQ(item.signal_id, sdl3d_game_data_find_signal(runtime, "signal.multiplayer.direct.disconnect"));
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 4, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.join");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.discovery"));
     EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
@@ -6215,6 +6232,87 @@ TEST(GameDataRuntime, RejectsPongNetworkControlWithMismatchedSchemaOrBadSize)
 
     destroy_runtime_session(sender_session, sender);
     destroy_runtime_session(receiver_session, receiver);
+}
+
+TEST(GameDataRuntime, AuthoredDirectConnectActionsUpdateSceneState)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "direct_connect_host", "");
+    sdl3d_properties_set_string(scene_state, "direct_connect_port", "27183");
+    sdl3d_properties_set_string(scene_state, "direct_connect_status", "Ready");
+    sdl3d_properties_set_string(scene_state, "direct_connect_state", "disconnected");
+    sdl3d_properties_set_bool(scene_state, "direct_connect_connected", true);
+
+    const int connect_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.direct.connect");
+    ASSERT_GE(connect_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Invalid host");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_state", ""), "error");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
+
+    sdl3d_properties_set_string(scene_state, "direct_connect_host", "127.0.0.1");
+    sdl3d_properties_set_string(scene_state, "direct_connect_port", "0");
+    sdl3d_properties_set_bool(scene_state, "direct_connect_connected", true);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Invalid port");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_state", ""), "error");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
+
+    const int disconnect_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.direct.disconnect");
+    ASSERT_GE(disconnect_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), disconnect_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Disconnected");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_state", ""), "disconnected");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, RejectsInvalidDirectConnectActions)
+{
+    const std::filesystem::path dir = unique_test_dir("bad_direct_connect_actions");
+    write_text(dir / "bad_direct_connect.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Direct Connect", "id": "test.bad_direct_connect", "version": "0.1.0" },
+  "world": { "name": "world.bad_direct_connect", "kind": "fixed_screen" },
+  "entities": [],
+  "signals": ["signal.connect"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.connect",
+        "actions": [
+          { "type": "network.direct_connect.start", "name": "direct", "host": "127.0.0.1", "port": 70000 }
+        ]
+      }
+    ]
+  }
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_direct_connect.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(
+        std::string(error).find("network.direct_connect.start port must be a non-empty string or integer 1..65535"),
+        std::string::npos)
+        << error;
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)


### PR DESCRIPTION
## Summary
- add runtime-owned direct-connect session actions for authored start/cancel/observe flows
- convert Pong direct-connect host/port entry to data-authored text controls and menu signals
- remove the native direct-connect form overlay while keeping host packet send/receive integration intact
- document direct-connect actions and add validation/runtime coverage

## Tests
- cmake --build build/debug --target sdl3d_game_data_test pong_demo -j4
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug --target sdl3d_network_test sdl3d_pong_multiplayer_test -j4
- ./build/debug/tests/sdl3d_network_test
- ./build/debug/tests/sdl3d_pong_multiplayer_test
- git diff --check

## Issue
- Part of #201