### PR TITLE
Add actor pool diagnostics

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1311,7 +1311,8 @@ run. Supported values are:
 
 `on_exhausted` is optional and defaults to `fail`. `reuse_oldest` may be
 authored when the oldest active pooled actor should be reset and reused instead
-of failing the spawn.
+of failing the spawn. Pool exhaustion logs an application warning with the pool
+name, capacity, and policy so authors can tune capacities from playtest logs.
 
 Pool actors receive deterministic runtime names in the form
 `<pool-name>.<index>`, such as `pool.player_shots.0`, and are initialized from
@@ -1320,6 +1321,10 @@ archetype, activates it, applies the requested position and property overrides,
 and writes `pool`, `pool_index`, and `pool_lifecycle` properties for
 diagnostics. `pool_lifecycle` is one of `inactive`, `spawning`, `active`, or
 `despawning`; `spawning` is a transient state during reset and activation.
+The engine also tracks pool diagnostics for Lua inspection: active count,
+available count, peak active count, spawn attempts, successful spawns, failed
+spawns, exhaustion count, reuse count, despawn count, last spawn-failure reason,
+and last despawn reason.
 Despawning hides the actor from active queries immediately, then resets it back
 to archetype defaults. If despawn is requested while signals, sensors,
 rendering, or network snapshot application are traversing runtime state, the
@@ -1546,17 +1551,47 @@ properties for diagnostics and generic scene filtering.
 
 `actor.despawn` requires `target`. When the target is a pooled actor, the
 runtime resets it to the pool archetype and marks it inactive. Non-pooled
-targets are simply marked inactive.
+targets are simply marked inactive. Optional `reason` is copied into the pool's
+last despawn diagnostic:
+
+```json
+{
+  "type": "actor.despawn",
+  "target": "pool.player_shots.0",
+  "reason": "hit_enemy"
+}
+```
 
 `actor.despawn_by_tag` requires `tag` and deactivates active pooled actors
-whose archetype declares that tag:
+whose archetype declares that tag. Optional `reason` is applied to each pooled
+actor despawned by the action:
 
 ```json
 {
   "type": "actor.despawn_by_tag",
-  "tag": "player_shot"
+  "tag": "player_shot",
+  "reason": "wave_reset"
 }
 ```
+
+For Space Invaders-style games, prefer small specialized pools rather than one
+large catch-all pool:
+
+- `pool.player_shots`: player projectiles, usually `capacity: 1` or a small
+  authored limit, `on_scene_exit: "despawn"`, and `on_exhausted: "fail"` when
+  the game rules limit simultaneous shots.
+- `pool.enemy_shots`: enemy projectiles sized to the maximum simultaneous enemy
+  fire pattern, also `on_scene_exit: "despawn"`.
+- `pool.invaders`: enemy actors for the current wave. Use `reset` when leaving
+  gameplay or `preserve` only if the wave must survive intermediate scenes.
+- `pool.explosions`: short-lived animated sprites or particles, commonly
+  `on_exhausted: "reuse_oldest"` because replacing the oldest effect is better
+  than dropping new feedback.
+
+Use pool peak and exhaustion counters during playtesting to prove the capacities
+cover the intended worst case. In LAN games, replicate the pooled actor
+`active` field, `position`, and any gameplay properties needed by the client;
+presentation-only effects can often remain local.
 
     Presentation state that changes continuously can be expressed with components instead of host
         code. `property.decay` moves an integer or

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -59,6 +59,15 @@ The `ctx` table provides:
 - `ctx:pool_capacity(pool)`: return the authored pool capacity, or `0` for an unknown pool
 - `ctx:pool_active_count(pool)`: return the active actor count for a pool
 - `ctx:pool_available_count(pool)`: return the inactive actor count for a pool
+- `ctx:pool_peak_active_count(pool)`: return the highest active count reached since load
+- `ctx:pool_spawn_attempt_count(pool)`: return attempted spawns
+- `ctx:pool_spawn_success_count(pool)`: return successful spawns
+- `ctx:pool_spawn_failure_count(pool)`: return failed spawns
+- `ctx:pool_exhaustion_count(pool)`: return times the pool was exhausted
+- `ctx:pool_reuse_count(pool)`: return times `reuse_oldest` replaced an actor
+- `ctx:pool_despawn_count(pool)`: return pooled actor despawns, including reuse replacement
+- `ctx:pool_last_spawn_failure_reason(pool)`: return the last spawn failure reason, or `none`
+- `ctx:pool_last_despawn_reason(pool)`: return the last despawn reason, or `none`
 - `ctx:state_get(key, fallback)`: read persistent scene state
 - `ctx:state_set(key, value)`: write persistent scene state; passing `nil` removes the key
 - `ctx:random()`: deterministic per-runtime pseudo-random value in `[0, 1)`
