### PR TITLE
Author network diagnostics policy

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -322,6 +322,19 @@
         "state": { "actor": "entity.match", "property": "paused" }
       }
     },
+    "diagnostics": {
+      "snapshots": [
+        {
+          "name": "multiplayer_state",
+          "replication": "play_state",
+          "enabled": true,
+          "level": "info",
+          "cadence_seconds": 0.25,
+          "include_session_state": true,
+          "message": "network {event} {description} {extra}"
+        }
+      ]
+    },
     "replication": [
       {
         "name": "play_state",

--- a/demos/pong/main.c
+++ b/demos/pong/main.c
@@ -54,6 +54,7 @@ static const char PONG_NETWORK_BINDING_CLIENT_DOWN[] = "client_down";
 static const char PONG_NETWORK_BINDING_MENU_SELECT[] = "menu_select";
 static const char PONG_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
 static const char PONG_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
+static const char PONG_NETWORK_DIAGNOSTIC_MULTIPLAYER_STATE[] = "multiplayer_state";
 static const char PONG_HOST_SESSION[] = "host";
 static const char PONG_DIRECT_CONNECT_SESSION[] = "direct_connect";
 static const char PONG_DIRECT_CONNECT_HOST_KEY[] = "direct_connect_host";
@@ -80,26 +81,16 @@ static Uint64 pong_log_timestamp_ms(void)
     return SDL_GetTicks();
 }
 
-static void pong_log_multiplayer_state(const char *prefix, const pong_state *state, Uint32 packet_tick,
-                                       const char *extra)
+static void log_network_snapshot_diagnostic(pong_state *state, Uint32 packet_tick, const char *event, const char *extra)
 {
-    char description[4096] = {0};
     char error[256] = {0};
-    const char *state_channel = NULL;
     if (state == NULL || state->data == NULL ||
-        !sdl3d_game_data_get_network_runtime_replication(state->data, PONG_NETWORK_BINDING_STATE_SNAPSHOT,
-                                                         &state_channel) ||
-        !sdl3d_game_data_describe_network_snapshot(state->data, state_channel, packet_tick, description,
-                                                   sizeof(description), error, sizeof(error)))
+        !sdl3d_game_data_log_network_snapshot_diagnostic(state->data, PONG_NETWORK_DIAGNOSTIC_MULTIPLAYER_STATE,
+                                                         packet_tick, event, extra, NULL, error, (int)sizeof(error)))
     {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Pong multiplayer state diagnostic failed: %s",
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "network snapshot diagnostic failed: %s",
                     error[0] != '\0' ? error : "runtime unavailable");
-        return;
     }
-
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "[%llu ms] Pong %s %s%s%s", (unsigned long long)pong_log_timestamp_ms(),
-                prefix != NULL ? prefix : "state", description, extra != NULL && extra[0] != '\0' ? " " : "",
-                extra != NULL ? extra : "");
 }
 
 static const char *active_scene_name(const pong_state *state)
@@ -659,7 +650,7 @@ static void update_direct_connect_session_status(sdl3d_game_context *ctx, pong_s
                             "Pong client received authoritative state before start command; entering play scene");
                 (void)run_network_flow_event(ctx, state, "client_state_before_start", NULL);
             }
-            pong_log_multiplayer_state("client<-host state", state, result.last_tick, "applied");
+            log_network_snapshot_diagnostic(state, result.last_tick, "client_snapshot_applied", "applied");
         }
 
         if (state->direct_connect_session == NULL)
@@ -843,7 +834,7 @@ static void publish_multiplayer_state(sdl3d_game_context *ctx, pong_state *state
                     error[0] != '\0' ? error : "unknown error");
         return;
     }
-    pong_log_multiplayer_state("host->client state", state, result.last_tick, "sent");
+    log_network_snapshot_diagnostic(state, result.last_tick, "host_snapshot_sent", "sent");
 }
 
 static void update_network_client_input_sensors(sdl3d_game_context *ctx, pong_state *state)

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -94,6 +94,12 @@ termination” can live in JSON instead of C. The runtime passes optional payloa
 properties, such as `reason`, into those actions; supported string fields may
 use `{reason}` placeholders.
 
