### PR TITLE
Author network session flow events

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -177,6 +177,118 @@
         "disconnect_prompts": {
           "match_terminated": "Match terminated: {reason} - Press Enter to return to title screen."
         }
+      },
+      "events": {
+        "host_start_game": {
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            {
+              "type": "scene.set",
+              "scene": "scene.play",
+              "payload": { "match_mode": "lan", "network_role": "host", "network_flow": "host" }
+            }
+          ]
+        },
+        "client_start_game": {
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            {
+              "type": "scene.set",
+              "scene": "scene.play",
+              "payload": { "match_mode": "lan", "network_role": "client", "network_flow": "direct" }
+            }
+          ]
+        },
+        "client_state_before_start": {
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            {
+              "type": "scene.set",
+              "scene": "scene.play",
+              "payload": { "match_mode": "lan", "network_role": "client", "network_flow": "direct" }
+            }
+          ]
+        },
+        "host_match_terminated": {
+          "pause": true,
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            { "type": "scene_state.set", "key": "network_match_termination_active", "value": true },
+            {
+              "type": "scene_state.set",
+              "key": "network_match_termination_message",
+              "value": "Match terminated: {reason} - Press Enter to return to title screen."
+            },
+            {
+              "type": "network.host.cancel",
+              "name": "host",
+              "status_key": "multiplayer_host_status",
+              "endpoint_key": "multiplayer_host_endpoint",
+              "peer_key": "multiplayer_host_client",
+              "connected_key": "multiplayer_host_connected",
+              "status": "{reason}"
+            }
+          ]
+        },
+        "client_match_terminated": {
+          "pause": true,
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            { "type": "scene_state.set", "key": "network_match_termination_active", "value": true },
+            {
+              "type": "scene_state.set",
+              "key": "network_match_termination_message",
+              "value": "Match terminated: {reason} - Press Enter to return to title screen."
+            },
+            {
+              "type": "network.direct_connect.cancel",
+              "name": "direct_connect",
+              "status_key": "direct_connect_status",
+              "state_key": "direct_connect_state",
+              "connected_key": "direct_connect_connected",
+              "status": "{reason}"
+            }
+          ]
+        },
+        "host_client_disconnected": {
+          "pause": false,
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            {
+              "type": "network.host.cancel",
+              "name": "host",
+              "status_key": "multiplayer_host_status",
+              "endpoint_key": "multiplayer_host_endpoint",
+              "peer_key": "multiplayer_host_client",
+              "connected_key": "multiplayer_host_connected",
+              "status": "{reason}"
+            },
+            { "type": "scene.set", "scene": "scene.multiplayer.lobby" }
+          ]
+        },
+        "client_connection_closed": {
+          "pause": false,
+          "actions": [
+            { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+            {
+              "type": "network.direct_connect.cancel",
+              "name": "direct_connect",
+              "status_key": "direct_connect_status",
+              "state_key": "direct_connect_state",
+              "connected_key": "direct_connect_connected",
+              "status": "{reason}"
+            },
+            { "type": "scene.set", "scene": "scene.multiplayer.join" }
+          ]
+        },
+        "network_match_termination_ack": {
+          "pause": false,
+          "actions": [
+            { "type": "scene_state.set", "key": "network_match_termination_active", "value": false },
+            { "type": "scene_state.set", "key": "network_match_termination_message", "value": "" },
+            { "type": "scene.set", "scene": "scene.title" }
+          ]
+        }
       }
     },
     "runtime_bindings": {

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -35,16 +35,13 @@ typedef struct pong_state
     int lobby_start_connection;
     int host_start_signal_id;
     int camera_toggle_signal_id;
-    bool network_match_termination_active;
     float network_match_termination_timer;
-    char network_match_termination_reason[96];
 } pong_state;
 
 static bool send_network_control_packet(pong_state *state, sdl3d_network_session *session, const char *binding,
                                         const char *label);
 static bool send_network_control_packet_repeated(pong_state *state, sdl3d_network_session *session, const char *binding,
                                                  const char *label, int count);
-static void publish_network_match_termination_scene_state(pong_state *state);
 
 static const char PONG_NETWORK_BINDING_STATE_SNAPSHOT[] = "state_snapshot";
 static const char PONG_NETWORK_BINDING_CLIENT_INPUT[] = "client_input";
@@ -181,6 +178,37 @@ static const char *network_disconnect_reason(const pong_state *state, const char
     return network_session_message(state, "disconnect_reasons", name, fallback);
 }
 
