### PR TITLE
Add safe actor pool lifecycle deferral

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1300,10 +1300,18 @@ Pool actors receive deterministic runtime names in the form
 `<pool-name>.<index>`, such as `pool.player_shots.0`, and are initialized from
 the archetype with `active=false`. Spawning resets the selected actor from the
 archetype, activates it, applies the requested position and property overrides,
-and writes `pool` and `pool_index` properties for diagnostics. Despawning a
-pooled actor resets it back to its archetype defaults and deactivates it.
+and writes `pool`, `pool_index`, and `pool_lifecycle` properties for
+diagnostics. `pool_lifecycle` is one of `inactive`, `spawning`, `active`, or
+`despawning`; `spawning` is a transient state during reset and activation.
+Despawning hides the actor from active queries immediately, then resets it back
+to archetype defaults. If despawn is requested while signals, sensors,
+rendering, or network snapshot application are traversing runtime state, the
+reset is deferred until that protected section finishes so actor wrappers and
+iteration pointers remain valid.
 
 Actor pools support JSON-authored lifecycle actions and Lua lifecycle helpers.
+Authored sensors may target either static entity names or deterministic pooled
+actor names, such as `pool.player_shots.0`.
 Tag-targeted sensors, pooled component iteration in every subsystem, and
 network replication of pooled actor state are planned follow-up work.
 

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -209,6 +209,13 @@ marks them inactive. For non-pooled actors, it only clears the active flag.
 active actors it despawned. Pool count helpers report capacity, active count,
 and available inactive slots.
 
+During signal handling, sensor updates, rendering traversal, and network
+snapshot application, pooled despawns are lifecycle-safe: the actor becomes
+inactive immediately, but the archetype reset is deferred until the protected
+section ends. Actor wrappers therefore remain safe to inspect for the rest of
+the callback. Pooled actors expose `pool_lifecycle` as `inactive`, `spawning`,
+`active`, or `despawning` for diagnostics.
+
 ## `Vec3`
 
 `Vec3` is available both as `sdl3d.Vec3` and as a global `Vec3` constructor.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -250,6 +250,14 @@ typedef enum actor_pool_exhaustion_policy
     ACTOR_POOL_EXHAUST_REUSE_OLDEST,
 } actor_pool_exhaustion_policy;
 
+typedef enum actor_lifecycle_state
+{
+    ACTOR_LIFECYCLE_INACTIVE,
+    ACTOR_LIFECYCLE_SPAWNING,
+    ACTOR_LIFECYCLE_ACTIVE,
+    ACTOR_LIFECYCLE_DESPAWNING,
+} actor_lifecycle_state;
+
 typedef struct actor_pool_runtime
 {
     char *name;
@@ -258,6 +266,7 @@ typedef struct actor_pool_runtime
     yyjson_val *archetype_json;
     char **actor_names;
     Uint64 *spawn_generations;
+    actor_lifecycle_state *lifecycle_states;
     Uint64 spawn_generation_counter;
     int capacity;
     bool initial_active;
@@ -374,6 +383,8 @@ typedef struct sdl3d_game_data_runtime
     network_diagnostic_runtime_state *network_diagnostics;
     int network_diagnostic_count;
     int network_diagnostic_capacity;
+    int actor_lifecycle_defer_depth;
+    bool actor_lifecycle_flush_pending;
     sdl3d_storage *storage;
     bool has_network_schema;
     Uint8 network_schema_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE];
@@ -551,7 +562,16 @@ static actor_pool_runtime *find_actor_pool_for_actor(sdl3d_game_data_runtime *ru
                                                      int *out_index);
 static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                                    int *out_index);
+static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index,
+                                           actor_lifecycle_state state);
+static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor, int index);
+static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor,
+                                          int index);
 static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active);
+static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                       sdl3d_registered_actor *actor, int index);
+static void actor_lifecycle_defer_begin(sdl3d_game_data_runtime *runtime);
+static void actor_lifecycle_defer_end(sdl3d_game_data_runtime *runtime);
 static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
 
 static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
@@ -989,6 +1009,7 @@ static int lua_spawn_actor(lua_State *lua)
         return 2;
     }
 
