### PR TITLE
Add managed data-game network runtime

### DIFF
--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -185,6 +185,14 @@
           "match_terminated": "Match terminated: {reason} - Press Enter to return to title screen."
         }
       },
+      "managed_runtime": {
+        "enabled": true,
+        "termination_ack_delay_seconds": 3.0,
+        "keep_alive_scenes": {
+          "host": ["host_lobby", "play"],
+          "direct_connect": ["direct_connect", "discovery", "play"]
+        }
+      },
       "events": {
         "host_start_game": {
           "actions": [

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -124,6 +124,13 @@
         "result_5": "session_5",
         "result_6": "session_6",
         "result_7": "session_7"
+      },
+      "direct_connect": {
+        "host": "direct_connect_host",
+        "port": "direct_connect_port",
+        "status": "direct_connect_status",
+        "state": "direct_connect_state",
+        "connected": "direct_connect_connected"
       }
     },
     "session_flow": {

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -23,12 +23,16 @@ The runtime currently owns:
   through data actions
 - runtime-bound host/client packet loops for authored control messages,
   client input replication, authoritative snapshots, and pause-state sync
+- optional managed network orchestration for authored host lobby,
+  direct-connect, start-game, pause/resume, disconnect, timeout, termination
+  acknowledgement, client camera-toggle, status publication, and snapshot
+  diagnostics
 - ordered cleanup
 
 The generic `sdl3d_runner` executable owns the outer SDL process loop for games
-that only need the current data runtime surface. For now, Pong still keeps a
-compatibility host for network scene transitions and termination UI, but the
-packet receive/send/apply loop now lives in the managed runtime.
+that only need the current data runtime surface. It enables managed network
+orchestration so data-authored games can use the standard direct-connect/LAN
+flow without game-specific C callbacks.
 
 ## Startup Shape
 
@@ -48,6 +52,8 @@ The descriptor may also include:
 - `media_dir`: built-in font/media root
 - `mount_assets`: callback used to mount a directory, pack, or embedded pack
 - `mount_userdata`: user data passed to `mount_assets`
+- `enable_managed_network`: opt-in authored host/direct-connect orchestration
+  for games that provide the standard network semantics below
 
 ## Frame Use
 
@@ -55,13 +61,11 @@ During the managed loop:
 
 - call `sdl3d_data_game_runtime_update_frame` from tick and pause tick paths
 - call `sdl3d_data_game_runtime_render` from the render callback
-- call `sdl3d_data_game_runtime_refresh_input_profile_on_device_change` when a
-  scene or host policy wants device-count hotplug rebinding
-- for LAN/direct-connect play, call
-  `sdl3d_data_game_runtime_update_network_host_session`,
-  `sdl3d_data_game_runtime_update_network_client_session`, and
-  `sdl3d_data_game_runtime_publish_network_host_snapshot` with semantic
-  runtime binding names from `network.runtime_bindings`
+- input-profile hotplug refresh runs automatically inside
+  `sdl3d_data_game_runtime_update_frame`
+- when `enable_managed_network` is true, host/client session updates and
+  snapshot publication also run automatically inside
+  `sdl3d_data_game_runtime_update_frame`
 
 The outer loop still controls fixed timestep, SDL events, input snapshots,
 audio frame updates, and presentation.
@@ -84,6 +88,28 @@ resolve those keys through authored `network.runtime_bindings`, then:
 The helpers intentionally report events instead of hard-coding transitions.
 That keeps game-specific flow in JSON/Lua or a thin compatibility host until
 scene/session orchestration is fully authored.
+
+For data-only games launched by `sdl3d_runner`, prefer
+`enable_managed_network`. The managed path uses standard semantic names:
+
+- host session: `host`
+- direct-connect session: `direct_connect`
+- replication bindings: `state_snapshot`, `client_input`
+- control bindings: `start_game`, `pause_request`, `resume_request`,
+  `disconnect`
+- action bindings: `menu_select`, `camera_toggle`
+- signal bindings: `lobby_start`, `camera_toggle`
+- session-flow scenes: `play`, `host_lobby`, `direct_connect`, `discovery`
+- session-flow events: `host_start_game`, `client_start_game`,
+  `client_state_before_start`, `host_match_terminated`,
+  `client_match_terminated`, `host_client_disconnected`,
+  `client_connection_closed`, and `network_match_termination_ack`
+
+Games can map those semantics to their own concrete scene ids, signal names,
+action names, replication channels, and control-message names with
+`network.session_flow`, `network.runtime_bindings`, and `network.scene_state`.
+Local-only games can omit networking entirely or leave managed networking
+disabled.
 
 Network session-flow events close that gap for transition policy. Games can
 author `network.session_flow.events` entries and a host or runner can execute

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -104,12 +104,17 @@ For data-only games launched by `sdl3d_runner`, prefer
   `client_state_before_start`, `host_match_terminated`,
   `client_match_terminated`, `host_client_disconnected`,
   `client_connection_closed`, and `network_match_termination_ack`
+- managed policy: `network.session_flow.managed_runtime.enabled`,
+  `termination_ack_delay_seconds`, and `keep_alive_scenes`
 
 Games can map those semantics to their own concrete scene ids, signal names,
 action names, replication channels, and control-message names with
 `network.session_flow`, `network.runtime_bindings`, and `network.scene_state`.
-Local-only games can omit networking entirely or leave managed networking
-disabled.
+The runner enables the engine-side managed path, but the game data must also
+author `managed_runtime.enabled: true`; local-only games can omit networking
+entirely or leave managed networking disabled. Keep-alive scene policy is
+authored so a game can move through loading, rematch, or lobby-adjacent scenes
+without dropping an otherwise healthy network session.
 
 Network session-flow events close that gap for transition policy. Games can
 author `network.session_flow.events` entries and a host or runner can execute

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1706,7 +1706,10 @@ UI state keys, grouped by scope. Host integration code can resolve entries with
 used by lobby or connection scenes. All scopes and values must be objects of
 non-empty string keys to non-empty string scene-state property names. These keys
 are presentation/orchestration metadata and are intentionally not part of the
-network schema hash.
+network schema hash. The generic data-game runner recognizes the standard
+`host` scope keys `status`, `endpoint`, `peer`, and `connected`, plus the
+standard `direct_connect` scope keys `status`, `state`, and `connected`, when
+managed networking is enabled.
 
 `session_flow` is optional. It gives host integration code semantic names for
 network scene orchestration without baking a particular demo's scene ids or
@@ -1930,6 +1933,16 @@ Generic session loops should prefer the runtime-binding variants:
 loop can dispatch on semantic names like `start_game`, `pause_request`, and
 `disconnect` without knowing the concrete control-message names in the
 authored wire schema.
+
+When a game is launched through `sdl3d_runner`, the data-game runtime enables
+managed network orchestration. That managed loop expects the same standard
+semantic names used in the helper examples: host session `host`,
+direct-connect session `direct_connect`, replication bindings `state_snapshot`
+and `client_input`, controls `start_game`, `pause_request`, `resume_request`,
+and `disconnect`, actions `menu_select` and `camera_toggle`, and signals
+`lobby_start` and `camera_toggle`. The concrete ids remain data-authored
+through `network.session_flow`, `network.runtime_bindings`, and
+`network.scene_state`.
 
 When a runtime loads game data with a valid `network` block, it computes a
 deterministic schema hash over protocol, replication, input, and control-message

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1727,6 +1727,37 @@ when the caller documents and substitutes them. Callers resolve these values wit
 `sdl3d_game_data_get_network_session_message()`. Like `scene_state`, these
 orchestration maps are not part of the replication schema hash.
 
+`session_flow.managed_runtime` opts a game into the generic managed network
+orchestrator used by `sdl3d_runner`:
+
+```json
+"managed_runtime": {
+  "enabled": true,
+  "termination_ack_delay_seconds": 3.0,
+  "keep_alive_scenes": {
+    "host": ["host_lobby", "play"],
+    "direct_connect": ["direct_connect", "discovery", "play"]
+  }
+}
+```
+
+`termination_ack_delay_seconds` controls how long the managed termination
+message must stay visible before the select action can acknowledge it.
+`keep_alive_scenes` lists session-flow scene semantics where each managed
+session remains alive; this lets games author intermediate loading, rematch, or
+briefing scenes without the runtime tearing down a host/client session simply
+because the active scene is not the lobby or gameplay scene. Entries reference
+keys in `session_flow.scenes`, not raw scene ids.
+
+When `managed_runtime.enabled` is true, validation requires the standard
+managed network semantics used by the runner: host and direct-connect
+scene-state outputs, `state_snapshot` and `client_input` replication bindings,
+`start_game`, `pause_request`, `resume_request`, and `disconnect` control
+bindings, `menu_select` and `camera_toggle` action bindings, `lobby_start` and
+`camera_toggle` signal bindings, required session-flow scenes/state keys/state
+values, all managed session-flow events, `termination_ack_delay_seconds`, and
+`keep_alive_scenes`.
+
 `session_flow.events` maps semantic network events to data actions. Each event
 may be an action array or an object with optional `pause` and `actions` fields:
 

--- a/docs/pong-c-audit.md
+++ b/docs/pong-c-audit.md
@@ -60,7 +60,9 @@ implementing per-game callbacks.
 
 ### Managed Network Session Orchestration
 
-The largest remaining custom surface is multiplayer session orchestration:
+Pong's legacy host still contains multiplayer session orchestration, but the
+generic data-game runtime now has an opt-in managed network path that covers
+this responsibility for `sdl3d_runner`:
 
 - host session creation/destruction and lobby state publishing
 - direct-connect session lifetime and status publishing
@@ -72,9 +74,11 @@ The largest remaining custom surface is multiplayer session orchestration:
 - authoritative host snapshot publishing
 - client input publishing
 
-Most packet content is already data driven. What remains is the transport
-session flow. This should become an engine-managed network session runner driven
-by authored `network.session_flow` and `network.runtime_bindings`.
+Most packet content is already data driven. The managed runtime path is driven
+by authored `network.session_flow`, `network.runtime_bindings`, and
+`network.scene_state`, using standard semantics such as `host`,
+`direct_connect`, `state_snapshot`, `client_input`, `start_game`, and
+`disconnect`.
 
 ### Runtime State Publication
 
@@ -94,17 +98,15 @@ log level, session-state inclusion, and message template.
 
 ## Remaining Pong-Specific C Literals
 
-The remaining `PONG_*` constants are mostly semantic runtime binding names such
+The remaining `PONG_*` constants in the compatibility host are mostly semantic runtime binding names such
 as `state_snapshot`, `client_input`, `start_game`, `pause_request`, and
 `direct_connect`. They are not hard-coded actor/property packet schemas, but
 they still prove that the current binary is a Pong host rather than a generic
 runner.
 
-A runner should either:
-
-- use standard semantic binding names defined by the engine, or
-- read a small authored runtime profile that declares which session, action,
-  signal, replication, and control roles the standard network loop should use.
+The generic runner now uses standard semantic binding names defined by the
+engine. The remaining task is replacing the demo binary path with the runner
+path and deleting the compatibility host when parity has been verified.
 
 ## No Longer Blocking JSON/Lua Authorship
 
@@ -121,17 +123,9 @@ systems:
 
 ## Next Practical Step
 
-Deprecate the custom Pong host by adding a generic SDL3D runner/runtime.
-
-Recommended first runtime slice:
-
-1. Add a small runner executable that launches a game data asset or pack through
-   that API.
-2. Convert `demos/pong/main.c` into either a thin compatibility wrapper around
-   the runner API or remove it from the normal path once the runner can launch
-   Pong.
-3. Keep multiplayer orchestration in Pong C only until the next slice moves it
-   into a managed network-session runtime.
+Verify full Pong parity through `sdl3d_runner`, then convert `demos/pong` to
+launch through the generic runner or keep only a tiny build-time wrapper for
+asset defaults.
 
 ## Definition Of Done For Pong Without `main.c`
 

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -56,6 +56,17 @@ extern "C"
         sdl3d_data_game_mount_assets_fn mount_assets;
         /** @brief Userdata passed to @ref mount_assets. */
         void *mount_userdata;
+        /**
+         * @brief Enable authored host/direct-connect network orchestration.
+         *
+         * When true, the runtime consumes the standard authored network
+         * semantics from `network.session_flow`, `network.runtime_bindings`,
+         * and `network.scene_state` to keep host/direct-connect sessions
+         * updated, send/receive runtime-bound replication packets, handle
+         * start/pause/disconnect controls, publish status, and run authored
+         * session-flow events. Local-only games can leave this false.
+         */
+        bool enable_managed_network;
     } sdl3d_data_game_runtime_desc;
 
     /**

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -996,6 +996,48 @@ extern "C"
                                                      const char *name, const char **out_message);
 
     /**
+     * @brief Return whether authored managed network orchestration is enabled.
+     *
+     * Managed networking is enabled by `network.session_flow.managed_runtime.enabled`.
+     * Hosts may still choose not to run it; this helper only reports the
+     * authored game-data policy.
+     *
+     * @param runtime Loaded game data runtime.
+     * @return true when the game authors managed runtime networking as enabled.
+     */
+    bool sdl3d_game_data_network_managed_runtime_enabled(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Resolve the authored delay before acknowledging a terminated network match.
+     *
+     * The value is authored at
+     * `network.session_flow.managed_runtime.termination_ack_delay_seconds`.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param out_seconds Receives the non-negative delay in seconds.
+     * @return true when the delay is authored and @p out_seconds was filled.
+     */
+    bool sdl3d_game_data_get_network_managed_termination_ack_delay(const sdl3d_game_data_runtime *runtime,
+                                                                   float *out_seconds);
+
+    /**
+     * @brief Test whether a scene keeps a managed network session alive.
+     *
+     * Scene semantics are authored under
+     * `network.session_flow.managed_runtime.keep_alive_scenes.<session>`.
+     * Each entry references a semantic from `network.session_flow.scenes`; this
+     * helper resolves those semantics and compares them with @p scene_name.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param session_name Managed session semantic, such as `host` or
+     * `direct_connect`.
+     * @param scene_name Concrete active scene id to test.
+     * @return true when the session should stay alive in the scene.
+     */
+    bool sdl3d_game_data_network_managed_keep_alive_scene_matches(const sdl3d_game_data_runtime *runtime,
+                                                                  const char *session_name, const char *scene_name);
+
+    /**
      * @brief Execute an authored network session-flow event.
      *
      * Events are authored under `network.session_flow.events.<name>`. An event

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -23,7 +23,26 @@ struct sdl3d_data_game_runtime
     int *haptics_signal_ids;
     int *haptics_connections;
     int haptics_connection_count;
+    bool managed_network_enabled;
+    int managed_network_lobby_start_signal_id;
+    int managed_network_lobby_start_connection;
+    int managed_network_camera_toggle_signal_id;
+    bool managed_network_lobby_start_requested;
+    float managed_network_termination_timer;
 };
+
+static const char SDL3D_MANAGED_NETWORK_HOST_SESSION[] = "host";
+static const char SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION[] = "direct_connect";
+static const char SDL3D_MANAGED_NETWORK_BINDING_STATE_SNAPSHOT[] = "state_snapshot";
+static const char SDL3D_MANAGED_NETWORK_BINDING_CLIENT_INPUT[] = "client_input";
+static const char SDL3D_MANAGED_NETWORK_BINDING_START_GAME[] = "start_game";
+static const char SDL3D_MANAGED_NETWORK_BINDING_PAUSE_REQUEST[] = "pause_request";
+static const char SDL3D_MANAGED_NETWORK_BINDING_RESUME_REQUEST[] = "resume_request";
+static const char SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT[] = "disconnect";
+static const char SDL3D_MANAGED_NETWORK_BINDING_MENU_SELECT[] = "menu_select";
+static const char SDL3D_MANAGED_NETWORK_BINDING_CAMERA_TOGGLE[] = "camera_toggle";
+static const char SDL3D_MANAGED_NETWORK_BINDING_LOBBY_START[] = "lobby_start";
+static const char SDL3D_MANAGED_NETWORK_DIAGNOSTIC_SNAPSHOT[] = "multiplayer_state";
 
 static void set_error(char *error_buffer, int error_buffer_size, const char *message)
 {
@@ -243,6 +262,590 @@ static void disconnect_haptics_policies(sdl3d_data_game_runtime *runtime)
     runtime->haptics_connection_count = 0;
 }
 
+static sdl3d_data_game_network_bindings managed_network_bindings(void)
+{
+    sdl3d_data_game_network_bindings bindings;
+    SDL_zero(bindings);
+    bindings.state_snapshot = SDL3D_MANAGED_NETWORK_BINDING_STATE_SNAPSHOT;
+    bindings.client_input = SDL3D_MANAGED_NETWORK_BINDING_CLIENT_INPUT;
+    bindings.start_game = SDL3D_MANAGED_NETWORK_BINDING_START_GAME;
+    bindings.pause_request = SDL3D_MANAGED_NETWORK_BINDING_PAUSE_REQUEST;
+    bindings.resume_request = SDL3D_MANAGED_NETWORK_BINDING_RESUME_REQUEST;
+    bindings.disconnect = SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT;
+    return bindings;
+}
+
+static const char *managed_network_session_scene(const sdl3d_data_game_runtime *runtime, const char *name,
+                                                 const char *fallback)
+{
+    const char *scene = NULL;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_session_scene(runtime->data, name, &scene))
+    {
+        return scene;
+    }
+    return fallback;
+}
+
+static const char *managed_network_session_state_key(const sdl3d_data_game_runtime *runtime, const char *name,
+                                                     const char *fallback)
+{
+    const char *key = NULL;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_session_state_key(runtime->data, name, &key))
+    {
+        return key;
+    }
+    return fallback;
+}
+
+static const char *managed_network_session_state_value(const sdl3d_data_game_runtime *runtime, const char *group,
+                                                       const char *name, const char *fallback)
+{
+    const char *value = NULL;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_session_state_value(runtime->data, group, name, &value))
+    {
+        return value;
+    }
+    return fallback;
+}
+
+static const char *managed_network_message(const sdl3d_data_game_runtime *runtime, const char *group, const char *name,
+                                           const char *fallback)
+{
+    const char *message = NULL;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_session_message(runtime->data, group, name, &message))
+    {
+        return message;
+    }
+    return fallback;
+}
+
+static const char *managed_network_scene_state_key(const sdl3d_data_game_runtime *runtime, const char *scope,
+                                                   const char *name, const char *fallback)
+{
+    const char *key = NULL;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_scene_state_key(runtime->data, scope, name, &key))
+    {
+        return key;
+    }
+    return fallback;
+}
+
+static const char *managed_network_scene_state_string(const sdl3d_data_game_runtime *runtime, const char *key_name,
+                                                      const char *fallback)
+{
+    const sdl3d_properties *scene_state =
+        runtime != NULL && runtime->data != NULL ? sdl3d_game_data_scene_state(runtime->data) : NULL;
+    const char *key = managed_network_session_state_key(runtime, key_name, key_name);
+    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
+}
+
+static bool managed_network_active_scene_is(const sdl3d_data_game_runtime *runtime, const char *scene_name,
+                                            const char *fallback)
+{
+    const char *active_scene =
+        runtime != NULL && runtime->data != NULL ? sdl3d_game_data_active_scene(runtime->data) : NULL;
+    const char *expected_scene = managed_network_session_scene(runtime, scene_name, fallback);
+    return active_scene != NULL && expected_scene != NULL && SDL_strcmp(active_scene, expected_scene) == 0;
+}
+
+static bool managed_network_is_lobby_scene(const sdl3d_data_game_runtime *runtime)
+{
+    return managed_network_active_scene_is(runtime, "host_lobby", "scene.multiplayer.lobby");
+}
+
+static bool managed_network_is_direct_connect_scene(const sdl3d_data_game_runtime *runtime)
+{
+    return managed_network_active_scene_is(runtime, "direct_connect", "scene.multiplayer.direct_connect");
+}
+
+static bool managed_network_is_discovery_scene(const sdl3d_data_game_runtime *runtime)
+{
+    return managed_network_active_scene_is(runtime, "discovery", "scene.multiplayer.discovery");
+}
+
+static bool managed_network_is_play_scene(const sdl3d_data_game_runtime *runtime)
+{
+    return managed_network_active_scene_is(runtime, "play", "scene.play");
+}
+
+static bool managed_network_is_network_match(const sdl3d_data_game_runtime *runtime)
+{
+    const char *match_mode = managed_network_scene_state_string(runtime, "match_mode", NULL);
+    return match_mode != NULL &&
+           SDL_strcmp(match_mode, managed_network_session_state_value(runtime, "match_mode", "network", "lan")) == 0;
+}
+
+static bool managed_network_is_role_host(const sdl3d_data_game_runtime *runtime)
+{
+    const char *network_role = managed_network_scene_state_string(runtime, "network_role", "none");
+    return managed_network_is_network_match(runtime) &&
+           SDL_strcmp(network_role, managed_network_session_state_value(runtime, "network_role", "host", "host")) == 0;
+}
+
+static bool managed_network_is_role_client(const sdl3d_data_game_runtime *runtime)
+{
+    const char *network_role = managed_network_scene_state_string(runtime, "network_role", "none");
+    return managed_network_is_network_match(runtime) &&
+           SDL_strcmp(network_role, managed_network_session_state_value(runtime, "network_role", "client", "client")) ==
+               0;
+}
+
+static int managed_network_action_id(const sdl3d_data_game_runtime *runtime, const char *binding_name)
+{
+    int action_id = -1;
+    if (runtime != NULL && runtime->data != NULL &&
+        sdl3d_game_data_get_network_runtime_action(runtime->data, binding_name, &action_id))
+    {
+        return action_id;
+    }
+    return -1;
+}
+
+static bool managed_network_run_flow_event(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx,
+                                           const char *event_name, const char *reason)
+{
+    char error[192] = {0};
+    sdl3d_properties *payload = NULL;
+    bool ok = false;
+
+    if (runtime == NULL || runtime->data == NULL || event_name == NULL || event_name[0] == '\0')
+        return false;
+
+    payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return false;
+    sdl3d_properties_set_string(payload, "event", event_name);
+    sdl3d_properties_set_string(payload, "reason", reason != NULL ? reason : "");
+
+    ok = sdl3d_game_data_run_network_session_flow_event(runtime->data, ctx, event_name, payload, error,
+                                                        (int)sizeof(error));
+    sdl3d_properties_destroy(payload);
+    if (!ok)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed network event '%s' failed: %s", event_name,
+                    error[0] != '\0' ? error : "unknown error");
+    }
+    return ok;
+}
+
+static bool managed_network_send_control(sdl3d_data_game_runtime *runtime, sdl3d_network_session *session,
+                                         const char *binding_name, const char *label)
+{
+    char error[160] = {0};
+    const Uint32 tick = data_game_input_tick(runtime);
+    if (!data_game_send_runtime_control(runtime, session, binding_name, tick, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed network control send failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+        return false;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed network sent control: %s binding=%s",
+                label != NULL ? label : "control", binding_name != NULL ? binding_name : "<null>");
+    return true;
+}
+
+static bool managed_network_send_control_repeated(sdl3d_data_game_runtime *runtime, sdl3d_network_session *session,
+                                                  const char *binding_name, const char *label, int count)
+{
+    bool sent_any = false;
+    const int attempts = SDL_max(count, 1);
+    for (int i = 0; i < attempts; ++i)
+    {
+        if (managed_network_send_control(runtime, session, binding_name, label))
+            sent_any = true;
+        if (session != NULL)
+            (void)sdl3d_network_session_update(session, 0.0f);
+    }
+    return sent_any;
+}
+
+static void managed_network_publish_host_status(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+
+    (void)sdl3d_game_data_network_host_publish_status(
+        runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION,
+        managed_network_scene_state_key(runtime, "host", "status", "multiplayer_host_status"),
+        managed_network_scene_state_key(runtime, "host", "endpoint", "multiplayer_host_endpoint"),
+        managed_network_scene_state_key(runtime, "host", "peer", "multiplayer_host_client"),
+        managed_network_scene_state_key(runtime, "host", "connected", "multiplayer_host_connected"));
+}
+
+static void managed_network_cancel_host(sdl3d_data_game_runtime *runtime, bool notify_peer, const char *status)
+{
+    sdl3d_network_session *session =
+        runtime != NULL && runtime->data != NULL
+            ? sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION)
+            : NULL;
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+    if (session != NULL && notify_peer)
+    {
+        (void)managed_network_send_control_repeated(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT,
+                                                    "host disconnect", 5);
+    }
+    (void)sdl3d_game_data_network_host_cancel(
+        runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION,
+        managed_network_scene_state_key(runtime, "host", "status", "multiplayer_host_status"),
+        managed_network_scene_state_key(runtime, "host", "endpoint", "multiplayer_host_endpoint"),
+        managed_network_scene_state_key(runtime, "host", "peer", "multiplayer_host_client"),
+        managed_network_scene_state_key(runtime, "host", "connected", "multiplayer_host_connected"),
+        status != NULL ? status : "Not hosting");
+}
+
+static void managed_network_publish_direct_connect_status(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+
+    (void)sdl3d_game_data_network_direct_connect_publish_status(
+        runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION,
+        managed_network_scene_state_key(runtime, "direct_connect", "status", "direct_connect_status"),
+        managed_network_scene_state_key(runtime, "direct_connect", "state", "direct_connect_state"),
+        managed_network_scene_state_key(runtime, "direct_connect", "connected", "direct_connect_connected"));
+}
+
+static void managed_network_cancel_direct_connect(sdl3d_data_game_runtime *runtime, bool notify_peer,
+                                                  const char *status)
+{
+    sdl3d_network_session *session = runtime != NULL && runtime->data != NULL
+                                         ? sdl3d_game_data_get_network_direct_connect_session(
+                                               runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION)
+                                         : NULL;
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+    if (session != NULL && notify_peer)
+    {
+        (void)managed_network_send_control_repeated(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT,
+                                                    "client disconnect", 5);
+    }
+    (void)sdl3d_game_data_network_direct_connect_cancel(
+        runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION,
+        managed_network_scene_state_key(runtime, "direct_connect", "status", "direct_connect_status"),
+        managed_network_scene_state_key(runtime, "direct_connect", "state", "direct_connect_state"),
+        managed_network_scene_state_key(runtime, "direct_connect", "connected", "direct_connect_connected"),
+        status != NULL ? status : "Disconnected");
+}
+
+static void managed_network_disconnect_flow(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, bool local_host,
+                                            const char *reason)
+{
+    const char *event_name = NULL;
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+
+    if (managed_network_is_play_scene(runtime))
+    {
+        runtime->managed_network_termination_timer = 0.0f;
+        event_name = local_host ? "host_match_terminated" : "client_match_terminated";
+    }
+    else
+    {
+        event_name = local_host ? "host_client_disconnected" : "client_connection_closed";
+    }
+
+    (void)managed_network_run_flow_event(
+        runtime, ctx, event_name,
+        reason != NULL && reason[0] != '\0'
+            ? reason
+            : managed_network_message(runtime, "disconnect_reasons", "peer_disconnected", "Peer disconnected"));
+}
+
+static void managed_network_lobby_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    sdl3d_data_game_runtime *runtime = (sdl3d_data_game_runtime *)userdata;
+    (void)payload;
+    if (runtime == NULL || signal_id != runtime->managed_network_lobby_start_signal_id)
+        return;
+    runtime->managed_network_lobby_start_requested = true;
+}
+
+static bool connect_managed_network(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL || runtime->data == NULL || runtime->session == NULL || !runtime->managed_network_enabled)
+        return true;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(runtime->session);
+    if (bus == NULL)
+        return true;
+
+    runtime->managed_network_lobby_start_signal_id = -1;
+    runtime->managed_network_camera_toggle_signal_id = -1;
+    (void)sdl3d_game_data_get_network_runtime_signal(runtime->data, SDL3D_MANAGED_NETWORK_BINDING_LOBBY_START,
+                                                     &runtime->managed_network_lobby_start_signal_id);
+    (void)sdl3d_game_data_get_network_runtime_signal(runtime->data, SDL3D_MANAGED_NETWORK_BINDING_CAMERA_TOGGLE,
+                                                     &runtime->managed_network_camera_toggle_signal_id);
+
+    if (runtime->managed_network_lobby_start_signal_id >= 0)
+    {
+        runtime->managed_network_lobby_start_connection = sdl3d_signal_connect(
+            bus, runtime->managed_network_lobby_start_signal_id, managed_network_lobby_signal, runtime);
+        if (runtime->managed_network_lobby_start_connection == 0)
+            return false;
+    }
+    return true;
+}
+
+static void disconnect_managed_network(sdl3d_data_game_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+
+    if (runtime->managed_network_enabled && runtime->data != NULL)
+    {
+        managed_network_cancel_host(runtime, true, "Not hosting");
+        managed_network_cancel_direct_connect(runtime, true, "Disconnected");
+    }
+
+    if (runtime->session != NULL && runtime->managed_network_lobby_start_connection > 0)
+    {
+        sdl3d_signal_disconnect(sdl3d_game_session_get_signal_bus(runtime->session),
+                                runtime->managed_network_lobby_start_connection);
+    }
+    runtime->managed_network_lobby_start_connection = 0;
+    runtime->managed_network_lobby_start_signal_id = -1;
+    runtime->managed_network_camera_toggle_signal_id = -1;
+    runtime->managed_network_lobby_start_requested = false;
+}
+
+static void managed_network_update_termination_ack(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
+{
+    const sdl3d_properties *scene_state =
+        runtime != NULL && runtime->data != NULL ? sdl3d_game_data_scene_state(runtime->data) : NULL;
+    const char *active_key =
+        managed_network_session_state_key(runtime, "match_termination_active", "network_match_termination_active");
+    const bool active = scene_state != NULL ? sdl3d_properties_get_bool(scene_state, active_key, false) : false;
+
+    if (runtime == NULL || !active)
+    {
+        if (runtime != NULL)
+            runtime->managed_network_termination_timer = 0.0f;
+        return;
+    }
+
+    if (ctx != NULL)
+        ctx->paused = true;
+
+    runtime->managed_network_termination_timer += SDL_max(dt, 0.0f);
+    if (runtime->managed_network_termination_timer < 0.25f)
+        return;
+
+    sdl3d_input_manager *input = runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+    const int select_action = managed_network_action_id(runtime, SDL3D_MANAGED_NETWORK_BINDING_MENU_SELECT);
+    if (input == NULL || select_action < 0 || !sdl3d_input_is_pressed(input, select_action))
+        return;
+
+    runtime->managed_network_termination_timer = 0.0f;
+    (void)managed_network_run_flow_event(runtime, ctx, "network_match_termination_ack", NULL);
+}
+
+static void managed_network_process_lobby_start(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || runtime->data == NULL || !runtime->managed_network_lobby_start_requested)
+        return;
+
+    runtime->managed_network_lobby_start_requested = false;
+    sdl3d_network_session *session =
+        sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION);
+    if (session == NULL || !sdl3d_network_session_is_connected(session))
+    {
+        managed_network_publish_host_status(runtime);
+        return;
+    }
+
+    if (managed_network_send_control(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_START_GAME, "start game"))
+    {
+        (void)managed_network_run_flow_event(runtime, ctx, "host_start_game", NULL);
+    }
+}
+
+static void managed_network_update_host(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
+{
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+
+    sdl3d_network_session *session =
+        sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION);
+    if (session == NULL)
+        return;
+
+    const sdl3d_data_game_network_bindings bindings = managed_network_bindings();
+    sdl3d_data_game_network_loop_result result;
+    char error[192] = {0};
+    if (!sdl3d_data_game_runtime_update_network_host_session(runtime, ctx, SDL3D_MANAGED_NETWORK_HOST_SESSION,
+                                                             &bindings, managed_network_is_play_scene(runtime), dt,
+                                                             &result, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed host session update failed: %s",
+                    error[0] != '\0' ? error : SDL_GetError());
+    }
+
+    if (result.received_disconnect)
+    {
+        managed_network_disconnect_flow(
+            runtime, ctx, true,
+            managed_network_message(runtime, "disconnect_reasons", "client_exited", "Client exited"));
+    }
+    else if (managed_network_is_play_scene(runtime) && result.session_state != SDL3D_NETWORK_STATE_CONNECTED)
+    {
+        managed_network_disconnect_flow(
+            runtime, ctx, true,
+            managed_network_message(runtime, "disconnect_reasons", "client_timed_out", "Client timed out"));
+    }
+
+    managed_network_publish_host_status(runtime);
+
+    session = sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION);
+    if (session == NULL)
+        return;
+
+    const bool keep_host_session = managed_network_is_lobby_scene(runtime) ||
+                                   (managed_network_is_play_scene(runtime) && managed_network_is_role_host(runtime));
+    if (!keep_host_session)
+        managed_network_cancel_host(runtime, true, "Not hosting");
+}
+
+static void managed_network_update_direct_connect(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
+{
+    if (runtime == NULL || runtime->data == NULL)
+        return;
+
+    sdl3d_network_session *session =
+        sdl3d_game_data_get_network_direct_connect_session(runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION);
+    if (session == NULL)
+        return;
+
+    const bool was_playing = managed_network_is_play_scene(runtime);
+    const bool playing = was_playing && managed_network_is_role_client(runtime);
+    const bool keep_direct_connect_session =
+        managed_network_is_direct_connect_scene(runtime) || managed_network_is_discovery_scene(runtime) || playing;
+    if (!keep_direct_connect_session)
+    {
+        managed_network_cancel_direct_connect(runtime, true, "Disconnected");
+        return;
+    }
+
+    managed_network_publish_direct_connect_status(runtime);
+
+    const sdl3d_data_game_network_bindings bindings = managed_network_bindings();
+    sdl3d_data_game_network_loop_result result;
+    char error[192] = {0};
+    if (!sdl3d_data_game_runtime_update_network_client_session(runtime, ctx,
+                                                               SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION, &bindings,
+                                                               playing, true, dt, &result, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed direct-connect update failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+    }
+
+    if (result.received_start_game)
+    {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed client received start-game control");
+        (void)managed_network_run_flow_event(runtime, ctx, "client_start_game", NULL);
+    }
+    if (result.received_disconnect)
+    {
+        managed_network_disconnect_flow(
+            runtime, ctx, false, managed_network_message(runtime, "disconnect_reasons", "host_exited", "Host exited"));
+        return;
+    }
+    if (result.applied_snapshot)
+    {
+        if (!was_playing)
+            (void)managed_network_run_flow_event(runtime, ctx, "client_state_before_start", NULL);
+        (void)sdl3d_game_data_log_network_snapshot_diagnostic(runtime->data, SDL3D_MANAGED_NETWORK_DIAGNOSTIC_SNAPSHOT,
+                                                              result.last_tick, "client_snapshot_applied", "applied",
+                                                              NULL, error, (int)sizeof(error));
+    }
+
+    session =
+        sdl3d_game_data_get_network_direct_connect_session(runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION);
+    if (session == NULL)
+        return;
+
+    const sdl3d_network_state state = result.session_state;
+    if (state == SDL3D_NETWORK_STATE_REJECTED || state == SDL3D_NETWORK_STATE_TIMED_OUT ||
+        state == SDL3D_NETWORK_STATE_ERROR)
+    {
+        const char *reason =
+            state == SDL3D_NETWORK_STATE_TIMED_OUT
+                ? managed_network_message(runtime, "disconnect_reasons", "host_timed_out", "Host timed out")
+            : state == SDL3D_NETWORK_STATE_REJECTED
+                ? managed_network_message(runtime, "disconnect_reasons", "host_rejected", "Host rejected connection")
+                : managed_network_message(runtime, "disconnect_reasons", "host_error", "Host connection error");
+        if (was_playing)
+            managed_network_disconnect_flow(runtime, ctx, false, reason);
+        else
+            (void)managed_network_run_flow_event(runtime, ctx, "client_connection_closed", reason);
+    }
+}
+
+static void managed_network_update_client_sensors(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || runtime->data == NULL || ctx == NULL || !managed_network_is_play_scene(runtime) ||
+        !managed_network_is_role_client(runtime) || runtime->managed_network_camera_toggle_signal_id < 0)
+    {
+        return;
+    }
+
+    sdl3d_input_manager *input = runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
+    const int camera_toggle_action = managed_network_action_id(runtime, SDL3D_MANAGED_NETWORK_BINDING_CAMERA_TOGGLE);
+    if (input != NULL && camera_toggle_action >= 0 && sdl3d_input_is_pressed(input, camera_toggle_action))
+    {
+        sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(ctx->session),
+                          runtime->managed_network_camera_toggle_signal_id, NULL);
+    }
+}
+
+static void managed_network_update_before_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx, float dt)
+{
+    if (runtime == NULL || !runtime->managed_network_enabled)
+        return;
+
+    managed_network_process_lobby_start(runtime, ctx);
+    managed_network_update_termination_ack(runtime, ctx, dt);
+    managed_network_update_host(runtime, ctx, dt);
+    managed_network_update_direct_connect(runtime, ctx, dt);
+    managed_network_update_client_sensors(runtime, ctx);
+}
+
+static void managed_network_update_after_frame(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || runtime->data == NULL || !runtime->managed_network_enabled)
+        return;
+
+    managed_network_process_lobby_start(runtime, ctx);
+
+    sdl3d_network_session *session =
+        sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION);
+    if (session == NULL || !sdl3d_network_session_is_connected(session) || !managed_network_is_play_scene(runtime) ||
+        !managed_network_is_role_host(runtime))
+    {
+        return;
+    }
+
+    const sdl3d_data_game_network_bindings bindings = managed_network_bindings();
+    sdl3d_data_game_network_loop_result result;
+    char error[192] = {0};
+    if (!sdl3d_data_game_runtime_publish_network_host_snapshot(runtime, ctx, SDL3D_MANAGED_NETWORK_HOST_SESSION,
+                                                               &bindings, &result, error, (int)sizeof(error)))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D managed host snapshot publish failed: %s",
+                    error[0] != '\0' ? error : "unknown error");
+        return;
+    }
+    (void)sdl3d_game_data_log_network_snapshot_diagnostic(runtime->data, SDL3D_MANAGED_NETWORK_DIAGNOSTIC_SNAPSHOT,
+                                                          result.last_tick, "host_snapshot_sent", "sent", NULL, error,
+                                                          (int)sizeof(error));
+}
+
 void sdl3d_data_game_runtime_desc_init(sdl3d_data_game_runtime_desc *desc)
 {
     if (desc == NULL)
@@ -279,6 +882,9 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
         return false;
     }
     runtime->session = desc->session;
+    runtime->managed_network_enabled = desc->enable_managed_network;
+    runtime->managed_network_lobby_start_signal_id = -1;
+    runtime->managed_network_camera_toggle_signal_id = -1;
     sdl3d_game_data_font_cache_init(&runtime->font_cache, desc->media_dir);
     sdl3d_game_data_particle_cache_init(&runtime->particle_cache);
     sdl3d_game_data_app_flow_init(&runtime->app_flow);
@@ -322,6 +928,12 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
         sdl3d_data_game_runtime_destroy(runtime);
         return false;
     }
+    if (!connect_managed_network(runtime))
+    {
+        set_error(error_buffer, error_buffer_size, SDL_GetError());
+        sdl3d_data_game_runtime_destroy(runtime);
+        return false;
+    }
 
     *out_runtime = runtime;
     return true;
@@ -334,6 +946,7 @@ void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime)
         return;
     }
 
+    disconnect_managed_network(runtime);
     disconnect_haptics_policies(runtime);
     sdl3d_game_data_particle_cache_free(&runtime->particle_cache);
     sdl3d_game_data_image_cache_free(&runtime->image_cache);
@@ -682,12 +1295,18 @@ bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3
     if (!refresh_active_input_profile_if_available(runtime))
         return false;
 
+    managed_network_update_before_frame(runtime, ctx, dt);
+
     const sdl3d_game_data_update_frame_desc frame = {.ctx = ctx,
                                                      .runtime = runtime->data,
                                                      .app_flow = &runtime->app_flow,
                                                      .particle_cache = &runtime->particle_cache,
                                                      .dt = dt};
-    return sdl3d_game_data_update_frame(&runtime->frame_state, &frame);
+    if (!sdl3d_game_data_update_frame(&runtime->frame_state, &frame))
+        return false;
+
+    managed_network_update_after_frame(runtime, ctx);
+    return true;
 }
 
 void sdl3d_data_game_runtime_render(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -353,24 +353,17 @@ static bool managed_network_active_scene_is(const sdl3d_data_game_runtime *runti
     return active_scene != NULL && expected_scene != NULL && SDL_strcmp(active_scene, expected_scene) == 0;
 }
 
-static bool managed_network_is_lobby_scene(const sdl3d_data_game_runtime *runtime)
-{
-    return managed_network_active_scene_is(runtime, "host_lobby", "scene.multiplayer.lobby");
-}
-
-static bool managed_network_is_direct_connect_scene(const sdl3d_data_game_runtime *runtime)
-{
-    return managed_network_active_scene_is(runtime, "direct_connect", "scene.multiplayer.direct_connect");
-}
-
-static bool managed_network_is_discovery_scene(const sdl3d_data_game_runtime *runtime)
-{
-    return managed_network_active_scene_is(runtime, "discovery", "scene.multiplayer.discovery");
-}
-
 static bool managed_network_is_play_scene(const sdl3d_data_game_runtime *runtime)
 {
     return managed_network_active_scene_is(runtime, "play", "scene.play");
+}
+
+static bool managed_network_keep_alive_scene_matches(const sdl3d_data_game_runtime *runtime, const char *session_name)
+{
+    const char *active_scene =
+        runtime != NULL && runtime->data != NULL ? sdl3d_game_data_active_scene(runtime->data) : NULL;
+    return sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime != NULL ? runtime->data : NULL,
+                                                                    session_name, active_scene);
 }
 
 static bool managed_network_is_network_match(const sdl3d_data_game_runtime *runtime)
@@ -600,8 +593,13 @@ static void disconnect_managed_network(sdl3d_data_game_runtime *runtime)
 
     if (runtime->managed_network_enabled && runtime->data != NULL)
     {
-        managed_network_cancel_host(runtime, true, "Not hosting");
-        managed_network_cancel_direct_connect(runtime, true, "Disconnected");
+        if (sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION) != NULL)
+            managed_network_cancel_host(runtime, true, "Not hosting");
+        if (sdl3d_game_data_get_network_direct_connect_session(runtime->data,
+                                                               SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION) != NULL)
+        {
+            managed_network_cancel_direct_connect(runtime, true, "Disconnected");
+        }
     }
 
     if (runtime->session != NULL && runtime->managed_network_lobby_start_connection > 0)
@@ -634,7 +632,9 @@ static void managed_network_update_termination_ack(sdl3d_data_game_runtime *runt
         ctx->paused = true;
 
     runtime->managed_network_termination_timer += SDL_max(dt, 0.0f);
-    if (runtime->managed_network_termination_timer < 0.25f)
+    float acknowledge_delay = 3.0f;
+    (void)sdl3d_game_data_get_network_managed_termination_ack_delay(runtime->data, &acknowledge_delay);
+    if (runtime->managed_network_termination_timer < acknowledge_delay)
         return;
 
     sdl3d_input_manager *input = runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
@@ -706,8 +706,9 @@ static void managed_network_update_host(sdl3d_data_game_runtime *runtime, sdl3d_
     if (session == NULL)
         return;
 
-    const bool keep_host_session = managed_network_is_lobby_scene(runtime) ||
-                                   (managed_network_is_play_scene(runtime) && managed_network_is_role_host(runtime));
+    const bool keep_host_session =
+        managed_network_keep_alive_scene_matches(runtime, SDL3D_MANAGED_NETWORK_HOST_SESSION) &&
+        (!managed_network_is_play_scene(runtime) || managed_network_is_role_host(runtime));
     if (!keep_host_session)
         managed_network_cancel_host(runtime, true, "Not hosting");
 }
@@ -725,7 +726,8 @@ static void managed_network_update_direct_connect(sdl3d_data_game_runtime *runti
     const bool was_playing = managed_network_is_play_scene(runtime);
     const bool playing = was_playing && managed_network_is_role_client(runtime);
     const bool keep_direct_connect_session =
-        managed_network_is_direct_connect_scene(runtime) || managed_network_is_discovery_scene(runtime) || playing;
+        managed_network_keep_alive_scene_matches(runtime, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION) &&
+        (!managed_network_is_play_scene(runtime) || managed_network_is_role_client(runtime));
     if (!keep_direct_connect_session)
     {
         managed_network_cancel_direct_connect(runtime, true, "Disconnected");
@@ -821,8 +823,6 @@ static void managed_network_update_after_frame(sdl3d_data_game_runtime *runtime,
     if (runtime == NULL || runtime->data == NULL || !runtime->managed_network_enabled)
         return;
 
-    managed_network_process_lobby_start(runtime, ctx);
-
     sdl3d_network_session *session =
         sdl3d_game_data_get_network_host_session(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION);
     if (session == NULL || !sdl3d_network_session_is_connected(session) || !managed_network_is_play_scene(runtime) ||
@@ -914,6 +914,8 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
         sdl3d_data_game_runtime_destroy(runtime);
         return false;
     }
+    runtime->managed_network_enabled =
+        runtime->managed_network_enabled && sdl3d_game_data_network_managed_runtime_enabled(runtime->data);
 
     sdl3d_game_data_image_cache_init(&runtime->image_cache, runtime->assets);
     if (!sdl3d_game_data_app_flow_start(&runtime->app_flow, runtime->data))

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -11656,6 +11656,61 @@ bool sdl3d_game_data_get_network_session_message(const sdl3d_game_data_runtime *
     return true;
 }
 
+static yyjson_val *network_managed_runtime_json(const sdl3d_game_data_runtime *runtime)
+{
+    return obj_get(network_session_flow_json(runtime), "managed_runtime");
+}
+
+bool sdl3d_game_data_network_managed_runtime_enabled(const sdl3d_game_data_runtime *runtime)
+{
+    return json_bool(network_managed_runtime_json(runtime), "enabled", false);
+}
+
+bool sdl3d_game_data_get_network_managed_termination_ack_delay(const sdl3d_game_data_runtime *runtime,
+                                                               float *out_seconds)
+{
+    if (out_seconds != NULL)
+        *out_seconds = 0.0f;
+    if (runtime == NULL || out_seconds == NULL)
+        return false;
+
+    yyjson_val *value = obj_get(network_managed_runtime_json(runtime), "termination_ack_delay_seconds");
+    if (!yyjson_is_num(value))
+        return false;
+
+    *out_seconds = SDL_max((float)yyjson_get_real(value), 0.0f);
+    return true;
+}
+
+bool sdl3d_game_data_network_managed_keep_alive_scene_matches(const sdl3d_game_data_runtime *runtime,
+                                                              const char *session_name, const char *scene_name)
+{
+    if (runtime == NULL || session_name == NULL || session_name[0] == '\0' || scene_name == NULL ||
+        scene_name[0] == '\0')
+    {
+        return false;
+    }
+
+    yyjson_val *keep_alive = obj_get(network_managed_runtime_json(runtime), "keep_alive_scenes");
+    yyjson_val *scenes = obj_get(keep_alive, session_name);
+    if (!yyjson_is_arr(scenes))
+        return false;
+
+    for (size_t i = 0U; i < yyjson_arr_size(scenes); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(scenes, i);
+        const char *semantic = yyjson_is_str(entry) ? yyjson_get_str(entry) : NULL;
+        const char *resolved_scene = NULL;
+        if (semantic != NULL && sdl3d_game_data_get_network_session_scene(runtime, semantic, &resolved_scene) &&
+            resolved_scene != NULL && SDL_strcmp(resolved_scene, scene_name) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool sdl3d_game_data_run_network_session_flow_event(sdl3d_game_data_runtime *runtime, sdl3d_game_context *ctx,
                                                     const char *name, const sdl3d_properties *payload,
                                                     char *error_buffer, int error_buffer_size)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -82,6 +82,8 @@ static bool require_unique_name(validation_context *ctx, name_table *table, cons
                                 const char *json_path);
 static bool require_ref(validation_context *ctx, const name_table *table, const char *kind, const char *name,
                         const char *json_path);
+static bool require_network_string_entry(validation_context *ctx, yyjson_val *map, const char *path, const char *label,
+                                         const char *name);
 static bool asset_path_exists(validation_context *ctx, const char *asset_path, const char *json_path,
                               const char *asset_kind);
 static void format_path(char *buffer, size_t buffer_size, const char *format, ...);
@@ -668,6 +670,43 @@ static bool validate_network_scene_state(validation_context *ctx, yyjson_val *ne
     return true;
 }
 
+static bool network_managed_runtime_enabled_json(yyjson_val *network)
+{
+    yyjson_val *enabled = obj_get(obj_get(obj_get(network, "session_flow"), "managed_runtime"), "enabled");
+    return yyjson_is_bool(enabled) && yyjson_get_bool(enabled);
+}
+
+static bool validate_managed_network_scene_state(validation_context *ctx, yyjson_val *network)
+{
+    if (!network_managed_runtime_enabled_json(network))
+        return true;
+
+    yyjson_val *scene_state = obj_get(network, "scene_state");
+    yyjson_val *host = obj_get(scene_state, "host");
+    yyjson_val *direct_connect = obj_get(scene_state, "direct_connect");
+    const char *host_keys[] = {"status", "endpoint", "peer", "connected"};
+    const char *direct_connect_keys[] = {"status", "state", "connected"};
+
+    for (size_t i = 0U; i < SDL_arraysize(host_keys); ++i)
+    {
+        if (!require_network_string_entry(ctx, host, "$.network.scene_state.host", "scene_state host key",
+                                          host_keys[i]))
+        {
+            return false;
+        }
+    }
+    for (size_t i = 0U; i < SDL_arraysize(direct_connect_keys); ++i)
+    {
+        if (!require_network_string_entry(ctx, direct_connect, "$.network.scene_state.direct_connect",
+                                          "scene_state direct_connect key", direct_connect_keys[i]))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
                                   validation_names *names);
 
@@ -694,6 +733,159 @@ static bool validate_network_session_string_map(validation_context *ctx, yyjson_
             return validation_error(ctx, path, "network session_flow %s value must be a non-empty string", label);
         if (scene_names != NULL && !require_ref(ctx, scene_names, "scene", yyjson_get_str(value), path))
             return false;
+    }
+
+    return true;
+}
+
+static bool require_network_string_entry(validation_context *ctx, yyjson_val *map, const char *path, const char *label,
+                                         const char *name)
+{
+    char entry_path[PATH_BUFFER_SIZE];
+    format_path(entry_path, sizeof(entry_path), "%s.%s", path, name);
+    if (map == NULL || !yyjson_is_obj(map) || !is_non_empty_string(map, name))
+        return validation_error(ctx, entry_path, "managed network requires %s '%s'", label, name);
+    return true;
+}
+
+static bool require_network_group_string_entry(validation_context *ctx, yyjson_val *groups, const char *path,
+                                               const char *label, const char *group_name, const char *name)
+{
+    yyjson_val *group = obj_get(groups, group_name);
+    char entry_path[PATH_BUFFER_SIZE];
+    format_path(entry_path, sizeof(entry_path), "%s.%s.%s", path, group_name, name);
+    if (group == NULL || !yyjson_is_obj(group) || !is_non_empty_string(group, name))
+        return validation_error(ctx, entry_path, "managed network requires %s '%s.%s'", label, group_name, name);
+    return true;
+}
+
+static bool validate_network_managed_keep_alive_scenes(validation_context *ctx, yyjson_val *managed, yyjson_val *scenes)
+{
+    yyjson_val *keep_alive = obj_get(managed, "keep_alive_scenes");
+    if (keep_alive == NULL)
+        return true;
+    if (!yyjson_is_obj(keep_alive))
+        return validation_error(ctx, "$.network.session_flow.managed_runtime.keep_alive_scenes",
+                                "managed network keep_alive_scenes must be an object");
+
+    yyjson_val *session_key;
+    yyjson_obj_iter session_iter;
+    yyjson_obj_iter_init(keep_alive, &session_iter);
+    while ((session_key = yyjson_obj_iter_next(&session_iter)) != NULL)
+    {
+        const char *session_name = yyjson_get_str(session_key);
+        yyjson_val *list = yyjson_obj_iter_get_val(session_key);
+        char session_path[PATH_BUFFER_SIZE];
+        format_path(session_path, sizeof(session_path), "$.network.session_flow.managed_runtime.keep_alive_scenes.%s",
+                    session_name != NULL ? session_name : "<invalid>");
+        if (session_name == NULL || session_name[0] == '\0')
+            return validation_error(ctx, session_path, "managed network keep-alive session name must be non-empty");
+        if (!yyjson_is_arr(list) || yyjson_arr_size(list) == 0)
+            return validation_error(ctx, session_path, "managed network keep-alive scenes must be a non-empty array");
+
+        for (size_t i = 0U; i < yyjson_arr_size(list); ++i)
+        {
+            yyjson_val *entry = yyjson_arr_get(list, i);
+            const char *scene_semantic = yyjson_is_str(entry) ? yyjson_get_str(entry) : NULL;
+            char entry_path[PATH_BUFFER_SIZE];
+            format_path(entry_path, sizeof(entry_path), "%s[%zu]", session_path, i);
+            if (scene_semantic == NULL || scene_semantic[0] == '\0')
+                return validation_error(ctx, entry_path, "managed network keep-alive scene must be a non-empty string");
+            if (!is_non_empty_string(scenes, scene_semantic))
+                return validation_error(ctx, entry_path,
+                                        "managed network keep-alive scene must reference session_flow.scenes");
+        }
+    }
+
+    return true;
+}
+
+static bool validate_network_managed_runtime(validation_context *ctx, yyjson_val *flow)
+{
+    yyjson_val *managed = obj_get(flow, "managed_runtime");
+    if (managed == NULL)
+        return true;
+    if (!yyjson_is_obj(managed))
+        return validation_error(ctx, "$.network.session_flow.managed_runtime",
+                                "managed network runtime must be an object");
+
+    yyjson_val *enabled = obj_get(managed, "enabled");
+    if (enabled != NULL && !yyjson_is_bool(enabled))
+        return validation_error(ctx, "$.network.session_flow.managed_runtime.enabled",
+                                "managed network enabled must be boolean");
+
+    yyjson_val *ack_delay = obj_get(managed, "termination_ack_delay_seconds");
+    if (ack_delay != NULL && (!yyjson_is_num(ack_delay) || yyjson_get_real(ack_delay) < 0.0))
+    {
+        return validation_error(ctx, "$.network.session_flow.managed_runtime.termination_ack_delay_seconds",
+                                "managed network termination_ack_delay_seconds must be a non-negative number");
+    }
+
+    yyjson_val *scenes = obj_get(flow, "scenes");
+    if (!validate_network_managed_keep_alive_scenes(ctx, managed, scenes))
+        return false;
+
+    if (enabled == NULL || !yyjson_get_bool(enabled))
+        return true;
+
+    yyjson_val *state_keys = obj_get(flow, "state_keys");
+    yyjson_val *state_values = obj_get(flow, "state_values");
+    yyjson_val *events = obj_get(flow, "events");
+    const char *required_scenes[] = {"play", "host_lobby", "direct_connect", "discovery"};
+    const char *required_state_keys[] = {"match_mode", "network_role", "network_flow", "match_termination_active"};
+    const char *required_events[] = {"host_start_game",           "client_start_game",
+                                     "client_state_before_start", "host_match_terminated",
+                                     "client_match_terminated",   "host_client_disconnected",
+                                     "client_connection_closed",  "network_match_termination_ack"};
+
+    for (size_t i = 0U; i < SDL_arraysize(required_scenes); ++i)
+    {
+        if (!require_network_string_entry(ctx, scenes, "$.network.session_flow.scenes", "session scene",
+                                          required_scenes[i]))
+        {
+            return false;
+        }
+    }
+    for (size_t i = 0U; i < SDL_arraysize(required_state_keys); ++i)
+    {
+        if (!require_network_string_entry(ctx, state_keys, "$.network.session_flow.state_keys", "session state key",
+                                          required_state_keys[i]))
+        {
+            return false;
+        }
+    }
+
+    if (!require_network_group_string_entry(ctx, state_values, "$.network.session_flow.state_values",
+                                            "session state value", "match_mode", "network") ||
+        !require_network_group_string_entry(ctx, state_values, "$.network.session_flow.state_values",
+                                            "session state value", "network_role", "host") ||
+        !require_network_group_string_entry(ctx, state_values, "$.network.session_flow.state_values",
+                                            "session state value", "network_role", "client") ||
+        !require_network_group_string_entry(ctx, state_values, "$.network.session_flow.state_values",
+                                            "session state value", "network_flow", "host") ||
+        !require_network_group_string_entry(ctx, state_values, "$.network.session_flow.state_values",
+                                            "session state value", "network_flow", "direct"))
+    {
+        return false;
+    }
+
+    for (size_t i = 0U; i < SDL_arraysize(required_events); ++i)
+    {
+        char event_path[PATH_BUFFER_SIZE];
+        format_path(event_path, sizeof(event_path), "$.network.session_flow.events.%s", required_events[i]);
+        if (events == NULL || !yyjson_is_obj(events) || obj_get(events, required_events[i]) == NULL)
+            return validation_error(ctx, event_path, "managed network requires session flow event '%s'",
+                                    required_events[i]);
+    }
+    if (obj_get(managed, "keep_alive_scenes") == NULL)
+    {
+        return validation_error(ctx, "$.network.session_flow.managed_runtime.keep_alive_scenes",
+                                "managed network requires keep_alive_scenes");
+    }
+    if (ack_delay == NULL)
+    {
+        return validation_error(ctx, "$.network.session_flow.managed_runtime.termination_ack_delay_seconds",
+                                "managed network requires termination_ack_delay_seconds");
     }
 
     return true;
@@ -798,7 +990,7 @@ static bool validate_network_session_flow(validation_context *ctx, yyjson_val *n
         }
     }
 
-    return true;
+    return validate_network_managed_runtime(ctx, flow);
 }
 
 static bool validate_network_runtime_binding_map(validation_context *ctx, yyjson_val *map, const char *json_path,
@@ -874,27 +1066,96 @@ static bool validate_network_runtime_pause_binding(validation_context *ctx, yyjs
     return true;
 }
 
+static bool require_network_runtime_binding(validation_context *ctx, yyjson_val *bindings, const char *section,
+                                            const char *name, const char *label, const name_table *references)
+{
+    yyjson_val *map = obj_get(bindings, section);
+    char path[PATH_BUFFER_SIZE];
+    format_path(path, sizeof(path), "$.network.runtime_bindings.%s.%s", section, name);
+    const char *value = json_string(map, name);
+    if (value == NULL || value[0] == '\0')
+        return validation_error(ctx, path, "managed network requires runtime binding '%s.%s'", section, name);
+    return require_ref(ctx, references, label, value, path);
+}
+
+static bool validate_managed_network_runtime_bindings(validation_context *ctx, yyjson_val *bindings,
+                                                      const name_table *replication_names,
+                                                      const name_table *control_names, validation_names *names)
+{
+    const char *replication_bindings[] = {"state_snapshot", "client_input"};
+    const char *control_bindings[] = {"start_game", "pause_request", "resume_request", "disconnect"};
+    const char *action_bindings[] = {"menu_select", "camera_toggle"};
+    const char *signal_bindings[] = {"lobby_start", "camera_toggle"};
+
+    for (size_t i = 0U; i < SDL_arraysize(replication_bindings); ++i)
+    {
+        if (!require_network_runtime_binding(ctx, bindings, "replication", replication_bindings[i],
+                                             "network replication", replication_names))
+        {
+            return false;
+        }
+    }
+    for (size_t i = 0U; i < SDL_arraysize(control_bindings); ++i)
+    {
+        if (!require_network_runtime_binding(ctx, bindings, "controls", control_bindings[i], "network control message",
+                                             control_names))
+        {
+            return false;
+        }
+    }
+    for (size_t i = 0U; i < SDL_arraysize(action_bindings); ++i)
+    {
+        if (!require_network_runtime_binding(ctx, bindings, "actions", action_bindings[i], "input action",
+                                             &names->actions))
+        {
+            return false;
+        }
+    }
+    for (size_t i = 0U; i < SDL_arraysize(signal_bindings); ++i)
+    {
+        if (!require_network_runtime_binding(ctx, bindings, "signals", signal_bindings[i], "signal", &names->signals))
+            return false;
+    }
+    if (obj_get(bindings, "pause") == NULL)
+    {
+        return validation_error(ctx, "$.network.runtime_bindings.pause",
+                                "managed network requires runtime_bindings.pause");
+    }
+
+    return true;
+}
+
 static bool validate_network_runtime_bindings(validation_context *ctx, yyjson_val *network,
                                               const name_table *replication_names, const name_table *control_names,
                                               validation_names *names)
 {
     yyjson_val *bindings = obj_get(network, "runtime_bindings");
+    const bool managed_required = network_managed_runtime_enabled_json(network);
     if (bindings == NULL)
+    {
+        if (managed_required)
+            return validation_error(ctx, "$.network.runtime_bindings", "managed network requires runtime_bindings");
         return true;
+    }
     if (!yyjson_is_obj(bindings))
         return validation_error(ctx, "$.network.runtime_bindings", "network runtime_bindings must be an object");
 
-    return validate_network_runtime_binding_map(ctx, obj_get(bindings, "replication"),
-                                                "$.network.runtime_bindings.replication", "network replication",
-                                                replication_names, false) &&
-           validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"),
-                                                "$.network.runtime_bindings.controls", "network control message",
-                                                control_names, true) &&
-           validate_network_runtime_binding_map(ctx, obj_get(bindings, "actions"), "$.network.runtime_bindings.actions",
-                                                "input action", &names->actions, false) &&
-           validate_network_runtime_binding_map(ctx, obj_get(bindings, "signals"), "$.network.runtime_bindings.signals",
-                                                "signal", &names->signals, false) &&
-           validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names);
+    if (!validate_network_runtime_binding_map(ctx, obj_get(bindings, "replication"),
+                                              "$.network.runtime_bindings.replication", "network replication",
+                                              replication_names, false) ||
+        !validate_network_runtime_binding_map(ctx, obj_get(bindings, "controls"), "$.network.runtime_bindings.controls",
+                                              "network control message", control_names, true) ||
+        !validate_network_runtime_binding_map(ctx, obj_get(bindings, "actions"), "$.network.runtime_bindings.actions",
+                                              "input action", &names->actions, false) ||
+        !validate_network_runtime_binding_map(ctx, obj_get(bindings, "signals"), "$.network.runtime_bindings.signals",
+                                              "signal", &names->signals, false) ||
+        !validate_network_runtime_pause_binding(ctx, obj_get(bindings, "pause"), names))
+    {
+        return false;
+    }
+
+    return !managed_required ||
+           validate_managed_network_runtime_bindings(ctx, bindings, replication_names, control_names, names);
 }
 
 static bool is_network_diagnostic_level(const char *level)
@@ -1002,6 +1263,8 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
     if (!validate_network_scene_state(ctx, network))
         return false;
     if (!validate_network_session_flow(ctx, network, names))
+        return false;
+    if (!validate_managed_network_scene_state(ctx, network))
         return false;
 
     yyjson_val *replication = obj_get(network, "replication");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1288,6 +1288,16 @@ TEST(GameDataRuntime, LoadsPongDataIntoGenericSessionServices)
     EXPECT_FALSE(
         sdl3d_game_data_get_network_session_message(runtime, "disconnect_reasons", "missing", &network_session_value));
     EXPECT_EQ(network_session_value, nullptr);
+    EXPECT_TRUE(sdl3d_game_data_network_managed_runtime_enabled(runtime));
+    float managed_ack_delay = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_network_managed_termination_ack_delay(runtime, &managed_ack_delay));
+    EXPECT_FLOAT_EQ(managed_ack_delay, 3.0f);
+    EXPECT_TRUE(sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime, "host", "scene.multiplayer.lobby"));
+    EXPECT_TRUE(sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime, "host", "scene.play"));
+    EXPECT_FALSE(sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime, "host", "scene.title"));
+    EXPECT_TRUE(sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime, "direct_connect",
+                                                                         "scene.multiplayer.discovery"));
+    EXPECT_TRUE(sdl3d_game_data_network_managed_keep_alive_scene_matches(runtime, "direct_connect", "scene.play"));
     const char *network_runtime_value = nullptr;
     ASSERT_TRUE(sdl3d_game_data_get_network_runtime_replication(runtime, "state_snapshot", &network_runtime_value));
     EXPECT_STREQ(network_runtime_value, "play_state");
@@ -1779,6 +1789,43 @@ TEST(GameDataRuntime, ManagedNetworkRuntimeStartsPongMatchAndReplicatesState)
     }
     EXPECT_TRUE(snapshot_applied);
     EXPECT_TRUE(client_ctx.paused);
+
+    sdl3d_properties *termination_payload = sdl3d_properties_create();
+    ASSERT_NE(termination_payload, nullptr);
+    sdl3d_properties_set_string(termination_payload, "reason", "Test disconnect");
+    ASSERT_TRUE(sdl3d_game_data_run_network_session_flow_event(client_data, &client_ctx, "client_match_terminated",
+                                                               termination_payload, error, sizeof(error)))
+        << error;
+    sdl3d_properties_destroy(termination_payload);
+    client_scene_state = sdl3d_game_data_scene_state(client_data);
+    ASSERT_NE(client_scene_state, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(client_scene_state, "network_match_termination_active", false));
+
+    int select_action = -1;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_action(client_data, "menu_select", &select_action));
+    sdl3d_input_manager *client_input = sdl3d_game_session_get_input(client_session);
+    ASSERT_NE(client_input, nullptr);
+    sdl3d_input_set_action_override(client_input, select_action, 1.0f);
+    ASSERT_NE(sdl3d_input_update(client_input, 5000), nullptr);
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 0.25f));
+    client_scene_state = sdl3d_game_data_scene_state(client_data);
+    ASSERT_NE(client_scene_state, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(client_scene_state, "network_match_termination_active", false));
+    EXPECT_STREQ(sdl3d_game_data_active_scene(client_data), "scene.play");
+
+    sdl3d_input_set_action_override(client_input, select_action, 0.0f);
+    ASSERT_NE(sdl3d_input_update(client_input, 5001), nullptr);
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 2.74f));
+    EXPECT_TRUE(sdl3d_properties_get_bool(client_scene_state, "network_match_termination_active", false));
+
+    sdl3d_input_set_action_override(client_input, select_action, 1.0f);
+    ASSERT_NE(sdl3d_input_update(client_input, 5002), nullptr);
+    ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 0.02f));
+    client_scene_state = sdl3d_game_data_scene_state(client_data);
+    ASSERT_NE(client_scene_state, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(client_scene_state, "network_match_termination_active", true));
+    EXPECT_FALSE(client_ctx.paused);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(client_data), "scene.title");
 
     sdl3d_data_game_runtime_destroy(client_runtime);
     sdl3d_data_game_runtime_destroy(host_runtime);
@@ -7635,6 +7682,60 @@ TEST(GameDataRuntime, RejectsInvalidNetworkReplicationSchemas)
     ]
   })json",
             "scene_state.set requires a non-empty key",
+        },
+        {
+            "bad_managed_network_missing_scene_semantic",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "session_flow": {
+      "managed_runtime": {
+        "enabled": true,
+        "termination_ack_delay_seconds": 3.0
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "managed network requires session scene 'play'",
+        },
+        {
+            "bad_managed_network_keep_alive_scene",
+            R"json({
+    "protocol": { "id": "sdl3d.test.network.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "session_flow": {
+      "managed_runtime": {
+        "enabled": false,
+        "keep_alive_scenes": {
+          "host": ["missing"]
+        }
+      }
+    },
+    "replication": [
+      {
+        "name": "play_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "actors": [
+          {
+            "entity": "entity.ball",
+            "fields": ["position"]
+          }
+        ]
+      }
+    ]
+  })json",
+            "managed network keep-alive scene must reference session_flow.scenes",
         },
         {
             "bad_runtime_replication_binding",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -1658,6 +1658,134 @@ TEST(GameDataRuntime, DataGameRuntimeNetworkLoopReplicatesPongInputStateAndContr
     sdl3d_game_session_destroy(host_session);
 }
 
+TEST(GameDataRuntime, ManagedNetworkRuntimeStartsPongMatchAndReplicatesState)
+{
+    sdl3d_game_session *host_session = nullptr;
+    sdl3d_game_session *client_session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &host_session));
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &client_session));
+
+    const std::filesystem::path data_path = SDL3D_PONG_DATA_PATH;
+    const std::string root = data_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + data_path.filename().string();
+
+    sdl3d_data_game_runtime_desc host_desc{};
+    sdl3d_data_game_runtime_desc_init(&host_desc);
+    host_desc.session = host_session;
+    host_desc.media_dir = SDL3D_MEDIA_DIR;
+    host_desc.data_asset_path = asset_path.c_str();
+    host_desc.mount_assets = mount_test_directory_assets;
+    host_desc.mount_userdata = const_cast<char *>(root.c_str());
+    host_desc.enable_managed_network = true;
+
+    sdl3d_data_game_runtime_desc client_desc = host_desc;
+    client_desc.session = client_session;
+
+    char error[512]{};
+    sdl3d_data_game_runtime *host_runtime = nullptr;
+    sdl3d_data_game_runtime *client_runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&host_desc, &host_runtime, error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&client_desc, &client_runtime, error, sizeof(error))) << error;
+    sdl3d_game_data_runtime *host_data = sdl3d_data_game_runtime_data(host_runtime);
+    sdl3d_game_data_runtime *client_data = sdl3d_data_game_runtime_data(client_runtime);
+    ASSERT_NE(host_data, nullptr);
+    ASSERT_NE(client_data, nullptr);
+
+    auto enter_scene = [](sdl3d_game_data_runtime *runtime, const char *scene, const char *network_flow) {
+        sdl3d_properties *payload = sdl3d_properties_create();
+        if (payload == nullptr)
+            return false;
+        sdl3d_properties_set_string(payload, "network_flow", network_flow);
+        const bool ok = sdl3d_game_data_set_active_scene_with_payload(runtime, scene, payload);
+        sdl3d_properties_destroy(payload);
+        return ok;
+    };
+    ASSERT_TRUE(enter_scene(host_data, "scene.multiplayer.lobby", "host"));
+    ASSERT_TRUE(enter_scene(client_data, "scene.multiplayer.direct_connect", "direct"));
+
+    const ::testing::TestInfo *test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+    const std::string test_name =
+        test_info != nullptr ? std::string(test_info->test_suite_name()) + "." + test_info->name() : "managed_net";
+    const int port = 30000 + (int)(std::hash<std::string>{}(test_name) % 20000U);
+    if (!sdl3d_game_data_network_host_start(host_data, "host", port, "SDL3D Test", "host_status", "host_endpoint",
+                                            "host_peer", "host_connected"))
+    {
+        sdl3d_data_game_runtime_destroy(client_runtime);
+        sdl3d_data_game_runtime_destroy(host_runtime);
+        sdl3d_game_session_destroy(client_session);
+        sdl3d_game_session_destroy(host_session);
+        GTEST_SKIP() << "network host unavailable: " << SDL_GetError();
+    }
+    ASSERT_TRUE(sdl3d_game_data_network_direct_connect_start(client_data, "direct_connect", "127.0.0.1", port,
+                                                             "direct_connect_status", "direct_connect_state",
+                                                             "direct_connect_connected"));
+
+    sdl3d_game_context host_ctx{};
+    host_ctx.session = host_session;
+    sdl3d_game_context client_ctx{};
+    client_ctx.session = client_session;
+
+    sdl3d_network_session *host_net = sdl3d_game_data_get_network_host_session(host_data, "host");
+    sdl3d_network_session *client_net =
+        sdl3d_game_data_get_network_direct_connect_session(client_data, "direct_connect");
+    ASSERT_NE(host_net, nullptr);
+    ASSERT_NE(client_net, nullptr);
+    bool connected = false;
+    for (int i = 0; i < 1200 && !connected; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(host_runtime, &host_ctx, 0.01f));
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 0.01f));
+        connected = sdl3d_network_session_is_connected(host_net) && sdl3d_network_session_is_connected(client_net);
+    }
+    ASSERT_TRUE(connected);
+
+    int lobby_start_signal = -1;
+    ASSERT_TRUE(sdl3d_game_data_get_network_runtime_signal(host_data, "lobby_start", &lobby_start_signal));
+    ASSERT_GE(lobby_start_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(host_session), lobby_start_signal, nullptr);
+
+    bool started = false;
+    for (int i = 0; i < 240 && !started; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(host_runtime, &host_ctx, 0.016f));
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 0.016f));
+        started = SDL_strcmp(sdl3d_game_data_active_scene(host_data), "scene.play") == 0 &&
+                  SDL_strcmp(sdl3d_game_data_active_scene(client_data), "scene.play") == 0;
+    }
+    ASSERT_TRUE(started);
+    const sdl3d_properties *host_scene_state = sdl3d_game_data_scene_state(host_data);
+    const sdl3d_properties *client_scene_state = sdl3d_game_data_scene_state(client_data);
+    ASSERT_NE(host_scene_state, nullptr);
+    ASSERT_NE(client_scene_state, nullptr);
+    EXPECT_STREQ(sdl3d_properties_get_string(host_scene_state, "match_mode", ""), "lan");
+    EXPECT_STREQ(sdl3d_properties_get_string(host_scene_state, "network_role", ""), "host");
+    EXPECT_STREQ(sdl3d_properties_get_string(client_scene_state, "match_mode", ""), "lan");
+    EXPECT_STREQ(sdl3d_properties_get_string(client_scene_state, "network_role", ""), "client");
+
+    sdl3d_registered_actor *host_ball = sdl3d_game_data_find_actor(host_data, "entity.ball");
+    sdl3d_registered_actor *client_ball = sdl3d_game_data_find_actor(client_data, "entity.ball");
+    ASSERT_NE(host_ball, nullptr);
+    ASSERT_NE(client_ball, nullptr);
+    host_ctx.paused = true;
+    client_ctx.paused = false;
+    host_ball->position = sdl3d_vec3_make(4.0f, 1.5f, 0.0f);
+    bool snapshot_applied = false;
+    for (int i = 0; i < 240 && !snapshot_applied; ++i)
+    {
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(host_runtime, &host_ctx, 0.016f));
+        ASSERT_TRUE(sdl3d_data_game_runtime_update_frame(client_runtime, &client_ctx, 0.016f));
+        snapshot_applied = SDL_fabsf(client_ball->position.x - host_ball->position.x) < 0.0001f &&
+                           SDL_fabsf(client_ball->position.y - host_ball->position.y) < 0.0001f;
+    }
+    EXPECT_TRUE(snapshot_applied);
+    EXPECT_TRUE(client_ctx.paused);
+
+    sdl3d_data_game_runtime_destroy(client_runtime);
+    sdl3d_data_game_runtime_destroy(host_runtime);
+    sdl3d_game_session_destroy(client_session);
+    sdl3d_game_session_destroy(host_session);
+}
+
 TEST(GameDataRuntime, AuthoredNetworkSessionFlowEventsDriveSceneTransitions)
 {
     sdl3d_game_session *session = nullptr;

--- a/tools/sdl3d_runner.c
+++ b/tools/sdl3d_runner.c
@@ -183,6 +183,7 @@ static bool runner_init(sdl3d_game_context *ctx, void *userdata)
     desc.media_dir = state->media_dir;
     desc.mount_assets = runner_mount_assets;
     desc.mount_userdata = state;
+    desc.enable_managed_network = true;
 
     if (!sdl3d_data_game_runtime_create(&desc, &state->runtime, error, (int)sizeof(error)))
     {


### PR DESCRIPTION
## Summary
- add opt-in managed network orchestration to the generic data-game runtime and enable it in sdl3d_runner
- drive host/direct-connect update, start-game, pause/resume, disconnect, termination ack, snapshot publishing, and diagnostics through authored network semantics
- add direct-connect scene-state bindings for Pong data and document the runner-managed networking contract

## Tests
- cmake --build build/debug --target sdl3d_game_data_test sdl3d_runner pong_demo -j 8
- ./build/debug/tests/sdl3d_game_data_test
- ./build/debug/sdl3d_runner --help

Refs #210