### PR TITLE
Move Pong interaction data into an import fragment

### DIFF
--- a/demos/pong/CMakeLists.txt
+++ b/demos/pong/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SDL3D_PONG_ASSET_FILES
     ${SDL3D_PONG_AUDIO_FILES}
     fragments/assets.json
     fragments/input.json
+    fragments/interaction.json
     fragments/logic.json
     fragments/network.json
     fragments/persistence.json

--- a/demos/pong/data/fragments/interaction.json
+++ b/demos/pong/data/fragments/interaction.json
@@ -1,0 +1,95 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "ui": { "text": [], "images": [] },
+  "signals": [
+    "signal.game.start",
+    "signal.ball.serve",
+    "signal.ball.hit_wall",
+    "signal.ball.hit_paddle",
+    "signal.goal.player",
+    "signal.goal.cpu",
+    "signal.score.player",
+    "signal.score.cpu",
+    "signal.round.reset",
+    "signal.match.player_won",
+    "signal.match.cpu_won",
+    "signal.match.reset",
+    "signal.match.restart",
+    "signal.camera.ball.toggle",
+    "signal.attract.round_reset",
+    "signal.presentation.flash_border",
+    "signal.persistence.load",
+    "signal.persistence.save_options",
+    "signal.settings.apply",
+    "signal.settings.apply_audio",
+    "signal.settings.vibration",
+    "signal.settings.reset_display",
+    "signal.settings.reset_keyboard",
+    "signal.settings.reset_mouse",
+    "signal.settings.reset_gamepad",
+    "signal.settings.reset_audio",
+    "signal.network.start_game",
+    "signal.network.terminate_match",
+    "signal.network.pause_changed",
+    "signal.multiplayer.lobby.start",
+    "signal.multiplayer.discovery.refresh",
+    "signal.multiplayer.discovery.connect",
+    "signal.multiplayer.discovery.cancel",
+    "signal.multiplayer.direct.connect",
+    "signal.multiplayer.direct.disconnect",
+    "signal.ui.menu.move",
+    "signal.ui.menu.select",
+    "signal.app.quit_fade_done"
+  ],
+  "adapters": [
+    {
+      "name": "adapter.pong.serve_random",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "serve_random",
+      "description": "Choose a non-extreme random serve vector for the ball."
+    },
+    {
+      "name": "adapter.pong.reflect_from_paddle",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "reflect_from_paddle",
+      "description": "Reflect ball velocity using Pong-specific hit-offset deflection."
+    },
+    {
+      "name": "adapter.pong.cpu_track_ball",
+      "kind": "controller",
+      "script": "script.pong",
+      "function": "cpu_track_ball",
+      "description": "Move the CPU paddle toward the current ball position."
+    },
+    {
+      "name": "adapter.pong.configure_play_input",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "configure_play_input",
+      "description": "Normalize Pong play scene input role state before the authored active input profile applies."
+    },
+    {
+      "name": "adapter.pong.load_persistence",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "load_persistence",
+      "description": "Load persisted Pong score records from user storage."
+    },
+    {
+      "name": "adapter.pong.record_player_win",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "record_player_win",
+      "description": "Record a player match win in persistent score data."
+    },
+    {
+      "name": "adapter.pong.record_cpu_win",
+      "kind": "action",
+      "script": "script.pong",
+      "function": "record_cpu_win",
+      "description": "Record a CPU match win in persistent score data."
+    }
+  ]
+}

--- a/demos/pong/data/pong.game.json
+++ b/demos/pong/data/pong.game.json
@@ -8,7 +8,8 @@
     { "path": "fragments/logic.json", "sections": ["logic"] },
     { "path": "fragments/presentation.json", "sections": ["presentation", "transitions", "haptics"] },
     { "path": "fragments/persistence.json", "sections": ["storage", "persistence"] },
-    { "path": "fragments/runtime.json", "sections": ["render", "update_phases", "profiles"] }
+    { "path": "fragments/runtime.json", "sections": ["render", "update_phases", "profiles"] },
+    { "path": "fragments/interaction.json", "sections": ["ui", "signals", "adapters"] }
   ],
   "metadata": {
     "name": "Pong",
@@ -348,7 +349,6 @@
       }
     }
   },