+Authored `network.diagnostics.snapshots` entries make multiplayer state logging
+policy data-driven as well. A compatibility host or generic runner can call
+`sdl3d_game_data_log_network_snapshot_diagnostic()` by policy name; the game
+data chooses the replication channel, log level, cadence, session-state
+inclusion, and message template.
+
 ## Generic Runner
 
 `sdl3d_runner` launches a game data asset without game-specific C callbacks.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1760,6 +1760,36 @@ is passed to actions and can be referenced from supported string fields with
 delivered to the target scene's enter signal; `scene_state.set` writes scalar
 scene-state values directly.
 
+`network.diagnostics.snapshots` lets authored data control schema-driven
+network snapshot logging. Each entry has a unique `name`, a `replication`
+channel reference, optional `enabled`, `level`, `cadence_seconds`,
+`include_session_state`, and `message` fields:
+
+```json
+"diagnostics": {
+  "snapshots": [
+    {
+      "name": "multiplayer_state",
+      "replication": "play_state",
+      "enabled": true,
+      "level": "info",
+      "cadence_seconds": 0.25,
+      "include_session_state": true,
+      "message": "network {event} {description} {extra}"
+    }
+  ]
+}
+```
+
+Hosts and generic runners call
+`sdl3d_game_data_log_network_snapshot_diagnostic()` with a diagnostic `name`,
+packet tick, event label, and optional context string. The runtime enforces the
+authored cadence and log level, formats the selected replication channel with
+`sdl3d_game_data_describe_network_snapshot()`, and expands `{name}`, `{event}`,
+`{extra}`, `{tick}`, and `{description}` placeholders in the message template.
+Missing payload fields expand to an empty string; malformed placeholders are
+treated as literal text.
+
 `runtime_bindings` is optional. It maps host integration semantics to concrete
 authored replication channels and control messages without baking those schema
 names into game host code. `replication` maps semantic names to entries in
@@ -1851,6 +1881,8 @@ Callers that need diagnostic logging can use
 authored `session_flow` state values, and every replicated actor field in schema
 order. This keeps debug output tied to the authored replication channel instead
 of hard-coding game actor ids or property paths in host C.
+`sdl3d_game_data_log_network_snapshot_diagnostic()` wraps that formatter with
+authored enablement, cadence, level, and message policy.
 
 Generic session loops should prefer the runtime-binding snapshot helpers:
 `sdl3d_game_data_encode_network_runtime_snapshot()`,

--- a/docs/pong-c-audit.md
+++ b/docs/pong-c-audit.md
@@ -87,9 +87,10 @@ termination reasons, and return scenes.
 
 ### Diagnostic Logging
 
-Snapshot diagnostics are schema-driven, but the host still decides when to log
-Pong multiplayer state. A generic runtime can expose an authored diagnostics
-policy for network sessions and replication channels.
+Snapshot diagnostic content and logging policy are now schema-driven. Pong C
+only notifies the engine that a generic network snapshot event occurred; the
+authored `network.diagnostics.snapshots` entry controls the channel, cadence,
+log level, session-state inclusion, and message template.
 
 ## Remaining Pong-Specific C Literals
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1210,6 +1210,32 @@ extern "C"
                                                    int error_buffer_size);
 
     /**
+     * @brief Emit an authored network snapshot diagnostic when policy allows.
+     *
+     * The named policy is read from `network.diagnostics.snapshots[]`. The
+     * policy chooses the replicated channel to describe, enabled state, log
+     * level, cadence, session-state inclusion, and message template. Template
+     * placeholders can reference `{name}`, `{event}`, `{extra}`, `{tick}`, and
+     * `{description}`.
+     *
+     * If the policy is disabled or cadence suppresses the message, the function
+     * returns true with @p out_logged set to false.
+     *
+     * @param runtime Runtime whose current state should be logged.
+     * @param diagnostic_name Authored diagnostic policy name.
+     * @param tick Simulation or packet tick to include in the description.
+     * @param event Optional event label, such as `host_snapshot_sent`.
+     * @param extra Optional caller-provided context string.
+     * @param out_logged Optional flag set true only when a log line is emitted.
+     * @param error_buffer Optional buffer for the first failure reason.
+     * @param error_buffer_size Size of @p error_buffer in bytes.
+     * @return true when the policy was handled successfully.
+     */
+    bool sdl3d_game_data_log_network_snapshot_diagnostic(sdl3d_game_data_runtime *runtime, const char *diagnostic_name,
+                                                         Uint32 tick, const char *event, const char *extra,
+                                                         bool *out_logged, char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Encode an authored host-to-client replication snapshot.
      *
      * The named replication channel must exist in the loaded `network`

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -10,6 +10,7 @@
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
 
 #include "game_data_standard_options.h"
 #include "game_data_validation.h"
@@ -261,6 +262,13 @@ typedef struct runtime_discovery_session
     sdl3d_network_discovery_session *session;
 } runtime_discovery_session;
 
