### PR TITLE
Add Lua actor pool lifecycle API

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1303,9 +1303,9 @@ archetype, activates it, applies the requested position and property overrides,
 and writes `pool` and `pool_index` properties for diagnostics. Despawning a
 pooled actor resets it back to its archetype defaults and deactivates it.
 
-The first actor-pool slice supports JSON-authored lifecycle actions. Lua
-helpers, tag-targeted sensors, pooled component iteration in every subsystem,
-and network replication of pooled actor state are planned follow-up work.
+Actor pools support JSON-authored lifecycle actions and Lua lifecycle helpers.
+Tag-targeted sensors, pooled component iteration in every subsystem, and
+network replication of pooled actor state are planned follow-up work.
 
 ### Presentation Components
 

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -52,6 +52,13 @@ The `ctx` table provides:
 - `ctx.dt`: delta time for this update
 - `ctx:actor(name)`: resolve an actor wrapper by exact name; returns `nil` when missing
 - `ctx:actor_with_tags(...)`: resolve the first actor matching one or more tags; returns `nil` when no actor matches
+- `ctx:active_actors_with_tags(...)`: return an array of active actor wrappers matching one or more tags
+- `ctx:spawn(pool, options)`: spawn one actor from an authored actor pool; returns `actor, actor_id, pool_index` or `nil, error`
+- `ctx:despawn(actor_or_name)`: despawn a pooled actor or deactivate a static actor; returns `true` or `false`
+- `ctx:despawn_by_tag(tag)`: despawn active pooled actors whose archetype has the tag; returns the despawn count
+- `ctx:pool_capacity(pool)`: return the authored pool capacity, or `0` for an unknown pool
+- `ctx:pool_active_count(pool)`: return the active actor count for a pool
+- `ctx:pool_available_count(pool)`: return the inactive actor count for a pool
 - `ctx:state_get(key, fallback)`: read persistent scene state
 - `ctx:state_set(key, value)`: write persistent scene state; passing `nil` removes the key
 - `ctx:random()`: deterministic per-runtime pseudo-random value in `[0, 1)`
@@ -62,6 +69,7 @@ The `ctx` table provides:
 
 - `ctx:actor(name)` is the cheapest way to reach a known entity name.
 - `ctx:actor_with_tags(...)` scans the actor registry and should be used for authored role discovery, not inner-loop per-frame work.
+- `ctx:active_actors_with_tags(...)` scans static entities and actor pools. It is useful for gameplay rules over small groups, but hot paths with many actors should use narrower engine sensors or future collection helpers.
 - `ctx.storage.*` performs filesystem I/O and should be used for saves, settings, caches, and similar infrequent tasks.
 - `ctx:random()` is deterministic within a runtime session, which makes it safe for gameplay logic that should replay or sync consistently.
 
@@ -94,6 +102,8 @@ Behavior notes:
 - Missing actor names return `nil` from `sdl3d.actor(name)`.
 - `get_position()` returns `nil` if the actor is missing.
 - `get_vec3()` returns `nil` if the actor is missing.
+- `active` and `is_active()` read the actor's current runtime active flag.
+- `despawn()` is shorthand for `sdl3d.despawn(actor)`.
 - Property getters fall back to authored defaults when the property is absent.
 - `position` and `velocity` are convenience fields backed by the same property accessors.
 
@@ -130,11 +140,68 @@ The runtime installs a small `sdl3d` table for low-level access and utility help
 - `sdl3d.state_set(key, value)`
 - `sdl3d.random()`
 - `sdl3d.actor_with_tags(...)`
+- `sdl3d.active_actors_with_tags(...)`
+- `sdl3d.spawn(pool, options)`
+- `sdl3d.despawn(actor_or_name)`
+- `sdl3d.despawn_by_tag(tag)`
+- `sdl3d.pool_capacity(pool)`
+- `sdl3d.pool_active_count(pool)`
+- `sdl3d.pool_available_count(pool)`
 - `sdl3d.log(message)`
 - `sdl3d.storage.*`
 - `sdl3d.json.*`
 
 The low-level `sdl3d.get_*` and `sdl3d.set_*` helpers are useful for compact scripts and host integration. Gameplay scripts should generally prefer the `Actor` wrapper for readability.