+    actor_pool_set_lifecycle_state(pool, actor, actor_index, ACTOR_LIFECYCLE_SPAWNING);
     if (!initialize_pooled_actor(pool, actor, actor_index, true))
     {
         lua_pushnil(lua);
@@ -1055,7 +1076,7 @@ static int lua_despawn_actor(lua_State *lua)
 
     int actor_index = -1;
     actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
-    const bool ok = pool != NULL && actor_index >= 0 ? initialize_pooled_actor(pool, actor, actor_index, false)
+    const bool ok = pool != NULL && actor_index >= 0 ? actor_pool_request_despawn(runtime, pool, actor, actor_index)
                                                      : (actor->active = false, true);
     lua_pushboolean(lua, ok);
     return 1;
@@ -1076,7 +1097,8 @@ static int lua_despawn_actors_by_tag(lua_State *lua)
             for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
             {
                 sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
-                if (actor != NULL && actor->active && initialize_pooled_actor(pool, actor, actor_index, false))
+                if (actor_pool_actor_is_active(pool, actor, actor_index) &&
+                    actor_pool_request_despawn(runtime, pool, actor, actor_index))
                     ++despawned;
             }
         }
@@ -1100,7 +1122,7 @@ static int lua_pool_active_count(lua_State *lua)
     for (int i = 0; pool != NULL && i < pool->capacity; ++i)
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor != NULL && actor->active)
+        if (actor_pool_actor_is_active(pool, actor, i))
             ++count;
     }
     lua_pushinteger(lua, count);
@@ -1115,7 +1137,7 @@ static int lua_pool_available_count(lua_State *lua)
     for (int i = 0; pool != NULL && i < pool->capacity; ++i)
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor != NULL && !actor->active)
+        if (actor_pool_actor_is_available(pool, actor, i))
             ++count;
     }
     lua_pushinteger(lua, count);
