### PR TITLE
Add data-authored LAN discovery actions

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -1854,6 +1854,8 @@
     "signal.network.pause_changed",
     "signal.multiplayer.lobby.start",
     "signal.multiplayer.discovery.refresh",
+    "signal.multiplayer.discovery.connect",
+    "signal.multiplayer.discovery.cancel",
     "signal.multiplayer.direct.connect",
     "signal.multiplayer.direct.disconnect",
     "signal.ui.menu.move",
@@ -1976,6 +1978,58 @@
         "signal": "signal.ui.menu.select",
         "actions": [
           { "type": "audio.play_sfx", "sound": "sound.ui.select" }
+        ]
+      },
+      {
+        "signal": "signal.multiplayer.discovery.refresh",
+        "actions": [
+          {
+            "type": "network.discovery.refresh",
+            "name": "local_matches",
+            "collection": "local_matches",
+            "default_port": 27183,
+            "status_key": "local_match_status",
+            "count_key": "local_match_count"
+          }
+        ]
+      },
+      {
+        "signal": "signal.multiplayer.discovery.connect",
+        "actions": [
+          {
+            "type": "network.discovery.connect_selected",
+            "name": "local_matches",
+            "collection": "local_matches",
+            "selected_index_key": "local_match_index",
+            "direct_connect_name": "direct_connect",
+            "host_key": "direct_connect_host",
+            "port_key": "direct_connect_port",
+            "status_key": "direct_connect_status",
+            "state_key": "direct_connect_state",
+            "connected_key": "direct_connect_connected",
+            "connecting_status": "Match found. Connecting..."
+          }
+        ]
+      },
+      {
+        "signal": "signal.multiplayer.discovery.cancel",
+        "actions": [
+          {
+            "type": "network.discovery.cancel",
+            "name": "local_matches",
+            "collection": "local_matches",
+            "status": "Discovery canceled",
+            "status_key": "local_match_status",
+            "count_key": "local_match_count"
+          },
+          {
+            "type": "network.direct_connect.cancel",
+            "name": "direct_connect",
+            "status": "Disconnected",
+            "status_key": "direct_connect_status",
+            "state_key": "direct_connect_state",
+            "connected_key": "direct_connect_connected"
+          }
         ]
       },
       {

--- a/demos/pong/data/scenes/multiplayer_discovery.scene.json
+++ b/demos/pong/data/scenes/multiplayer_discovery.scene.json
@@ -28,8 +28,30 @@
     "enabled": true,
     "input": "any",
     "reset_periodic_on_input": false,
-    "on_enter": [{ "type": "signal.emit", "signal": "signal.multiplayer.discovery.refresh" }],
+    "on_enter": [
+      {
+        "type": "network.discovery.start",
+        "name": "local_matches",
+        "collection": "local_matches",
+        "default_port": 27183,
+        "status_key": "local_match_status",
+        "count_key": "local_match_count"
+      }
+    ],
     "periodic": [
+      {
+        "interval": 0.05,
+        "actions": [
+          {
+            "type": "network.discovery.observe",
+            "name": "local_matches",
+            "collection": "local_matches",
+            "update_seconds": 0.05,
+            "status_key": "local_match_status",
+            "count_key": "local_match_count"
+          }
+        ]
+      },
       {
         "interval": 15.0,
         "actions": [
@@ -38,6 +60,41 @@
       }
     ]
   },
+  "menus": [
+    {
+      "name": "menu.multiplayer.discovery",
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "back_action": "action.menu.back",
+      "move_signal": "signal.ui.menu.move",
+      "select_signal": "signal.ui.menu.select",
+      "items": [
+        {
+          "type": "dynamic_list",
+          "name": "list.local_matches",
+          "source": {
+            "type": "runtime_collection",
+            "collection": "local_matches",
+            "label_field": "label",
+            "value_field": "endpoint"
+          },
+          "empty_label": "Searching local network...",
+          "label_format": "{label}",
+          "selected_index_key": "local_match_index",
+          "selected_value_key": "local_match_endpoint",
+          "visible_count": 5,
+          "signal": "signal.multiplayer.discovery.connect"
+        },
+        {
+          "label": "Back",
+          "signal": "signal.multiplayer.discovery.cancel",
+          "scene": "scene.multiplayer.join",
+          "scene_state": { "key": "network_flow", "value": "lan_discovery" }
+        }
+      ]
+    }
+  ],
   "ui": {
     "text": [
       {
@@ -49,8 +106,49 @@
         "normalized": true,
         "centered": true,
         "color": [242, 248, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.discovery.status",
+        "font": "font.hud",
+        "text": [
+          "Status: ",
+          { "type": "scene_state", "key": "local_match_status" }
+        ],
+        "x": 0.5,
+        "y": 0.70,
+        "normalized": true,
+        "centered": true,
+        "color": [210, 232, 255, 255]
+      },
+      {
+        "name": "ui.multiplayer.discovery.connection_status",
+        "font": "font.hud",
+        "text": [
+          "Connection: ",
+          { "type": "scene_state", "key": "direct_connect_status" }
+        ],
+        "x": 0.5,
+        "y": 0.76,
+        "normalized": true,
+        "centered": true,
+        "color": [190, 220, 250, 255]
       }
     ],
-    "menus": []
+    "menus": [
+      {
+        "name": "ui.multiplayer.discovery.menu",
+        "menu": "menu.multiplayer.discovery",
+        "font": "font.hud",
+        "x": 0.30,
+        "y": 0.32,
+        "gap": 0.07,
+        "normalized": true,
+        "align": "left",
+        "selected_prefix": "> ",
+        "unselected_prefix": "  ",
+        "color": [222, 236, 255, 255],
+        "selected_color": [255, 232, 128, 255]
+      }
+    ]
   }
 }

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -34,10 +34,8 @@ typedef struct pong_state
     sdl3d_input_manager *input;
     sdl3d_font direct_connect_font;
     sdl3d_ui_context *direct_connect_ui;
-    sdl3d_ui_context *discovery_ui;
     sdl3d_network_session *host_session;
     sdl3d_network_session *direct_connect_session;
-    sdl3d_network_discovery_session *discovery_session;
     char host_status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     char host_endpoint[SDL3D_NETWORK_MAX_STATUS_LENGTH];
     char direct_connect_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
@@ -49,8 +47,6 @@ typedef struct pong_state
     int lobby_start_connection;
     int host_start_signal_id;
     int camera_toggle_signal_id;
-    int discovery_refresh_signal_id;
-    int discovery_refresh_connection;
     sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
     bool network_match_termination_active;
     float network_match_termination_timer;
@@ -79,11 +75,8 @@ static const char PONG_NETWORK_BINDING_DISCONNECT[] = "disconnect";
 static const char PONG_NETWORK_BINDING_CLIENT_UP[] = "client_up";
 static const char PONG_NETWORK_BINDING_CLIENT_DOWN[] = "client_down";
 static const char PONG_NETWORK_BINDING_MENU_SELECT[] = "menu_select";
-static const char PONG_NETWORK_BINDING_MENU_BACK[] = "menu_back";
 static const char PONG_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
 static const char PONG_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
-static const char PONG_NETWORK_BINDING_DISCOVERY_REFRESH[] = "discovery_refresh";
-static const char PONG_NETWORK_BINDING_UI_SELECT[] = "ui_select";
 static const char PONG_DIRECT_CONNECT_SESSION[] = "direct_connect";
 static const char PONG_DIRECT_CONNECT_HOST_KEY[] = "direct_connect_host";
 static const char PONG_DIRECT_CONNECT_PORT_KEY[] = "direct_connect_port";
@@ -1210,247 +1203,6 @@ static void update_network_match_termination(sdl3d_game_context *ctx, pong_state
     }
 }
 