+
+## Actor Pools
+
+Lua can allocate from JSON-authored `actor_pools` without native game code:
+
+```lua
+local projectile, actor_id, pool_index = ctx:spawn("pool.player_shots", {
+  from = ctx:actor("entity.player"),
+  offset = Vec3(0, 0.5, 0),
+  properties = {
+    damage = 2,
+    owner = "player",
+    velocity = Vec3(0, 11, 0)
+  }
+})
+
+if projectile ~= nil then
+  ctx:log("spawned " .. projectile.name)
+end
+```
+
+`options` is optional. Supported keys:
+
+- `position`: `Vec3`, `{x,y,z}`, or `{x, y, z}` table for an explicit spawn position
+- `from`: actor wrapper or actor name whose current position should be copied
+- `offset`: vector added after `position` or `from`
+- `properties`: scalar or vector property overrides applied after archetype reset
+
+`spawn` resets the selected pooled actor to its archetype, activates it, applies
+the final position and property overrides, and returns the actor wrapper,
+registry id, and pool slot index. When the pool is missing or exhausted, it
+returns `nil, error_message`.
+
+`ctx:active_actors_with_tags(...)` returns only currently active actors. Static
+entities are matched by their authored tags; pooled actors are matched by their
+archetype tags:
+
+```lua
+for _, shot in ipairs(ctx:active_actors_with_tags("player_shot")) do
+  if shot.position.y > 6.0 then
+    shot:despawn()
+  end
+end
+```
+
+`ctx:despawn(actor_or_name)` resets pooled actors back to archetype defaults and
+marks them inactive. For non-pooled actors, it only clears the active flag.
+`ctx:despawn_by_tag(tag)` applies to pooled actors and returns the number of
+active actors it despawned. Pool count helpers report capacity, active count,
+and available inactive slots.
 
 ## `Vec3`
 
@@ -189,6 +256,8 @@ Paths must use `user://` or `cache://`. Absolute paths, `..`, empty segments, ba
 
 - Missing actor name: `ctx:actor()` returns `nil`.
 - Missing actor tags: `ctx:actor_with_tags()` returns `nil`.
+- Missing or exhausted actor pool: `ctx:spawn()` returns `nil, error_message`.
+- Missing despawn target: `ctx:despawn()` returns `false`.
 - Missing state key: `ctx:state_get()` returns the authored fallback.
 - Missing JSON data: `sdl3d.json.decode()` returns `nil, error`.
 - Unsupported JSON value: `sdl3d.json.encode()` returns `nil, error`.

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -180,6 +180,12 @@ end
 - `offset`: vector added after `position` or `from`
 - `properties`: scalar or vector property overrides applied after archetype reset
 
+Vector-like tables used by `position`, `offset`, or vector property overrides
+must provide `x` and `y` fields, or array-style `[1]` and `[2]` fields. The `z`
+component is optional and defaults to the current/fallback `z` value for that
+operation, which keeps 2D gameplay scripts concise while still allowing 3D
+values when needed.
+
 `spawn` resets the selected pooled actor to its archetype, activates it, applies
 the final position and property overrides, and returns the actor wrapper,
 registry id, and pool slot index. When the pool is missing or exhausted, it
@@ -215,7 +221,9 @@ It supports:
 - `Vec3.clamp(v, lo, hi)`
 - `+`, `-`, and `*` arithmetic operators
 