+static bool run_network_flow_event(sdl3d_game_context *ctx, pong_state *state, const char *event_name,
+                                   const char *reason)
+{
+    char error[192] = {0};
+    sdl3d_properties *payload = NULL;
+    bool ok = false;
+
+    if (state == NULL || state->data == NULL || event_name == NULL || event_name[0] == '\0')
+    {
+        return false;
+    }
+
+    payload = sdl3d_properties_create();
+    if (payload == NULL)
+    {
+        return false;
+    }
+    sdl3d_properties_set_string(payload, "event", event_name);
+    sdl3d_properties_set_string(payload, "reason", reason != NULL && reason[0] != '\0' ? reason : "");
+
+    ok = sdl3d_game_data_run_network_session_flow_event(state->data, ctx, event_name, payload, error,
+                                                        (int)sizeof(error));
+    sdl3d_properties_destroy(payload);
+    if (!ok)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong network flow event '%s' failed: %s", event_name,
+                    error[0] != '\0' ? error : "unknown error");
+    }
+    return ok;
+}
+
 static const char *network_session_state_string(const pong_state *state, const char *key_name, const char *fallback)
 {
     const sdl3d_properties *scene_state =
@@ -261,52 +289,6 @@ static bool is_network_role_client(const pong_state *state)
     return is_network_match_mode(state) &&
            SDL_strcmp(network_role_name(state),
                       network_session_state_value(state, "network_role", "client", "client")) == 0;
-}
-
-static bool enter_multiplayer_play_scene(pong_state *state, const char *match_mode_value,
-                                         const char *network_role_value, const char *network_flow_value)
-{
-    sdl3d_properties *payload = NULL;
-    bool ok = false;
-
-    if (state == NULL || state->data == NULL)
-    {
-        return false;
-    }
-
-    payload = sdl3d_properties_create();
-    if (payload == NULL)
-    {
-        return false;
-    }
-
-    if (match_mode_value != NULL)
-    {
-        sdl3d_properties_set_string(payload, network_session_state_key(state, "match_mode", "match_mode"),
-                                    match_mode_value);
-    }
-    if (network_role_value != NULL)
-    {
-        sdl3d_properties_set_string(payload, network_session_state_key(state, "network_role", "network_role"),
-                                    network_role_value);
-    }
-    if (network_flow_value != NULL)
-    {
-        sdl3d_properties_set_string(payload, network_session_state_key(state, "network_flow", "network_flow"),
-                                    network_flow_value);
-    }
-
-    ok = sdl3d_game_data_set_active_scene_with_payload(state->data, network_session_scene(state, "play", "scene.play"),
-                                                       payload);
-    sdl3d_properties_destroy(payload);
-    return ok;
-}
-
-static bool enter_network_multiplayer_play_scene(pong_state *state, const char *role_name, const char *flow_name)
-{
-    return enter_multiplayer_play_scene(state, network_session_state_value(state, "match_mode", "network", "lan"),
-                                        network_session_state_value(state, "network_role", role_name, role_name),
-                                        network_session_state_value(state, "network_flow", flow_name, flow_name));
 }
 
 static const char *network_scene_state_key(const pong_state *state, const char *scope, const char *name,
@@ -539,7 +521,7 @@ static bool send_host_start_packet(pong_state *state)
     return true;
 }
 
-static bool start_selected_lobby_match(pong_state *state)
+static bool start_selected_lobby_match(sdl3d_game_context *ctx, pong_state *state)
 {
     if (state == NULL)
     {
@@ -558,63 +540,12 @@ static bool start_selected_lobby_match(pong_state *state)
         return false;
     }
 
-    clear_network_action_overrides(state);
-    if (!enter_network_multiplayer_play_scene(state, "host", "host"))
-    {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong host failed to enter multiplayer play scene: %s",
-                    SDL_GetError());
-        return false;
-    }
-
-    return true;
+    return run_network_flow_event(ctx, state, "host_start_game", NULL);
 }
 