@@ -147,6 +156,15 @@ The runtime installs a small `sdl3d` table for low-level access and utility help
 - `sdl3d.pool_capacity(pool)`
 - `sdl3d.pool_active_count(pool)`
 - `sdl3d.pool_available_count(pool)`
+- `sdl3d.pool_peak_active_count(pool)`
+- `sdl3d.pool_spawn_attempt_count(pool)`
+- `sdl3d.pool_spawn_success_count(pool)`
+- `sdl3d.pool_spawn_failure_count(pool)`
+- `sdl3d.pool_exhaustion_count(pool)`
+- `sdl3d.pool_reuse_count(pool)`
+- `sdl3d.pool_despawn_count(pool)`
+- `sdl3d.pool_last_spawn_failure_reason(pool)`
+- `sdl3d.pool_last_despawn_reason(pool)`
 - `sdl3d.log(message)`
 - `sdl3d.storage.*`
 - `sdl3d.json.*`
@@ -203,11 +221,19 @@ for _, shot in ipairs(ctx:active_actors_with_tags("player_shot")) do
 end
 ```
 
-`ctx:despawn(actor_or_name)` resets pooled actors back to archetype defaults and
-marks them inactive. For non-pooled actors, it only clears the active flag.
-`ctx:despawn_by_tag(tag)` applies to pooled actors and returns the number of
-active actors it despawned. Pool count helpers report capacity, active count,
-and available inactive slots.
+`ctx:despawn(actor_or_name, reason)` resets pooled actors back to archetype
+defaults and marks them inactive. For non-pooled actors, it only clears the
+active flag. The optional reason is stored in the pool's last despawn
+diagnostic. `ctx:despawn_by_tag(tag, reason)` applies to pooled actors and
+returns the number of active actors it despawned.
+
+Pool helpers report capacity, active count, available inactive slots, peak
+active count, spawn attempts, spawn successes, spawn failures, exhaustion
+events, reuse events, despawns, and the latest spawn/despawn reason. Use these
+diagnostics while tuning projectile, enemy, pickup, and effect pools. An
+exhausted pool logs an application warning; repeated warnings usually mean the
+authored capacity or exhaustion policy does not match the game's intended worst
+case.
 
 During signal handling, sensor updates, rendering traversal, and network
 snapshot application, pooled despawns are lifecycle-safe: the actor becomes

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -297,6 +297,15 @@ typedef struct actor_pool_runtime
     Uint64 *spawn_generations;
     actor_lifecycle_state *lifecycle_states;
     Uint64 spawn_generation_counter;
+    Uint64 spawn_attempt_count;
+    Uint64 spawn_success_count;
+    Uint64 spawn_failure_count;
+    Uint64 exhaustion_count;
+    Uint64 reuse_count;
+    Uint64 despawn_count;
+    int peak_active_count;
+    char last_spawn_failure_reason[64];
+    char last_despawn_reason[64];
     int capacity;
     bool initial_active;
     actor_pool_exhaustion_policy exhaustion;
@@ -602,11 +611,16 @@ static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, sdl3d_regis
 static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor, int index);
 static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const sdl3d_registered_actor *actor,
                                           int index);
+static int actor_pool_active_count(const sdl3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
+static int actor_pool_available_count(const sdl3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
+static void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
+static void actor_pool_note_spawn_success(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool);
+static void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
 static bool initialize_pooled_actor(actor_pool_runtime *pool, sdl3d_registered_actor *actor, int index, bool active);
 static bool actor_pool_initialize_slot(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
                                        bool active);
 static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                       sdl3d_registered_actor *actor, int index);
+                                       sdl3d_registered_actor *actor, int index, const char *reason);
 static bool apply_actor_pool_scene_exit_policies(sdl3d_game_data_runtime *runtime, const char *from_scene,
                                                  const char *to_scene);
 static void actor_lifecycle_defer_begin(sdl3d_game_data_runtime *runtime);
@@ -616,6 +630,11 @@ static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, in
 static sdl3d_game_data_runtime *lua_runtime(lua_State *lua)
 {
     return (sdl3d_game_data_runtime *)lua_touserdata(lua, lua_upvalueindex(1));
+}
+
+static lua_Integer lua_counter_value(Uint64 value)
+{
+    return (lua_Integer)SDL_min(value, (Uint64)LUA_MAXINTEGER);
 }
 
 static sdl3d_registered_actor *lua_actor_arg(lua_State *lua, sdl3d_game_data_runtime *runtime, int index)
@@ -1039,10 +1058,12 @@ static int lua_spawn_actor(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
     actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
+    actor_pool_note_spawn_attempt(pool);
     int actor_index = -1;
     sdl3d_registered_actor *actor = actor_pool_allocate(runtime, pool, &actor_index);
     if (pool == NULL || actor == NULL || actor_index < 0)
     {
+        actor_pool_note_spawn_failure(pool, "exhausted");
         lua_pushnil(lua);
         lua_pushstring(lua, "actor pool exhausted or missing");
         return 2;
@@ -1051,6 +1072,7 @@ static int lua_spawn_actor(lua_State *lua)
     actor_pool_set_lifecycle_state(pool, actor, actor_index, ACTOR_LIFECYCLE_SPAWNING);
     if (!initialize_pooled_actor(pool, actor, actor_index, true))
     {
+        actor_pool_note_spawn_failure(pool, "initialize_failed");
         lua_pushnil(lua);
         lua_pushstring(lua, "failed to initialize pooled actor");
         return 2;
@@ -1097,6 +1119,7 @@ static int lua_spawn_actor(lua_State *lua)
     }
 
     actor_set_position(actor, position);
+    actor_pool_note_spawn_success(runtime, pool);
     lua_push_actor_wrapper(lua, actor);
     lua_pushinteger(lua, actor->id);
     lua_pushinteger(lua, actor_index);
@@ -1115,8 +1138,10 @@ static int lua_despawn_actor(lua_State *lua)
 
     int actor_index = -1;
     actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
-    const bool ok = pool != NULL && actor_index >= 0 ? actor_pool_request_despawn(runtime, pool, actor, actor_index)
-                                                     : (actor->active = false, true);
+    const char *reason = lua_isstring(lua, 2) ? lua_tostring(lua, 2) : "lua";
+    const bool ok = pool != NULL && actor_index >= 0
+                        ? actor_pool_request_despawn(runtime, pool, actor, actor_index, reason)
+                        : (actor->active = false, true);
     lua_pushboolean(lua, ok);
     return 1;
 }
@@ -1125,6 +1150,7 @@ static int lua_despawn_actors_by_tag(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
     const char *tag = luaL_checkstring(lua, 1);
+    const char *reason = lua_isstring(lua, 2) ? lua_tostring(lua, 2) : "lua_tag";
     int despawned = 0;
     if (runtime != NULL && tag != NULL && tag[0] != '\0')
     {
@@ -1137,7 +1163,7 @@ static int lua_despawn_actors_by_tag(lua_State *lua)
             {
                 sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
                 if (actor_pool_actor_is_active(pool, actor, actor_index) &&
-                    actor_pool_request_despawn(runtime, pool, actor, actor_index))
+                    actor_pool_request_despawn(runtime, pool, actor, actor_index, reason))
                     ++despawned;
             }
         }
@@ -1157,14 +1183,7 @@ static int lua_pool_active_count(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
     actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
-    int count = 0;
-    for (int i = 0; pool != NULL && i < pool->capacity; ++i)
-    {
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor_pool_actor_is_active(pool, actor, i))
-            ++count;
-    }
-    lua_pushinteger(lua, count);
+    lua_pushinteger(lua, actor_pool_active_count(runtime, pool));
     return 1;
 }
 
@@ -1172,14 +1191,71 @@ static int lua_pool_available_count(lua_State *lua)
 {
     sdl3d_game_data_runtime *runtime = lua_runtime(lua);
     actor_pool_runtime *pool = find_actor_pool(runtime, luaL_checkstring(lua, 1));
-    int count = 0;
-    for (int i = 0; pool != NULL && i < pool->capacity; ++i)
-    {
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
-        if (actor_pool_actor_is_available(pool, actor, i))
-            ++count;
-    }
-    lua_pushinteger(lua, count);
+    lua_pushinteger(lua, actor_pool_available_count(runtime, pool));
+    return 1;
+}
+
+static int lua_pool_peak_active_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? pool->peak_active_count : 0);
+    return 1;
+}
+
+static int lua_pool_spawn_attempt_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->spawn_attempt_count) : 0);
+    return 1;
+}
+
+static int lua_pool_spawn_success_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->spawn_success_count) : 0);
+    return 1;
+}
+
+static int lua_pool_spawn_failure_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->spawn_failure_count) : 0);
+    return 1;
+}
+
+static int lua_pool_exhaustion_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->exhaustion_count) : 0);
+    return 1;
+}
+
+static int lua_pool_reuse_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->reuse_count) : 0);
+    return 1;
+}
+
+static int lua_pool_despawn_count(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushinteger(lua, pool != NULL ? lua_counter_value(pool->despawn_count) : 0);
+    return 1;
+}
+
+static int lua_pool_last_spawn_failure_reason(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushstring(lua, pool != NULL && pool->last_spawn_failure_reason[0] != '\0' ? pool->last_spawn_failure_reason
+                                                                                   : "none");
+    return 1;
+}
+
+static int lua_pool_last_despawn_reason(lua_State *lua)
+{
+    actor_pool_runtime *pool = find_actor_pool(lua_runtime(lua), luaL_checkstring(lua, 1));
+    lua_pushstring(lua, pool != NULL && pool->last_despawn_reason[0] != '\0' ? pool->last_despawn_reason : "none");
     return 1;
 }
 
@@ -1645,17 +1721,17 @@ static void install_lua_helpers(lua_State *lua)
         "            end\n"
         "            return sdl3d.spawn(self_or_pool, maybe_pool)\n"
         "        end,\n"
-        "        despawn = function(self_or_actor, maybe_actor)\n"
+        "        despawn = function(self_or_actor, maybe_actor, maybe_reason)\n"
         "            if type(self_or_actor) == 'table' and self_or_actor.adapter ~= nil then\n"
-        "                return sdl3d.despawn(maybe_actor)\n"
+        "                return sdl3d.despawn(maybe_actor, maybe_reason)\n"
         "            end\n"
-        "            return sdl3d.despawn(self_or_actor)\n"
+        "            return sdl3d.despawn(self_or_actor, maybe_actor)\n"
         "        end,\n"
-        "        despawn_by_tag = function(self_or_tag, maybe_tag)\n"
+        "        despawn_by_tag = function(self_or_tag, maybe_tag, maybe_reason)\n"
         "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
-        "                return sdl3d.despawn_by_tag(maybe_tag)\n"
+        "                return sdl3d.despawn_by_tag(maybe_tag, maybe_reason)\n"
         "            end\n"
-        "            return sdl3d.despawn_by_tag(self_or_tag)\n"
+        "            return sdl3d.despawn_by_tag(self_or_tag, maybe_tag)\n"
         "        end,\n"
         "        actor_with_tags = function(self_or_tag, maybe_tag, ...)\n"
         "            if type(self_or_tag) == 'table' and self_or_tag.adapter ~= nil then\n"
@@ -1679,6 +1755,33 @@ static void install_lua_helpers(lua_State *lua)
         "        end,\n"
         "        pool_available_count = function(self_or_pool, maybe_pool)\n"
         "            return sdl3d.pool_available_count(maybe_pool or self_or_pool)\n"
+        "        end,\n",
+        "        pool_peak_active_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_peak_active_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_spawn_attempt_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_spawn_attempt_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_spawn_success_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_spawn_success_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_spawn_failure_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_spawn_failure_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_exhaustion_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_exhaustion_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_reuse_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_reuse_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_despawn_count = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_despawn_count(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_last_spawn_failure_reason = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_last_spawn_failure_reason(maybe_pool or self_or_pool)\n"
+        "        end,\n"
+        "        pool_last_despawn_reason = function(self_or_pool, maybe_pool)\n"
+        "            return sdl3d.pool_last_despawn_reason(maybe_pool or self_or_pool)\n"
         "        end,\n",
         "        state_get = function(self_or_key, maybe_key, fallback)\n"
         "            if type(self_or_key) == 'table' and self_or_key.adapter ~= nil then\n"
@@ -1784,6 +1887,15 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("pool_capacity", lua_pool_capacity);
     SDL3D_LUA_BIND("pool_active_count", lua_pool_active_count);
     SDL3D_LUA_BIND("pool_available_count", lua_pool_available_count);
+    SDL3D_LUA_BIND("pool_peak_active_count", lua_pool_peak_active_count);
+    SDL3D_LUA_BIND("pool_spawn_attempt_count", lua_pool_spawn_attempt_count);
+    SDL3D_LUA_BIND("pool_spawn_success_count", lua_pool_spawn_success_count);
+    SDL3D_LUA_BIND("pool_spawn_failure_count", lua_pool_spawn_failure_count);
+    SDL3D_LUA_BIND("pool_exhaustion_count", lua_pool_exhaustion_count);
+    SDL3D_LUA_BIND("pool_reuse_count", lua_pool_reuse_count);
+    SDL3D_LUA_BIND("pool_despawn_count", lua_pool_despawn_count);
+    SDL3D_LUA_BIND("pool_last_spawn_failure_reason", lua_pool_last_spawn_failure_reason);
+    SDL3D_LUA_BIND("pool_last_despawn_reason", lua_pool_last_despawn_reason);
     SDL3D_LUA_BIND("log", lua_log);
     SDL3D_LUA_BIND("storage_read", lua_storage_read);
     SDL3D_LUA_BIND("storage_write", lua_storage_write);
@@ -2736,7 +2848,7 @@ static bool game_data_apply_actor_replication_field(sdl3d_game_data_runtime *run
             }
             if (actor_pool_lifecycle_state(pool, actor_index) == ACTOR_LIFECYCLE_INACTIVE)
                 return true;
-            return actor_pool_request_despawn(runtime, pool, actor, actor_index);
+            return actor_pool_request_despawn(runtime, pool, actor, actor_index, "network_snapshot");
         }
         actor->active = value->value.as_bool;
         return true;
@@ -7859,6 +7971,69 @@ static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const 
             actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_INACTIVE);
 }
 
+static void actor_pool_copy_reason(char *target, size_t target_size, const char *reason)
+{
+    if (target == NULL || target_size == 0U)
+        return;
+    SDL_strlcpy(target, reason != NULL && reason[0] != '\0' ? reason : "none", target_size);
+}
+
+static int actor_pool_active_count(const sdl3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
+{
+    int count = 0;
+    for (int i = 0; runtime != NULL && pool != NULL && i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor_pool_actor_is_active(pool, actor, i))
+            ++count;
+    }
+    return count;
+}
+
+static int actor_pool_available_count(const sdl3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
+{
+    int count = 0;
+    for (int i = 0; runtime != NULL && pool != NULL && i < pool->capacity; ++i)
+    {
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[i]);
+        if (actor_pool_actor_is_available(pool, actor, i))
+            ++count;
+    }
+    return count;
+}
+
+static void actor_pool_update_peak_active_count(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool)
+{
+    if (runtime == NULL || pool == NULL)
+        return;
+    const int active_count = actor_pool_active_count(runtime, pool);
+    if (active_count > pool->peak_active_count)
+        pool->peak_active_count = active_count;
+}
+
+static void actor_pool_note_spawn_attempt(actor_pool_runtime *pool)
+{
+    if (pool != NULL)
+        pool->spawn_attempt_count++;
+}
+
+static void actor_pool_note_spawn_success(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool)
+{
+    if (pool == NULL)
+        return;
+    pool->spawn_success_count++;
+    actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason), "none");
+    actor_pool_update_peak_active_count(runtime, pool);
+}
+
+static void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason)
+{
+    if (pool == NULL)
+        return;
+    pool->spawn_failure_count++;
+    actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason), reason);
+}
+
 static void actor_lifecycle_defer_begin(sdl3d_game_data_runtime *runtime)
 {
     if (runtime != NULL)
@@ -7880,7 +8055,10 @@ static void actor_lifecycle_flush(sdl3d_game_data_runtime *runtime)
                 continue;
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
             if (actor != NULL)
-                (void)initialize_pooled_actor(pool, actor, actor_index, false);
+            {
+                if (initialize_pooled_actor(pool, actor, actor_index, false))
+                    sdl3d_properties_set_string(actor->props, "pool_last_despawn_reason", pool->last_despawn_reason);
+            }
         }
     }
 }
@@ -7907,6 +8085,8 @@ static bool actor_pool_initialize_slot(sdl3d_game_data_runtime *runtime, actor_p
         sdl3d_properties_set_int(actor->props, "pool_spawn_generation",
                                  (int)SDL_min(pool->spawn_generations[index], (Uint64)SDL_MAX_SINT32));
     }
+    if (active)
+        actor_pool_update_peak_active_count(runtime, pool);
     return true;
 }
 
@@ -7947,7 +8127,7 @@ static bool apply_actor_pool_scene_exit_policies(sdl3d_game_data_runtime *runtim
             if (pool->scene_exit_policy == ACTOR_POOL_SCENE_EXIT_DESPAWN)
             {
                 if (actor_pool_lifecycle_state(pool, actor_index) != ACTOR_LIFECYCLE_INACTIVE &&
-                    !actor_pool_request_despawn(runtime, pool, actor, actor_index))
+                    !actor_pool_request_despawn(runtime, pool, actor, actor_index, "scene_exit"))
                 {
                     return false;
                 }
@@ -8039,6 +8219,8 @@ static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root,
         pool->scene_exit_policy = actor_pool_scene_exit_policy_from_string(
             json_string(pool_json, "on_scene_exit", NULL),
             pool->scene_count > 0 ? ACTOR_POOL_SCENE_EXIT_RESET : ACTOR_POOL_SCENE_EXIT_PRESERVE);
+        actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason), "none");
+        actor_pool_copy_reason(pool->last_despawn_reason, sizeof(pool->last_despawn_reason), "none");
         pool->actor_names = (char **)SDL_calloc((size_t)capacity, sizeof(*pool->actor_names));
         pool->spawn_generations = (Uint64 *)SDL_calloc((size_t)capacity, sizeof(*pool->spawn_generations));
         pool->lifecycle_states = (actor_lifecycle_state *)SDL_calloc((size_t)capacity, sizeof(*pool->lifecycle_states));
@@ -8071,6 +8253,7 @@ static bool load_actor_pools(sdl3d_game_data_runtime *runtime, yyjson_val *root,
                 pool->spawn_generations[actor_index] = ++pool->spawn_generation_counter;
                 sdl3d_properties_set_int(actor->props, "pool_spawn_generation",
                                          (int)SDL_min(pool->spawn_generations[actor_index], (Uint64)SDL_MAX_SINT32));
+                actor_pool_update_peak_active_count(runtime, pool);
             }
         }
     }
@@ -10810,7 +10993,17 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
     }
 
     if (pool->exhaustion != ACTOR_POOL_EXHAUST_REUSE_OLDEST || pool->capacity <= 0)
+    {
+        if (pool != NULL)
+        {
+            pool->exhaustion_count++;
+            actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason),
+                                   "exhausted");
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D actor pool exhausted: pool=%s capacity=%d policy=fail",
+                        pool->name != NULL ? pool->name : "<unnamed>", pool->capacity);
+        }
         return NULL;
+    }
 
     int index = -1;
     Uint64 oldest_generation = SDL_MAX_UINT64;
@@ -10827,18 +11020,36 @@ static sdl3d_registered_actor *actor_pool_allocate(sdl3d_game_data_runtime *runt
         }
     }
     if (index < 0)
+    {
+        pool->exhaustion_count++;
+        actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason), "exhausted");
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D actor pool exhausted: pool=%s capacity=%d no reusable actor",
+                    pool->name != NULL ? pool->name : "<unnamed>", pool->capacity);
         return NULL;
+    }
     if (out_index != NULL)
         *out_index = index;
+    pool->exhaustion_count++;
+    pool->reuse_count++;
+    pool->despawn_count++;
+    actor_pool_copy_reason(pool->last_despawn_reason, sizeof(pool->last_despawn_reason), "reuse_oldest");
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D actor pool exhausted: pool=%s capacity=%d reusing actor=%s",
+                pool->name != NULL ? pool->name : "<unnamed>", pool->capacity,
+                pool->actor_names[index] != NULL ? pool->actor_names[index] : "<unnamed>");
     return sdl3d_game_data_find_actor(runtime, pool->actor_names[index]);
 }
 
 static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                       sdl3d_registered_actor *actor, int index)
+                                       sdl3d_registered_actor *actor, int index, const char *reason)
 {
     if (runtime == NULL || pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
         return false;
 
+    if (!actor->active && actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_INACTIVE)
+        return true;
+
+    pool->despawn_count++;
+    actor_pool_copy_reason(pool->last_despawn_reason, sizeof(pool->last_despawn_reason), reason);
     actor->active = false;
     actor_pool_set_lifecycle_state(pool, actor, index, ACTOR_LIFECYCLE_DESPAWNING);
     if (runtime->actor_lifecycle_defer_depth > 0)
@@ -10846,7 +11057,10 @@ static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_p
         runtime->actor_lifecycle_flush_pending = true;
         return true;
     }
-    return initialize_pooled_actor(pool, actor, index, false);
+    if (!initialize_pooled_actor(pool, actor, index, false))
+        return false;
+    sdl3d_properties_set_string(actor->props, "pool_last_despawn_reason", pool->last_despawn_reason);
+    return true;
 }
 
 static void apply_actor_spawn_properties(sdl3d_registered_actor *actor, yyjson_val *properties)
@@ -10894,14 +11108,21 @@ static sdl3d_vec3 actor_spawn_position_from_action(sdl3d_game_data_runtime *runt
 static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_val *action)
 {
     actor_pool_runtime *pool = find_actor_pool(runtime, json_string(action, "pool", NULL));
+    actor_pool_note_spawn_attempt(pool);
     int actor_index = -1;
     sdl3d_registered_actor *actor = actor_pool_allocate(runtime, pool, &actor_index);
     if (pool == NULL || actor == NULL || actor_index < 0)
+    {
+        actor_pool_note_spawn_failure(pool, "exhausted");
         return false;
+    }
 
     actor_pool_set_lifecycle_state(pool, actor, actor_index, ACTOR_LIFECYCLE_SPAWNING);
     if (!initialize_pooled_actor(pool, actor, actor_index, true))
+    {
+        actor_pool_note_spawn_failure(pool, "initialize_failed");
         return false;
+    }
     if (pool->spawn_generations != NULL)
     {
         pool->spawn_generations[actor_index] = ++pool->spawn_generation_counter;
@@ -10910,6 +11131,7 @@ static bool execute_actor_spawn_action(sdl3d_game_data_runtime *runtime, yyjson_
     }
     actor_set_position(actor, actor_spawn_position_from_action(runtime, action, actor->position));
     apply_actor_spawn_properties(actor, obj_get(action, "properties"));
+    actor_pool_note_spawn_success(runtime, pool);
 
     const char *actor_key = json_string(action, "output_actor_key", NULL);
     if (runtime != NULL && runtime->scene_state != NULL && actor_key != NULL)
@@ -10933,7 +11155,7 @@ static bool execute_actor_despawn_action(sdl3d_game_data_runtime *runtime, yyjso
     int actor_index = -1;
     actor_pool_runtime *pool = find_actor_pool_for_actor(runtime, actor->name, &actor_index);
     if (pool != NULL && actor_index >= 0)
-        return actor_pool_request_despawn(runtime, pool, actor, actor_index);
+        return actor_pool_request_despawn(runtime, pool, actor, actor_index, json_string(action, "reason", "action"));
 
     actor->active = false;
     return true;
@@ -10955,7 +11177,8 @@ static bool execute_actor_despawn_by_tag_action(sdl3d_game_data_runtime *runtime
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
             if (actor_pool_actor_is_active(pool, actor, actor_index))
             {
-                (void)actor_pool_request_despawn(runtime, pool, actor, actor_index);
+                (void)actor_pool_request_despawn(runtime, pool, actor, actor_index,
+                                                 json_string(action, "reason", "action_tag"));
             }
         }
     }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3166,12 +3166,18 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "actor.despawn requires a non-empty target");
         if (!name_table_contains(&names->entities, target) && !name_table_contains(&names->actor_pool_actors, target))
             return validation_error(ctx, json_path, "unknown actor.despawn target '%s'", target);
+        yyjson_val *reason = obj_get(action, "reason");
+        if (reason != NULL && !yyjson_is_str(reason))
+            return validation_error(ctx, json_path, "actor.despawn reason must be a string");
         return true;
     }
     if (SDL_strcmp(type, "actor.despawn_by_tag") == 0)
     {
         if (!is_non_empty_string(action, "tag"))
             return validation_error(ctx, json_path, "actor.despawn_by_tag requires a non-empty tag");
+        yyjson_val *reason = obj_get(action, "reason");
+        if (reason != NULL && !yyjson_is_str(reason))
+            return validation_error(ctx, json_path, "actor.despawn_by_tag reason must be a string");
         return true;
     }
     if (SDL_strcmp(type, "input.reset_bindings") == 0)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6898,6 +6898,159 @@ return rules
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, ActorPoolDiagnosticsTrackUsageAndExhaustion)
+{
+    const std::filesystem::path dir = unique_test_dir("actor_pool_diagnostics");
+    write_text(dir / "scripts" / "rules.lua",
+               R"lua(
+local rules = {}
+
+function rules.run(_, _, ctx)
+  local first, _, first_index = ctx:spawn("pool.fail", { position = Vec3(1.0, 2.0, 0.0) })
+  local second, err = ctx:spawn("pool.fail", { position = Vec3(3.0, 4.0, 0.0) })
+  ctx:state_set("fail_first_index", first_index or -1)
+  ctx:state_set("fail_second_missing", second == nil)
+  ctx:state_set("fail_error", err or "")
+  ctx:state_set("fail_attempts", ctx:pool_spawn_attempt_count("pool.fail"))
+  ctx:state_set("fail_success", ctx:pool_spawn_success_count("pool.fail"))
+  ctx:state_set("fail_failures", ctx:pool_spawn_failure_count("pool.fail"))
+  ctx:state_set("fail_exhaustion", ctx:pool_exhaustion_count("pool.fail"))
+  ctx:state_set("fail_peak", ctx:pool_peak_active_count("pool.fail"))
+  ctx:state_set("fail_last_failure", ctx:pool_last_spawn_failure_reason("pool.fail"))
+  ctx:state_set("fail_active", ctx:pool_active_count("pool.fail"))
+  ctx:state_set("fail_available", ctx:pool_available_count("pool.fail"))
+  if first ~= nil then
+    ctx:despawn(first, "hit_enemy")
+  end
+  ctx:state_set("fail_despawns", ctx:pool_despawn_count("pool.fail"))
+  ctx:state_set("fail_last_despawn", ctx:pool_last_despawn_reason("pool.fail"))
+
+  ctx:spawn("pool.reuse", { position = Vec3(1.0, 0.0, 0.0), properties = { generation = 1 } })
+  ctx:spawn("pool.reuse", { position = Vec3(2.0, 0.0, 0.0), properties = { generation = 2 } })
+  ctx:state_set("reuse_attempts", ctx:pool_spawn_attempt_count("pool.reuse"))
+  ctx:state_set("reuse_success", ctx:pool_spawn_success_count("pool.reuse"))
+  ctx:state_set("reuse_failures", ctx:pool_spawn_failure_count("pool.reuse"))
+  ctx:state_set("reuse_exhaustion", ctx:pool_exhaustion_count("pool.reuse"))
+  ctx:state_set("reuse_count", ctx:pool_reuse_count("pool.reuse"))
+  ctx:state_set("reuse_despawns", ctx:pool_despawn_count("pool.reuse"))
+  ctx:state_set("reuse_last_despawn", ctx:pool_last_despawn_reason("pool.reuse"))
+  ctx:state_set("reuse_peak", ctx:pool_peak_active_count("pool.reuse"))
+  ctx:state_set("reuse_active", ctx:pool_active_count("pool.reuse"))
+  return true
+end
+
+return rules
+)lua");
+    write_text(dir / "actor_pool_diagnostics.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Actor Pool Diagnostics", "id": "test.actor_pool_diagnostics", "version": "0.1.0" },
+  "world": { "name": "world.actor_pool_diagnostics", "kind": "fixed_screen" },
+  "scripts": [
+    { "id": "script.rules", "path": "scripts/rules.lua", "module": "test.actor_pool_diagnostics" }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.projectile",
+      "tags": ["projectile"],
+      "properties": {
+        "generation": { "type": "int", "value": 0 }
+      }
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.fail",
+      "archetype": "archetype.projectile",
+      "capacity": 1,
+      "scene": "scene.play",
+      "on_exhausted": "fail"
+    },
+    {
+      "name": "pool.reuse",
+      "archetype": "archetype.projectile",
+      "capacity": 1,
+      "scene": "scene.play",
+      "on_exhausted": "reuse_oldest"
+    }
+  ],
+  "signals": ["signal.run"],
+  "adapters": [
+    { "name": "adapter.run", "kind": "action", "script": "script.rules", "function": "run" }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.run",
+        "actions": [
+          { "type": "adapter.invoke", "adapter": "adapter.run" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play"
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "actor_pool_diagnostics.game.json").string().c_str(), session,
+                                          &runtime, error, sizeof(error)))
+        << error;
+
+    SDLLogOutputGuard log_guard;
+    CapturedLogMessage captured_log;
+    SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE);
+    SDL_SetLogOutputFunction(capture_log_output, &captured_log);
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.run"), nullptr);
+
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(runtime);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_first_index", -1), 0);
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "fail_second_missing", false));
+    EXPECT_NE(std::string(sdl3d_properties_get_string(scene_state, "fail_error", "")).find("exhausted"),
+              std::string::npos);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_attempts", -1), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_success", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_failures", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_exhaustion", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_peak", -1), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "fail_last_failure", ""), "exhausted");
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_active", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_available", -1), 0);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "fail_despawns", -1), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "fail_last_despawn", ""), "hit_enemy");
+
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_attempts", -1), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_success", -1), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_failures", -1), 0);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_exhaustion", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_count", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_despawns", -1), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "reuse_last_despawn", ""), "reuse_oldest");
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_peak", -1), 1);
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "reuse_active", -1), 1);
+    sdl3d_registered_actor *reused = sdl3d_game_data_find_actor(runtime, "pool.reuse.0");
+    ASSERT_NE(reused, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(reused->props, "generation", -1), 2);
+
+    EXPECT_EQ(captured_log.category, SDL_LOG_CATEGORY_APPLICATION);
+    EXPECT_EQ(captured_log.priority, SDL_LOG_PRIORITY_WARN);
+    EXPECT_NE(captured_log.message.find("SDL3D actor pool exhausted"), std::string::npos);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, LoadsLuaBackedGameDataFromMemoryPack)
 {
     const std::string game_json = read_fixture_file("module_success.game.json");


### PR DESCRIPTION
## Summary
- add actor-pool usage diagnostics for attempts, successes, failures, exhaustion, reuse, despawns, peak active count, and last spawn/despawn reasons
- expose diagnostics to Lua and allow authored/Lua despawn reasons
- log pool exhaustion warnings and document Space Invaders-style pool tuning patterns

## Tests
- cmake --build build/debug --target sdl3d_game_data_test -j 8
- ./build/debug/tests/sdl3d_game_data_test
- ctest --test-dir build/debug --output-on-failure