### PR TITLE
Move network packet loop into data runtime

### DIFF
--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -65,6 +65,19 @@ static const char PONG_DIRECT_CONNECT_STATUS_KEY[] = "direct_connect_status";
 static const char PONG_DIRECT_CONNECT_STATE_KEY[] = "direct_connect_state";
 static const char PONG_DIRECT_CONNECT_CONNECTED_KEY[] = "direct_connect_connected";
 
+static sdl3d_data_game_network_bindings pong_network_bindings(void)
+{
+    sdl3d_data_game_network_bindings bindings;
+    SDL_zero(bindings);
+    bindings.state_snapshot = PONG_NETWORK_BINDING_STATE_SNAPSHOT;
+    bindings.client_input = PONG_NETWORK_BINDING_CLIENT_INPUT;
+    bindings.start_game = PONG_NETWORK_BINDING_START_GAME;
+    bindings.pause_request = PONG_NETWORK_BINDING_PAUSE_REQUEST;
+    bindings.resume_request = PONG_NETWORK_BINDING_RESUME_REQUEST;
+    bindings.disconnect = PONG_NETWORK_BINDING_DISCONNECT;
+    return bindings;
+}
+
 static Uint64 pong_log_timestamp_ms(void)
 {
     return SDL_GetTicks();
@@ -501,32 +514,6 @@ static bool send_network_control_packet_repeated(pong_state *state, sdl3d_networ
     return sent_any;
 }
 
-static bool read_network_control_packet(pong_state *state, const Uint8 *packet, int packet_size,
-                                        const char *expected_binding, Uint32 *out_tick)
-{
-    sdl3d_game_data_network_control control;
-    const char *binding = NULL;
-    char error[160] = {0};
-
-    if (state == NULL || state->data == NULL || packet == NULL || packet_size <= 0 || expected_binding == NULL)
-    {
-        return false;
-    }
-
-    if (!sdl3d_game_data_decode_network_runtime_control(state->data, packet, (size_t)packet_size, &binding, &control,
-                                                        error, (int)sizeof(error)) ||
-        binding == NULL || SDL_strcmp(binding, expected_binding) != 0)
-    {
-        return false;
-    }
-
-    if (out_tick != NULL)
-    {
-        *out_tick = control.tick;
-    }
-    return true;
-}
-
 static bool send_host_start_packet(pong_state *state)
 {
     if (state == NULL)
@@ -579,159 +566,6 @@ static bool start_selected_lobby_match(pong_state *state)
         return false;
     }
 
-    return true;
-}
-
-static bool send_client_input_packet(pong_state *state)
-{
-    char error[160] = {0};
-    const int p2_up = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_UP);
-    const int p2_down = network_runtime_action_id(state, PONG_NETWORK_BINDING_CLIENT_DOWN);
-
-    if (state == NULL || state->direct_connect_session == NULL || state->input == NULL || p2_up < 0 || p2_down < 0 ||
-        !sdl3d_network_session_is_connected(state->direct_connect_session))
-    {
-        return false;
-    }
-
-    const sdl3d_input_snapshot *snapshot = sdl3d_input_get_snapshot(state->input);
-    const float up_value = snapshot != NULL ? snapshot->actions[p2_up].value : 0.0f;
-    const float down_value = snapshot != NULL ? snapshot->actions[p2_down].value : 0.0f;
-    const Uint32 tick = snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U;
-
-    if (!sdl3d_game_data_send_network_runtime_input(state->data, state->direct_connect_session,
-                                                    PONG_NETWORK_BINDING_CLIENT_INPUT, state->input, tick, error,
-                                                    (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client input packet send failed: %s", error);
-        return false;
-    }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client->host input tick=%u up=%.3f down=%.3f scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick, up_value, down_value,
-                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
-                    ? sdl3d_game_data_active_scene(state->data)
-                    : "<none>");
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "[%llu ms] Pong client input packet queued: role=%s flow=%s p2_up=%.3f p2_down=%.3f",
-                (unsigned long long)pong_log_timestamp_ms(), network_role_name(state),
-                network_session_state_string(state, "network_flow", "none"), up_value, down_value);
-    return true;
-}
-
-static void send_client_pause_request_if_pressed(sdl3d_game_context *ctx, pong_state *state)
-{
-    int pause_action = -1;
-    const char *request_binding = NULL;
-
-    if (ctx == NULL || state == NULL || state->input == NULL || state->data == NULL ||
-        state->direct_connect_session == NULL)
-    {
-        return;
-    }
-    if (!is_multiplayer_play_scene(state) || !is_network_role_client(state) ||
-        !sdl3d_network_session_is_connected(state->direct_connect_session))
-    {
-        return;
-    }
-    if (!sdl3d_game_data_get_network_runtime_pause_action(state->data, &pause_action) ||
-        !sdl3d_input_is_pressed(state->input, pause_action))
-    {
-        return;
-    }
-
-    request_binding = ctx->paused ? PONG_NETWORK_BINDING_RESUME_REQUEST : PONG_NETWORK_BINDING_PAUSE_REQUEST;
-    (void)send_network_control_packet(
-        state, state->direct_connect_session, request_binding,
-        SDL_strcmp(request_binding, PONG_NETWORK_BINDING_PAUSE_REQUEST) == 0 ? "pause request" : "resume request");
-}
-
-static bool sync_match_pause_from_context(sdl3d_game_context *ctx, pong_state *state)
-{
-    char error[160] = {0};
-    if (ctx == NULL || state == NULL || state->data == NULL)
-    {
-        return false;
-    }
-
-    if (!sdl3d_game_data_set_network_runtime_pause_state(state->data, ctx->paused, error, (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network pause state write failed: %s", error);
-        return false;
-    }
-    return true;
-}
-
-static bool sync_context_pause_from_match(sdl3d_game_context *ctx, pong_state *state)
-{
-    bool paused = false;
-    char error[160] = {0};
-    if (ctx == NULL || state == NULL || state->data == NULL)
-    {
-        return false;
-    }
-
-    if (!sdl3d_game_data_get_network_runtime_pause_state(state->data, &paused, error, (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network pause state read failed: %s", error);
-        return false;
-    }
-    if (ctx->paused != paused)
-    {
-        ctx->paused = paused;
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client mirrored host pause state: paused=%d",
-                    (unsigned long long)pong_log_timestamp_ms(), ctx->paused ? 1 : 0);
-    }
-    return true;
-}
-
-static bool process_host_input_packet(pong_state *state, const Uint8 *packet, int packet_size)
-{
-    Uint32 tick = 0U;
-    char error[160] = {0};
-
-    if (state == NULL || state->data == NULL || state->input == NULL || packet == NULL || packet_size <= 0)
-    {
-        return false;
-    }
-
-    if (!sdl3d_game_data_apply_network_runtime_input(state->data, PONG_NETWORK_BINDING_CLIENT_INPUT, state->input,
-                                                     packet, (size_t)packet_size, &tick, error, (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host input packet apply failed: %s", error);
-        return false;
-    }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host<-client input tick=%u scene=%s",
-                (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick,
-                state != NULL && state->data != NULL && sdl3d_game_data_active_scene(state->data) != NULL
-                    ? sdl3d_game_data_active_scene(state->data)
-                    : "<none>");
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host queued remote paddle input overrides",
-                (unsigned long long)pong_log_timestamp_ms());
-    return true;
-}
-
-static bool process_client_state_packet(sdl3d_game_context *ctx, pong_state *state, const Uint8 *packet,
-                                        int packet_size)
-{
-    Uint32 tick = 0U;
-    char error[160] = {0};
-
-    if (state == NULL || state->data == NULL || packet == NULL || packet_size <= 0)
-    {
-        return false;
-    }
-
-    if (!sdl3d_game_data_apply_network_runtime_snapshot(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT, packet,
-                                                        (size_t)packet_size, &tick, error, (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client state packet apply failed: %s", error);
-        return false;
-    }
-
-    (void)sync_context_pause_from_match(ctx, state);
-    pong_log_multiplayer_state("client<-host state", state, tick, "applied");
     return true;
 }
 
@@ -821,77 +655,6 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
     }
 }
 
-static bool process_decoded_network_control_packet(sdl3d_game_context *ctx, pong_state *state, const char *binding,
-                                                   Uint32 tick)
-{
-    if (binding == NULL)
-    {
-        return false;
-    }
-
-    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_PAUSE_REQUEST) == 0)
-    {
-        if (ctx != NULL && is_network_role_host(state))
-        {
-            ctx->paused = true;
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer pause request tick=%u",
-                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-        }
-        return true;
-    }
-    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_RESUME_REQUEST) == 0)
-    {
-        if (ctx != NULL && is_network_role_host(state))
-        {
-            ctx->paused = false;
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer resume request tick=%u",
-                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-        }
-        return true;
-    }
-    if (SDL_strcmp(binding, PONG_NETWORK_BINDING_DISCONNECT) == 0)
-    {
-        return_to_multiplayer_after_disconnect(
-            ctx, state, is_network_role_host(state),
-            network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
-        return true;
-    }
-
-    return false;
-}
-
-static bool send_host_state_packet(sdl3d_game_context *ctx, pong_state *state)
-{
-    const sdl3d_input_snapshot *snapshot = NULL;
-    char error[160] = {0};
-
-    if (state == NULL || state->host_session == NULL || !sdl3d_network_session_is_connected(state->host_session) ||
-        state->data == NULL || state->input == NULL)
-    {
-        return false;
-    }
-
-    snapshot = sdl3d_input_get_snapshot(state->input);
-    if (snapshot == NULL || !sync_match_pause_from_context(ctx, state))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet encode failed: %s",
-                    error[0] != '\0' ? error : "input snapshot unavailable");
-        return false;
-    }
-
-    if (!sdl3d_game_data_send_network_runtime_snapshot(state->data, state->host_session,
-                                                       PONG_NETWORK_BINDING_STATE_SNAPSHOT,
-                                                       (Uint32)SDL_max(snapshot->tick, 0), error, (int)sizeof(error)))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host state packet send failed: %s", error);
-        return false;
-    }
-
-    pong_log_multiplayer_state("host->client state", state, snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : 0U,
-                               "sent");
-    return true;
-}
-
 static bool start_direct_connect_session(pong_state *state)
 {
     int port = 0;
@@ -930,7 +693,7 @@ static bool start_direct_connect_session(pong_state *state)
     return true;
 }
 