-`Vec3` accepts tables with `x/y/z` or array-style `[1]/[2]/[3]` fields through the helper conversion rules.
+Engine Lua APIs that accept vector-like tables require `x/y` or array-style
+`[1]/[2]` fields. The `z` or `[3]` field is optional and defaults to the API's
+current/fallback `z` value.
 
 ## JSON Helpers
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -543,6 +543,16 @@ static sdl3d_input_manager *runtime_input(const sdl3d_game_data_runtime *runtime
 static void actor_set_position(sdl3d_registered_actor *actor, sdl3d_vec3 position);
 static void lua_push_actor_wrapper(lua_State *lua, const sdl3d_registered_actor *actor);
 static void copy_property_value(sdl3d_properties *target, const char *key, const sdl3d_value *value);
+static yyjson_val *obj_get(yyjson_val *object, const char *key);
+static const char *json_string(yyjson_val *object, const char *key, const char *fallback);
+static yyjson_val *runtime_root(const sdl3d_game_data_runtime *runtime);
+static actor_pool_runtime *find_actor_pool(sdl3d_game_data_runtime *runtime, const char *name);
+static actor_pool_runtime *find_actor_pool_for_actor(sdl3d_game_data_runtime *runtime, const char *actor_name,
+                                                     int *out_index);
+static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                                   int *out_index);
+static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active);
+static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
 
 static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
 {
@@ -702,6 +712,14 @@ static int lua_set_vec3(lua_State *lua)
     return 0;
 }
 
+static int lua_actor_active(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    sdl3d_registered_actor *actor = lua_actor_arg(lua, runtime, 1);
+    lua_pushboolean(lua, actor != NULL && actor->active);
+    return 1;
+}
+
 static int lua_get_dt(lua_State *lua)
 {
     lua_pushnumber(lua, sdl3d_game_data_delta_time(lua_runtime(lua)));
@@ -842,6 +860,307 @@ static int lua_actor_with_tags(lua_State *lua)
     }
 
     lua_push_actor_wrapper(lua, sdl3d_game_data_find_actor_with_tags(runtime, tags, tag_count));
