### PR TITLE
Add actor pool network replication

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1335,8 +1335,9 @@ sensors inspect active static actors and active pooled actors in the current
 scene, emit one enter signal per actor pair, and track pair activity separately
 so a second projectile can still report a hit while the first projectile remains
 overlapping. This is the preferred pattern for arcade projectile-vs-enemy rules.
-Pooled component iteration in every subsystem and network replication of pooled
-actor state are planned follow-up work.
+Pooled component iteration in every subsystem and host-to-client network
+replication of pooled actor state are supported by the same deterministic actor
+names.
 
 ### Presentation Components
 
@@ -2018,16 +2019,22 @@ orchestration metadata and are not part of the replication schema hash.
 
 Replication channel directions are `host_to_client` or `client_to_host`, and
 `rate` must be a positive integer.
-Host-to-client channels author `actors`; each actor must reference an existing
-entity and declare a non-empty `fields` array. Field strings are allowed for
-built-in transform fields with known types (`position`, `rotation`, `scale`,
-all encoded as `vec3`). Property fields should use object form with an explicit
-`path` and `type`. Supported field types are `bool`, `int32`, `float32`,
-`enum_id`, `vec2`, and `vec3`; aliases `boolean`, `int`, `float`, and
-`string_id` are accepted where obvious. The generic JSON type name `number` is
-not accepted for network fields; authors should choose `int32` or `float32`
-explicitly. Duplicate actor entries and duplicate fields within an actor are
-rejected.
+Host-to-client channels author `actors`, `pools`, or both. Each `actors` entry
+must reference an existing static entity and declare a non-empty `fields` array.
+Each `pools` entry must reference an existing actor pool and declare a non-empty
+`fields` array; the packet expands that field list over every deterministic
+pool slot in ascending index order. Replicated pool layout is part of the schema
+hash: changing a pool name, capacity, field path, or field type makes snapshots
+incompatible.
+
+Field strings are allowed for built-in actor fields with known types: `active`
+(`bool`) and `position`, `rotation`, `scale` (all `vec3`). Property fields
+should use object form with an explicit `path` and `type`. Supported field types
+are `bool`, `int32`, `float32`, `enum_id`, `vec2`, and `vec3`; aliases
+`boolean`, `int`, `float`, and `string_id` are accepted where obvious. The
+generic JSON type name `number` is not accepted for network fields; authors
+should choose `int32` or `float32` explicitly. Duplicate actor entries,
+duplicate pool entries, and duplicate fields within an entry are rejected.
 
 Client-to-host channels author `inputs`; each input must reference an existing
 input action. Duplicate input actions within a channel are rejected.
@@ -2045,6 +2052,10 @@ mismatched schema hashes, wrong field counts, wrong field tags, truncation, and
 trailing bytes. Built-in `position` fields update the actor transform; object
 paths under `properties.` update actor properties. `vec2` property replication
 is stored in SDL3D's existing vec3 property bag by updating x/y and preserving z.
+For pooled actors, replicate `active` first when the peer needs lifecycle state:
+`active=true` initializes the destination pool slot from its archetype before
+later fields are applied, while `active=false` despawns and resets the slot
+after the protected snapshot-apply section completes.
 Callers that need diagnostic logging can use
 `sdl3d_game_data_describe_network_snapshot()` to format the active scene,
 authored `session_flow` state values, and every replicated actor field in schema

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -588,6 +588,7 @@ static yyjson_val *obj_get(yyjson_val *object, const char *key);
 static const char *json_string(yyjson_val *object, const char *key, const char *fallback);
 static yyjson_val *runtime_root(const sdl3d_game_data_runtime *runtime);
 static actor_pool_runtime *find_actor_pool(sdl3d_game_data_runtime *runtime, const char *name);
+static const actor_pool_runtime *find_actor_pool_const(const sdl3d_game_data_runtime *runtime, const char *name);
 static actor_pool_runtime *find_actor_pool_for_actor(sdl3d_game_data_runtime *runtime, const char *actor_name,
                                                      int *out_index);
 static const actor_pool_runtime *find_actor_pool_for_actor_const(const sdl3d_game_data_runtime *runtime,
@@ -595,12 +596,15 @@ static const actor_pool_runtime *find_actor_pool_for_actor_const(const sdl3d_gam
 static bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
 static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                                    int *out_index);
+static actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index);
 static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index,
                                            actor_lifecycle_state state);
 static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor, int index);
 static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor,
                                           int index);
 static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active);
+static bool actor_pool_initialize_slot(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
+                                       bool active);
 static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                        sdl3d_registered_actor *actor, int index);
 static bool apply_actor_pool_scene_exit_policies(sdl3d_game_data_runtime *runtime, const char *from_scene,
@@ -2400,20 +2404,54 @@ static bool game_data_replication_channel_is_client_to_host(yyjson_val *channel)
     return SDL_strcmp(json_string(channel, "direction", ""), "client_to_host") == 0;
 }
 