-static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_state *state)
+static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     if (state == NULL)
     {
@@ -943,8 +706,11 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             : state->direct_connect_session;
     if (state->direct_connect_session != NULL)
     {
-        Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
-        int packet_size = 0;
+        const bool was_playing = is_multiplayer_play_scene(state);
+        const bool playing = was_playing && is_network_role_client(state);
+        const sdl3d_data_game_network_bindings bindings = pong_network_bindings();
+        sdl3d_data_game_network_loop_result result;
+        char error[192] = {0};
         const char *status = sdl3d_network_session_status(state->direct_connect_session);
         SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
                      status != NULL && status[0] != '\0' ? status : "Connecting");
@@ -952,30 +718,35 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             state->data, PONG_DIRECT_CONNECT_SESSION, PONG_DIRECT_CONNECT_STATUS_KEY, PONG_DIRECT_CONNECT_STATE_KEY,
             PONG_DIRECT_CONNECT_CONNECTED_KEY);
 
-        while ((packet_size =
-                    sdl3d_network_session_receive(state->direct_connect_session, packet, (int)sizeof(packet))) > 0)
+        if (!sdl3d_data_game_runtime_update_network_client_session(state->runtime, ctx, PONG_DIRECT_CONNECT_SESSION,
+                                                                   &bindings, playing, true, dt, &result, error,
+                                                                   (int)sizeof(error)))
         {
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_START_GAME, NULL))
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong direct-connect network update failed: %s",
+                        error[0] != '\0' ? error : "unknown error");
+        }
+
+        if (result.received_start_game)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
+            clear_network_action_overrides(state);
+            if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
             {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
-                clear_network_action_overrides(state);
-                if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
-                {
-                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
-                                SDL_GetError());
-                }
-                continue;
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
+                            SDL_GetError());
             }
