### PR TITLE
Resolve network replication by runtime binding

### DIFF
--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -584,10 +584,7 @@ static bool start_selected_lobby_match(pong_state *state)
 
 static bool send_client_input_packet(pong_state *state)
 {
-    Uint8 packet[128];
-    size_t packet_size = 0U;
     char error[160] = {0};
-    const char *client_input_channel = NULL;
     const int p2_up = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_UP);
     const int p2_down = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_DOWN);
 
@@ -596,29 +593,17 @@ static bool send_client_input_packet(pong_state *state)
     {
         return false;
     }
-    if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT,
-                                                         &client_input_channel))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: replication.%s",
-                    PONG_NETWORK_BINDING_CLIENT_INPUT);
-        return false;
-    }
 
     const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(state->input);
     const float up_value = snapshot != NULL ? snapshot->actions[p2_up].value : 0.0f;
     const float down_value = snapshot != NULL ? snapshot->actions[p2_down].value : 0.0f;
     const Uint32 tick = snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U;
 
-    if (!sdl3d_game_data_encode_network_input(state->data, client_input_channel, state->input, tick, packet,
-                                              sizeof(packet), &packet_size, error, (int)sizeof(error)))
+    if (!sdl3d_game_data_send_network_runtime_input(state->data, state->direct_connect_session,
+                                                    PONG_NETWORK_BINDING_CLIENT_INPUT, state->input, tick, error,
+                                                    (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet encode failed: %s", error);
-        return false;
-    }
-
-    if (!sdl3d_network_session_send(state->direct_connect_session, packet, (int)packet_size))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", SDL_GetError());
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", error);
         return false;
     }
 
@@ -710,8 +695,8 @@ static bool process_host_input_packet(pong_state *state, const Uint8 *packet, in
         return false;
     }
 
-    if (!sdl3d_game_data_apply_network_input(state->data, state->input, packet, (size_t)packet_size, &tick, error,
-                                             (int)sizeof(error)))
+    if (!sdl3d_game_data_apply_network_runtime_input(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT, state->input,
+                                                     packet, (size_t)packet_size, &tick, error, (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host input packet apply failed: %s", error);
         return false;
@@ -738,8 +723,8 @@ static bool process_client_state_packet(sdl3d_game_context *ctx, pong_state *sta
         return false;
     }
 
-    if (!sdl3d_game_data_apply_network_snapshot(state->data, packet, (size_t)packet_size, &tick, error,
-                                                (int)sizeof(error)))
+    if (!sdl3d_game_data_apply_network_runtime_snapshot(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT, packet,
+                                                        (size_t)packet_size, &tick, error, (int)sizeof(error)))
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client state packet apply failed: %s", error);
         return false;
@@ -878,36 +863,27 @@ static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong
 static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
 {
     const sdl3d_input_snapshot *snapshot = NULL;
-    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
-    size_t packet_size = 0U;
     char error[160] = {0};
-    const char *state_channel = NULL;
 
     if (state == NULL || state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session) ||
         state->data == NULL || state->input == NULL)
     {
         return false;
     }
-    if (!sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
-                                                         &state_channel))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network binding missing: replication.%s",
-                    PONG_NETWORK_BINDING_STATE_SNAPSHOT);
-        return false;
-    }
 
     snapshot = sdl3d_input_get_snapshot(state->input);
-    if (snapshot == NULL || !sync_match_pause_from_context(ctx, state) ||
-        !sdl3d_game_data_encode_network_snapshot(state->data, state_channel, (Uint32)SDL_max(snapshot->tick, 0), packet,
-                                                 sizeof(packet), &packet_size, error, (int)sizeof(error)))
+    if (snapshot == NULL || !sync_match_pause_from_context(ctx, state))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed: %s", error);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed: %s",
+                    error[0] != '\0' ? error : "input snapshot unavailable");
         return false;
     }
 