-static size_t game_data_replication_channel_field_count(yyjson_val *channel)
+static size_t game_data_replication_field_array_count(yyjson_val *fields)
+{
+    return yyjson_is_arr(fields) ? yyjson_arr_size(fields) : 0U;
+}
+
+static size_t game_data_replication_channel_field_count(const sdl3d_game_data_runtime *runtime, yyjson_val *channel)
 {
     size_t count = 0U;
     yyjson_val *actors = obj_get(channel, "actors");
     for (size_t i = 0; yyjson_is_arr(actors) && i < yyjson_arr_size(actors); ++i)
     {
-        yyjson_val *fields = obj_get(yyjson_arr_get(actors, i), "fields");
-        if (yyjson_is_arr(fields))
-            count += yyjson_arr_size(fields);
+        count += game_data_replication_field_array_count(obj_get(yyjson_arr_get(actors, i), "fields"));
+    }
+
+    yyjson_val *pools = obj_get(channel, "pools");
+    for (size_t i = 0; yyjson_is_arr(pools) && i < yyjson_arr_size(pools); ++i)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, i);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, json_string(pool_schema, "pool", NULL));
+        if (pool != NULL && pool->capacity > 0)
+            count += (size_t)pool->capacity * game_data_replication_field_array_count(obj_get(pool_schema, "fields"));
     }
     return count;
 }
 
-static bool game_data_replication_channel_packet_size(yyjson_val *channel, size_t *out_size)
+static bool game_data_add_replication_fields_packet_size(yyjson_val *fields, size_t multiplier, size_t *size)
+{
+    if (size == NULL)
+        return false;
+
+    for (size_t repeat = 0U; repeat < multiplier; ++repeat)
+    {
+        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+        {
+            sdl3d_replication_field_descriptor field;
+            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field))
+                return false;
+            const size_t field_size = sdl3d_replication_field_wire_size(field.type);
+            if (field_size == 0U || *size > SIZE_MAX - 1U - field_size)
+                return false;
+            *size += 1U + field_size;
+        }
+    }
+    return true;
+}
+
+static bool game_data_replication_channel_packet_size(const sdl3d_game_data_runtime *runtime, yyjson_val *channel,
+                                                      size_t *out_size)
 {
     if (out_size != NULL)
         *out_size = 0U;
@@ -2424,17 +2462,21 @@ static bool game_data_replication_channel_packet_size(yyjson_val *channel, size_
     yyjson_val *actors = obj_get(channel, "actors");
     for (size_t actor_index = 0U; yyjson_is_arr(actors) && actor_index < yyjson_arr_size(actors); ++actor_index)
     {
-        yyjson_val *fields = obj_get(yyjson_arr_get(actors, actor_index), "fields");
-        for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
-        {
-            sdl3d_replication_field_descriptor field;
-            if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field))
-                return false;
-            const size_t field_size = sdl3d_replication_field_wire_size(field.type);
-            if (field_size == 0U || size > SIZE_MAX - 1U - field_size)
-                return false;
-            size += 1U + field_size;
-        }
+        if (!game_data_add_replication_fields_packet_size(obj_get(yyjson_arr_get(actors, actor_index), "fields"), 1U,
+                                                          &size))
+            return false;
+    }
+
+    yyjson_val *pools = obj_get(channel, "pools");
+    for (size_t pool_index = 0U; yyjson_is_arr(pools) && pool_index < yyjson_arr_size(pools); ++pool_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_index);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, json_string(pool_schema, "pool", NULL));
+        if (pool == NULL || pool->capacity < 0)
+            return false;
+        if (!game_data_add_replication_fields_packet_size(obj_get(pool_schema, "fields"), (size_t)pool->capacity,
+                                                          &size))
+            return false;
     }
 
     if (out_size != NULL)
