### PR TITLE
Document data-only game contract

### DIFF
--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -175,7 +175,7 @@ work that should move into reusable data-driven systems.
 
 ## Why This Matters
 
-This API is a stepping stone toward fully data-only games. Once network session
-transition/termination policy is also managed by the engine runtime, a package
-such as Pong should be able to ship as JSON, Lua, and assets rather than as a
-custom C program linked against SDL3D.
+This API is the runtime foundation for data-only games. Pong's normal demo path
+now ships as JSON, Lua, and assets loaded by the generic runner rather than as a
+custom Pong C program. See [Data-Only Games](data-only-games.md) for the
+authoring contract and parity checklist.

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -1,0 +1,123 @@
+# Data-Only Games
+
+SDL3D's data-only target is that a game can ship as JSON, Lua, and assets
+loaded by the generic engine runner. The game should not need a custom
+`my_game/main.c` unless it is proving a new engine feature or integrating a
+platform service the engine does not yet expose.
+
+## Runtime Contract
+
+The generic runner owns process-level behavior:
+
+- SDL window and renderer creation from authored app/window config.
+- Asset mounting from a development directory, `.sdl3dpak`, or embedded pack.
+- Root game JSON loading.
+- Fixed/update/pause/render callback ownership.
+- Input snapshots, text input, and gamepad hotplug refresh.
+- Audio frame updates and authored audio actions.
+- Haptics policy wiring.
+- Managed network session loops when the game opts in with authored data.
+- Ordered shutdown.
+
+The runner must stay game-agnostic. It may accept build-time defaults such as
+an embedded asset symbol or root `asset://game.json` path, but it must not know
+the game's scenes, actors, input actions, replication channels, control
+messages, rules, scores, or UI labels.
+
+## JSON Responsibilities
+
+JSON is for reusable engine primitives and authored composition:
+
+- app, window, renderer, storage, and audio defaults
+- scenes, transitions, menus, widgets, text entry, and dynamic lists
+- actors, components, cameras, lights, sprites, materials, and effects
+- input actions, bindings, profiles, and device-assignment policy
+- sensors, timers, signal bindings, and generic logic actions
+- options screens and settings reset/default behavior
+- persistence declarations and authored save/cache paths
+- network protocol, replication schemas, control messages, runtime bindings,
+  session-flow events, keep-alive scenes, and diagnostics policy
+
+If an author can express behavior by connecting existing primitives, it belongs
+in JSON rather than host C.
+
+## Lua Responsibilities
+
+Lua is for game-exclusive rules or calculations that should not become engine
+policy:
+
+- scoring rules and win/lose conditions
+- enemy or CPU decision logic
+- serve/randomization rules
+- game-specific collision responses or movement math
+- level-specific scripts
+- save-game interpretation and game-specific persistence payloads
+
+Lua should call engine APIs through stable adapter contexts and keep reusable
+systems reusable. If the same script pattern becomes common across multiple
+games, promote the underlying primitive into JSON-backed engine behavior.
+
+## When C Is Still Appropriate
+
+C changes are appropriate when the game needs a new reusable engine capability:
+
+- a new renderer/world model, such as tile maps, sectors, brush worlds, or open
+  world streaming
+- a new asset loader or compression/encryption primitive
+- a new platform subsystem such as achievements, platform user identity, or
+  store integration
+- a new generic UI widget, input device feature, audio feature, or network
+  transport feature
+- a performance-critical reusable primitive that Lua cannot reasonably provide
+
+Once implemented, the feature should be consumed from JSON and Lua by all games
+that need it.
+
+## Pong Status
+
+Pong is now the reference data-only game:
+
+- normal `pong_demo` builds from `tools/sdl3d_runner.c`
+- Pong's embedded assets and `asset://pong.game.json` are build-time defaults
+- Pong gameplay rules are authored in `demos/pong/data/scripts/pong.lua`
+- scenes, options, input, audio, haptics, rendering, networking, diagnostics,
+  and app flow are authored in JSON
+- `demos/pong/main.c` remains only as an opt-in legacy compatibility host
+
+Run Pong through the generic runner from a directory:
+
+```sh
+build/debug/sdl3d_runner --root demos/pong/data --data asset://pong.game.json
+```
+
+Run Pong through a pack file:
+
+```sh
+build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json
+```
+
+Run the default embedded demo target:
+
+```sh
+build/debug/demos/pong/pong_demo
+```
+
+## Parity Checklist
+
+Before deleting a legacy host, validate the runner-backed game path:
+
+- startup loads the root game JSON and first scene
+- splash/title/attract flow works
+- single-player gameplay works
+- local multiplayer input assignment works
+- options menus, input rebinding, audio sliders, and display settings work
+- pause/resume/title exit paths work
+- LAN direct connect and LAN discovery work
+- host/client enter the same network play scene
+- network input, snapshots, pause, termination, and disconnect handling work
+- audio and haptics policies still trigger where platform support exists
+- pack-file and embedded asset launch paths both work
+
+Automated tests should cover reusable primitives and headless multiplayer
+logic. Manual parity passes are still useful for audio, haptics, and
+cross-machine LAN behavior.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -559,8 +559,10 @@ window and audio examples.
 
 For a project-oriented adoption checklist and a minimal reference game file,
 see [docs/standard-options.md](standard-options.md).
