### PR TITLE
Author runtime-owned host sessions

### DIFF
--- a/demos/pong/data/scenes/multiplayer_lobby.scene.json
+++ b/demos/pong/data/scenes/multiplayer_lobby.scene.json
@@ -23,6 +23,38 @@
     "enter": "scene_in",
     "exit": "scene_out"
   },
+  "activity": {
+    "enabled": true,
+    "input": "any",
+    "reset_periodic_on_input": false,
+    "on_enter": [
+      {
+        "type": "network.host.start",
+        "name": "host",
+        "default_port": 27183,
+        "session_name": "SDL3D Pong",
+        "status_key": "multiplayer_host_status",
+        "endpoint_key": "multiplayer_host_endpoint",
+        "peer_key": "multiplayer_host_client",
+        "connected_key": "multiplayer_host_connected"
+      }
+    ],
+    "periodic": [
+      {
+        "interval": 0.1,
+        "actions": [
+          {
+            "type": "network.host.observe",
+            "name": "host",
+            "status_key": "multiplayer_host_status",
+            "endpoint_key": "multiplayer_host_endpoint",
+            "peer_key": "multiplayer_host_client",
+            "connected_key": "multiplayer_host_connected"
+          }
+        ]
+      }
+    ]
+  },
   "menus": [
     {
       "name": "menu.multiplayer.lobby.connected",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -65,6 +65,7 @@ static const char PONG_NETWORK_BINDING_CLIENT_DOWN[] = "client_down";
 static const char PONG_NETWORK_BINDING_MENU_SELECT[] = "menu_select";
 static const char PONG_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
 static const char PONG_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
+static const char PONG_HOST_SESSION[] = "host";
 static const char PONG_DIRECT_CONNECT_SESSION[] = "direct_connect";
 static const char PONG_DIRECT_CONNECT_HOST_KEY[] = "direct_connect_host";
 static const char PONG_DIRECT_CONNECT_PORT_KEY[] = "direct_connect_port";
@@ -359,46 +360,12 @@ static void update_host_session_scene_state(pong_state *state)
         return;
     }
 
-    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(state->data);
-    if (scene_state == NULL)
-    {
-        return;
-    }
-
-    const char *status =
-        state->host_session != NULL ? sdl3d_network_session_status(state->host_session) : state->host_status;
-    const Uint16 port =
-        state->host_session != NULL ? sdl3d_network_session_port(state->host_session) : SDL3D_NETWORK_DEFAULT_PORT;
-    char client_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 48];
-    char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
-    Uint16 peer_port = 0;
-    const bool client_connected =
-        state->host_session != NULL && sdl3d_network_session_is_connected(state->host_session);
-    SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
-                 status != NULL && status[0] != '\0' ? status : "Not hosting");
-    SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u", (unsigned int)port);
-    SDL_snprintf(client_label, sizeof(client_label), "Waiting for client");
-    SDL_zero(peer_host);
-    if (client_connected &&
-        sdl3d_network_session_get_peer_endpoint(state->host_session, peer_host, (int)sizeof(peer_host), &peer_port))
-    {
-        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
-    }
-    else if (client_connected)
-    {
-        SDL_snprintf(client_label, sizeof(client_label), "Client 1 - Connected");
-    }
-
-    sdl3d_properties_set_string(
-        scene_state, network_scene_state_key(state, "host", "status", "multiplayer_host_status"), state->host_status);
-    sdl3d_properties_set_string(scene_state,
-                                network_scene_state_key(state, "host", "endpoint", "multiplayer_host_endpoint"),
-                                state->host_endpoint);
-    sdl3d_properties_set_string(scene_state, network_scene_state_key(state, "host", "peer", "multiplayer_host_client"),
-                                client_label);
-    sdl3d_properties_set_bool(scene_state,
-                              network_scene_state_key(state, "host", "connected", "multiplayer_host_connected"),
-                              client_connected);
+    state->host_session = sdl3d_game_data_get_network_host_session(state->data, PONG_HOST_SESSION);
+    (void)sdl3d_game_data_network_host_publish_status(
+        state->data, PONG_HOST_SESSION, network_scene_state_key(state, "host", "status", "multiplayer_host_status"),
+        network_scene_state_key(state, "host", "endpoint", "multiplayer_host_endpoint"),
+        network_scene_state_key(state, "host", "peer", "multiplayer_host_client"),
+        network_scene_state_key(state, "host", "connected", "multiplayer_host_connected"));
 }
 
 static void destroy_host_session_internal(pong_state *state, bool notify_peer)