@@ -2556,6 +2598,13 @@ static bool game_data_read_actor_replication_field(const sdl3d_registered_actor 
         return false;
 
     out_value->type = field->type;
+    if (SDL_strcmp(field->path, "active") == 0)
+    {
+        if (field->type != SDL3D_REPLICATION_FIELD_BOOL)
+            return false;
+        out_value->value.as_bool = actor->active;
+        return true;
+    }
     if (SDL_strcmp(field->path, "position") == 0)
     {
         if (field->type != SDL3D_REPLICATION_FIELD_VEC3)
@@ -2664,13 +2713,34 @@ static bool game_data_read_snapshot_value(sdl3d_replication_reader *reader, sdl3
     }
 }
 
-static bool game_data_apply_actor_replication_field(sdl3d_registered_actor *actor,
+static bool game_data_apply_actor_replication_field(sdl3d_game_data_runtime *runtime, sdl3d_registered_actor *actor,
                                                     const sdl3d_replication_field_descriptor *field,
                                                     const game_data_snapshot_value *value)
 {
     if (actor == NULL || field == NULL || value == NULL || field->path == NULL || field->type != value->type)
         return false;
 
+    if (SDL_strcmp(field->path, "active") == 0)
+    {
+        if (value->type != SDL3D_REPLICATION_FIELD_BOOL)
+            return false;
+        int actor_index = -1;
+        actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
+        if (pool != NULL && actor_index >= 0)
+        {
+            if (value->value.as_bool)
+            {
+                if (actor_pool_actor_is_active(pool, actor, actor_index))
+                    return true;
+                return actor_pool_initialize_slot(runtime, pool, actor_index, true);
+            }
+            if (actor_pool_lifecycle_state(pool, actor_index) == ACTOR_LIFECYCLE_INACTIVE)
+                return true;
+            return actor_pool_request_despawn(runtime, pool, actor, actor_index);
+        }
+        actor->active = value->value.as_bool;
+        return true;
+    }
     if (SDL_strcmp(field->path, "position") == 0)
     {
         if (value->type != SDL3D_REPLICATION_FIELD_VEC3)
@@ -10656,6 +10726,18 @@ static actor_pool_runtime *find_actor_pool(sdl3d_game_data_runtime *runtime, con
     return NULL;
 }
 
+static const actor_pool_runtime *find_actor_pool_const(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->actor_pool_count; ++i)
+    {
+        if (runtime->actor_pools[i].name != NULL && SDL_strcmp(runtime->actor_pools[i].name, name) == 0)
+            return &runtime->actor_pools[i];
+    }
+    return NULL;
+}
+
 static int actor_pool_index_for_actor(const actor_pool_runtime *pool, const char *actor_name)
 {
     if (pool == NULL || actor_name == NULL)
@@ -13452,6 +13534,54 @@ static bool game_data_describe_network_snapshot_ex(const sdl3d_game_data_runtime
         }
     }
 
+    yyjson_val *pools = obj_get(channel, "pools");
+    for (size_t pool_index = 0U; yyjson_is_arr(pools) && pool_index < yyjson_arr_size(pools); ++pool_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_index);
+        const char *pool_name = json_string(pool_schema, "pool", NULL);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, pool_name);
+        if (pool == NULL)
+        {
+            set_errorf(error_buffer, error_buffer_size, "network snapshot describe pool '%s' not found",
+                       pool_name != NULL ? pool_name : "<null>");
+            return false;
+        }
+
+        yyjson_val *fields = obj_get(pool_schema, "fields");
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            const char *actor_name = pool->actor_names[actor_index];
+            const sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, actor_name);
+            if (actor == NULL)
+            {
+                set_errorf(error_buffer, error_buffer_size, "network snapshot describe pooled actor '%s' not found",
+                           actor_name != NULL ? actor_name : "<null>");
+                return false;
+            }
+            for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+            {
+                sdl3d_replication_field_descriptor field;
+                game_data_snapshot_value value;
+                if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
+                    !game_data_read_actor_replication_field(actor, &field, &value))
+                {
+                    set_errorf(error_buffer, error_buffer_size,
+                               "network snapshot describe failed to read field '%s' on pooled actor '%s'",
+                               field.path != NULL ? field.path : "<invalid>",
+                               actor_name != NULL ? actor_name : "<null>");
+                    return false;
+                }
+                if (!append_format(buffer, buffer_size, &offset, " %s.%s=", actor_name != NULL ? actor_name : "<null>",
+                                   field.path != NULL ? field.path : "<invalid>") ||
+                    !game_data_append_snapshot_value(buffer, buffer_size, &offset, &value))
+                {
+                    set_error(error_buffer, error_buffer_size, "network snapshot describe buffer is too small");
+                    return false;
+                }
+            }
+        }
+    }
+
     return true;
 }
 
@@ -13669,14 +13799,14 @@ bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runt
         return false;
     }
 
-    const size_t field_count = game_data_replication_channel_field_count(channel);
+    const size_t field_count = game_data_replication_channel_field_count(runtime, channel);
     if (field_count > SDL_MAX_UINT32 || channel_index < 0)
     {
         set_error(error_buffer, error_buffer_size, "network snapshot channel is too large");
         return false;
     }
     size_t required_size = 0U;