@@ -1154,7 +1176,7 @@ static int lua_active_actors_with_tags(lua_State *lua)
         for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
         {
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
-            if (actor != NULL && actor->active)
+            if (actor_pool_actor_is_active(pool, actor, actor_index))
             {
                 lua_push_actor_wrapper(lua, actor);
                 lua_seti(lua, -2, out_index++);
@@ -3837,8 +3859,11 @@ static bool for_each_render_primitive_internal(const sdl3d_game_data_runtime *ru
     if (runtime == NULL || callback == NULL)
         return false;
 
+    sdl3d_game_data_runtime *mutable_runtime = (sdl3d_game_data_runtime *)runtime;
+    actor_lifecycle_defer_begin(mutable_runtime);
+    bool keep_iterating = true;
     yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
-    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    for (size_t i = 0; keep_iterating && yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
         yyjson_val *entity = yyjson_arr_get(entities, i);
         const char *entity_name = json_string(entity, "name", NULL);
@@ -3893,9 +3918,13 @@ static bool for_each_render_primitive_internal(const sdl3d_game_data_runtime *ru
             if (eval != NULL)
                 apply_render_effects(runtime, component, eval, &primitive);
             if (!callback(userdata, &primitive))
-                return true;
+            {
+                keep_iterating = false;
+                break;
+            }
         }
     }
+    actor_lifecycle_defer_end(mutable_runtime);
     return true;
 }
 
@@ -3981,8 +4010,11 @@ bool sdl3d_game_data_for_each_particle_emitter(const sdl3d_game_data_runtime *ru
     if (runtime == NULL || callback == NULL)
         return false;
 
+    sdl3d_game_data_runtime *mutable_runtime = (sdl3d_game_data_runtime *)runtime;
+    actor_lifecycle_defer_begin(mutable_runtime);
+    bool keep_iterating = true;
     yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
-    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    for (size_t i = 0; keep_iterating && yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
         yyjson_val *entity = yyjson_arr_get(entities, i);
         const char *entity_name = json_string(entity, "name", NULL);
@@ -4002,8 +4034,9 @@ bool sdl3d_game_data_for_each_particle_emitter(const sdl3d_game_data_runtime *ru
         (void)sdl3d_game_data_get_particle_emitter_draw_emissive(runtime, entity_name, &emitter.draw_emissive);
 
         if (!callback(userdata, &emitter))
-            return true;
+            keep_iterating = false;
     }
+    actor_lifecycle_defer_end(mutable_runtime);
     return true;
 }
 
@@ -7644,6 +7677,88 @@ static actor_pool_exhaustion_policy actor_pool_exhaustion_from_string(const char
     return ACTOR_POOL_EXHAUST_FAIL;
 }
 
+static const char *actor_lifecycle_state_name(actor_lifecycle_state state)
+{
+    switch (state)
+    {
+    case ACTOR_LIFECYCLE_SPAWNING:
+        return "spawning";
+    case ACTOR_LIFECYCLE_ACTIVE:
+        return "active";
+    case ACTOR_LIFECYCLE_DESPAWNING:
+        return "despawning";
+    case ACTOR_LIFECYCLE_INACTIVE:
+    default:
+        return "inactive";
+    }
+}
+
+static actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index)
+{
+    if (pool == NULL || index < 0 || index >= pool->capacity || pool->lifecycle_states == NULL)
+        return ACTOR_LIFECYCLE_INACTIVE;
+    return pool->lifecycle_states[index];
+}
+
+static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index,
+                                           actor_lifecycle_state state)
+{
+    if (pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
+        return;
+    if (pool->lifecycle_states != NULL)
+        pool->lifecycle_states[index] = state;
+    sdl3d_properties_set_string(actor->props, "pool_lifecycle", actor_lifecycle_state_name(state));
+}
+
+static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor, int index)
+{
+    return actor != NULL && actor->active &&
+           (pool == NULL || pool->lifecycle_states == NULL ||
+            actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_ACTIVE);
+}
+
+static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor,
+                                          int index)
+{
+    return actor != NULL && !actor->active &&
+           (pool == NULL || pool->lifecycle_states == NULL ||
+            actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_INACTIVE);
+}
+
+static void actor_lifecycle_defer_begin(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime != NULL)
+        runtime->actor_lifecycle_defer_depth++;
+}
+
+static void actor_lifecycle_flush(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->actor_lifecycle_defer_depth > 0 || !runtime->actor_lifecycle_flush_pending)
+        return;
+
+    runtime->actor_lifecycle_flush_pending = false;
+    for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+    {
+        actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            if (actor_pool_lifecycle_state(pool, actor_index) != ACTOR_LIFECYCLE_DESPAWNING)
+                continue;
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+            if (actor != NULL)
+                (void)initialize_pooled_actor(pool, actor, actor_index, false);
+        }
+    }
+}
+
+static void actor_lifecycle_defer_end(sdl3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->actor_lifecycle_defer_depth <= 0)
+        return;
+    runtime->actor_lifecycle_defer_depth--;
+    actor_lifecycle_flush(runtime);
+}
+
 static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active)
 {
     if (pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
@@ -7655,6 +7770,7 @@ static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_a
         sdl3d_properties_set_string(actor->props, "pool_scene", pool->scene);
     if (!active && pool->spawn_generations != NULL)
         pool->spawn_generations[index] = 0U;
+    actor_pool_set_lifecycle_state(pool, actor, index, active ? ACTOR_LIFECYCLE_ACTIVE : ACTOR_LIFECYCLE_INACTIVE);
     return true;
 }
 
@@ -7703,7 +7819,9 @@ static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root,
         pool->exhaustion = actor_pool_exhaustion_from_string(json_string(pool_json, "on_exhausted", "fail"));
         pool->actor_names = (char **)SDL_calloc((size_t)capacity, sizeof(*pool->actor_names));
         pool->spawn_generations = (Uint64 *)SDL_calloc((size_t)capacity, sizeof(*pool->spawn_generations));
-        if (pool->name == NULL || pool->actor_names == NULL || pool->spawn_generations == NULL)
+        pool->lifecycle_states = (actor_lifecycle_state *)SDL_calloc((size_t)capacity, sizeof(*pool->lifecycle_states));
+        if (pool->name == NULL || pool->actor_names == NULL || pool->spawn_generations == NULL ||
+            pool->lifecycle_states == NULL)
         {
             set_error(error_buffer, error_buffer_size, "failed to allocate actor pool entries");
             return false;
@@ -10429,7 +10547,7 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
     for (int i = 0; i < pool->capacity; ++i)
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor != NULL && !actor->active)
+        if (actor_pool_actor_is_available(pool, actor, i))
         {
             if (out_index != NULL)
                 *out_index = i;
@@ -10445,7 +10563,7 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
     for (int i = 0; i < pool->capacity; ++i)
     {
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor == NULL || !actor->active)
+        if (!actor_pool_actor_is_active(pool, actor, i))
             continue;
         const Uint64 generation = pool->spawn_generations != NULL ? pool->spawn_generations[i] : 0U;
         if (index < 0 || generation < oldest_generation)
@@ -10459,6 +10577,22 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
     if (out_index != NULL)
         *out_index = index;
     return sdl3d_game_data_find_actor(runtime, pool->actor_names[index]);
+}
+
+static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                       sdl3d_registered_actor *actor, int index)
+{
+    if (runtime == NULL || pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
+        return false;
+
+    actor->active = false;
+    actor_pool_set_lifecycle_state(pool, actor, index, ACTOR_LIFECYCLE_DESPAWNING);
+    if (runtime->actor_lifecycle_defer_depth > 0)
+    {
+        runtime->actor_lifecycle_flush_pending = true;
+        return true;
+    }
+    return initialize_pooled_actor(pool, actor, index, false);
 }
 
 static void apply_actor_spawn_properties(sdl3d_registered_actor *actor, yyjson_val *properties)
@@ -10511,6 +10645,7 @@ static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_
     if (pool == NULL || actor == NULL || actor_index < 0)
         return false;
 
+    actor_pool_set_lifecycle_state(pool, actor, actor_index, ACTOR_LIFECYCLE_SPAWNING);
     if (!initialize_pooled_actor(pool, actor, actor_index, true))
         return false;
     if (pool->spawn_generations != NULL)
@@ -10544,7 +10679,7 @@ static bool execute_actor_despawn_action(sdl3d_game_data_runtime *runtime, yyjso
     int actor_index = -1;
     actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
     if (pool != NULL && actor_index >= 0)
-        return initialize_pooled_actor(pool, actor, actor_index, false);
+        return actor_pool_request_despawn(runtime, pool, actor, actor_index);
 
     actor->active = false;
     return true;
@@ -10564,9 +10699,9 @@ static bool execute_actor_despawn_by_tag_action(sdl3d_game_data_runtime *runtime
         for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
         {
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
-            if (actor != NULL && actor->active)
+            if (actor_pool_actor_is_active(pool, actor, actor_index))
             {
-                (void)initialize_pooled_actor(pool, actor, actor_index, false);
+                (void)actor_pool_request_despawn(runtime, pool, actor, actor_index);
             }
         }
     }
@@ -10899,6 +11034,7 @@ static bool execute_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *a
     if (!yyjson_is_arr(actions))
         return false;
 
+    actor_lifecycle_defer_begin(runtime);
     bool ok = true;
     for (size_t i = 0; i < yyjson_arr_size(actions); ++i)
     {
@@ -10906,6 +11042,7 @@ static bool execute_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *a
         if (yyjson_is_obj(action))
             ok = execute_one_action(runtime, action, payload) && ok;
     }
+    actor_lifecycle_defer_end(runtime);
     return ok;
 }
 
@@ -11760,9 +11897,11 @@ bool sdl3d_game_data_update(sdl3d_game_data_runtime *runtime, float dt)
     runtime->current_dt = dt;
 
     yyjson_val *root = yyjson_doc_get_root(runtime->doc);
+    actor_lifecycle_defer_begin(runtime);
     update_control_components(runtime, root, dt);
     update_motion_components(runtime, root, dt);
     update_sensors(runtime);
+    actor_lifecycle_defer_end(runtime);
     return true;
 }
 
