### PR TITLE
Move Pong runtime policy into an import fragment

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SDL3D_PONG_ASSET_FILES
     fragments/network.json
     fragments/persistence.json
     fragments/presentation.json
+    fragments/runtime.json
     fragments/scripts.json
     images/ball-texture.png
     images/splash-logo.jpg

--- a/demos/pong/data/fragments/runtime.json
+++ b/demos/pong/data/fragments/runtime.json
@@ -1,0 +1,36 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "render": {
+    "clear_color": [3, 4, 8, 255],
+    "lighting": true,
+    "bloom": true,
+    "ssao": true,
+    "tonemap": "aces"
+  },
+  "update_phases": {
+    "app_flow": { "active": true, "when_paused": true },
+    "presentation": { "active": true, "when_paused": true },
+    "property_effects": { "active": true, "when_paused": true },
+    "particles": { "active": true, "when_paused": true },
+    "simulation": { "active": true, "when_paused": false }
+  },
+  "profiles": [
+    {
+      "name": "profile.fixed_screen_arcade",
+      "required_modules": [
+        "actor_registry",
+        "input",
+        "logic",
+        "timers",
+        "collision_2d",
+        "render_primitives",
+        "cameras"
+      ],
+      "optional_modules": [
+        "particles",
+        "audio",
+        "post_processing"
+      ]
+    }
+  ]
+}

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -7,7 +7,8 @@
     { "path": "fragments/network.json", "sections": ["network"] },
     { "path": "fragments/logic.json", "sections": ["logic"] },
     { "path": "fragments/presentation.json", "sections": ["presentation", "transitions", "haptics"] },
-    { "path": "fragments/persistence.json", "sections": ["storage", "persistence"] }
+    { "path": "fragments/persistence.json", "sections": ["storage", "persistence"] },
+    { "path": "fragments/runtime.json", "sections": ["render", "update_phases", "profiles"] }
   ],
   "metadata": {
     "name": "Pong",
@@ -347,39 +348,6 @@
       }
     }
   },
-  "render": {
-    "clear_color": [3, 4, 8, 255],
-    "lighting": true,
-    "bloom": true,
-    "ssao": true,
-    "tonemap": "aces"
-  },
-  "update_phases": {
-    "app_flow": { "active": true, "when_paused": true },
-    "presentation": { "active": true, "when_paused": true },
-    "property_effects": { "active": true, "when_paused": true },
-    "particles": { "active": true, "when_paused": true },
-    "simulation": { "active": true, "when_paused": false }
-  },
-  "profiles": [
-    {
-      "name": "profile.fixed_screen_arcade",
-      "required_modules": [
-        "actor_registry",
-        "input",
-        "logic",
-        "timers",
-        "collision_2d",
-        "render_primitives",
-        "cameras"
-      ],
-      "optional_modules": [
-        "particles",
-        "audio",
-        "post_processing"
-      ]
-    }
-  ],
   "ui": { "text": [], "images": [] },
   "world": {
     "name": "world.pong",

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -249,6 +249,9 @@ TEST(GameDataJson, PongDataDeclaresGenericTopLevelModel)
     EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("storage")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("persistence")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("render")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("update_phases")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("profiles")));
 }
 
 TEST(GameDataJson, PongDataUsesStructuredImports)
@@ -257,7 +260,7 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     ASSERT_NE(doc.root(), nullptr) << doc.error();
 
     yyjson_val *imports = required_array(doc.root(), "imports");
-    ASSERT_EQ(yyjson_arr_size(imports), 7u);
+    ASSERT_EQ(yyjson_arr_size(imports), 8u);
     EXPECT_TRUE(yyjson_is_obj(doc.section("assets")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("scripts")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("input")));
@@ -268,6 +271,9 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_TRUE(yyjson_is_obj(doc.section("haptics")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("storage")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("persistence")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("render")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("update_phases")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("profiles")));
     EXPECT_EQ(yyjson_obj_get(doc.root(), "assets"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "scripts"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "input"), nullptr);
@@ -278,6 +284,9 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_EQ(yyjson_obj_get(doc.root(), "haptics"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "storage"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "persistence"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "render"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "update_phases"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "profiles"), nullptr);
 }
 
 TEST(GameDataJson, PongUsesStandardOptionsScenePackage)


### PR DESCRIPTION
## Summary
- move Pong's authored `render`, `update_phases`, and `profiles` sections into `demos/pong/data/fragments/runtime.json`
- import the runtime policy fragment from `pong.game.json` to keep the root file focused on entry-point structure
- include the new fragment in Pong embedded/disk pack asset lists
- update JSON parity tests to resolve composed runtime-policy sections and assert they are no longer root-authored

Continues #231.

## Tests
- `jq empty demos/pong/data/pong.game.json demos/pong/data/fragments/runtime.json`
- `cmake --build build/debug --target game_data_json_test sdl3d_game_data_test -j 8`
- `./build/debug/tests/game_data_json_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesPongDataWithoutDiagnostics:GameDataRuntime.LoadsPongDataIntoGenericSessionServices:GameDataRuntime.DataAuthoredInputPolicyUpdatePhasesAndPresentationClocks:GameDataRuntime.DataGameRuntimeOwnsGenericPongLifecycle'`
- `cmake --build build/debug-demos --target pong_demo -j 8`
- `ctest --test-dir build/debug --output-on-failure`