### PR TITLE
Move Pong presentation data into an import fragment

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SDL3D_PONG_ASSET_FILES
     fragments/input.json
     fragments/logic.json
     fragments/network.json
+    fragments/presentation.json
     fragments/scripts.json
     images/ball-texture.png
     images/splash-logo.jpg

--- a/demos/pong/data/fragments/presentation.json
+++ b/demos/pong/data/fragments/presentation.json
@@ -1,0 +1,121 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "presentation": {
+    "metrics": {
+      "fps_sample_seconds": 0.25
+    },
+    "ui_pulse_clock": "clock.pause_flash",
+    "clocks": [
+      {
+        "name": "clock.pause_flash",
+        "target": "entity.presentation",
+        "key": "pause_flash",
+        "speed_property": {
+          "target": "entity.presentation",
+          "key": "pause_flash_speed"
+        },
+        "wrap": 1.0,
+        "reset_on_pause_enter": true,
+        "reset_value": 0.0,
+        "active_if": {
+          "type": "app.paused",
+          "equals": true
+        }
+      }
+    ]
+  },
+  "transitions": {
+    "startup": {
+      "type": "fade",
+      "direction": "in",
+      "color": [
+        0,
+        0,
+        0,
+        255
+      ],
+      "duration": 0.7
+    },
+    "quit": {
+      "type": "fade",
+      "direction": "out",
+      "color": [
+        0,
+        0,
+        0,
+        255
+      ],
+      "duration": 0.45,
+      "done_signal": "signal.app.quit_fade_done"
+    },
+    "scene_out": {
+      "type": "fade",
+      "direction": "out",
+      "color": [
+        0,
+        0,
+        0,
+        255
+      ],
+      "duration": 0.28
+    },
+    "scene_in": {
+      "type": "fade",
+      "direction": "in",
+      "color": [
+        0,
+        0,
+        0,
+        255
+      ],
+      "duration": 0.28
+    }
+  },
+  "haptics": {
+    "policies": [
+      {
+        "name": "haptics.gamepad.vibration_test",
+        "signal": "signal.settings.vibration",
+        "low_frequency": 0.30,
+        "high_frequency": 0.70,
+        "duration_ms": 100
+      },
+      {
+        "name": "haptics.gamepad.paddle_hit",
+        "signal": "signal.ball.hit_paddle",
+        "enabled_if": {
+          "type": "property.compare",
+          "target": "entity.settings",
+          "key": "vibration",
+          "op": "==",
+          "value": true
+        },
+        "low_frequency": 0.45,
+        "high_frequency": 0.75,
+        "duration_ms": 120,
+        "payload_actor_filters": [
+          {
+            "key": "other_actor_name",
+            "tags": [
+              "paddle",
+              "player"
+            ]
+          },
+          {
+            "key": "other_actor_name",
+            "tags": [
+              "paddle",
+              "cpu"
+            ],
+            "active_if": {
+              "type": "scene_state.compare",
+              "key": "match_mode",
+              "op": "==",
+              "value": "local"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -5,7 +5,8 @@
     { "path": "fragments/scripts.json", "sections": ["scripts"] },
     { "path": "fragments/input.json", "sections": ["input"] },
     { "path": "fragments/network.json", "sections": ["network"] },
-    { "path": "fragments/logic.json", "sections": ["logic"] }
+    { "path": "fragments/logic.json", "sections": ["logic"] },
+    { "path": "fragments/presentation.json", "sections": ["presentation", "transitions", "haptics"] }
   ],
   "metadata": {
     "name": "Pong",
@@ -389,51 +390,6 @@
     "property_effects": { "active": true, "when_paused": true },
     "particles": { "active": true, "when_paused": true },
     "simulation": { "active": true, "when_paused": false }
-  },
-  "presentation": {
-    "metrics": {
-      "fps_sample_seconds": 0.25
-    },
-    "ui_pulse_clock": "clock.pause_flash",
-    "clocks": [
-      {
-        "name": "clock.pause_flash",
-        "target": "entity.presentation",
-        "key": "pause_flash",
-        "speed_property": { "target": "entity.presentation", "key": "pause_flash_speed" },
-        "wrap": 1.0,
-        "reset_on_pause_enter": true,
-        "reset_value": 0.0,
-        "active_if": { "type": "app.paused", "equals": true }
-      }
-    ]
-  },
-  "transitions": {
-    "startup": {
-      "type": "fade",
-      "direction": "in",
-      "color": [0, 0, 0, 255],
-      "duration": 0.7
-    },
-    "quit": {
-      "type": "fade",
-      "direction": "out",
-      "color": [0, 0, 0, 255],
-      "duration": 0.45,
-      "done_signal": "signal.app.quit_fade_done"
-    },
-    "scene_out": {
-      "type": "fade",
-      "direction": "out",
-      "color": [0, 0, 0, 255],
-      "duration": 0.28
-    },
-    "scene_in": {
-      "type": "fade",
-      "direction": "in",
-      "color": [0, 0, 0, 255],
-      "duration": 0.28
-    }
   },
   "profiles": [
     {
@@ -1224,33 +1180,6 @@
       }
     }
   ],
-  "haptics": {
-    "policies": [
-      {
-        "name": "haptics.gamepad.vibration_test",
-        "signal": "signal.settings.vibration",
-        "low_frequency": 0.30,
-        "high_frequency": 0.70,
-        "duration_ms": 100
-      },
-      {
-        "name": "haptics.gamepad.paddle_hit",
-        "signal": "signal.ball.hit_paddle",
-        "enabled_if": { "type": "property.compare", "target": "entity.settings", "key": "vibration", "op": "==", "value": true },
-        "low_frequency": 0.45,
-        "high_frequency": 0.75,
-        "duration_ms": 120,
-        "payload_actor_filters": [
-          { "key": "other_actor_name", "tags": ["paddle", "player"] },
-          {
-            "key": "other_actor_name",
-            "tags": ["paddle", "cpu"],
-            "active_if": { "type": "scene_state.compare", "key": "match_mode", "op": "==", "value": "local" }
-          }
-        ]
-      }
-    ]
-  },
   "signals": [
     "signal.game.start",
     "signal.ball.serve",

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -244,6 +244,9 @@ TEST(GameDataJson, PongDataDeclaresGenericTopLevelModel)
     EXPECT_TRUE(yyjson_is_arr(yyjson_obj_get(doc.root(), "entities")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("scripts")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("logic")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("presentation")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("transitions")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
 }
 
 TEST(GameDataJson, PongDataUsesStructuredImports)
@@ -252,17 +255,23 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     ASSERT_NE(doc.root(), nullptr) << doc.error();
 
     yyjson_val *imports = required_array(doc.root(), "imports");
-    ASSERT_EQ(yyjson_arr_size(imports), 5u);
+    ASSERT_EQ(yyjson_arr_size(imports), 6u);
     EXPECT_TRUE(yyjson_is_obj(doc.section("assets")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("scripts")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("input")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("network")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("logic")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("presentation")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("transitions")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
     EXPECT_EQ(yyjson_obj_get(doc.root(), "assets"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "scripts"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "input"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "network"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "logic"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "presentation"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "transitions"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "haptics"), nullptr);
 }
 
 TEST(GameDataJson, PongUsesStandardOptionsScenePackage)


### PR DESCRIPTION
## Summary
- move Pong's authored `presentation`, `transitions`, and `haptics` sections into `demos/pong/data/fragments/presentation.json`
- import those sections from `pong.game.json` so the root game file is smaller
- include the new fragment in Pong embedded/disk pack asset lists
- update JSON parity tests to resolve the composed sections and assert they are no longer root-authored

Continues #231.

## Tests
- `jq empty demos/pong/data/pong.game.json demos/pong/data/fragments/presentation.json`
- `cmake --build build/debug --target game_data_json_test sdl3d_game_data_test -j 8`
- `./build/debug/tests/game_data_json_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesPongDataWithoutDiagnostics:GameDataRuntime.ExposesAuthoredPongPresentationData:GameDataRuntime.PongStandardOptionsUseImmediateApplyContract:GameDataRuntime.DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks'`
- `cmake --build build/debug-demos --target pong_demo -j 8`
- `ctest --test-dir build/debug --output-on-failure`