-For a concise new-game checklist that mirrors the Pong template structure,
-see [docs/pong-template-checklist.md](pong-template-checklist.md).
+For the JSON/Lua/runner authoring contract, see
+[docs/data-only-games.md](data-only-games.md). For a concise new-game checklist
+that mirrors the Pong template structure, see
+[docs/pong-template-checklist.md](pong-template-checklist.md).
 
 Standard display properties:
 
@@ -2003,7 +2005,10 @@ Validation warnings are non-fatal by default. Tooling can set `treat_warnings_as
 
 ## Pong Data Proof
 
-`demos/pong/data/pong.game.json` is the first concrete file using this format. It is loaded by the Pong demo through `sdl3d_game_data_load_file()`, which instantiates the authored actors, input actions, signals, timers, sensors, and bindings into the managed game session.
+`demos/pong/data/pong.game.json` is the first concrete file using this format.
+The normal Pong demo path loads it through the generic `sdl3d_runner` and
+`sdl3d_data_game_runtime`, which instantiate the authored actors, input
+actions, signals, timers, sensors, and bindings into the managed game session.
 
 - fixed-screen non-sector world
 - player and CPU paddles
@@ -2020,7 +2025,11 @@ Pong keeps specialized math and policy in Lua adapters loaded from `demos/pong/d
 - `adapter.pong.reflect_from_paddle`
 - `adapter.pong.cpu_track_ball`
 
-The JSON decides when those adapters run and handles the ordinary composition around them, such as score increments, round reset, serve timers, camera toggles, and goal/wall/contact sensors. The Pong executable does not register Pong-specific C rule callbacks; its C code owns presentation, rendering, and process lifecycle.
+The JSON decides when those adapters run and handles the ordinary composition
+around them, such as score increments, round reset, serve timers, camera
+toggles, and goal/wall/contact sensors. The normal Pong executable does not
+register Pong-specific C rule callbacks or own a custom callback table; it is a
+runner-backed data game.
 
 ## Loader Acceptance Criteria
 

--- a/docs/pong-template-checklist.md
+++ b/docs/pong-template-checklist.md
@@ -65,4 +65,8 @@ If the template is healthy, a new arcade demo should be able to start with:
 - a small set of scene JSON files
 - one or more Lua scripts
 - mostly assets and authored data