+typedef struct network_diagnostic_runtime_state
+{
+    char *name;
+    Uint64 last_log_ms;
+    bool logged;
+} network_diagnostic_runtime_state;
+
 typedef struct scene_activity_state
 {
     const char *scene;
@@ -341,6 +349,9 @@ typedef struct sdl3d_game_data_runtime
     runtime_discovery_session *discovery_sessions;
     int discovery_session_count;
     int discovery_session_capacity;
+    network_diagnostic_runtime_state *network_diagnostics;
+    int network_diagnostic_count;
+    int network_diagnostic_capacity;
     sdl3d_storage *storage;
     bool has_network_schema;
     Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
@@ -12034,9 +12045,9 @@ static bool game_data_append_snapshot_value(char *buffer, size_t buffer_size, si
     }
 }
 
-bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
-                                               Uint32 tick, char *buffer, size_t buffer_size, char *error_buffer,
-                                               int error_buffer_size)
+static bool game_data_describe_network_snapshot_ex(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                                   Uint32 tick, bool include_session_state, char *buffer,
+                                                   size_t buffer_size, char *error_buffer, int error_buffer_size)
 {
     if (buffer != NULL && buffer_size > 0U)
         buffer[0] = '\0';
@@ -12074,7 +12085,7 @@ bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *ru
     }
 
     yyjson_val *state_keys = obj_get(network_session_flow_json(runtime), "state_keys");
-    if (yyjson_is_obj(state_keys))
+    if (include_session_state && yyjson_is_obj(state_keys))
     {
         yyjson_val *state_key = NULL;
         yyjson_val *state_value_key = NULL;
@@ -12130,6 +12141,189 @@ bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *ru
         }
     }
 