+    return 1;
+}
+
+static int lua_collect_tags(lua_State *lua, int start_index, const char **tags, int max_tags)
+{
+    const int arg_count = lua_gettop(lua);
+    int tag_count = 0;
+    if (lua_istable(lua, start_index))
+    {
+        const lua_Integer count = luaL_len(lua, start_index);
+        for (lua_Integer i = 1; i <= count && tag_count < max_tags; ++i)
+        {
+            lua_geti(lua, start_index, i);
+            const char *tag = lua_tostring(lua, -1);
+            if (tag != NULL && tag[0] != '\0')
+                tags[tag_count++] = tag;
+            lua_pop(lua, 1);
+        }
+        return tag_count;
+    }
+
+    for (int i = start_index; i <= arg_count && tag_count < max_tags; ++i)
+    {
+        const char *tag = lua_tostring(lua, i);
+        if (tag != NULL && tag[0] != '\0')
+            tags[tag_count++] = tag;
+    }
+    return tag_count;
+}
+
+static bool lua_read_vec3_value(lua_State *lua, int index, sdl3d_vec3 fallback, sdl3d_vec3 *out_value)
+{
+    if (out_value != NULL)
+        *out_value = fallback;
+    if (!lua_istable(lua, index))
+        return false;
+
+    index = lua_absindex(lua, index);
+    lua_getfield(lua, index, "x");
+    lua_getfield(lua, index, "y");
+    lua_getfield(lua, index, "z");
+    bool has_xy = lua_isnumber(lua, -3) && lua_isnumber(lua, -2);
+    sdl3d_vec3 value = sdl3d_vec3_make(has_xy ? (float)lua_tonumber(lua, -3) : fallback.x,
+                                       has_xy ? (float)lua_tonumber(lua, -2) : fallback.y,
+                                       lua_isnumber(lua, -1) ? (float)lua_tonumber(lua, -1) : fallback.z);
+    lua_pop(lua, 3);
+
+    if (!has_xy)
+    {
+        lua_geti(lua, index, 1);
+        lua_geti(lua, index, 2);
+        lua_geti(lua, index, 3);
+        has_xy = lua_isnumber(lua, -3) && lua_isnumber(lua, -2);
+        value = sdl3d_vec3_make(has_xy ? (float)lua_tonumber(lua, -3) : fallback.x,
+                                has_xy ? (float)lua_tonumber(lua, -2) : fallback.y,
+                                lua_isnumber(lua, -1) ? (float)lua_tonumber(lua, -1) : fallback.z);
+        lua_pop(lua, 3);
+    }
+
+    if (!has_xy)
+        return false;
+    if (out_value != NULL)
+        *out_value = value;
+    return true;
+}
+
+static bool lua_read_vec3_field(lua_State *lua, int table_index, const char *field, sdl3d_vec3 fallback,
+                                sdl3d_vec3 *out_value)
+{
+    if (!lua_istable(lua, table_index) || field == NULL)
+        return false;
+    table_index = lua_absindex(lua, table_index);
+    lua_getfield(lua, table_index, field);
+    const bool ok = lua_read_vec3_value(lua, -1, fallback, out_value);
+    lua_pop(lua, 1);
+    return ok;
+}
+
+static void lua_set_actor_property_from_value(lua_State *lua, sdl3d_registered_actor *actor, const char *key, int index)
+{
+    if (actor == NULL || key == NULL)
+        return;
+    index = lua_absindex(lua, index);
+    if (lua_isboolean(lua, index))
+        sdl3d_properties_set_bool(actor->props, key, lua_toboolean(lua, index));
+    else if (lua_isinteger(lua, index))
+        sdl3d_properties_set_int(actor->props, key, (int)lua_tointeger(lua, index));
+    else if (lua_isnumber(lua, index))
+        sdl3d_properties_set_float(actor->props, key, (float)lua_tonumber(lua, index));
+    else if (lua_isstring(lua, index))
+        sdl3d_properties_set_string(actor->props, key, lua_tostring(lua, index));
+    else if (lua_istable(lua, index))
+    {
+        sdl3d_vec3 value;
+        if (lua_read_vec3_value(lua, index, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), &value))
+            sdl3d_properties_set_vec3(actor->props, key, value);
+    }
+}
+
+static sdl3d_registered_actor *lua_actor_from_value(lua_State *lua, sdl3d_game_data_runtime *runtime, int index)
+{
+    if (lua_isnoneornil(lua, index))
+        return NULL;
+    if (lua_istable(lua, index))
+    {
+        lua_getfield(lua, index, "_name");
+        const char *name = lua_tostring(lua, -1);
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, name);
+        lua_pop(lua, 1);
+        return actor;
+    }
+    if (lua_isstring(lua, index))
+        return sdl3d_game_data_find_actor(runtime, lua_tostring(lua, index));
+    return NULL;
+}
+
+static int lua_spawn_actor(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
+    int actor_index = -1;
+    sdl3d_registered_actor *actor = actor_pool_allocate(runtime, pool, &actor_index);
+    if (pool == NULL || actor == NULL || actor_index < 0)
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, "actor pool exhausted or missing");
+        return 2;
+    }
+
+    if (!initialize_pooled_actor(pool, actor, actor_index, true))
+    {
+        lua_pushnil(lua);
+        lua_pushstring(lua, "failed to initialize pooled actor");
+        return 2;
+    }
+
+    if (pool->spawn_generations != NULL)
+    {
+        pool->spawn_generations[actor_index] = ++pool->spawn_generation_counter;
+        sdl3d_properties_set_int(actor->props, "pool_spawn_generation",
+                                 (int)SDL_min(pool->spawn_generations[actor_index], (Uint64)SDL_MAX_SINT32));
+    }
+
+    sdl3d_vec3 position = actor->position;
+    if (lua_istable(lua, 2))
+    {
+        lua_read_vec3_field(lua, 2, "position", position, &position);
+        lua_getfield(lua, 2, "from");
+        sdl3d_registered_actor *from_actor = lua_actor_from_value(lua, runtime, -1);
+        lua_pop(lua, 1);
+        if (from_actor != NULL)
+            position = from_actor->position;
+
+        sdl3d_vec3 offset = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+        if (lua_read_vec3_field(lua, 2, "offset", offset, &offset))
+        {
+            position.x += offset.x;
+            position.y += offset.y;
+            position.z += offset.z;
+        }
+
+        lua_getfield(lua, 2, "properties");
+        if (lua_istable(lua, -1))
+        {
+            lua_pushnil(lua);
+            while (lua_next(lua, -2) != 0)
+            {
+                const char *key = lua_tostring(lua, -2);
+                if (key != NULL && key[0] != '\0')
+                    lua_set_actor_property_from_value(lua, actor, key, -1);
+                lua_pop(lua, 1);
+            }
+        }
+        lua_pop(lua, 1);
+    }
+
+    actor_set_position(actor, position);
+    lua_push_actor_wrapper(lua, actor);
+    lua_pushinteger(lua, actor->id);
+    lua_pushinteger(lua, actor_index);
+    return 3;
+}
+
+static int lua_despawn_actor(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    sdl3d_registered_actor *actor = lua_actor_from_value(lua, runtime, 1);
+    if (actor == NULL)
+    {
+        lua_pushboolean(lua, false);
+        return 1;
+    }
+
+    int actor_index = -1;
+    actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
+    const bool ok = pool != NULL && actor_index >= 0 ? initialize_pooled_actor(pool, actor, actor_index, false)
+                                                     : (actor->active = false, true);
+    lua_pushboolean(lua, ok);
+    return 1;
+}
+
+static int lua_despawn_actors_by_tag(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *tag = luaL_checkstring(lua, 1);
+    int despawned = 0;
+    if (runtime != NULL && tag != NULL && tag[0] != '\0')
+    {
+        for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+        {
+            actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+            if (!entity_json_has_tags(pool->archetype_json, &tag, 1))
+                continue;
+            for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+            {
+                sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+                if (actor != NULL && actor->active && initialize_pooled_actor(pool, actor, actor_index, false))
+                    ++despawned;
+            }
+        }
+    }
+    lua_pushinteger(lua, despawned);
+    return 1;
+}
+
+static int lua_pool_capacity(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? pool->capacity : 0);
+    return 1;
+}
+
+static int lua_pool_active_count(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
+    int count = 0;
+    for (int i = 0; pool != NULL && i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor != NULL && actor->active)
+            ++count;
+    }
+    lua_pushinteger(lua, count);
+    return 1;
+}
+
+static int lua_pool_available_count(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
+    int count = 0;
+    for (int i = 0; pool != NULL && i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor != NULL && !actor->active)
+            ++count;
+    }
+    lua_pushinteger(lua, count);
+    return 1;
+}
+
+static int lua_active_actors_with_tags(lua_State *lua)
+{
+    sdl3d_game_data_runtime *runtime = lua_runtime(lua);
+    const char *tags[16];
+    const int tag_count = lua_collect_tags(lua, 1, tags, (int)SDL_arraysize(tags));
+    lua_newtable(lua);
+    if (runtime == NULL || tag_count <= 0)
+        return 1;
+
+    int out_index = 1;
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        if (!entity_json_has_tags(entity, tags, tag_count))
+            continue;
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(entity, "name", NULL));
+        if (actor != NULL && actor->active)
+        {
+            lua_push_actor_wrapper(lua, actor);
+            lua_seti(lua, -2, out_index++);
+        }
+    }
+
+    for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+    {
+        actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+        if (!entity_json_has_tags(pool->archetype_json, tags, tag_count))
+            continue;
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+            if (actor != NULL && actor->active)
+            {
+                lua_push_actor_wrapper(lua, actor);
+                lua_seti(lua, -2, out_index++);
+            }
+        }
+    }
     return 1;
 }
 