-static void begin_network_match_termination(sdl3d_game_context *ctx, pong_state *state, bool local_host,
-                                            const char *reason)
+static void run_network_disconnect_flow(sdl3d_game_context *ctx, pong_state *state, bool local_host, const char *reason)
 {
-    if (state == NULL || state->data == NULL)
-    {
-        return;
-    }
-
-    clear_network_action_overrides(state);
-    if (ctx != NULL)
-    {
-        ctx->paused = true;
-    }
-
-    SDL_snprintf(state->network_match_termination_reason, sizeof(state->network_match_termination_reason), "%s",
-                 reason != NULL && reason[0] != '\0'
-                     ? reason
-                     : network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
-    state->network_match_termination_timer = 0.0f;
-    state->network_match_termination_active = true;
-    publish_network_match_termination_scene_state(state);
-
-    if (local_host)
-    {
-        destroy_host_session_internal(state, false);
-        SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
-                     reason != NULL && reason[0] != '\0'
-                         ? reason
-                         : network_disconnect_reason(state, "client_disconnected", "Client disconnected"));
-        update_host_session_scene_state(state);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong host match terminated: %s", state->host_status);
-    }
-    else
-    {
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                     reason != NULL && reason[0] != '\0'
-                         ? reason
-                         : network_disconnect_reason(state, "host_disconnected", "Host disconnected"));
-        destroy_direct_connect_session_internal(state, false);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client match terminated: %s", state->direct_connect_status);
-    }
-}
-
-static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong_state *state, bool local_host,
-                                                   const char *reason)
-{
+    const char *event_name = NULL;
     if (state == NULL || state->data == NULL)
     {
         return;
@@ -622,37 +553,18 @@ static void return_to_multiplayer_after_disconnect(sdl3d_game_context *ctx, pong
 
     if (is_multiplayer_play_scene(state))
     {
-        begin_network_match_termination(ctx, state, local_host, reason);
-        return;
-    }
-
-    clear_network_action_overrides(state);
-    if (ctx != NULL)
-    {
-        ctx->paused = false;
-    }
-
-    if (local_host)
-    {
-        SDL_snprintf(state->host_status, sizeof(state->host_status), "%s",
-                     reason != NULL && reason[0] != '\0'
-                         ? reason
-                         : network_disconnect_reason(state, "client_disconnected", "Client disconnected"));
-        destroy_host_session_internal(state, false);
-        update_host_session_scene_state(state);
-        (void)sdl3d_game_data_set_active_scene(state->data,
-                                               network_session_scene(state, "host_lobby", "scene.multiplayer.lobby"));
+        state->network_match_termination_timer = 0.0f;
+        event_name = local_host ? "host_match_terminated" : "client_match_terminated";
     }
     else
     {
-        SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s",
-                     reason != NULL && reason[0] != '\0'
-                         ? reason
-                         : network_disconnect_reason(state, "host_disconnected", "Host disconnected"));
-        destroy_direct_connect_session_internal(state, false);
-        (void)sdl3d_game_data_set_active_scene(state->data,
-                                               network_session_scene(state, "join", "scene.multiplayer.join"));
+        event_name = local_host ? "host_client_disconnected" : "client_connection_closed";
     }
+
+    (void)run_network_flow_event(ctx, state, event_name,
+                                 reason != NULL && reason[0] != '\0'
+                                     ? reason
+                                     : network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
 }
 
 static bool start_direct_connect_session(pong_state *state)
@@ -729,19 +641,14 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
         if (result.received_start_game)
         {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Pong client received multiplayer start request");
-            clear_network_action_overrides(state);
-            if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
-            {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong client failed to enter multiplayer play scene: %s",
-                            SDL_GetError());
-            }
+            (void)run_network_flow_event(ctx, state, "client_start_game", NULL);
         }
         if (result.received_disconnect)
         {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong client received host disconnect tick=%u",
                         (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
-            return_to_multiplayer_after_disconnect(ctx, state, false,
-                                                   network_disconnect_reason(state, "host_exited", "Host exited"));
+            run_network_disconnect_flow(ctx, state, false,
+                                        network_disconnect_reason(state, "host_exited", "Host exited"));
             return;
         }
         if (result.applied_snapshot)
@@ -750,13 +657,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
             {
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                             "Pong client received authoritative state before start command; entering play scene");
-                clear_network_action_overrides(state);
-                if (!enter_network_multiplayer_play_scene(state, "client", "direct"))
-                {
-                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                                "Pong client failed to enter multiplayer play scene from state packet: %s",
-                                SDL_GetError());
-                }
+                (void)run_network_flow_event(ctx, state, "client_state_before_start", NULL);
             }
             pong_log_multiplayer_state("client<-host state", state, result.last_tick, "applied");
         }
@@ -777,12 +678,11 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                                      : network_disconnect_reason(state, "host_error", "Host connection error");
             if (was_playing)
             {
-                return_to_multiplayer_after_disconnect(ctx, state, false, reason);
+                run_network_disconnect_flow(ctx, state, false, reason);
             }
             else
             {
-                SDL_snprintf(state->direct_connect_status, sizeof(state->direct_connect_status), "%s", reason);
-                destroy_direct_connect_session_internal(state, false);
+                (void)run_network_flow_event(ctx, state, "client_connection_closed", reason);
             }
         }
     }
@@ -791,8 +691,16 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
 static void update_network_match_termination(sdl3d_game_context *ctx, pong_state *state, float dt)
 {
     const int select_action = network_runtime_action_id(state, PONG_NETWORK_BINDING_MENU_SELECT);
+    const sdl3d_properties *scene_state =
+        state != NULL && state->data != NULL ? sdl3d_game_data_scene_state(state->data) : NULL;
+    const bool active = scene_state != NULL
+                            ? sdl3d_properties_get_bool(scene_state,
+                                                        network_session_state_key(state, "match_termination_active",
+                                                                                  "network_match_termination_active"),
+                                                        false)
+                            : false;
 
-    if (state == NULL || !state->network_match_termination_active)
+    if (state == NULL || !active)
     {
         return;
     }
@@ -813,18 +721,8 @@ static void update_network_match_termination(sdl3d_game_context *ctx, pong_state
         return;
     }
 
-    state->network_match_termination_active = false;
     state->network_match_termination_timer = 0.0f;
-    state->network_match_termination_reason[0] = '\0';
-    publish_network_match_termination_scene_state(state);
-    if (ctx != NULL)
-    {
-        ctx->paused = false;
-    }
-    if (state->data != NULL)
-    {
-        (void)sdl3d_game_data_set_active_scene(state->data, network_session_scene(state, "title", "scene.title"));
-    }
+    (void)run_network_flow_event(ctx, state, "network_match_termination_ack", NULL);
 }
 
 static void update_host_session_status(sdl3d_game_context *ctx, pong_state *state, float dt)
