### PR TITLE
Add generic SDL3D data runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,13 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     target_compile_features(sdl3d_pack PRIVATE c_std_17)
     sdl3d_enable_warnings(sdl3d_pack)
     sdl3d_enable_sanitizers(sdl3d_pack)
+
+    add_executable(sdl3d_runner tools/sdl3d_runner.c)
+    target_link_libraries(sdl3d_runner PRIVATE SDL3D::sdl3d)
+    target_compile_features(sdl3d_runner PRIVATE c_std_17)
+    target_compile_definitions(sdl3d_runner PRIVATE SDL3D_MEDIA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/media")
+    sdl3d_enable_warnings(sdl3d_runner)
+    sdl3d_enable_sanitizers(sdl3d_runner)
 endif()
 
 if(SDL3D_BUILD_TESTS)

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -18,13 +18,13 @@ The runtime currently owns:
 - authored app-flow startup and frame update
 - authored frame render through `sdl3d_game_data_draw_frame`
 - haptics policy signal wiring
-- input-profile hotplug refresh state
+- input-profile hotplug refresh state and automatic gamepad-count rebinding
 - ordered cleanup
 
-Hosts still own the outer SDL process loop through `sdl3d_run_game`. For now,
-Pong also still owns network session orchestration. Future slices should move
-that orchestration into a managed network runtime so Pong can run through a
-generic runner without a custom `main.c`.
+The generic `sdl3d_runner` executable owns the outer SDL process loop for games
+that only need the current data runtime surface. For now, Pong still keeps a
+compatibility host for full LAN networking because network session
+orchestration has not moved into the managed runtime yet.
 
 ## Startup Shape
 
@@ -57,9 +57,41 @@ During the managed loop:
 The outer loop still controls fixed timestep, SDL events, input snapshots,
 audio frame updates, and presentation.
 
+## Generic Runner
+
+`sdl3d_runner` launches a game data asset without game-specific C callbacks.
+It can mount either a development directory or a built `.sdl3dpak`, then reads
+the app/window/audio config from the root game JSON before entering the managed
+loop.
+
+Development directory example:
+
+```sh
+build/debug/sdl3d_runner --root demos/pong/data --data asset://pong.game.json
+```
+
+Pack-file example:
+
+```sh
+build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json
+```
+
+Optional flags:
+
+- `--media <dir>` overrides the built-in media directory used for engine fonts
+  and shared media.
+- `--embedded` is available only when a build target defines
+  `SDL3D_RUNNER_EMBEDDED_ASSETS` and provides the generic
+  `sdl3d_runner_embedded_assets` pack blob symbols.
+
+The runner is game-agnostic: it does not reference Pong symbols, scene names,
+actions, actors, replication channels, or controls. Any remaining need for a
+custom host indicates engine runtime work that should move into reusable JSON
+or Lua-driven systems.
+
 ## Why This Matters
 
-This API is a stepping stone toward a generic SDL3D runner. Once network
-session orchestration is also managed by the engine runtime, a game package
+This API is a stepping stone toward fully data-only games. Once network session
+orchestration is also managed by the engine runtime, a package such as Pong
 should be able to ship as JSON, Lua, and assets rather than as a custom C
 program linked against SDL3D.

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -21,10 +21,10 @@ The runtime currently owns:
 - input-profile hotplug refresh state
 - ordered cleanup
 
-Hosts still own the outer SDL process loop through `sdl3d_run_game`. For now,
-Pong also still owns network session orchestration. Future slices should move
-that orchestration into a managed network runtime so Pong can run through a
-generic runner without a custom `main.c`.
+The generic `sdl3d_runner` executable owns the outer SDL process loop for games
+that only need the current data runtime surface. For now, Pong still keeps a
+compatibility host for full LAN networking because network session
+orchestration has not moved into the managed runtime yet.
 
 ## Startup Shape
 
@@ -57,9 +57,41 @@ During the managed loop:
 The outer loop still controls fixed timestep, SDL events, input snapshots,
 audio frame updates, and presentation.
 
+## Generic Runner
+
+`sdl3d_runner` launches a game data asset without game-specific C callbacks.
+It can mount either a development directory or a built `.sdl3dpak`, then reads
+the app/window/audio config from the root game JSON before entering the managed
+loop.
+
+Development directory example:
+
+```sh
+build/debug/sdl3d_runner --root demos/pong/data --data asset://pong.game.json
+```
+
+Pack-file example:
+
+```sh
+build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json
+```
+
+Optional flags:
+
+- `--media <dir>` overrides the built-in media directory used for engine fonts
+  and shared media.
+- `--embedded` is available only when a build target defines
+  `SDL3D_RUNNER_EMBEDDED_ASSETS` and provides the generic
+  `sdl3d_runner_embedded_assets` pack blob symbols.
+
+The runner is game-agnostic: it does not reference Pong symbols, scene names,
+actions, actors, replication channels, or controls. Any remaining need for a
+custom host indicates engine runtime work that should move into reusable JSON
+or Lua-driven systems.
+
 ## Why This Matters
 
-This API is a stepping stone toward a generic SDL3D runner. Once network
-session orchestration is also managed by the engine runtime, a game package
+This API is a stepping stone toward fully data-only games. Once network session
+orchestration is also managed by the engine runtime, a package such as Pong
 should be able to ship as JSON, Lua, and assets rather than as a custom C
 program linked against SDL3D.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -694,12 +694,15 @@ Logic bindings can apply profiles directly:
 
 Use an adapter or data actions before `input.apply_active_profile` when a game
 needs to normalize scene-state values that choose the active profile.
-For hotplug support, hosts can keep a
+For hotplug support, `sdl3d_data_game_runtime_update_frame()` automatically
+refreshes the active profile when the connected gamepad count changes. Custom
+hosts that do not use the data-game runtime can keep a
 `sdl3d_game_data_input_profile_refresh_state` and call
-`sdl3d_game_data_apply_active_input_profile_on_device_change()` from their
-frame loop while a profile-managed scene is active. The helper applies the
-active profile on first use and after the connected gamepad count changes,
-leaving scene-entry profile application in authored data actions.
+`sdl3d_game_data_apply_active_input_profile_on_device_change()` while a
+profile-managed scene is active. Use
+`sdl3d_game_data_get_active_input_profile_name()` first when polling
+automatically so scenes with no matching profile are treated as idle rather
+than as errors.
 
 Direct-connect multiplayer forms should use menu `text` controls for the host
 and port fields, then invoke data-authored network actions from menu signals:

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -111,6 +111,9 @@ extern "C"
      *
      * This does not update the outer SDL3D game session tick counters; callers
      * should invoke it from their managed-loop tick or pause_tick callback.
+     * The runtime also refreshes the active authored input profile when the
+     * connected gamepad count changes and the current scene state has a
+     * matching profile.
      */
     bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt);
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -2123,6 +2123,22 @@ extern "C"
                                                     int error_buffer_size);
 
     /**
+     * @brief Return the first input profile whose authored conditions match.
+     *
+     * This is a side-effect-free query for hosts and generic runtimes that
+     * need to know whether automatic input-profile refresh is currently
+     * applicable. It uses the same authored-order, `active_if`, and gamepad
+     * gate rules as @ref sdl3d_game_data_apply_active_input_profile.
+     *
+     * @param runtime Runtime containing authored profile data.
+     * @param input Input manager used for live gamepad-count gates.
+     * @param out_profile_name Receives the matching runtime-owned profile name, if non-NULL.
+     * @return true when a profile currently matches.
+     */
+    bool sdl3d_game_data_get_active_input_profile_name(const sdl3d_game_data_runtime *runtime,
+                                                       const sdl3d_input_manager *input, const char **out_profile_name);
+
+    /**
      * @brief Apply the active input profile when connected gamepad count changes.
      *
      * This helper centralizes the common hotplug policy for data-authored input

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -277,12 +277,43 @@ bool sdl3d_data_game_runtime_refresh_input_profile_on_device_change(sdl3d_data_g
         error_buffer_size);
 }
 
+static bool refresh_active_input_profile_if_available(sdl3d_data_game_runtime *runtime)
+{
+    sdl3d_input_manager *input =
+        runtime != NULL && runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+    if (runtime == NULL || runtime->data == NULL || input == NULL)
+    {
+        return true;
+    }
+
+    if (!sdl3d_game_data_get_active_input_profile_name(runtime->data, input, NULL))
+    {
+        sdl3d_game_data_input_profile_refresh_state_init(&runtime->input_profile_refresh);
+        return true;
+    }
+
+    char error[256] = "";
+    const char *profile_name = NULL;
+    bool applied = false;
+    if (!sdl3d_data_game_runtime_refresh_input_profile_on_device_change(runtime, input, &profile_name, &applied, error,
+                                                                        (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D input profile hotplug refresh failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+        return false;
+    }
+    return true;
+}
+
 bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
 {
     if (runtime == NULL || runtime->data == NULL)
     {
         return false;
     }
+
+    if (!refresh_active_input_profile_if_available(runtime))
+        return false;
 
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = runtime->data,

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7560,6 +7560,22 @@ static bool input_profile_matches(const sdl3d_game_data_runtime *runtime, const 
     return eval_data_condition(runtime, obj_get(profile, "active_if"), NULL);
 }
 
+static yyjson_val *find_active_input_profile_json(const sdl3d_game_data_runtime *runtime,
+                                                  const sdl3d_input_manager *input)
+{
+    if (runtime == NULL || input == NULL)
+        return NULL;
+
+    yyjson_val *profiles = obj_get(obj_get(runtime_root(runtime), "input"), "profiles");
+    for (size_t i = 0; yyjson_is_arr(profiles) && i < yyjson_arr_size(profiles); ++i)
+    {
+        yyjson_val *profile = yyjson_arr_get(profiles, i);
+        if (input_profile_matches(runtime, input, profile))
+            return profile;
+    }
+    return NULL;
+}
+
 bool sdl3d_game_data_apply_input_profile(sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
                                          const char *profile_name, char *error_buffer, int error_buffer_size)
 {
@@ -7585,23 +7601,34 @@ bool sdl3d_game_data_apply_active_input_profile(sdl3d_game_data_runtime *runtime
         return false;
     }
 
-    yyjson_val *profiles = obj_get(obj_get(runtime_root(runtime), "input"), "profiles");
-    for (size_t i = 0; yyjson_is_arr(profiles) && i < yyjson_arr_size(profiles); ++i)
+    yyjson_val *profile = find_active_input_profile_json(runtime, input);
+    if (profile != NULL)
     {
-        yyjson_val *profile = yyjson_arr_get(profiles, i);
-        if (input_profile_matches(runtime, input, profile))
-        {
-            const char *name = json_string(profile, "name", NULL);
-            if (!apply_input_profile_json(runtime, input, profile, error_buffer, error_buffer_size))
-                return false;
-            if (out_profile_name != NULL)
-                *out_profile_name = name;
-            return true;
-        }
+        const char *name = json_string(profile, "name", NULL);
+        if (!apply_input_profile_json(runtime, input, profile, error_buffer, error_buffer_size))
+            return false;
+        if (out_profile_name != NULL)
+            *out_profile_name = name;
+        return true;
     }
 
     set_error(error_buffer, error_buffer_size, "no authored input profile matched the current state");
     return false;
+}
+
+bool sdl3d_game_data_get_active_input_profile_name(const sdl3d_game_data_runtime *runtime,
+                                                   const sdl3d_input_manager *input, const char **out_profile_name)
+{
+    if (out_profile_name != NULL)
+        *out_profile_name = NULL;
+
+    yyjson_val *profile = find_active_input_profile_json(runtime, input);
+    if (profile == NULL)
+        return false;
+
+    if (out_profile_name != NULL)
+        *out_profile_name = json_string(profile, "name", NULL);
+    return true;
 }
 
 void sdl3d_game_data_input_profile_refresh_state_init(sdl3d_game_data_input_profile_refresh_state *state)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1373,6 +1373,82 @@ TEST(GameDataRuntime, DataGameRuntimeOwnsGenericPongLifecycle)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, DataGameRuntimeRefreshesInputProfilesOnGamepadHotplug)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    if (sdl3d_input_gamepad_count(input) != 0)
+    {
+        sdl3d_game_session_destroy(session);
+        GTEST_SKIP() << "requires no pre-connected gamepads";
+    }
+
+    const std::filesystem::path data_path = SDL3D_PONG_DATA_PATH;
+    const std::string root = data_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + data_path.filename().string();
+
+    sdl3d_data_game_runtime_desc desc{};
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SDL3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+
+    char error[512]{};
+    sdl3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    sdl3d_game_data_runtime *data = sdl3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+
+    const int p1_up = sdl3d_game_data_find_action(data, "action.paddle.up");
+    const int p2_up = sdl3d_game_data_find_action(data, "action.paddle.local.up");
+    ASSERT_GE(p1_up, 0);
+    ASSERT_GE(p2_up, 0);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(data);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_string(scene_state, "match_mode", "local");
+    sdl3d_properties_set_string(scene_state, "network_role", "none");
+    sdl3d_properties_set_string(scene_state, "network_flow", "none");
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(runtime, &ctx, 0.016f));
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 1.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 0.0f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+
+    SDL_Event event{};
+    event.type = SDL_EVENT_GAMEPAD_ADDED;
+    event.gdevice.which = 7301;
+    sdl3d_input_process_event(input, &event);
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(runtime, &ctx, 0.016f));
+
+    event.type = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+    event.gbutton.which = 7301;
+    event.gbutton.button = SDL_GAMEPAD_BUTTON_DPAD_UP;
+    sdl3d_input_process_event(input, &event);
+    sdl3d_input_update(input, 3);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p1_up), 0.0f);
+    EXPECT_FLOAT_EQ(sdl3d_input_get_value(input, p2_up), 1.0f);
+
+    sdl3d_data_game_runtime_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, ReadsSpriteAssetMetadata)
 {
     sdl3d_game_session *session = nullptr;

--- a/tools/sdl3d_runner.c
+++ b/tools/sdl3d_runner.c
@@ -1,0 +1,255 @@
+/**
+ * @file sdl3d_runner.c
+ * @brief Generic SDL3D data-game runner.
+ */
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include <stdio.h>
+
+#include "sdl3d/sdl3d.h"
+
+#if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
+extern const unsigned char sdl3d_runner_embedded_assets[];
+extern const size_t sdl3d_runner_embedded_assets_size;
+#endif
+
+typedef enum runner_mount_kind
+{
+    RUNNER_MOUNT_NONE = 0,
+    RUNNER_MOUNT_DIRECTORY,
+    RUNNER_MOUNT_PACK,
+    RUNNER_MOUNT_EMBEDDED
+} runner_mount_kind;
+
+typedef struct runner_state
+{
+    runner_mount_kind mount_kind;
+    const char *mount_path;
+    const char *data_asset_path;
+    const char *media_dir;
+    bool help_requested;
+    sdl3d_game_config config;
+    char title[128];
+    sdl3d_data_game_runtime *runtime;
+} runner_state;
+
+static void runner_set_error(char *error_buffer, int error_buffer_size, const char *message)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s", message != NULL ? message : "unknown error");
+}
+
+static void print_usage(const char *argv0)
+{
+    const char *program = argv0 != NULL ? argv0 : "sdl3d_runner";
+    fprintf(stderr,
+            "Usage:\n"
+            "  %s --root <asset-root> --data <asset://game.json> [--media <media-dir>]\n"
+            "  %s --pack <game.sdl3dpak> --data <asset://game.json> [--media <media-dir>]\n",
+            program, program);
+#if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
+    fprintf(stderr, "  %s --embedded --data <asset://game.json> [--media <media-dir>]\n", program);
+#endif
+}
+
+static bool parse_args(int argc, char **argv, runner_state *state)
+{
+    SDL_zero(*state);
+    state->data_asset_path = NULL;
+#if defined(SDL3D_MEDIA_DIR)
+    state->media_dir = SDL3D_MEDIA_DIR;
+#endif
+
+    for (int i = 1; i < argc; ++i)
+    {
+        if (SDL_strcmp(argv[i], "--root") == 0 && i + 1 < argc)
+        {
+            if (state->mount_kind != RUNNER_MOUNT_NONE)
+                return false;
+            state->mount_kind = RUNNER_MOUNT_DIRECTORY;
+            state->mount_path = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--pack") == 0 && i + 1 < argc)
+        {
+            if (state->mount_kind != RUNNER_MOUNT_NONE)
+                return false;
+            state->mount_kind = RUNNER_MOUNT_PACK;
+            state->mount_path = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--embedded") == 0)
+        {
+#if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
+            if (state->mount_kind != RUNNER_MOUNT_NONE)
+                return false;
+            state->mount_kind = RUNNER_MOUNT_EMBEDDED;
+#else
+            return false;
+#endif
+        }
+        else if (SDL_strcmp(argv[i], "--data") == 0 && i + 1 < argc)
+        {
+            state->data_asset_path = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--media") == 0 && i + 1 < argc)
+        {
+            state->media_dir = argv[++i];
+        }
+        else if (SDL_strcmp(argv[i], "--help") == 0 || SDL_strcmp(argv[i], "-h") == 0)
+        {
+            state->help_requested = true;
+            return false;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    return state->mount_kind != RUNNER_MOUNT_NONE && state->data_asset_path != NULL &&
+           state->data_asset_path[0] != '\0';
+}
+
+static bool runner_mount_assets(sdl3d_asset_resolver *assets, void *userdata, char *error_buffer, int error_buffer_size)
+{
+    const runner_state *state = (const runner_state *)userdata;
+    if (assets == NULL || state == NULL)
+    {
+        runner_set_error(error_buffer, error_buffer_size, "invalid runner asset mount arguments");
+        return false;
+    }
+
+    switch (state->mount_kind)
+    {
+    case RUNNER_MOUNT_DIRECTORY:
+        return sdl3d_asset_resolver_mount_directory(assets, state->mount_path, error_buffer, error_buffer_size);
+    case RUNNER_MOUNT_PACK:
+        return sdl3d_asset_resolver_mount_pack_file(assets, state->mount_path, error_buffer, error_buffer_size);
+    case RUNNER_MOUNT_EMBEDDED:
+#if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
+        return sdl3d_asset_resolver_mount_memory_pack(assets, sdl3d_runner_embedded_assets,
+                                                      sdl3d_runner_embedded_assets_size, "sdl3d_runner.embedded",
+                                                      error_buffer, error_buffer_size);
+#else
+        runner_set_error(error_buffer, error_buffer_size, "runner was not built with embedded assets");
+        return false;
+#endif
+    case RUNNER_MOUNT_NONE:
+    default:
+        runner_set_error(error_buffer, error_buffer_size, "no asset mount was configured");
+        return false;
+    }
+}
+
+static bool load_runner_config(runner_state *state, char *error_buffer, int error_buffer_size)
+{
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (assets == NULL)
+    {
+        runner_set_error(error_buffer, error_buffer_size, "failed to create asset resolver");
+        return false;
+    }
+
+    bool ok = runner_mount_assets(assets, state, error_buffer, error_buffer_size);
+    if (ok)
+    {
+        SDL_zero(state->config);
+        SDL_snprintf(state->title, sizeof(state->title), "%s", "SDL3D");
+        ok = sdl3d_game_data_load_app_config_asset(assets, state->data_asset_path, &state->config, state->title,
+                                                   (int)sizeof(state->title), error_buffer, error_buffer_size);
+    }
+
+    sdl3d_asset_resolver_destroy(assets);
+    return ok;
+}
+
+static bool runner_init(sdl3d_game_context *ctx, void *userdata)
+{
+    runner_state *state = (runner_state *)userdata;
+    sdl3d_data_game_runtime_desc desc;
+    char error[512] = "";
+
+    if (ctx == NULL || state == NULL)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner received invalid init arguments");
+        return false;
+    }
+
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = ctx->session;
+    desc.data_asset_path = state->data_asset_path;
+    desc.media_dir = state->media_dir;
+    desc.mount_assets = runner_mount_assets;
+    desc.mount_userdata = state;
+
+    if (!sdl3d_data_game_runtime_create(&desc, &state->runtime, error, (int)sizeof(error)))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner data load failed: %s", error);
+        return false;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner loaded data asset: %s", state->data_asset_path);
+    return true;
+}
+
+static void runner_tick(sdl3d_game_context *ctx, void *userdata, float dt)
+{
+    runner_state *state = (runner_state *)userdata;
+    if (state != NULL)
+        (void)sdl3d_data_game_runtime_update_frame(state->runtime, ctx, dt);
+}
+
+static void runner_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
+{
+    runner_state *state = (runner_state *)userdata;
+    if (state != NULL)
+        (void)sdl3d_data_game_runtime_update_frame(state->runtime, ctx, real_dt);
+}
+
+static void runner_render(sdl3d_game_context *ctx, void *userdata, float alpha)
+{
+    runner_state *state = (runner_state *)userdata;
+    (void)alpha;
+    if (state != NULL)
+        sdl3d_data_game_runtime_render(state->runtime, ctx);
+}
+
+static void runner_shutdown(sdl3d_game_context *ctx, void *userdata)
+{
+    runner_state *state = (runner_state *)userdata;
+    (void)ctx;
+    if (state != NULL)
+    {
+        sdl3d_data_game_runtime_destroy(state->runtime);
+        state->runtime = NULL;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    runner_state state;
+    if (!parse_args(argc, argv, &state))
+    {
+        print_usage(argc > 0 ? argv[0] : NULL);
+        return state.help_requested ? 0 : 2;
+    }
+
+    char error[512] = "";
+    if (!load_runner_config(&state, error, (int)sizeof(error)))
+    {
+        fprintf(stderr, "sdl3d_runner: %s\n", error[0] != '\0' ? error : "failed to load app config");
+        return 1;
+    }
+
+    sdl3d_game_callbacks callbacks;
+    SDL_zero(callbacks);
+    callbacks.init = runner_init;
+    callbacks.tick = runner_tick;
+    callbacks.pause_tick = runner_pause_tick;
+    callbacks.render = runner_render;
+    callbacks.shutdown = runner_shutdown;
+
+    return sdl3d_run_game(&state.config, &callbacks, &state);
+}


### PR DESCRIPTION
## Summary

- Add `sdl3d_runner`, a generic data-game executable that mounts an asset directory, `.sdl3dpak`, or optional embedded pack and launches a root game JSON through `sdl3d_data_game_runtime`.
- Load app/window/audio config from the authored game JSON before entering the managed loop.
- Move input-profile hotplug refresh into the generic data-game runtime update path so runner-launched games rebind active profiles when gamepad count changes.
- Document directory, pack-file, optional embedded runner usage, and the runtime-owned hotplug behavior.

## Verification

- `cmake -S . -B build/debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build/debug --target sdl3d_runner pong_demo sdl3d_game_data_test -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.DataGameRuntimeRefreshesInputProfilesOnGamepadHotplug:GameDataRuntime.DataGameRuntimeOwnsGenericPongLifecycle:GameDataRuntime.RefreshesActiveInputProfileWhenGamepadCountChanges`
- `./build/debug/sdl3d_runner --help`
- Smoke launched and terminated `./build/debug/sdl3d_runner --root demos/pong/data --data asset://pong.game.json`
- Smoke launched and terminated `./build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json`
- `git diff --check`

## Next Slice

Move managed network session runtime configuration into the engine runtime so the runner can own direct-connect/discovery/lobby/session lifecycle without Pong-specific C.

Closes slice 2 of #210.