### PR TITLE
Move Pong persistence data into an import fragment

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SDL3D_PONG_ASSET_FILES
     fragments/input.json
     fragments/logic.json
     fragments/network.json
+    fragments/persistence.json
     fragments/presentation.json
     fragments/scripts.json
     images/ball-texture.png

--- a/demos/pong/data/fragments/persistence.json
+++ b/demos/pong/data/fragments/persistence.json
@@ -1,0 +1,34 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "storage": {
+    "organization": "Blue Sentinel Security",
+    "application": "SDL3D Pong",
+    "profile": "default"
+  },
+  "persistence": {
+    "entries": [
+      {
+        "name": "persistence.options",
+        "path": "user://settings/options.json",
+        "schema": "sdl3d.options.v1",
+        "version": 1,
+        "target": "entity.settings",
+        "enabled_if": {
+          "type": "property.bool",
+          "target": "entity.settings",
+          "key": "options_persistence_enabled",
+          "equals": true
+        },
+        "properties": [
+          "display_mode",
+          "vsync",
+          "renderer",
+          "gamepad_icons",
+          "vibration",
+          "sfx_volume",
+          "music_volume"
+        ]
+      }
+    ]
+  }
+}

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -6,44 +6,14 @@
     { "path": "fragments/input.json", "sections": ["input"] },
     { "path": "fragments/network.json", "sections": ["network"] },
     { "path": "fragments/logic.json", "sections": ["logic"] },
-    { "path": "fragments/presentation.json", "sections": ["presentation", "transitions", "haptics"] }
+    { "path": "fragments/presentation.json", "sections": ["presentation", "transitions", "haptics"] },
+    { "path": "fragments/persistence.json", "sections": ["storage", "persistence"] }
   ],
   "metadata": {
     "name": "Pong",
     "id": "demo.pong",
     "version": "0.1.0",
     "description": "Fixed-screen arcade proof that SDL3D gameplay rules can be authored through generic entities, sensors, signals, timers, and actions."
-  },
-  "storage": {
-    "organization": "Blue Sentinel Security",
-    "application": "SDL3D Pong",
-    "profile": "default"
-  },
-  "persistence": {
-    "entries": [
-      {
-        "name": "persistence.options",
-        "path": "user://settings/options.json",
-        "schema": "sdl3d.options.v1",
-        "version": 1,
-        "target": "entity.settings",
-        "enabled_if": {
-          "type": "property.bool",
-          "target": "entity.settings",
-          "key": "options_persistence_enabled",
-          "equals": true
-        },
-        "properties": [
-          "display_mode",
-          "vsync",
-          "renderer",
-          "gamepad_icons",
-          "vibration",
-          "sfx_volume",
-          "music_volume"
-        ]
-      }
-    ]
   },
   "app": {
     "title": "SDL3D Pong",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -521,18 +521,19 @@ std::filesystem::path copy_pong_data_with_storage_overrides(const std::filesyste
                           std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing);
 
     const std::filesystem::path game_path = dest / "pong.game.json";
-    std::string game_json = read_text(game_path);
+    const std::filesystem::path persistence_path = dest / "fragments" / "persistence.json";
+    std::string persistence_json = read_text(persistence_path);
     const std::string marker = R"json("profile": "default")json";
     const std::string replacement = std::string(R"json("profile": "default",
     "user_root_override": ")json") + user_root.generic_string() +
                                     R"json(",
     "cache_root_override": ")json" + cache_root.generic_string() +
                                     R"json(")json";
-    const size_t marker_pos = game_json.find(marker);
+    const size_t marker_pos = persistence_json.find(marker);
     if (marker_pos == std::string::npos)
         throw std::runtime_error("Pong storage profile marker not found");
-    game_json.replace(marker_pos, marker.size(), replacement);
-    write_text(game_path, game_json.c_str());
+    persistence_json.replace(marker_pos, marker.size(), replacement);
+    write_text(persistence_path, persistence_json.c_str());
     return game_path;
 }
 

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -247,6 +247,8 @@ TEST(GameDataJson, PongDataDeclaresGenericTopLevelModel)
     EXPECT_TRUE(yyjson_is_obj(doc.section("presentation")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("transitions")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("storage")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("persistence")));
 }
 
 TEST(GameDataJson, PongDataUsesStructuredImports)
@@ -255,7 +257,7 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     ASSERT_NE(doc.root(), nullptr) << doc.error();
 
     yyjson_val *imports = required_array(doc.root(), "imports");
-    ASSERT_EQ(yyjson_arr_size(imports), 6u);
+    ASSERT_EQ(yyjson_arr_size(imports), 7u);
     EXPECT_TRUE(yyjson_is_obj(doc.section("assets")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("scripts")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("input")));
@@ -264,6 +266,8 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_TRUE(yyjson_is_obj(doc.section("presentation")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("transitions")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("storage")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("persistence")));
     EXPECT_EQ(yyjson_obj_get(doc.root(), "assets"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "scripts"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "input"), nullptr);
@@ -272,6 +276,8 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_EQ(yyjson_obj_get(doc.root(), "presentation"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "transitions"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "haptics"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "storage"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "persistence"), nullptr);
 }
 
 TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
@@ -338,7 +344,8 @@ TEST(GameDataJson, PongOptionsUseGenericPersistenceEntry)
     JsonDoc doc(kPongDataPath);
     ASSERT_NE(doc.root(), nullptr) << doc.error();
 
-    yyjson_val *persistence = required_object(doc.root(), "persistence");
+    yyjson_val *persistence = doc.section("persistence");
+    ASSERT_TRUE(yyjson_is_obj(persistence));
     yyjson_val *entries = required_array(persistence, "entries");
     ASSERT_EQ(yyjson_arr_size(entries), 1u);
 


### PR DESCRIPTION
## Summary
- move Pong's authored `storage` and `persistence` sections into `demos/pong/data/fragments/persistence.json`
- import the persistence fragment from `pong.game.json` so the root game file continues shrinking
- include the new fragment in Pong embedded/disk pack asset lists
- update JSON parity tests and storage override test helpers to resolve composed persistence data

Continues #231.

## Tests
- `jq empty demos/pong/data/pong.game.json demos/pong/data/fragments/persistence.json`
- `cmake --build build/debug --target game_data_json_test sdl3d_game_data_test -j 8`
- `./build/debug/tests/game_data_json_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesPongDataWithoutDiagnostics:GameDataRuntime.ExposesAuthoredPongPresentationData:GameDataRuntime.DataGameRuntimeOwnsGenericPongLifecycle'`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesAuthoredStorageConfig:GameDataRuntime.GenericPersistenceSavesOptionsAndPongLuaLoadsHighScores'`
- `cmake --build build/debug-demos --target pong_demo -j 8`
- `ctest --test-dir build/debug --output-on-failure`