-static void destroy_discovery_session(pong_state *state)
-{
-    if (state != NULL && state->discovery_session != NULL)
-    {
-        sdl3d_network_discovery_session_destroy(state->discovery_session);
-        state->discovery_session = NULL;
-    }
-}
-
-static bool start_discovery_session(pong_state *state)
-{
-    sdl3d_network_discovery_session_desc desc;
-
-    if (state == NULL)
-    {
-        return false;
-    }
-
-    if (state->discovery_session != NULL)
-    {
-        return sdl3d_network_discovery_session_refresh(state->discovery_session);
-    }
-
-    sdl3d_network_discovery_session_desc_init(&desc);
-    desc.host = NULL;
-    desc.port = SDL3D_NETWORK_DEFAULT_PORT;
-    desc.local_port = 0;
-
-    if (!sdl3d_network_discovery_session_create(&desc, &state->discovery_session))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery create failed: %s", SDL_GetError());
-        return false;
-    }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery scanner ready for UDP %u",
-                (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
-    return sdl3d_network_discovery_session_refresh(state->discovery_session);
-}
-
-static void update_discovery_scene_state(pong_state *state)
-{
-    sdl3d_properties *scene_state = NULL;
-    const int result_count = state != NULL && state->discovery_session != NULL
-                                 ? sdl3d_network_discovery_session_result_count(state->discovery_session)
-                                 : 0;
-
-    if (state == NULL || state->data == NULL)
-    {
-        return;
-    }
-
-    scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-    if (scene_state == NULL)
-    {
-        return;
-    }
-
-    sdl3d_properties_set_int(
-        scene_state, network_scene_state_key(state, "discovery", "count", "multiplayer_discovery_count"), result_count);
-    sdl3d_properties_set_string(
-        scene_state, network_scene_state_key(state, "discovery", "status", "multiplayer_discovery_status"),
-        state->discovery_session != NULL ? sdl3d_network_discovery_session_status(state->discovery_session) : "Idle");
-    for (int i = 0; i < SDL3D_NETWORK_MAX_DISCOVERY_RESULTS; ++i)
-    {
-        char key_name[16];
-        char fallback_key[16];
-        sdl3d_network_discovery_result result;
-        char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
-        SDL_zero(result);
-        label[0] = '\0';
-        SDL_snprintf(key_name, sizeof(key_name), "result_%d", i);
-        SDL_snprintf(fallback_key, sizeof(fallback_key), "session_%d", i);
-
-        if (i < result_count && sdl3d_network_discovery_session_get_result(state->discovery_session, i, &result))
-        {
-            SDL_snprintf(label, sizeof(label), "%s  %s:%u%s%s",
-                         result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", result.host,
-                         (unsigned int)result.port, result.status[0] != '\0' ? "  " : "",
-                         result.status[0] != '\0' ? result.status : "");
-        }
-        sdl3d_properties_set_string(scene_state, network_scene_state_key(state, "discovery", key_name, fallback_key),
-                                    label);
-    }
-}
-
-static bool refresh_discovery_session(pong_state *state)
-{
-    if (state == NULL)
-    {
-        return false;
-    }
-
-    if (!start_discovery_session(state))
-    {
-        return false;
-    }
-
-    update_discovery_scene_state(state);
-    return true;
-}
-
-static bool start_discovered_match_connection(pong_state *state, int index)
-{
-    sdl3d_network_discovery_result result;
-    char port_buffer[16];
-
-    if (state == NULL || state->discovery_session == NULL)
-    {
-        return false;
-    }
-
-    SDL_zero(result);
-    if (!sdl3d_network_discovery_session_get_result(state->discovery_session, index, &result))
-    {
-        return false;
-    }
-
-    SDL_strlcpy(state->direct_connect_host, result.host, sizeof(state->direct_connect_host));
-    SDL_snprintf(port_buffer, sizeof(port_buffer), "%u", (unsigned int)result.port);
-    SDL_strlcpy(state->direct_connect_port, port_buffer, sizeof(state->direct_connect_port));
-    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-    if (scene_state != NULL)
-    {
-        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_HOST_KEY, state->direct_connect_host);
-        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_PORT_KEY, state->direct_connect_port);
-    }
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery auto-connecting to result %d: %s:%u session=%s",
-                index, result.host, (unsigned int)result.port,
-                result.session_name[0] != '\0' ? result.session_name : "SDL3D Session");
-    destroy_discovery_session(state);
-    if (!start_direct_connect_session(state))
-    {
-        return false;
-    }
-    SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "Match found. Connecting...");
-    if (scene_state != NULL)
-        sdl3d_properties_set_string(scene_state, PONG_DIRECT_CONNECT_STATUS_KEY, state->direct_connect_status);
-    return true;
-}
-
-static void emit_network_runtime_signal(sdl3d_game_context *ctx, pong_state *state, const char *name)
-{
-    const int signal_id = network_runtime_signal_id(state, name);
-    if (ctx == NULL || state == NULL || signal_id < 0)
-    {
-        return;
-    }
-    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(ctx->session), signal_id, NULL);
-}
-
-static void update_discovery_controls(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (ctx == NULL || state == NULL || state->data == NULL || state->input == NULL ||
-        !is_multiplayer_discovery_scene(state))
-    {
-        return;
-    }
-
-    const int back_action = network_runtime_action_id(state, PONG_NETWORK_BINDING_MENU_BACK);
-
-    if (back_action >= 0 && sdl3d_input_is_pressed(state->input, back_action))
-    {
-        emit_network_runtime_signal(ctx, state, PONG_NETWORK_BINDING_UI_SELECT);
-        destroy_discovery_session(state);
-        destroy_direct_connect_session(state);
-        (void)sdl3d_game_data_set_active_scene(state->data,
-                                               network_session_scene(state, "join", "scene.multiplayer.join"));
-    }
-}
-
-static void draw_discovery_overlay(sdl3d_game_context *ctx, pong_state *state)
-{
-    const int result_count = state != NULL && state->discovery_session != NULL
-                                 ? sdl3d_network_discovery_session_result_count(state->discovery_session)
-                                 : 0;
-    float panel_w;
-    float panel_h;
-    float panel_x;
-    float panel_y;
-
-    if (ctx == NULL || state == NULL || state->discovery_ui == NULL)
-    {
-        return;
-    }
-
-    panel_w = 820.0f;
-    panel_h = 500.0f;
-    panel_x = ((float)sdl3d_get_render_context_width(ctx->renderer) - panel_w) * 0.5f;
-    panel_y = ((float)sdl3d_get_render_context_height(ctx->renderer) - panel_h) * 0.5f;
-
-    sdl3d_ui_begin_panel(state->discovery_ui, panel_x, panel_y, panel_w, panel_h);
-    sdl3d_ui_begin_vbox(state->discovery_ui, panel_x + 28.0f, panel_y + 24.0f, panel_w - 56.0f, panel_h - 48.0f);
-    sdl3d_ui_layout_label(state->discovery_ui, "DISCOVER LOCAL MATCHES");
-    sdl3d_ui_separator(state->discovery_ui);
-
-    if (state->discovery_session != NULL)
-    {
-        const char *status = sdl3d_network_discovery_session_status(state->discovery_session);
-        if (status != NULL && status[0] != '\0')
-        {
-            sdl3d_ui_layout_label(state->discovery_ui, status);
-        }
-    }
-    else if (state->direct_connect_session != NULL)
-    {
-        if (sdl3d_network_session_is_connected(state->direct_connect_session))
-        {
-            sdl3d_ui_layout_label(state->discovery_ui, "Connected. Waiting for host to start...");
-        }
-        else
-        {
-            sdl3d_ui_layout_label(state->discovery_ui, state->direct_connect_status);
-        }
-    }
-
-    if (state->direct_connect_session != NULL)
-    {
-        sdl3d_ui_layout_label(state->discovery_ui, "The host will start the match.");
-    }
-    else if (result_count == 0)
-    {
-        sdl3d_ui_layout_label(state->discovery_ui, "Searching local network...");
-    }
-    else
-    {
-        sdl3d_ui_layout_label(state->discovery_ui, "Match found. Connecting...");
-    }
-
-    sdl3d_ui_separator(state->discovery_ui);
-    if (sdl3d_ui_layout_button(state->discovery_ui, "Back"))
-    {
-        destroy_discovery_session(state);
-        destroy_direct_connect_session(state);
-        (void)sdl3d_game_data_set_active_scene(state->data,
-                                               network_session_scene(state, "join", "scene.multiplayer.join"));
-    }
-
-    sdl3d_ui_end_vbox(state->discovery_ui);
-    sdl3d_ui_end_panel(state->discovery_ui);
-}
-
 static void update_host_session_status(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     if (state == NULL)
@@ -1539,30 +1291,6 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
     if (state->host_session != NULL)
     {
         update_host_session_scene_state(state);
-    }
-
-    if (is_multiplayer_discovery_scene(state) && state->direct_connect_session == NULL)
-    {
-        if (state->discovery_session == NULL)
-        {
-            (void)refresh_discovery_session(state);
-        }
-        else
-        {
-            if (!sdl3d_network_discovery_session_update(state->discovery_session, dt))
-            {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong LAN discovery update failed: %s", SDL_GetError());
-            }
-            update_discovery_scene_state(state);
-            if (sdl3d_network_discovery_session_result_count(state->discovery_session) > 0)
-            {
-                (void)start_discovered_match_connection(state, 0);
-            }
-        }
-    }
-    else if (state->discovery_session != NULL)
-    {
-        destroy_discovery_session(state);
     }
 
     if (state->direct_connect_session != NULL)
@@ -1809,22 +1537,6 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
     (void)start_selected_lobby_match(state);
 }
 