@@ -13447,8 +13586,10 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
         }
     }
 
+    actor_lifecycle_defer_begin(runtime);
+    bool apply_ok = true;
     size_t apply_index = 0U;
-    for (size_t actor_index = 0U; actor_index < actor_count; ++actor_index)
+    for (size_t actor_index = 0U; apply_ok && actor_index < actor_count; ++actor_index)
     {
         yyjson_val *actor_schema = yyjson_arr_get(actors, actor_index);
         sdl3d_registered_actor *actor = resolved_actors[actor_index];
@@ -13460,15 +13601,21 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
                 apply_index >= field_count ||
                 !game_data_apply_actor_replication_field(actor, &field, &values[apply_index]))
             {
-                SDL_free(resolved_actors);
-                SDL_free(values);
                 set_errorf(error_buffer, error_buffer_size, "network snapshot failed to apply field '%s' on actor '%s'",
                            field.path != NULL ? field.path : "<invalid>",
                            actor_schema != NULL ? json_string(actor_schema, "entity", "<null>") : "<null>");
-                return false;
+                apply_ok = false;
+                break;
             }
             ++apply_index;
         }
+    }
+    actor_lifecycle_defer_end(runtime);
+    if (!apply_ok)
+    {
+        SDL_free(resolved_actors);
+        SDL_free(values);
+        return false;
     }
 
     SDL_free(resolved_actors);