-- only a thin amount of host code for true engine integration points
+- no game-specific host code when the generic runner covers the needed systems
+
+Custom C should mean the game has discovered a missing reusable engine feature.
+After that feature lands, expose it through JSON/Lua so future games do not
+need their own host code for the same behavior.

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -340,8 +340,8 @@ static const char *managed_network_scene_state_string(const sdl3d_data_game_runt
 {
     const sdl3d_properties *scene_state =
         runtime != NULL && runtime->data != NULL ? sdl3d_game_data_scene_state(runtime->data) : NULL;
-    const char *key = managed_network_session_state_key(runtime, key_name, key_name);
-    return scene_state != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
+    const char *key = managed_network_session_state_key(runtime, key_name, NULL);
+    return scene_state != NULL && key != NULL ? sdl3d_properties_get_string(scene_state, key, fallback) : fallback;
 }
 
 static bool managed_network_active_scene_is(const sdl3d_data_game_runtime *runtime, const char *scene_name,
@@ -355,7 +355,7 @@ static bool managed_network_active_scene_is(const sdl3d_data_game_runtime *runti
 
 static bool managed_network_is_play_scene(const sdl3d_data_game_runtime *runtime)
 {
-    return managed_network_active_scene_is(runtime, "play", "scene.play");
+    return managed_network_active_scene_is(runtime, "play", NULL);
 }
 
 static bool managed_network_keep_alive_scene_matches(const sdl3d_data_game_runtime *runtime, const char *session_name)
@@ -369,23 +369,24 @@ static bool managed_network_keep_alive_scene_matches(const sdl3d_data_game_runti
 static bool managed_network_is_network_match(const sdl3d_data_game_runtime *runtime)
 {
     const char *match_mode = managed_network_scene_state_string(runtime, "match_mode", NULL);
-    return match_mode != NULL &&
-           SDL_strcmp(match_mode, managed_network_session_state_value(runtime, "match_mode", "network", "lan")) == 0;
+    const char *network_value = managed_network_session_state_value(runtime, "match_mode", "network", NULL);
+    return match_mode != NULL && network_value != NULL && SDL_strcmp(match_mode, network_value) == 0;
 }
 
 static bool managed_network_is_role_host(const sdl3d_data_game_runtime *runtime)
 {
-    const char *network_role = managed_network_scene_state_string(runtime, "network_role", "none");
-    return managed_network_is_network_match(runtime) &&
-           SDL_strcmp(network_role, managed_network_session_state_value(runtime, "network_role", "host", "host")) == 0;
+    const char *network_role = managed_network_scene_state_string(runtime, "network_role", NULL);
+    const char *host_value = managed_network_session_state_value(runtime, "network_role", "host", NULL);
+    return managed_network_is_network_match(runtime) && network_role != NULL && host_value != NULL &&
+           SDL_strcmp(network_role, host_value) == 0;
 }
 
 static bool managed_network_is_role_client(const sdl3d_data_game_runtime *runtime)
 {
-    const char *network_role = managed_network_scene_state_string(runtime, "network_role", "none");
-    return managed_network_is_network_match(runtime) &&
-           SDL_strcmp(network_role, managed_network_session_state_value(runtime, "network_role", "client", "client")) ==
-               0;
+    const char *network_role = managed_network_scene_state_string(runtime, "network_role", NULL);
+    const char *client_value = managed_network_session_state_value(runtime, "network_role", "client", NULL);
+    return managed_network_is_network_match(runtime) && network_role != NULL && client_value != NULL &&
+           SDL_strcmp(network_role, client_value) == 0;
 }
 
 static int managed_network_action_id(const sdl3d_data_game_runtime *runtime, const char *binding_name)
@@ -465,10 +466,10 @@ static void managed_network_publish_host_status(sdl3d_data_game_runtime *runtime
 
     (void)sdl3d_game_data_network_host_publish_status(
         runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION,
-        managed_network_scene_state_key(runtime, "host", "status", "multiplayer_host_status"),
-        managed_network_scene_state_key(runtime, "host", "endpoint", "multiplayer_host_endpoint"),
-        managed_network_scene_state_key(runtime, "host", "peer", "multiplayer_host_client"),
-        managed_network_scene_state_key(runtime, "host", "connected", "multiplayer_host_connected"));
+        managed_network_scene_state_key(runtime, "host", "status", NULL),
+        managed_network_scene_state_key(runtime, "host", "endpoint", NULL),
+        managed_network_scene_state_key(runtime, "host", "peer", NULL),
+        managed_network_scene_state_key(runtime, "host", "connected", NULL));
 }
 
 static void managed_network_cancel_host(sdl3d_data_game_runtime *runtime, bool notify_peer, const char *status)
@@ -484,13 +485,12 @@ static void managed_network_cancel_host(sdl3d_data_game_runtime *runtime, bool n
         (void)managed_network_send_control_repeated(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT,
                                                     "host disconnect", 5);
     }
-    (void)sdl3d_game_data_network_host_cancel(
-        runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION,
-        managed_network_scene_state_key(runtime, "host", "status", "multiplayer_host_status"),
-        managed_network_scene_state_key(runtime, "host", "endpoint", "multiplayer_host_endpoint"),
-        managed_network_scene_state_key(runtime, "host", "peer", "multiplayer_host_client"),
-        managed_network_scene_state_key(runtime, "host", "connected", "multiplayer_host_connected"),
-        status != NULL ? status : "Not hosting");
+    (void)sdl3d_game_data_network_host_cancel(runtime->data, SDL3D_MANAGED_NETWORK_HOST_SESSION,
+                                              managed_network_scene_state_key(runtime, "host", "status", NULL),
+                                              managed_network_scene_state_key(runtime, "host", "endpoint", NULL),
+                                              managed_network_scene_state_key(runtime, "host", "peer", NULL),
+                                              managed_network_scene_state_key(runtime, "host", "connected", NULL),
+                                              status != NULL ? status : "Not hosting");
 }
 
 static void managed_network_publish_direct_connect_status(sdl3d_data_game_runtime *runtime)
@@ -500,9 +500,9 @@ static void managed_network_publish_direct_connect_status(sdl3d_data_game_runtim
 
     (void)sdl3d_game_data_network_direct_connect_publish_status(
         runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION,
-        managed_network_scene_state_key(runtime, "direct_connect", "status", "direct_connect_status"),
-        managed_network_scene_state_key(runtime, "direct_connect", "state", "direct_connect_state"),
-        managed_network_scene_state_key(runtime, "direct_connect", "connected", "direct_connect_connected"));
+        managed_network_scene_state_key(runtime, "direct_connect", "status", NULL),
+        managed_network_scene_state_key(runtime, "direct_connect", "state", NULL),
+        managed_network_scene_state_key(runtime, "direct_connect", "connected", NULL));
 }
 
 static void managed_network_cancel_direct_connect(sdl3d_data_game_runtime *runtime, bool notify_peer,
@@ -521,9 +521,9 @@ static void managed_network_cancel_direct_connect(sdl3d_data_game_runtime *runti
     }
     (void)sdl3d_game_data_network_direct_connect_cancel(
         runtime->data, SDL3D_MANAGED_NETWORK_DIRECT_CONNECT_SESSION,
-        managed_network_scene_state_key(runtime, "direct_connect", "status", "direct_connect_status"),
-        managed_network_scene_state_key(runtime, "direct_connect", "state", "direct_connect_state"),
-        managed_network_scene_state_key(runtime, "direct_connect", "connected", "direct_connect_connected"),
+        managed_network_scene_state_key(runtime, "direct_connect", "status", NULL),
+        managed_network_scene_state_key(runtime, "direct_connect", "state", NULL),
+        managed_network_scene_state_key(runtime, "direct_connect", "connected", NULL),
         status != NULL ? status : "Disconnected");
 }
 
@@ -617,9 +617,9 @@ static void managed_network_update_termination_ack(sdl3d_data_game_runtime *runt
 {
     const sdl3d_properties *scene_state =
         runtime != NULL && runtime->data != NULL ? sdl3d_game_data_scene_state(runtime->data) : NULL;
-    const char *active_key =
-        managed_network_session_state_key(runtime, "match_termination_active", "network_match_termination_active");
-    const bool active = scene_state != NULL ? sdl3d_properties_get_bool(scene_state, active_key, false) : false;
+    const char *active_key = managed_network_session_state_key(runtime, "match_termination_active", NULL);
+    const bool active =
+        scene_state != NULL && active_key != NULL ? sdl3d_properties_get_bool(scene_state, active_key, false) : false;
 
     if (runtime == NULL || !active)
     {


### PR DESCRIPTION
## Summary

- document the JSON/Lua/runner data-only game contract and Pong parity checklist
- update Pong/runtime docs to reflect that the normal Pong path is runner-backed
- remove managed-network concrete scene/status fallbacks so the generic loop relies on authored `session_flow` and `scene_state` keys instead of Pong names

## Verification

- `cmake --build build/debug --target sdl3d_game_data_test pong_demo sdl3d_runner -j 8`
- `./build/debug/tests/sdl3d_game_data_test`
- smoke-launched `./build/debug/demos/pong/pong_demo` and confirmed runner loaded `asset://pong.game.json`
- smoke-launched `./build/debug/sdl3d_runner --pack build/debug/demos/pong/pong.sdl3dpak --data asset://pong.game.json` and confirmed runner loaded `asset://pong.game.json`
- smoke-launched `./build/debug/sdl3d_runner --root demos/pong/data --data asset://pong.game.json` and confirmed runner loaded `asset://pong.game.json`
- `git diff --check`