@@ -1237,6 +1556,7 @@ static void install_lua_helpers(lua_State *lua)
         "end\n"
         "Actor.__index = function(self, key)\n"
         "    if key == 'name' then return rawget(self, '_name') end\n"
+        "    if key == 'active' then return sdl3d.actor_active(self) end\n"
         "    if key == 'position' then return Actor.get_position(self) end\n"
         "    if key == 'velocity' then return Actor.get_vec3(self, 'velocity', Vec3(0, 0, 0)) end\n"
         "    return Actor[key]\n"
@@ -1245,24 +1565,60 @@ static void install_lua_helpers(lua_State *lua)
         "    if key == 'position' then Actor.set_position(self, value); return end\n"
         "    if key == 'velocity' then Actor.set_vec3(self, 'velocity', value); return end\n"
         "    rawset(self, key, value)\n"
-        "end\n"
+        "end\n",
         "function sdl3d.actor(name)\n"
         "    if name == nil or name == '' then return nil end\n"
         "    return setmetatable({ _name = name }, Actor)\n"
         "end\n"
+        "function Actor:is_active() return sdl3d.actor_active(self) end\n"
+        "function Actor:despawn() return sdl3d.despawn(self) end\n"
         "function sdl3d._context(adapter, dt)\n"
         "    return {\n"
         "        adapter = adapter,\n"
         "        name = adapter,\n"
         "        dt = dt or 0,\n"
         "        actor = function(self_or_name, maybe_name) return sdl3d.actor(maybe_name or self_or_name) end,\n"