+    return true;
+}
+
+bool sdl3d_game_data_describe_network_snapshot(const sdl3d_game_data_runtime *runtime, const char *replication_name,
+                                               Uint32 tick, char *buffer, size_t buffer_size, char *error_buffer,
+                                               int error_buffer_size)
+{
+    return game_data_describe_network_snapshot_ex(runtime, replication_name, tick, true, buffer, buffer_size,
+                                                  error_buffer, error_buffer_size);
+}
+
+static yyjson_val *network_diagnostics_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(obj_get(runtime_root(runtime), "network"), "diagnostics");
+}
+
+static yyjson_val *find_network_snapshot_diagnostic_json(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    yyjson_val *snapshots = obj_get(network_diagnostics_json(runtime), "snapshots");
+    if (name == NULL || name[0] == '\0' || !yyjson_is_arr(snapshots))
+        return NULL;
+
+    for (size_t i = 0U; i < yyjson_arr_size(snapshots); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(snapshots, i);
+        const char *entry_name = json_string(entry, "name", NULL);
+        if (entry_name != NULL && SDL_strcmp(entry_name, name) == 0)
+            return entry;
+    }
+    return NULL;
+}
+
+static SDL_LogPriority network_diagnostic_log_priority(const char *level)
+{
+    if (level == NULL || level[0] == '\0' || SDL_strcmp(level, "info") == 0)
+        return SDL_LOG_PRIORITY_INFO;
+    if (SDL_strcmp(level, "debug") == 0)
+        return SDL_LOG_PRIORITY_DEBUG;
+    if (SDL_strcmp(level, "warn") == 0 || SDL_strcmp(level, "warning") == 0)
+        return SDL_LOG_PRIORITY_WARN;
+    if (SDL_strcmp(level, "error") == 0)
+        return SDL_LOG_PRIORITY_ERROR;
+    if (SDL_strcmp(level, "critical") == 0)
+        return SDL_LOG_PRIORITY_CRITICAL;
+    return SDL_LOG_PRIORITY_INFO;
+}
+
+static network_diagnostic_runtime_state *find_network_diagnostic_state(sdl3d_game_data_runtime *runtime,
+                                                                       const char *name)
+{
+    if (runtime == NULL || name == NULL || name[0] == '\0')
+        return NULL;
+    for (int i = 0; i < runtime->network_diagnostic_count; ++i)
+    {
+        if (runtime->network_diagnostics[i].name != NULL && SDL_strcmp(runtime->network_diagnostics[i].name, name) == 0)
+        {
+            return &runtime->network_diagnostics[i];
+        }
+    }
+    return NULL;
+}
+
+static bool ensure_network_diagnostic_state_capacity(sdl3d_game_data_runtime *runtime, int required)
+{
+    if (runtime == NULL)
+        return false;
+    if (required <= runtime->network_diagnostic_capacity)
+        return true;
+
+    int next_capacity = runtime->network_diagnostic_capacity < 4 ? 4 : runtime->network_diagnostic_capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    network_diagnostic_runtime_state *states = (network_diagnostic_runtime_state *)SDL_realloc(
+        runtime->network_diagnostics, (size_t)next_capacity * sizeof(*states));
+    if (states == NULL)
+        return false;
+
+    SDL_memset(states + runtime->network_diagnostic_capacity, 0,
+               (size_t)(next_capacity - runtime->network_diagnostic_capacity) * sizeof(*states));
+    runtime->network_diagnostics = states;
+    runtime->network_diagnostic_capacity = next_capacity;
+    return true;
+}
+
+static network_diagnostic_runtime_state *ensure_network_diagnostic_state(sdl3d_game_data_runtime *runtime,
+                                                                         const char *name)
+{
+    network_diagnostic_runtime_state *state = find_network_diagnostic_state(runtime, name);
+    if (state != NULL)
+        return state;
+    if (runtime == NULL || name == NULL || name[0] == '\0' ||
+        !ensure_network_diagnostic_state_capacity(runtime, runtime->network_diagnostic_count + 1))
+    {
+        return NULL;
+    }
+
+    state = &runtime->network_diagnostics[runtime->network_diagnostic_count];
+    state->name = SDL_strdup(name);
+    if (state->name == NULL)
+        return NULL;
+    state->last_log_ms = 0U;
+    state->logged = false;
+    runtime->network_diagnostic_count++;
+    return state;
+}
+
+bool sdl3d_game_data_log_network_snapshot_diagnostic(sdl3d_game_data_runtime *runtime, const char *diagnostic_name,
+                                                     Uint32 tick, const char *event, const char *extra,
+                                                     bool *out_logged, char *error_buffer, int error_buffer_size)
+{
+    if (out_logged != NULL)
+        *out_logged = false;
+    if (runtime == NULL || diagnostic_name == NULL || diagnostic_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot diagnostic requires runtime and name");
+        return false;
+    }
+
+    yyjson_val *diagnostic = find_network_snapshot_diagnostic_json(runtime, diagnostic_name);
+    if (diagnostic == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot diagnostic not found");
+        return false;
+    }
+    if (!json_bool(diagnostic, "enabled", true))
+        return true;
+
+    network_diagnostic_runtime_state *state = ensure_network_diagnostic_state(runtime, diagnostic_name);
+    if (state == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot diagnostic state allocation failed");
+        return false;
+    }
+
+    const float cadence_seconds = SDL_max(json_float(diagnostic, "cadence_seconds", 0.0f), 0.0f);
+    const Uint64 now = SDL_GetTicks();
+    if (state->logged && cadence_seconds > 0.0f &&
+        (double)(now - state->last_log_ms) < (double)cadence_seconds * 1000.0)
+    {
+        return true;
+    }
+
+    const char *replication_name = json_string(diagnostic, "replication", NULL);
+    char description[4096] = {0};
+    if (!game_data_describe_network_snapshot_ex(runtime, replication_name, tick,
+                                                json_bool(diagnostic, "include_session_state", true), description,
+                                                sizeof(description), error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+
+    char tick_text[32];
+    SDL_snprintf(tick_text, sizeof(tick_text), "%u", (unsigned int)tick);
+
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot diagnostic payload allocation failed");
+        return false;
+    }
+    sdl3d_properties_set_string(payload, "name", diagnostic_name);
+    sdl3d_properties_set_string(payload, "event", event != NULL ? event : "");
+    sdl3d_properties_set_string(payload, "extra", extra != NULL ? extra : "");
+    sdl3d_properties_set_string(payload, "tick", tick_text);
+    sdl3d_properties_set_string(payload, "description", description);
+
+    char message[4096] = {0};
+    const char *message_template = json_string(diagnostic, "message", "{event} {description} {extra}");
+    const bool formatted = format_payload_string(payload, message_template, message, sizeof(message));
+    sdl3d_properties_destroy(payload);
+    if (!formatted)
+    {
+        set_error(error_buffer, error_buffer_size, "network snapshot diagnostic message is too long");
+        return false;
+    }
+
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION,
+                   network_diagnostic_log_priority(json_string(diagnostic, "level", NULL)), "%s", message);
+    state->last_log_ms = now;
+    state->logged = true;
+    if (out_logged != NULL)
+        *out_logged = true;
     return true;
 }
 
