### PR TITLE
Resolve network controls by runtime binding

### DIFF
--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -40,18 +40,10 @@ typedef struct pong_state
     char network_match_termination_reason[96];
 } pong_state;
 
-typedef enum pong_network_message_kind
-{
-    PONG_NETWORK_MESSAGE_START_GAME,
-    PONG_NETWORK_MESSAGE_PAUSE_REQUEST,
-    PONG_NETWORK_MESSAGE_RESUME_REQUEST,
-    PONG_NETWORK_MESSAGE_DISCONNECT,
-} pong_network_message_kind;
-
-static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session,
-                                        pong_network_message_kind kind, const char *label);
-static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session,
-                                                 pong_network_message_kind kind, const char *label, int count);
+static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session, const char *binding,
+                                        const char *label);
+static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session, const char *binding,
+                                                 const char *label, int count);
 static void publish_network_match_termination_scene_state(pong_state *state);
 
 static const char PONG_NETWORK_BINDING_STATE_SNAPSHOT[] = "state_snapshot";
@@ -72,19 +64,6 @@ static const char PONG_DIRECT_CONNECT_PORT_KEY[] = "direct_connect_port";
 static const char PONG_DIRECT_CONNECT_STATUS_KEY[] = "direct_connect_status";
 static const char PONG_DIRECT_CONNECT_STATE_KEY[] = "direct_connect_state";
 static const char PONG_DIRECT_CONNECT_CONNECTED_KEY[] = "direct_connect_connected";
-
-typedef struct pong_network_control_binding
-{
-    pong_network_message_kind kind;
-    const char *binding;
-} pong_network_control_binding;
-
-static const pong_network_control_binding PONG_NETWORK_CONTROL_BINDINGS[] = {
-    {PONG_NETWORK_MESSAGE_START_GAME, PONG_NETWORK_BINDING_START_GAME},
-    {PONG_NETWORK_MESSAGE_PAUSE_REQUEST, PONG_NETWORK_BINDING_PAUSE_REQUEST},
-    {PONG_NETWORK_MESSAGE_RESUME_REQUEST, PONG_NETWORK_BINDING_RESUME_REQUEST},
-    {PONG_NETWORK_MESSAGE_DISCONNECT, PONG_NETWORK_BINDING_DISCONNECT},
-};
 
 static Uint64 pong_log_timestamp_ms(void)
 {
@@ -374,7 +353,7 @@ static void destroy_host_session_internal(pong_state *state, bool notify_peer)
     {
         if (notify_peer)
         {
-            (void)send_network_control_packet_repeated(state, state->host_session, PONG_NETWORK_MESSAGE_DISCONNECT,
+            (void)send_network_control_packet_repeated(state, state->host_session, PONG_NETWORK_BINDING_DISCONNECT,
                                                        "host disconnect", 5);
         }
         (void)sdl3d_game_data_network_host_cancel(
@@ -413,7 +392,7 @@ static void destroy_direct_connect_session_internal(pong_state *state, bool noti
         if (notify_peer)
         {
             (void)send_network_control_packet_repeated(state, state->direct_connect_session,
-                                                       PONG_NETWORK_MESSAGE_DISCONNECT, "client disconnect", 5);
+                                                       PONG_NETWORK_BINDING_DISCONNECT, "client disconnect", 5);
         }
         (void)sdl3d_game_data_network_direct_connect_cancel(
             state->data, PONG_DIRECT_CONNECT_SESSION, PONG_DIRECT_CONNECT_STATUS_KEY, PONG_DIRECT_CONNECT_STATE_KEY,
@@ -480,96 +459,36 @@ static void reset_direct_connect_defaults(pong_state *state)
     }
 }
 
-static const char *network_control_binding_for_kind(pong_network_message_kind kind)
+static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session, const char *binding,
+                                        const char *label)
 {
-    for (size_t i = 0; i < SDL_arraysize(PONG_NETWORK_CONTROL_BINDINGS); ++i)
-    {
-        if (PONG_NETWORK_CONTROL_BINDINGS[i].kind == kind)
-            return PONG_NETWORK_CONTROL_BINDINGS[i].binding;
-    }
-    return NULL;
-}
-
-static const char *network_control_name_for_kind(const pong_state *state, pong_network_message_kind kind)
-{
-    const char *control_name = NULL;
-    const char *binding = network_control_binding_for_kind(kind);
-    if (state == NULL || state->data == NULL || binding == NULL ||
-        !sdl3d_game_data_get_network_runtime_control(state->data, binding, &control_name))
-    {
-        return NULL;
-    }
-    return control_name;
-}
-
-static bool network_control_kind_from_name(const pong_state *state, const char *name,
-                                           pong_network_message_kind *out_kind)
-{
-    if (state == NULL || state->data == NULL || name == NULL)
-    {
-        return false;
-    }
-    for (size_t i = 0; i < SDL_arraysize(PONG_NETWORK_CONTROL_BINDINGS); ++i)
-    {
-        const pong_network_message_kind kind = PONG_NETWORK_CONTROL_BINDINGS[i].kind;
-        const char *control_name = network_control_name_for_kind(state, kind);
-        if (control_name != NULL && SDL_strcmp(name, control_name) == 0)
-        {
-            if (out_kind != NULL)
-                *out_kind = kind;
-            return true;
-        }
-    }
-    return false;
-}
-
-static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session,
-                                        pong_network_message_kind kind, const char *label)
-{
-    Uint8 packet[SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE];
-    size_t packet_size = 0U;
     char error[160] = {0};
     const Uint32 tick = (Uint32)SDL_GetTicks();
-    if (state == NULL || state->data == NULL || session == NULL || !sdl3d_network_session_is_connected(session))
+    if (state == NULL || state->data == NULL || session == NULL || binding == NULL || binding[0] == '\0')
     {
-        return false;
-    }
-    const char *control_name = network_control_name_for_kind(state, kind);
-    if (control_name == NULL)
-    {
-        const char *binding = network_control_binding_for_kind(kind);
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: controls.%s",
-                    binding != NULL ? binding : "<unknown>");
         return false;
     }
 
-    if (!sdl3d_game_data_encode_network_control(state->data, control_name, tick, packet, sizeof(packet), &packet_size,
-                                                error, (int)sizeof(error)))
+    if (!sdl3d_game_data_send_network_runtime_control(state->data, session, binding, tick, error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet encode failed: %s", error);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet send failed: %s", error);
         return false;
     }
 
-    if (!sdl3d_network_session_send(session, packet, (int)packet_size))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network control packet send failed: %s", SDL_GetError());
-        return false;
-    }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong sent network control: %s kind=%u",
-                (unsigned long long)pong_log_timestamp_ms(), label != NULL ? label : "control", (unsigned int)kind);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong sent network control: %s binding=%s",
+                (unsigned long long)pong_log_timestamp_ms(), label != NULL ? label : "control", binding);
     return true;
 }
 