-            Uint32 tick = 0U;
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_DISCONNECT, &tick))
-            {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
-                            (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                return_to_multiplayer_after_disconnect(ctx, state, false,
-                                                       network_disconnect_reason(state, "host_exited", "Host exited"));
-                break;
-            }
-            if (!is_multiplayer_play_scene(state))
+        }
+        if (result.received_disconnect)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
+            return_to_multiplayer_after_disconnect(ctx, state, false,
+                                                   network_disconnect_reason(state, "host_exited", "Host exited"));
+            return;
+        }
+        if (result.applied_snapshot)
+        {
+            if (!was_playing)
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                             "Pong client received authoritative state before start command; entering play scene");
@@ -985,13 +756,9 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                                 "Pong client failed to enter multiplayer play scene from state packet: %s",
                                 SDL_GetError());
-                    continue;
                 }
             }
-            if (process_client_state_packet(ctx, state, packet, packet_size))
-            {
-                SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong client applied authoritative state packet");
-            }
+            pong_log_multiplayer_state("client<-host state", state, result.last_tick, "applied");
         }
 
         if (state->direct_connect_session == NULL)
@@ -999,11 +766,10 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             return;
         }
 
-        const sdl3d_network_state session_state = sdl3d_network_session_state(state->direct_connect_session);
+        const sdl3d_network_state session_state = result.session_state;
         if (session_state == SDL3D_NETWORK_STATE_REJECTED || session_state == SDL3D_NETWORK_STATE_TIMED_OUT ||
             session_state == SDL3D_NETWORK_STATE_ERROR)
         {
-            const bool was_playing = is_multiplayer_play_scene(state);
             const char *reason = session_state == SDL3D_NETWORK_STATE_TIMED_OUT
                                      ? network_disconnect_reason(state, "host_timed_out", "Host timed out")
                                  : session_state == SDL3D_NETWORK_STATE_REJECTED
@@ -1070,43 +836,36 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
 
     if (state->host_session != NULL)
     {
-        if (!sdl3d_network_session_update(state->host_session, dt))
+        const sdl3d_data_game_network_bindings bindings = pong_network_bindings();
+        sdl3d_data_game_network_loop_result result;
+        char error[192] = {0};
+        if (!sdl3d_data_game_runtime_update_network_host_session(state->runtime, ctx, PONG_HOST_SESSION, &bindings,
+                                                                 is_multiplayer_play_scene(state), dt, &result, error,
+                                                                 (int)sizeof(error)))
         {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host session update failed: %s", SDL_GetError());
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host session update failed: %s",
+                        error[0] != '\0' ? error : SDL_GetError());
         }
-
-        Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
-        int packet_size = 0;
-        while ((packet_size = sdl3d_network_session_receive(state->host_session, packet, (int)sizeof(packet))) > 0)
+        if (result.received_disconnect)
         {
-            Uint32 tick = 0U;
-            if (read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_DISCONNECT, &tick))
-            {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
-                            (unsigned long long)pong_log_timestamp_ms(), (unsigned int)tick);
-                return_to_multiplayer_after_disconnect(
-                    ctx, state, true, network_disconnect_reason(state, "client_exited", "Client exited"));
-                break;
-            }
-            if (is_multiplayer_play_scene(state) &&
-                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_PAUSE_REQUEST, &tick))
-            {
-                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_BINDING_PAUSE_REQUEST, tick);
-                continue;
-            }
-            if (is_multiplayer_play_scene(state) &&
-                read_network_control_packet(state, packet, packet_size, PONG_NETWORK_BINDING_RESUME_REQUEST, &tick))
-            {
-                (void)process_decoded_network_control_packet(ctx, state, PONG_NETWORK_BINDING_RESUME_REQUEST, tick);
-                continue;
-            }
-            if (is_multiplayer_play_scene(state))
-            {
-                if (process_host_input_packet(state, packet, packet_size))
-                {
-                    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong host applied remote input packet");
-                }
-            }
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
+            return_to_multiplayer_after_disconnect(ctx, state, true,
+                                                   network_disconnect_reason(state, "client_exited", "Client exited"));
+        }
+        if (result.received_pause_request)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer pause request tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
+        }
+        if (result.received_resume_request)
+        {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host accepted peer resume request tick=%u",
+                        (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
+        }
+        if (result.applied_input)
+        {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "Pong host applied remote input packet");
         }
 
         update_host_session_scene_state(state);
@@ -1119,7 +878,7 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
             destroy_host_session(state);
         }
         else if (is_multiplayer_play_scene(state) && state->host_session != NULL &&
-                 sdl3d_network_session_state(state->host_session) != SDL3D_NETWORK_STATE_CONNECTED)
+                 result.session_state != SDL3D_NETWORK_STATE_CONNECTED)
         {
             begin_network_match_termination(ctx, state, true,
                                             network_disconnect_reason(state, "client_timed_out", "Client timed out"));
@@ -1164,18 +923,7 @@ static void update_multiplayer_sessions(sdl3d_game_context *ctx, pong_state *sta
             return;
         }
 
-        if (!sdl3d_network_session_update(state->direct_connect_session, dt))
-        {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong direct-connect session update failed: %s", SDL_GetError());
-        }
-
-        update_direct_connect_session_status(ctx, state);
-    }
-
-    if (state->direct_connect_session != NULL && is_multiplayer_play_scene(state) && is_network_role_client(state))
-    {
-        send_client_pause_request_if_pressed(ctx, state);
-        (void)send_client_input_packet(state);
+        update_direct_connect_session_status(ctx, state, dt);
     }
 }
 
@@ -1187,10 +935,17 @@ static void publish_multiplayer_state(sdl3d_game_context *ctx, pong_state *state
         return;
     }
 
-    if (!send_host_state_packet(ctx, state))
+    const sdl3d_data_game_network_bindings bindings = pong_network_bindings();
+    sdl3d_data_game_network_loop_result result;
+    char error[192] = {0};
+    if (!sdl3d_data_game_runtime_publish_network_host_snapshot(state->runtime, ctx, PONG_HOST_SESSION, &bindings,
+                                                               &result, error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to publish multiplayer state");
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to publish multiplayer state: %s",
+                    error[0] != '\0' ? error : "unknown error");
+        return;
     }