-static void on_multiplayer_discovery_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
-{
-    pong_state *state = (pong_state *)userdata;
-    (void)payload;
-
-    if (state == NULL || signal_id != state->discovery_refresh_signal_id)
-    {
-        return;
-    }
-
-    if (state->direct_connect_session == NULL)
-    {
-        (void)refresh_discovery_session(state);
-    }
-}
-
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
 {
 #if SDL3D_PONG_EMBEDDED_ASSETS
@@ -1904,18 +1616,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         state->assets = NULL;
         return false;
     }
-    if (!sdl3d_ui_create(&state->direct_connect_font, &state->discovery_ui))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong discovery UI create failed: %s", SDL_GetError());
-        sdl3d_ui_destroy(state->direct_connect_ui);
-        state->direct_connect_ui = NULL;
-        sdl3d_free_font(&state->direct_connect_font);
-        sdl3d_game_data_destroy(state->data);
-        state->data = NULL;
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
-        return false;
-    }
     reset_direct_connect_defaults(state);
     if (ctx != NULL && ctx->window != NULL)
     {
@@ -1925,19 +1625,10 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_ui_begin_frame_ex(state->direct_connect_ui, ctx->renderer, ctx->window);
     }
-    if (state->discovery_ui != NULL && ctx != NULL && ctx->renderer != NULL && ctx->window != NULL)
-    {
-        sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
-    }
     sdl3d_game_data_image_cache_init(&state->image_cache, state->assets);
     if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
     {
         sdl3d_game_data_image_cache_free(&state->image_cache);
-        if (state->discovery_ui != NULL)
-        {
-            sdl3d_ui_destroy(state->discovery_ui);
-            state->discovery_ui = NULL;
-        }
         if (state->direct_connect_ui != NULL)
         {
             sdl3d_ui_destroy(state->direct_connect_ui);
@@ -1965,10 +1656,8 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     }
     state->haptics_connection_count = 0;
     state->lobby_start_connection = 0;
-    state->discovery_refresh_connection = 0;
     state->host_start_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_LOBBY_START);
     state->camera_toggle_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_CAMERA_TOGGLE);
-    state->discovery_refresh_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_DISCOVERY_REFRESH);
     sdl3d_game_data_input_profile_refresh_state_init(&state->input_profile_refresh);
     SDL_snprintf(state->host_status, sizeof(state->host_status), "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",
@@ -1983,34 +1672,14 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
                 sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session), state->host_start_signal_id,
                                      on_multiplayer_lobby_signal, state);
         }