-static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session,
-                                                 pong_network_message_kind kind, const char *label, int count)
+static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session, const char *binding,
+                                                 const char *label, int count)
 {
     bool sent_any = false;
     const int attempts = SDL_max(count, 1);
 
     for (int i = 0; i < attempts; ++i)
     {
-        if (send_network_control_packet(state, session, kind, label))
+        if (send_network_control_packet(state, session, binding, label))
         {
             sent_any = true;
         }
@@ -583,20 +502,20 @@ static bool send_network_control_packet_repeated(pong_state *state, sdl3d_networ
 }
 
 static bool read_network_control_packet(pong_state *state, const Uint8 *packet, int packet_size,
-                                        pong_network_message_kind expected, Uint32 *out_tick)
+                                        const char *expected_binding, Uint32 *out_tick)
 {
     sdl3d_game_data_network_control control;
-    pong_network_message_kind actual = 0;
+    const char *binding = NULL;
     char error[160] = {0};
 
-    if (state == NULL || state->data == NULL || packet == NULL || packet_size <= 0)
+    if (state == NULL || state->data == NULL || packet == NULL || packet_size <= 0 || expected_binding == NULL)
     {
         return false;
     }
 
-    if (!sdl3d_game_data_decode_network_control(state->data, packet, (size_t)packet_size, &control, error,
-                                                (int)sizeof(error)) ||
-        !network_control_kind_from_name(state, control.name, &actual) || actual != expected)
+    if (!sdl3d_game_data_decode_network_runtime_control(state->data, packet, (size_t)packet_size, &binding, &control,
+                                                        error, (int)sizeof(error)) ||
+        binding == NULL || SDL_strcmp(binding, expected_binding) != 0)
     {
         return false;
     }
@@ -622,7 +541,7 @@ static bool send_host_start_packet(pong_state *state)
         return false;
     }
 
-    if (!send_network_control_packet(state, state->host_session, PONG_NETWORK_MESSAGE_START_GAME, "start game"))
+    if (!send_network_control_packet(state, state->host_session, PONG_NETWORK_BINDING_START_GAME, "start game"))
     {
         SDL_snprintf(state->host_status, sizeof(state->host_status), "%s", SDL_GetError());
         update_host_session_scene_state(state);
@@ -718,7 +637,7 @@ static bool send_client_input_packet(pong_state *state)
 static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_state *state)
 {
     int pause_action = -1;
-    pong_network_message_kind request_kind;
+    const char *request_binding = NULL;
 
     if (ctx == NULL || state == NULL || state->input == NULL || state->data == NULL ||
         state->direct_connect_session == NULL)
@@ -736,10 +655,10 @@ static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_s
         return;
     }
 
-    request_kind = ctx->paused ? PONG_NETWORK_MESSAGE_RESUME_REQUEST : PONG_NETWORK_MESSAGE_PAUSE_REQUEST;
-    (void)send_network_control_packet(state, state->direct_connect_session, request_kind,
-                                      request_kind == PONG_NETWORK_MESSAGE_PAUSE_REQUEST ? "pause request"
-                                                                                         : "resume request");
+    request_binding = ctx->paused ? PONG_NETWORK_BINDING_RESUME_REQUEST : PONG_NETWORK_BINDING_PAUSE_REQUEST;
+    (void)send_network_control_packet(
+        state, state->direct_connect_session, request_binding,
+        SDL_strcmp(request_binding, PONG_NETWORK_BINDING_PAUSE_REQUEST) == 0 ? "pause request" : "resume request");
 }
 
 static bool sync_match_pause_from_context(sdl3d_game_context *ctx, pong_state *state)