-  "ui": { "text": [], "images": [] },
   "world": {
     "name": "world.pong",
     "kind": "fixed_screen",
@@ -1116,97 +1116,6 @@
         "session_6": { "type": "string", "value": "" },
         "session_7": { "type": "string", "value": "" }
       }
-    }
-  ],
-  "signals": [
-    "signal.game.start",
-    "signal.ball.serve",
-    "signal.ball.hit_wall",
-    "signal.ball.hit_paddle",
-    "signal.goal.player",
-    "signal.goal.cpu",
-    "signal.score.player",
-    "signal.score.cpu",
-    "signal.round.reset",
-    "signal.match.player_won",
-    "signal.match.cpu_won",
-    "signal.match.reset",
-    "signal.match.restart",
-    "signal.camera.ball.toggle",
-    "signal.attract.round_reset",
-    "signal.presentation.flash_border",
-    "signal.persistence.load",
-    "signal.persistence.save_options",
-    "signal.settings.apply",
-    "signal.settings.apply_audio",
-    "signal.settings.vibration",
-    "signal.settings.reset_display",
-    "signal.settings.reset_keyboard",
-    "signal.settings.reset_mouse",
-    "signal.settings.reset_gamepad",
-    "signal.settings.reset_audio",
-    "signal.network.start_game",
-    "signal.network.terminate_match",
-    "signal.network.pause_changed",
-    "signal.multiplayer.lobby.start",
-    "signal.multiplayer.discovery.refresh",
-    "signal.multiplayer.discovery.connect",
-    "signal.multiplayer.discovery.cancel",
-    "signal.multiplayer.direct.connect",
-    "signal.multiplayer.direct.disconnect",
-    "signal.ui.menu.move",
-    "signal.ui.menu.select",
-    "signal.app.quit_fade_done"
-  ],
-  "adapters": [
-    {
-      "name": "adapter.pong.serve_random",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "serve_random",
-      "description": "Choose a non-extreme random serve vector for the ball."
-    },
-    {
-      "name": "adapter.pong.reflect_from_paddle",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "reflect_from_paddle",
-      "description": "Reflect ball velocity using Pong-specific hit-offset deflection."
-    },
-    {
-      "name": "adapter.pong.cpu_track_ball",
-      "kind": "controller",
-      "script": "script.pong",
-      "function": "cpu_track_ball",
-      "description": "Move the CPU paddle toward the current ball position."
-    },
-    {
-      "name": "adapter.pong.configure_play_input",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "configure_play_input",
-      "description": "Normalize Pong play scene input role state before the authored active input profile applies."
-    },
-    {
-      "name": "adapter.pong.load_persistence",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "load_persistence",
-      "description": "Load persisted Pong score records from user storage."
-    },
-    {
-      "name": "adapter.pong.record_player_win",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "record_player_win",
-      "description": "Record a player match win in persistent score data."
-    },
-    {
-      "name": "adapter.pong.record_cpu_win",
-      "kind": "action",
-      "script": "script.pong",
-      "function": "record_cpu_win",
-      "description": "Record a CPU match win in persistent score data."
     }
   ]
 }

--- a/tests/test_game_data_json.cpp
+++ b/tests/test_game_data_json.cpp
@@ -252,6 +252,9 @@ TEST(GameDataJson, PongDataDeclaresGenericTopLevelModel)
     EXPECT_TRUE(yyjson_is_obj(doc.section("render")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("update_phases")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("profiles")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("ui")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("signals")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("adapters")));
 }
 
 TEST(GameDataJson, PongDataUsesStructuredImports)
@@ -260,7 +263,7 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     ASSERT_NE(doc.root(), nullptr) << doc.error();
 
     yyjson_val *imports = required_array(doc.root(), "imports");
-    ASSERT_EQ(yyjson_arr_size(imports), 8u);
+    ASSERT_EQ(yyjson_arr_size(imports), 9u);
     EXPECT_TRUE(yyjson_is_obj(doc.section("assets")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("scripts")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("input")));
@@ -274,6 +277,9 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_TRUE(yyjson_is_obj(doc.section("render")));
     EXPECT_TRUE(yyjson_is_obj(doc.section("update_phases")));
     EXPECT_TRUE(yyjson_is_arr(doc.section("profiles")));