-        if (state->discovery_refresh_signal_id >= 0)
-        {
-            state->discovery_refresh_connection =
-                sdl3d_signal_connect(sdl3d_game_session_get_signal_bus(ctx->session),
-                                     state->discovery_refresh_signal_id, on_multiplayer_discovery_signal, state);
-        }
-    }
-    if (is_multiplayer_discovery_scene(state))
-    {
-        (void)refresh_discovery_session(state);
     }
     return true;
 }
 
 static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
 {
-    pong_state *state = (pong_state *)userdata;
-    if (state != NULL && is_multiplayer_discovery_scene(state) && state->discovery_ui != NULL && event != NULL)
-    {
-        const bool mouse_event = event->type == SDL_EVENT_MOUSE_MOTION || event->type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
-                                 event->type == SDL_EVENT_MOUSE_BUTTON_UP || event->type == SDL_EVENT_MOUSE_WHEEL;
-
-        if (mouse_event)
-        {
-            (void)sdl3d_ui_process_event(state->discovery_ui, event);
-            ctx->input_event_consumed = true;
-        }
-    }
+    (void)userdata;
+    (void)event;
     (void)ctx;
     return true;
 }
@@ -2021,7 +1690,6 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     refresh_local_play_input(state);
     update_network_match_termination(ctx, state, dt);
     update_multiplayer_sessions(ctx, state, dt);
-    update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
@@ -2039,7 +1707,6 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     refresh_local_play_input(state);
     update_network_match_termination(ctx, state, real_dt);
     update_multiplayer_sessions(ctx, state, real_dt);
-    update_discovery_controls(ctx, state);
     update_network_client_input_sensors(ctx, state);
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
@@ -2071,22 +1738,12 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
     frame.pulse_phase = state->frame_state.ui_pulse_phase;
     sdl3d_game_data_draw_frame(&frame);
 
-    if (is_multiplayer_discovery_scene(state))
-    {
-        draw_discovery_overlay(ctx, state);
-    }
     draw_network_match_termination_overlay(ctx, state);
     if (state->direct_connect_ui != NULL)
     {
         sdl3d_ui_end_frame(state->direct_connect_ui);
         sdl3d_ui_render(state->direct_connect_ui, ctx->renderer);
         sdl3d_ui_begin_frame_ex(state->direct_connect_ui, ctx->renderer, ctx->window);
-    }
-    if (state->discovery_ui != NULL)
-    {
-        sdl3d_ui_end_frame(state->discovery_ui);
-        sdl3d_ui_render(state->discovery_ui, ctx->renderer);
-        sdl3d_ui_begin_frame_ex(state->discovery_ui, ctx->renderer, ctx->window);
     }
 }
 
@@ -2103,17 +1760,6 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     {
         sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->lobby_start_connection);
         state->lobby_start_connection = 0;
-    }
-    if (state->discovery_refresh_connection > 0)
-    {
-        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->discovery_refresh_connection);
-        state->discovery_refresh_connection = 0;
-    }
-    destroy_discovery_session(state);
-    if (state->discovery_ui != NULL)
-    {
-        sdl3d_ui_destroy(state->discovery_ui);
-        state->discovery_ui = NULL;
     }
     if (state->direct_connect_ui != NULL)
     {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -1676,14 +1676,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     return true;
 }
 