@@ -917,12 +836,16 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
     }
 }
 
-static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong_state *state,
-                                                   pong_network_message_kind kind, Uint32 tick)
+static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong_state *state, const char *binding,
+                                                   Uint32 tick)
 {
-    switch (kind)
+    if (binding == NULL)
     {
-    case PONG_NETWORK_MESSAGE_PAUSE_REQUEST:
+        return false;
+    }
+
+    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_PAUSE_REQUEST) == 0)
+    {
         if (ctx != NULL && is_network_role_host(state))
         {
             ctx->paused = true;
@@ -930,7 +853,9 @@ static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong
                         (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
         }
         return true;
-    case PONG_NETWORK_MESSAGE_RESUME_REQUEST:
+    }
+    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_RESUME_REQUEST) == 0)
+    {
         if (ctx != NULL && is_network_role_host(state))
         {
             ctx->paused = false;
@@ -938,14 +863,16 @@ static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong
                         (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
         }
         return true;
-    case PONG_NETWORK_MESSAGE_DISCONNECT:
+    }
+    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_DISCONNECT) == 0)
+    {
         return_to_multiplayer_after_disconnect(
             ctx, state, is_network_role_host(state),
             network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
         return true;
-    default:
-        return false;
     }
+
+    return false;
 }
 
 static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
@@ -1052,7 +979,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
         while ((packet_size =
                     sdl3d_network_session_receive(state->direct_connect_session, packet, (int)sizeof(packet))) > 0)
         {
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_START_GAME, NULL))
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_START_GAME, NULL))
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
                 clear_network_action_overrides(state);
@@ -1064,7 +991,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                 continue;
             }
             Uint32 tick = 0U;
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_DISCONNECT, &tick))
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
                             (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
@@ -1177,7 +1104,7 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         while ((packet_size = sdl3d_network_session_receive(state->host_session, packet, (int)sizeof(packet))) > 0)
         {
             Uint32 tick = 0U;
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_DISCONNECT, &tick))
+            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_DISCONNECT, &tick))
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
                             (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
@@ -1186,15 +1113,15 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
                 break;
             }
             if (is_multiplayer_play_scene(state) &&
-                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_PAUSE_REQUEST, &tick))
+                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_PAUSE_REQUEST, &tick))
             {
-                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_MESSAGE_PAUSE_REQUEST, tick);
+                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_BINDING_PAUSE_REQUEST, tick);
                 continue;
             }
             if (is_multiplayer_play_scene(state) &&
-                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_MESSAGE_RESUME_REQUEST, &tick))
+                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_RESUME_REQUEST, &tick))
             {
-                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_MESSAGE_RESUME_REQUEST, tick);
+                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_BINDING_RESUME_REQUEST, tick);
                 continue;
             }
             if (is_multiplayer_play_scene(state))

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1729,8 +1729,12 @@ names into game host code. `replication` maps semantic names to entries in
 `network.replication`, and `controls` maps semantic names to entries in
 `network.control_messages`. `actions` maps semantic names to input actions, and
 `signals` maps semantic names to signals. Values are validated as references.
