### PR TITLE
Launch Pong through generic runner

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -27,17 +27,38 @@ sdl3d_add_embedded_asset_pack(pong_assets
     FILES ${SDL3D_PONG_ASSET_FILES})
 
 add_executable(pong_demo
-    main.c)
+    "${CMAKE_SOURCE_DIR}/tools/sdl3d_runner.c")
 target_link_libraries(pong_demo PRIVATE SDL3D::sdl3d)
 target_link_libraries(pong_demo PRIVATE pong_assets)
 target_compile_features(pong_demo PRIVATE c_std_17)
 target_compile_definitions(pong_demo PRIVATE
     SDL3D_MEDIA_DIR="${CMAKE_SOURCE_DIR}/media"
-    SDL3D_PONG_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data"
-    SDL3D_PONG_DATA_ASSET_PATH="asset://pong.game.json"
-    SDL3D_PONG_EMBEDDED_ASSETS=1)
+    SDL3D_RUNNER_EMBEDDED_ASSETS=1
+    SDL3D_RUNNER_EMBEDDED_ASSETS_DATA=sdl3d_pong_assets
+    SDL3D_RUNNER_EMBEDDED_ASSETS_SIZE=sdl3d_pong_assets_size
+    SDL3D_RUNNER_DEFAULT_DATA_ASSET_PATH="asset://pong.game.json"
+    SDL3D_RUNNER_DEFAULT_EMBEDDED=1)
 set_target_properties(pong_demo PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/demos/pong")
+
+option(SDL3D_BUILD_PONG_LEGACY_HOST "Build the deprecated Pong custom C host" OFF)
+if(SDL3D_BUILD_PONG_LEGACY_HOST)
+    add_executable(pong_legacy_demo
+        main.c)
+    target_link_libraries(pong_legacy_demo PRIVATE SDL3D::sdl3d)
+    target_link_libraries(pong_legacy_demo PRIVATE pong_assets)
+    target_compile_features(pong_legacy_demo PRIVATE c_std_17)
+    target_compile_definitions(pong_legacy_demo PRIVATE
+        SDL3D_MEDIA_DIR="${CMAKE_SOURCE_DIR}/media"
+        SDL3D_PONG_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data"
+        SDL3D_PONG_DATA_ASSET_PATH="asset://pong.game.json"
+        SDL3D_PONG_EMBEDDED_ASSETS=1)
+    set_target_properties(pong_legacy_demo PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/demos/pong")
+    if(NOT WIN32)
+        target_link_libraries(pong_legacy_demo PRIVATE m)
+    endif()
+endif()
 
 if(TARGET sdl3d_pack)
     sdl3d_add_asset_pack(pong_asset_pack
@@ -45,8 +66,7 @@ if(TARGET sdl3d_pack)
         OUTPUT "${CMAKE_BINARY_DIR}/demos/pong/pong.sdl3dpak"
         FILES ${SDL3D_PONG_ASSET_FILES})
     add_dependencies(pong_demo pong_asset_pack)
-endif()
-
-if(NOT WIN32)
-    target_link_libraries(pong_demo PRIVATE m)
+    if(TARGET pong_legacy_demo)
+        add_dependencies(pong_legacy_demo pong_asset_pack)
+    endif()
 endif()

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -150,6 +150,14 @@ Pack-file example:
 build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json
 ```
 
+Pong's normal demo target is now a game-specific build of this same runner
+source with embedded Pong assets and a default data asset. It can be launched
+without arguments:
+
+```sh
+build/debug/demos/pong/pong_demo
+```
+
 Optional flags:
 
 - `--media <dir>` overrides the built-in media directory used for engine fonts
@@ -158,10 +166,12 @@ Optional flags:
   `SDL3D_RUNNER_EMBEDDED_ASSETS` and provides the generic
   `sdl3d_runner_embedded_assets` pack blob symbols.
 
-The runner is game-agnostic: it does not reference Pong symbols, scene names,
-actions, actors, replication channels, or controls. Any remaining need for a
-custom host indicates engine runtime work that should move into reusable JSON
-or Lua-driven systems.
+The generic runner source is game-agnostic: it does not reference Pong scene
+names, actions, actors, replication channels, or controls. Demo-specific runner
+targets may supply build-time defaults such as an embedded asset symbol and a
+root data asset path, but gameplay and runtime behavior should remain authored
+in JSON and Lua. Any remaining need for a custom host indicates engine runtime
+work that should move into reusable data-driven systems.
 
 ## Why This Matters
 

--- a/docs/pong-c-audit.md
+++ b/docs/pong-c-audit.md
@@ -1,9 +1,10 @@
 # Pong C Host Audit
 
-This audit records the state of `demos/pong/main.c` after the multiplayer UI
-migration. The long-term target is for Pong to be authored as JSON, Lua, and
-assets loaded by a generic SDL3D runner. In that model, a game does not need a
-custom `my_game/main.c`; it supplies data to the engine runtime.
+This audit records the state of Pong after the runner cutover. Pong's normal
+demo target now builds from the generic SDL3D runner source with embedded Pong
+assets and a default root data asset. The deprecated `demos/pong/main.c`
+compatibility host remains available only through the opt-in
+`SDL3D_BUILD_PONG_LEGACY_HOST` CMake option while parity is verified.
 
 ## Current Status
 
@@ -20,23 +21,24 @@ Pong gameplay is now substantially data driven:
   dynamic-list, runtime-collection, and network data actions
 - no native UI context remains in `demos/pong/main.c`
 
-The remaining Pong C is no longer gameplay-rule code. It is mostly a custom
-runtime host that wires generic engine systems together for this one demo.
+The remaining Pong C is no longer part of the normal demo path and is not
+gameplay-rule code. It is retained as a temporary compatibility host for
+comparison and debugging.
 
 ## Remaining C Surface
 
-`demos/pong/main.c` is still large because it owns several responsibilities that
-should move behind reusable engine/runtime APIs.
+`demos/pong/main.c` is still large because it preserves the old custom host.
+The normal `pong_demo` executable no longer compiles it.
 
 ### SDL Process And Asset Bootstrap
 
-The file still creates the SDL3D game config, mounts embedded/pack/directory
-assets, loads `asset://pong.game.json`, initializes caches, starts text input,
-and calls `sdl3d_game_run`.
+The compatibility host still creates the SDL3D game config, mounts
+embedded/pack/directory assets, loads `asset://pong.game.json`, initializes
+caches, starts text input, and calls `sdl3d_game_run`.
 
-This is generic runner work. A reusable SDL3D runtime should accept a game data
-asset path or pack path, load app/window/audio settings from game data, mount
-assets, and run without game-specific C.
+This work has moved to `sdl3d_runner` and `sdl3d_data_game_runtime`. The
+normal `pong_demo` target supplies only build-time defaults: embedded Pong
+assets and `asset://pong.game.json`.
 
 ### Generic Data Game Loop
 
@@ -45,24 +47,23 @@ longer owns asset resolver creation, game-data loading, app-flow/frame state,
 presentation caches, haptics policy wiring, or authored frame rendering
 directly.
 
-`pong_tick`, `pong_pause_tick`, `pong_render`, and `pong_shutdown` still exist,
-but they are now compatibility callbacks around generic runtime calls plus
-Pong's remaining network orchestration:
+`pong_tick`, `pong_pause_tick`, `pong_render`, and `pong_shutdown` still exist
+only in the deprecated compatibility host. The generic runner now owns the
+normal Pong loop through `sdl3d_data_game_runtime`.
 
 - input profile hotplug refresh
 - network session updates
 - game-data frame update/render
 - cleanup for remaining session state
 
-These should become a managed data-game loop in the engine runtime. A game
-package should opt into standard phases and policies from JSON instead of
-implementing per-game callbacks.
+Games opt into standard phases and policies from JSON instead of implementing
+per-game callbacks.
 
 ### Managed Network Session Orchestration
 
-Pong's legacy host still contains multiplayer session orchestration, but the
-generic data-game runtime now has an opt-in managed network path that covers
-this responsibility for `sdl3d_runner`:
+Pong's legacy host still contains old multiplayer session orchestration, but
+the generic data-game runtime now has an opt-in managed network path that
+covers this responsibility for `sdl3d_runner` and the normal `pong_demo`:
 
 - host session creation/destruction and lobby state publishing
 - direct-connect session lifetime and status publishing
@@ -82,12 +83,9 @@ by authored `network.session_flow`, `network.runtime_bindings`, and
 
 ### Runtime State Publication
 
-Pong C still publishes scene-state values for host lobby status, direct-connect
-status, match termination messages, and network role/flow handoff.
-
-These are generic UI/runtime status concepts. The runner should provide data
-actions or managed bindings for session status, peer lists, selected peers,
-termination reasons, and return scenes.
+Runtime state publication for host lobby status, direct-connect status, match
+termination messages, and network role/flow handoff now runs through authored
+data actions and managed runtime bindings in the normal runner path.
 
 ### Diagnostic Logging
 
@@ -98,15 +96,14 @@ log level, session-state inclusion, and message template.
 
 ## Remaining Pong-Specific C Literals
 
-The remaining `PONG_*` constants in the compatibility host are mostly semantic runtime binding names such
-as `state_snapshot`, `client_input`, `start_game`, `pause_request`, and
-`direct_connect`. They are not hard-coded actor/property packet schemas, but
-they still prove that the current binary is a Pong host rather than a generic
-runner.
+The remaining `PONG_*` constants in the compatibility host are mostly semantic
+runtime binding names such as `state_snapshot`, `client_input`, `start_game`,
+`pause_request`, and `direct_connect`. They are not hard-coded actor/property
+packet schemas, and they no longer affect the normal `pong_demo` binary.
 
 The generic runner now uses standard semantic binding names defined by the
-engine. The remaining task is replacing the demo binary path with the runner
-path and deleting the compatibility host when parity has been verified.
+engine. The remaining task is deleting the compatibility host when parity has
+been verified.
 
 ## No Longer Blocking JSON/Lua Authorship
 
@@ -123,16 +120,15 @@ systems:
 
 ## Next Practical Step
 
-Verify full Pong parity through `sdl3d_runner`, then convert `demos/pong` to
-launch through the generic runner or keep only a tiny build-time wrapper for
-asset defaults.
+Verify full Pong parity through the runner-backed `pong_demo`, then remove the
+deprecated custom host and its opt-in CMake target.
 
 ## Definition Of Done For Pong Without `main.c`
 
 Pong can be considered JSON/Lua-only when:
 
 - the same generic runner binary can launch Pong from a pack or directory
-- Pong has no custom C callback table
+- the normal Pong demo path has no custom C callback table
 - standard single-player, local multiplayer, direct connect, LAN discovery,
   options, pause, haptics, audio, and rendering behavior still work
 - Pong-specific gameplay behavior remains in `demos/pong/data/scripts/pong.lua`

--- a/tools/sdl3d_runner.c
+++ b/tools/sdl3d_runner.c
@@ -12,8 +12,14 @@
 #include "sdl3d/sdl3d.h"
 
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
-extern const unsigned char sdl3d_runner_embedded_assets[];
-extern const size_t sdl3d_runner_embedded_assets_size;
+#if !defined(SDL3D_RUNNER_EMBEDDED_ASSETS_DATA)
+#define SDL3D_RUNNER_EMBEDDED_ASSETS_DATA sdl3d_runner_embedded_assets
+#endif
+#if !defined(SDL3D_RUNNER_EMBEDDED_ASSETS_SIZE)
+#define SDL3D_RUNNER_EMBEDDED_ASSETS_SIZE sdl3d_runner_embedded_assets_size
+#endif
+extern const unsigned char SDL3D_RUNNER_EMBEDDED_ASSETS_DATA[];
+extern const size_t SDL3D_RUNNER_EMBEDDED_ASSETS_SIZE;
 #endif
 
 typedef enum runner_mount_kind
@@ -62,28 +68,38 @@ static bool parse_args(int argc, char **argv, runner_state *state)
 #if defined(SDL3D_MEDIA_DIR)
     state->media_dir = SDL3D_MEDIA_DIR;
 #endif
+#if defined(SDL3D_RUNNER_DEFAULT_DATA_ASSET_PATH)
+    state->data_asset_path = SDL3D_RUNNER_DEFAULT_DATA_ASSET_PATH;
+#endif
+#if defined(SDL3D_RUNNER_DEFAULT_EMBEDDED) && defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
+    state->mount_kind = RUNNER_MOUNT_EMBEDDED;
+#endif
 
+    bool explicit_mount = false;
     for (int i = 1; i < argc; ++i)
     {
         if (SDL_strcmp(argv[i], "--root") == 0 && i + 1 < argc)
         {
-            if (state->mount_kind != RUNNER_MOUNT_NONE)
+            if (explicit_mount)
                 return false;
+            explicit_mount = true;
             state->mount_kind = RUNNER_MOUNT_DIRECTORY;
             state->mount_path = argv[++i];
         }
         else if (SDL_strcmp(argv[i], "--pack") == 0 && i + 1 < argc)
         {
-            if (state->mount_kind != RUNNER_MOUNT_NONE)
+            if (explicit_mount)
                 return false;
+            explicit_mount = true;
             state->mount_kind = RUNNER_MOUNT_PACK;
             state->mount_path = argv[++i];
         }
         else if (SDL_strcmp(argv[i], "--embedded") == 0)
         {
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
-            if (state->mount_kind != RUNNER_MOUNT_NONE)
+            if (explicit_mount)
                 return false;
+            explicit_mount = true;
             state->mount_kind = RUNNER_MOUNT_EMBEDDED;
 #else
             return false;
@@ -129,8 +145,8 @@ static bool runner_mount_assets(sdl3d_asset_resolver *assets, void *userdata, ch
         return sdl3d_asset_resolver_mount_pack_file(assets, state->mount_path, error_buffer, error_buffer_size);
     case RUNNER_MOUNT_EMBEDDED:
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
-        return sdl3d_asset_resolver_mount_memory_pack(assets, sdl3d_runner_embedded_assets,
-                                                      sdl3d_runner_embedded_assets_size, "sdl3d_runner.embedded",
+        return sdl3d_asset_resolver_mount_memory_pack(assets, SDL3D_RUNNER_EMBEDDED_ASSETS_DATA,
+                                                      SDL3D_RUNNER_EMBEDDED_ASSETS_SIZE, "sdl3d_runner.embedded",
                                                       error_buffer, error_buffer_size);
 #else
         runner_set_error(error_buffer, error_buffer_size, "runner was not built with embedded assets");


### PR DESCRIPTION
## Summary

- build the normal `pong_demo` executable from the generic `sdl3d_runner` source with embedded Pong assets and a default `asset://pong.game.json`
- keep the deprecated custom Pong C host behind opt-in `SDL3D_BUILD_PONG_LEGACY_HOST` as `pong_legacy_demo`
- let embedded runner builds override the embedded asset symbol and provide default launch args
- update runner/Pong docs to describe the runner-backed demo path

## Verification

- `cmake --build build/debug --target pong_demo sdl3d_runner -j 8`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/demos/pong/pong_demo --help`
- smoke-launched `./build/debug/demos/pong/pong_demo` with no args and terminated it after startup logs confirmed `SDL3D runner loaded data asset: asset://pong.game.json`
- `git diff --check`

Closes the runner cutover slice of #210.