### PR TITLE
Add generic data game runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(
         src/audio.c
         src/camera.c
         src/collision.c
+        src/data_game.c
         src/door.c
         src/drawing3d.c
         src/effects.c

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -9,9 +9,9 @@
 #include <string.h>
 
 #include "sdl3d/asset.h"
+#include "sdl3d/data_game.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
-#include "sdl3d/game_presentation.h"
 #include "sdl3d/network.h"
 #include "sdl3d/properties.h"
 #include "sdl3d/signal_bus.h"
@@ -22,13 +22,8 @@
 
 typedef struct pong_state
 {
-    sdl3d_asset_resolver *assets;
+    sdl3d_data_game_runtime *runtime;
     sdl3d_game_data_runtime *data;
-    sdl3d_game_data_font_cache font_cache;
-    sdl3d_game_data_image_cache image_cache;
-    sdl3d_game_data_particle_cache particle_cache;
-    sdl3d_game_data_app_flow app_flow;
-    sdl3d_game_data_frame_state frame_state;
     sdl3d_input_manager *input;
     sdl3d_network_session *host_session;
     sdl3d_network_session *direct_connect_session;
@@ -37,13 +32,9 @@ typedef struct pong_state
     char direct_connect_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
     char direct_connect_port[16];
     char direct_connect_status[SDL3D_NETWORK_MAX_STATUS_LENGTH];
-    int *haptics_signal_ids;
-    int *haptics_connections;
-    int haptics_connection_count;
     int lobby_start_connection;
     int host_start_signal_id;
     int camera_toggle_signal_id;
-    sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
     bool network_match_termination_active;
     float network_match_termination_timer;
     char network_match_termination_reason[96];
@@ -1415,113 +1406,17 @@ static void refresh_local_play_input(pong_state *state)
     char error[256] = {0};
     const char *profile_name = NULL;
     bool applied = false;
-    if (!sdl3d_game_data_apply_active_input_profile_on_device_change(
-            state->data, state->input, &state->input_profile_refresh, &profile_name, &applied, error, sizeof(error)))
+    if (!sdl3d_data_game_runtime_refresh_input_profile_on_device_change(state->runtime, state->input, &profile_name,
+                                                                        &applied, error, sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile hotplug refresh failed: %s",
                     error[0] != '\0' ? error : "unknown error");
     }
     else if (applied)
     {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile refreshed: profile=%s role=%s gamepads=%d",
-                    profile_name != NULL ? profile_name : "<none>", network_role_name(state),
-                    state->input_profile_refresh.gamepad_count);
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong input profile refreshed: profile=%s role=%s",
+                    profile_name != NULL ? profile_name : "<none>", network_role_name(state));
     }
-}
-
-static void on_gamepad_feedback(void *userdata, int signal_id, const sdl3d_properties *payload)
-{
-    pong_state *state = (pong_state *)userdata;
-    if (state == NULL || state->data == NULL || state->input == NULL)
-    {
-        return;
-    }
-
-    const int policy_count = sdl3d_game_data_haptics_policy_count(state->data);
-    for (int i = 0; i < policy_count; ++i)
-    {
-        sdl3d_game_data_haptics_policy policy;
-        if (!sdl3d_game_data_match_haptics_policy(state->data, i, signal_id, payload, &policy))
-            continue;
-        if (!sdl3d_input_rumble_all_gamepads(state->input, policy.low_frequency, policy.high_frequency,
-                                             policy.duration_ms))
-        {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Pong haptics policy '%s' requested rumble but no gamepad accepted it",
-                        policy.name != NULL ? policy.name : "<unnamed>");
-        }
-    }
-}
-
-static bool pong_haptics_signal_connected(const pong_state *state, int signal_id)
-{
-    if (state == NULL || signal_id < 0)
-        return true;
-    for (int i = 0; i < state->haptics_connection_count; ++i)
-    {
-        if (state->haptics_signal_ids != NULL && state->haptics_signal_ids[i] == signal_id)
-            return true;
-    }
-    return false;
-}
-
-static void connect_haptics_policies(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (ctx == NULL || state == NULL || state->data == NULL || state->input == NULL)
-        return;
-
-    const int policy_count = sdl3d_game_data_haptics_policy_count(state->data);
-    if (policy_count <= 0)
-        return;
-
-    state->haptics_signal_ids = SDL_calloc((size_t)policy_count, sizeof(*state->haptics_signal_ids));
-    state->haptics_connections = SDL_calloc((size_t)policy_count, sizeof(*state->haptics_connections));
-    if (state->haptics_signal_ids == NULL || state->haptics_connections == NULL)
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong failed to allocate haptics signal connections");
-        SDL_free(state->haptics_signal_ids);
-        SDL_free(state->haptics_connections);
-        state->haptics_signal_ids = NULL;
-        state->haptics_connections = NULL;
-        return;
-    }
-
-    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
-    for (int i = 0; i < policy_count; ++i)
-    {
-        sdl3d_game_data_haptics_policy policy;
-        if (!sdl3d_game_data_get_haptics_policy_at(state->data, i, &policy) ||
-            pong_haptics_signal_connected(state, policy.signal_id))
-        {
-            continue;
-        }
-
-        const int connection = sdl3d_signal_connect(bus, policy.signal_id, on_gamepad_feedback, state);
-        if (connection > 0)
-        {
-            state->haptics_signal_ids[state->haptics_connection_count] = policy.signal_id;
-            state->haptics_connections[state->haptics_connection_count] = connection;
-            ++state->haptics_connection_count;
-        }
-    }
-}
-
-static void disconnect_haptics_policies(sdl3d_game_context *ctx, pong_state *state)
-{
-    if (ctx == NULL || state == NULL)
-        return;
-
-    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(ctx->session);
-    for (int i = 0; i < state->haptics_connection_count; ++i)
-    {
-        if (state->haptics_connections != NULL && state->haptics_connections[i] > 0)
-            sdl3d_signal_disconnect(bus, state->haptics_connections[i]);
-    }
-    SDL_free(state->haptics_signal_ids);
-    SDL_free(state->haptics_connections);
-    state->haptics_signal_ids = NULL;
-    state->haptics_connections = NULL;
-    state->haptics_connection_count = 0;
 }
 
 static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