@@ -14078,6 +14225,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
             SDL_free(runtime->actor_pools[i].actor_names[actor_index]);
         SDL_free(runtime->actor_pools[i].actor_names);
         SDL_free(runtime->actor_pools[i].spawn_generations);
+        SDL_free(runtime->actor_pools[i].lifecycle_states);
     }
     for (int i = 0; i < runtime->direct_connect_session_count; ++i)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -468,6 +468,16 @@ static bool require_ref(validation_context *ctx, const name_table *table, const 
     return true;
 }
 
+static bool require_actor_ref(validation_context *ctx, const validation_names *names, const char *name,
+                              const char *json_path)
+{
+    if (name == NULL || name[0] == '\0')
+        return validation_error(ctx, json_path, "missing actor reference");
+    if (!name_table_contains(&names->entities, name) && !name_table_contains(&names->actor_pool_actors, name))
+        return validation_error(ctx, json_path, "unknown actor reference '%s'", name);
+    return true;
+}
+
 static bool note_name(name_table *table, const char *name, const char *json_path)
 {
     if (name == NULL || name[0] == '\0' || name_table_contains(table, name))
@@ -3469,7 +3479,7 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
             return validation_error(ctx, path, "sensor requires a non-empty type");
         if (SDL_strcmp(type, "sensor.bounds_exit") == 0)
         {
-            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "entity"), path) ||
+            if (!require_actor_ref(ctx, names, json_string(sensor, "entity"), path) ||
                 !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_enter"), path) ||
                 (!is_axis_name(json_string(sensor, "axis")) &&
                  !validation_error(ctx, path, "sensor.bounds_exit requires axis x, y, or z")) ||
@@ -3480,7 +3490,7 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
         }
         if (SDL_strcmp(type, "sensor.bounds_reflect") == 0)
         {
-            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "entity"), path) ||
+            if (!require_actor_ref(ctx, names, json_string(sensor, "entity"), path) ||
                 !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_reflect"), path) ||
                 (!is_axis_name(json_string(sensor, "axis")) &&
                  !validation_error(ctx, path, "sensor.bounds_reflect requires axis x, y, or z")))