@@ -13111,6 +13305,8 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->discovery_sessions[i].name);
         sdl3d_network_discovery_session_destroy(runtime->discovery_sessions[i].session);
     }
+    for (int i = 0; i < runtime->network_diagnostic_count; ++i)
+        SDL_free(runtime->network_diagnostics[i].name);
 
     clear_menu_text_entry_capture(runtime);
     sdl3d_script_engine_destroy(runtime->scripts);
@@ -13136,6 +13332,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->direct_connect_sessions);
     SDL_free(runtime->host_sessions);
     SDL_free(runtime->discovery_sessions);
+    SDL_free(runtime->network_diagnostics);
     SDL_free(runtime->activity.periodic_elapsed);
     yyjson_doc_free(runtime->doc);
     SDL_free(runtime);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -897,6 +897,84 @@ static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_va
            validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names);
 }
 
+static bool is_network_diagnostic_level(const char *level)
+{
+    return level == NULL || SDL_strcmp(level, "debug") == 0 || SDL_strcmp(level, "info") == 0 ||
+           SDL_strcmp(level, "warn") == 0 || SDL_strcmp(level, "warning") == 0 || SDL_strcmp(level, "error") == 0 ||
+           SDL_strcmp(level, "critical") == 0;
+}
+
+static bool validate_network_diagnostics(validation_context *ctx, yyjson_val *network,
+                                         const name_table *replication_names)
+{
+    yyjson_val *diagnostics = obj_get(network, "diagnostics");
+    if (diagnostics == NULL)
+        return true;
+    if (!yyjson_is_obj(diagnostics))
+        return validation_error(ctx, "$.network.diagnostics", "network diagnostics must be an object");
+
+    yyjson_val *snapshots = obj_get(diagnostics, "snapshots");
+    if (snapshots == NULL)
+        return true;
+    if (!yyjson_is_arr(snapshots))
+        return validation_error(ctx, "$.network.diagnostics.snapshots",
+                                "network diagnostics snapshots must be an array");
+
+    name_table diagnostic_names = {0};
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(snapshots); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.network.diagnostics.snapshots[%zu]", i);
+        yyjson_val *entry = yyjson_arr_get(snapshots, i);
+        if (!yyjson_is_obj(entry))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic must be an object");
+            break;
+        }
+        if (!require_unique_name(ctx, &diagnostic_names, "network snapshot diagnostic", json_string(entry, "name"),
+                                 path) ||
+            !require_ref(ctx, replication_names, "network replication", json_string(entry, "replication"), path))
+        {
+            ok = false;
+            break;
+        }
+        yyjson_val *enabled = obj_get(entry, "enabled");
+        if (enabled != NULL && !yyjson_is_bool(enabled))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic enabled must be boolean");
+            break;
+        }
+        yyjson_val *include_session_state = obj_get(entry, "include_session_state");
+        if (include_session_state != NULL && !yyjson_is_bool(include_session_state))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic include_session_state must be boolean");
+            break;
+        }
+        yyjson_val *cadence = obj_get(entry, "cadence_seconds");
+        if (cadence != NULL && (!yyjson_is_num(cadence) || yyjson_get_real(cadence) < 0.0))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic cadence_seconds must be non-negative");
+            break;
+        }
+        const char *level = json_string(entry, "level");
+        if (!is_network_diagnostic_level(level))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic level is unsupported");
+            break;
+        }
+        yyjson_val *message = obj_get(entry, "message");
+        if (message != NULL && (!yyjson_is_str(message) || yyjson_get_len(message) == 0))
+        {
+            ok = validation_error(ctx, path, "network snapshot diagnostic message must be a non-empty string");
+            break;
+        }
+    }
+
+    name_table_destroy(&diagnostic_names);
+    return ok;
+}
+
 static bool validate_network(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *network = obj_get(root, "network");
@@ -1040,6 +1118,8 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
     }
     if (ok)
         ok = validate_network_runtime_bindings(ctx, network, &replication_names, &control_names, names);