@@ -410,7 +377,11 @@ static void destroy_host_session_internal(pong_state *state, bool notify_peer)
             (void)send_network_control_packet_repeated(state, state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT,
                                                        "host disconnect", 5);
         }
-        sdl3d_network_session_destroy(state->host_session);
+        (void)sdl3d_game_data_network_host_cancel(
+            state->data, PONG_HOST_SESSION, network_scene_state_key(state, "host", "status", "multiplayer_host_status"),
+            network_scene_state_key(state, "host", "endpoint", "multiplayer_host_endpoint"),
+            network_scene_state_key(state, "host", "peer", "multiplayer_host_client"),
+            network_scene_state_key(state, "host", "connected", "multiplayer_host_connected"), "Not hosting");
         state->host_session = NULL;
     }
 
@@ -458,8 +429,6 @@ static void destroy_direct_connect_session(pong_state *state)
 
 static bool start_host_session(pong_state *state)
 {
-    sdl3d_network_session_desc desc;
-
     if (state == NULL)
     {
         return false;
@@ -470,16 +439,12 @@ static bool start_host_session(pong_state *state)
         return true;
     }
 
-    sdl3d_network_session_desc_init(&desc);
-    desc.role = SDL3D_NETWORK_ROLE_HOST;
-    desc.host = NULL;
-    desc.port = SDL3D_NETWORK_DEFAULT_PORT;
-    desc.local_port = 0;
-    desc.handshake_timeout = 5.0f;
-    desc.idle_timeout = 10.0f;
-    desc.session_name = "Pong";
-
-    if (!sdl3d_network_session_create(&desc, &state->host_session))
+    if (!sdl3d_game_data_network_host_start(
+            state->data, PONG_HOST_SESSION, SDL3D_NETWORK_DEFAULT_PORT, "SDL3D Pong",
+            network_scene_state_key(state, "host", "status", "multiplayer_host_status"),
+            network_scene_state_key(state, "host", "endpoint", "multiplayer_host_endpoint"),
+            network_scene_state_key(state, "host", "peer", "multiplayer_host_client"),
+            network_scene_state_key(state, "host", "connected", "multiplayer_host_connected")))
     {
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s", SDL_GetError());
         SDL_snprintf(state->host_endpoint, sizeof(state->host_endpoint), "UDP %u",
@@ -489,7 +454,7 @@ static bool start_host_session(pong_state *state)
     }
 
     update_host_session_scene_state(state);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host lobby session active: %s", state->host_endpoint);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host lobby session active");
     return true;
 }
 
@@ -1275,6 +1240,8 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
         state->data != NULL
             ? sdl3d_game_data_get_network_direct_connect_session(state->data, PONG_DIRECT_CONNECT_SESSION)
             : state->direct_connect_session;
+    state->host_session = state->data != NULL ? sdl3d_game_data_get_network_host_session(state->data, PONG_HOST_SESSION)
+                                              : state->host_session;
 
     update_host_session_status(ctx, state, dt);
 

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -19,6 +19,8 @@ The runtime currently owns:
 - authored frame render through `sdl3d_game_data_draw_frame`
 - haptics policy signal wiring
 - input-profile hotplug refresh state and automatic gamepad-count rebinding