@@ -1549,34 +1444,35 @@ static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int err
 #endif
 }
 
+static bool mount_pong_assets_for_runtime(sdl3d_asset_resolver *assets, void *userdata, char *error, int error_size)
+{
+    (void)userdata;
+    return mount_pong_assets(assets, error, error_size);
+}
+
 static bool init_game_data(sdl3d_game_context *ctx, pong_state *state)
 {
-    state->assets = sdl3d_asset_resolver_create();
-    if (state->assets == NULL)
+    sdl3d_data_game_runtime_desc desc;
+    char error[512] = {0};
+
+    if (ctx == NULL || state == NULL)
     {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong asset resolver allocation failed");
         return false;
     }
 
-    char error[512];
-    bool assets_ready = mount_pong_assets(state->assets, error, (int)sizeof(error));
-    if (!assets_ready)
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong asset mount failed: %s", error);
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
-        return false;
-    }
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = ctx->session;
+    desc.data_asset_path = SDL3D_PONG_DATA_ASSET_PATH;
+    desc.media_dir = SDL3D_MEDIA_DIR;
+    desc.mount_assets = mount_pong_assets_for_runtime;
 
-    if (!sdl3d_game_data_load_asset(state->assets, SDL3D_PONG_DATA_ASSET_PATH, ctx->session, &state->data, error,
-                                    (int)sizeof(error)))
+    if (!sdl3d_data_game_runtime_create(&desc, &state->runtime, error, (int)sizeof(error)))
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pong data load failed: %s", error);
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
         return false;
     }
 
+    state->data = sdl3d_data_game_runtime_data(state->runtime);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong data loaded: asset=%s active_scene=%s", SDL3D_PONG_DATA_ASSET_PATH,
                 sdl3d_game_data_active_scene(state->data) != NULL ? sdl3d_game_data_active_scene(state->data)
                                                                   : "<none>");
@@ -1588,10 +1484,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
 {
     pong_state *state = (pong_state *)userdata;
     SDL_zero(*state);
-    sdl3d_game_data_font_cache_init(&state->font_cache, SDL3D_MEDIA_DIR);
-    sdl3d_game_data_particle_cache_init(&state->particle_cache);
-    sdl3d_game_data_app_flow_init(&state->app_flow);
-    sdl3d_game_data_frame_state_init(&state->frame_state);
 
     if (!init_game_data(ctx, state))
     {
@@ -1599,24 +1491,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
     }
     reset_direct_connect_defaults(state);
     publish_network_match_termination_scene_state(state);
-    if (ctx != NULL && ctx->window != NULL)
-    {
-        SDL_StartTextInput(ctx->window);
-    }
-    sdl3d_game_data_image_cache_init(&state->image_cache, state->assets);
-    if (!sdl3d_game_data_app_flow_start(&state->app_flow, state->data))
-    {
-        sdl3d_game_data_image_cache_free(&state->image_cache);
-        if (ctx != NULL && ctx->window != NULL)
-        {
-            SDL_StopTextInput(ctx->window);
-        }
-        sdl3d_game_data_destroy(state->data);
-        state->data = NULL;
-        sdl3d_asset_resolver_destroy(state->assets);
-        state->assets = NULL;
-        return false;
-    }
 
     state->input = sdl3d_game_session_get_input(ctx->session);
     const int gamepad_count = state->input != NULL ? sdl3d_input_gamepad_count(state->input) : 0;
@@ -1626,18 +1500,15 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong gamepad slot: slot=%d id=%d connected=%d", i,
                     sdl3d_input_gamepad_id_at(state->input, i), sdl3d_input_gamepad_is_connected(state->input, i));
     }