@@ -850,8 +748,8 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong host received client disconnect tick=%u",
                         (unsigned long long)pong_log_timestamp_ms(), (unsigned int)result.last_tick);
-            return_to_multiplayer_after_disconnect(ctx, state, true,
-                                                   network_disconnect_reason(state, "client_exited", "Client exited"));
+            run_network_disconnect_flow(ctx, state, true,
+                                        network_disconnect_reason(state, "client_exited", "Client exited"));
         }
         if (result.received_pause_request)
         {
@@ -880,8 +778,8 @@ static void update_host_session_status(sdl3d_game_context *ctx, pong_state *stat
         else if (is_multiplayer_play_scene(state) && state->host_session != NULL &&
                  result.session_state != SDL3D_NETWORK_STATE_CONNECTED)
         {
-            begin_network_match_termination(ctx, state, true,
-                                            network_disconnect_reason(state, "client_timed_out", "Client timed out"));
+            run_network_disconnect_flow(ctx, state, true,
+                                        network_disconnect_reason(state, "client_timed_out", "Client timed out"));
         }
         return;
     }
@@ -965,60 +863,6 @@ static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_st
     }
 }
 
-static void format_network_termination_prompt(const pong_state *state, char *buffer, size_t buffer_size,
-                                              const char *reason)
-{
-    const char *template =
-        network_session_message(state, "disconnect_prompts", "match_terminated",
-                                "Match terminated: {reason} - Press Enter to return to title screen.");
-    const char *placeholder = template != NULL ? SDL_strstr(template, "{reason}") : NULL;
-
-    if (buffer == NULL || buffer_size == 0)
-    {
-        return;
-    }
-    if (placeholder == NULL)
-    {
-        SDL_snprintf(buffer, buffer_size, "%s", template != NULL ? template : "");
-        return;
-    }
-
-    const size_t prefix_len = (size_t)(placeholder - template);
-    SDL_snprintf(buffer, buffer_size, "%.*s%s%s", (int)prefix_len, template, reason != NULL ? reason : "",
-                 placeholder + SDL_strlen("{reason}"));
-}
-
-static void publish_network_match_termination_scene_state(pong_state *state)
-{
-    char message[192];
-    sdl3d_properties *scene_state =
-        state != NULL && state->data != NULL ? sdl3d_game_data_mutable_scene_state(state->data) : NULL;
-
-    if (scene_state == NULL)
-    {
-        return;
-    }
-
-    sdl3d_properties_set_bool(
-        scene_state, network_session_state_key(state, "match_termination_active", "network_match_termination_active"),
-        state->network_match_termination_active);
-    if (!state->network_match_termination_active)
-    {
-        sdl3d_properties_set_string(
-            scene_state,
-            network_session_state_key(state, "match_termination_message", "network_match_termination_message"), "");
-        return;
-    }
-
-    format_network_termination_prompt(state, message, sizeof(message),
-                                      state->network_match_termination_reason[0] != '\0'
-                                          ? state->network_match_termination_reason
-                                          : network_disconnect_reason(state, "peer_disconnected", "Peer disconnected"));
-    sdl3d_properties_set_string(
-        scene_state, network_session_state_key(state, "match_termination_message", "network_match_termination_message"),
-        message);
-}
-
 static void refresh_local_play_input(pong_state *state)
 {
     const char *active_scene = state != NULL && state->data != NULL ? sdl3d_game_data_active_scene(state->data) : NULL;
@@ -1054,7 +898,7 @@ static void on_multiplayer_lobby_signal(void *userdata, int signal_id, const sdl
         return;
     }
 
-    (void)start_selected_lobby_match(state);
+    (void)start_selected_lobby_match(NULL, state);
 }
 
 static bool mount_pong_assets(sdl3d_asset_resolver *assets, char *error, int error_size)
@@ -1115,7 +959,6 @@ static bool pong_init(sdl3d_game_context *ctx, void *userdata)
         return false;
     }
     reset_direct_connect_defaults(state);
-    publish_network_match_termination_scene_state(state);
 
     state->input = sdl3d_game_session_get_input(ctx->session);
     const int gamepad_count = state->input != NULL ? sdl3d_input_gamepad_count(state->input) : 0;

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -85,6 +85,15 @@ The helpers intentionally report events instead of hard-coding transitions.
 That keeps game-specific flow in JSON/Lua or a thin compatibility host until
 scene/session orchestration is fully authored.
 
+Network session-flow events close that gap for transition policy. Games can
+author `network.session_flow.events` entries and a host or runner can execute
+them with `sdl3d_game_data_run_network_session_flow_event()`. Each event may
+set pause state and run ordinary data actions, so policies such as “client
+received start game”, “peer disconnected during play”, or “acknowledge match
+termination” can live in JSON instead of C. The runtime passes optional payload
+properties, such as `reason`, into those actions; supported string fields may
+use `{reason}` placeholders.
+
 ## Generic Runner
 
 `sdl3d_runner` launches a game data asset without game-specific C callbacks.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1724,6 +1724,42 @@ when the caller documents and substitutes them. Callers resolve these values wit
 `sdl3d_game_data_get_network_session_message()`. Like `scene_state`, these
 orchestration maps are not part of the replication schema hash.
 