+- runtime-owned direct-connect, host, and discovery session primitives exposed
+  through data actions
 - ordered cleanup
 
 The generic `sdl3d_runner` executable owns the outer SDL process loop for games

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -740,6 +740,53 @@ owns session lifetime; host code can inspect the runtime-owned pointer with
 `sdl3d_game_data_get_network_direct_connect_session()` when it needs to send or
 receive game packets.
 
+Host lobby screens can create and publish a runtime-owned UDP host session from
+scene activity:
+
+```json
+{
+    "activity" : {
+        "enabled" : true,
+        "on_enter" : [
+            {
+                "type" : "network.host.start",
+                "name" : "host",
+                "default_port" : 27183,
+                "session_name" : "SDL3D Pong",
+                "status_key" : "multiplayer_host_status",
+                "endpoint_key" : "multiplayer_host_endpoint",
+                "peer_key" : "multiplayer_host_client",
+                "connected_key" : "multiplayer_host_connected"
+            }
+        ],
+        "periodic" : [
+            {
+                "interval" : 0.1,
+                "actions" : [
+                    {
+                        "type" : "network.host.observe",
+                        "name" : "host",
+                        "status_key" : "multiplayer_host_status",
+                        "endpoint_key" : "multiplayer_host_endpoint",
+                        "peer_key" : "multiplayer_host_client",
+                        "connected_key" : "multiplayer_host_connected"
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+`network.host.start` creates a runtime-owned host session if one is not already
+active. `name` identifies the session, `port` / `default_port` select the UDP
+listen port, and `session_name` is advertised to LAN discovery clients.
+`network.host.observe` republishes status, endpoint, peer label, and connection
+state into scene state. `network.host.cancel` destroys the named host session
+and writes a disconnected status. Host packet loops can inspect the
+runtime-owned pointer with `sdl3d_game_data_get_network_host_session()` until
+generic replication-loop ownership moves into the data-game runtime.
+
 LAN discovery flows can also be authored with reusable network data actions and
 dynamic-list menus. A typical scene starts or refreshes discovery on enter,
 observes it periodically, and lets a runtime-collection-backed list connect the

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1938,6 +1938,42 @@ extern "C"
                                                                               const char *session_name);
 
     /**
+     * @brief Start or keep a named runtime-owned UDP host session alive.
+     *
+     * Host sessions listen for exactly one client. The session is owned by
+     * @p runtime and remains valid until canceled, replaced, or the runtime is
+     * destroyed. Optional scene-state keys publish human-readable status,
+     * endpoint, peer label, and connected state.
+     */
+    bool sdl3d_game_data_network_host_start(sdl3d_game_data_runtime *runtime, const char *session_name, int port,
+                                            const char *advertised_name, const char *status_key,
+                                            const char *endpoint_key, const char *peer_key, const char *connected_key);
+
+    /**
+     * @brief Cancel and destroy a named runtime-owned host session.
+     *
+     * Canceling an unknown host session is a successful no-op.
+     */
+    bool sdl3d_game_data_network_host_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                             const char *status_key, const char *endpoint_key, const char *peer_key,
+                                             const char *connected_key, const char *status);
+
+    /**
+     * @brief Publish a named runtime-owned host session's status into scene state.
+     */
+    bool sdl3d_game_data_network_host_publish_status(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                     const char *status_key, const char *endpoint_key,
+                                                     const char *peer_key, const char *connected_key);
+
+    /**
+     * @brief Return a runtime-owned host session, or NULL when absent.
+     *
+     * The caller must not destroy the returned pointer.
+     */
+    sdl3d_network_session *sdl3d_game_data_get_network_host_session(sdl3d_game_data_runtime *runtime,
+                                                                    const char *session_name);
+
+    /**
      * @brief Start or refresh a named runtime-owned LAN discovery scanner.
      *
      * Results are published to @p collection_name when provided. Each row

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -249,6 +249,12 @@ typedef struct runtime_direct_connect_session
     sdl3d_network_session *session;
 } runtime_direct_connect_session;
 
+typedef struct runtime_host_session
+{
+    char *name;
+    sdl3d_network_session *session;
+} runtime_host_session;
+
 typedef struct runtime_discovery_session
 {
     char *name;
@@ -329,6 +335,9 @@ typedef struct sdl3d_game_data_runtime
     runtime_direct_connect_session *direct_connect_sessions;
     int direct_connect_session_count;
     int direct_connect_session_capacity;
+    runtime_host_session *host_sessions;
+    int host_session_count;
+    int host_session_capacity;
     runtime_discovery_session *discovery_sessions;
     int discovery_session_count;
     int discovery_session_capacity;
@@ -4953,6 +4962,181 @@ bool sdl3d_game_data_network_direct_connect_start(sdl3d_game_data_runtime *runti
     }
 
     direct_connect_publish_status_entry(runtime, entry, status_key, state_key, connected_key, "Connecting");
+    return true;
+}
+
+static runtime_host_session *find_host_session(sdl3d_game_data_runtime *runtime, const char *session_name)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->host_session_count; ++i)
+    {
+        if (SDL_strcmp(runtime->host_sessions[i].name, session_name) == 0)
+            return &runtime->host_sessions[i];
+    }
+    return NULL;
+}
+
+static runtime_host_session *get_or_create_host_session(sdl3d_game_data_runtime *runtime, const char *session_name)
+{
+    runtime_host_session *existing = find_host_session(runtime, session_name);
+    if (existing != NULL)
+        return existing;
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return NULL;
+
+    if (runtime->host_session_count >= runtime->host_session_capacity)
+    {
+        const int next_capacity = runtime->host_session_capacity > 0 ? runtime->host_session_capacity * 2 : 2;
+        runtime_host_session *next =
+            (runtime_host_session *)SDL_realloc(runtime->host_sessions, (size_t)next_capacity * sizeof(*next));
+        if (next == NULL)
+            return NULL;
+        SDL_memset(next + runtime->host_session_capacity, 0,
+                   (size_t)(next_capacity - runtime->host_session_capacity) * sizeof(*next));
+        runtime->host_sessions = next;
+        runtime->host_session_capacity = next_capacity;
+    }
+
+    runtime_host_session *entry = &runtime->host_sessions[runtime->host_session_count];
+    SDL_zero(*entry);
+    entry->name = SDL_strdup(session_name);
+    if (entry->name == NULL)
+        return NULL;
+    ++runtime->host_session_count;
+    return entry;
+}
+
+static void host_publish_manual_status(sdl3d_game_data_runtime *runtime, const char *status_key,
+                                       const char *endpoint_key, const char *peer_key, const char *connected_key,
+                                       const char *status, Uint16 port, const char *peer, bool connected)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    if (status_key != NULL && status_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, status_key, status != NULL ? status : "");
+    if (endpoint_key != NULL && endpoint_key[0] != '\0')
+    {
+        char endpoint[32];
+        SDL_snprintf(endpoint, sizeof(endpoint), "UDP %u", (unsigned int)port);
+        sdl3d_properties_set_string(runtime->scene_state, endpoint_key, endpoint);
+    }
+    if (peer_key != NULL && peer_key[0] != '\0')
+        sdl3d_properties_set_string(runtime->scene_state, peer_key, peer != NULL ? peer : "Waiting for client");
+    if (connected_key != NULL && connected_key[0] != '\0')
+        sdl3d_properties_set_bool(runtime->scene_state, connected_key, connected);
+}
+
+static void host_publish_status_entry(sdl3d_game_data_runtime *runtime, const runtime_host_session *entry,
+                                      const char *status_key, const char *endpoint_key, const char *peer_key,
+                                      const char *connected_key, const char *fallback_status, Uint16 fallback_port)
+{
+    const sdl3d_network_state state = entry != NULL && entry->session != NULL
+                                          ? sdl3d_network_session_state(entry->session)
+                                          : SDL3D_NETWORK_STATE_DISCONNECTED;
+    const char *status = entry != NULL && entry->session != NULL ? sdl3d_network_session_status(entry->session) : NULL;
+    const Uint16 port =
+        entry != NULL && entry->session != NULL ? sdl3d_network_session_port(entry->session) : fallback_port;
+    char peer_label[SDL3D_NETWORK_MAX_HOST_LENGTH + 48];
+    char peer_host[SDL3D_NETWORK_MAX_HOST_LENGTH];
+    Uint16 peer_port = 0;
+    const bool connected =
+        entry != NULL && entry->session != NULL && sdl3d_network_session_is_connected(entry->session);
+
+    if (status == NULL || status[0] == '\0')
+        status = fallback_status != NULL ? fallback_status : game_data_network_state_name(state);
+    SDL_snprintf(peer_label, sizeof(peer_label), "Waiting for client");
+    SDL_zero(peer_host);
+    if (connected &&
+        sdl3d_network_session_get_peer_endpoint(entry->session, peer_host, (int)sizeof(peer_host), &peer_port))
+        SDL_snprintf(peer_label, sizeof(peer_label), "Client 1 - %s:%u", peer_host, (unsigned int)peer_port);
+    else if (connected)
+        SDL_snprintf(peer_label, sizeof(peer_label), "Client 1 - Connected");
+
+    host_publish_manual_status(runtime, status_key, endpoint_key, peer_key, connected_key, status, port, peer_label,
+                               connected);
+}
+
+sdl3d_network_session *sdl3d_game_data_get_network_host_session(sdl3d_game_data_runtime *runtime,
+                                                                const char *session_name)
+{
+    runtime_host_session *entry = find_host_session(runtime, session_name);
+    return entry != NULL ? entry->session : NULL;
+}
+
+bool sdl3d_game_data_network_host_publish_status(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                                 const char *status_key, const char *endpoint_key, const char *peer_key,
+                                                 const char *connected_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    host_publish_status_entry(runtime, find_host_session(runtime, session_name), status_key, endpoint_key, peer_key,
+                              connected_key, "Not hosting", SDL3D_NETWORK_DEFAULT_PORT);
+    return true;
+}
+
+bool sdl3d_game_data_network_host_cancel(sdl3d_game_data_runtime *runtime, const char *session_name,
+                                         const char *status_key, const char *endpoint_key, const char *peer_key,
+                                         const char *connected_key, const char *status)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_host_session *entry = find_host_session(runtime, session_name);
+    Uint16 port = SDL3D_NETWORK_DEFAULT_PORT;
+    if (entry != NULL && entry->session != NULL)
+    {
+        port = sdl3d_network_session_port(entry->session);
+        sdl3d_network_session_destroy(entry->session);
+        entry->session = NULL;
+    }
+    host_publish_manual_status(runtime, status_key, endpoint_key, peer_key, connected_key,
+                               status != NULL ? status : "Not hosting", port, "Waiting for client", false);
+    return true;
+}
+
+bool sdl3d_game_data_network_host_start(sdl3d_game_data_runtime *runtime, const char *session_name, int port,
+                                        const char *advertised_name, const char *status_key, const char *endpoint_key,
+                                        const char *peer_key, const char *connected_key)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0')
+        return false;
+    runtime_host_session *entry = get_or_create_host_session(runtime, session_name);
+    if (entry == NULL)
+        return false;
+
+    if (entry->session != NULL)
+    {
+        host_publish_status_entry(runtime, entry, status_key, endpoint_key, peer_key, connected_key, "Waiting",
+                                  (Uint16)port);
+        return true;
+    }
+
+    if (port <= 0 || port > 65535)
+    {
+        host_publish_manual_status(runtime, status_key, endpoint_key, peer_key, connected_key, "Invalid host port",
+                                   SDL3D_NETWORK_DEFAULT_PORT, "Waiting for client", false);
+        return false;
+    }
+
+    sdl3d_network_session_desc desc;
+    sdl3d_network_session_desc_init(&desc);
+    desc.role = SDL3D_NETWORK_ROLE_HOST;
+    desc.host = NULL;
+    desc.port = (Uint16)port;
+    desc.local_port = 0;
+    desc.handshake_timeout = 5.0f;
+    desc.idle_timeout = 10.0f;
+    desc.session_name = advertised_name != NULL && advertised_name[0] != '\0' ? advertised_name : "SDL3D Session";
+
+    if (!sdl3d_network_session_create(&desc, &entry->session))
+    {
+        host_publish_manual_status(runtime, status_key, endpoint_key, peer_key, connected_key, SDL_GetError(),
+                                   (Uint16)SDL_max(port, 0), "Waiting for client", false);
+        return false;
+    }
+
+    host_publish_status_entry(runtime, entry, status_key, endpoint_key, peer_key, connected_key, "Waiting",
+                              (Uint16)port);
     return true;
 }
 
@@ -9693,6 +9877,33 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
             json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL));
     }
 
+    if (SDL_strcmp(type, "network.host.start") == 0)
+    {
+        const int default_port = json_int(action, "default_port", SDL3D_NETWORK_DEFAULT_PORT);
+        const int port = json_int_or_string(action, "port", default_port);
+        return sdl3d_game_data_network_host_start(
+            runtime, json_string(action, "name", NULL), port,
+            json_string(action, "session_name", json_string(action, "advertised_name", NULL)),
+            json_string(action, "status_key", NULL), json_string(action, "endpoint_key", NULL),
+            json_string(action, "peer_key", NULL), json_string(action, "connected_key", NULL));
+    }
+
+    if (SDL_strcmp(type, "network.host.cancel") == 0)
+    {
+        return sdl3d_game_data_network_host_cancel(
+            runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "endpoint_key", NULL), json_string(action, "peer_key", NULL),
+            json_string(action, "connected_key", NULL), json_string(action, "status", "Not hosting"));
+    }
+
+    if (SDL_strcmp(type, "network.host.observe") == 0)
+    {
+        return sdl3d_game_data_network_host_publish_status(
+            runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
+            json_string(action, "endpoint_key", NULL), json_string(action, "peer_key", NULL),
+            json_string(action, "connected_key", NULL));
+    }
+
     if (SDL_strcmp(type, "network.discovery.start") == 0 || SDL_strcmp(type, "network.discovery.refresh") == 0)
     {
         const int default_port = json_int(action, "default_port", SDL3D_NETWORK_DEFAULT_PORT);
@@ -12410,6 +12621,11 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->direct_connect_sessions[i].name);
         sdl3d_network_session_destroy(runtime->direct_connect_sessions[i].session);
     }
+    for (int i = 0; i < runtime->host_session_count; ++i)
+    {
+        SDL_free(runtime->host_sessions[i].name);
+        sdl3d_network_session_destroy(runtime->host_sessions[i].session);
+    }
     for (int i = 0; i < runtime->discovery_session_count; ++i)
     {
         SDL_free(runtime->discovery_sessions[i].name);
@@ -12438,6 +12654,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->property_snapshots);
     SDL_free(runtime->collections);
     SDL_free(runtime->direct_connect_sessions);
+    SDL_free(runtime->host_sessions);
     SDL_free(runtime->discovery_sessions);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2565,6 +2565,24 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "%s requires a non-empty name", type);
         return true;
     }
+    if (SDL_strcmp(type, "network.host.start") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "network.host.start requires a non-empty name");
+        if (!validate_network_port_value(ctx, obj_get(action, "port"), json_path, "network.host.start port"))
+            return false;
+        yyjson_val *default_port = obj_get(action, "default_port");
+        if (default_port != NULL &&
+            (!yyjson_is_int(default_port) || yyjson_get_int(default_port) <= 0 || yyjson_get_int(default_port) > 65535))
+            return validation_error(ctx, json_path, "network.host.start default_port must be integer 1..65535");
+        return true;
+    }
+    if (SDL_strcmp(type, "network.host.cancel") == 0 || SDL_strcmp(type, "network.host.observe") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "%s requires a non-empty name", type);
+        return true;
+    }
     if (SDL_strcmp(type, "network.discovery.start") == 0 || SDL_strcmp(type, "network.discovery.refresh") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6462,6 +6462,49 @@ TEST(GameDataRuntime, AuthoredDirectConnectActionsUpdateSceneState)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, RuntimeOwnedHostSessionPublishesSceneState)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(SDL3D_PONG_DATA_PATH, session, &runtime, error, sizeof(error))) << error;
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    const ::testing::TestInfo *test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+    const std::string test_name =
+        test_info != nullptr ? std::string(test_info->test_suite_name()) + "." + test_info->name() : "host";
+    const int port = 30000 + (int)(std::hash<std::string>{}(test_name) % 20000U);
+    if (!sdl3d_game_data_network_host_start(runtime, "test_host", port, "SDL3D Test", "host_status", "host_endpoint",
+                                            "host_peer", "host_connected"))
+    {
+        sdl3d_game_data_destroy(runtime);
+        sdl3d_game_session_destroy(session);
+        GTEST_SKIP() << "network host session unavailable: " << SDL_GetError();
+    }
+
+    sdl3d_network_session *host = sdl3d_game_data_get_network_host_session(runtime, "test_host");
+    ASSERT_NE(host, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "host_connected", true));
+    EXPECT_NE(std::string(sdl3d_properties_get_string(scene_state, "host_endpoint", "")).find("UDP "),
+              std::string::npos);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "host_peer", ""), "Waiting for client");
+
+    ASSERT_TRUE(sdl3d_game_data_network_host_publish_status(runtime, "test_host", "host_status", "host_endpoint",
+                                                            "host_peer", "host_connected"));
+    ASSERT_TRUE(sdl3d_game_data_network_host_cancel(runtime, "test_host", "host_status", "host_endpoint", "host_peer",
+                                                    "host_connected", "Not hosting"));
+    EXPECT_EQ(sdl3d_game_data_get_network_host_session(runtime, "test_host"), nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "host_status", ""), "Not hosting");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "host_connected", true));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, AuthoredDiscoveryConnectActionsUpdateSceneState)
 {
     sdl3d_game_session *session = nullptr;
@@ -6562,6 +6605,37 @@ TEST(GameDataRuntime, RejectsInvalidDirectConnectActions)
     EXPECT_NE(
         std::string(error).find("network.direct_connect.start port must be a non-empty string or integer 1..65535"),
         std::string::npos)
+        << error;
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidHostActions)
+{
+    const std::filesystem::path dir = unique_test_dir("bad_host_actions");
+    write_text(dir / "bad_host.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Host", "id": "test.bad_host", "version": "0.1.0" },
+  "world": { "name": "world.bad_host", "kind": "fixed_screen" },
+  "entities": [],
+  "signals": ["signal.host"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.host",
+        "actions": [
+          { "type": "network.host.start", "name": "host", "port": 70000 }
+        ]
+      }
+    ]
+  }
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "bad_host.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("network.host.start port must be a non-empty string or integer 1..65535"),
+              std::string::npos)
         << error;
     remove_test_dir(dir);
 }


### PR DESCRIPTION
## Summary
- add runtime-owned UDP host session primitives and data actions (`network.host.start`, `network.host.observe`, `network.host.cancel`)
- author the Pong multiplayer lobby to start and observe the host session from scene JSON
- migrate Pong host-session creation, cancellation, and lobby state publishing onto game-data runtime helpers
- document the host-session actions and add focused validation/runtime tests

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Notes
This slice intentionally leaves Pong packet send/receive orchestration in `demos/pong/main.c`. The next practical slice should move more of that session-loop behavior into generic runtime-managed networking so the Pong host continues shrinking toward JSON/Lua-only game definition.

Part of #210.