-    state->haptics_connection_count = 0;
     state->lobby_start_connection = 0;
     state->host_start_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_LOBBY_START);
     state->camera_toggle_signal_id = network_runtime_signal_id(state, PONG_NETWORK_BINDING_CAMERA_TOGGLE);
-    sdl3d_game_data_input_profile_refresh_state_init(&state->input_profile_refresh);
     SDL_snprintf(state->host_status, sizeof(state->host_status), "Not hosting");
     SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",
                  (unsigned int)SDL3D_NETWORK_DEFAULT_PORT);
     update_host_session_scene_state(state);
     if (state->input != NULL)
     {
-        connect_haptics_policies(ctx, state);
         if (state->host_start_signal_id >= 0)
         {
             state->lobby_start_connection =
@@ -1655,13 +1526,7 @@ static void pong_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     update_network_match_termination(ctx, state, dt);
     update_multiplayer_sessions(ctx, state, dt);
     update_network_client_input_sensors(ctx, state);
-
-    const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
-                                                     .runtime = state->data,
-                                                     .app_flow = &state->app_flow,
-                                                     .particle_cache = &state->particle_cache,
-                                                     .dt = dt};
-    (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
+    (void)sdl3d_data_game_runtime_update_frame(state->runtime, ctx, dt);
     publish_multiplayer_state(ctx, state);
 }
 
@@ -1672,13 +1537,7 @@ static void pong_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     update_network_match_termination(ctx, state, real_dt);
     update_multiplayer_sessions(ctx, state, real_dt);
     update_network_client_input_sensors(ctx, state);
-
-    const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
-                                                     .runtime = state->data,
-                                                     .app_flow = &state->app_flow,
-                                                     .particle_cache = &state->particle_cache,
-                                                     .dt = real_dt};
-    (void)sdl3d_game_data_update_frame(&state->frame_state, &frame);
+    (void)sdl3d_data_game_runtime_update_frame(state->runtime, ctx, real_dt);
     publish_multiplayer_state(ctx, state);
 }
 
@@ -1686,32 +1545,13 @@ static void pong_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 {
     pong_state *state = (pong_state *)userdata;
     (void)alpha;
-
-    sdl3d_game_data_frame_state_record_render(&state->frame_state, ctx, state->data);
-
-    sdl3d_game_data_frame_desc frame;
-    SDL_zero(frame);
-    frame.runtime = state->data;
-    frame.renderer = ctx->renderer;
-    frame.font_cache = &state->font_cache;
-    frame.image_cache = &state->image_cache;
-    frame.particle_cache = &state->particle_cache;
-    frame.app_flow = &state->app_flow;
-    frame.metrics = &state->frame_state.metrics;
-    frame.render_eval = &state->frame_state.render_eval;
-    frame.pulse_phase = state->frame_state.ui_pulse_phase;
-    sdl3d_game_data_draw_frame(&frame);
+    sdl3d_data_game_runtime_render(state->runtime, ctx);
 }
 
 static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
 {
     pong_state *state = (pong_state *)userdata;
-    (void)ctx;
 
-    sdl3d_game_data_particle_cache_free(&state->particle_cache);
-    sdl3d_game_data_image_cache_free(&state->image_cache);
-    sdl3d_game_data_font_cache_free(&state->font_cache);
-    disconnect_haptics_policies(ctx, state);
     if (state->lobby_start_connection > 0)
     {
         sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(ctx->session), state->lobby_start_connection);
@@ -1719,15 +1559,10 @@ static void pong_shutdown(sdl3d_game_context *ctx, void *userdata)
     }
     destroy_host_session(state);
     destroy_direct_connect_session(state);
-    if (ctx != NULL && ctx->window != NULL)
-    {
-        SDL_StopTextInput(ctx->window);
-    }
     state->input = NULL;
-    sdl3d_game_data_destroy(state->data);
+    sdl3d_data_game_runtime_destroy(state->runtime);
+    state->runtime = NULL;
     state->data = NULL;