+`session_flow.events` maps semantic network events to data actions. Each event
+may be an action array or an object with optional `pause` and `actions` fields:
+
+```json
+"events": {
+  "client_start_game": {
+    "actions": [
+      { "type": "input.clear_network_input_overrides", "channel": "client_input" },
+      {
+        "type": "scene.set",
+        "scene": "scene.play",
+        "payload": { "match_mode": "lan", "network_role": "client" }
+      }
+    ]
+  },
+  "client_match_terminated": {
+    "pause": true,
+    "actions": [
+      { "type": "scene_state.set", "key": "network_match_termination_active", "value": true },
+      {
+        "type": "scene_state.set",
+        "key": "network_match_termination_message",
+        "value": "Match terminated: {reason}"
+      }
+    ]
+  }
+}
+```
+
+Hosts and generic runners execute these events with
+`sdl3d_game_data_run_network_session_flow_event()`. The optional event payload
+is passed to actions and can be referenced from supported string fields with
+`{field}` placeholders. `scene.set` may author a scalar `payload` object that is
+delivered to the target scene's enter signal; `scene_state.set` writes scalar
+scene-state values directly.
+
 `runtime_bindings` is optional. It maps host integration semantics to concrete
 authored replication channels and control messages without baking those schema
 names into game host code. `replication` maps semantic names to entries in

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -996,6 +996,28 @@ extern "C"
                                                      const char *name, const char **out_message);
 
     /**
+     * @brief Execute an authored network session-flow event.
+     *
+     * Events are authored under `network.session_flow.events.<name>`. An event
+     * may be either an action array or an object with optional `pause` and
+     * `actions` fields. The action array uses the same data action vocabulary
+     * as logic bindings and scene activity actions. String values in supported
+     * actions can reference string payload fields with `{field}` placeholders.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param ctx Optional game context; required only when the event authors a
+     * `pause` field.
+     * @param name Authored event semantic name.
+     * @param payload Optional payload passed to event actions.
+     * @param error_buffer Optional buffer for a failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the event exists and all actions execute.
+     */
+    bool sdl3d_game_data_run_network_session_flow_event(sdl3d_game_data_runtime *runtime, sdl3d_game_context *ctx,
+                                                        const char *name, const sdl3d_properties *payload,
+                                                        char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Resolve an authored network runtime replication channel binding.
      *
      * Runtime bindings are authored under `network.runtime_bindings.replication`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7073,8 +7073,12 @@ static bool format_payload_string(const sdl3d_properties *payload, const char *f
         const char *close = SDL_strchr(open + 1, '}');
         if (close == NULL)
         {
-            cursor = open;
-            continue;
+            const size_t remaining = buffer_size - offset;
+            const size_t copied = SDL_strlcpy(buffer + offset, open, remaining);
+            offset += SDL_min(copied, remaining > 0U ? remaining - 1U : 0U);
+            if (copied < remaining)
+                cursor = open + copied;
+            break;
         }
 
         char key[64];

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7034,6 +7034,113 @@ static void set_actor_property_from_json(sdl3d_registered_actor *actor, const ch
         sdl3d_properties_set_vec3(actor->props, key, json_vec3_value(value, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
 }
 
+static bool format_payload_string(const sdl3d_properties *payload, const char *format, char *buffer, size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0U)
+        return false;
+    buffer[0] = '\0';
+    if (format == NULL)
+        return true;
+    if (payload == NULL || SDL_strchr(format, '{') == NULL)
+    {
+        SDL_strlcpy(buffer, format, buffer_size);
+        return SDL_strlen(format) < buffer_size;
+    }
+
+    size_t offset = 0U;
+    const char *cursor = format;
+    while (*cursor != '\0' && offset + 1U < buffer_size)
+    {
+        const char *open = SDL_strchr(cursor, '{');
+        if (open == NULL)
+        {
+            const size_t remaining = buffer_size - offset;
+            const size_t copied = SDL_strlcpy(buffer + offset, cursor, remaining);
+            offset += SDL_min(copied, remaining > 0U ? remaining - 1U : 0U);
+            if (copied < remaining)
+                cursor += copied;
+            break;
+        }
+
+        const size_t literal_len = (size_t)(open - cursor);
+        const size_t literal_copy = SDL_min(literal_len, buffer_size - offset - 1U);
+        SDL_memcpy(buffer + offset, cursor, literal_copy);
+        offset += literal_copy;
+        buffer[offset] = '\0';
+        if (literal_copy < literal_len)
+            break;
+
+        const char *close = SDL_strchr(open + 1, '}');
+        if (close == NULL)
+        {
+            cursor = open;
+            continue;
+        }
+
+        char key[64];
+        const size_t key_len = (size_t)(close - open - 1);
+        if (key_len > 0U && key_len < sizeof(key))
+        {
+            SDL_memcpy(key, open + 1, key_len);
+            key[key_len] = '\0';
+            const char *replacement = sdl3d_properties_get_string(payload, key, "");
+            const size_t remaining = buffer_size - offset;
+            const size_t copied = SDL_strlcpy(buffer + offset, replacement, remaining);
+            offset += SDL_min(copied, remaining > 0U ? remaining - 1U : 0U);
+        }
+        cursor = close + 1;
+    }
+    buffer[buffer_size - 1U] = '\0';
+    return cursor[0] == '\0';
+}
+
+static bool set_property_from_json_with_payload(sdl3d_properties *props, const char *key, yyjson_val *value,
+                                                const sdl3d_properties *payload)
+{
+    if (props == NULL || key == NULL || value == NULL)
+        return false;
+    if (yyjson_is_str(value))
+    {
+        char formatted[256];
+        if (!format_payload_string(payload, yyjson_get_str(value), formatted, sizeof(formatted)))
+            return false;
+        sdl3d_properties_set_string(props, key, formatted);
+        return true;
+    }
+    return set_property_from_json(props, key, value);
+}
+
+static sdl3d_properties *properties_from_json_payload(yyjson_val *json, const sdl3d_properties *source_payload)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    if (json == NULL)
+        return payload;
+    if (!yyjson_is_obj(json))
+    {
+        sdl3d_properties_destroy(payload);
+        return NULL;
+    }
+
+    yyjson_val *key;
+    yyjson_val *value;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(json, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        value = yyjson_obj_iter_get_val(key);
+        if (name == NULL || name[0] == '\0' ||
+            !set_property_from_json_with_payload(payload, name, value, source_payload))
+        {
+            sdl3d_properties_destroy(payload);
+            return NULL;
+        }
+    }
+    return payload;
+}
+
 static void load_actor_properties(sdl3d_registered_actor *actor, yyjson_val *properties)
 {
     if (actor == NULL || !yyjson_is_obj(properties))
@@ -9843,6 +9950,15 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return true;
     }
 
+    if (SDL_strcmp(type, "scene_state.set") == 0)
+    {
+        const char *key = json_string(action, "key", NULL);
+        yyjson_val *value = obj_get(action, "value");
+        if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0' || value == NULL)
+            return false;
+        return set_property_from_json_with_payload(runtime->scene_state, key, value, payload);
+    }
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);
@@ -9864,10 +9980,12 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "network.direct_connect.cancel") == 0)
     {
+        char status[256];
+        const char *status_text = json_string(action, "status", "Disconnected");
+        (void)format_payload_string(payload, status_text, status, sizeof(status));
         return sdl3d_game_data_network_direct_connect_cancel(
             runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
-            json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL),
-            json_string(action, "status", "Disconnected"));
+            json_string(action, "state_key", NULL), json_string(action, "connected_key", NULL), status);
     }
 
     if (SDL_strcmp(type, "network.direct_connect.observe") == 0)