-    if (!game_data_replication_channel_packet_size(channel, &required_size))
+    if (!game_data_replication_channel_packet_size(runtime, channel, &required_size))
     {
         set_error(error_buffer, error_buffer_size, "network snapshot channel contains unsupported field data");
         return false;
@@ -13730,6 +13860,52 @@ bool sdl3d_game_data_encode_network_snapshot(const sdl3d_game_data_runtime *runt
             {
                 set_error(error_buffer, error_buffer_size, "network snapshot buffer is too small for field data");
                 return false;
+            }
+        }
+    }
+
+    yyjson_val *pools = obj_get(channel, "pools");
+    for (size_t pool_index = 0U; yyjson_is_arr(pools) && pool_index < yyjson_arr_size(pools); ++pool_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_index);
+        const char *pool_name = json_string(pool_schema, "pool", NULL);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, pool_name);
+        if (pool == NULL)
+        {
+            set_errorf(error_buffer, error_buffer_size, "network snapshot pool '%s' not found",
+                       pool_name != NULL ? pool_name : "<null>");
+            return false;
+        }
+
+        yyjson_val *fields = obj_get(pool_schema, "fields");
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            const char *actor_name = pool->actor_names[actor_index];
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, actor_name);
+            if (actor == NULL)
+            {
+                set_errorf(error_buffer, error_buffer_size, "network snapshot pooled actor '%s' not found",
+                           actor_name != NULL ? actor_name : "<null>");
+                return false;
+            }
+            for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+            {
+                sdl3d_replication_field_descriptor field;
+                game_data_snapshot_value value;
+                if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
+                    !game_data_read_actor_replication_field(actor, &field, &value))
+                {
+                    set_errorf(error_buffer, error_buffer_size,
+                               "network snapshot failed to read field '%s' on pooled actor '%s'",
+                               field.path != NULL ? field.path : "<invalid>",
+                               actor_name != NULL ? actor_name : "<null>");
+                    return false;
+                }
+                if (!game_data_write_snapshot_value(&writer, &value))
+                {
+                    set_error(error_buffer, error_buffer_size, "network snapshot buffer is too small for field data");
+                    return false;
+                }
             }
         }
     }
@@ -13909,7 +14085,7 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
         return false;
     }
 
-    const size_t field_count = game_data_replication_channel_field_count(channel);
+    const size_t field_count = game_data_replication_channel_field_count(runtime, channel);
     if ((Uint32)field_count != packet_field_count)
     {
         set_error(error_buffer, error_buffer_size, "network snapshot field count does not match schema");
@@ -13938,6 +14114,31 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
                  decoded_index < field_count &&
                  game_data_read_snapshot_value(&reader, field.type, &values[decoded_index]);
             ++decoded_index;
+        }
+    }
+    yyjson_val *pools = obj_get(channel, "pools");
+    for (size_t pool_schema_index = 0U; ok && yyjson_is_arr(pools) && pool_schema_index < yyjson_arr_size(pools);
+         ++pool_schema_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_schema_index);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, json_string(pool_schema, "pool", NULL));
+        yyjson_val *fields = obj_get(pool_schema, "fields");
+        if (pool == NULL)
+        {
+            ok = false;
+            break;
+        }
+        for (int actor_index = 0; ok && actor_index < pool->capacity; ++actor_index)
+        {
+            for (size_t field_index = 0U; ok && yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields);
+                 ++field_index)
+            {
+                sdl3d_replication_field_descriptor field;
+                ok = sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) &&
+                     decoded_index < field_count &&
+                     game_data_read_snapshot_value(&reader, field.type, &values[decoded_index]);
+                ++decoded_index;
+            }
         }
     }
     if (ok && decoded_index != field_count)
@@ -13977,6 +14178,57 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
         }
     }
 
+    size_t pooled_actor_count = 0U;
+    for (size_t pool_schema_index = 0U; yyjson_is_arr(pools) && pool_schema_index < yyjson_arr_size(pools);
+         ++pool_schema_index)
+    {
+        const actor_pool_runtime *pool =
+            find_actor_pool_const(runtime, json_string(yyjson_arr_get(pools, pool_schema_index), "pool", NULL));
+        if (pool == NULL || pool->capacity < 0)
+        {
+            SDL_free(resolved_actors);
+            SDL_free(values);
+            set_error(error_buffer, error_buffer_size, "network snapshot pool not found");
+            return false;
+        }
+        pooled_actor_count += (size_t)pool->capacity;
+    }
+    sdl3d_registered_actor **resolved_pooled_actors =
+        pooled_actor_count > 0U
+            ? (sdl3d_registered_actor **)SDL_calloc(pooled_actor_count, sizeof(*resolved_pooled_actors))
+            : NULL;
+    if (resolved_pooled_actors == NULL && pooled_actor_count > 0U)
+    {
+        SDL_free(resolved_actors);
+        SDL_free(values);
+        set_error(error_buffer, error_buffer_size, "network snapshot failed to allocate pooled actor lookup storage");
+        return false;
+    }
+
+    size_t resolved_pool_actor_index = 0U;
+    for (size_t pool_schema_index = 0U; yyjson_is_arr(pools) && pool_schema_index < yyjson_arr_size(pools);
+         ++pool_schema_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_schema_index);
+        const char *pool_name = json_string(pool_schema, "pool", NULL);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, pool_name);
+        for (int actor_index = 0; pool != NULL && actor_index < pool->capacity; ++actor_index)
+        {
+            const char *actor_name = pool->actor_names[actor_index];
+            resolved_pooled_actors[resolved_pool_actor_index] = sdl3d_game_data_find_actor(runtime, actor_name);
+            if (resolved_pooled_actors[resolved_pool_actor_index] == NULL)
+            {
+                SDL_free(resolved_pooled_actors);
+                SDL_free(resolved_actors);
+                SDL_free(values);
+                set_errorf(error_buffer, error_buffer_size, "network snapshot pooled actor '%s' not found",
+                           actor_name != NULL ? actor_name : "<null>");
+                return false;
+            }
+            ++resolved_pool_actor_index;
+        }
+    }
+
     actor_lifecycle_defer_begin(runtime);
     bool apply_ok = true;
     size_t apply_index = 0U;