-    sdl3d_asset_resolver_destroy(state->assets);
-    state->assets = NULL;
 }
 
 int main(int argc, char **argv)

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -1,0 +1,65 @@
+# Data Game Runtime
+
+`sdl3d_data_game_runtime` is the first engine-owned runtime layer for games
+authored primarily with JSON, Lua, and assets. It is intended to replace
+per-demo lifecycle code such as Pong's custom asset/data/caches/app-flow setup.
+
+The runtime is game-agnostic. It does not know scene names, actor names, input
+actions, or replication channels for a specific game.
+
+## Responsibilities
+
+The runtime currently owns:
+
+- asset resolver creation
+- caller-provided asset mounting
+- root game JSON loading
+- font, image, and particle presentation caches
+- authored app-flow startup and frame update
+- authored frame render through `sdl3d_game_data_draw_frame`
+- haptics policy signal wiring
+- input-profile hotplug refresh state
+- ordered cleanup
+
+Hosts still own the outer SDL process loop through `sdl3d_run_game`. For now,
+Pong also still owns network session orchestration. Future slices should move
+that orchestration into a managed network runtime so Pong can run through a
+generic runner without a custom `main.c`.
+
+## Startup Shape
+
+A host creates a normal `sdl3d_game_session`, fills a
+`sdl3d_data_game_runtime_desc`, and calls
+`sdl3d_data_game_runtime_create`.
+
+The descriptor requires:
+
+- `session`: the game session that provides input, signals, timers, logic, and
+  optional audio
+- `data_asset_path`: the root game JSON asset path, for example
+  `asset://pong.game.json`
+
+The descriptor may also include:
+
+- `media_dir`: built-in font/media root
+- `mount_assets`: callback used to mount a directory, pack, or embedded pack
+- `mount_userdata`: user data passed to `mount_assets`
+
+## Frame Use
+
+During the managed loop:
+
+- call `sdl3d_data_game_runtime_update_frame` from tick and pause tick paths
+- call `sdl3d_data_game_runtime_render` from the render callback
+- call `sdl3d_data_game_runtime_refresh_input_profile_on_device_change` when a
+  scene or host policy wants device-count hotplug rebinding
+
+The outer loop still controls fixed timestep, SDL events, input snapshots,
+audio frame updates, and presentation.
+
+## Why This Matters
+
+This API is a stepping stone toward a generic SDL3D runner. Once network
+session orchestration is also managed by the engine runtime, a game package
+should be able to ship as JSON, Lua, and assets rather than as a custom C
+program linked against SDL3D.

--- a/docs/pong-c-audit.md
+++ b/docs/pong-c-audit.md
@@ -40,16 +40,19 @@ assets, and run without game-specific C.
 
 ### Generic Data Game Loop
 
-`pong_tick`, `pong_pause_tick`, `pong_render`, and `pong_shutdown` mostly call
-generic systems:
+The first reusable runtime slice now lives in `sdl3d_data_game_runtime`. Pong no
+longer owns asset resolver creation, game-data loading, app-flow/frame state,
+presentation caches, haptics policy wiring, or authored frame rendering
+directly.
+
+`pong_tick`, `pong_pause_tick`, `pong_render`, and `pong_shutdown` still exist,
+but they are now compatibility callbacks around generic runtime calls plus
+Pong's remaining network orchestration:
 
 - input profile hotplug refresh
-- game-data frame update
-- app-flow update
-- particle/image/font caches
-- presentation frame drawing
-- haptics policy signal wiring
-- cleanup for sessions and data runtime
+- network session updates
+- game-data frame update/render
+- cleanup for remaining session state
 
 These should become a managed data-game loop in the engine runtime. A game
 package should opt into standard phases and policies from JSON instead of
@@ -81,12 +84,6 @@ status, match termination messages, and network role/flow handoff.
 These are generic UI/runtime status concepts. The runner should provide data
 actions or managed bindings for session status, peer lists, selected peers,
 termination reasons, and return scenes.
-
-### Haptics Policy Wiring
-
-Pong still connects haptics policy signals in C. The policies themselves are
-data-authored and generic. The engine runtime can connect these automatically
-when a game data runtime is loaded.
 
 ### Diagnostic Logging
 
@@ -127,15 +124,12 @@ Deprecate the custom Pong host by adding a generic SDL3D runner/runtime.
 
 Recommended first runtime slice:
 
-1. Add an `sdl3d_data_game_runtime` API that owns asset mounting, data loading,
-   app-flow/frame state, caches, haptics policy wiring, input-profile refresh,
-   update, render, pause update, and shutdown.
-2. Add a small runner executable that launches a game data asset or pack through
+1. Add a small runner executable that launches a game data asset or pack through
    that API.
-3. Convert `demos/pong/main.c` into either a thin compatibility wrapper around
+2. Convert `demos/pong/main.c` into either a thin compatibility wrapper around
    the runner API or remove it from the normal path once the runner can launch
    Pong.