+Control binding values must be unique, because generic network loops decode
+packets by reversing the concrete control-message name back to one semantic
+runtime binding.
 Callers resolve them with `sdl3d_game_data_get_network_runtime_replication()`,
 `sdl3d_game_data_get_network_runtime_control()`,
+`sdl3d_game_data_get_network_runtime_control_binding()`,
 `sdl3d_game_data_get_network_runtime_action()`, and
 `sdl3d_game_data_get_network_runtime_signal()`. `pause` can additionally bind
 a network pause action and the bool actor property that mirrors pause state into
@@ -1832,6 +1836,15 @@ reject unsupported versions, mismatched schema hashes, invalid control indexes,
 truncation, and trailing bytes. Applying a valid control message emits the
 authored signal with a payload containing `network_control`,
 `network_direction`, and `network_tick`.
+
+Generic session loops should prefer the runtime-binding variants:
+`sdl3d_game_data_encode_network_runtime_control()`,
+`sdl3d_game_data_decode_network_runtime_control()`, and
+`sdl3d_game_data_send_network_runtime_control()`. These helpers resolve
+`network.runtime_bindings.controls` before encoding and after decoding, so the
+loop can dispatch on semantic names like `start_game`, `pause_request`, and
+`disconnect` without knowing the concrete control-message names in the
+authored wire schema.
 
 When a runtime loads game data with a valid `network` block, it computes a
 deterministic schema hash over protocol, replication, input, and control-message

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1028,6 +1028,23 @@ extern "C"
                                                      const char **out_control);
 
     /**
+     * @brief Resolve the semantic runtime binding for an authored control message.
+     *
+     * This is the reverse lookup for
+     * @ref sdl3d_game_data_get_network_runtime_control. It lets generic
+     * network loops decode a control packet and dispatch on the authored
+     * runtime semantic, such as `pause_request` or `disconnect`, without
+     * knowing the concrete control-message name in the wire schema.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param control_name Authored control message name from `network.control_messages`.
+     * @param out_binding Receives the semantic binding name owned by @p runtime.
+     * @return true when a runtime control binding maps to @p control_name.
+     */
+    bool sdl3d_game_data_get_network_runtime_control_binding(const sdl3d_game_data_runtime *runtime,
+                                                             const char *control_name, const char **out_binding);
+
+    /**
      * @brief Resolve an authored network runtime input action binding.
      *
      * Runtime action bindings are authored under
@@ -1300,6 +1317,18 @@ extern "C"
                                                 char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Encode an authored control packet by runtime binding semantic.
+     *
+     * @p binding_name is resolved through `network.runtime_bindings.controls`
+     * before encoding. Use this from generic session/runtime code so the loop
+     * does not need to know concrete control-message names.
+     */
+    bool sdl3d_game_data_encode_network_runtime_control(const sdl3d_game_data_runtime *runtime,
+                                                        const char *binding_name, Uint32 tick, void *buffer,
+                                                        size_t buffer_size, size_t *out_size, char *error_buffer,
+                                                        int error_buffer_size);
+
+    /**
      * @brief Decode an authored network control message packet.
      *
      * The packet must match the runtime schema hash and reference an authored
@@ -1317,6 +1346,29 @@ extern "C"
     bool sdl3d_game_data_decode_network_control(const sdl3d_game_data_runtime *runtime, const void *packet,
                                                 size_t packet_size, sdl3d_game_data_network_control *out_control,
                                                 char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Decode an authored control packet and resolve its runtime binding.
+     *
+     * On success, @p out_binding receives the semantic name from
+     * `network.runtime_bindings.controls`, while @p out_control receives the
+     * concrete decoded control metadata. Both strings are owned by @p runtime.
+     */
+    bool sdl3d_game_data_decode_network_runtime_control(const sdl3d_game_data_runtime *runtime, const void *packet,
+                                                        size_t packet_size, const char **out_binding,
+                                                        sdl3d_game_data_network_control *out_control,
+                                                        char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Encode and send an authored control packet by runtime binding.
+     *
+     * This helper is transport-light: the caller still owns the session and
+     * higher-level flow, but packet naming, encoding, and send error reporting
+     * are centralized in the engine.
+     */
+    bool sdl3d_game_data_send_network_runtime_control(const sdl3d_game_data_runtime *runtime,
+                                                      sdl3d_network_session *session, const char *binding_name,
+                                                      Uint32 tick, char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Decode and emit an authored network control message signal.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -11544,6 +11544,46 @@ bool sdl3d_game_data_get_network_runtime_control(const sdl3d_game_data_runtime *
     return game_data_get_network_runtime_binding(runtime, "controls", name, out_control);
 }
 
+static bool game_data_get_network_runtime_binding_name_for_value(const sdl3d_game_data_runtime *runtime,
+                                                                 const char *section, const char *value,
+                                                                 const char **out_name)
+{
+    if (out_name != NULL)
+        *out_name = NULL;
+    if (runtime == NULL || section == NULL || section[0] == '\0' || value == NULL || value[0] == '\0' ||
+        out_name == NULL)
+    {
+        return false;
+    }
+
+    yyjson_val *bindings = obj_get(network_runtime_bindings_json(runtime), section);
+    if (!yyjson_is_obj(bindings))
+        return false;
+
+    yyjson_val *key = NULL;
+    yyjson_val *binding_value = NULL;
+    size_t index = 0U;
+    size_t max = 0U;
+    yyjson_obj_foreach(bindings, index, max, key, binding_value)
+    {
+        const char *semantic_name = yyjson_is_str(key) ? yyjson_get_str(key) : NULL;
+        const char *concrete_value = yyjson_is_str(binding_value) ? yyjson_get_str(binding_value) : NULL;
+        if (semantic_name != NULL && concrete_value != NULL && SDL_strcmp(concrete_value, value) == 0)
+        {
+            *out_name = semantic_name;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool sdl3d_game_data_get_network_runtime_control_binding(const sdl3d_game_data_runtime *runtime,
+                                                         const char *control_name, const char **out_binding)
+{
+    return game_data_get_network_runtime_binding_name_for_value(runtime, "controls", control_name, out_binding);
+}
+
 bool sdl3d_game_data_get_network_runtime_action(const sdl3d_game_data_runtime *runtime, const char *name,
                                                 int *out_action)
 {
@@ -12456,6 +12496,23 @@ bool sdl3d_game_data_encode_network_control(const sdl3d_game_data_runtime *runti
     return true;
 }
 
+bool sdl3d_game_data_encode_network_runtime_control(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                    Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                                    char *error_buffer, int error_buffer_size)
+{
+    const char *control_name = NULL;
+    if (!sdl3d_game_data_get_network_runtime_control(runtime, binding_name, &control_name))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime control binding '%s' not found",
+                   binding_name != NULL ? binding_name : "<null>");
+        if (out_size != NULL)
+            *out_size = 0U;
+        return false;
+    }
+    return sdl3d_game_data_encode_network_control(runtime, control_name, tick, buffer, buffer_size, out_size,
+                                                  error_buffer, error_buffer_size);
+}
+
 bool sdl3d_game_data_decode_network_control(const sdl3d_game_data_runtime *runtime, const void *packet,
                                             size_t packet_size, sdl3d_game_data_network_control *out_control,
                                             char *error_buffer, int error_buffer_size)
@@ -12536,6 +12593,59 @@ bool sdl3d_game_data_decode_network_control(const sdl3d_game_data_runtime *runti
         out_control->direction = direction;
         out_control->signal_id = signal_id;
         out_control->tick = tick;
+    }
+    return true;
+}
+
+bool sdl3d_game_data_decode_network_runtime_control(const sdl3d_game_data_runtime *runtime, const void *packet,
+                                                    size_t packet_size, const char **out_binding,
+                                                    sdl3d_game_data_network_control *out_control, char *error_buffer,
+                                                    int error_buffer_size)
+{
+    sdl3d_game_data_network_control control;
+    if (out_binding != NULL)
+        *out_binding = NULL;
+    if (!sdl3d_game_data_decode_network_control(runtime, packet, packet_size, &control, error_buffer,
+                                                error_buffer_size))
+    {
+        return false;
+    }
+
+    const char *binding = NULL;
+    if (!sdl3d_game_data_get_network_runtime_control_binding(runtime, control.name, &binding))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime control binding for '%s' not found",
+                   control.name != NULL ? control.name : "<null>");
+        return false;
+    }
+
+    if (out_binding != NULL)
+        *out_binding = binding;
+    if (out_control != NULL)
+        *out_control = control;
+    return true;
+}
+
+bool sdl3d_game_data_send_network_runtime_control(const sdl3d_game_data_runtime *runtime,
+                                                  sdl3d_network_session *session, const char *binding_name, Uint32 tick,
+                                                  char *error_buffer, int error_buffer_size)
+{
+    Uint8 packet[SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE];
+    size_t packet_size = 0U;
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime control send requires connected session");
+        return false;
+    }
+    if (!sdl3d_game_data_encode_network_runtime_control(runtime, binding_name, tick, packet, sizeof(packet),
+                                                        &packet_size, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (!sdl3d_network_session_send(session, packet, (int)packet_size))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime control send failed: %s", SDL_GetError());
+        return false;
     }
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -754,31 +754,46 @@ static bool validate_network_session_flow(validation_context *ctx, yyjson_val *n
 }
 
 static bool validate_network_runtime_binding_map(validation_context *ctx, yyjson_val *map, const char *json_path,
-                                                 const char *label, const name_table *references)
+                                                 const char *label, const name_table *references,
+                                                 bool require_unique_values)
 {
     if (map == NULL)
         return true;
     if (!yyjson_is_obj(map))
         return validation_error(ctx, json_path, "network runtime_bindings %s must be an object", label);
 
+    name_table values = {0};
+    bool ok = true;
     yyjson_val *key;
     yyjson_obj_iter iter;
     yyjson_obj_iter_init(map, &iter);
-    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    while (ok && (key = yyjson_obj_iter_next(&iter)) != NULL)
     {
         const char *name = yyjson_get_str(key);
         yyjson_val *value = yyjson_obj_iter_get_val(key);
         char path[PATH_BUFFER_SIZE];
         format_path(path, sizeof(path), "%s.%s", json_path, name != NULL ? name : "<invalid>");
         if (name == NULL || name[0] == '\0')
-            return validation_error(ctx, path, "network runtime_bindings %s key must be non-empty", label);
-        if (!yyjson_is_str(value) || yyjson_get_len(value) == 0)
-            return validation_error(ctx, path, "network runtime_bindings %s value must be a non-empty string", label);
-        if (!require_ref(ctx, references, label, yyjson_get_str(value), path))
-            return false;
+        {
+            ok = validation_error(ctx, path, "network runtime_bindings %s key must be non-empty", label);
+        }
+        else if (!yyjson_is_str(value) || yyjson_get_len(value) == 0)
+        {
+            ok = validation_error(ctx, path, "network runtime_bindings %s value must be a non-empty string", label);
+        }
+        else if (!require_ref(ctx, references, label, yyjson_get_str(value), path))
+        {
+            ok = false;
+        }
+        else if (require_unique_values &&
+                 !require_unique_name(ctx, &values, "network runtime binding value", yyjson_get_str(value), path))
+        {
+            ok = false;
+        }
     }
 
-    return true;
+    name_table_destroy(&values);
+    return ok;
 }
 
 static bool validate_network_runtime_pause_binding(validation_context *ctx, yyjson_val *pause, validation_names *names)
@@ -823,14 +838,14 @@ static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_va
 
     return validate_network_runtime_binding_map(ctx, obj_get(bindings, "replication"),
                                                 "$.network.runtime_bindings.replication", "network replication",
-                                                replication_names) &&
+                                                replication_names, false) &&
            validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"),
                                                 "$.network.runtime_bindings.controls", "network control message",