+        "        spawn = function(self_or_pool, maybe_pool, maybe_options)\n"
+        "            if type(self_or_pool) == 'table' and self_or_pool.adapter ~= nil then\n"
+        "                return sdl3d.spawn(maybe_pool, maybe_options)\n"
+        "            end\n"
+        "            return sdl3d.spawn(self_or_pool, maybe_pool)\n"
+        "        end,\n"
+        "        despawn = function(self_or_actor, maybe_actor)\n"
+        "            if type(self_or_actor) == 'table' and self_or_actor.adapter ~= nil then\n"
+        "                return sdl3d.despawn(maybe_actor)\n"
+        "            end\n"
+        "            return sdl3d.despawn(self_or_actor)\n"
+        "        end,\n"
+        "        despawn_by_tag = function(self_or_tag, maybe_tag)\n"
+        "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
+        "                return sdl3d.despawn_by_tag(maybe_tag)\n"
+        "            end\n"
+        "            return sdl3d.despawn_by_tag(self_or_tag)\n"
+        "        end,\n"
         "        actor_with_tags = function(self_or_tag, maybe_tag, ...)\n"
         "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
         "                return sdl3d.actor_with_tags(maybe_tag, ...)\n"
         "            end\n"
         "            if type(self_or_tag) == 'table' then return sdl3d.actor_with_tags(self_or_tag) end\n"
         "            return sdl3d.actor_with_tags(self_or_tag, maybe_tag, ...)\n"
+        "        end,\n",
+        "        active_actors_with_tags = function(self_or_tag, maybe_tag, ...)\n"
+        "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
+        "                return sdl3d.active_actors_with_tags(maybe_tag, ...)\n"
+        "            end\n"
+        "            if type(self_or_tag) == 'table' then return sdl3d.active_actors_with_tags(self_or_tag) end\n"
+        "            return sdl3d.active_actors_with_tags(self_or_tag, maybe_tag, ...)\n"
         "        end,\n"
+        "        pool_capacity = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_capacity(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_active_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_active_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_available_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_available_count(maybe_pool or self_or_pool)\n"
+        "        end,\n",
         "        state_get = function(self_or_key, maybe_key, fallback)\n"
         "            if type(self_or_key) == 'table' and self_or_key.adapter ~= nil then\n"
         "                return sdl3d.state_get(maybe_key, fallback)\n"