+    pong_log_multiplayer_state("host->client state", state, result.last_tick, "sent");
 }
 
 static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_state *state)

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -21,12 +21,14 @@ The runtime currently owns:
 - input-profile hotplug refresh state and automatic gamepad-count rebinding
 - runtime-owned direct-connect, host, and discovery session primitives exposed
   through data actions
+- runtime-bound host/client packet loops for authored control messages,
+  client input replication, authoritative snapshots, and pause-state sync
 - ordered cleanup
 
 The generic `sdl3d_runner` executable owns the outer SDL process loop for games
 that only need the current data runtime surface. For now, Pong still keeps a
-compatibility host for full LAN networking because network session
-orchestration has not moved into the managed runtime yet.
+compatibility host for network scene transitions and termination UI, but the
+packet receive/send/apply loop now lives in the managed runtime.
 
 ## Startup Shape
 
@@ -55,9 +57,33 @@ During the managed loop:
 - call `sdl3d_data_game_runtime_render` from the render callback
 - call `sdl3d_data_game_runtime_refresh_input_profile_on_device_change` when a
   scene or host policy wants device-count hotplug rebinding
+- for LAN/direct-connect play, call
+  `sdl3d_data_game_runtime_update_network_host_session`,
+  `sdl3d_data_game_runtime_update_network_client_session`, and
+  `sdl3d_data_game_runtime_publish_network_host_snapshot` with semantic
+  runtime binding names from `network.runtime_bindings`
 
 The outer loop still controls fixed timestep, SDL events, input snapshots,
 audio frame updates, and presentation.
+
+## Network Packet Loops
+
+The runtime network helpers are game-agnostic. Callers provide session names
+and semantic binding keys, such as `state_snapshot`, `client_input`,
+`start_game`, `pause_request`, `resume_request`, and `disconnect`. The helpers
+resolve those keys through authored `network.runtime_bindings`, then:
+
+- update the runtime-owned host or direct-connect transport session
+- decode control packets and return result flags for scene-flow decisions
+- apply client input overrides on the host
+- apply host snapshots on the client
+- mirror authored network pause state between host context and client context
+- send client input packets while network play is active
+- send host snapshots after the authoritative simulation step
+
+The helpers intentionally report events instead of hard-coding transitions.
+That keeps game-specific flow in JSON/Lua or a thin compatibility host until
+scene/session orchestration is fully authored.
 
 ## Generic Runner
 
@@ -94,6 +120,6 @@ or Lua-driven systems.
 ## Why This Matters
 
 This API is a stepping stone toward fully data-only games. Once network session
-orchestration is also managed by the engine runtime, a package such as Pong
-should be able to ship as JSON, Lua, and assets rather than as a custom C
-program linked against SDL3D.
+transition/termination policy is also managed by the engine runtime, a package
+such as Pong should be able to ship as JSON, Lua, and assets rather than as a
+custom C program linked against SDL3D.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -783,9 +783,10 @@ active. `name` identifies the session, `port` / `default_port` select the UDP
 listen port, and `session_name` is advertised to LAN discovery clients.
 `network.host.observe` republishes status, endpoint, peer label, and connection
 state into scene state. `network.host.cancel` destroys the named host session
