### PR TITLE
Add data-driven actor pools and spawn actions

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1496,7 +1496,8 @@ game-specific host code:
         "velocity": { "type": "vec2", "value": [0.0, 11.0] }
       },
       "output_actor_key": "last_spawned_actor",
-      "output_id_key": "last_spawned_pool_index"
+      "output_id_key": "last_spawned_actor_id",
+      "output_pool_index_key": "last_spawned_pool_index"
     }
   ]
 }
@@ -1506,7 +1507,10 @@ game-specific host code:
 `position` or derived from another actor with `from` plus optional `offset`.
 `properties` is optional and uses the same typed property shape as entity
 defaults. `output_actor_key` and `output_id_key` are optional scene-state
-outputs that receive the spawned actor name and pool index.
+outputs that receive the spawned actor name and actor registry id.
+`output_pool_index_key` receives the selected pool slot index when authored.
+Spawned pooled actors also receive `pool`, `pool_index`, and `pool_scene`
+properties for diagnostics and generic scene filtering.
 
 `actor.despawn` requires `target`. When the target is a pooled actor, the
 runtime resets it to the pool archetype and marks it inactive. Non-pooled

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -33,6 +33,8 @@ Every file is a JSON object with these fields:
 | `transitions` | no | Named screen transition descriptors such as startup and quit fades. |
 | `ui` | no | Authored UI descriptors. |
 | `entities` | yes | Stable named actors with tags, transforms, properties, and components. |
+| `actor_archetypes` | no | Reusable actor templates used by runtime actor pools. |
+| `actor_pools` | no | Preallocated runtime actor pools for deterministic spawn/despawn. |
 | `signals` | no | Authored signal names. |
 | `logic` | no | Sensors, timers, bindings, conditions, and actions. |
 | `adapters` | no | Named game-specific extension points used by logic actions or controllers. |
@@ -1251,6 +1253,60 @@ Entities are the data form of actor registry entries plus optional component own
 Core fields are generic. Components are module-owned and may be ignored by
 runtimes that do not load that module.
 
+### Actor Archetypes And Pools
+
+Games that need runtime-created gameplay objects, such as bullets, enemies,
+pickups, particles, projectiles, hazards, or temporary effects, should use
+`actor_archetypes` plus `actor_pools`. Pools are preallocated during load so
+runtime spawn/despawn is deterministic and does not depend on heap allocation
+in the middle of gameplay.
+
+```json
+{
+  "actor_archetypes": [
+    {
+      "name": "archetype.player_shot",
+      "tags": ["projectile", "player_shot"],
+      "transform": { "position": [0.0, 0.0, 0.12] },
+      "properties": {
+        "velocity": { "type": "vec2", "value": [0.0, 9.0] },
+        "damage": { "type": "int", "value": 1 }
+      },
+      "components": [
+        { "type": "render.sprite", "sprite": "sprite.player_shot" },
+        { "type": "collision.circle", "radius": 0.1 }
+      ]
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.player_shots",
+      "archetype": "archetype.player_shot",
+      "capacity": 24,
+      "scene": "scene.play",
+      "on_exhausted": "fail"
+    }
+  ]
+}
+```
+
+Pool names must be unique. `capacity` must be a positive integer. `scene` is
+optional; when present, pooled actors are considered part of that scene for
+generic scene filtering. `on_exhausted` is optional and defaults to `fail`.
+`reuse_oldest` may be authored when the oldest active pooled actor should be
+reset and reused instead of failing the spawn.
+
+Pool actors receive deterministic runtime names in the form
+`<pool-name>.<index>`, such as `pool.player_shots.0`, and are initialized from
+the archetype with `active=false`. Spawning resets the selected actor from the
+archetype, activates it, applies the requested position and property overrides,
+and writes `pool` and `pool_index` properties for diagnostics. Despawning a
+pooled actor resets it back to its archetype defaults and deactivates it.
+
+The first actor-pool slice supports JSON-authored lifecycle actions. Lua
+helpers, tag-targeted sensors, pooled component iteration in every subsystem,
+and network replication of pooled actor state are planned follow-up work.
+
 ### Presentation Components
 
 The first generic presentation components are deliberately simple descriptors:
@@ -1394,7 +1450,7 @@ and transient flashes without host code.
                                                                                                  and boolean `active`,
     used to include or
         exclude an entity from generic updates and
-                rendering - `transform
+                rendering - `actor.spawn` - `actor.despawn` - `actor.despawn_by_tag` - `transform
                                 .set_position` - `motion
                                                      .set_velocity` - `signal
                                                                           .emit` - `timer
@@ -1421,6 +1477,48 @@ and transient flashes without host code.
         {"type" : "transform.set_position", "target" : "entity.ball", "position" : [ 0, 0, 0.12 ]},
         {"type" : "timer.start", "timer" : "timer.round.serve", "delay" : 1.0, "signal" : "signal.ball.serve"}
     ]