-4. Keep multiplayer orchestration in Pong C only until the next slice moves it
+3. Keep multiplayer orchestration in Pong C only until the next slice moves it
    into a managed network-session runtime.
 
 ## Definition Of Done For Pong Without `main.c`

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -1,0 +1,129 @@
+/**
+ * @file data_game.h
+ * @brief Generic runtime for JSON/Lua-authored SDL3D games.
+ *
+ * The data-game runtime owns the common lifecycle needed by games authored
+ * through SDL3D game data: asset mounting, game JSON loading, app-flow/frame
+ * state, presentation caches, haptics policy wiring, input-profile hotplug
+ * state, update, render, and shutdown. Game-specific hosts should prefer this
+ * API over duplicating lifecycle code.
+ */
+
+#ifndef SDL3D_DATA_GAME_H
+#define SDL3D_DATA_GAME_H
+
+#include <stdbool.h>
+
+#include "sdl3d/asset.h"
+#include "sdl3d/game.h"
+#include "sdl3d/game_data.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /** @brief Opaque runtime for one loaded data-authored game package. */
+    typedef struct sdl3d_data_game_runtime sdl3d_data_game_runtime;
+
+    /**
+     * @brief Callback used to mount game assets into a new resolver.
+     *
+     * The runtime creates the resolver and then calls this function before
+     * loading @ref sdl3d_data_game_runtime_desc::data_asset_path. The callback
+     * should mount a directory, pack file, embedded pack, or any combination of
+     * asset roots needed by the game package.
+     *
+     * @param assets Runtime-owned resolver to populate.
+     * @param userdata Caller-provided pointer from the runtime descriptor.
+     * @param error_buffer Optional buffer for a failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true on success, false on mount failure.
+     */
+    typedef bool (*sdl3d_data_game_mount_assets_fn)(sdl3d_asset_resolver *assets, void *userdata, char *error_buffer,
+                                                    int error_buffer_size);
+
+    /** @brief Creation descriptor for a generic data-game runtime. */
+    typedef struct sdl3d_data_game_runtime_desc
+    {
+        /** @brief Session containing input, signals, timers, logic, and optional audio. Required. */
+        sdl3d_game_session *session;
+        /** @brief Asset path to the root game JSON, such as `asset://pong.game.json`. Required. */
+        const char *data_asset_path;
+        /** @brief Media directory used by built-in font loading. Optional. */
+        const char *media_dir;
+        /** @brief Optional callback that mounts game assets into the runtime resolver. */
+        sdl3d_data_game_mount_assets_fn mount_assets;
+        /** @brief Userdata passed to @ref mount_assets. */
+        void *mount_userdata;
+    } sdl3d_data_game_runtime_desc;
+
+    /**
+     * @brief Initialize a runtime descriptor with NULL/default fields.
+     */
+    void sdl3d_data_game_runtime_desc_init(sdl3d_data_game_runtime_desc *desc);
+
+    /**
+     * @brief Create and start a generic data-game runtime.
+     *
+     * This creates an asset resolver, mounts assets, loads the authored game
+     * data into @p desc->session, initializes presentation caches, starts the
+     * authored app flow, and connects authored haptics policies.
+     *
+     * @param desc Runtime descriptor.
+     * @param out_runtime Receives the created runtime on success.
+     * @param error_buffer Optional buffer for a failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true on success, false on startup failure.
+     */
+    bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sdl3d_data_game_runtime **out_runtime,
+                                        char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Destroy a data-game runtime and all resources it owns.
+     *
+     * Safe to call with NULL.
+     */
+    void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime);
+
+    /** @brief Return the runtime-owned asset resolver, or NULL. */
+    sdl3d_asset_resolver *sdl3d_data_game_runtime_assets(const sdl3d_data_game_runtime *runtime);
+
+    /** @brief Return the loaded game-data runtime, or NULL. */
+    sdl3d_game_data_runtime *sdl3d_data_game_runtime_data(const sdl3d_data_game_runtime *runtime);
+
+    /**
+     * @brief Refresh authored input profiles when device count changes.
+     *
+     * This is a thin runtime-owned wrapper around
+     * sdl3d_game_data_apply_active_input_profile_on_device_change(). It stores
+     * the refresh state inside the data-game runtime so hosts do not need
+     * per-game bookkeeping.
+     */
+    bool sdl3d_data_game_runtime_refresh_input_profile_on_device_change(sdl3d_data_game_runtime *runtime,
+                                                                        sdl3d_input_manager *input,
+                                                                        const char **out_profile_name,
+                                                                        bool *out_applied, char *error_buffer,
+                                                                        int error_buffer_size);
+
+    /**
+     * @brief Advance authored frame/app-flow/presentation systems.
+     *
+     * This does not update the outer SDL3D game session tick counters; callers
+     * should invoke it from their managed-loop tick or pause_tick callback.
+     */
+    bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt);
+
+    /**
+     * @brief Draw the active authored game-data frame.
+     *
+     * Records render metrics and draws world primitives, particles, UI, images,
+     * and transitions through the runtime-owned caches.
+     */
+    void sdl3d_data_game_runtime_render(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDL3D_DATA_GAME_H */

--- a/include/sdl3d/sdl3d.h
+++ b/include/sdl3d/sdl3d.h
@@ -12,6 +12,7 @@
 #include "sdl3d/audio.h"
 #include "sdl3d/camera.h"
 #include "sdl3d/collision.h"
+#include "sdl3d/data_game.h"
 #include "sdl3d/door.h"
 #include "sdl3d/drawing3d.h"
 #include "sdl3d/effects.h"

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -1,0 +1,316 @@
+#include "sdl3d/data_game.h"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "sdl3d/game_presentation.h"
+#include "sdl3d/input.h"
+#include "sdl3d/properties.h"
+#include "sdl3d/signal_bus.h"
+
+struct sdl3d_data_game_runtime
+{
+    sdl3d_asset_resolver *assets;
+    sdl3d_game_data_runtime *data;
+    sdl3d_game_data_font_cache font_cache;
+    sdl3d_game_data_image_cache image_cache;
+    sdl3d_game_data_particle_cache particle_cache;
+    sdl3d_game_data_app_flow app_flow;
+    sdl3d_game_data_frame_state frame_state;
+    sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
+    sdl3d_game_session *session;
+    int *haptics_signal_ids;
+    int *haptics_connections;
+    int haptics_connection_count;
+};
+
+static void set_error(char *error_buffer, int error_buffer_size, const char *message)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+    {
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s", message != NULL ? message : "");
+    }
+}
+
+static bool haptics_signal_connected(const sdl3d_data_game_runtime *runtime, int signal_id)
+{
+    if (runtime == NULL || signal_id < 0)
+    {
+        return true;
+    }
+
+    for (int i = 0; i < runtime->haptics_connection_count; ++i)
+    {
+        if (runtime->haptics_signal_ids != NULL && runtime->haptics_signal_ids[i] == signal_id)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void on_haptics_policy_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    sdl3d_data_game_runtime *runtime = (sdl3d_data_game_runtime *)userdata;
+    sdl3d_input_manager *input =
+        runtime != NULL && runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+    if (runtime == NULL || runtime->data == NULL || input == NULL)
+    {
+        return;
+    }
+
+    const int policy_count = sdl3d_game_data_haptics_policy_count(runtime->data);
+    for (int i = 0; i < policy_count; ++i)
+    {
+        sdl3d_game_data_haptics_policy policy;
+        if (!sdl3d_game_data_match_haptics_policy(runtime->data, i, signal_id, payload, &policy))
+        {
+            continue;
+        }
+        if (!sdl3d_input_rumble_all_gamepads(input, policy.low_frequency, policy.high_frequency, policy.duration_ms))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "SDL3D haptics policy '%s' requested rumble but no gamepad accepted it",
+                        policy.name != NULL ? policy.name : "<unnamed>");
+        }
+    }
+}
+
+static bool connect_haptics_policies(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL || runtime->data == NULL || runtime->session == NULL)
+    {
+        return true;
+    }
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(runtime->session);
+    if (bus == NULL || sdl3d_game_session_get_input(runtime->session) == NULL)
+    {
+        return true;
+    }
+
+    const int policy_count = sdl3d_game_data_haptics_policy_count(runtime->data);
+    if (policy_count <= 0)
+    {
+        return true;
+    }
+
+    runtime->haptics_signal_ids = (int *)SDL_calloc((size_t)policy_count, sizeof(*runtime->haptics_signal_ids));
+    runtime->haptics_connections = (int *)SDL_calloc((size_t)policy_count, sizeof(*runtime->haptics_connections));
+    if (runtime->haptics_signal_ids == NULL || runtime->haptics_connections == NULL)
+    {
+        SDL_free(runtime->haptics_signal_ids);
+        SDL_free(runtime->haptics_connections);
+        runtime->haptics_signal_ids = NULL;
+        runtime->haptics_connections = NULL;
+        SDL_OutOfMemory();
+        return false;
+    }
+
+    for (int i = 0; i < policy_count; ++i)
+    {
+        sdl3d_game_data_haptics_policy policy;
+        if (!sdl3d_game_data_get_haptics_policy_at(runtime->data, i, &policy) ||
+            haptics_signal_connected(runtime, policy.signal_id))
+        {
+            continue;
+        }
+
+        const int connection = sdl3d_signal_connect(bus, policy.signal_id, on_haptics_policy_signal, runtime);
+        if (connection > 0)
+        {
+            runtime->haptics_signal_ids[runtime->haptics_connection_count] = policy.signal_id;
+            runtime->haptics_connections[runtime->haptics_connection_count] = connection;
+            ++runtime->haptics_connection_count;
+        }
+    }
+    return true;
+}
+
+static void disconnect_haptics_policies(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL || runtime->session == NULL)
+    {
+        return;
+    }
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(runtime->session);
+    if (bus != NULL)
+    {
+        for (int i = 0; i < runtime->haptics_connection_count; ++i)
+        {
+            if (runtime->haptics_connections != NULL && runtime->haptics_connections[i] > 0)
+            {
+                sdl3d_signal_disconnect(bus, runtime->haptics_connections[i]);
+            }
+        }
+    }
+    SDL_free(runtime->haptics_signal_ids);
+    SDL_free(runtime->haptics_connections);
+    runtime->haptics_signal_ids = NULL;
+    runtime->haptics_connections = NULL;
+    runtime->haptics_connection_count = 0;
+}
+
+void sdl3d_data_game_runtime_desc_init(sdl3d_data_game_runtime_desc *desc)
+{
+    if (desc == NULL)
+    {
+        return;
+    }
+    SDL_zero(*desc);
+}
+
+bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sdl3d_data_game_runtime **out_runtime,
+                                    char *error_buffer, int error_buffer_size)
+{
+    char load_error[512] = {0};
+    sdl3d_data_game_runtime *runtime = NULL;
+
+    if (out_runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "data-game runtime create requires out_runtime");
+        return false;
+    }
+    *out_runtime = NULL;
+
+    if (desc == NULL || desc->session == NULL || desc->data_asset_path == NULL || desc->data_asset_path[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "data-game runtime requires session and data_asset_path");
+        return false;
+    }
+
+    runtime = (sdl3d_data_game_runtime *)SDL_calloc(1, sizeof(*runtime));
+    if (runtime == NULL)
+    {
+        SDL_OutOfMemory();
+        set_error(error_buffer, error_buffer_size, SDL_GetError());
+        return false;
+    }
+    runtime->session = desc->session;
+    sdl3d_game_data_font_cache_init(&runtime->font_cache, desc->media_dir);
+    sdl3d_game_data_particle_cache_init(&runtime->particle_cache);
+    sdl3d_game_data_app_flow_init(&runtime->app_flow);
+    sdl3d_game_data_frame_state_init(&runtime->frame_state);
+    sdl3d_game_data_input_profile_refresh_state_init(&runtime->input_profile_refresh);
+
+    runtime->assets = sdl3d_asset_resolver_create();
+    if (runtime->assets == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, SDL_GetError());
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
+
+    if (desc->mount_assets != NULL &&
+        !desc->mount_assets(runtime->assets, desc->mount_userdata, load_error, (int)sizeof(load_error)))
+    {
+        set_error(error_buffer, error_buffer_size, load_error[0] != '\0' ? load_error : "asset mount failed");
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
+
+    if (!sdl3d_game_data_load_asset(runtime->assets, desc->data_asset_path, desc->session, &runtime->data, load_error,
+                                    (int)sizeof(load_error)))
+    {
+        set_error(error_buffer, error_buffer_size, load_error[0] != '\0' ? load_error : "game data load failed");
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
+
+    sdl3d_game_data_image_cache_init(&runtime->image_cache, runtime->assets);
+    if (!sdl3d_game_data_app_flow_start(&runtime->app_flow, runtime->data))
+    {
+        set_error(error_buffer, error_buffer_size, SDL_GetError());
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
+    if (!connect_haptics_policies(runtime))
+    {
+        set_error(error_buffer, error_buffer_size, SDL_GetError());
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
+
+    *out_runtime = runtime;
+    return true;
+}
+
+void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL)
+    {
+        return;
+    }
+
+    disconnect_haptics_policies(runtime);
+    sdl3d_game_data_particle_cache_free(&runtime->particle_cache);
+    sdl3d_game_data_image_cache_free(&runtime->image_cache);
+    sdl3d_game_data_font_cache_free(&runtime->font_cache);
+    sdl3d_game_data_destroy(runtime->data);
+    sdl3d_asset_resolver_destroy(runtime->assets);
+    SDL_free(runtime);
+}
+
+sdl3d_asset_resolver *sdl3d_data_game_runtime_assets(const sdl3d_data_game_runtime *runtime)
+{
+    return runtime != NULL ? runtime->assets : NULL;
+}
+
+sdl3d_game_data_runtime *sdl3d_data_game_runtime_data(const sdl3d_data_game_runtime *runtime)
+{
+    return runtime != NULL ? runtime->data : NULL;
+}
+
+bool sdl3d_data_game_runtime_refresh_input_profile_on_device_change(sdl3d_data_game_runtime *runtime,
+                                                                    sdl3d_input_manager *input,
+                                                                    const char **out_profile_name, bool *out_applied,
+                                                                    char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL || runtime->data == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "input profile refresh requires data-game runtime");
+        return false;
+    }
+    return sdl3d_game_data_apply_active_input_profile_on_device_change(
+        runtime->data, input, &runtime->input_profile_refresh, out_profile_name, out_applied, error_buffer,
+        error_buffer_size);
+}
+
+bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
+{
+    if (runtime == NULL || runtime->data == NULL)
+    {
+        return false;
+    }
+
+    const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
+                                                     .runtime = runtime->data,
+                                                     .app_flow = &runtime->app_flow,
+                                                     .particle_cache = &runtime->particle_cache,
+                                                     .dt = dt};
+    return sdl3d_game_data_update_frame(&runtime->frame_state, &frame);
+}
+
+void sdl3d_data_game_runtime_render(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || runtime->data == NULL || ctx == NULL)
+    {
+        return;
+    }
+
+    sdl3d_game_data_frame_state_record_render(&runtime->frame_state, ctx, runtime->data);
+
+    sdl3d_game_data_frame_desc frame;
+    SDL_zero(frame);
+    frame.runtime = runtime->data;
+    frame.renderer = ctx->renderer;
+    frame.font_cache = &runtime->font_cache;
+    frame.image_cache = &runtime->image_cache;
+    frame.particle_cache = &runtime->particle_cache;
+    frame.app_flow = &runtime->app_flow;
+    frame.metrics = &runtime->frame_state.metrics;
+    frame.render_eval = &runtime->frame_state.render_eval;
+    frame.pulse_phase = runtime->frame_state.ui_pulse_phase;
+    sdl3d_game_data_draw_frame(&frame);
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -17,6 +17,7 @@ extern "C"
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/asset.h"
+#include "sdl3d/data_game.h"
 #include "sdl3d/game.h"
 #include "sdl3d/game_data.h"
 #include "sdl3d/game_presentation.h"