@@ -9890,10 +10008,13 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "network.host.cancel") == 0)
     {
+        char status[256];
+        const char *status_text = json_string(action, "status", "Not hosting");
+        (void)format_payload_string(payload, status_text, status, sizeof(status));
         return sdl3d_game_data_network_host_cancel(
             runtime, json_string(action, "name", NULL), json_string(action, "status_key", NULL),
             json_string(action, "endpoint_key", NULL), json_string(action, "peer_key", NULL),
-            json_string(action, "connected_key", NULL), json_string(action, "status", "Not hosting"));
+            json_string(action, "connected_key", NULL), status);
     }
 
     if (SDL_strcmp(type, "network.host.observe") == 0)
@@ -9996,7 +10117,19 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
     }
 
     if (SDL_strcmp(type, "scene.set") == 0)
-        return sdl3d_game_data_set_active_scene_with_payload(runtime, json_string(action, "scene", NULL), payload);
+    {
+        yyjson_val *authored_payload = obj_get(action, "payload");
+        if (authored_payload == NULL)
+            return sdl3d_game_data_set_active_scene_with_payload(runtime, json_string(action, "scene", NULL), payload);
+
+        sdl3d_properties *scene_payload = properties_from_json_payload(authored_payload, payload);
+        if (scene_payload == NULL)
+            return false;
+        const bool ok =
+            sdl3d_game_data_set_active_scene_with_payload(runtime, json_string(action, "scene", NULL), scene_payload);
+        sdl3d_properties_destroy(scene_payload);
+        return ok;
+    }
 
     if (SDL_strcmp(type, "adapter.invoke") == 0)
     {
@@ -11505,6 +11638,46 @@ bool sdl3d_game_data_get_network_session_message(const sdl3d_game_data_runtime *
         return false;
 
     *out_message = value;
+    return true;
+}
+
+bool sdl3d_game_data_run_network_session_flow_event(sdl3d_game_data_runtime *runtime, sdl3d_game_context *ctx,
+                                                    const char *name, const sdl3d_properties *payload,
+                                                    char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL || name == NULL || name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "network session flow event requires runtime and name");
+        return false;
+    }
+
+    yyjson_val *events = obj_get(network_session_flow_json(runtime), "events");
+    yyjson_val *event = obj_get(events, name);
+    if (event == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network session flow event not found");
+        return false;
+    }
+
+    yyjson_val *actions = event;
+    if (yyjson_is_obj(event))
+    {
+        yyjson_val *pause = obj_get(event, "pause");
+        if (pause != NULL && ctx == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "network session flow event pause requires a game context");
+            return false;
+        }
+        if (pause != NULL && yyjson_is_bool(pause))
+            ctx->paused = yyjson_get_bool(pause);
+        actions = obj_get(event, "actions");
+    }
+
+    if (!execute_optional_action_array(runtime, actions, payload))
+    {
+        set_error(error_buffer, error_buffer_size, "network session flow event action failed");
+        return false;
+    }
     return true;
 }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -668,6 +668,9 @@ static bool validate_network_scene_state(validation_context *ctx, yyjson_val *ne
     return true;
 }
 