@@ -3489,8 +3499,8 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
         }
         if (SDL_strcmp(type, "sensor.contact_2d") == 0)
         {
-            if (!require_ref(ctx, &names->entities, "entity", json_string(sensor, "a"), path) ||
-                !require_ref(ctx, &names->entities, "entity", json_string(sensor, "b"), path) ||
+            if (!require_actor_ref(ctx, names, json_string(sensor, "a"), path) ||
+                !require_actor_ref(ctx, names, json_string(sensor, "b"), path) ||
                 !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_enter"), path))
                 return false;
             continue;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6315,8 +6315,25 @@ function rules.despawn_first(_, _, ctx)
   ctx:state_set("before_despawn", #active)
   if active[1] ~= nil then
     ctx:despawn(active[1])
+    ctx:state_set("during_despawn_active", active[1].active)
+    ctx:state_set("during_despawn_damage", active[1]:get_int("damage", -1))
+    ctx:state_set("during_despawn_lifecycle", active[1]:get_string("pool_lifecycle", ""))
+    ctx:state_set("during_despawn_available", ctx:pool_available_count("pool.projectiles"))
   end
   ctx:state_set("after_despawn", #ctx:active_actors_with_tags("projectile"))
+  return true
+end
+
+function rules.inspect_sensor_despawn(_, _, ctx)
+  local shot = ctx:actor("pool.projectiles.0")
+  local active = true
+  if shot ~= nil then
+    active = shot.active
+  end
+  ctx:state_set("sensor_during_active", active)
+  ctx:state_set("sensor_during_damage", shot and shot:get_int("damage", -1) or -1)
+  ctx:state_set("sensor_during_lifecycle", shot and shot:get_string("pool_lifecycle", "") or "")
+  ctx:state_set("sensor_during_available", ctx:pool_available_count("pool.projectiles"))
   return true
 end
 
@@ -6364,14 +6381,19 @@ return rules
   "signals": [
     "signal.spawn",
     "signal.despawn.first",
-    "signal.despawn.all"
+    "signal.despawn.all",
+    "signal.pool.exit"
   ],
   "adapters": [
     { "name": "adapter.spawn_projectile", "kind": "action", "script": "script.rules", "function": "spawn_projectile" },
     { "name": "adapter.despawn_first", "kind": "action", "script": "script.rules", "function": "despawn_first" },
+    { "name": "adapter.inspect_sensor_despawn", "kind": "action", "script": "script.rules", "function": "inspect_sensor_despawn" },
     { "name": "adapter.despawn_all", "kind": "action", "script": "script.rules", "function": "despawn_all" }
   ],
   "logic": {
+    "sensors": [
+      { "type": "sensor.bounds_exit", "entity": "pool.projectiles.0", "axis": "y", "side": "max", "threshold": 2.0, "on_enter": "signal.pool.exit" }
+    ],
     "bindings": [
       {
         "signal": "signal.spawn",
@@ -6389,6 +6411,13 @@ return rules
         "signal": "signal.despawn.all",
         "actions": [
           { "type": "adapter.invoke", "adapter": "adapter.despawn_all" }
+        ]
+      },
+      {
+        "signal": "signal.pool.exit",
+        "actions": [
+          { "type": "actor.despawn", "target": "pool.projectiles.0" },
+          { "type": "adapter.invoke", "adapter": "adapter.inspect_sensor_despawn" }
         ]
       }
     ]
@@ -6433,12 +6462,32 @@ return rules
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "pool_available", -1), 1);
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "active_projectiles", -1), 1);
 
+    EXPECT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_FALSE(shot0->active);
+    EXPECT_FALSE(sdl3d_properties_get_bool(sdl3d_game_data_scene_state(runtime), "sensor_during_active", true));
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "sensor_during_damage", -1), 5);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "sensor_during_lifecycle", ""),
+                 "despawning");
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "sensor_during_available", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "pool_lifecycle", ""), "inactive");
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.spawn"), nullptr);
+    EXPECT_TRUE(shot0->active);
+    EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 5);
+
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.first"), nullptr);
     EXPECT_FALSE(shot0->active);
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "before_despawn", -1), 1);
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "after_despawn", -1), 0);
+    EXPECT_FALSE(sdl3d_properties_get_bool(sdl3d_game_data_scene_state(runtime), "during_despawn_active", true));
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "during_despawn_damage", -1), 5);
+    EXPECT_STREQ(sdl3d_properties_get_string(sdl3d_game_data_scene_state(runtime), "during_despawn_lifecycle", ""),
+                 "despawning");
+    EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "during_despawn_available", -1), 1);
     EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "damage", 0), 1);
     EXPECT_EQ(sdl3d_properties_get_int(shot0->props, "touched", -1), 0);
+    EXPECT_STREQ(sdl3d_properties_get_string(shot0->props, "pool_lifecycle", ""), "inactive");
 
     sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.despawn.all"), nullptr);
     EXPECT_EQ(sdl3d_properties_get_int(sdl3d_game_data_scene_state(runtime), "despawned_count", -1), 1);


### PR DESCRIPTION
## Summary

- add internal pooled-actor lifecycle states and `pool_lifecycle` diagnostics
- defer pooled actor archetype reset while actions, sensors, render traversal, or network snapshot apply are iterating runtime state
- allow authored sensors to target deterministic pooled actor names
- document lifecycle semantics and sensor targeting for pooled actors

## Tests

- `./build/debug/tests/sdl3d_game_data_test`
- `ctest --test-dir build/debug --output-on-failure`
- `cmake --build build/debug --target sdl3d_runner pong_demo -j 8`

Part of #223.