### PR TITLE
Add runner direct scene launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     sdl3d_enable_warnings(sdl3d_pack)
     sdl3d_enable_sanitizers(sdl3d_pack)
 
-    add_executable(sdl3d_runner tools/sdl3d_runner.c tools/sdl3d_runner_cli.c)
+    add_executable(sdl3d_runner tools/sdl3d_runner.c tools/sdl3d_runner_cli.c tools/sdl3d_runner_state.c)
     target_link_libraries(sdl3d_runner PRIVATE SDL3D::sdl3d sdl3d_argtable3)
     target_compile_features(sdl3d_runner PRIVATE c_std_17)
     target_include_directories(sdl3d_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ From a pack file:
 build/debug/sdl3d_runner --pack path/to/game.sdl3dpak --data asset://game.game.json
 ```
 
+Start directly in a scene for development:
+
+```sh
+build/debug/sdl3d_runner \
+  --root path/to/game/data \
+  --data asset://game.game.json \
+  --scene scene.level_1 \
+  --state checkpoint=midboss
+```
+
 Demo targets may also build a game-specific executable from the same generic
 runner source with embedded assets and a default root data asset. That wrapper
 must not contain game-specific rules.

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -163,9 +163,27 @@ Optional flags:
 
 - `--media <dir>` overrides the built-in media directory used for engine fonts
   and shared media.
+- `--scene <scene-id>` starts directly in a loaded scene instead of
+  `scenes.initial`. This is intended for editor and developer workflows such as
+  play-testing a level without sitting through splash, title, or cutscene flow.
+- `--state <key=value>` injects one scene-state value before the direct scene
+  enter signal runs. The value is parsed as JSON when possible, so
+  `--state lives=3`, `--state debug=true`, `--state spawn=[1,2,3]`, and
+  `--state label=checkpoint_a` are all valid. Repeat the flag for multiple
+  values.
+- `--state-json <object>` injects multiple scene-state values from an inline
+  JSON object.
+- `--state-file <path-or-asset>` injects scene-state values from a JSON object
+  file. Files may be host paths or mounted `asset://` paths.
 - `--embedded` is available only when a build target defines
   `SDL3D_RUNNER_EMBEDDED_ASSETS` and provides the generic
   `sdl3d_runner_embedded_assets` pack blob symbols.
+
+State inputs are applied in this order: `--state-file`, then `--state-json`,
+then `--state`. Later values overwrite earlier values with the same key.
+Injected state is available to the scene's `on_enter` signal and to authored
+conditions during scene entry. Direct scene launch also suppresses startup
+app-flow transitions so the requested scene is immediately usable.
 
 The generic runner source is game-agnostic: it does not reference game scene
 names, actions, actors, replication channels, controls, score state, menus, or

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -87,6 +87,22 @@ Run through a pack file:
 build/debug/sdl3d_runner --pack path/to/game.sdl3dpak --data asset://game.game.json
 ```
 
+Start directly in a scene while play-testing:
+
+```sh
+build/debug/sdl3d_runner \
+  --root path/to/game/data \
+  --data asset://game.game.json \
+  --scene scene.level_1 \
+  --state checkpoint=midboss \
+  --state lives=3
+```
+
+For larger setup payloads, use `--state-json '{"checkpoint":"midboss"}'` or
+`--state-file dev/level_1_state.json`. Direct-start state is applied before the
+scene enter signal runs, so authored setup logic can read it through normal
+scene-state conditions and Lua state APIs.
+
 Demo targets may compile the same runner source with embedded assets and a
 default root data path. That wrapper should only supply build-time defaults; it
 should not contain game rules.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -239,6 +239,12 @@ grows.
 Scene files use `sdl3d.scene.v0`. They can select entities, input actions,
 menus, UI text, update phases, transitions, and activity hooks.
 
+`scenes.initial` is the normal startup scene. Development tools may override it
+at launch time; for example, `sdl3d_runner --scene scene.level_1` enters a
+loaded scene directly and may inject scene state before that scene's enter
+signal runs. Authored data should still define a valid `scenes.initial` so the
+game has a complete production startup path.
+
 ## Actors
 
 Actors describe runtime objects:

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -56,6 +56,14 @@ extern "C"
         sdl3d_data_game_mount_assets_fn mount_assets;
         /** @brief Userdata passed to @ref mount_assets. */
         void *mount_userdata;
+        /** @brief Optional scene name to enter instead of the authored `scenes.initial` scene. */
+        const char *initial_scene_override;
+        /** @brief Optional persistent scene-state values copied before the first scene-enter signal. */
+        const sdl3d_properties *initial_scene_state;
+        /** @brief Optional transient payload passed to the first scene-enter signal. */
+        const sdl3d_properties *initial_scene_payload;
+        /** @brief Suppress the authored app startup transition when using direct-start tooling. */
+        bool skip_app_flow_startup;
         /**
          * @brief Enable authored host/direct-connect network orchestration.
          *

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -834,6 +834,28 @@ extern "C"
                                    char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Optional game-data load-time overrides.
+     *
+     * Hosts normally load the authored `scenes.initial` scene and emit that
+     * scene's enter signal. Development tools and editors can provide
+     * `initial_scene_override` to enter a different scene before any enter
+     * signal fires. `initial_scene_state` is copied into the persistent
+     * scene-state bag before the first enter signal; `initial_scene_payload`
+     * is passed only to that initial scene-enter signal.
+     */
+    typedef struct sdl3d_game_data_load_options
+    {
+        /** @brief Game session that receives authored signals, timers, and input bindings. Required. */
+        sdl3d_game_session *session;
+        /** @brief Optional authored scene name to enter instead of `scenes.initial`. */
+        const char *initial_scene_override;
+        /** @brief Optional persistent scene-state values copied before first scene enter. */
+        const sdl3d_properties *initial_scene_state;
+        /** @brief Optional transient payload passed to the first scene-enter signal. */
+        const sdl3d_properties *initial_scene_payload;
+    } sdl3d_game_data_load_options;
+
+    /**
      * @brief Load a JSON game data asset through a resolver.
      *
      * This is the preferred loading entry point for games that may ship data in
@@ -852,6 +874,19 @@ extern "C"
      */
     bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,
                                     sdl3d_game_data_runtime **out_runtime, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Load a JSON game data asset through a resolver with load-time overrides.
+     *
+     * This uses the same resolver and ownership rules as
+     * @ref sdl3d_game_data_load_asset, with the additional ability to choose
+     * the first active scene and seed scene state before any scene-enter signal
+     * runs.
+     */
+    bool sdl3d_game_data_load_asset_with_options(sdl3d_asset_resolver *assets, const char *asset_path,
+                                                 const sdl3d_game_data_load_options *options,
+                                                 sdl3d_game_data_runtime **out_runtime, char *error_buffer,
+                                                 int error_buffer_size);
 
     /**
      * @brief Read the managed-loop config authored in a JSON game data asset.

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -8,6 +8,7 @@
 #include "sdl3d/input.h"
 #include "sdl3d/properties.h"
 #include "sdl3d/signal_bus.h"
+#include "sdl3d/transition.h"
 
 struct sdl3d_data_game_runtime
 {
@@ -907,8 +908,14 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
         return false;
     }
 
-    if (!sdl3d_game_data_load_asset(runtime->assets, desc->data_asset_path, desc->session, &runtime->data, load_error,
-                                    (int)sizeof(load_error)))
+    sdl3d_game_data_load_options load_options;
+    SDL_zero(load_options);
+    load_options.session = desc->session;
+    load_options.initial_scene_override = desc->initial_scene_override;
+    load_options.initial_scene_state = desc->initial_scene_state;
+    load_options.initial_scene_payload = desc->initial_scene_payload;
+    if (!sdl3d_game_data_load_asset_with_options(runtime->assets, desc->data_asset_path, &load_options, &runtime->data,
+                                                 load_error, (int)sizeof(load_error)))
     {
         set_error(error_buffer, error_buffer_size, load_error[0] != '\0' ? load_error : "game data load failed");
         sdl3d_data_game_runtime_destroy(runtime);
@@ -924,6 +931,8 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
         sdl3d_data_game_runtime_destroy(runtime);
         return false;
     }
+    if (desc->skip_app_flow_startup)
+        sdl3d_transition_reset(&runtime->app_flow.transition);
     if (!connect_haptics_policies(runtime))
     {
         set_error(error_buffer, error_buffer_size, SDL_GetError());

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -481,7 +481,7 @@ static void managed_network_cancel_host(sdl3d_data_game_runtime *runtime, bool n
             : NULL;
     if (runtime == NULL || runtime->data == NULL)
         return;
-    if (session != NULL && notify_peer)
+    if (session != NULL && notify_peer && sdl3d_network_session_is_connected(session))
     {
         (void)managed_network_send_control_repeated(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT,
                                                     "host disconnect", 5);
@@ -515,7 +515,7 @@ static void managed_network_cancel_direct_connect(sdl3d_data_game_runtime *runti
                                          : NULL;
     if (runtime == NULL || runtime->data == NULL)
         return;
-    if (session != NULL && notify_peer)
+    if (session != NULL && notify_peer && sdl3d_network_session_is_connected(session))
     {
         (void)managed_network_send_control_repeated(runtime, session, SDL3D_MANAGED_NETWORK_BINDING_DISCONNECT,
                                                     "client disconnect", 5);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -12018,7 +12018,19 @@ static bool load_scene_package(sdl3d_game_data_runtime *runtime, yyjson_val *roo
     return ok;
 }
 
-static bool load_scenes(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
+static void copy_all_properties(sdl3d_properties *target, const sdl3d_properties *source)
+{
+    const int count = sdl3d_properties_count(source);
+    for (int i = 0; i < count; ++i)
+    {
+        const char *key = NULL;
+        if (sdl3d_properties_get_key_at(source, i, &key, NULL))
+            copy_property_value(target, key, sdl3d_properties_get_value(source, key));
+    }
+}
+
+static bool load_scenes(sdl3d_game_data_runtime *runtime, yyjson_val *root, const sdl3d_game_data_load_options *options,
+                        char *error_buffer, int error_buffer_size)
 {
     yyjson_val *scenes = obj_get(root, "scenes");
     yyjson_val *files = obj_get(scenes, "files");
@@ -12069,21 +12081,29 @@ static bool load_scenes(sdl3d_game_data_runtime *runtime, yyjson_val *root, char
     }
 
     runtime->active_scene_index = runtime->scene_count > 0 ? 0 : -1;
-    const char *initial = json_string(scenes, "initial", NULL);
+    const bool using_initial_override =
+        options != NULL && options->initial_scene_override != NULL && options->initial_scene_override[0] != '\0';
+    const char *initial =
+        using_initial_override ? options->initial_scene_override : json_string(scenes, "initial", NULL);
     if (initial != NULL)
     {
         scene_entry *scene = find_scene(runtime, initial);
         if (scene == NULL)
         {
-            set_error(error_buffer, error_buffer_size, "initial scene does not reference a loaded scene");
+            set_error(error_buffer, error_buffer_size,
+                      using_initial_override ? "initial scene override does not reference a loaded scene"
+                                             : "initial scene does not reference a loaded scene");
             return false;
         }
         runtime->active_scene_index = (int)(scene - runtime->scenes);
     }
+    if (options != NULL && options->initial_scene_state != NULL)
+        copy_all_properties(runtime->scene_state, options->initial_scene_state);
     apply_scene_camera(runtime, active_scene_entry(runtime));
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SDL3D game data initial scene: %s",
                  sdl3d_game_data_active_scene(runtime) != NULL ? sdl3d_game_data_active_scene(runtime) : "<none>");
-    emit_scene_enter_signal(runtime, active_scene_entry(runtime), NULL, NULL);
+    emit_scene_enter_signal(runtime, active_scene_entry(runtime), NULL,
+                            options != NULL ? options->initial_scene_payload : NULL);
     return true;
 }
 
@@ -12913,9 +12933,22 @@ bool sdl3d_game_data_load_app_config_file(const char *path, sdl3d_game_config *o
 bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_path, sdl3d_game_session *session,
                                 sdl3d_game_data_runtime **out_runtime, char *error_buffer, int error_buffer_size)
 {
+    sdl3d_game_data_load_options options;
+    SDL_zero(options);
+    options.session = session;
+    return sdl3d_game_data_load_asset_with_options(assets, asset_path, &options, out_runtime, error_buffer,
+                                                   error_buffer_size);
+}
+
+bool sdl3d_game_data_load_asset_with_options(sdl3d_asset_resolver *assets, const char *asset_path,
+                                             const sdl3d_game_data_load_options *options,
+                                             sdl3d_game_data_runtime **out_runtime, char *error_buffer,
+                                             int error_buffer_size)
+{
     if (out_runtime != NULL)
         *out_runtime = NULL;
-    if (assets == NULL || asset_path == NULL || asset_path[0] == '\0' || session == NULL || out_runtime == NULL)
+    if (assets == NULL || asset_path == NULL || asset_path[0] == '\0' || options == NULL || options->session == NULL ||
+        out_runtime == NULL)
     {
         set_error(error_buffer, error_buffer_size, "invalid game data load arguments");
         return false;
@@ -12944,7 +12977,7 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
         return false;
     }
     runtime->doc = doc;
-    runtime->session = session;
+    runtime->session = options->session;
     runtime->assets = assets;
     runtime->base_dir = path_dirname(asset_path_without_scheme(asset_path));
     runtime->scene_state = sdl3d_properties_create();
@@ -12982,7 +13015,7 @@ bool sdl3d_game_data_load_asset(sdl3d_asset_resolver *assets, const char *asset_
               load_scripts(runtime, root, error_buffer, error_buffer_size) &&
               load_lua_adapters(runtime, root, error_buffer, error_buffer_size) &&
               load_bindings(runtime, logic, error_buffer, error_buffer_size) &&
-              load_scenes(runtime, root, error_buffer, error_buffer_size);
+              load_scenes(runtime, root, options, error_buffer, error_buffer_size);
     if (!ok)
     {
         sdl3d_game_data_destroy(runtime);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,6 +285,7 @@ else()
         PRIVATE
             ${CMAKE_SOURCE_DIR}/tools/sdl3d_pack_cli.c
             ${CMAKE_SOURCE_DIR}/tools/sdl3d_runner_cli.c
+            ${CMAKE_SOURCE_DIR}/tools/sdl3d_runner_state.c
     )
     target_link_libraries(sdl3d_tool_cli_test PRIVATE sdl3d_argtable3)
     target_include_directories(sdl3d_tool_cli_test PRIVATE ${CMAKE_SOURCE_DIR}/tools)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -572,6 +572,62 @@ void write_hot_reload_json(const std::filesystem::path &dir)
 })json");
 }
 
+void write_direct_start_json(const std::filesystem::path &dir)
+{
+    write_text(dir / "direct_start.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Direct Start", "id": "test.direct_start", "version": "0.1.0" },
+  "world": { "name": "world.direct_start", "kind": "fixed_screen" },
+  "signals": ["signal.intro.enter", "signal.level.enter"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.intro.enter",
+        "actions": [
+          { "type": "scene_state.set", "key": "intro_entered", "value": true }
+        ]
+      },
+      {
+        "signal": "signal.level.enter",
+        "actions": [
+          { "type": "scene_state.set", "key": "level_entered", "value": true },
+          { "type": "scene_state.set", "key": "payload_level", "value": "{selected_level}" },
+          { "type": "scene_state.set", "key": "payload_from_scene", "value": "{from_scene}" },
+          { "type": "scene_state.set", "key": "payload_to_scene", "value": "{to_scene}" },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "checkpoint", "op": "==", "value": "midboss" },
+            "then": [
+              { "type": "scene_state.set", "key": "checkpoint_visible_on_enter", "value": true }
+            ],
+            "else": [
+              { "type": "scene_state.set", "key": "checkpoint_visible_on_enter", "value": false }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": {
+    "initial": "scene.intro",
+    "files": ["scenes/intro.scene.json", "scenes/level1.scene.json"]
+  }
+})json");
+    write_text(dir / "scenes" / "intro.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.intro",
+  "on_enter_signal": "signal.intro.enter"
+})json");
+    write_text(dir / "scenes" / "level1.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.level1",
+  "on_enter_signal": "signal.level.enter"
+})json");
+}
+
 void write_timeline_json(const std::filesystem::path &dir)
 {
     write_text(dir / "timeline.game.json",
@@ -1518,6 +1574,124 @@ TEST(GameDataRuntime, DataGameRuntimeOwnsGenericPongLifecycle)
     EXPECT_TRUE(sdl3d_data_game_runtime_update_frame(runtime, &ctx, 0.016f));
     sdl3d_data_game_runtime_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, DirectStartEntersRequestedSceneBeforeInitialSceneRuns)
+{
+    const std::filesystem::path dir = unique_test_dir("direct_start");
+    write_direct_start_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    ASSERT_NE(assets, nullptr);
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_directory(assets, dir.string().c_str(), error, sizeof(error))) << error;
+
+    sdl3d_properties *initial_state = sdl3d_properties_create();
+    sdl3d_properties *initial_payload = sdl3d_properties_create();
+    ASSERT_NE(initial_state, nullptr);
+    ASSERT_NE(initial_payload, nullptr);
+    sdl3d_properties_set_string(initial_state, "checkpoint", "midboss");
+    sdl3d_properties_set_int(initial_state, "lives", 3);
+    sdl3d_properties_set_string(initial_payload, "selected_level", "level1");
+
+    sdl3d_game_data_load_options options{};
+    options.session = session;
+    options.initial_scene_override = "scene.level1";
+    options.initial_scene_state = initial_state;
+    options.initial_scene_payload = initial_payload;
+
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_asset_with_options(assets, "asset://direct_start.game.json", &options, &runtime,
+                                                        error, sizeof(error)))
+        << error;
+    ASSERT_NE(runtime, nullptr);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.level1");
+
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_FALSE(sdl3d_properties_get_bool(scene_state, "intro_entered", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "level_entered", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "checkpoint_visible_on_enter", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "checkpoint", ""), "midboss");
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "lives", 0), 3);
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "payload_level", ""), "level1");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "payload_from_scene", "missing"), "");
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "payload_to_scene", ""), "scene.level1");
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_properties_destroy(initial_payload);
+    sdl3d_properties_destroy(initial_state);
+    sdl3d_asset_resolver_destroy(assets);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, DirectStartRejectsUnknownScene)
+{
+    const std::filesystem::path dir = unique_test_dir("direct_start_bad_scene");
+    write_direct_start_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    ASSERT_NE(assets, nullptr);
+    char error[512]{};
+    ASSERT_TRUE(sdl3d_asset_resolver_mount_directory(assets, dir.string().c_str(), error, sizeof(error))) << error;
+
+    sdl3d_game_data_load_options options{};
+    options.session = session;
+    options.initial_scene_override = "scene.missing";
+
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_asset_with_options(assets, "asset://direct_start.game.json", &options, &runtime,
+                                                         error, sizeof(error)));
+    EXPECT_EQ(runtime, nullptr);
+    EXPECT_NE(std::string(error).find("initial scene override"), std::string::npos);
+
+    sdl3d_asset_resolver_destroy(assets);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, DataGameRuntimeDirectStartPassesSceneState)
+{
+    const std::filesystem::path dir = unique_test_dir("data_runtime_direct_start");
+    write_direct_start_json(dir);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    sdl3d_properties *initial_state = sdl3d_properties_create();
+    ASSERT_NE(initial_state, nullptr);
+    sdl3d_properties_set_string(initial_state, "checkpoint", "midboss");
+
+    sdl3d_data_game_runtime_desc desc{};
+    const std::string root = dir.string();
+    sdl3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.data_asset_path = "asset://direct_start.game.json";
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+    desc.initial_scene_override = "scene.level1";
+    desc.initial_scene_state = initial_state;
+    desc.skip_app_flow_startup = true;
+
+    char error[512]{};
+    sdl3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    sdl3d_game_data_runtime *data = sdl3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+    EXPECT_STREQ(sdl3d_game_data_active_scene(data), "scene.level1");
+    EXPECT_TRUE(sdl3d_properties_get_bool(sdl3d_game_data_scene_state(data), "checkpoint_visible_on_enter", false));
+
+    sdl3d_data_game_runtime_destroy(runtime);
+    sdl3d_properties_destroy(initial_state);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, DataGameRuntimeRefreshesInputProfilesOnGamepadHotplug)

--- a/tests/test_tool_cli.cpp
+++ b/tests/test_tool_cli.cpp
@@ -1,12 +1,19 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
 extern "C"
 {
+#include "sdl3d/math.h"
+#include "sdl3d/properties.h"
 #include "sdl3d_pack_cli.h"
 #include "sdl3d_runner_cli.h"
+#include "sdl3d_runner_state.h"
 }
 
 namespace
@@ -18,6 +25,19 @@ std::vector<char *> argv_from(std::initializer_list<const char *> args)
     for (const char *arg : args)
         argv.push_back(const_cast<char *>(arg));
     return argv;
+}
+
+std::filesystem::path unique_cli_test_path(const char *name)
+{
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return std::filesystem::temp_directory_path() /
+           ("sdl3d_tool_cli_" + std::string(name) + "_" + std::to_string(stamp) + ".json");
+}
+
+void write_text(const std::filesystem::path &path, const char *text)
+{
+    std::ofstream out(path, std::ios::binary);
+    out << text;
 }
 } // namespace
 
@@ -55,6 +75,24 @@ TEST(ToolCli, RunnerHelpDoesNotRequireMountOrData)
     EXPECT_EQ(sdl3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SDL3D_TOOL_CLI_HELP);
 }
 
+TEST(ToolCli, RunnerParsesDirectStartStateInputs)
+{
+    std::vector<char *> argv = argv_from({"sdl3d_runner", "--root", "game/data", "--data", "asset://game.game.json",
+                                          "--scene", "scene.level1", "--state-file", "dev/level1.json", "--state-json",
+                                          "{\"lives\":3}", "--state", "checkpoint=midboss", "--state", "debug=true"});
+    sdl3d_runner_args args;
+    ASSERT_EQ(sdl3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SDL3D_TOOL_CLI_OK);
+    EXPECT_STREQ(args.scene, "scene.level1");
+    ASSERT_EQ(args.state_file_count, 1);
+    EXPECT_STREQ(args.state_files[0], "dev/level1.json");
+    ASSERT_EQ(args.state_json_count, 1);
+    EXPECT_STREQ(args.state_json_values[0], "{\"lives\":3}");
+    ASSERT_EQ(args.state_assignment_count, 2);
+    EXPECT_STREQ(args.state_assignments[0], "checkpoint=midboss");
+    EXPECT_STREQ(args.state_assignments[1], "debug=true");
+    sdl3d_runner_args_destroy(&args);
+}
+
 TEST(ToolCli, PackParsesRepeatedFiles)
 {
     std::vector<char *> argv = argv_from({"sdl3d_pack", "--output", "game.sdl3dpak", "--root", "game/data", "--file",
@@ -84,4 +122,53 @@ TEST(ToolCli, PackRejectsEmptyFile)
     sdl3d_pack_args args;
     EXPECT_EQ(sdl3d_pack_args_parse((int)argv.size(), argv.data(), &args, nullptr), SDL3D_TOOL_CLI_ERROR);
     sdl3d_pack_args_destroy(&args);
+}
+
+TEST(ToolCli, RunnerStateInputsMergeWithExpectedPrecedenceAndTypes)
+{
+    const std::filesystem::path path = unique_cli_test_path("state");
+    write_text(path, R"json({"lives":1,"checkpoint":"from_file","debug":false})json");
+
+    sdl3d_properties *props = sdl3d_properties_create();
+    ASSERT_NE(props, nullptr);
+    char error[256]{};
+    ASSERT_TRUE(sdl3d_runner_apply_state_json_file(props, path.string().c_str(), error, sizeof(error))) << error;
+    const char state_json[] = R"json({"lives":2,"speed":1.5,"spawn":[1,2,3]})json";
+    ASSERT_TRUE(sdl3d_runner_apply_state_json_object(props, state_json, std::strlen(state_json), "--state-json", error,
+                                                     sizeof(error)))
+        << error;
+    ASSERT_TRUE(sdl3d_runner_apply_state_assignment(props, "lives=3", error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_runner_apply_state_assignment(props, "checkpoint=midboss", error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_runner_apply_state_assignment(props, "debug=true", error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_runner_apply_state_assignment(props, "label=not_json", error, sizeof(error))) << error;
+    ASSERT_TRUE(sdl3d_runner_apply_state_assignment(props, "quoted=\"hello\"", error, sizeof(error))) << error;
+
+    EXPECT_EQ(sdl3d_properties_get_int(props, "lives", 0), 3);
+    EXPECT_STREQ(sdl3d_properties_get_string(props, "checkpoint", ""), "midboss");
+    EXPECT_TRUE(sdl3d_properties_get_bool(props, "debug", false));
+    EXPECT_FLOAT_EQ(sdl3d_properties_get_float(props, "speed", 0.0f), 1.5f);
+    const sdl3d_vec3 spawn = sdl3d_properties_get_vec3(props, "spawn", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_FLOAT_EQ(spawn.x, 1.0f);
+    EXPECT_FLOAT_EQ(spawn.y, 2.0f);
+    EXPECT_FLOAT_EQ(spawn.z, 3.0f);
+    EXPECT_STREQ(sdl3d_properties_get_string(props, "label", ""), "not_json");
+    EXPECT_STREQ(sdl3d_properties_get_string(props, "quoted", ""), "hello");
+
+    sdl3d_properties_destroy(props);
+    std::filesystem::remove(path);
+}
+
+TEST(ToolCli, RunnerStateInputsRejectMalformedValues)
+{
+    sdl3d_properties *props = sdl3d_properties_create();
+    ASSERT_NE(props, nullptr);
+    char error[256]{};
+    EXPECT_FALSE(sdl3d_runner_apply_state_assignment(props, "missing_equals", error, sizeof(error)));
+    const char array_json[] = "[1,2,3]";
+    const char nested_json[] = R"json({"nested":{"bad":true}})json";
+    EXPECT_FALSE(sdl3d_runner_apply_state_json_object(props, array_json, std::strlen(array_json), "--state-json", error,
+                                                      sizeof(error)));
+    EXPECT_FALSE(sdl3d_runner_apply_state_json_object(props, nested_json, std::strlen(nested_json), "--state-json",
+                                                      error, sizeof(error)));
+    sdl3d_properties_destroy(props);
 }

--- a/tools/sdl3d_runner.c
+++ b/tools/sdl3d_runner.c
@@ -12,6 +12,7 @@
 #include "sdl3d/sdl3d.h"
 
 #include "sdl3d_runner_cli.h"
+#include "sdl3d_runner_state.h"
 
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
 #if !defined(SDL3D_RUNNER_EMBEDDED_ASSETS_DATA)
@@ -31,6 +32,11 @@ typedef struct runner_state
     char title[128];
     sdl3d_data_game_runtime *runtime;
 } runner_state;
+
+static bool runner_is_asset_path(const char *path)
+{
+    return path != NULL && SDL_strncmp(path, "asset://", 8) == 0;
+}
 
 static void runner_set_error(char *error_buffer, int error_buffer_size, const char *message)
 {
@@ -69,6 +75,113 @@ static bool runner_mount_assets(sdl3d_asset_resolver *assets, void *userdata, ch
     }
 }
 
+static bool runner_set_errorf(char *error_buffer, int error_buffer_size, const char *fmt, const char *value)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, fmt, value != NULL ? value : "");
+    return false;
+}
+
+static bool runner_read_asset_state_file(runner_state *state, const char *path, char **out_text, size_t *out_size,
+                                         char *error_buffer, int error_buffer_size)
+{
+    *out_text = NULL;
+    *out_size = 0u;
+    sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
+    if (assets == NULL)
+        return runner_set_errorf(error_buffer, error_buffer_size, "failed to create asset resolver for '%s'", path);
+
+    bool ok = runner_mount_assets(assets, state, error_buffer, error_buffer_size);
+    sdl3d_asset_buffer buffer;
+    SDL_zero(buffer);
+    if (ok)
+        ok = sdl3d_asset_resolver_read_file(assets, path, &buffer, error_buffer, error_buffer_size);
+    if (ok)
+    {
+        char *text = (char *)SDL_malloc(buffer.size + 1u);
+        if (text == NULL)
+        {
+            ok = false;
+            runner_set_error(error_buffer, error_buffer_size, "failed to allocate state file buffer");
+        }
+        else
+        {
+            SDL_memcpy(text, buffer.data, buffer.size);
+            text[buffer.size] = '\0';
+            *out_text = text;
+            *out_size = buffer.size;
+        }
+    }
+    sdl3d_asset_buffer_free(&buffer);
+    sdl3d_asset_resolver_destroy(assets);
+    return ok;
+}
+
+static bool runner_build_initial_state(runner_state *state, sdl3d_properties **out_state, char *error_buffer,
+                                       int error_buffer_size)
+{
+    *out_state = NULL;
+    if (state->args.state_file_count <= 0 && state->args.state_json_count <= 0 &&
+        state->args.state_assignment_count <= 0)
+    {
+        return true;
+    }
+
+    sdl3d_properties *props = sdl3d_properties_create();
+    if (props == NULL)
+    {
+        runner_set_error(error_buffer, error_buffer_size, "failed to allocate initial scene state");
+        return false;
+    }
+
+    for (int i = 0; i < state->args.state_file_count; ++i)
+    {
+        if (runner_is_asset_path(state->args.state_files[i]))
+        {
+            char *text = NULL;
+            size_t size = 0u;
+            if (!runner_read_asset_state_file(state, state->args.state_files[i], &text, &size, error_buffer,
+                                              error_buffer_size) ||
+                !sdl3d_runner_apply_state_json_object(props, text, size, state->args.state_files[i], error_buffer,
+                                                      error_buffer_size))
+            {
+                SDL_free(text);
+                sdl3d_properties_destroy(props);
+                return false;
+            }
+            SDL_free(text);
+            continue;
+        }
+        if (!sdl3d_runner_apply_state_json_file(props, state->args.state_files[i], error_buffer, error_buffer_size))
+        {
+            sdl3d_properties_destroy(props);
+            return false;
+        }
+    }
+    for (int i = 0; i < state->args.state_json_count; ++i)
+    {
+        const char *json = state->args.state_json_values[i];
+        if (json == NULL || !sdl3d_runner_apply_state_json_object(props, json, SDL_strlen(json), "--state-json",
+                                                                  error_buffer, error_buffer_size))
+        {
+            sdl3d_properties_destroy(props);
+            return false;
+        }
+    }
+    for (int i = 0; i < state->args.state_assignment_count; ++i)
+    {
+        if (!sdl3d_runner_apply_state_assignment(props, state->args.state_assignments[i], error_buffer,
+                                                 error_buffer_size))
+        {
+            sdl3d_properties_destroy(props);
+            return false;
+        }
+    }
+
+    *out_state = props;
+    return true;
+}
+
 static bool load_runner_config(runner_state *state, char *error_buffer, int error_buffer_size)
 {
     sdl3d_asset_resolver *assets = sdl3d_asset_resolver_create();
@@ -95,11 +208,19 @@ static bool runner_init(sdl3d_game_context *ctx, void *userdata)
 {
     runner_state *state = (runner_state *)userdata;
     sdl3d_data_game_runtime_desc desc;
+    sdl3d_properties *initial_state = NULL;
     char error[512] = "";
 
     if (ctx == NULL || state == NULL)
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner received invalid init arguments");
+        return false;
+    }
+
+    if (!runner_build_initial_state(state, &initial_state, error, (int)sizeof(error)))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner direct-start state failed: %s",
+                     error[0] != '\0' ? error : "unknown error");
         return false;
     }
 
@@ -110,12 +231,18 @@ static bool runner_init(sdl3d_game_context *ctx, void *userdata)
     desc.mount_assets = runner_mount_assets;
     desc.mount_userdata = state;
     desc.enable_managed_network = true;
+    desc.initial_scene_override = state->args.scene;
+    desc.initial_scene_state = initial_state;
+    desc.initial_scene_payload = initial_state;
+    desc.skip_app_flow_startup = state->args.scene != NULL && state->args.scene[0] != '\0';
 
     if (!sdl3d_data_game_runtime_create(&desc, &state->runtime, error, (int)sizeof(error)))
     {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner data load failed: %s", error);
+        sdl3d_properties_destroy(initial_state);
         return false;
     }
+    sdl3d_properties_destroy(initial_state);
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SDL3D runner loaded data asset: %s", state->args.data_asset_path);
     return true;
@@ -168,6 +295,7 @@ int main(int argc, char **argv)
     if (!load_runner_config(&state, error, (int)sizeof(error)))
     {
         fprintf(stderr, "sdl3d_runner: %s\n", error[0] != '\0' ? error : "failed to load app config");
+        sdl3d_runner_args_destroy(&state.args);
         return 1;
     }
 
@@ -179,5 +307,7 @@ int main(int argc, char **argv)
     callbacks.render = runner_render;
     callbacks.shutdown = runner_shutdown;
 
-    return sdl3d_run_game(&state.config, &callbacks, &state);
+    const int result = sdl3d_run_game(&state.config, &callbacks, &state);
+    sdl3d_runner_args_destroy(&state.args);
+    return result;
 }

--- a/tools/sdl3d_runner_cli.c
+++ b/tools/sdl3d_runner_cli.c
@@ -15,12 +15,51 @@ void sdl3d_runner_args_print_usage(const char *argv0, FILE *stream)
     const char *program = argv0 != NULL ? argv0 : "sdl3d_runner";
     fprintf(out,
             "Usage:\n"
-            "  %s --root <asset-root> --data <asset://game.json> [--media <media-dir>]\n"
-            "  %s --pack <game.sdl3dpak> --data <asset://game.json> [--media <media-dir>]\n",
+            "  %s --root <asset-root> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n"
+            "  %s --pack <game.sdl3dpak> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n",
             program, program);
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
-    fprintf(out, "  %s --embedded --data <asset://game.json> [--media <media-dir>]\n", program);
+    fprintf(out,
+            "  %s --embedded --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n",
+            program);
 #endif
+}
+
+static bool copy_string_list(const char ***out_values, int *out_count, const char **values, int count)
+{
+    if (out_values == NULL || out_count == NULL)
+        return false;
+    *out_values = NULL;
+    *out_count = 0;
+    if (count <= 0)
+        return true;
+
+    const char **copy = (const char **)SDL_calloc((size_t)count, sizeof(*copy));
+    if (copy == NULL)
+        return false;
+    for (int i = 0; i < count; ++i)
+        copy[i] = values[i];
+    *out_values = copy;
+    *out_count = count;
+    return true;
+}
+
+void sdl3d_runner_args_destroy(sdl3d_runner_args *args)
+{
+    if (args == NULL)
+        return;
+    SDL_free(args->state_assignments);
+    SDL_free(args->state_json_values);
+    SDL_free(args->state_files);
+    args->state_assignments = NULL;
+    args->state_json_values = NULL;
+    args->state_files = NULL;
+    args->state_assignment_count = 0;
+    args->state_json_count = 0;
+    args->state_file_count = 0;
 }
 
 sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runner_args *args, FILE *stream)
@@ -32,6 +71,12 @@ sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runne
 #endif
     struct arg_str *data = arg_str0(NULL, "data", "<asset://game.json>", "root game-data asset path");
     struct arg_str *media = arg_str0(NULL, "media", "<media-dir>", "built-in media directory");
+    struct arg_str *scene = arg_str0(NULL, "scene", "<scene>", "start directly in an authored scene");
+    struct arg_str *state = arg_strn(NULL, "state", "<key=value>", 0, argc > 0 ? argc : 1, "scene-state override");
+    struct arg_str *state_json =
+        arg_strn(NULL, "state-json", "<json-object>", 0, argc > 0 ? argc : 1, "scene-state JSON object");
+    struct arg_str *state_file =
+        arg_strn(NULL, "state-file", "<path-or-asset>", 0, argc > 0 ? argc : 1, "scene-state JSON file");
     struct arg_lit *help = arg_lit0("h", "help", "print this help and exit");
     struct arg_end *end = arg_end(20);
     void *argtable[] = {
@@ -39,7 +84,7 @@ sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runne
 #if defined(SDL3D_RUNNER_EMBEDDED_ASSETS)
         embedded,
 #endif
-        data,     media, help, end,
+        data,     media, scene, state, state_json, state_file, help, end,
     };
     const char *program = argc > 0 && argv != NULL && argv[0] != NULL ? argv[0] : "sdl3d_runner";
     FILE *out = stream != NULL ? stream : stderr;
@@ -113,6 +158,8 @@ sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runne
         args->data_asset_path = data->sval[0];
     if (media->count > 0)
         args->media_dir = media->sval[0];
+    if (scene->count > 0)
+        args->scene = scene->sval[0];
 
     const bool mount_path_required =
         args->mount_kind == SDL3D_RUNNER_MOUNT_DIRECTORY || args->mount_kind == SDL3D_RUNNER_MOUNT_PACK;
@@ -123,6 +170,17 @@ sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runne
         fprintf(out, "%s: an asset mount and --data are required\n", program);
         fprintf(out, "Try '%s --help' for more information.\n", program);
         arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+        return SDL3D_TOOL_CLI_ERROR;
+    }
+
+    if ((args->scene != NULL && args->scene[0] == '\0') ||
+        !copy_string_list(&args->state_assignments, &args->state_assignment_count, state->sval, state->count) ||
+        !copy_string_list(&args->state_json_values, &args->state_json_count, state_json->sval, state_json->count) ||
+        !copy_string_list(&args->state_files, &args->state_file_count, state_file->sval, state_file->count))
+    {
+        fprintf(out, "%s: invalid or out-of-memory direct-start arguments\n", program);
+        arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+        sdl3d_runner_args_destroy(args);
         return SDL3D_TOOL_CLI_ERROR;
     }
 

--- a/tools/sdl3d_runner_cli.h
+++ b/tools/sdl3d_runner_cli.h
@@ -30,9 +30,17 @@ extern "C"
         const char *mount_path;
         const char *data_asset_path;
         const char *media_dir;
+        const char *scene;
+        const char **state_assignments;
+        int state_assignment_count;
+        const char **state_json_values;
+        int state_json_count;
+        const char **state_files;
+        int state_file_count;
     } sdl3d_runner_args;
 
     sdl3d_tool_cli_result sdl3d_runner_args_parse(int argc, char **argv, sdl3d_runner_args *args, FILE *stream);
+    void sdl3d_runner_args_destroy(sdl3d_runner_args *args);
     void sdl3d_runner_args_print_usage(const char *argv0, FILE *stream);
 
 #ifdef __cplusplus

--- a/tools/sdl3d_runner_state.c
+++ b/tools/sdl3d_runner_state.c
@@ -1,0 +1,166 @@
+/**
+ * @file sdl3d_runner_state.c
+ * @brief Scene-state parsing helpers for sdl3d_runner direct scene launches.
+ */
+
+#include "sdl3d_runner_state.h"
+
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include <limits.h>
+#include <stdint.h>
+
+#include "sdl3d/math.h"
+
+#include "../vendor/yyjson/yyjson.h"
+
+static void runner_state_set_error(char *error_buffer, int error_buffer_size, const char *message)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s", message != NULL ? message : "unknown error");
+}
+
+static bool runner_state_set_errorf(char *error_buffer, int error_buffer_size, const char *fmt, const char *value)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, fmt, value != NULL ? value : "");
+    return false;
+}
+
+static bool runner_state_apply_json_value(sdl3d_properties *props, const char *key, yyjson_val *value,
+                                          char *error_buffer, int error_buffer_size)
+{
+    if (props == NULL || key == NULL || key[0] == '\0')
+        return runner_state_set_errorf(error_buffer, error_buffer_size, "invalid empty state key '%s'", key);
+
+    if (yyjson_is_str(value))
+    {
+        sdl3d_properties_set_string(props, key, yyjson_get_str(value));
+        return true;
+    }
+    if (yyjson_is_bool(value))
+    {
+        sdl3d_properties_set_bool(props, key, yyjson_get_bool(value));
+        return true;
+    }
+    if (yyjson_is_int(value))
+    {
+        const int64_t number = yyjson_get_sint(value);
+        if (number < INT_MIN || number > INT_MAX)
+            return runner_state_set_errorf(error_buffer, error_buffer_size, "state integer out of range for key '%s'",
+                                           key);
+        sdl3d_properties_set_int(props, key, (int)number);
+        return true;
+    }
+    if (yyjson_is_real(value))
+    {
+        sdl3d_properties_set_float(props, key, (float)yyjson_get_real(value));
+        return true;
+    }
+    if (yyjson_is_arr(value) && yyjson_arr_size(value) == 3u)
+    {
+        yyjson_val *x = yyjson_arr_get(value, 0);
+        yyjson_val *y = yyjson_arr_get(value, 1);
+        yyjson_val *z = yyjson_arr_get(value, 2);
+        if (!yyjson_is_num(x) || !yyjson_is_num(y) || !yyjson_is_num(z))
+            return runner_state_set_errorf(error_buffer, error_buffer_size,
+                                           "state vector must contain numbers for key '%s'", key);
+        sdl3d_properties_set_vec3(
+            props, key, sdl3d_vec3_make((float)yyjson_get_num(x), (float)yyjson_get_num(y), (float)yyjson_get_num(z)));
+        return true;
+    }
+    if (yyjson_is_null(value))
+    {
+        sdl3d_properties_remove(props, key);
+        return true;
+    }
+
+    return runner_state_set_errorf(error_buffer, error_buffer_size,
+                                   "state value for key '%s' must be a scalar or three-number vector", key);
+}
+
+bool sdl3d_runner_apply_state_json_object(sdl3d_properties *props, const char *json, size_t json_size,
+                                          const char *source_name, char *error_buffer, int error_buffer_size)
+{
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)json, json_size, YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s JSON error %u at byte %llu: %s",
+                         source_name != NULL ? source_name : "state", err.code, (unsigned long long)err.pos,
+                         err.msg != NULL ? err.msg : "");
+        }
+        return false;
+    }
+
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    if (!yyjson_is_obj(root))
+    {
+        yyjson_doc_free(doc);
+        runner_state_set_error(error_buffer, error_buffer_size, "state JSON must be an object");
+        return false;
+    }
+
+    bool ok = true;
+    size_t index = 0;
+    size_t max = 0;
+    yyjson_val *key = NULL;
+    yyjson_val *value = NULL;
+    yyjson_obj_foreach(root, index, max, key, value)
+    {
+        if (!runner_state_apply_json_value(props, yyjson_get_str(key), value, error_buffer, error_buffer_size))
+        {
+            ok = false;
+            break;
+        }
+    }
+    yyjson_doc_free(doc);
+    return ok;
+}
+
+bool sdl3d_runner_apply_state_assignment(sdl3d_properties *props, const char *assignment, char *error_buffer,
+                                         int error_buffer_size)
+{
+    const char *equals = assignment != NULL ? SDL_strchr(assignment, '=') : NULL;
+    if (equals == NULL || equals == assignment)
+        return runner_state_set_errorf(error_buffer, error_buffer_size, "state override must use key=value: '%s'",
+                                       assignment);
+
+    const size_t key_len = (size_t)(equals - assignment);
+    char key[128];
+    if (key_len == 0u || key_len >= sizeof(key))
+        return runner_state_set_errorf(error_buffer, error_buffer_size, "state key is too long: '%s'", assignment);
+    SDL_memcpy(key, assignment, key_len);
+    key[key_len] = '\0';
+
+    const char *raw_value = equals + 1;
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)raw_value, SDL_strlen(raw_value), YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        sdl3d_properties_set_string(props, key, raw_value);
+        return true;
+    }
+
+    const bool ok =
+        runner_state_apply_json_value(props, key, yyjson_doc_get_root(doc), error_buffer, error_buffer_size);
+    yyjson_doc_free(doc);
+    return ok;
+}
+
+bool sdl3d_runner_apply_state_json_file(sdl3d_properties *props, const char *path, char *error_buffer,
+                                        int error_buffer_size)
+{
+    size_t size = 0u;
+    void *data = SDL_LoadFile(path, &size);
+    if (data == NULL)
+        return runner_state_set_errorf(error_buffer, error_buffer_size, "failed to read state file '%s'", path);
+
+    const bool ok =
+        sdl3d_runner_apply_state_json_object(props, (const char *)data, size, path, error_buffer, error_buffer_size);
+    SDL_free(data);
+    return ok;
+}

--- a/tools/sdl3d_runner_state.h
+++ b/tools/sdl3d_runner_state.h
@@ -1,0 +1,30 @@
+/**
+ * @file sdl3d_runner_state.h
+ * @brief Scene-state parsing helpers for sdl3d_runner direct scene launches.
+ */
+
+#ifndef SDL3D_RUNNER_STATE_H
+#define SDL3D_RUNNER_STATE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "sdl3d/properties.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    bool sdl3d_runner_apply_state_assignment(sdl3d_properties *props, const char *assignment, char *error_buffer,
+                                             int error_buffer_size);
+    bool sdl3d_runner_apply_state_json_object(sdl3d_properties *props, const char *json, size_t json_size,
+                                              const char *source_name, char *error_buffer, int error_buffer_size);
+    bool sdl3d_runner_apply_state_json_file(sdl3d_properties *props, const char *path, char *error_buffer,
+                                            int error_buffer_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

- add `--scene`, repeatable `--state`, repeatable `--state-json`, and repeatable `--state-file` to `sdl3d_runner`
- add game-data/data-game runtime load options so direct scene launch happens before the first scene enter signal
- parse direct-start state as typed scene-state values, including bools, ints, floats, strings, null removal, and vec3 arrays
- document direct scene launch and state injection for data-only game development workflows

## Correctness

- unknown direct-start scenes fail during runtime load before the wrong scene can enter
- injected persistent state is copied before the requested scene enter signal runs
- injected payload values are forwarded through normal scene-enter payload handling, including `from_scene` and `to_scene`
- runner state sources merge deterministically: `--state-file`, then `--state-json`, then `--state`

## Verification

- `cmake --build --preset default --target sdl3d_runner sdl3d_tool_cli_test sdl3d_game_data_test`
- `./build/default/tests/sdl3d_tool_cli_test --gtest_filter='ToolCli.Runner*'`
- `./build/default/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DirectStart*:GameDataRuntime.DataGameRuntimeDirectStart*'`
- `ctest --test-dir build/default -R 'ToolCli\\.Runner|GameDataRuntime\\.(DirectStart|DataGameRuntimeDirectStart)' --output-on-failure`
- `./build/default/sdl3d_runner --help`
- `./scripts/check_clang_format.sh`
- `git diff --check`

Closes #244.


## Smoke Testing

Direct-start smoke-tested real Pong scenes through `sdl3d_runner` with short startup runs:

- `--scene scene.title`
- `--scene scene.play --state match_mode=single`
- `--scene scene.play --state match_mode=local`
- `--scene scene.options`
- `--scene scene.multiplayer.lobby --state match_mode=lan --state network_role=host --state network_flow=host`
- `--scene scene.multiplayer.direct_connect --state match_mode=lan --state network_role=client --state network_flow=direct`

The LAN lobby smoke test exposed managed-network shutdown warnings when closing a listening host with no connected peer. The PR now fixes that root cause by sending graceful disconnect controls only when the session is actually connected.