@@ -13990,7 +14242,7 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
             sdl3d_replication_field_descriptor field;
             if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
                 apply_index >= field_count ||
-                !game_data_apply_actor_replication_field(actor, &field, &values[apply_index]))
+                !game_data_apply_actor_replication_field(runtime, actor, &field, &values[apply_index]))
             {
                 set_errorf(error_buffer, error_buffer_size, "network snapshot failed to apply field '%s' on actor '%s'",
                            field.path != NULL ? field.path : "<invalid>",
@@ -14001,14 +14253,45 @@ bool sdl3d_game_data_apply_network_snapshot(sdl3d_game_data_runtime *runtime, co
             ++apply_index;
         }
     }
+    size_t pooled_apply_actor_index = 0U;
+    for (size_t pool_schema_index = 0U; apply_ok && yyjson_is_arr(pools) && pool_schema_index < yyjson_arr_size(pools);
+         ++pool_schema_index)
+    {
+        yyjson_val *pool_schema = yyjson_arr_get(pools, pool_schema_index);
+        const char *pool_name = json_string(pool_schema, "pool", NULL);
+        const actor_pool_runtime *pool = find_actor_pool_const(runtime, pool_name);
+        yyjson_val *fields = obj_get(pool_schema, "fields");
+        for (int actor_index = 0; pool != NULL && actor_index < pool->capacity; ++actor_index)
+        {
+            sdl3d_registered_actor *actor = resolved_pooled_actors[pooled_apply_actor_index++];
+            const char *actor_name = actor != NULL ? actor->name : "<null>";
+            for (size_t field_index = 0U; yyjson_is_arr(fields) && field_index < yyjson_arr_size(fields); ++field_index)
+            {
+                sdl3d_replication_field_descriptor field;
+                if (!sdl3d_replication_field_descriptor_from_json(yyjson_arr_get(fields, field_index), &field) ||
+                    apply_index >= field_count ||
+                    !game_data_apply_actor_replication_field(runtime, actor, &field, &values[apply_index]))
+                {
+                    set_errorf(error_buffer, error_buffer_size,
+                               "network snapshot failed to apply field '%s' on pooled actor '%s'",
+                               field.path != NULL ? field.path : "<invalid>", actor_name);
+                    apply_ok = false;
+                    break;
+                }
+                ++apply_index;
+            }
+        }
+    }
     actor_lifecycle_defer_end(runtime);
     if (!apply_ok)
     {
+        SDL_free(resolved_pooled_actors);
         SDL_free(resolved_actors);
         SDL_free(values);
         return false;
     }
 
+    SDL_free(resolved_pooled_actors);
     SDL_free(resolved_actors);
     SDL_free(values);
     if (out_tick != NULL)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -610,6 +610,40 @@ static bool validate_network_actors(validation_context *ctx, yyjson_val *actors,
     return ok;
 }
 
+static bool validate_network_pools(validation_context *ctx, yyjson_val *pools, const char *json_path,
+                                   validation_names *names)
+{
+    if (!yyjson_is_arr(pools) || yyjson_arr_size(pools) == 0)
+        return validation_error(ctx, json_path, "network pools must be a non-empty array");
+
+    name_table pool_names;
+    SDL_zero(pool_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(pools); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *pool = yyjson_arr_get(pools, i);
+        if (!yyjson_is_obj(pool))
+        {
+            ok = validation_error(ctx, path, "network pool entry must be an object");
+            break;
+        }
+        const char *pool_name = json_string(pool, "pool");
+        if (!require_ref(ctx, &names->actor_pools, "actor pool", pool_name, path) ||
+            !require_unique_name(ctx, &pool_names, "network pool", pool_name, path))
+        {
+            ok = false;
+            break;
+        }
+        char fields_path[PATH_BUFFER_SIZE];
+        format_path(fields_path, sizeof(fields_path), "%s.fields", path);
+        ok = validate_network_actor_fields(ctx, obj_get(pool, "fields"), fields_path);
+    }
+    name_table_destroy(&pool_names);
+    return ok;
+}
+
 static bool validate_network_inputs(validation_context *ctx, yyjson_val *inputs, const char *json_path,
                                     validation_names *names)
 {
@@ -1315,12 +1349,13 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
             break;
         }
         yyjson_val *actors = obj_get(entry, "actors");
+        yyjson_val *pools = obj_get(entry, "pools");
         yyjson_val *inputs = obj_get(entry, "inputs");
         if (SDL_strcmp(direction, "host_to_client") == 0)
         {
-            if (actors == NULL)
+            if (actors == NULL && pools == NULL)
             {
-                ok = validation_error(ctx, path, "host_to_client network replication must declare actors");
+                ok = validation_error(ctx, path, "host_to_client network replication must declare actors or pools");
                 break;
             }
             if (inputs != NULL)
@@ -1330,7 +1365,14 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
             }
             char actors_path[PATH_BUFFER_SIZE];
             format_path(actors_path, sizeof(actors_path), "%s.actors", path);
-            ok = validate_network_actors(ctx, actors, actors_path, names);
+            if (actors != NULL)
+                ok = validate_network_actors(ctx, actors, actors_path, names);
+            if (ok && pools != NULL)
+            {
+                char pools_path[PATH_BUFFER_SIZE];
+                format_path(pools_path, sizeof(pools_path), "%s.pools", path);
+                ok = validate_network_pools(ctx, pools, pools_path, names);
+            }
         }
         else
         {
@@ -1342,6 +1384,11 @@ static bool validate_network(validation_context *ctx, yyjson_val *root, validati
             if (actors != NULL)
             {
                 ok = validation_error(ctx, path, "client_to_host network replication must not declare actors");
+                break;
+            }
+            if (pools != NULL)
+            {
+                ok = validation_error(ctx, path, "client_to_host network replication must not declare pools");
                 break;
             }
             char inputs_path[PATH_BUFFER_SIZE];
@@ -1531,6 +1578,18 @@ static void hash_network_actor_fields(sdl3d_crypto_hash32_state *state, yyjson_v
     }
 }
 
+static Sint64 network_actor_pool_capacity(yyjson_val *root, const char *pool_name)
+{
+    yyjson_val *pools = obj_get(root, "actor_pools");
+    for (size_t i = 0; yyjson_is_arr(pools) && i < yyjson_arr_size(pools); ++i)
+    {
+        yyjson_val *pool = yyjson_arr_get(pools, i);
+        if (SDL_strcmp(json_string(pool, "name"), pool_name != NULL ? pool_name : "") == 0)
+            return yyjson_get_sint(obj_get(pool, "capacity"));
+    }
+    return 0;
+}
+
 bool sdl3d_game_data_network_schema_hash(yyjson_val *root, Uint8 out_hash[SDL3D_REPLICATION_SCHEMA_HASH_SIZE],
                                          bool *out_present)
 {
@@ -1576,6 +1635,17 @@ bool sdl3d_game_data_network_schema_hash(yyjson_val *root, Uint8 out_hash[SDL3D_
             yyjson_val *actor = yyjson_arr_get(actors, a);
             network_hash_update(&state, "actor.entity", json_string(actor, "entity"));
             hash_network_actor_fields(&state, obj_get(actor, "fields"));
+        }
+
+        yyjson_val *pools = obj_get(entry, "pools");
+        network_hash_update_int(&state, "pool_count", (Sint64)yyjson_arr_size(pools));
+        for (size_t p = 0; yyjson_is_arr(pools) && p < yyjson_arr_size(pools); ++p)
+        {
+            yyjson_val *pool = yyjson_arr_get(pools, p);
+            const char *pool_name = json_string(pool, "pool");
+            network_hash_update(&state, "pool.name", pool_name);
+            network_hash_update_int(&state, "pool.capacity", network_actor_pool_capacity(root, pool_name));
+            hash_network_actor_fields(&state, obj_get(pool, "fields"));
         }
 
         yyjson_val *inputs = obj_get(entry, "inputs");

--- a/src/network_replication_schema.c
+++ b/src/network_replication_schema.c
@@ -68,6 +68,12 @@ const char *sdl3d_replication_field_type_name(sdl3d_replication_field_type type)
 
 bool sdl3d_replication_builtin_field_type(const char *field, sdl3d_replication_field_type *out_type)
 {
+    if (field != NULL && SDL_strcmp(field, "active") == 0)
+    {
+        if (out_type != NULL)
+            *out_type = SDL3D_REPLICATION_FIELD_BOOL;
+        return true;
+    }
     if (field != NULL &&
         (SDL_strcmp(field, "position") == 0 || SDL_strcmp(field, "rotation") == 0 || SDL_strcmp(field, "scale") == 0))
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -387,6 +387,84 @@ std::string valid_network_schema_json(const char *ball_velocity_type = "vec3")
   })json";
 }
 
+std::string actor_pool_replication_game_json(int pool_capacity)
+{
+    return std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Actor Pool Replication", "id": "test.actor_pool_replication", "version": "0.1.0" },
+  "world": { "name": "world.actor_pool_replication", "kind": "fixed_screen" },
+  "entities": [],
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "tags": ["projectile"],
+      "transform": { "position": [0.0, 0.0, 0.25] },
+      "properties": {
+        "damage": { "type": "int", "value": 1 },
+        "velocity": { "type": "vec2", "value": [0.0, 0.0] }
+      }
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.shots",
+      "archetype": "archetype.shot",
+      "capacity": )json") +
+           std::to_string(pool_capacity) + R"json(,
+      "scene": "scene.play",
+      "initial_active": false,
+      "on_exhausted": "fail"
+    }
+  ],
+  "signals": [
+    "signal.spawn",
+    "signal.despawn"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          {
+            "type": "actor.spawn",
+            "pool": "pool.shots",
+            "position": [2.0, 3.0, 4.0],
+            "properties": { "damage": 7 }
+          }
+        ]
+      },
+      {
+        "signal": "signal.despawn",
+        "actions": [
+          { "type": "actor.despawn", "target": "pool.shots.0" }
+        ]
+      }
+    ]
+  },
+  "network": {
+    "protocol": { "id": "sdl3d.test.pool.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "pool_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "pools": [
+          {
+            "pool": "pool.shots",
+            "fields": [
+              "active",
+              "position",
+              { "path": "properties.damage", "type": "int32" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+}
+
 std::array<Uint8, SDL3D_REPLICATION_SCHEMA_HASH_SIZE> load_network_schema_hash(const std::filesystem::path &path)
 {
     sdl3d_game_session *session = nullptr;
@@ -7685,6 +7763,145 @@ TEST(GameDataRuntime, RejectsPongNetworkSnapshotsWithMismatchedSchemaOrTruncatio
 
     destroy_runtime_session(host_session, host);
     destroy_runtime_session(client_session, client);
+}
+
+TEST(GameDataRuntime, EncodesAndAppliesPooledActorNetworkSnapshots)
+{
+    const std::filesystem::path dir = unique_test_dir("actor_pool_replication");
+    write_text(dir / "pool.game.json", actor_pool_replication_game_json(2).c_str());
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true
+})json");
+
+    sdl3d_game_session *host_session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &host_session));
+    sdl3d_game_data_runtime *host = nullptr;
+    char error[512]{};
+    ASSERT_TRUE(
+        sdl3d_game_data_load_file((dir / "pool.game.json").string().c_str(), host_session, &host, error, sizeof(error)))
+        << error;
+
+    sdl3d_game_session *client_session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &client_session));
+    sdl3d_game_data_runtime *client = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "pool.game.json").string().c_str(), client_session, &client, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_registered_actor *host_shot0 = sdl3d_game_data_find_actor(host, "pool.shots.0");
+    sdl3d_registered_actor *host_shot1 = sdl3d_game_data_find_actor(host, "pool.shots.1");
+    sdl3d_registered_actor *client_shot0 = sdl3d_game_data_find_actor(client, "pool.shots.0");
+    sdl3d_registered_actor *client_shot1 = sdl3d_game_data_find_actor(client, "pool.shots.1");
+    ASSERT_NE(host_shot0, nullptr);
+    ASSERT_NE(host_shot1, nullptr);
+    ASSERT_NE(client_shot0, nullptr);
+    ASSERT_NE(client_shot1, nullptr);
+    EXPECT_FALSE(host_shot0->active);
+    EXPECT_FALSE(client_shot0->active);
+
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(host_session),
+                      sdl3d_game_data_find_signal(host, "signal.spawn"), nullptr);
+    ASSERT_TRUE(host_shot0->active);
+    EXPECT_FALSE(host_shot1->active);
+    host_shot0->position = sdl3d_vec3_make(5.0f, 6.0f, 7.0f);
+    sdl3d_properties_set_int(host_shot0->props, "damage", 11);
+
+    std::array<Uint8, 256> packet{};
+    size_t packet_size = 0U;
+    ASSERT_TRUE(sdl3d_game_data_encode_network_snapshot(host, "pool_state", 55U, packet.data(), packet.size(),
+                                                        &packet_size, error, sizeof(error)))
+        << error;
+    Uint32 tick = 0U;
+    ASSERT_TRUE(sdl3d_game_data_apply_network_snapshot(client, packet.data(), packet_size, &tick, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(tick, 55U);
+    EXPECT_TRUE(client_shot0->active);
+    EXPECT_FALSE(client_shot1->active);
+    expect_vec3_near(client_shot0->position, host_shot0->position);
+    EXPECT_EQ(sdl3d_properties_get_int(client_shot0->props, "damage", 0), 11);
+    EXPECT_STREQ(sdl3d_properties_get_string(client_shot0->props, "pool_lifecycle", ""), "active");
+
+    char description[1024]{};
+    ASSERT_TRUE(sdl3d_game_data_describe_network_snapshot(host, "pool_state", 56U, description, sizeof(description),
+                                                          error, sizeof(error)))
+        << error;
+    EXPECT_NE(std::string(description).find("pool.shots.0.active=true"), std::string::npos);
+    EXPECT_NE(std::string(description).find("pool.shots.0.properties.damage=11"), std::string::npos);
+
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(host_session),
+                      sdl3d_game_data_find_signal(host, "signal.despawn"), nullptr);
+    ASSERT_FALSE(host_shot0->active);
+    ASSERT_TRUE(sdl3d_game_data_encode_network_snapshot(host, "pool_state", 56U, packet.data(), packet.size(),
+                                                        &packet_size, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(sdl3d_game_data_apply_network_snapshot(client, packet.data(), packet_size, &tick, error, sizeof(error)))
+        << error;
+    EXPECT_FALSE(client_shot0->active);
+    EXPECT_STREQ(sdl3d_properties_get_string(client_shot0->props, "pool_lifecycle", ""), "inactive");
+    EXPECT_EQ(sdl3d_properties_get_int(client_shot0->props, "damage", 0), 1);
+    expect_vec3_near(client_shot0->position, sdl3d_vec3_make(0.0f, 0.0f, 0.25f));
+
+    destroy_runtime_session(host_session, host);
+    destroy_runtime_session(client_session, client);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, PooledActorNetworkSchemaHashIncludesPoolCapacity)
+{
+    const std::filesystem::path dir = unique_test_dir("actor_pool_replication_hash");
+    write_text(dir / "capacity_2.game.json", actor_pool_replication_game_json(2).c_str());
+    write_text(dir / "capacity_3.game.json", actor_pool_replication_game_json(3).c_str());
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true
+})json");
+
+    char error[512]{};
+    ASSERT_TRUE(
+        sdl3d_game_data_validate_file((dir / "capacity_2.game.json").string().c_str(), nullptr, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(
+        sdl3d_game_data_validate_file((dir / "capacity_3.game.json").string().c_str(), nullptr, error, sizeof(error)))
+        << error;
+
+    EXPECT_NE(load_network_schema_hash(dir / "capacity_2.game.json"),
+              load_network_schema_hash(dir / "capacity_3.game.json"));
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsUnknownPooledActorNetworkReplicationRefs)
+{
+    const std::filesystem::path dir = unique_test_dir("bad_actor_pool_replication");
+    const std::string network_json = R"json({
+    "protocol": { "id": "sdl3d.test.pool.v1", "version": 1, "transport": "udp", "tick_rate": 60 },
+    "replication": [
+      {
+        "name": "pool_state",
+        "direction": "host_to_client",
+        "rate": 60,
+        "pools": [
+          {
+            "pool": "pool.missing",
+            "fields": ["active"]
+          }
+        ]
+      }
+    ]
+  })json";
+    write_text(dir / "bad_pool_ref.game.json", network_schema_game_json(network_json).c_str());
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_pool_ref.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("actor pool"), std::string::npos) << error;
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, EncodesAndAppliesPongNetworkInputFromAuthoredSchema)


### PR DESCRIPTION
## Summary
- adds host-to-client snapshot replication for authored actor pools, expanding pool fields over deterministic pool slots
- adds `active` as a built-in replicated actor field and applies pooled active state through lifecycle-safe pool helpers
- includes replicated pool layout/capacity in the network schema hash and validates network pool references
- documents pooled actor replication behavior and lifecycle authoring guidance

## Tests
- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.*PooledActorNetwork*:GameDataRuntime.RejectsUnknownPooledActorNetworkReplicationRefs:GameDataRuntime.EncodesAndAppliesPongNetworkSnapshotFromAuthoredSchema`
- `./build/debug/tests/sdl3d_game_data_test`
- `ctest --test-dir build/debug --output-on-failure`

Closes slice 7 of #223.