@@ -1354,11 +1710,19 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("set_string", lua_set_string);
     SDL3D_LUA_BIND("get_vec3", lua_get_vec3);
     SDL3D_LUA_BIND("set_vec3", lua_set_vec3);
+    SDL3D_LUA_BIND("actor_active", lua_actor_active);
     SDL3D_LUA_BIND("dt", lua_get_dt);
     SDL3D_LUA_BIND("state_get", lua_state_get);
     SDL3D_LUA_BIND("state_set", lua_state_set);
     SDL3D_LUA_BIND("random", lua_random);
     SDL3D_LUA_BIND("actor_with_tags", lua_actor_with_tags);
+    SDL3D_LUA_BIND("active_actors_with_tags", lua_active_actors_with_tags);
+    SDL3D_LUA_BIND("spawn", lua_spawn_actor);
+    SDL3D_LUA_BIND("despawn", lua_despawn_actor);
+    SDL3D_LUA_BIND("despawn_by_tag", lua_despawn_actors_by_tag);
+    SDL3D_LUA_BIND("pool_capacity", lua_pool_capacity);
+    SDL3D_LUA_BIND("pool_active_count", lua_pool_active_count);
+    SDL3D_LUA_BIND("pool_available_count", lua_pool_available_count);
     SDL3D_LUA_BIND("log", lua_log);
     SDL3D_LUA_BIND("storage_read", lua_storage_read);
     SDL3D_LUA_BIND("storage_write", lua_storage_write);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6274,6 +6274,181 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, LuaCanSpawnIterateAndDespawnPooledActors)