+static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
+                                  validation_names *names);
+
 static bool validate_network_session_string_map(validation_context *ctx, yyjson_val *map, const char *json_path,
                                                 const char *label, const name_table *scene_names)
 {
@@ -747,6 +750,51 @@ static bool validate_network_session_flow(validation_context *ctx, yyjson_val *n
                                         grouped_maps[map_index].label);
             if (!validate_network_session_string_map(ctx, group, group_path, grouped_maps[map_index].label, NULL))
                 return false;
+        }
+    }
+
+    yyjson_val *events = obj_get(flow, "events");
+    if (events != NULL)
+    {
+        if (!yyjson_is_obj(events))
+            return validation_error(ctx, "$.network.session_flow.events",
+                                    "network session_flow events must be an object");
+        yyjson_val *event_key;
+        yyjson_obj_iter event_iter;
+        yyjson_obj_iter_init(events, &event_iter);
+        while ((event_key = yyjson_obj_iter_next(&event_iter)) != NULL)
+        {
+            const char *event_name = yyjson_get_str(event_key);
+            yyjson_val *event = yyjson_obj_iter_get_val(event_key);
+            char event_path[PATH_BUFFER_SIZE];
+            format_path(event_path, sizeof(event_path), "$.network.session_flow.events.%s",
+                        event_name != NULL ? event_name : "<invalid>");
+            if (event_name == NULL || event_name[0] == '\0')
+                return validation_error(ctx, event_path, "network session_flow event name must be non-empty");
+            if (yyjson_is_arr(event))
+            {
+                if (!validate_action_array(ctx, event, event_path, names))
+                    return false;
+            }
+            else if (yyjson_is_obj(event))
+            {
+                yyjson_val *pause = obj_get(event, "pause");
+                if (pause != NULL && !yyjson_is_bool(pause))
+                    return validation_error(ctx, event_path, "network session_flow event pause must be boolean");
+                yyjson_val *actions = obj_get(event, "actions");
+                if (actions != NULL)
+                {
+                    char actions_path[PATH_BUFFER_SIZE];
+                    format_path(actions_path, sizeof(actions_path), "%s.actions", event_path);
+                    if (!validate_action_array(ctx, actions, actions_path, names))
+                        return false;
+                }
+            }
+            else
+            {
+                return validation_error(ctx, event_path,
+                                        "network session_flow event must be an action array or object");
+            }
         }
     }
 
@@ -2340,9 +2388,6 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
     return true;
 }
 
-static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
-                                  validation_names *names);
-
 static bool is_tween_easing(const char *easing)
 {
     return easing == NULL || SDL_strcmp(easing, "linear") == 0 || SDL_strcmp(easing, "in_quad") == 0 ||
@@ -2552,6 +2597,15 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return require_ref(ctx, &names->network_input_channels, "network input channel", json_string(action, "channel"),
                            json_path);
     }
+    if (SDL_strcmp(type, "scene_state.set") == 0)
+    {
+        if (!is_non_empty_string(action, "key"))
+            return validation_error(ctx, json_path, "scene_state.set requires a non-empty key");
+        yyjson_val *value = obj_get(action, "value");
+        if (value == NULL || !(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value)))
+            return validation_error(ctx, json_path, "scene_state.set requires a scalar value");
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))
@@ -2687,7 +2741,29 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     if (SDL_strcmp(type, "camera.set") == 0)
         return require_ref(ctx, &names->cameras, "camera", json_string(action, "camera"), json_path);
     if (SDL_strcmp(type, "scene.set") == 0)