-static bool pong_handle_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
-{
-    (void)userdata;
-    (void)event;
-    (void)ctx;
-    return true;
-}
-
 static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 {
     pong_state *state = (pong_state *)userdata;
@@ -1804,7 +1796,6 @@ int main(int argc, char **argv)
     sdl3d_game_callbacks callbacks;
     SDL_zero(callbacks);
     callbacks.init = pong_init;
-    callbacks.event = pong_handle_event;
     callbacks.tick = pong_tick;
     callbacks.pause_tick = pong_pause_tick;
     callbacks.render = pong_render;

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -737,6 +737,86 @@ owns session lifetime; host code can inspect the runtime-owned pointer with
 `sdl3d_game_data_get_network_direct_connect_session()` when it needs to send or
 receive game packets.
 
+LAN discovery flows can also be authored with reusable network data actions and
+dynamic-list menus. A typical scene starts or refreshes discovery on enter,
+observes it periodically, and lets a runtime-collection-backed list connect the
+selected row through the same direct-connect session used by manual host/port
+entry:
+
+```json
+{
+    "activity" : {
+        "enabled" : true,
+        "on_enter" : [
+            {
+                "type" : "network.discovery.start",
+                "name" : "local_matches",
+                "collection" : "local_matches",
+                "default_port" : 27183,
+                "status_key" : "local_match_status",
+                "count_key" : "local_match_count"
+            }
+        ],
+        "periodic" : [
+            {
+                "interval" : 0.05,
+                "actions" : [
+                    {
+                        "type" : "network.discovery.observe",
+                        "name" : "local_matches",
+                        "collection" : "local_matches",
+                        "update_seconds" : 0.05,
+                        "status_key" : "local_match_status",
+                        "count_key" : "local_match_count"
+                    }
+                ]
+            }
+        ]
+    },
+    "menus" : [
+        {
+            "name" : "menu.discovery",
+            "items" : [
+                {
+                    "type" : "dynamic_list",
+                    "name" : "list.local_matches",
+                    "source" : {
+                        "type" : "runtime_collection",
+                        "collection" : "local_matches",
+                        "label_field" : "label",
+                        "value_field" : "endpoint"
+                    },
+                    "empty_label" : "Searching local network...",
+                    "selected_index_key" : "local_match_index",
+                    "selected_value_key" : "local_match_endpoint",
+                    "signal" : "signal.discovery.connect"
+                }
+            ]
+        }
+    ]
+}
+```
+
+`network.discovery.start` and `network.discovery.refresh` create or refresh a
+runtime-owned UDP discovery scanner. `name` identifies the scanner,
+`collection` names the runtime collection populated with results, and `port` or
+`default_port` selects the discovery target port. Optional `host` and
+`local_port` fields are forwarded to the network discovery layer; omit `host`
+for normal LAN discovery behavior. Each result row publishes `label`, `name`,
+`host`, `port`, `status`, and `endpoint` fields. `network.discovery.observe`
+advances an existing scanner by `dt` or `update_seconds`, republishes the
+collection, and writes optional status/count scene-state outputs.
+`network.discovery.cancel` destroys the named scanner and clears the collection.
+
+`network.discovery.connect_selected` bridges discovery to direct connect. It
+reads `selected_index_key` or a literal `selected_index`, fetches `host` and
+`port` from that runtime collection row, writes optional `host_key` and
+`port_key` scene-state values for UI visibility, cancels discovery, and starts
+the named direct-connect session from `direct_connect_name`. `status_key`,
+`state_key`, and `connected_key` are the same direct-connect outputs described
+above. If no row is selected, it writes a "No session selected" error and does
+not create a session.
+
 Reusable options scenes should prefer immediate apply for settings where the
 player benefits from real-time feedback. Use Apply/Cancel snapshots only for
 screens that intentionally stage changes before committing them.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1938,6 +1938,46 @@ extern "C"
                                                                               const char *session_name);
 
     /**
+     * @brief Start or refresh a named runtime-owned LAN discovery scanner.
+     *
+     * Results are published to @p collection_name when provided. Each row
+     * contains `label`, `name`, `host`, `port`, `status`, and `endpoint`
+     * fields. @p status_key and @p count_key are optional scene-state outputs.
+     */
+    bool sdl3d_game_data_network_discovery_start(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                 const char *host, int port, int local_port,
+                                                 const char *collection_name, const char *status_key,
+                                                 const char *count_key);
+
+    /**
+     * @brief Advance a named discovery scanner and republish results.
+     */
+    bool sdl3d_game_data_network_discovery_update(sdl3d_game_data_runtime *runtime, const char *session_name, float dt,
+                                                  const char *collection_name, const char *status_key,
+                                                  const char *count_key);
+
+    /**
+     * @brief Cancel and destroy a named discovery scanner.
+     *
+     * Canceling an unknown scanner is a successful no-op.
+     */
+    bool sdl3d_game_data_network_discovery_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                  const char *collection_name, const char *status_key,
+                                                  const char *count_key, const char *status);
+
+    /**
+     * @brief Connect a direct-connect session to one row from a discovery collection.
+     *
+     * The selected collection row must contain `host` and `port` fields.
+     */
+    bool sdl3d_game_data_network_discovery_connect_selected(sdl3d_game_data_runtime *runtime,
+                                                            const char *discovery_name, const char *collection_name,
+                                                            int selected_index, const char *direct_connect_name,
+                                                            const char *host_key, const char *port_key,
+                                                            const char *status_key, const char *state_key,
+                                                            const char *connected_key, const char *connecting_status);
+
+    /**
      * @brief Read one item from an authored menu.
      *
      * @p index is zero based. Static returned strings remain owned by the

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -249,6 +249,12 @@ typedef struct runtime_direct_connect_session
     sdl3d_network_session *session;
 } runtime_direct_connect_session;
 
+typedef struct runtime_discovery_session
+{
+    char *name;
+    sdl3d_network_discovery_session *session;
+} runtime_discovery_session;
+
 typedef struct scene_activity_state
 {
     const char *scene;
@@ -323,6 +329,9 @@ typedef struct sdl3d_game_data_runtime
     runtime_direct_connect_session *direct_connect_sessions;
     int direct_connect_session_count;
     int direct_connect_session_capacity;
+    runtime_discovery_session *discovery_sessions;
+    int discovery_session_count;
+    int discovery_session_capacity;
     sdl3d_storage *storage;
     bool has_network_schema;
     Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
@@ -4947,6 +4956,240 @@ bool sdl3d_game_data_network_direct_connect_start(sdl3d_game_data_runtime *runti
     return true;
 }
 
+static runtime_discovery_session *find_discovery_session(sdl3d_game_data_runtime *runtime, const char *session_name)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->discovery_session_count; ++i)
+    {
+        if (SDL_strcmp(runtime->discovery_sessions[i].name, session_name) == 0)
+            return &runtime->discovery_sessions[i];
+    }
+    return NULL;
+}
+
+static runtime_discovery_session *get_or_create_discovery_session(sdl3d_game_data_runtime *runtime,
+                                                                  const char *session_name)
+{
+    runtime_discovery_session *existing = find_discovery_session(runtime, session_name);
+    if (existing != NULL)
+        return existing;
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+
+    if (runtime->discovery_session_count >= runtime->discovery_session_capacity)
+    {
+        const int next_capacity = runtime->discovery_session_capacity > 0 ? runtime->discovery_session_capacity * 2 : 2;
+        runtime_discovery_session *next = (runtime_discovery_session *)SDL_realloc(
+            runtime->discovery_sessions, (size_t)next_capacity * sizeof(*runtime->discovery_sessions));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + runtime->discovery_session_capacity, 0,
+                   (size_t)(next_capacity - runtime->discovery_session_capacity) *
+                       sizeof(*runtime->discovery_sessions));
+        runtime->discovery_sessions = next;
+        runtime->discovery_session_capacity = next_capacity;
+    }
+
+    runtime_discovery_session *entry = &runtime->discovery_sessions[runtime->discovery_session_count];
+    SDL_zero(*entry);
+    entry->name = SDL_strdup(session_name);
+    if (entry->name == NULL)
+        return NULL;
+    ++runtime->discovery_session_count;
+    return entry;
+}
+
+static void discovery_publish_manual_status(sdl3d_game_data_runtime *runtime, const char *collection_name,
+                                            const char *status_key, const char *count_key, const char *status,
+                                            int count)
+{
+    if (runtime == NULL)
+        return;
+    if (collection_name != NULL && collection_name[0] != '\0')
+        (void)sdl3d_game_data_runtime_collection_clear(runtime, collection_name);
+    if (runtime->scene_state != NULL && status_key != NULL && status_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, status_key, status != NULL ? status : "");
+    if (runtime->scene_state != NULL && count_key != NULL && count_key[0] != '\0')
+        sdl3d_properties_set_int(runtime->scene_state, count_key, count);
+}
+
+static void discovery_publish_results(sdl3d_game_data_runtime *runtime, const runtime_discovery_session *entry,
+                                      const char *collection_name, const char *status_key, const char *count_key)
+{
+    if (runtime == NULL)
+        return;
+
+    const int result_count =
+        entry != NULL && entry->session != NULL ? sdl3d_network_discovery_session_result_count(entry->session) : 0;
+    const char *status =
+        entry != NULL && entry->session != NULL ? sdl3d_network_discovery_session_status(entry->session) : "Idle";
+    if (status == NULL || status[0] == '\0')
+        status = result_count > 0 ? "Session found" : "Scanning";
+
+    if (collection_name != NULL && collection_name[0] != '\0')
+    {
+        (void)sdl3d_game_data_runtime_collection_clear(runtime, collection_name);
+        for (int i = 0; i < result_count; ++i)
+        {
+            sdl3d_network_discovery_result result;
+            char label[SDL3D_NETWORK_MAX_STATUS_LENGTH + SDL3D_NETWORK_MAX_HOST_LENGTH + 32];
+            char endpoint[SDL3D_NETWORK_MAX_HOST_LENGTH + 16];
+            SDL_zero(result);
+            if (!sdl3d_network_discovery_session_get_result(entry->session, i, &result))
+                continue;
+
+            SDL_snprintf(endpoint, sizeof(endpoint), "%s:%u", result.host, (unsigned int)result.port);
+            SDL_snprintf(label, sizeof(label), "%s  %s%s%s",
+                         result.session_name[0] != '\0' ? result.session_name : "SDL3D Session", endpoint,
+                         result.status[0] != '\0' ? "  " : "", result.status[0] != '\0' ? result.status : "");
+            (void)sdl3d_game_data_runtime_collection_set_string(runtime, collection_name, i, "label", label);
+            (void)sdl3d_game_data_runtime_collection_set_string(runtime, collection_name, i, "name",
+                                                                result.session_name[0] != '\0' ? result.session_name
+                                                                                               : "SDL3D Session");
+            (void)sdl3d_game_data_runtime_collection_set_string(runtime, collection_name, i, "host", result.host);
+            (void)sdl3d_game_data_runtime_collection_set_int(runtime, collection_name, i, "port", (int)result.port);
+            (void)sdl3d_game_data_runtime_collection_set_string(runtime, collection_name, i, "status", result.status);
+            (void)sdl3d_game_data_runtime_collection_set_string(runtime, collection_name, i, "endpoint", endpoint);
+        }
+    }
+
+    if (runtime->scene_state != NULL && status_key != NULL && status_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, status_key, status);
+    if (runtime->scene_state != NULL && count_key != NULL && count_key[0] != '\0')
+        sdl3d_properties_set_int(runtime->scene_state, count_key, result_count);
+}
+
+bool sdl3d_game_data_network_discovery_start(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                             const char *host, int port, int local_port, const char *collection_name,
+                                             const char *status_key, const char *count_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_discovery_session *entry = get_or_create_discovery_session(runtime, session_name);
+    if (entry == NULL)
+        return false;
+
+    if (port <= 0 || port > 65535 || local_port < 0 || local_port > 65535)
+    {
+        discovery_publish_manual_status(runtime, collection_name, status_key, count_key, "Invalid discovery port", 0);
+        return false;
+    }
+
+    if (entry->session == NULL)
+    {
+        sdl3d_network_discovery_session_desc desc;
+        sdl3d_network_discovery_session_desc_init(&desc);
+        desc.host = host != NULL && host[0] != '\0' ? host : NULL;
+        desc.port = (Uint16)port;
+        desc.local_port = (Uint16)local_port;
+        if (!sdl3d_network_discovery_session_create(&desc, &entry->session))
+        {
+            discovery_publish_manual_status(runtime, collection_name, status_key, count_key, SDL_GetError(), 0);
+            return false;
+        }
+    }
+
+    if (!sdl3d_network_discovery_session_refresh(entry->session))
+    {
+        discovery_publish_manual_status(runtime, collection_name, status_key, count_key, SDL_GetError(), 0);
+        return false;
+    }
+
+    discovery_publish_results(runtime, entry, collection_name, status_key, count_key);
+    return true;
+}
+
+bool sdl3d_game_data_network_discovery_update(sdl3d_game_data_runtime *runtime, const char *session_name, float dt,
+                                              const char *collection_name, const char *status_key,
+                                              const char *count_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_discovery_session *entry = find_discovery_session(runtime, session_name);
+    if (entry == NULL || entry->session == NULL)
+    {
+        discovery_publish_manual_status(runtime, collection_name, status_key, count_key, "Idle", 0);
+        return true;
+    }
+    if (dt < 0.0f)
+        dt = 0.0f;
+    if (!sdl3d_network_discovery_session_update(entry->session, dt))
+    {
+        discovery_publish_results(runtime, entry, collection_name, status_key, count_key);
+        return false;
+    }
+    discovery_publish_results(runtime, entry, collection_name, status_key, count_key);
+    return true;
+}
+
+bool sdl3d_game_data_network_discovery_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                              const char *collection_name, const char *status_key,
+                                              const char *count_key, const char *status)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_discovery_session *entry = find_discovery_session(runtime, session_name);
+    if (entry != NULL && entry->session != NULL)
+    {
+        sdl3d_network_discovery_session_destroy(entry->session);
+        entry->session = NULL;
+    }
+    discovery_publish_manual_status(runtime, collection_name, status_key, count_key,
+                                    status != NULL ? status : "Discovery canceled", 0);
+    return true;
+}
+
+bool sdl3d_game_data_network_discovery_connect_selected(sdl3d_game_data_runtime *runtime, const char *discovery_name,
+                                                        const char *collection_name, int selected_index,
+                                                        const char *direct_connect_name, const char *host_key,
+                                                        const char *port_key, const char *status_key,
+                                                        const char *state_key, const char *connected_key,
+                                                        const char *connecting_status)
+{
+    if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0' || selected_index < 0 ||
+        direct_connect_name == NULL || direct_connect_name[0] == '\0')
+    {
+        return false;
+    }
+
+    const runtime_collection *collection = find_runtime_collection_const(runtime, collection_name);
+    if (collection == NULL || selected_index >= collection->row_count || collection->rows[selected_index] == NULL)
+    {
+        direct_connect_publish_manual_status(runtime, status_key, state_key, connected_key, "No session selected",
+                                             "error", false);
+        return false;
+    }
+
+    const char *host = sdl3d_properties_get_string(collection->rows[selected_index], "host", NULL);
+    const sdl3d_value *port_value = sdl3d_properties_get_value(collection->rows[selected_index], "port");
+    const int port = port_value != NULL && port_value->type == SDL3D_VALUE_INT
+                         ? port_value->as_int
+                         : SDL_atoi(sdl3d_properties_get_string(collection->rows[selected_index], "port", "0"));
+    if (runtime->scene_state != NULL)
+    {
+        if (host_key != NULL && host_key[0] != '\0')
+            sdl3d_properties_set_string(runtime->scene_state, host_key, host != NULL ? host : "");
+        if (port_key != NULL && port_key[0] != '\0')
+        {
+            char port_text[16];
+            SDL_snprintf(port_text, sizeof(port_text), "%d", port);
+            sdl3d_properties_set_string(runtime->scene_state, port_key, port_text);
+        }
+    }
+
+    (void)sdl3d_game_data_network_discovery_cancel(runtime, discovery_name, collection_name, NULL, NULL,
+                                                   "Discovery canceled");
+    const bool ok = sdl3d_game_data_network_direct_connect_start(runtime, direct_connect_name, host, port, status_key,
+                                                                 state_key, connected_key);
+    if (ok && connecting_status != NULL && connecting_status[0] != '\0' && runtime->scene_state != NULL &&
+        status_key != NULL && status_key[0] != '\0')
+    {
+        sdl3d_properties_set_string(runtime->scene_state, status_key, connecting_status);
+    }
+    return ok;
+}
+
 static sdl3d_game_data_menu_control_type parse_menu_control_type(const char *type)
 {
     if (type == NULL)
@@ -9421,6 +9664,49 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
             json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL));
     }
 
+    if (SDL_strcmp(type, "network.discovery.start") == 0 || SDL_strcmp(type, "network.discovery.refresh") == 0)
+    {
+        const int default_port = json_int(action, "default_port", SDL3D_NETWORK_DEFAULT_PORT);
+        const int port = json_int_or_string(action, "port", default_port);
+        const int local_port = json_int_or_string(action, "local_port", 0);
+        return sdl3d_game_data_network_discovery_start(
+            runtime, json_string(action, "name", NULL), json_string(action, "host", NULL), port, local_port,
+            json_string(action, "collection", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "count_key", NULL));
+    }
+
+    if (SDL_strcmp(type, "network.discovery.observe") == 0)
+    {
+        return sdl3d_game_data_network_discovery_update(
+            runtime, json_string(action, "name", NULL),
+            json_float(action, "dt", json_float(action, "update_seconds", 0.016f)),
+            json_string(action, "collection", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "count_key", NULL));
+    }
+
+    if (SDL_strcmp(type, "network.discovery.cancel") == 0)
+    {
+        return sdl3d_game_data_network_discovery_cancel(
+            runtime, json_string(action, "name", NULL), json_string(action, "collection", NULL),
+            json_string(action, "status_key", NULL), json_string(action, "count_key", NULL),
+            json_string(action, "status", "Discovery canceled"));
+    }
+
+    if (SDL_strcmp(type, "network.discovery.connect_selected") == 0)
+    {
+        const char *index_key = json_string(action, "selected_index_key", NULL);
+        const int selected_index =
+            runtime != NULL && runtime->scene_state != NULL && index_key != NULL
+                ? sdl3d_properties_get_int(runtime->scene_state, index_key, json_int(action, "selected_index", 0))
+                : json_int(action, "selected_index", 0);
+        return sdl3d_game_data_network_discovery_connect_selected(
+            runtime, json_string(action, "name", NULL), json_string(action, "collection", NULL), selected_index,
+            json_string(action, "direct_connect_name", NULL), json_string(action, "host_key", NULL),
+            json_string(action, "port_key", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL),
+            json_string(action, "connecting_status", NULL));
+    }
+
     if (SDL_strcmp(type, "ui.animate") == 0)
         return start_ui_animation_from_json(runtime, action);
 
@@ -12095,6 +12381,11 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->direct_connect_sessions[i].name);
         sdl3d_network_session_destroy(runtime->direct_connect_sessions[i].session);
     }
+    for (int i = 0; i < runtime->discovery_session_count; ++i)
+    {
+        SDL_free(runtime->discovery_sessions[i].name);
+        sdl3d_network_discovery_session_destroy(runtime->discovery_sessions[i].session);
+    }
 
     clear_menu_text_entry_capture(runtime);
     sdl3d_script_engine_destroy(runtime->scripts);
@@ -12118,6 +12409,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->property_snapshots);
     SDL_free(runtime->collections);
     SDL_free(runtime->direct_connect_sessions);
+    SDL_free(runtime->discovery_sessions);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5162,14 +5162,16 @@ bool sdl3d_game_data_network_discovery_connect_selected(sdl3d_game_data_runtime 
     }
 
     const char *host = sdl3d_properties_get_string(collection->rows[selected_index], "host", NULL);
+    char host_copy[SDL3D_NETWORK_MAX_HOST_LENGTH];
     const sdl3d_value *port_value = sdl3d_properties_get_value(collection->rows[selected_index], "port");
     const int port = port_value != NULL && port_value->type == SDL3D_VALUE_INT
                          ? port_value->as_int
                          : SDL_atoi(sdl3d_properties_get_string(collection->rows[selected_index], "port", "0"));
+    SDL_strlcpy(host_copy, host != NULL ? host : "", sizeof(host_copy));
     if (runtime->scene_state != NULL)
     {
         if (host_key != NULL && host_key[0] != '\0')
-            sdl3d_properties_set_string(runtime->scene_state, host_key, host != NULL ? host : "");
+            sdl3d_properties_set_string(runtime->scene_state, host_key, host_copy);
         if (port_key != NULL && port_key[0] != '\0')
         {
             char port_text[16];
@@ -5180,8 +5182,8 @@ bool sdl3d_game_data_network_discovery_connect_selected(sdl3d_game_data_runtime 
 
     (void)sdl3d_game_data_network_discovery_cancel(runtime, discovery_name, collection_name, NULL, NULL,
                                                    "Discovery canceled");
-    const bool ok = sdl3d_game_data_network_direct_connect_start(runtime, direct_connect_name, host, port, status_key,
-                                                                 state_key, connected_key);
+    const bool ok = sdl3d_game_data_network_direct_connect_start(runtime, direct_connect_name, host_copy, port,
+                                                                 status_key, state_key, connected_key);
     if (ok && connecting_status != NULL && connecting_status[0] != '\0' && runtime->scene_state != NULL &&
         status_key != NULL && status_key[0] != '\0')
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2565,6 +2565,51 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "%s requires a non-empty name", type);
         return true;
     }
+    if (SDL_strcmp(type, "network.discovery.start") == 0 || SDL_strcmp(type, "network.discovery.refresh") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "%s requires a non-empty name", type);
+        if (!is_non_empty_string(action, "collection"))
+            return validation_error(ctx, json_path, "%s requires a non-empty collection", type);
+        if (!validate_network_port_value(ctx, obj_get(action, "port"), json_path, "network.discovery port"))
+            return false;
+        yyjson_val *default_port = obj_get(action, "default_port");
+        if (default_port != NULL &&
+            (!yyjson_is_int(default_port) || yyjson_get_int(default_port) <= 0 || yyjson_get_int(default_port) > 65535))
+            return validation_error(ctx, json_path, "network.discovery default_port must be integer 1..65535");
+        yyjson_val *local_port = obj_get(action, "local_port");
+        if (local_port != NULL &&
+            (!yyjson_is_int(local_port) || yyjson_get_int(local_port) < 0 || yyjson_get_int(local_port) > 65535))
+            return validation_error(ctx, json_path, "network.discovery local_port must be integer 0..65535");
+        return true;
+    }
+    if (SDL_strcmp(type, "network.discovery.observe") == 0 || SDL_strcmp(type, "network.discovery.cancel") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "%s requires a non-empty name", type);
+        if (!is_non_empty_string(action, "collection"))
+            return validation_error(ctx, json_path, "%s requires a non-empty collection", type);
+        return true;
+    }
+    if (SDL_strcmp(type, "network.discovery.connect_selected") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "network.discovery.connect_selected requires a non-empty name");
+        if (!is_non_empty_string(action, "collection"))
+            return validation_error(ctx, json_path,
+                                    "network.discovery.connect_selected requires a non-empty collection");
+        if (!is_non_empty_string(action, "selected_index_key") && obj_get(action, "selected_index") == NULL)
+            return validation_error(ctx, json_path,
+                                    "network.discovery.connect_selected requires selected_index_key or selected_index");
+        yyjson_val *selected_index = obj_get(action, "selected_index");
+        if (selected_index != NULL && (!yyjson_is_int(selected_index) || yyjson_get_int(selected_index) < 0))
+            return validation_error(ctx, json_path,
+                                    "network.discovery.connect_selected selected_index must be an integer >= 0");
+        if (!is_non_empty_string(action, "direct_connect_name"))
+            return validation_error(ctx, json_path,
+                                    "network.discovery.connect_selected requires a non-empty direct_connect_name");
+        return true;
+    }
     if (SDL_strcmp(type, "ui.animate") == 0)
     {
         if (!is_non_empty_string(action, "target") && !is_non_empty_string(action, "ui"))

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6340,11 +6340,20 @@ TEST(GameDataRuntime, AuthoredDiscoveryConnectActionsUpdateSceneState)
         sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "endpoint", "127.0.0.1:65535"));
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
 
-    EXPECT_NE(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
     EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_host", ""), "127.0.0.1");
     EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_port", ""), "65535");
-    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Match found. Connecting...");
     EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
+    if (sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect") != nullptr)
+    {
+        EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""),
+                     "Match found. Connecting...");
+    }
+    else
+    {
+        EXPECT_NE(std::string(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""))
+                      .find("networking is disabled"),
+                  std::string::npos);
+    }
 
     const int cancel_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.discovery.cancel");
     ASSERT_GE(cancel_signal, 0);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1918,7 +1918,17 @@ TEST(GameDataRuntime, ExposesDataDrivenScenesAndMenus)
     EXPECT_STREQ(item.scene, "scene.multiplayer.join");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.multiplayer.discovery"));
-    EXPECT_FALSE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    ASSERT_TRUE(sdl3d_game_data_get_active_menu(runtime, &menu));
+    EXPECT_STREQ(menu.name, "menu.multiplayer.discovery");
+    EXPECT_EQ(menu.item_count, 2);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 0, &item));
+    EXPECT_TRUE(item.dynamic_list_item);
+    EXPECT_EQ(item.dynamic_list_index, -1);
+    EXPECT_STREQ(item.label, "Searching local network...");
+    EXPECT_EQ(item.signal_id, -1);
+    ASSERT_TRUE(sdl3d_game_data_get_menu_item(runtime, menu.name, 1, &item));
+    EXPECT_STREQ(item.label, "Back");
+    EXPECT_STREQ(item.scene, "scene.multiplayer.join");
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.options"));
     EXPECT_FALSE(sdl3d_game_data_active_scene_updates_game(runtime));
@@ -6283,6 +6293,55 @@ TEST(GameDataRuntime, AuthoredDirectConnectActionsUpdateSceneState)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, AuthoredDiscoveryConnectActionsUpdateSceneState)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    const int connect_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.discovery.connect");
+    ASSERT_GE(connect_signal, 0);
+
+    sdl3d_properties_set_int(scene_state, "local_match_index", 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "No session selected");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_state", ""), "error");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
+
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "label", "Local Pong Host"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "name", "Local Pong Host"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "host", "127.0.0.1"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_int(runtime, "local_matches", 0, "port", 0));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "endpoint", "127.0.0.1:0"));
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 1);
+
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
+
+    EXPECT_EQ(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_host", ""), "127.0.0.1");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_port", ""), "0");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Invalid port");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_state", ""), "error");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
+
+    const int cancel_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.discovery.cancel");
+    ASSERT_GE(cancel_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), cancel_signal, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "local_match_status", ""), "Discovery canceled");
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "local_match_count", -1), 0);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, RejectsInvalidDirectConnectActions)
 {
     const std::filesystem::path dir = unique_test_dir("bad_direct_connect_actions");
@@ -6312,6 +6371,67 @@ TEST(GameDataRuntime, RejectsInvalidDirectConnectActions)
         std::string(error).find("network.direct_connect.start port must be a non-empty string or integer 1..65535"),
         std::string::npos)
         << error;
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidDiscoveryActions)
+{
+    struct Case
+    {
+        const char *name;
+        const char *action_json;
+        const char *expected_error;
+    };
+
+    const Case cases[] = {
+        {
+            "bad_port",
+            R"json({ "type": "network.discovery.start", "name": "local", "collection": "matches", "port": 70000 })json",
+            "network.discovery port must be a non-empty string or integer 1..65535",
+        },
+        {
+            "missing_collection",
+            R"json({ "type": "network.discovery.observe", "name": "local" })json",
+            "network.discovery.observe requires a non-empty collection",
+        },
+        {
+            "missing_selection",
+            R"json({ "type": "network.discovery.connect_selected", "name": "local", "collection": "matches", "direct_connect_name": "direct" })json",
+            "network.discovery.connect_selected requires selected_index_key or selected_index",
+        },
+    };
+
+    const std::filesystem::path dir = unique_test_dir("bad_discovery_actions");
+    for (const Case &test_case : cases)
+    {
+        const std::string json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Discovery", "id": "test.bad_discovery", "version": "0.1.0" },
+  "world": { "name": "world.bad_discovery", "kind": "fixed_screen" },
+  "entities": [],
+  "signals": ["signal.discovery"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.discovery",
+        "actions": [
+)json") + test_case.action_json +
+                                 R"json(
+        ]
+      }
+    ]
+  }
+})json";
+        write_text(dir / (std::string(test_case.name) + ".game.json"), json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(
+            (dir / (std::string(test_case.name) + ".game.json")).string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
     remove_test_dir(dir);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6332,6 +6332,20 @@ TEST(GameDataRuntime, AuthoredDiscoveryConnectActionsUpdateSceneState)
     EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "direct_connect_connected", true));
     EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
 
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "label", "Valid Pong Host"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "name", "Valid Pong Host"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "host", "127.0.0.1"));
+    ASSERT_TRUE(sdl3d_game_data_runtime_collection_set_int(runtime, "local_matches", 0, "port", 65535));
+    ASSERT_TRUE(
+        sdl3d_game_data_runtime_collection_set_string(runtime, "local_matches", 0, "endpoint", "127.0.0.1:65535"));
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), connect_signal, nullptr);
+
+    EXPECT_NE(sdl3d_game_data_get_network_direct_connect_session(runtime, "direct_connect"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_host", ""), "127.0.0.1");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_port", ""), "65535");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Match found. Connecting...");
+    EXPECT_EQ(sdl3d_game_data_runtime_collection_count(runtime, "local_matches"), 0);
+
     const int cancel_signal = sdl3d_game_data_find_signal(runtime, "signal.multiplayer.discovery.cancel");
     ASSERT_GE(cancel_signal, 0);
     sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), cancel_signal, nullptr);


### PR DESCRIPTION
## Summary
- Add reusable game-data network discovery actions for start/refresh/observe/cancel/connect-selected flows
- Publish LAN discovery results through runtime collections for dynamic-list menus
- Convert Pong local-match discovery from native overlay/input code to authored scene activity, signals, and UI
- Document discovery actions and add focused validation/runtime coverage

## Tests
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_network_test sdl3d_pong_multiplayer_test pong_demo -j4`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_network_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `python3 -m json.tool demos/pong/data/pong.game.json`
- `python3 -m json.tool demos/pong/data/scenes/multiplayer_discovery.scene.json`
- `git diff --check`

Part of #201.