+    if (ok)
+        ok = validate_network_diagnostics(ctx, network, &replication_names);
     name_table_destroy(&control_names);
     name_table_destroy(&replication_names);
     return ok;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15,6 +15,7 @@
 
 extern "C"
 {
+#include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
 #include "sdl3d/asset.h"
@@ -46,6 +47,42 @@ struct CapturedDiagnostic
 struct DiagnosticCapture
 {
     std::vector<CapturedDiagnostic> diagnostics;
+};
+
+struct CapturedLogMessage
+{
+    int category = -1;
+    SDL_LogPriority priority = SDL_LOG_PRIORITY_INVALID;
+    std::string message;
+};
+
+void SDLCALL capture_log_output(void *userdata, int category, SDL_LogPriority priority, const char *message)
+{
+    auto *capture = static_cast<CapturedLogMessage *>(userdata);
+    capture->category = category;
+    capture->priority = priority;
+    capture->message = message != nullptr ? message : "";
+}
+
+class SDLLogOutputGuard
+{
+  public:
+    SDLLogOutputGuard()
+    {
+        SDL_GetLogOutputFunction(&callback_, &userdata_);
+        priority_ = SDL_GetLogPriority(SDL_LOG_CATEGORY_APPLICATION);
+    }
+
+    ~SDLLogOutputGuard()
+    {
+        SDL_SetLogOutputFunction(callback_, userdata_);
+        SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, priority_);
+    }
+
+  private:
+    SDL_LogOutputFunction callback_ = nullptr;
+    void *userdata_ = nullptr;
+    SDL_LogPriority priority_ = SDL_LOG_PRIORITY_INFO;
 };
 
 struct NetworkSignalCapture
@@ -6300,6 +6337,23 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
         "state": { "actor": "entity.match", "property": "paused" }
       }
     })json");
+    std::string network_with_diagnostics = network_json;
+    const size_t diagnostics_insert = network_with_diagnostics.rfind("\n  }");
+    ASSERT_NE(diagnostics_insert, std::string::npos);
+    network_with_diagnostics.insert(diagnostics_insert, R"json(,
+    "diagnostics": {
+      "snapshots": [
+        {
+          "name": "multiplayer_state",
+          "replication": "play_state",
+          "enabled": true,
+          "level": "debug",
+          "cadence_seconds": 0.5,
+          "include_session_state": true,
+          "message": "{event} {description}"
+        }
+      ]
+    })json");
 
     write_text(dir / "network_a.game.json", network_schema_game_json(network_json, "Network Schema A").c_str());
     write_text(dir / "network_b.game.json", network_schema_game_json(network_json, "Different Metadata").c_str());
@@ -6307,6 +6361,8 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
                network_schema_game_json(network_with_session_flow, "Network Schema A").c_str());
     write_text(dir / "network_runtime_bindings.game.json",
                network_schema_game_json(network_with_runtime_bindings, "Network Schema A").c_str());
+    write_text(dir / "network_diagnostics.game.json",
+               network_schema_game_json(network_with_diagnostics, "Network Schema A").c_str());
     write_text(dir / "network_changed.game.json",
                network_schema_game_json(valid_network_schema_json("vec2"), "Network Schema A").c_str());
 
@@ -6319,11 +6375,13 @@ TEST(GameDataRuntime, ValidatesNetworkReplicationSchemaAndComputesStableHash)
     const auto hash_b = load_network_schema_hash(dir / "network_b.game.json");
     const auto hash_with_session_flow = load_network_schema_hash(dir / "network_session_flow.game.json");
     const auto hash_with_runtime_bindings = load_network_schema_hash(dir / "network_runtime_bindings.game.json");