-        return require_ref(ctx, &names->scenes, "scene", json_string(action, "scene"), json_path);
+    {
+        if (!require_ref(ctx, &names->scenes, "scene", json_string(action, "scene"), json_path))
+            return false;
+        yyjson_val *payload = obj_get(action, "payload");
+        if (payload != NULL)
+        {
+            if (!yyjson_is_obj(payload))
+                return validation_error(ctx, json_path, "scene.set payload must be an object");
+            yyjson_val *key;
+            yyjson_obj_iter iter;
+            yyjson_obj_iter_init(payload, &iter);
+            while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+            {
+                const char *name = yyjson_get_str(key);
+                yyjson_val *value = yyjson_obj_iter_get_val(key);
+                if (name == NULL || name[0] == '\0')
+                    return validation_error(ctx, json_path, "scene.set payload keys must be non-empty");
+                if (!(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value)))
+                    return validation_error(ctx, json_path, "scene.set payload values must be scalar");
+            }
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "adapter.invoke") == 0)
     {
         const char *adapter = json_string(action, "adapter");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1621,6 +1621,73 @@ TEST(GameDataRuntime, DataGameRuntimeNetworkLoopReplicatesPongInputStateAndContr
     sdl3d_game_session_destroy(host_session);
 }
 
+TEST(GameDataRuntime, AuthoredNetworkSessionFlowEventsDriveSceneTransitions)
+{
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    const std::filesystem::path data_path = SDL3D_PONG_DATA_PATH;
+    const std::string root = data_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + data_path.filename().string();
+
+    sdl3d_data_game_runtime_desc desc{};
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SDL3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+
+    char error[512]{};
+    sdl3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    sdl3d_game_data_runtime *data = sdl3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+
+    ASSERT_TRUE(
+        sdl3d_game_data_run_network_session_flow_event(data, &ctx, "client_start_game", nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(sdl3d_game_data_active_scene(data), "scene.play");
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(data);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "match_mode", ""), "lan");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_role", ""), "client");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_flow", ""), "direct");
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    ASSERT_NE(payload, nullptr);
+    sdl3d_properties_set_string(payload, "reason", "Cable unplugged");
+    ctx.paused = false;
+    ASSERT_TRUE(sdl3d_game_data_run_network_session_flow_event(data, &ctx, "client_match_terminated", payload, error,
+                                                               sizeof(error)))
+        << error;
+    sdl3d_properties_destroy(payload);
+    scene_state = sdl3d_game_data_scene_state(data);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(ctx.paused);
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "network_match_termination_active", false));
+    EXPECT_NE(SDL_strstr(sdl3d_properties_get_string(scene_state, "network_match_termination_message", ""),
+                         "Cable unplugged"),
+              nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "direct_connect_status", ""), "Cable unplugged");
+
+    ASSERT_TRUE(sdl3d_game_data_run_network_session_flow_event(data, &ctx, "network_match_termination_ack", nullptr,
+                                                               error, sizeof(error)))
+        << error;
+    scene_state = sdl3d_game_data_scene_state(data);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_FALSE(ctx.paused);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(data), "scene.title");
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "network_match_termination_active", true));
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "network_match_termination_message", "x"), "");
+
+    sdl3d_data_game_runtime_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, ReadsSpriteAssetMetadata)
 {
     sdl3d_game_session *session = nullptr;
@@ -7280,6 +7347,36 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "network session_flow messages value must be a non-empty string",
+        },
+        {
+            "bad_session_flow_event",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "session_flow": {
+      "events": {
+        "disconnect": {
+          "pause": true,
+          "actions": [
+            { "type": "scene_state.set", "value": true }
+          ]
+        }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "scene_state.set requires a non-empty key",
         },
         {
             "bad_runtime_replication_binding",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1688,6 +1688,53 @@ TEST(GameDataRuntime, AuthoredNetworkSessionFlowEventsDriveSceneTransitions)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, NetworkSessionFlowPlaceholderMalformedBraceIsLiteral)
+{
+    const std::filesystem::path dir = unique_test_dir("network_flow_malformed_placeholder");
+    const std::filesystem::path source = std::filesystem::path(SDL3D_PONG_DATA_PATH).parent_path();
+    const std::filesystem::path dest = dir / "pong_data";
+    std::filesystem::copy(source, dest,
+                          std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing);
+
+    const std::filesystem::path game_path = dest / "pong.game.json";
+    std::string game_json = read_text(game_path);
+    const std::string marker = R"json("events": {)json";
+    const size_t marker_pos = game_json.find(marker);
+    ASSERT_NE(marker_pos, std::string::npos);
+    game_json.insert(marker_pos + marker.size(), R"json(
+        "malformed_placeholder": {
+          "actions": [
+            {
+              "type": "scene_state.set",
+              "key": "malformed_placeholder_result",
+              "value": "literal {reason"
+            }
+          ]
+        },
+)json");
+    write_text(game_path, game_json.c_str());
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(game_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_NE(runtime, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_run_network_session_flow_event(runtime, nullptr, "malformed_placeholder", nullptr,
+                                                               error, sizeof(error)))
+        << error;
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "malformed_placeholder_result", ""), "literal {reason");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ReadsSpriteAssetMetadata)
 {
     sdl3d_game_session *session = nullptr;


### PR DESCRIPTION
## Summary
- add `network.session_flow.events` so network start/disconnect/termination transitions can run authored data actions
- add generic `scene_state.set` and `scene.set` payload support, including payload placeholder formatting for event reasons
- move Pong network start/termination scene flow into JSON-authored events and delete host-side scene/termination formatting logic
- cover authored network-flow event execution and invalid event validation

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next Slice
The next practical slice is authored diagnostics policy from issue #210: move remaining Pong-specific multiplayer logging decisions into data so diagnostics can be enabled, throttled, and scoped per authored channel/session state.