+}
+```
+
+Runtime actor lifecycle actions allocate and release pooled actors without
+game-specific host code:
+
+```json
+{
+  "signal": "signal.player.fire",
+  "actions": [
+    {
+      "type": "actor.spawn",
+      "pool": "pool.player_shots",
+      "from": "entity.player",
+      "offset": [0.0, 0.5, 0.0],
+      "properties": {
+        "velocity": { "type": "vec2", "value": [0.0, 11.0] }
+      },
+      "output_actor_key": "last_spawned_actor",
+      "output_id_key": "last_spawned_pool_index"
+    }
+  ]
+}
+```
+
+`actor.spawn` requires `pool`. Position may be authored directly with
+`position` or derived from another actor with `from` plus optional `offset`.
+`properties` is optional and uses the same typed property shape as entity
+defaults. `output_actor_key` and `output_id_key` are optional scene-state
+outputs that receive the spawned actor name and pool index.
+
+`actor.despawn` requires `target`. When the target is a pooled actor, the
+runtime resets it to the pool archetype and marks it inactive. Non-pooled
+targets are simply marked inactive.
+
+`actor.despawn_by_tag` requires `tag` and deactivates active pooled actors
+whose archetype declares that tag:
+
+```json
+{
+  "type": "actor.despawn_by_tag",
+  "tag": "player_shot"
 }
 ```
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -244,6 +244,25 @@ typedef struct runtime_collection
     int row_capacity;
 } runtime_collection;
 
+typedef enum actor_pool_exhaustion_policy
+{
+    ACTOR_POOL_EXHAUST_FAIL,
+    ACTOR_POOL_EXHAUST_REUSE_OLDEST,
+} actor_pool_exhaustion_policy;
+
+typedef struct actor_pool_runtime
+{
+    char *name;
+    const char *archetype;
+    const char *scene;
+    yyjson_val *archetype_json;
+    char **actor_names;
+    int capacity;
+    int next_reuse;
+    bool initial_active;
+    actor_pool_exhaustion_policy exhaustion;
+} actor_pool_runtime;
+
 typedef struct runtime_direct_connect_session
 {
     char *name;
@@ -340,6 +359,8 @@ typedef struct sdl3d_game_data_runtime
     runtime_collection *collections;
     int collection_count;
     int collection_capacity;
+    actor_pool_runtime *actor_pools;
+    int actor_pool_count;
     runtime_direct_connect_session *direct_connect_sessions;
     int direct_connect_session_count;
     int direct_connect_session_capacity;
@@ -1536,7 +1557,23 @@ static bool scene_has_entity(const scene_entry *scene, const char *entity_name)
 
 static bool active_scene_has_entity_internal(const sdl3d_game_data_runtime *runtime, const char *entity_name)
 {
-    return scene_has_entity(active_scene_entry_const(runtime), entity_name);
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    if (scene_has_entity(scene, entity_name))
+        return true;
+    if (runtime == NULL || scene == NULL || entity_name == NULL)
+        return false;
+    for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+    {
+        const actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+        if (pool->scene == NULL || SDL_strcmp(pool->scene, scene->name) != 0)
+            continue;
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            if (pool->actor_names[actor_index] != NULL && SDL_strcmp(pool->actor_names[actor_index], entity_name) == 0)
+                return true;
+        }
+    }
+    return false;
 }
 
 static void apply_scene_camera(sdl3d_game_data_runtime *runtime, const scene_entry *scene)
@@ -7181,6 +7218,21 @@ static void load_actor_properties(sdl3d_registered_actor *actor, yyjson_val *pro
     }
 }
 
+static void initialize_actor_from_json(sdl3d_registered_actor *actor, yyjson_val *entity, const char *classname,
+                                       bool active)
+{
+    if (actor == NULL)
+        return;
+
+    actor->active = active;
+    sdl3d_properties_clear(actor->props);
+    sdl3d_properties_set_string(actor->props, "classname", classname != NULL ? classname : actor->name);
+
+    yyjson_val *transform = obj_get(entity, "transform");
+    actor_set_position(actor, json_vec3(transform, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    load_actor_properties(actor, obj_get(entity, "properties"));
+}
+
 static bool load_entities(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     sdl3d_actor_registry *registry = runtime_registry(runtime);
@@ -7210,12 +7262,110 @@ static bool load_entities(sdl3d_game_data_runtime *runtime, yyjson_val *root, ch
             set_error(error_buffer, error_buffer_size, "failed to register JSON actor");
             return false;
         }
-        actor->active = json_bool(entity, "active", true);
-        sdl3d_properties_set_string(actor->props, "classname", name);
+        initialize_actor_from_json(actor, entity, name, json_bool(entity, "active", true));
+    }
 
-        yyjson_val *transform = obj_get(entity, "transform");
-        actor_set_position(actor, json_vec3(transform, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
-        load_actor_properties(actor, obj_get(entity, "properties"));
+    return true;
+}
+
+static yyjson_val *find_actor_archetype_json(yyjson_val *root, const char *name)
+{
+    yyjson_val *archetypes = obj_get(root, "actor_archetypes");
+    for (size_t i = 0; yyjson_is_arr(archetypes) && i < yyjson_arr_size(archetypes); ++i)
+    {
+        yyjson_val *archetype = yyjson_arr_get(archetypes, i);
+        const char *archetype_name = json_string(archetype, "name", NULL);
+        if (archetype_name != NULL && name != NULL && SDL_strcmp(archetype_name, name) == 0)
+            return archetype;
+    }
+    return NULL;
+}
+
+static actor_pool_exhaustion_policy actor_pool_exhaustion_from_string(const char *value)
+{
+    if (value != NULL && SDL_strcmp(value, "reuse_oldest") == 0)
+        return ACTOR_POOL_EXHAUST_REUSE_OLDEST;
+    return ACTOR_POOL_EXHAUST_FAIL;
+}
+
+static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active)
+{
+    if (pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
+        return false;
+    initialize_actor_from_json(actor, pool->archetype_json, pool->archetype, active);
+    sdl3d_properties_set_string(actor->props, "pool", pool->name);
+    sdl3d_properties_set_int(actor->props, "pool_index", index);
+    return true;
+}
+
+static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                             int error_buffer_size)
+{
+    sdl3d_actor_registry *registry = runtime_registry(runtime);
+    yyjson_val *pools = obj_get(root, "actor_pools");
+    if (!yyjson_is_arr(pools))
+        return true;
+    if (registry == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "game data actor pools require an actor registry");
+        return false;
+    }
+
+    runtime->actor_pool_count = (int)yyjson_arr_size(pools);
+    runtime->actor_pools =
+        (actor_pool_runtime *)SDL_calloc((size_t)runtime->actor_pool_count, sizeof(*runtime->actor_pools));
+    if (runtime->actor_pools == NULL && runtime->actor_pool_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate actor pools");
+        return false;
+    }
+
+    for (int i = 0; i < runtime->actor_pool_count; ++i)
+    {
+        yyjson_val *pool_json = yyjson_arr_get(pools, (size_t)i);
+        actor_pool_runtime *pool = &runtime->actor_pools[i];
+        const char *name = json_string(pool_json, "name", NULL);
+        const char *archetype = json_string(pool_json, "archetype", NULL);
+        const int capacity = json_int(pool_json, "capacity", 0);
+        yyjson_val *archetype_json = find_actor_archetype_json(root, archetype);
+        if (name == NULL || archetype == NULL || capacity <= 0 || archetype_json == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "invalid actor pool declaration");
+            return false;
+        }
+
+        pool->name = SDL_strdup(name);
+        pool->archetype = archetype;
+        pool->scene = json_string(pool_json, "scene", NULL);
+        pool->archetype_json = archetype_json;
+        pool->capacity = capacity;
+        pool->initial_active = json_bool(pool_json, "initial_active", false);
+        pool->exhaustion = actor_pool_exhaustion_from_string(json_string(pool_json, "on_exhausted", "fail"));
+        pool->actor_names = (char **)SDL_calloc((size_t)capacity, sizeof(*pool->actor_names));
+        if (pool->name == NULL || pool->actor_names == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate actor pool entries");
+            return false;
+        }
+
+        for (int actor_index = 0; actor_index < capacity; ++actor_index)
+        {
+            char actor_name[256];
+            SDL_snprintf(actor_name, sizeof(actor_name), "%s.%d", name, actor_index);
+            sdl3d_registered_actor *actor = sdl3d_actor_registry_add(registry, actor_name);
+            if (actor == NULL)
+            {
+                set_error(error_buffer, error_buffer_size, "failed to register pooled actor");
+                return false;
+            }
+            pool->actor_names[actor_index] = SDL_strdup(actor_name);
+            if (pool->actor_names[actor_index] == NULL ||
+                !initialize_pooled_actor(pool, actor, actor_index, pool->initial_active))
+            {
+                set_error(error_buffer, error_buffer_size, "failed to initialize pooled actor");
+                return false;
+            }
+        }
     }
 
     return true;
@@ -9857,6 +10007,184 @@ static bool reset_actor_properties_to_authored_defaults(sdl3d_game_data_runtime 
     return true;
 }
 
+static actor_pool_runtime *find_actor_pool(sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->actor_pool_count; ++i)
+    {
+        if (runtime->actor_pools[i].name != NULL && SDL_strcmp(runtime->actor_pools[i].name, name) == 0)
+            return &runtime->actor_pools[i];
+    }
+    return NULL;
+}
+
+static int actor_pool_index_for_actor(const actor_pool_runtime *pool, const char *actor_name)
+{
+    if (pool == NULL || actor_name == NULL)
+        return -1;
+    for (int i = 0; i < pool->capacity; ++i)
+    {
+        if (pool->actor_names[i] != NULL && SDL_strcmp(pool->actor_names[i], actor_name) == 0)
+            return i;
+    }
+    return -1;
+}
+
+static actor_pool_runtime *find_actor_pool_for_actor(sdl3d_game_data_runtime *runtime, const char *actor_name,
+                                                     int *out_index)
+{
+    if (out_index != NULL)
+        *out_index = -1;
+    if (runtime == NULL || actor_name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->actor_pool_count; ++i)
+    {
+        const int index = actor_pool_index_for_actor(&runtime->actor_pools[i], actor_name);
+        if (index >= 0)
+        {
+            if (out_index != NULL)
+                *out_index = index;
+            return &runtime->actor_pools[i];
+        }
+    }
+    return NULL;
+}
+
+static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                                   int *out_index)
+{
+    if (out_index != NULL)
+        *out_index = -1;
+    if (runtime == NULL || pool == NULL)
+        return NULL;
+
+    for (int i = 0; i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor != NULL && !actor->active)
+        {
+            if (out_index != NULL)
+                *out_index = i;
+            if (pool->capacity > 0)
+                pool->next_reuse = (i + 1) % pool->capacity;
+            return actor;
+        }
+    }
+
+    if (pool->exhaustion != ACTOR_POOL_EXHAUST_REUSE_OLDEST || pool->capacity <= 0)
+        return NULL;
+
+    const int index = SDL_clamp(pool->next_reuse, 0, pool->capacity - 1);
+    pool->next_reuse = (index + 1) % pool->capacity;
+    if (out_index != NULL)
+        *out_index = index;
+    return sdl3d_game_data_find_actor(runtime, pool->actor_names[index]);
+}
+
+static void apply_actor_spawn_properties(sdl3d_registered_actor *actor, yyjson_val *properties)
+{
+    if (actor == NULL || !yyjson_is_obj(properties))
+        return;
+
+    yyjson_val *key;
+    yyjson_val *value;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(properties, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        value = yyjson_obj_iter_get_val(key);
+        if (name != NULL)
+            set_actor_property_from_json(actor, name, value);
+    }
+}
+
+static sdl3d_vec3 actor_spawn_position_from_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   sdl3d_vec3 fallback)
+{
+    sdl3d_vec3 position = fallback;
+    yyjson_val *position_json = obj_get(action, "position");
+    if (position_json != NULL)
+        position = json_vec3_value(position_json, position);
+
+    const char *from_actor_name = json_string(action, "from", NULL);
+    sdl3d_registered_actor *from_actor = sdl3d_game_data_find_actor(runtime, from_actor_name);
+    if (from_actor != NULL)
+        position = from_actor->position;
+
+    yyjson_val *offset_json = obj_get(action, "offset");
+    if (offset_json != NULL)
+    {
+        const sdl3d_vec3 offset = json_vec3_value(offset_json, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        position.x += offset.x;
+        position.y += offset.y;
+        position.z += offset.z;
+    }
+    return position;
+}
+
+static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    actor_pool_runtime *pool = find_actor_pool(runtime, json_string(action, "pool", NULL));
+    int actor_index = -1;
+    sdl3d_registered_actor *actor = actor_pool_allocate(runtime, pool, &actor_index);
+    if (pool == NULL || actor == NULL || actor_index < 0)
+        return false;
+
+    if (!initialize_pooled_actor(pool, actor, actor_index, true))
+        return false;
+    actor_set_position(actor, actor_spawn_position_from_action(runtime, action, actor->position));
+    apply_actor_spawn_properties(actor, obj_get(action, "properties"));
+
+    const char *actor_key = json_string(action, "output_actor_key", NULL);
+    if (runtime != NULL && runtime->scene_state != NULL && actor_key != NULL)
+        sdl3d_properties_set_string(runtime->scene_state, actor_key, actor->name);
+    const char *id_key = json_string(action, "output_id_key", NULL);
+    if (runtime != NULL && runtime->scene_state != NULL && id_key != NULL)
+        sdl3d_properties_set_int(runtime->scene_state, id_key, actor->id);
+    return true;
+}
+
+static bool execute_actor_despawn_action(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", NULL);
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    if (actor == NULL)
+        return false;
+
+    int actor_index = -1;
+    actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
+    if (pool != NULL && actor_index >= 0)
+        return initialize_pooled_actor(pool, actor, actor_index, false);
+
+    actor->active = false;
+    return true;
+}
+
+static bool execute_actor_despawn_by_tag_action(sdl3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *tag = json_string(action, "tag", NULL);
+    if (runtime == NULL || tag == NULL || tag[0] == '\0')
+        return false;
+
+    for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+    {
+        actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+        if (!entity_json_has_tags(pool->archetype_json, &tag, 1))
+            continue;
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+            if (actor != NULL && actor->active)
+            {
+                (void)initialize_pooled_actor(pool, actor, actor_index, false);
+            }
+        }
+    }
+    return true;
+}
+
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
@@ -10101,6 +10429,15 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         actor->active = yyjson_get_bool(active);
         return true;
     }
+
+    if (SDL_strcmp(type, "actor.spawn") == 0)
+        return execute_actor_spawn_action(runtime, action);
+
+    if (SDL_strcmp(type, "actor.despawn") == 0)
+        return execute_actor_despawn_action(runtime, action);
+
+    if (SDL_strcmp(type, "actor.despawn_by_tag") == 0)
+        return execute_actor_despawn_by_tag_action(runtime, action);
 
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {
@@ -11446,6 +11783,7 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
     load_active_camera(runtime, root);
     bool ok = load_signals(runtime, root, error_buffer, error_buffer_size) &&
               load_entities(runtime, root, error_buffer, error_buffer_size) &&
+              load_actor_pools(runtime, root, error_buffer, error_buffer_size) &&
               load_input(runtime, root, error_buffer, error_buffer_size) &&
               load_timers(runtime, logic, error_buffer, error_buffer_size) && load_sensors(runtime, logic) &&
               load_scripts(runtime, root, error_buffer, error_buffer_size) &&
@@ -13345,6 +13683,13 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
             sdl3d_properties_destroy(runtime->collections[i].rows[row]);
         SDL_free(runtime->collections[i].rows);
     }
+    for (int i = 0; i < runtime->actor_pool_count; ++i)
+    {
+        SDL_free(runtime->actor_pools[i].name);
+        for (int actor_index = 0; actor_index < runtime->actor_pools[i].capacity; ++actor_index)
+            SDL_free(runtime->actor_pools[i].actor_names[actor_index]);
+        SDL_free(runtime->actor_pools[i].actor_names);
+    }
     for (int i = 0; i < runtime->direct_connect_session_count; ++i)
     {
         SDL_free(runtime->direct_connect_sessions[i].name);
@@ -13384,6 +13729,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->audio_files);
     SDL_free(runtime->property_snapshots);
     SDL_free(runtime->collections);
+    SDL_free(runtime->actor_pools);
     SDL_free(runtime->direct_connect_sessions);
     SDL_free(runtime->host_sessions);
     SDL_free(runtime->discovery_sessions);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -257,8 +257,9 @@ typedef struct actor_pool_runtime
     const char *scene;
     yyjson_val *archetype_json;
     char **actor_names;
+    Uint64 *spawn_generations;
+    Uint64 spawn_generation_counter;
     int capacity;
-    int next_reuse;
     bool initial_active;
     actor_pool_exhaustion_policy exhaustion;
 } actor_pool_runtime;
@@ -1562,18 +1563,9 @@ static bool active_scene_has_entity_internal(const sdl3d_game_data_runtime *runt
         return true;
     if (runtime == NULL || scene == NULL || entity_name == NULL)
         return false;
-    for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
-    {
-        const actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
-        if (pool->scene == NULL || SDL_strcmp(pool->scene, scene->name) != 0)
-            continue;
-        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
-        {
-            if (pool->actor_names[actor_index] != NULL && SDL_strcmp(pool->actor_names[actor_index], entity_name) == 0)
-                return true;
-        }
-    }
-    return false;
+    const sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+    const char *pool_scene = actor != NULL ? sdl3d_properties_get_string(actor->props, "pool_scene", NULL) : NULL;
+    return pool_scene != NULL && scene->name != NULL && SDL_strcmp(pool_scene, scene->name) == 0;
 }
 
 static void apply_scene_camera(sdl3d_game_data_runtime *runtime, const scene_entry *scene)
@@ -7295,6 +7287,10 @@ static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_a
     initialize_actor_from_json(actor, pool->archetype_json, pool->archetype, active);
     sdl3d_properties_set_string(actor->props, "pool", pool->name);
     sdl3d_properties_set_int(actor->props, "pool_index", index);
+    if (pool->scene != NULL)
+        sdl3d_properties_set_string(actor->props, "pool_scene", pool->scene);
+    if (!active && pool->spawn_generations != NULL)
+        pool->spawn_generations[index] = 0U;
     return true;
 }
 
@@ -7342,7 +7338,8 @@ static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root,
         pool->initial_active = json_bool(pool_json, "initial_active", false);
         pool->exhaustion = actor_pool_exhaustion_from_string(json_string(pool_json, "on_exhausted", "fail"));
         pool->actor_names = (char **)SDL_calloc((size_t)capacity, sizeof(*pool->actor_names));
-        if (pool->name == NULL || pool->actor_names == NULL)
+        pool->spawn_generations = (Uint64 *)SDL_calloc((size_t)capacity, sizeof(*pool->spawn_generations));
+        if (pool->name == NULL || pool->actor_names == NULL || pool->spawn_generations == NULL)
         {
             set_error(error_buffer, error_buffer_size, "failed to allocate actor pool entries");
             return false;
@@ -7364,6 +7361,12 @@ static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root,
             {
                 set_error(error_buffer, error_buffer_size, "failed to initialize pooled actor");
                 return false;
+            }
+            if (pool->initial_active)
+            {
+                pool->spawn_generations[actor_index] = ++pool->spawn_generation_counter;
+                sdl3d_properties_set_int(actor->props, "pool_spawn_generation",
+                                         (int)SDL_min(pool->spawn_generations[actor_index], (Uint64)SDL_MAX_SINT32));
             }
         }
     }
@@ -10066,8 +10069,6 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
         {
             if (out_index != NULL)
                 *out_index = i;
-            if (pool->capacity > 0)
-                pool->next_reuse = (i + 1) % pool->capacity;
             return actor;
         }
     }
@@ -10075,8 +10076,22 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
     if (pool->exhaustion != ACTOR_POOL_EXHAUST_REUSE_OLDEST || pool->capacity <= 0)
         return NULL;
 
-    const int index = SDL_clamp(pool->next_reuse, 0, pool->capacity - 1);
-    pool->next_reuse = (index + 1) % pool->capacity;
+    int index = -1;
+    Uint64 oldest_generation = SDL_MAX_UINT64;
+    for (int i = 0; i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor == NULL || !actor->active)
+            continue;
+        const Uint64 generation = pool->spawn_generations != NULL ? pool->spawn_generations[i] : 0U;
+        if (index < 0 || generation < oldest_generation)
+        {
+            index = i;
+            oldest_generation = generation;
+        }
+    }
+    if (index < 0)
+        return NULL;
     if (out_index != NULL)
         *out_index = index;
     return sdl3d_game_data_find_actor(runtime, pool->actor_names[index]);
@@ -10134,6 +10149,12 @@ static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_
 
     if (!initialize_pooled_actor(pool, actor, actor_index, true))
         return false;
+    if (pool->spawn_generations != NULL)
+    {
+        pool->spawn_generations[actor_index] = ++pool->spawn_generation_counter;
+        sdl3d_properties_set_int(actor->props, "pool_spawn_generation",
+                                 (int)SDL_min(pool->spawn_generations[actor_index], (Uint64)SDL_MAX_SINT32));
+    }
     actor_set_position(actor, actor_spawn_position_from_action(runtime, action, actor->position));
     apply_actor_spawn_properties(actor, obj_get(action, "properties"));
 
@@ -10143,6 +10164,9 @@ static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_
     const char *id_key = json_string(action, "output_id_key", NULL);
     if (runtime != NULL && runtime->scene_state != NULL && id_key != NULL)
         sdl3d_properties_set_int(runtime->scene_state, id_key, actor->id);
+    const char *pool_index_key = json_string(action, "output_pool_index_key", NULL);
+    if (runtime != NULL && runtime->scene_state != NULL && pool_index_key != NULL)
+        sdl3d_properties_set_int(runtime->scene_state, pool_index_key, actor_index);
     return true;
 }
 
@@ -13689,6 +13713,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         for (int actor_index = 0; actor_index < runtime->actor_pools[i].capacity; ++actor_index)
             SDL_free(runtime->actor_pools[i].actor_names[actor_index]);
         SDL_free(runtime->actor_pools[i].actor_names);
+        SDL_free(runtime->actor_pools[i].spawn_generations);
     }
     for (int i = 0; i < runtime->direct_connect_session_count; ++i)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -51,6 +51,8 @@ typedef struct validation_context
 typedef struct validation_names
 {
     name_table entities;
+    name_table actor_archetypes;
+    name_table actor_pools;
     name_table signals;
     name_table scripts;
     name_table script_modules;
@@ -1816,6 +1818,49 @@ static bool collect_entities(validation_context *ctx, yyjson_val *root, validati
     return true;
 }
 
+static bool collect_actor_archetypes(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *archetypes = obj_get(root, "actor_archetypes");
+    if (archetypes == NULL)
+        return true;
+    if (!yyjson_is_arr(archetypes))
+        return validation_error(ctx, "$.actor_archetypes", "actor_archetypes must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(archetypes); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_archetypes[%zu]", i);
+        yyjson_val *archetype = yyjson_arr_get(archetypes, i);
+        if (!yyjson_is_obj(archetype))
+            return validation_error(ctx, path, "actor archetype entries must be objects");
+        if (!require_unique_name(ctx, &names->actor_archetypes, "actor archetype", json_string(archetype, "name"),
+                                 path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_actor_pools(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *pools = obj_get(root, "actor_pools");
+    if (pools == NULL)
+        return true;
+    if (!yyjson_is_arr(pools))
+        return validation_error(ctx, "$.actor_pools", "actor_pools must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(pools); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_pools[%zu]", i);
+        yyjson_val *pool = yyjson_arr_get(pools, i);
+        if (!yyjson_is_obj(pool))
+            return validation_error(ctx, path, "actor pool entries must be objects");
+        if (!require_unique_name(ctx, &names->actor_pools, "actor pool", json_string(pool, "name"), path))
+            return false;
+    }
+    return true;
+}
+
 static bool collect_cameras(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *cameras = obj_get(obj_get(root, "world"), "cameras");
@@ -2262,6 +2307,7 @@ static bool collect_network_input_channels(validation_context *ctx, yyjson_val *
 static bool collect_names(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
+           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
            collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
            collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
            collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
@@ -2731,6 +2777,54 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
     return true;
 }
 
+static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *archetypes = obj_get(root, "actor_archetypes");
+    for (size_t i = 0; yyjson_is_arr(archetypes) && i < yyjson_arr_size(archetypes); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_archetypes[%zu]", i);
+        yyjson_val *archetype = yyjson_arr_get(archetypes, i);
+        yyjson_val *components = obj_get(archetype, "components");
+        if (components != NULL && !yyjson_is_arr(components))
+            return validation_error(ctx, path, "actor archetype components must be an array");
+        for (size_t c = 0; yyjson_is_arr(components) && c < yyjson_arr_size(components); ++c)
+        {
+            char component_path[PATH_BUFFER_SIZE];
+            format_path(component_path, sizeof(component_path), "%s.components[%zu]", path, c);
+            yyjson_val *component = yyjson_arr_get(components, c);
+            const char *type = json_string(component, "type");
+            if (type == NULL || type[0] == '\0')
+                return validation_error(ctx, component_path, "component requires a non-empty type");
+            if (!is_supported_component_type(type) &&
+                !validation_warning(ctx, component_path, "unsupported component type '%s'", type))
+            {
+                return false;
+            }
+        }
+    }
+
+    yyjson_val *pools = obj_get(root, "actor_pools");
+    for (size_t i = 0; yyjson_is_arr(pools) && i < yyjson_arr_size(pools); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_pools[%zu]", i);
+        yyjson_val *pool = yyjson_arr_get(pools, i);
+        if (!require_ref(ctx, &names->actor_archetypes, "actor archetype", json_string(pool, "archetype"), path))
+            return false;
+        yyjson_val *capacity = obj_get(pool, "capacity");
+        if (!yyjson_is_int(capacity) || yyjson_get_int(capacity) <= 0 || yyjson_get_int(capacity) > 4096)
+            return validation_error(ctx, path, "actor pool capacity must be an integer in 1..4096");
+        const char *scene = json_string(pool, "scene");
+        if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, path))
+            return false;
+        const char *policy = json_string(pool, "on_exhausted");
+        if (policy != NULL && SDL_strcmp(policy, "fail") != 0 && SDL_strcmp(policy, "reuse_oldest") != 0)
+            return validation_error(ctx, path, "actor pool on_exhausted must be fail or reuse_oldest");
+    }
+    return true;
+}
+
 static bool is_tween_easing(const char *easing)
 {
     return easing == NULL || SDL_strcmp(easing, "linear") == 0 || SDL_strcmp(easing, "in_quad") == 0 ||
@@ -2916,6 +3010,31 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             if (!yyjson_is_str(yyjson_arr_get(keys, i)))
                 return validation_error(ctx, json_path, "property.reset_defaults keys must be strings");
         }
+        return true;
+    }
+    if (SDL_strcmp(type, "actor.spawn") == 0)
+    {
+        if (!require_ref(ctx, &names->actor_pools, "actor pool", json_string(action, "pool"), json_path))
+            return false;
+        const char *from = json_string(action, "from");
+        if (from != NULL && !require_ref(ctx, &names->entities, "entity", from, json_path))
+            return false;
+        yyjson_val *properties = obj_get(action, "properties");
+        if (properties != NULL && !yyjson_is_obj(properties))
+            return validation_error(ctx, json_path, "actor.spawn properties must be an object");
+        return true;
+    }
+    if (SDL_strcmp(type, "actor.despawn") == 0)
+    {
+        const char *target = json_string(action, "target");
+        if (target == NULL || target[0] == '\0')
+            return validation_error(ctx, json_path, "actor.despawn requires a non-empty target");
+        return true;
+    }
+    if (SDL_strcmp(type, "actor.despawn_by_tag") == 0)
+    {
+        if (!is_non_empty_string(action, "tag"))
+            return validation_error(ctx, json_path, "actor.despawn_by_tag requires a non-empty tag");
         return true;
     }
     if (SDL_strcmp(type, "input.reset_bindings") == 0)
@@ -4658,8 +4777,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_input_profiles(ctx, root, names) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
-           validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
-           validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
+           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
            validate_lights(ctx, root, names) && validate_haptics(ctx, root, names) &&
            validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
@@ -4675,6 +4794,8 @@ static void validation_names_destroy(validation_names *names)
         SDL_free(names->script_manifests[i].dependencies);
     SDL_free(names->script_manifests);
     name_table_destroy(&names->entities);
+    name_table_destroy(&names->actor_archetypes);
+    name_table_destroy(&names->actor_pools);
     name_table_destroy(&names->signals);
     name_table_destroy(&names->scripts);
     name_table_destroy(&names->script_modules);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -53,6 +53,7 @@ typedef struct validation_names
     name_table entities;
     name_table actor_archetypes;
     name_table actor_pools;
+    name_table actor_pool_actors;
     name_table signals;
     name_table scripts;
     name_table script_modules;
@@ -1855,8 +1856,33 @@ static bool collect_actor_pools(validation_context *ctx, yyjson_val *root, valid
         yyjson_val *pool = yyjson_arr_get(pools, i);
         if (!yyjson_is_obj(pool))
             return validation_error(ctx, path, "actor pool entries must be objects");
-        if (!require_unique_name(ctx, &names->actor_pools, "actor pool", json_string(pool, "name"), path))
+        const char *pool_name = json_string(pool, "name");
+        if (!require_unique_name(ctx, &names->actor_pools, "actor pool", pool_name, path))
             return false;
+        yyjson_val *capacity_json = obj_get(pool, "capacity");
+        if (!yyjson_is_int(capacity_json))
+            continue;
+        const int capacity = yyjson_get_int(capacity_json);
+        if (capacity <= 0 || capacity > 4096)
+            continue;
+        for (int actor_index = 0; actor_index < capacity; ++actor_index)
+        {
+            char actor_name[256];
+            SDL_snprintf(actor_name, sizeof(actor_name), "%s.%d", pool_name, actor_index);
+            if (name_table_contains(&names->entities, actor_name))
+            {
+                return validation_error(ctx, path, "actor pool generated actor '%s' collides with entity at %s",
+                                        actor_name, name_table_path(&names->entities, actor_name));
+            }
+            if (name_table_contains(&names->actor_pool_actors, actor_name))
+            {
+                return validation_error(ctx, path,
+                                        "actor pool generated actor '%s' collides with generated actor at %s",
+                                        actor_name, name_table_path(&names->actor_pool_actors, actor_name));
+            }
+            if (!name_table_add(&names->actor_pool_actors, actor_name, path))
+                return validation_error(ctx, path, "failed to allocate validation name table for actor pool actor");
+        }
     }
     return true;
 }
@@ -3017,8 +3043,13 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (!require_ref(ctx, &names->actor_pools, "actor pool", json_string(action, "pool"), json_path))
             return false;
         const char *from = json_string(action, "from");
-        if (from != NULL && !require_ref(ctx, &names->entities, "entity", from, json_path))
-            return false;
+        if (from != NULL && from[0] == '\0')
+            return validation_error(ctx, json_path, "actor.spawn from requires a non-empty actor reference");
+        if (from != NULL && !name_table_contains(&names->entities, from) &&
+            !name_table_contains(&names->actor_pool_actors, from))
+        {
+            return validation_error(ctx, json_path, "unknown actor.spawn from actor reference '%s'", from);
+        }
         yyjson_val *properties = obj_get(action, "properties");
         if (properties != NULL && !yyjson_is_obj(properties))
             return validation_error(ctx, json_path, "actor.spawn properties must be an object");
@@ -3029,6 +3060,8 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         const char *target = json_string(action, "target");
         if (target == NULL || target[0] == '\0')
             return validation_error(ctx, json_path, "actor.despawn requires a non-empty target");
+        if (!name_table_contains(&names->entities, target) && !name_table_contains(&names->actor_pool_actors, target))
+            return validation_error(ctx, json_path, "unknown actor.despawn target '%s'", target);
         return true;
     }
     if (SDL_strcmp(type, "actor.despawn_by_tag") == 0)
@@ -4796,6 +4829,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->entities);
     name_table_destroy(&names->actor_archetypes);
     name_table_destroy(&names->actor_pools);
+    name_table_destroy(&names->actor_pool_actors);
     name_table_destroy(&names->signals);
     name_table_destroy(&names->scripts);
     name_table_destroy(&names->script_modules);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -5900,6 +5900,270 @@ TEST(GameDataRuntime, LoadsLuaScriptDependenciesBeforeDependentAdapters)
     sdl3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
+{
+    const std::filesystem::path dir = unique_test_dir("actor_pools");
+    write_text(dir / "actor_pools.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Actor Pools", "id": "test.actor_pools", "version": "0.1.0" },
+  "world": { "name": "world.actor_pools", "kind": "fixed_screen" },
+  "entities": [
+    { "name": "entity.player", "transform": { "position": [1.0, 2.0, 3.0] } }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.player_shot",
+      "tags": ["projectile", "player_projectile"],
+      "transform": { "position": [0.0, 0.0, 0.25] },
+      "properties": {
+        "damage": { "type": "int", "value": 1 },
+        "velocity": { "type": "vec2", "value": [0.0, 12.0] }
+      },
+      "components": [
+        { "type": "render.sprite", "sprite": "sprite.player_shot" },
+        { "type": "collision.circle", "radius": 0.08 }
+      ]
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.player_shots",
+      "archetype": "archetype.player_shot",
+      "capacity": 2,
+      "scene": "scene.play",
+      "initial_active": false,
+      "on_exhausted": "fail"
+    },
+    {
+      "name": "pool.reusable_shots",
+      "archetype": "archetype.player_shot",
+      "capacity": 1,
+      "scene": "scene.play",
+      "initial_active": false,
+      "on_exhausted": "reuse_oldest"
+    }
+  ],
+  "signals": [
+    "signal.spawn",
+    "signal.spawn.second",
+    "signal.spawn.reuse",
+    "signal.spawn.reuse.again",
+    "signal.despawn.first",
+    "signal.despawn.projectiles"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          {
+            "type": "actor.spawn",
+            "pool": "pool.player_shots",
+            "from": "entity.player",
+            "offset": [0.5, 0.0, 0.0],
+            "properties": { "damage": 7 },
+            "output_actor_key": "last_actor",
+            "output_id_key": "last_actor_id"
+          }
+        ]
+      },
+      {
+        "signal": "signal.spawn.second",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.player_shots", "position": [4.0, 5.0, 6.0] }
+        ]
+      },
+      {
+        "signal": "signal.spawn.reuse",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.reusable_shots", "position": [7.0, 8.0, 9.0] }
+        ]
+      },
+      {
+        "signal": "signal.spawn.reuse.again",
+        "actions": [
+          {
+            "type": "actor.spawn",
+            "pool": "pool.reusable_shots",
+            "position": [10.0, 11.0, 12.0],
+            "properties": { "damage": 99 }
+          }
+        ]
+      },
+      {
+        "signal": "signal.despawn.first",
+        "actions": [
+          { "type": "actor.despawn", "target": "pool.player_shots.0" }
+        ]
+      },
+      {
+        "signal": "signal.despawn.projectiles",
+        "actions": [
+          { "type": "actor.despawn_by_tag", "tag": "player_projectile" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "actor_pools.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_registered_actor *shot0 = sdl3d_game_data_find_actor(runtime, "pool.player_shots.0");
+    sdl3d_registered_actor *shot1 = sdl3d_game_data_find_actor(runtime, "pool.player_shots.1");
+    sdl3d_registered_actor *reusable_shot = sdl3d_game_data_find_actor(runtime, "pool.reusable_shots.0");
+    ASSERT_NE(shot0, nullptr);
+    ASSERT_NE(shot1, nullptr);
+    ASSERT_NE(reusable_shot, nullptr);
+    EXPECT_FALSE(shot0->active);
+    EXPECT_FALSE(shot1->active);
+    EXPECT_FALSE(reusable_shot->active);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "pool", ""), "pool.player_shots");
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "pool_index", -1), 0);
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn"), nullptr);
+    EXPECT_TRUE(shot0->active);
+    EXPECT_FALSE(shot1->active);
+    expect_vec3_near(shot0->position, sdl3d_vec3_make(1.5f, 2.0f, 3.0f));
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 7);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "last_actor", ""),
+                 "pool.player_shots.0");
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "last_actor_id", -1), shot0->id);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.second"), nullptr);
+    EXPECT_TRUE(shot1->active);
+    expect_vec3_near(shot1->position, sdl3d_vec3_make(4.0f, 5.0f, 6.0f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse"), nullptr);
+    EXPECT_TRUE(reusable_shot->active);
+    expect_vec3_near(reusable_shot->position, sdl3d_vec3_make(7.0f, 8.0f, 9.0f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse.again"), nullptr);
+    EXPECT_TRUE(reusable_shot->active);
+    expect_vec3_near(reusable_shot->position, sdl3d_vec3_make(10.0f, 11.0f, 12.0f));
+    EXPECT_EQ(sdl3d_properties_get_int(reusable_shot->props, "damage", 0), 99);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.first"), nullptr);
+    EXPECT_FALSE(shot0->active);
+    EXPECT_TRUE(shot1->active);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
+    expect_vec3_near(shot0->position, sdl3d_vec3_make(0.0f, 0.0f, 0.25f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.second"), nullptr);
+    EXPECT_TRUE(shot0->active);
+    expect_vec3_near(shot0->position, sdl3d_vec3_make(4.0f, 5.0f, 6.0f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.projectiles"), nullptr);
+    EXPECT_FALSE(shot0->active);
+    EXPECT_FALSE(shot1->active);
+    EXPECT_FALSE(reusable_shot->active);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.projectiles"), nullptr);
+    EXPECT_FALSE(shot0->active);
+    EXPECT_FALSE(shot1->active);
+    EXPECT_FALSE(reusable_shot->active);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
+{
+    const std::filesystem::path dir = unique_test_dir("actor_pool_validation");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play"
+})json");
+
+    struct Case
+    {
+        const char *name;
+        const char *json;
+        const char *message;
+    };
+
+    const Case cases[] = {
+        {
+            "missing_archetype",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "actor_pools": [
+    { "name": "pool.bad", "archetype": "archetype.missing", "capacity": 1 }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "unknown actor archetype",
+        },
+        {
+            "bad_capacity",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "actor_archetypes": [
+    { "name": "archetype.shot" }
+  ],
+  "actor_pools": [
+    { "name": "pool.bad", "archetype": "archetype.shot", "capacity": 0 }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "capacity",
+        },
+        {
+            "bad_spawn_pool",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "signals": ["signal.spawn"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.missing" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "unknown actor pool",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path path = dir / (std::string(test_case.name) + ".game.json");
+        write_text(path, test_case.json);
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.message), std::string::npos) << test_case.name << ": " << error;
+    }
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, LoadsLuaBackedGameDataFromMemoryPack)
 {
     const std::string game_json = read_fixture_file("module_success.game.json");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -5938,7 +5938,7 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
     {
       "name": "pool.reusable_shots",
       "archetype": "archetype.player_shot",
-      "capacity": 1,
+      "capacity": 2,
       "scene": "scene.play",
       "initial_active": false,
       "on_exhausted": "reuse_oldest"
@@ -5948,7 +5948,10 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
     "signal.spawn",
     "signal.spawn.second",
     "signal.spawn.reuse",
+    "signal.spawn.reuse.second",
+    "signal.despawn.reuse.first",
     "signal.spawn.reuse.again",
+    "signal.spawn.reuse.exhausted",
     "signal.despawn.first",
     "signal.despawn.projectiles"
   ],
@@ -5964,7 +5967,8 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
             "offset": [0.5, 0.0, 0.0],
             "properties": { "damage": 7 },
             "output_actor_key": "last_actor",
-            "output_id_key": "last_actor_id"
+            "output_id_key": "last_actor_id",
+            "output_pool_index_key": "last_actor_pool_index"
           }
         ]
       },
@@ -5981,6 +5985,18 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
         ]
       },
       {
+        "signal": "signal.spawn.reuse.second",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.reusable_shots", "position": [8.0, 9.0, 10.0] }
+        ]
+      },
+      {
+        "signal": "signal.despawn.reuse.first",
+        "actions": [
+          { "type": "actor.despawn", "target": "pool.reusable_shots.0" }
+        ]
+      },
+      {
         "signal": "signal.spawn.reuse.again",
         "actions": [
           {
@@ -5989,6 +6005,12 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
             "position": [10.0, 11.0, 12.0],
             "properties": { "damage": 99 }
           }
+        ]
+      },
+      {
+        "signal": "signal.spawn.reuse.exhausted",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.reusable_shots", "position": [13.0, 14.0, 15.0] }
         ]
       },
       {
@@ -6025,15 +6047,19 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
 
     sdl3d_registered_actor *shot0 = sdl3d_game_data_find_actor(runtime, "pool.player_shots.0");
     sdl3d_registered_actor *shot1 = sdl3d_game_data_find_actor(runtime, "pool.player_shots.1");
-    sdl3d_registered_actor *reusable_shot = sdl3d_game_data_find_actor(runtime, "pool.reusable_shots.0");
+    sdl3d_registered_actor *reusable_shot0 = sdl3d_game_data_find_actor(runtime, "pool.reusable_shots.0");
+    sdl3d_registered_actor *reusable_shot1 = sdl3d_game_data_find_actor(runtime, "pool.reusable_shots.1");
     ASSERT_NE(shot0, nullptr);
     ASSERT_NE(shot1, nullptr);
-    ASSERT_NE(reusable_shot, nullptr);
+    ASSERT_NE(reusable_shot0, nullptr);
+    ASSERT_NE(reusable_shot1, nullptr);
     EXPECT_FALSE(shot0->active);
     EXPECT_FALSE(shot1->active);
-    EXPECT_FALSE(reusable_shot->active);
+    EXPECT_FALSE(reusable_shot0->active);
+    EXPECT_FALSE(reusable_shot1->active);
     EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
     EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "pool", ""), "pool.player_shots");
+    EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "pool_scene", ""), "scene.play");
     EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "pool_index", -1), 0);
 
     sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
@@ -6046,19 +6072,37 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
     EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "last_actor", ""),
                  "pool.player_shots.0");
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "last_actor_id", -1), shot0->id);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "last_actor_pool_index", -1), 0);
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.second"), nullptr);
     EXPECT_TRUE(shot1->active);
     expect_vec3_near(shot1->position, sdl3d_vec3_make(4.0f, 5.0f, 6.0f));
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse"), nullptr);
-    EXPECT_TRUE(reusable_shot->active);
-    expect_vec3_near(reusable_shot->position, sdl3d_vec3_make(7.0f, 8.0f, 9.0f));
+    EXPECT_TRUE(reusable_shot0->active);
+    EXPECT_FALSE(reusable_shot1->active);
+    expect_vec3_near(reusable_shot0->position, sdl3d_vec3_make(7.0f, 8.0f, 9.0f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse.second"), nullptr);
+    EXPECT_TRUE(reusable_shot0->active);
+    EXPECT_TRUE(reusable_shot1->active);
+    expect_vec3_near(reusable_shot1->position, sdl3d_vec3_make(8.0f, 9.0f, 10.0f));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.reuse.first"), nullptr);
+    EXPECT_FALSE(reusable_shot0->active);
+    EXPECT_TRUE(reusable_shot1->active);
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse.again"), nullptr);
-    EXPECT_TRUE(reusable_shot->active);
-    expect_vec3_near(reusable_shot->position, sdl3d_vec3_make(10.0f, 11.0f, 12.0f));
-    EXPECT_EQ(sdl3d_properties_get_int(reusable_shot->props, "damage", 0), 99);
+    EXPECT_TRUE(reusable_shot0->active);
+    EXPECT_TRUE(reusable_shot1->active);
+    expect_vec3_near(reusable_shot0->position, sdl3d_vec3_make(10.0f, 11.0f, 12.0f));
+    EXPECT_EQ(sdl3d_properties_get_int(reusable_shot0->props, "damage", 0), 99);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn.reuse.exhausted"), nullptr);
+    EXPECT_TRUE(reusable_shot0->active);
+    EXPECT_TRUE(reusable_shot1->active);
+    expect_vec3_near(reusable_shot0->position, sdl3d_vec3_make(10.0f, 11.0f, 12.0f));
+    expect_vec3_near(reusable_shot1->position, sdl3d_vec3_make(13.0f, 14.0f, 15.0f));
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.first"), nullptr);
     EXPECT_FALSE(shot0->active);
@@ -6073,12 +6117,14 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.projectiles"), nullptr);
     EXPECT_FALSE(shot0->active);
     EXPECT_FALSE(shot1->active);
-    EXPECT_FALSE(reusable_shot->active);
+    EXPECT_FALSE(reusable_shot0->active);
+    EXPECT_FALSE(reusable_shot1->active);
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.projectiles"), nullptr);
     EXPECT_FALSE(shot0->active);
     EXPECT_FALSE(shot1->active);
-    EXPECT_FALSE(reusable_shot->active);
+    EXPECT_FALSE(reusable_shot0->active);
+    EXPECT_FALSE(reusable_shot1->active);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -6148,6 +6194,70 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "unknown actor pool",
+        },
+        {
+            "bad_spawn_from",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "actor_archetypes": [
+    { "name": "archetype.shot" }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "signals": ["signal.spawn"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          { "type": "actor.spawn", "pool": "pool.shots", "from": "entity.missing" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "unknown actor.spawn from actor",
+        },
+        {
+            "bad_despawn_target",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "signals": ["signal.despawn"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.despawn",
+        "actions": [
+          { "type": "actor.despawn", "target": "entity.missing" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "unknown actor.despawn target",
+        },
+        {
+            "pool_actor_collision",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "entities": [
+    { "name": "pool.shots.0" }
+  ],
+  "actor_archetypes": [
+    { "name": "archetype.shot" }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "collides with entity",
         },
     };
 


### PR DESCRIPTION
## Summary
- Adds JSON-authored `actor_archetypes` and preallocated `actor_pools` for deterministic runtime actors.
- Adds `actor.spawn`, `actor.despawn`, and `actor.despawn_by_tag` actions, including spawn position derivation, property overrides, scene-state outputs, and deterministic reuse policy.
- Adds validation and docs for the new schema/actions.
- Adds focused game-data tests for spawn/despawn/reset behavior, reuse-on-exhaustion, idempotent tag despawn, and invalid authored data.

This is the first implementation slice for #223. Follow-up slices should add Lua helpers, tag-targeted sensors, pooled actor iteration through every relevant subsystem, and replication support.

## Verification
- `clang-format -i src/game_data.c src/game_data_validation.c tests/test_game_data.cpp`
- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ActorPoolsSpawnDespawnAndResetActors:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions'`
- `./build/debug/tests/sdl3d_game_data_test`
- `git diff --check`