+    const auto hash_with_diagnostics = load_network_schema_hash(dir / "network_diagnostics.game.json");
     const auto hash_changed = load_network_schema_hash(dir / "network_changed.game.json");
 
     EXPECT_EQ(hash_a, hash_b);
     EXPECT_EQ(hash_a, hash_with_session_flow);
     EXPECT_EQ(hash_a, hash_with_runtime_bindings);
+    EXPECT_EQ(hash_a, hash_with_diagnostics);
     EXPECT_NE(hash_a, hash_changed);
 
     remove_test_dir(dir);
@@ -6466,6 +6524,31 @@ TEST(GameDataRuntime, EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema)
     EXPECT_FALSE(sdl3d_game_data_describe_network_snapshot(host, "play_state", 12345U, tiny_description,
                                                            sizeof(tiny_description), error, sizeof(error)));
     EXPECT_NE(std::string(error).find("buffer is too small"), std::string::npos);
+
+    SDLLogOutputGuard log_guard;
+    CapturedLogMessage captured_log;
+    SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE);
+    SDL_SetLogOutputFunction(capture_log_output, &captured_log);
+
+    bool logged = false;
+    ASSERT_TRUE(sdl3d_game_data_log_network_snapshot_diagnostic(host, "multiplayer_state", 12346U, "test_event",
+                                                                "first", &logged, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(logged);
+    EXPECT_EQ(captured_log.category, SDL_LOG_CATEGORY_APPLICATION);
+    EXPECT_EQ(captured_log.priority, SDL_LOG_PRIORITY_INFO);
+    EXPECT_NE(captured_log.message.find("network test_event"), std::string::npos);
+    EXPECT_NE(captured_log.message.find("tick=12346"), std::string::npos);
+    EXPECT_NE(captured_log.message.find("entity.ball.properties.velocity=(3.250,-1.750)"), std::string::npos);
+    EXPECT_NE(captured_log.message.find("first"), std::string::npos);
+
+    captured_log = {};
+    logged = true;
+    ASSERT_TRUE(sdl3d_game_data_log_network_snapshot_diagnostic(host, "multiplayer_state", 12347U, "test_event",
+                                                                "second", &logged, error, sizeof(error)))
+        << error;
+    EXPECT_FALSE(logged);
+    EXPECT_TRUE(captured_log.message.empty());
 
     destroy_runtime_session(host_session, host);
     destroy_runtime_session(client_session, client);
@@ -7449,6 +7532,63 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "unknown network replication reference",
+        },
+        {
+            "bad_snapshot_diagnostic_replication",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "diagnostics": {
+      "snapshots": [
+        {
+          "name": "multiplayer_state",
+          "replication": "missing_channel"
+        }
+      ]
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "unknown network replication reference",
+        },
+        {
+            "bad_snapshot_diagnostic_level",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "diagnostics": {
+      "snapshots": [
+        {
+          "name": "multiplayer_state",
+          "replication": "play_state",
+          "level": "chatty"
+        }
+      ]
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "network snapshot diagnostic level is unsupported",
         },
         {
             "bad_runtime_control_binding",


### PR DESCRIPTION
## Summary
- add authored `network.diagnostics.snapshots` policies for schema-driven multiplayer state logging
- add `sdl3d_game_data_log_network_snapshot_diagnostic()` with enabled state, cadence, log level, session-state inclusion, and message templates
- move Pong multiplayer snapshot log formatting/selection into JSON and remove host-side schema/channel formatting decisions
- validate diagnostic policies and document the data-only diagnostics contract

## Verification
- `cmake --build build/debug --target sdl3d_game_data_test pong_demo -j8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema:GameDataRuntime.ValidatesNetworkReplicationSchemaAndComputesStableHash:GameDataRuntime.RejectsInvalidNetworkReplicationSchemas'`
- `cmake --build build/debug --target sdl3d_game_data_test sdl3d_pong_multiplayer_test pong_demo sdl3d_runner -j8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_pong_multiplayer_test`
- `git diff --check`

## Next Slice
The next issue-210 slice should be replacing the Pong compatibility host with the generic runner path, or reducing it to a tiny asset-mount wrapper, so Pong becomes a JSON/Lua/assets package launched by the engine runtime.