@@ -1185,6 +1186,13 @@ std::vector<std::uint8_t> make_pack(const std::vector<std::pair<std::string, std
     return bytes;
 }
 
+bool mount_test_directory_assets(sdl3d_asset_resolver *assets, void *userdata, char *error_buffer,
+                                 int error_buffer_size)
+{
+    return sdl3d_asset_resolver_mount_directory(assets, static_cast<const char *>(userdata), error_buffer,
+                                                error_buffer_size);
+}
+
 } // namespace
 
 TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
@@ -1328,6 +1336,40 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_EQ(sdl3d_timer_pool_active_count(sdl3d_game_session_get_timer_pool(session)), 0);
 
     sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, DataGameRuntimeOwnsGenericPongLifecycle)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    const std::filesystem::path data_path = SDL3D_PONG_DATA_PATH;
+    const std::string root = data_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + data_path.filename().string();
+
+    sdl3d_data_game_runtime_desc desc{};
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SDL3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+
+    char error[512]{};
+    sdl3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    ASSERT_NE(runtime, nullptr);
+    ASSERT_NE(sdl3d_data_game_runtime_assets(runtime), nullptr);
+    sdl3d_game_data_runtime *data = sdl3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(data), "scene.splash");
+    EXPECT_NE(sdl3d_game_data_find_actor(data, "entity.ball"), nullptr);
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    EXPECT_TRUE(sdl3d_data_game_runtime_update_frame(runtime, &ctx, 0.016f));
+    sdl3d_data_game_runtime_destroy(runtime);
     sdl3d_game_session_destroy(session);
 }
 


### PR DESCRIPTION
## Summary
- add `sdl3d_data_game_runtime`, a generic lifecycle wrapper for JSON/Lua-authored games
- move asset mounting, game-data loading, app-flow/frame state, presentation caches, haptics policy wiring, frame update, and render behind the new runtime
- migrate Pong to use the generic runtime while leaving network session orchestration in the demo host for the next issue slice
- document the data-game runtime and update the Pong C audit
- add coverage proving the generic runtime can load and advance Pong data

Addresses the first slice of #210.

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target sdl3d_pong_multiplayer_test -j8 && ./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next slice
- Add the generic runner executable that launches a game package through `sdl3d_data_game_runtime` without a game-specific `main.c`.