+    EXPECT_TRUE(yyjson_is_obj(doc.section("ui")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("signals")));
+    EXPECT_TRUE(yyjson_is_arr(doc.section("adapters")));
     EXPECT_EQ(yyjson_obj_get(doc.root(), "assets"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "scripts"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "input"), nullptr);
@@ -287,6 +293,9 @@ TEST(GameDataJson, PongDataUsesStructuredImports)
     EXPECT_EQ(yyjson_obj_get(doc.root(), "render"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "update_phases"), nullptr);
     EXPECT_EQ(yyjson_obj_get(doc.root(), "profiles"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "ui"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "signals"), nullptr);
+    EXPECT_EQ(yyjson_obj_get(doc.root(), "adapters"), nullptr);
 }
 
 TEST(GameDataJson, PongUsesStandardOptionsScenePackage)
@@ -407,8 +416,12 @@ TEST(GameDataJson, PongDataHasUniqueAuthoredNames)
     std::set<std::string> adapter_names;
     std::set<std::string> script_names;
     collect_named_objects(required_array(doc.root(), "entities"), "name", &entity_names);
-    collect_signals(required_array(doc.root(), "signals"), &signal_names);
-    collect_named_objects(required_array(doc.root(), "adapters"), "name", &adapter_names);
+    yyjson_val *signals_section = doc.section("signals");
+    yyjson_val *adapters_section = doc.section("adapters");
+    ASSERT_TRUE(yyjson_is_arr(signals_section));
+    ASSERT_TRUE(yyjson_is_arr(adapters_section));
+    collect_signals(signals_section, &signal_names);
+    collect_named_objects(adapters_section, "name", &adapter_names);
     collect_named_objects(doc.section("scripts"), "id", &script_names);
 
     EXPECT_NE(entity_names.find("entity.ball"), entity_names.end());
@@ -431,11 +444,16 @@ TEST(GameDataJson, PongLogicReferencesKnownEntitiesSignalsTimersCamerasAndAdapte
     std::set<std::string> scripts;
 
     collect_named_objects(required_array(doc.root(), "entities"), "name", &entities);
-    collect_signals(required_array(doc.root(), "signals"), &signals);
-    collect_named_objects(required_array(doc.root(), "adapters"), "name", &adapters);
+    yyjson_val *signals_section = doc.section("signals");
+    yyjson_val *adapters_section = doc.section("adapters");
+    ASSERT_TRUE(yyjson_is_arr(signals_section));
+    ASSERT_TRUE(yyjson_is_arr(adapters_section));
+    collect_signals(signals_section, &signals);
+    collect_named_objects(adapters_section, "name", &adapters);
     collect_named_objects(doc.section("scripts"), "id", &scripts);
 
-    yyjson_val *adapter_array = required_array(doc.root(), "adapters");
+    yyjson_val *adapter_array = doc.section("adapters");
+    ASSERT_TRUE(yyjson_is_arr(adapter_array));
     yyjson_val *script_array = doc.section("scripts");
     ASSERT_TRUE(yyjson_is_arr(script_array));
     for (size_t i = 0; i < yyjson_arr_size(script_array); ++i)


### PR DESCRIPTION
## Summary
- move Pong's authored `ui`, `signals`, and `adapters` sections into `demos/pong/data/fragments/interaction.json`
- import the interaction fragment from `pong.game.json` so the root is now focused on entry-point structure plus entities
- include the new fragment in Pong embedded/disk pack asset lists
- update JSON parity tests to resolve composed signals/adapters and assert these sections are no longer root-authored

Continues #231.

## Tests
- `jq empty demos/pong/data/pong.game.json demos/pong/data/fragments/interaction.json`
- `cmake --build build/debug --target game_data_json_test sdl3d_game_data_test -j 8`
- `./build/debug/tests/game_data_json_test`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ValidatesPongDataWithoutDiagnostics:GameDataRuntime.LoadsPongDataIntoGenericSessionServices:GameDataRuntime.PongMatchStateAndRestartAreAuthoredLogic:GameDataRuntime.DataGameRuntimeOwnsGenericPongLifecycle'`
- `cmake --build build/debug-demos --target pong_demo -j 8`
- `ctest --test-dir build/debug --output-on-failure`