-                                                control_names) &&
+                                                control_names, true) &&
            validate_network_runtime_binding_map(ctx, obj_get(bindings, "actions"), "$.network.runtime_bindings.actions",
-                                                "input action", &names->actions) &&
+                                                "input action", &names->actions, false) &&
            validate_network_runtime_binding_map(ctx, obj_get(bindings, "signals"), "$.network.runtime_bindings.signals",
-                                                "signal", &names->signals) &&
+                                                "signal", &names->signals, false) &&
            validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6374,6 +6374,69 @@ TEST(GameDataRuntime, EncodesDecodesAndAppliesPongNetworkControlFromAuthoredSche
     destroy_runtime_session(receiver_session, receiver);
 }
 
+TEST(GameDataRuntime, ResolvesRuntimeControlBindingsForGenericNetworkLoops)
+{
+    const std::filesystem::path dir = unique_test_dir("network_runtime_control_bindings");
+    std::string network_json = valid_network_schema_json();
+    const size_t insert = network_json.rfind("\n  }");
+    ASSERT_NE(insert, std::string::npos);
+    network_json.insert(insert, R"json(,
+    "runtime_bindings": {
+      "controls": {
+        "semantic_pause": "pause"
+      }
+    })json");
+    write_text(dir / "network_runtime_controls.game.json", network_schema_game_json(network_json).c_str());
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "network_runtime_controls.game.json").string().c_str(), session,
+                                          &runtime, error, sizeof(error)))
+        << error;
+
+    const char *control_name = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_control(runtime, "semantic_pause", &control_name));
+    EXPECT_STREQ(control_name, "pause");
+
+    const char *binding_name = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_control_binding(runtime, "pause", &binding_name));
+    EXPECT_STREQ(binding_name, "semantic_pause");
+
+    std::array<Uint8, SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE> packet{};
+    size_t packet_size = 0U;
+    ASSERT_TRUE(sdl3d_game_data_encode_network_runtime_control(runtime, "semantic_pause", 99U, packet.data(),
+                                                               packet.size(), &packet_size, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(packet_size, SDL3D_GAME_DATA_NETWORK_CONTROL_PACKET_SIZE);
+
+    sdl3d_game_data_network_control control{};
+    const char *decoded_binding = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_decode_network_runtime_control(runtime, packet.data(), packet_size, &decoded_binding,
+                                                               &control, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(decoded_binding, "semantic_pause");
+    EXPECT_STREQ(control.name, "pause");
+    EXPECT_EQ(control.tick, 99U);
+
+    EXPECT_FALSE(sdl3d_game_data_encode_network_runtime_control(runtime, "missing", 1U, packet.data(), packet.size(),
+                                                                &packet_size, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("network runtime control binding 'missing' not found"), std::string::npos)
+        << error;
+
+    ASSERT_TRUE(sdl3d_game_data_encode_network_control(runtime, "start_game", 100U, packet.data(), packet.size(),
+                                                       &packet_size, error, sizeof(error)))
+        << error;
+    EXPECT_FALSE(sdl3d_game_data_decode_network_runtime_control(runtime, packet.data(), packet_size, &decoded_binding,
+                                                                &control, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("network runtime control binding for 'start_game' not found"), std::string::npos)
+        << error;
+
+    destroy_runtime_session(session, runtime);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsPongNetworkControlWithMismatchedSchemaOrBadSize)
 {
     sdl3d_game_session *sender_session = nullptr;
@@ -7032,6 +7095,35 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "unknown network control message reference",
+        },
+        {
+            "duplicate_runtime_control_binding_value",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "runtime_bindings": {
+      "controls": {
+        "pause_request": "pause",
+        "resume_request": "pause"
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ],
+    "control_messages": [
+      { "name": "pause", "direction": "bidirectional", "signal": "signal.network.pause" }
+    ]
+  })json",
+            "duplicate network runtime binding value 'pause'",
         },
         {
             "bad_runtime_action_binding",


### PR DESCRIPTION
## Summary
- add generic runtime-control helpers to encode, decode, reverse-resolve, and send control packets by `network.runtime_bindings.controls` semantics
- reject duplicate runtime control binding values so decoded packets map back to exactly one semantic binding
- remove Pong's native control enum/name bridge and dispatch control packets by authored runtime binding names
- document the runtime-binding control packet helpers and add focused validation/runtime tests

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo -j8`
- `cmake --build build/debug --target sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next Slice
The next practical slice is to move generic input/snapshot packet send/apply helpers behind runtime replication bindings, then begin consolidating the host/client per-frame packet loop into `sdl3d_data_game_runtime`.