+{
+    const std::filesystem::path dir = unique_test_dir("lua_actor_pools");
+    write_text(dir / "scripts" / "rules.lua",
+               R"lua(
+local rules = {}
+
+function rules.spawn_projectile(_, _, ctx)
+  local player = ctx:actor("entity.player")
+  local shot, actor_id, pool_index = ctx:spawn("pool.projectiles", {
+    from = player,
+    offset = Vec3(0.25, 0.5, 0.0),
+    properties = {
+      damage = 5,
+      critical = true,
+      owner = "player",
+      velocity = Vec3(1.0, 2.0, 0.0)
+    }
+  })
+
+  ctx:state_set("spawn_name", shot and shot.name or "")
+  ctx:state_set("spawn_actor_id", actor_id or -1)
+  ctx:state_set("spawn_pool_index", pool_index or -1)
+  ctx:state_set("spawn_active", shot and shot.active or false)
+  ctx:state_set("pool_capacity", ctx:pool_capacity("pool.projectiles"))
+  ctx:state_set("pool_active", ctx:pool_active_count("pool.projectiles"))
+  ctx:state_set("pool_available", ctx:pool_available_count("pool.projectiles"))
+
+  local active = ctx:active_actors_with_tags("projectile")
+  ctx:state_set("active_projectiles", #active)
+  if active[1] ~= nil then
+    active[1]:set_int("touched", 1)
+  end
+  return true
+end
+
+function rules.despawn_first(_, _, ctx)
+  local active = ctx:active_actors_with_tags({ "projectile" })
+  ctx:state_set("before_despawn", #active)
+  if active[1] ~= nil then
+    ctx:despawn(active[1])
+  end
+  ctx:state_set("after_despawn", #ctx:active_actors_with_tags("projectile"))
+  return true
+end
+
+function rules.despawn_all(_, _, ctx)
+  ctx:spawn("pool.projectiles", { position = Vec3(4.0, 5.0, 6.0) })
+  ctx:state_set("despawned_count", ctx:despawn_by_tag("projectile"))
+  return true
+end
+
+return rules
+)lua");
+    write_text(dir / "lua_actor_pools.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Lua Actor Pools", "id": "test.lua_actor_pools", "version": "0.1.0" },
+  "world": { "name": "world.lua_actor_pools", "kind": "fixed_screen" },
+  "scripts": [
+    { "id": "script.rules", "path": "scripts/rules.lua", "module": "test.actor_pools" }
+  ],
+  "entities": [
+    { "name": "entity.player", "transform": { "position": [1.0, 2.0, 3.0] } }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.projectile",
+      "tags": ["projectile", "player_projectile"],
+      "transform": { "position": [0.0, 0.0, 0.25] },
+      "properties": {
+        "damage": { "type": "int", "value": 1 },
+        "critical": { "type": "bool", "value": false },
+        "owner": { "type": "string", "value": "none" },
+        "velocity": { "type": "vec2", "value": [0.0, 10.0] },
+        "touched": { "type": "int", "value": 0 }
+      }
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.projectiles",
+      "archetype": "archetype.projectile",
+      "capacity": 2,
+      "scene": "scene.play"
+    }
+  ],
+  "signals": [
+    "signal.spawn",
+    "signal.despawn.first",
+    "signal.despawn.all"
+  ],
+  "adapters": [
+    { "name": "adapter.spawn_projectile", "kind": "action", "script": "script.rules", "function": "spawn_projectile" },
+    { "name": "adapter.despawn_first", "kind": "action", "script": "script.rules", "function": "despawn_first" },
+    { "name": "adapter.despawn_all", "kind": "action", "script": "script.rules", "function": "despawn_all" }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.spawn_projectile" }
+        ]
+      },
+      {
+        "signal": "signal.despawn.first",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.despawn_first" }
+        ]
+      },
+      {
+        "signal": "signal.despawn.all",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.despawn_all" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play"
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "lua_actor_pools.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn"), nullptr);
+
+    sdl3d_registered_actor *shot0 = sdl3d_game_data_find_actor(runtime, "pool.projectiles.0");
+    ASSERT_NE(shot0, nullptr);
+    EXPECT_TRUE(shot0->active);
+    expect_vec3_near(shot0->position, sdl3d_vec3_make(1.25f, 2.5f, 3.0f));
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 5);
+    EXPECT_TRUE(sdl3d_properties_get_bool(shot0->props, "critical", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "owner", ""), "player");
+    expect_vec3_near(sdl3d_properties_get_vec3(shot0->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f)),
+                     sdl3d_vec3_make(1.0f, 2.0f, 0.0f));
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "touched", 0), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "spawn_name", ""),
+                 "pool.projectiles.0");
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "spawn_actor_id", -1), shot0->id);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "spawn_pool_index", -1), 0);
+    EXPECT_TRUE(sdl3d_properties_get_bool(sdl3d_game_data_scene_state(runtime), "spawn_active", false));
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "pool_capacity", -1), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "pool_active", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "pool_available", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "active_projectiles", -1), 1);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.first"), nullptr);
+    EXPECT_FALSE(shot0->active);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "before_despawn", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "after_despawn", -1), 0);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "touched", -1), 0);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.all"), nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "despawned_count", -1), 1);
+    EXPECT_FALSE(shot0->active);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, LoadsLuaBackedGameDataFromMemoryPack)
 {
     const std::string game_json = read_fixture_file("module_success.game.json");


### PR DESCRIPTION
## Summary
- Adds Lua helpers for data-authored actor pools: `ctx:spawn`, `ctx:despawn`, `ctx:despawn_by_tag`, active tag iteration, and pool count helpers.
- Exposes matching low-level `sdl3d.*` helpers and actor wrapper conveniences for active state and despawn.
- Supports spawn options for explicit position, source actor + offset, and scalar/vector property overrides.
- Documents the Lua actor pool contract and updates the JSON docs now that Lua lifecycle helpers exist.
- Adds a focused Lua-backed game-data test proving spawn, active iteration, property overrides, count helpers, and despawn reset behavior.

Continues #223.

## Verification
- `clang-format -i src/game_data.c tests/test_game_data.cpp`
- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LuaCanSpawnIterateAndDespawnPooledActors:GameDataRuntime.ActorPoolsSpawnDespawnAndResetActors'`
- `./build/debug/tests/sdl3d_game_data_test`
- `git diff --check`