-    if (!sdl3d_network_session_send(state->host_session, packet, (int)packet_size))
+    if (!sdl3d_game_data_send_network_runtime_snapshot(state->data, state->host_session,
+                                                       PONG_NETWORK_BINDING_STATE_SNAPSHOT,
+                                                       (Uint32)SDL_max(snapshot->tick, 0), error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet send failed: %s", SDL_GetError());
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet send failed: %s", error);
         return false;
     }
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1815,6 +1815,14 @@ authored `session_flow` state values, and every replicated actor field in schema
 order. This keeps debug output tied to the authored replication channel instead
 of hard-coding game actor ids or property paths in host C.
 
+Generic session loops should prefer the runtime-binding snapshot helpers:
+`sdl3d_game_data_encode_network_runtime_snapshot()`,
+`sdl3d_game_data_apply_network_runtime_snapshot()`, and
+`sdl3d_game_data_send_network_runtime_snapshot()`. These resolve
+`network.runtime_bindings.replication` values such as `state_snapshot` to
+concrete host-to-client channels and verify incoming packets use the expected
+channel before mutating actor state.
+
 Client-to-host input channels can be encoded with
 `sdl3d_game_data_encode_network_input()` and applied with
 `sdl3d_game_data_apply_network_input()`. Input packets use the same strict
@@ -1826,6 +1834,14 @@ normal action snapshot APIs. Malformed packets are rejected before any override
 is changed. When a peer disconnects or a network scene exits, callers should
 use `sdl3d_game_data_clear_network_input_overrides()` for the same channel so
 remote input cannot leak into later local play.
+
+Generic session loops should prefer the runtime-binding input helpers:
+`sdl3d_game_data_encode_network_runtime_input()`,
+`sdl3d_game_data_apply_network_runtime_input()`, and
+`sdl3d_game_data_send_network_runtime_input()`. These resolve
+`network.runtime_bindings.replication` values such as `client_input` to concrete
+client-to-host channels and verify incoming packets use the expected channel
+before applying action overrides.
 
 Control messages can be encoded with
 `sdl3d_game_data_encode_network_control()`, decoded with

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1211,6 +1211,25 @@ extern "C"
                                                  char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Encode a host-to-client snapshot packet by runtime binding semantic.
+     *
+     * @p binding_name is resolved through `network.runtime_bindings.replication`
+     * before encoding. Use this from generic session/runtime code so the loop
+     * does not need to know concrete replication channel names.
+     */
+    bool sdl3d_game_data_encode_network_runtime_snapshot(const sdl3d_game_data_runtime *runtime,
+                                                         const char *binding_name, Uint32 tick, void *buffer,
+                                                         size_t buffer_size, size_t *out_size, char *error_buffer,
+                                                         int error_buffer_size);
+
+    /**
+     * @brief Encode and send a host-to-client snapshot packet by runtime binding.
+     */
+    bool sdl3d_game_data_send_network_runtime_snapshot(const sdl3d_game_data_runtime *runtime,
+                                                       sdl3d_network_session *session, const char *binding_name,
+                                                       Uint32 tick, char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Decode and apply an authored host-to-client replication snapshot.
      *
      * The packet must match the runtime schema hash and reference a
@@ -1230,6 +1249,17 @@ extern "C"
     bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, const void *packet,
                                                 size_t packet_size, Uint32 *out_tick, char *error_buffer,
                                                 int error_buffer_size);
+
+    /**
+     * @brief Decode and apply a host-to-client snapshot expected by runtime binding.
+     *
+     * The packet must be a valid snapshot packet for the concrete replication
+     * channel mapped by @p binding_name. This prevents generic session loops
+     * from accidentally applying a valid but unexpected channel.
+     */
+    bool sdl3d_game_data_apply_network_runtime_snapshot(sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                        const void *packet, size_t packet_size, Uint32 *out_tick,
+                                                        char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Encode an authored client-to-host input replication packet.
@@ -1257,6 +1287,22 @@ extern "C"
                                               int error_buffer_size);
 
     /**
+     * @brief Encode a client-to-host input packet by runtime binding semantic.
+     */
+    bool sdl3d_game_data_encode_network_runtime_input(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                      const sdl3d_input_manager *input, Uint32 tick, void *buffer,
+                                                      size_t buffer_size, size_t *out_size, char *error_buffer,
+                                                      int error_buffer_size);
+
+    /**
+     * @brief Encode and send a client-to-host input packet by runtime binding.
+     */
+    bool sdl3d_game_data_send_network_runtime_input(const sdl3d_game_data_runtime *runtime,
+                                                    sdl3d_network_session *session, const char *binding_name,
+                                                    const sdl3d_input_manager *input, Uint32 tick, char *error_buffer,
+                                                    int error_buffer_size);
+
+    /**
      * @brief Decode and apply an authored client-to-host input packet.
      *
      * The packet must match the runtime schema hash and reference a
@@ -1276,6 +1322,17 @@ extern "C"
     bool sdl3d_game_data_apply_network_input(const sdl3d_game_data_runtime *runtime, sdl3d_input_manager *input,
                                              const void *packet, size_t packet_size, Uint32 *out_tick,
                                              char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Decode and apply a client-to-host input packet expected by runtime binding.
+     *
+     * The packet must be a valid input packet for the concrete replication
+     * channel mapped by @p binding_name. On failure, no input overrides are
+     * changed.
+     */
+    bool sdl3d_game_data_apply_network_runtime_input(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                     sdl3d_input_manager *input, const void *packet, size_t packet_size,
+                                                     Uint32 *out_tick, char *error_buffer, int error_buffer_size);
 
     /**
      * @brief Clear action overrides declared by an authored input replication channel.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -12057,6 +12057,125 @@ bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runt
     return true;
 }
 
+bool sdl3d_game_data_encode_network_runtime_snapshot(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                     Uint32 tick, void *buffer, size_t buffer_size, size_t *out_size,
+                                                     char *error_buffer, int error_buffer_size)
+{
+    const char *replication_name = NULL;
+    if (!sdl3d_game_data_get_network_runtime_replication(runtime, binding_name, &replication_name))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime replication binding '%s' not found",
+                   binding_name != NULL ? binding_name : "<null>");
+        if (out_size != NULL)
+            *out_size = 0U;
+        return false;
+    }
+    return sdl3d_game_data_encode_network_snapshot(runtime, replication_name, tick, buffer, buffer_size, out_size,
+                                                   error_buffer, error_buffer_size);
+}
+
+bool sdl3d_game_data_send_network_runtime_snapshot(const sdl3d_game_data_runtime *runtime,
+                                                   sdl3d_network_session *session, const char *binding_name,
+                                                   Uint32 tick, char *error_buffer, int error_buffer_size)
+{
+    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+    size_t packet_size = 0U;
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime snapshot send requires connected session");
+        return false;
+    }
+    if (!sdl3d_game_data_encode_network_runtime_snapshot(runtime, binding_name, tick, packet, sizeof(packet),
+                                                         &packet_size, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (!sdl3d_network_session_send(session, packet, (int)packet_size))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime snapshot send failed: %s", SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+static bool game_data_network_packet_matches_replication_binding(const sdl3d_game_data_runtime *runtime,
+                                                                 const char *binding_name, const void *packet,
+                                                                 size_t packet_size, Uint32 expected_magic,
+                                                                 Uint32 expected_version, bool host_to_client,
+                                                                 char *error_buffer, int error_buffer_size)
+{
+    const char *expected_channel = NULL;
+    if (runtime == NULL || packet == NULL || packet_size == 0U)
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication check requires runtime and packet");
+        return false;
+    }
+    if (!runtime->has_network_schema)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "network runtime replication check requires an authored network schema");
+        return false;
+    }
+    if (!sdl3d_game_data_get_network_runtime_replication(runtime, binding_name, &expected_channel))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime replication binding '%s' not found",
+                   binding_name != NULL ? binding_name : "<null>");
+        return false;
+    }
+
+    sdl3d_replication_reader reader;
+    sdl3d_replication_reader_init(&reader, packet, packet_size);
+    Uint32 magic = 0U;
+    Uint32 version = 0U;
+    Uint32 tick = 0U;
+    Uint32 channel_index = 0U;
+    Uint8 schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
+    if (!sdl3d_replication_read_uint32(&reader, &magic) || !sdl3d_replication_read_uint32(&reader, &version) ||
+        !sdl3d_replication_read_uint32(&reader, &tick) || !sdl3d_replication_read_uint32(&reader, &channel_index) ||
+        !sdl3d_replication_read_bytes(&reader, schema_hash, sizeof(schema_hash)))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication packet is too small for header");
+        return false;
+    }
+    if (magic != expected_magic || version != expected_version)
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication packet has unsupported header");
+        return false;
+    }
+    if (SDL_memcmp(schema_hash, runtime->network_schema_hash, SDL3D_REPLICATION_SCHEMA_HASH_SIZE) != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication schema hash does not match runtime");
+        return false;
+    }
+
+    yyjson_val *channel = game_data_find_replication_channel_by_index(runtime, channel_index);
+    if (channel == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication channel is invalid for this runtime");
+        return false;
+    }
+    if (host_to_client && !game_data_replication_channel_is_host_to_client(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication channel must be host_to_client");
+        return false;
+    }
+    if (!host_to_client && !game_data_replication_channel_is_client_to_host(channel))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime replication channel must be client_to_host");
+        return false;
+    }
+
+    const char *actual_channel = json_string(channel, "name", NULL);
+    if (actual_channel == NULL || SDL_strcmp(actual_channel, expected_channel) != 0)
+    {
+        set_errorf(error_buffer, error_buffer_size,
+                   "network runtime replication packet channel '%s' does not match binding '%s'",
+                   actual_channel != NULL ? actual_channel : "<null>", binding_name != NULL ? binding_name : "<null>");
+        return false;
+    }
+    return true;
+}
+
 bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, const void *packet, size_t packet_size,
                                             Uint32 *out_tick, char *error_buffer, int error_buffer_size)
 {
@@ -12207,6 +12326,22 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
     return true;
 }
 
+bool sdl3d_game_data_apply_network_runtime_snapshot(sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                    const void *packet, size_t packet_size, Uint32 *out_tick,
+                                                    char *error_buffer, int error_buffer_size)
+{
+    if (!game_data_network_packet_matches_replication_binding(
+            runtime, binding_name, packet, packet_size, SDL3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC,
+            SDL3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION, true, error_buffer, error_buffer_size))
+    {
+        if (out_tick != NULL)
+            *out_tick = 0U;
+        return false;
+    }
+    return sdl3d_game_data_apply_network_snapshot(runtime, packet, packet_size, out_tick, error_buffer,
+                                                  error_buffer_size);
+}
+
 bool sdl3d_game_data_encode_network_input(const sdl3d_game_data_runtime *runtime, const char *replication_name,
                                           const sdl3d_input_manager *input, Uint32 tick, void *buffer,
                                           size_t buffer_size, size_t *out_size, char *error_buffer,
@@ -12295,6 +12430,48 @@ bool sdl3d_game_data_encode_network_input(const sdl3d_game_data_runtime *runtime
 
     if (out_size != NULL)
         *out_size = sdl3d_replication_writer_offset(&writer);
+    return true;
+}
+
+bool sdl3d_game_data_encode_network_runtime_input(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                  const sdl3d_input_manager *input, Uint32 tick, void *buffer,
+                                                  size_t buffer_size, size_t *out_size, char *error_buffer,
+                                                  int error_buffer_size)
+{
+    const char *replication_name = NULL;
+    if (!sdl3d_game_data_get_network_runtime_replication(runtime, binding_name, &replication_name))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime replication binding '%s' not found",
+                   binding_name != NULL ? binding_name : "<null>");
+        if (out_size != NULL)
+            *out_size = 0U;
+        return false;
+    }
+    return sdl3d_game_data_encode_network_input(runtime, replication_name, input, tick, buffer, buffer_size, out_size,
+                                                error_buffer, error_buffer_size);
+}
+
+bool sdl3d_game_data_send_network_runtime_input(const sdl3d_game_data_runtime *runtime, sdl3d_network_session *session,
+                                                const char *binding_name, const sdl3d_input_manager *input, Uint32 tick,
+                                                char *error_buffer, int error_buffer_size)
+{
+    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+    size_t packet_size = 0U;
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        set_error(error_buffer, error_buffer_size, "network runtime input send requires connected session");
+        return false;
+    }
+    if (!sdl3d_game_data_encode_network_runtime_input(runtime, binding_name, input, tick, packet, sizeof(packet),
+                                                      &packet_size, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (!sdl3d_network_session_send(session, packet, (int)packet_size))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network runtime input send failed: %s", SDL_GetError());
+        return false;
+    }
     return true;
 }
 
@@ -12393,6 +12570,22 @@ bool sdl3d_game_data_apply_network_input(const sdl3d_game_data_runtime *runtime,
     if (out_tick != NULL)
         *out_tick = tick;
     return true;
+}
+
+bool sdl3d_game_data_apply_network_runtime_input(const sdl3d_game_data_runtime *runtime, const char *binding_name,
+                                                 sdl3d_input_manager *input, const void *packet, size_t packet_size,
+                                                 Uint32 *out_tick, char *error_buffer, int error_buffer_size)
+{
+    if (!game_data_network_packet_matches_replication_binding(
+            runtime, binding_name, packet, packet_size, SDL3D_GAME_DATA_NETWORK_INPUT_MAGIC,
+            SDL3D_GAME_DATA_NETWORK_INPUT_VERSION, false, error_buffer, error_buffer_size))
+    {
+        if (out_tick != NULL)
+            *out_tick = 0U;
+        return false;
+    }
+    return sdl3d_game_data_apply_network_input(runtime, input, packet, packet_size, out_tick, error_buffer,
+                                               error_buffer_size);
 }
 
 bool sdl3d_game_data_clear_network_input_overrides(const sdl3d_game_data_runtime *runtime, const char *replication_name,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6281,6 +6281,72 @@ TEST(GameDataRuntime, EncodesAndAppliesPongNetworkInputFromAuthoredSchema)
     destroy_runtime_session(host_session, host);
 }
 
+TEST(GameDataRuntime, RuntimeReplicationBindingsEncodeAndApplyPongPackets)
+{
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_data_runtime *host = nullptr;
+    load_pong_runtime(&host_session, &host);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(host));
+
+    sdl3d_game_session *client_session = nullptr;
+    sdl3d_game_data_runtime *client = nullptr;
+    load_pong_runtime(&client_session, &client);
+    ASSERT_TRUE(sdl3d_game_data_has_network_schema(client));
+
+    sdl3d_registered_actor *host_ball = sdl3d_game_data_find_actor(host, "entity.ball");
+    sdl3d_registered_actor *client_ball = sdl3d_game_data_find_actor(client, "entity.ball");
+    ASSERT_NE(host_ball, nullptr);
+    ASSERT_NE(client_ball, nullptr);
+    host_ball->position = {2.0f, 3.0f, 0.25f};
+
+    std::array<Uint8, 512> packet{};
+    size_t packet_size = 0U;
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_encode_network_runtime_snapshot(host, "state_snapshot", 123U, packet.data(),
+                                                                packet.size(), &packet_size, error, sizeof(error)))
+        << error;
+
+    Uint32 tick = 0U;
+    ASSERT_TRUE(sdl3d_game_data_apply_network_runtime_snapshot(client, "state_snapshot", packet.data(), packet_size,
+                                                               &tick, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(tick, 123U);
+    expect_vec3_near(client_ball->position, host_ball->position);
+
+    EXPECT_FALSE(sdl3d_game_data_apply_network_runtime_input(host, "client_input",
+                                                             sdl3d_game_session_get_input(host_session), packet.data(),
+                                                             packet_size, nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unsupported header"), std::string::npos) << error;
+
+    sdl3d_input_manager *client_input = sdl3d_game_session_get_input(client_session);
+    sdl3d_input_manager *host_input = sdl3d_game_session_get_input(host_session);
+    ASSERT_NE(client_input, nullptr);
+    ASSERT_NE(host_input, nullptr);
+    const int client_up_action = sdl3d_game_data_find_action(client, "action.paddle.local.up");
+    const int host_up_action = sdl3d_game_data_find_action(host, "action.paddle.local.up");
+    ASSERT_GE(client_up_action, 0);
+    ASSERT_GE(host_up_action, 0);
+    sdl3d_input_set_action_override(client_input, client_up_action, 0.5f);
+    ASSERT_NE(sdl3d_input_update(client_input, 321), nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_encode_network_runtime_input(client, "client_input", client_input, 321U, packet.data(),
+                                                             packet.size(), &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(sdl3d_game_data_apply_network_runtime_input(host, "client_input", host_input, packet.data(),
+                                                            packet_size, &tick, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(tick, 321U);
+    ASSERT_NE(sdl3d_input_update(host_input, 322), nullptr);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_up_action), 0.5f, 0.0001f);
+
+    EXPECT_FALSE(sdl3d_game_data_apply_network_runtime_snapshot(client, "state_snapshot", packet.data(), packet_size,
+                                                                nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unsupported header"), std::string::npos) << error;
+
+    destroy_runtime_session(host_session, host);
+    destroy_runtime_session(client_session, client);
+}
+
 TEST(GameDataRuntime, RejectsPongNetworkInputWithMismatchedSchemaOrTruncation)
 {
     sdl3d_game_session *client_session = nullptr;


### PR DESCRIPTION
## Summary
- add runtime-binding helpers for snapshot/input encode, apply, and send paths
- verify incoming snapshot/input packets match the expected authored replication binding before mutating actors or input overrides
- migrate Pong host state and client input packet helpers to semantic runtime replication bindings
- document the new runtime-binding replication helpers and add focused Pong round-trip coverage

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next Slice
The next practical slice is to move the remaining host/client per-frame packet receive/send loop into `sdl3d_data_game_runtime`, using the runtime-bound control, snapshot, and input helpers now in place.