-and writes a disconnected status. Host packet loops can inspect the
-runtime-owned pointer with `sdl3d_game_data_get_network_host_session()` until
-generic replication-loop ownership moves into the data-game runtime.
+and writes a disconnected status. Generic hosts can inspect the runtime-owned
+pointer with `sdl3d_game_data_get_network_host_session()`, or use the
+data-game runtime helpers to update the host packet loop and publish
+authoritative snapshots by semantic runtime binding.
 
 LAN discovery flows can also be authored with reusable network data actions and
 dynamic-list menus. A typical scene starts or refreshes discovery on enter,

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -107,6 +107,105 @@ extern "C"
                                                                         int error_buffer_size);
 
     /**
+     * @brief Runtime-binding names used by the generic network packet loop.
+     *
+     * Each field is a semantic key from `network.runtime_bindings`, not a
+     * concrete replication channel or control-message name. Games can author
+     * different schema names while reusing the same host/client loop.
+     */
+    typedef struct sdl3d_data_game_network_bindings
+    {
+        /** @brief Host-to-client snapshot replication binding, or NULL if unused. */
+        const char *state_snapshot;
+        /** @brief Client-to-host input replication binding, or NULL if unused. */
+        const char *client_input;
+        /** @brief Host-to-client start-game control binding, or NULL if unused. */
+        const char *start_game;
+        /** @brief Client-to-host pause request control binding, or NULL if unused. */
+        const char *pause_request;
+        /** @brief Client-to-host resume request control binding, or NULL if unused. */
+        const char *resume_request;
+        /** @brief Bidirectional graceful disconnect control binding, or NULL if unused. */
+        const char *disconnect;
+    } sdl3d_data_game_network_bindings;
+
+    /**
+     * @brief Summary of one generic network packet-loop update.
+     */
+    typedef struct sdl3d_data_game_network_loop_result
+    {
+        /** @brief Current transport state after the update, if a session exists. */
+        sdl3d_network_state session_state;
+        /** @brief Number of user packets consumed from the session queue. */
+        int packets_received;
+        /** @brief Last decoded packet/control tick, or zero when none was decoded. */
+        Uint32 last_tick;
+        /** @brief True when a start-game control was received. */
+        bool received_start_game;
+        /** @brief True when a graceful disconnect control was received. */
+        bool received_disconnect;
+        /** @brief True when a pause request control was received and applied to @p ctx. */
+        bool received_pause_request;
+        /** @brief True when a resume request control was received and applied to @p ctx. */
+        bool received_resume_request;
+        /** @brief True when a client input packet was applied. */
+        bool applied_input;
+        /** @brief True when an authoritative snapshot packet was applied. */
+        bool applied_snapshot;
+        /** @brief True when the client sent an input packet. */
+        bool sent_input;
+        /** @brief True when the host sent an authoritative snapshot packet. */
+        bool sent_snapshot;
+        /** @brief True when the client sent a pause request control. */
+        bool sent_pause_request;
+        /** @brief True when the client sent a resume request control. */
+        bool sent_resume_request;
+    } sdl3d_data_game_network_loop_result;
+
+    /**
+     * @brief Advance a runtime-owned host session and consume client packets.
+     *
+     * The function updates the named `network.host` session, decodes authored
+     * runtime control packets, applies client input packets when @p playing is
+     * true, and mirrors pause/resume requests into @p ctx. Scene transitions
+     * remain caller-owned; callers inspect @p out_result to decide what to do.
+     */
+    bool sdl3d_data_game_runtime_update_network_host_session(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                             const char *session_name,
+                                                             const sdl3d_data_game_network_bindings *bindings,
+                                                             bool playing, float dt,
+                                                             sdl3d_data_game_network_loop_result *out_result,
+                                                             char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Send one authoritative host snapshot over a runtime-owned host session.
+     *
+     * Before encoding, this writes @p ctx->paused into the authored network
+     * pause property so clients can mirror host pause state through snapshots.
+     */
+    bool sdl3d_data_game_runtime_publish_network_host_snapshot(sdl3d_data_game_runtime *runtime,
+                                                               sdl3d_game_context *ctx, const char *session_name,
+                                                               const sdl3d_data_game_network_bindings *bindings,
+                                                               sdl3d_data_game_network_loop_result *out_result,
+                                                               char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Advance a runtime-owned direct-connect client session.
+     *
+     * The function updates the named direct-connect session, consumes
+     * host-to-client control/snapshot packets, mirrors snapshot pause state
+     * into @p ctx, and when @p playing is true sends client input packets. If
+     * @p allow_pause_requests is true, a pressed authored pause action sends
+     * pause/resume request controls based on @p ctx->paused.
+     */
+    bool sdl3d_data_game_runtime_update_network_client_session(sdl3d_data_game_runtime *runtime,
+                                                               sdl3d_game_context *ctx, const char *session_name,
+                                                               const sdl3d_data_game_network_bindings *bindings,
+                                                               bool playing, bool allow_pause_requests, float dt,
+                                                               sdl3d_data_game_network_loop_result *out_result,
+                                                               char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Advance authored frame/app-flow/presentation systems.
      *
      * This does not update the outer SDL3D game session tick counters; callers

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -2,6 +2,7 @@
 
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
 
 #include "sdl3d/game_presentation.h"
 #include "sdl3d/input.h"
@@ -30,6 +31,96 @@ static void set_error(char *error_buffer, int error_buffer_size, const char *mes
     {
         SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s", message != NULL ? message : "");
     }
+}
+
+static void set_errorf(char *error_buffer, int error_buffer_size, const char *fmt, const char *value)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+    {
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, fmt != NULL ? fmt : "%s", value != NULL ? value : "");
+    }
+}
+
+static void network_loop_result_init(sdl3d_data_game_network_loop_result *result, sdl3d_network_session *session)
+{
+    if (result == NULL)
+    {
+        return;
+    }
+
+    SDL_zero(*result);
+    result->session_state = session != NULL ? sdl3d_network_session_state(session) : SDL3D_NETWORK_STATE_DISCONNECTED;
+}
+
+static Uint32 data_game_input_tick(const sdl3d_data_game_runtime *runtime)
+{
+    sdl3d_input_manager *input =
+        runtime != NULL && runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+    const sdl3d_input_snapshot *snapshot = input != NULL ? sdl3d_input_get_snapshot(input) : NULL;
+    return snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : (Uint32)SDL_GetTicks();
+}
+
+static bool data_game_binding_matches(const char *actual, const char *expected)
+{
+    return actual != NULL && expected != NULL && expected[0] != '\0' && SDL_strcmp(actual, expected) == 0;
+}
+
+static bool data_game_decode_runtime_control(sdl3d_data_game_runtime *runtime, const Uint8 *packet, int packet_size,
+                                             const char **out_binding, sdl3d_game_data_network_control *out_control)
+{
+    char error[160] = {0};
+    if (out_binding != NULL)
+        *out_binding = NULL;
+    if (runtime == NULL || runtime->data == NULL || packet == NULL || packet_size <= 0)
+    {
+        return false;
+    }
+
+    return sdl3d_game_data_decode_network_runtime_control(runtime->data, packet, (size_t)packet_size, out_binding,
+                                                          out_control, error, (int)sizeof(error));
+}
+
+static bool data_game_send_runtime_control(sdl3d_data_game_runtime *runtime, sdl3d_network_session *session,
+                                           const char *binding_name, Uint32 tick, char *error_buffer,
+                                           int error_buffer_size)
+{
+    if (runtime == NULL || runtime->data == NULL || session == NULL || binding_name == NULL || binding_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "network control send requires runtime, session, and binding");
+        return false;
+    }
+
+    return sdl3d_game_data_send_network_runtime_control(runtime->data, session, binding_name, tick, error_buffer,
+                                                        error_buffer_size);
+}
+
+static bool data_game_sync_network_pause_from_context(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                      char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL || runtime->data == NULL || ctx == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network pause sync requires runtime and context");
+        return false;
+    }
+
+    return sdl3d_game_data_set_network_runtime_pause_state(runtime->data, ctx->paused, error_buffer, error_buffer_size);
+}
+
+static bool data_game_sync_context_pause_from_network(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                      char *error_buffer, int error_buffer_size)
+{
+    bool paused = false;
+    if (runtime == NULL || runtime->data == NULL || ctx == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network pause sync requires runtime and context");
+        return false;
+    }
+    if (!sdl3d_game_data_get_network_runtime_pause_state(runtime->data, &paused, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    ctx->paused = paused;
+    return true;
 }
 
 static bool haptics_signal_connected(const sdl3d_data_game_runtime *runtime, int signal_id)
@@ -275,6 +366,282 @@ bool sdl3d_data_game_runtime_refresh_input_profile_on_device_change(sdl3d_data_g
     return sdl3d_game_data_apply_active_input_profile_on_device_change(
         runtime->data, input, &runtime->input_profile_refresh, out_profile_name, out_applied, error_buffer,
         error_buffer_size);
+}
+
+bool sdl3d_data_game_runtime_update_network_host_session(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                         const char *session_name,
+                                                         const sdl3d_data_game_network_bindings *bindings, bool playing,
+                                                         float dt, sdl3d_data_game_network_loop_result *out_result,
+                                                         char *error_buffer, int error_buffer_size)
+{
+    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+    sdl3d_network_session *session = runtime != NULL && runtime->data != NULL
+                                         ? sdl3d_game_data_get_network_host_session(runtime->data, session_name)
+                                         : NULL;
+    network_loop_result_init(out_result, session);
+    if (runtime == NULL || runtime->data == NULL || bindings == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network host update requires runtime and bindings");
+        return false;
+    }
+    if (session == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network host session '%s' not found",
+                   session_name != NULL ? session_name : "<null>");
+        return false;
+    }
+
+    if (!sdl3d_network_session_update(session, dt))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network host session update failed: %s", SDL_GetError());
+        network_loop_result_init(out_result, session);
+        return false;
+    }
+
+    int packet_size = 0;
+    while ((packet_size = sdl3d_network_session_receive(session, packet, (int)sizeof(packet))) > 0)
+    {
+        if (out_result != NULL)
+            ++out_result->packets_received;
+
+        const char *control_binding = NULL;
+        sdl3d_game_data_network_control control;
+        if (data_game_decode_runtime_control(runtime, packet, packet_size, &control_binding, &control))
+        {
+            if (out_result != NULL)
+                out_result->last_tick = control.tick;
+            if (data_game_binding_matches(control_binding, bindings->disconnect))
+            {
+                if (out_result != NULL)
+                    out_result->received_disconnect = true;
+                continue;
+            }
+            if (playing && data_game_binding_matches(control_binding, bindings->pause_request))
+            {
+                if (ctx != NULL)
+                    ctx->paused = true;
+                if (out_result != NULL)
+                    out_result->received_pause_request = true;
+                continue;
+            }
+            if (playing && data_game_binding_matches(control_binding, bindings->resume_request))
+            {
+                if (ctx != NULL)
+                    ctx->paused = false;
+                if (out_result != NULL)
+                    out_result->received_resume_request = true;
+                continue;
+            }
+            continue;
+        }
+
+        if (playing && bindings->client_input != NULL && bindings->client_input[0] != '\0')
+        {
+            Uint32 tick = 0U;
+            char apply_error[160] = {0};
+            sdl3d_input_manager *input =
+                runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+            if (sdl3d_game_data_apply_network_runtime_input(runtime->data, bindings->client_input, input, packet,
+                                                            (size_t)packet_size, &tick, apply_error,
+                                                            (int)sizeof(apply_error)))
+            {
+                if (out_result != NULL)
+                {
+                    out_result->applied_input = true;
+                    out_result->last_tick = tick;
+                }
+            }
+        }
+    }
+
+    if (out_result != NULL)
+        out_result->session_state = sdl3d_network_session_state(session);
+    return true;
+}
+
+bool sdl3d_data_game_runtime_publish_network_host_snapshot(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                           const char *session_name,
+                                                           const sdl3d_data_game_network_bindings *bindings,
+                                                           sdl3d_data_game_network_loop_result *out_result,
+                                                           char *error_buffer, int error_buffer_size)
+{
+    sdl3d_network_session *session = runtime != NULL && runtime->data != NULL
+                                         ? sdl3d_game_data_get_network_host_session(runtime->data, session_name)
+                                         : NULL;
+    network_loop_result_init(out_result, session);
+    if (runtime == NULL || runtime->data == NULL || bindings == NULL || bindings->state_snapshot == NULL ||
+        bindings->state_snapshot[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "network host snapshot publish requires runtime and binding");
+        return false;
+    }
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        set_error(error_buffer, error_buffer_size, "network host snapshot publish requires connected host session");
+        return false;
+    }
+    if (!data_game_sync_network_pause_from_context(runtime, ctx, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+
+    const Uint32 tick = data_game_input_tick(runtime);
+    if (!sdl3d_game_data_send_network_runtime_snapshot(runtime->data, session, bindings->state_snapshot, tick,
+                                                       error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (out_result != NULL)
+    {
+        out_result->sent_snapshot = true;
+        out_result->last_tick = tick;
+        out_result->session_state = sdl3d_network_session_state(session);
+    }
+    return true;
+}
+
+bool sdl3d_data_game_runtime_update_network_client_session(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                                           const char *session_name,
+                                                           const sdl3d_data_game_network_bindings *bindings,
+                                                           bool playing, bool allow_pause_requests, float dt,
+                                                           sdl3d_data_game_network_loop_result *out_result,
+                                                           char *error_buffer, int error_buffer_size)
+{
+    Uint8 packet[SDL3D_NETWORK_MAX_PACKET_SIZE];
+    sdl3d_network_session *session =
+        runtime != NULL && runtime->data != NULL
+            ? sdl3d_game_data_get_network_direct_connect_session(runtime->data, session_name)
+            : NULL;
+    network_loop_result_init(out_result, session);
+    if (runtime == NULL || runtime->data == NULL || bindings == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network client update requires runtime and bindings");
+        return false;
+    }
+    if (session == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "network client session '%s' not found",
+                   session_name != NULL ? session_name : "<null>");
+        return false;
+    }
+
+    if (!sdl3d_network_session_update(session, dt))
+    {
+        set_errorf(error_buffer, error_buffer_size, "network client session update failed: %s", SDL_GetError());
+        network_loop_result_init(out_result, session);
+        return false;
+    }
+
+    int packet_size = 0;
+    while ((packet_size = sdl3d_network_session_receive(session, packet, (int)sizeof(packet))) > 0)
+    {
+        if (out_result != NULL)
+            ++out_result->packets_received;
+
+        const char *control_binding = NULL;
+        sdl3d_game_data_network_control control;
+        if (data_game_decode_runtime_control(runtime, packet, packet_size, &control_binding, &control))
+        {
+            if (out_result != NULL)
+                out_result->last_tick = control.tick;
+            if (data_game_binding_matches(control_binding, bindings->start_game))
+            {
+                if (out_result != NULL)
+                    out_result->received_start_game = true;
+                continue;
+            }
+            if (data_game_binding_matches(control_binding, bindings->disconnect))
+            {
+                if (out_result != NULL)
+                    out_result->received_disconnect = true;
+                continue;
+            }
+            if (data_game_binding_matches(control_binding, bindings->pause_request))
+            {
+                if (ctx != NULL)
+                    ctx->paused = true;
+                if (out_result != NULL)
+                    out_result->received_pause_request = true;
+                continue;
+            }
+            if (data_game_binding_matches(control_binding, bindings->resume_request))
+            {
+                if (ctx != NULL)
+                    ctx->paused = false;
+                if (out_result != NULL)
+                    out_result->received_resume_request = true;
+                continue;
+            }
+            continue;
+        }
+
+        if (bindings->state_snapshot != NULL && bindings->state_snapshot[0] != '\0')
+        {
+            Uint32 tick = 0U;
+            char apply_error[160] = {0};
+            if (sdl3d_game_data_apply_network_runtime_snapshot(runtime->data, bindings->state_snapshot, packet,
+                                                               (size_t)packet_size, &tick, apply_error,
+                                                               (int)sizeof(apply_error)))
+            {
+                (void)data_game_sync_context_pause_from_network(runtime, ctx, apply_error, (int)sizeof(apply_error));
+                if (out_result != NULL)
+                {
+                    out_result->applied_snapshot = true;
+                    out_result->last_tick = tick;
+                }
+            }
+        }
+    }
+
+    if (playing && sdl3d_network_session_is_connected(session))
+    {
+        sdl3d_input_manager *input = runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+        const Uint32 tick = data_game_input_tick(runtime);
+        if (allow_pause_requests && ctx != NULL)
+        {
+            int pause_action = -1;
+            if (sdl3d_game_data_get_network_runtime_pause_action(runtime->data, &pause_action) && input != NULL &&
+                sdl3d_input_is_pressed(input, pause_action))
+            {
+                const bool want_resume = ctx->paused;
+                const char *control_binding = want_resume ? bindings->resume_request : bindings->pause_request;
+                if (control_binding == NULL || control_binding[0] == '\0')
+                {
+                    set_error(error_buffer, error_buffer_size, "network client pause request requires control binding");
+                    return false;
+                }
+                if (!data_game_send_runtime_control(runtime, session, control_binding, tick, error_buffer,
+                                                    error_buffer_size))
+                {
+                    return false;
+                }
+                if (out_result != NULL)
+                {
+                    out_result->sent_pause_request = !want_resume;
+                    out_result->sent_resume_request = want_resume;
+                    out_result->last_tick = tick;
+                }
+            }
+        }
+
+        if (bindings->client_input != NULL && bindings->client_input[0] != '\0' && input != NULL)
+        {
+            if (!sdl3d_game_data_send_network_runtime_input(runtime->data, session, bindings->client_input, input, tick,
+                                                            error_buffer, error_buffer_size))
+            {
+                return false;
+            }
+            if (out_result != NULL)
+            {
+                out_result->sent_input = true;
+                out_result->last_tick = tick;
+            }
+        }
+    }
+
+    if (out_result != NULL)
+        out_result->session_state = sdl3d_network_session_state(session);
+    return true;
 }
 
 static bool refresh_active_input_profile_if_available(sdl3d_data_game_runtime *runtime)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iterator>
 #include <stdexcept>
 #include <string>
@@ -1447,6 +1448,177 @@ TEST(GameDataRuntime, DataGameRuntimeRefreshesInputProfilesOnGamepadHotplug)
 
     sdl3d_data_game_runtime_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, DataGameRuntimeNetworkLoopReplicatesPongInputStateAndControls)
+{
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_session *client_session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &host_session));
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &client_session));
+
+    const std::filesystem::path data_path = SDL3D_PONG_DATA_PATH;
+    const std::string root = data_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + data_path.filename().string();
+
+    sdl3d_data_game_runtime_desc host_desc{};
+    sdl3d_data_game_runtime_desc_init(&host_desc);
+    host_desc.session = host_session;
+    host_desc.media_dir = SDL3D_MEDIA_DIR;
+    host_desc.data_asset_path = asset_path.c_str();
+    host_desc.mount_assets = mount_test_directory_assets;
+    host_desc.mount_userdata = const_cast<char *>(root.c_str());
+
+    sdl3d_data_game_runtime_desc client_desc = host_desc;
+    client_desc.session = client_session;
+
+    char error[512]{};
+    sdl3d_data_game_runtime *host_runtime = nullptr;
+    sdl3d_data_game_runtime *client_runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&host_desc, &host_runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&client_desc, &client_runtime, error, sizeof(error))) << error;
+    sdl3d_game_data_runtime *host_data = sdl3d_data_game_runtime_data(host_runtime);
+    sdl3d_game_data_runtime *client_data = sdl3d_data_game_runtime_data(client_runtime);
+    ASSERT_NE(host_data, nullptr);
+    ASSERT_NE(client_data, nullptr);
+
+    auto enter_play = [](sdl3d_game_data_runtime *runtime, const char *role) {
+        sdl3d_properties *payload = sdl3d_properties_create();
+        if (payload == nullptr)
+            return false;
+        sdl3d_properties_set_string(payload, "match_mode", "lan");
+        sdl3d_properties_set_string(payload, "network_role", role);
+        sdl3d_properties_set_string(payload, "network_flow", SDL_strcmp(role, "host") == 0 ? "host" : "direct");
+        const bool ok = sdl3d_game_data_set_active_scene_with_payload(runtime, "scene.play", payload);
+        sdl3d_properties_destroy(payload);
+        return ok;
+    };
+    ASSERT_TRUE(enter_play(host_data, "host"));
+    ASSERT_TRUE(enter_play(client_data, "client"));
+
+    const ::testing::TestInfo *test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+    const std::string test_name =
+        test_info != nullptr ? std::string(test_info->test_suite_name()) + "." + test_info->name() : "runtime_net";
+    const int port = 30000 + (int)(std::hash<std::string>{}(test_name) % 20000U);
+    if (!sdl3d_game_data_network_host_start(host_data, "host", port, "SDL3D Test", "host_status", "host_endpoint",
+                                            "host_peer", "host_connected"))
+    {
+        sdl3d_data_game_runtime_destroy(client_runtime);
+        sdl3d_data_game_runtime_destroy(host_runtime);
+        sdl3d_game_session_destroy(client_session);
+        sdl3d_game_session_destroy(host_session);
+        GTEST_SKIP() << "network host unavailable: " << SDL_GetError();
+    }
+    ASSERT_TRUE(sdl3d_game_data_network_direct_connect_start(client_data, "direct_connect", "127.0.0.1", port,
+                                                             "direct_status", "direct_state", "direct_connected"));
+
+    const sdl3d_data_game_network_bindings bindings = {"state_snapshot", "client_input",   "start_game",
+                                                       "pause_request",  "resume_request", "disconnect"};
+    sdl3d_game_context host_ctx{};
+    host_ctx.session = host_session;
+    sdl3d_game_context client_ctx{};
+    client_ctx.session = client_session;
+    sdl3d_data_game_network_loop_result host_result{};
+    sdl3d_data_game_network_loop_result client_result{};
+
+    sdl3d_network_session *host_net = sdl3d_game_data_get_network_host_session(host_data, "host");
+    sdl3d_network_session *client_net =
+        sdl3d_game_data_get_network_direct_connect_session(client_data, "direct_connect");
+    ASSERT_NE(host_net, nullptr);
+    ASSERT_NE(client_net, nullptr);
+    bool connected = false;
+    for (int i = 0; i < 1200 && !connected; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_host_session(
+            host_runtime, &host_ctx, "host", &bindings, false, 0.01f, &host_result, error, sizeof(error)))
+            << error;
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_client_session(client_runtime, &client_ctx, "direct_connect",
+                                                                          &bindings, false, false, 0.01f,
+                                                                          &client_result, error, sizeof(error)))
+            << error;
+        connected = sdl3d_network_session_is_connected(host_net) && sdl3d_network_session_is_connected(client_net);
+    }
+    ASSERT_TRUE(connected);
+
+    sdl3d_input_manager *client_input = sdl3d_game_session_get_input(client_session);
+    sdl3d_input_manager *host_input = sdl3d_game_session_get_input(host_session);
+    ASSERT_NE(client_input, nullptr);
+    ASSERT_NE(host_input, nullptr);
+    const int client_up = sdl3d_game_data_find_action(client_data, "action.paddle.local.up");
+    const int host_up = sdl3d_game_data_find_action(host_data, "action.paddle.local.up");
+    ASSERT_GE(client_up, 0);
+    ASSERT_GE(host_up, 0);
+    sdl3d_input_set_action_override(client_input, client_up, 1.0f);
+    ASSERT_NE(sdl3d_input_update(client_input, 101), nullptr);
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_network_client_session(client_runtime, &client_ctx, "direct_connect",
+                                                                      &bindings, true, false, 0.016f, &client_result,
+                                                                      error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(client_result.sent_input);
+    for (int i = 0; i < 120 && !host_result.applied_input; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_host_session(
+            host_runtime, &host_ctx, "host", &bindings, true, 0.01f, &host_result, error, sizeof(error)))
+            << error;
+    }
+    ASSERT_TRUE(host_result.applied_input);
+    ASSERT_NE(sdl3d_input_update(host_input, 102), nullptr);
+    EXPECT_NEAR(sdl3d_input_get_value(host_input, host_up), 1.0f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_send_network_runtime_control(client_data, client_net, "pause_request", 202U, error,
+                                                             sizeof(error)))
+        << error;
+    host_ctx.paused = false;
+    host_result = {};
+    for (int i = 0; i < 120 && !host_result.received_pause_request; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_host_session(
+            host_runtime, &host_ctx, "host", &bindings, true, 0.01f, &host_result, error, sizeof(error)))
+            << error;
+    }
+    EXPECT_TRUE(host_result.received_pause_request);
+    EXPECT_TRUE(host_ctx.paused);
+
+    sdl3d_registered_actor *host_ball = sdl3d_game_data_find_actor(host_data, "entity.ball");
+    sdl3d_registered_actor *client_ball = sdl3d_game_data_find_actor(client_data, "entity.ball");
+    ASSERT_NE(host_ball, nullptr);
+    ASSERT_NE(client_ball, nullptr);
+    host_ball->position = sdl3d_vec3_make(3.0f, 2.0f, 0.0f);
+    ASSERT_TRUE(sdl3d_data_game_runtime_publish_network_host_snapshot(host_runtime, &host_ctx, "host", &bindings,
+                                                                      &host_result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(host_result.sent_snapshot);
+    client_ctx.paused = false;
+    client_result = {};
+    for (int i = 0; i < 120 && !client_result.applied_snapshot; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_client_session(client_runtime, &client_ctx, "direct_connect",
+                                                                          &bindings, true, false, 0.01f, &client_result,
+                                                                          error, sizeof(error)))
+            << error;
+    }
+    ASSERT_TRUE(client_result.applied_snapshot);
+    EXPECT_NEAR(client_ball->position.x, host_ball->position.x, 0.0001f);
+    EXPECT_NEAR(client_ball->position.y, host_ball->position.y, 0.0001f);
+    EXPECT_TRUE(client_ctx.paused);
+
+    ASSERT_TRUE(
+        sdl3d_game_data_send_network_runtime_control(host_data, host_net, "start_game", 303U, error, sizeof(error)))
+        << error;
+    client_result = {};
+    for (int i = 0; i < 120 && !client_result.received_start_game; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_network_client_session(client_runtime, &client_ctx, "direct_connect",
+                                                                          &bindings, true, false, 0.01f, &client_result,
+                                                                          error, sizeof(error)))
+            << error;
+    }
+    EXPECT_TRUE(client_result.received_start_game);
+
+    sdl3d_data_game_runtime_destroy(client_runtime);
+    sdl3d_data_game_runtime_destroy(host_runtime);
+    sdl3d_game_session_destroy(client_session);
+    sdl3d_game_session_destroy(host_session);
 }
 
 TEST(GameDataRuntime, ReadsSpriteAssetMetadata)


### PR DESCRIPTION
## Summary
- add generic data-game runtime helpers for host/client network packet loops using authored runtime bindings
- move Pong client input, host snapshot, pause/resume, start, and disconnect packet handling onto the generic runtime surface
- add headless data-game runtime coverage for input replication, pause control, snapshot sync, and start controls
- update runtime/data docs to describe the managed network packet loop

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next Slice
The next practical slice is to move the remaining network scene transition and termination policy into authored data/runtime flow so Pong no longer decides start-game, disconnect, timeout, and return-to-title behavior in its compatibility host.
