### PR TITLE
Add data-authored sector level loading

### DIFF
--- a/demos/doom_level/data/fragments/world/sector_levels.json
+++ b/demos/doom_level/data/fragments/world/sector_levels.json
@@ -1,0 +1,412 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_levels": [
+    {
+      "name": "sector.doom.e1m1",
+      "materials": [
+        {
+          "name": "rock_floor",
+          "texture": "asset://textures/rock_floor.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "ceiling_metal",
+          "texture": "asset://textures/ceiling_metal.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.8,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "wall_metal",
+          "texture": "asset://textures/wall_metal.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.7,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "lava",
+          "texture": "asset://textures/lava.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "wall_metal_dark",
+          "texture": "asset://textures/wall_metal.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.6,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "rock_floor_alt",
+          "texture": "asset://textures/rock_floor.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 4.0
+        }
+      ],
+      "sectors": [
+        {
+          "name": "start_room",
+          "points": [[0, 0], [10, 0], [10, 8], [0, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "south_corridor",
+          "points": [[3, 8], [7, 8], [7, 16], [3, 16]],
+          "floor_y": 0.0,
+          "ceil_y": 3.5,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "nukage_basin",
+          "points": [[-2, 16], [10, 16], [10, 26], [-2, 26]],
+          "floor_y": -0.5,
+          "ceil_y": 4.5,
+          "floor_material": "lava",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal",
+          "damage_per_second": 18.0
+        },
+        {
+          "name": "east_passage",
+          "points": [[10, 18], [16, 18], [16, 22], [10, 22]],
+          "floor_y": 0.0,
+          "ceil_y": 3.5,
+          "floor_material": "rock_floor",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "courtyard",
+          "points": [[16, 14], [28, 14], [28, 26], [16, 26]],
+          "floor_y": 0.0,
+          "ceil_y": 8.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "exit_room",
+          "points": [[20, 26], [28, 26], [28, 32], [20, 32]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "west_alcove",
+          "points": [[-10, 18], [-2, 18], [-2, 24], [-10, 24]],
+          "floor_y": -0.5,
+          "ceil_y": 3.5,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "upper_hall",
+          "points": [[10, 2], [18, 2], [18, 6], [10, 6]],
+          "floor_y": 0.0,
+          "ceil_y": 3.5,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "computer_core",
+          "points": [[18, 0], [30, 0], [30, 8], [18, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "security_bend",
+          "points": [[22, 8], [26, 8], [26, 14], [22, 14]],
+          "floor_y": 0.0,
+          "ceil_y": 3.2,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "storage",
+          "points": [[28, 12], [34, 12], [34, 24], [28, 24]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "reactor_hall",
+          "points": [[18, 32], [30, 32], [30, 44], [18, 44]],
+          "floor_y": 0.0,
+          "ceil_y": 5.5,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "secret_annex",
+          "points": [[32, 24], [40, 24], [40, 30], [32, 30]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "exterior_yard",
+          "points": [[-2, 58], [50, 58], [50, 104], [-2, 104]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "stair_0",
+          "points": [[34, 20], [40, 20], [40, 24], [34, 24]],
+          "floor_y": 0.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "stair_1",
+          "points": [[34, 18], [40, 18], [40, 20], [34, 20]],
+          "floor_y": 1.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "stair_2",
+          "points": [[34, 16], [40, 16], [40, 18], [34, 18]],
+          "floor_y": 2.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "stair_3",
+          "points": [[34, 14], [40, 14], [40, 16], [34, 16]],
+          "floor_y": 3.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "stair_4",
+          "points": [[34, 12], [40, 12], [40, 14], [34, 14]],
+          "floor_y": 4.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "stair_5",
+          "points": [[34, 10], [40, 10], [40, 12], [34, 12]],
+          "floor_y": 5.0,
+          "ceil_y": 10.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "upper_landing",
+          "points": [[29, 4], [40, 4], [40, 10], [29, 10]],
+          "floor_y": 6.0,
+          "ceil_y": 10.0,
+          "floor_material": "lava",
+          "ceil_material": "ceiling_metal",
+          "wall_material": "rock_floor_alt"
+        },
+        {
+          "name": "east_rampart_low_north",
+          "points": [[50, 44], [54, 44], [54, 49], [50, 49]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "east_rampart_slope_up",
+          "points": [[50, 49], [54, 49], [54, 57], [50, 57]],
+          "floor_y": 1.25,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal",
+          "floor_normal": [0.0, 0.95448, -0.298275]
+        },
+        {
+          "name": "east_rampart_high",
+          "points": [[50, 57], [54, 57], [54, 69], [50, 69]],
+          "floor_y": 2.5,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "east_rampart_slope_down",
+          "points": [[50, 69], [54, 69], [54, 77], [50, 77]],
+          "floor_y": 1.25,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal",
+          "floor_normal": [0.0, 0.95448, 0.298275]
+        },
+        {
+          "name": "east_rampart_low_south",
+          "points": [[50, 77], [54, 77], [54, 104], [50, 104]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "west_rampart_low_north",
+          "points": [[-6, 44], [-2, 44], [-2, 56], [-6, 56]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "west_rampart_slope_up",
+          "points": [[-6, 56], [-2, 56], [-2, 64], [-6, 64]],
+          "floor_y": 1.25,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal",
+          "floor_normal": [0.0, 0.95448, -0.298275]
+        },
+        {
+          "name": "west_rampart_high",
+          "points": [[-6, 64], [-2, 64], [-2, 72], [-6, 72]],
+          "floor_y": 2.5,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "west_rampart_slope_down",
+          "points": [[-6, 72], [-2, 72], [-2, 80], [-6, 80]],
+          "floor_y": 1.25,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal",
+          "floor_normal": [0.0, 0.95448, 0.298275]
+        },
+        {
+          "name": "west_rampart_low_south",
+          "points": [[-6, 80], [-2, 80], [-2, 104], [-6, 104]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "lift_bay_west",
+          "points": [[54, 57], [60, 57], [60, 69], [54, 69]],
+          "floor_y": 2.5,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "lift",
+          "points": [[60, 57], [68, 57], [68, 69], [60, 69]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "none",
+          "wall_material": "wall_metal_dark"
+        },
+        {
+          "name": "upper_deck",
+          "points": [[68, 57], [78, 57], [78, 69], [68, 69]],
+          "floor_y": 2.5,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "conveyor_entry",
+          "points": [[-2, 44], [8, 44], [8, 58], [-2, 58]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "conveyor",
+          "points": [[8, 44], [30, 44], [30, 58], [8, 58]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "wall_metal_dark",
+          "ceil_material": "none",
+          "wall_material": "wall_metal",
+          "push_velocity": [8.0, 0.0, 0.0]
+        },
+        {
+          "name": "conveyor_exit",
+          "points": [[30, 44], [50, 44], [50, 58], [30, 58]],
+          "floor_y": 0.0,
+          "ceil_y": 12.0,
+          "floor_material": "rock_floor_alt",
+          "ceil_material": "none",
+          "wall_material": "wall_metal"
+        }
+      ],
+      "lights": [
+        { "position": [5, 3.5, 4], "color": [1.0, 0.82, 0.58], "intensity": 2.4, "range": 9.5 },
+        { "position": [5, 3.0, 12], "color": [1.0, 0.68, 0.28], "intensity": 1.4, "range": 7.0 },
+        { "position": [4, 1.0, 21], "color": [1.0, 0.16, 0.10], "intensity": 3.1, "range": 12.0 },
+        { "position": [-6, 1.8, 21], "color": [0.25, 0.95, 0.35], "intensity": 2.4, "range": 8.5 },
+        { "position": [14, 2.7, 4], "color": [0.7, 0.8, 1.0], "intensity": 1.3, "range": 7.0 },
+        { "position": [24, 3.2, 4], "color": [0.15, 0.85, 1.0], "intensity": 2.4, "range": 10.5 },
+        { "position": [24, 2.6, 11], "color": [1.0, 0.9, 0.45], "intensity": 1.4, "range": 6.0 },
+        { "position": [22, 7.0, 20], "color": [0.36, 0.46, 0.78], "intensity": 2.3, "range": 14.0 },
+        { "position": [33, 3.0, 18], "color": [0.9, 0.35, 1.0], "intensity": 1.9, "range": 10.0 },
+        { "position": [24, 2.5, 29], "color": [0.2, 1.0, 0.2], "intensity": 3.2, "range": 8.0 },
+        { "position": [24, 3.8, 38], "color": [0.45, 0.35, 1.0], "intensity": 2.2, "range": 11.0 },
+        { "position": [36, 2.2, 27], "color": [1.0, 0.55, 0.22], "intensity": 1.5, "range": 7.0 },
+        { "position": [24, 8.5, 74], "color": [0.32, 0.38, 0.7], "intensity": 2.4, "range": 32.0 },
+        { "position": [37, 2.5, 22], "color": [1.0, 0.8, 0.5], "intensity": 1.5, "range": 8.0 },
+        { "position": [37, 5.0, 15], "color": [0.8, 0.6, 1.0], "intensity": 1.8, "range": 10.0 },
+        { "position": [34, 8.5, 7], "color": [1.0, 0.95, 0.8], "intensity": 3.0, "range": 16.0 },
+        { "position": [66, 6.0, 63], "color": [0.25, 0.7, 1.0], "intensity": 2.1, "range": 14.0 }
+      ]
+    }
+  ]
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -41,6 +41,7 @@ Every root game file is a JSON object.
 | `entities` | no | Named actors with tags, transforms, properties, and components. |
 | `grid_maps` | no | Authored tile grids for maze, board, and grid-locked games. |
 | `grid_pickup_layers` | no | Dense grid-indexed pickup layers rendered and collected without one actor per pickup. |
+| `sector_levels` | no | Authored sector/portal worlds for Doom/Quake-style indoor levels. |
 | `actor_archetypes` | no | Templates used by runtime actor pools. |
 | `actor_pools` | no | Preallocated spawn/despawn pools. |
 | `signals` | no | Authored signal names. |
@@ -81,6 +82,7 @@ a JSON object with schema `sdl3d.fragment.v0`.
   "imports": [
     { "path": "fragments/assets.json", "sections": ["assets"] },
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
+    { "path": "fragments/world/e1m1.sectors.json", "sections": ["sector_levels"] },
     { "path": "fragments/input/profiles.json", "sections": ["input"] },
     { "path": "fragments/network/replication.json", "sections": ["network"] }
   ]
@@ -237,6 +239,97 @@ any other specific world type.
 World kinds may include fixed-screen playfields, tile grids, room graphs,
 sector/portal maps, brush worlds, or general 3D scenes as engine support
 grows.
+
+## Sector Levels
+
+`sector_levels` describe sector/portal worlds as data. This is the reusable
+foundation for Doom-like indoor maps: materials, sector floor plans, heights,
+sector metadata, and baked lights are authored in JSON and loaded into runtime
+`sdl3d_level` variants.
+
+```json
+{
+  "sector_levels": [
+    {
+      "name": "sector.e1m1",
+      "materials": [
+        {
+          "name": "rock_floor",
+          "texture": "asset://textures/rock_floor.jpg",
+          "albedo": [1.0, 1.0, 1.0, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 4.0
+        },
+        {
+          "name": "wall_metal",
+          "texture": "asset://textures/wall_metal.jpg",
+          "roughness": 0.7,
+          "tex_scale": 4.0
+        }
+      ],
+      "sectors": [
+        {
+          "name": "start_room",
+          "points": [[0, 0], [10, 0], [10, 8], [0, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "wall_metal",
+          "wall_material": "wall_metal"
+        },
+        {
+          "name": "hazard_basin",
+          "points": [[-2, 16], [10, 16], [10, 26], [-2, 26]],
+          "floor_y": -0.5,
+          "ceil_y": 4.5,
+          "floor_material": "rock_floor",
+          "ceil_material": "wall_metal",
+          "wall_material": "wall_metal",
+          "damage_per_second": 18.0,
+          "ambient_sound_id": 1,
+          "push_velocity": [0.0, 0.0, 0.0]
+        }
+      ],
+      "lights": [
+        {
+          "position": [5.0, 3.5, 4.0],
+          "color": [1.0, 0.82, 0.58],
+          "intensity": 2.4,
+          "range": 9.5
+        }
+      ]
+    }
+  ]
+}
+```
+
+Sector material references may be material names or zero-based material
+indices. Prefer names for maintainability. `floor_material` and
+`ceil_material` may be omitted, `null`, `-1`, or `"none"` to omit that
+surface; `wall_material` must reference a declared material.
+
+Validation requires:
+
+- unique sector level names
+- a non-empty `materials` array with unique material names
+- a non-empty `sectors` array
+- each sector to contain 3..32 vec2 `points`
+- numeric `floor_y` and `ceil_y`, with `ceil_y > floor_y`
+- valid material references
+- optional `floor_normal`, `ceil_normal`, and `push_velocity` as vec3 arrays
+- non-negative `ambient_sound_id` and `damage_per_second`
+- optional lights with `position` vec3, optional `color` vec3, non-negative
+  `intensity`, and positive `range`
+
+At load time SDL3D builds three runtime variants per sector level:
+
+- `lightmapped`: baked lights plus lightmap atlas data
+- `vertex_baked`: baked vertex lighting without a lightmap atlas
+- `unlit`: raw material color/texture without baked lights
+
+Later renderer and controller phases should consume these runtime descriptors
+instead of parsing JSON directly. `world.kind` remains a high-level statement
+of spatial intent; `sector_levels` is the concrete sector-world data.
 
 ## Scenes
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -23,6 +23,7 @@
 #include "sdl3d/effects.h"
 #include "sdl3d/font.h"
 #include "sdl3d/game.h"
+#include "sdl3d/level.h"
 #include "sdl3d/lighting.h"
 #include "sdl3d/network.h"
 #include "sdl3d/network_replication.h"
@@ -214,6 +215,39 @@ extern "C"
         /** @brief Duration of the effect ramp, in seconds. */
         float effect_duration;
     } sdl3d_game_data_sprite_asset;
+
+    /**
+     * @brief Runtime descriptor for a JSON-authored sector level.
+     *
+     * Sector levels are data-authored Doom/Quake-style indoor worlds. The
+     * runtime owns all pointers in this descriptor. They remain valid until
+     * sdl3d_game_data_destroy().
+     */
+    typedef struct sdl3d_game_data_sector_level
+    {
+        /** @brief Stable authored level name. */
+        const char *name;
+        /** @brief Runtime sector definitions used for collision, sensors, and future mutation. */
+        const sdl3d_sector *sectors;
+        /** @brief Optional authored sector names parallel to @p sectors. */
+        const char *const *sector_names;
+        /** @brief Number of entries in @p sectors and @p sector_names. */
+        int sector_count;
+        /** @brief Runtime material palette used to build the sector meshes. */
+        const sdl3d_level_material *materials;
+        /** @brief Number of entries in @p materials. */
+        int material_count;
+        /** @brief Authored baked-light definitions. */
+        const sdl3d_level_light *lights;
+        /** @brief Number of entries in @p lights. */
+        int light_count;
+        /** @brief Level built with authored baked lights and lightmap atlas data. */
+        const sdl3d_level *lightmapped;
+        /** @brief Level built with baked vertex colors but no lightmap atlas data. */
+        const sdl3d_level *vertex_baked;
+        /** @brief Level built without baked lights. */
+        const sdl3d_level *unlit;
+    } sdl3d_game_data_sector_level;
 
     /**
      * @brief Runtime metrics used when evaluating data-authored UI bindings.
@@ -773,6 +807,21 @@ extern "C"
      * @see sdl3d_game_data_mutable_scene_state
      */
     const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Look up a JSON-authored sector level by name.
+     *
+     * This exposes loaded and built sector-world data to renderer,
+     * controller, sensor, and editor systems without making callers parse
+     * JSON. The returned pointers are runtime-owned.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored sector level name.
+     * @param out_level Receives runtime-owned sector level pointers.
+     * @return true when @p name resolves to an authored sector level.
+     */
+    bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
+                                          sdl3d_game_data_sector_level *out_level);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum sdl3d_game_data_diagnostic_severity

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5,6 +5,7 @@
 
 #include "sdl3d/game_data.h"
 
+#include <SDL3/SDL_error.h>
 #include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_log.h>
@@ -323,6 +324,21 @@ typedef struct grid_pickup_layer_runtime
     int render_position_capacity;
 } grid_pickup_layer_runtime;
 
+typedef struct sector_level_runtime
+{
+    char *name;
+    sdl3d_sector *sectors;
+    const char **sector_names;
+    int sector_count;
+    sdl3d_level_material *materials;
+    int material_count;
+    sdl3d_level_light *lights;
+    int light_count;
+    sdl3d_level lightmapped;
+    sdl3d_level vertex_baked;
+    sdl3d_level unlit;
+} sector_level_runtime;
+
 typedef enum actor_pool_exhaustion_policy
 {
     ACTOR_POOL_EXHAUST_FAIL,
@@ -476,6 +492,8 @@ typedef struct sdl3d_game_data_runtime
     int grid_actor_index_capacity;
     grid_pickup_layer_runtime *grid_pickup_layers;
     int grid_pickup_layer_count;
+    sector_level_runtime *sector_levels;
+    int sector_level_count;
     actor_pool_runtime *actor_pools;
     int actor_pool_count;
     runtime_direct_connect_session *direct_connect_sessions;
@@ -2868,6 +2886,252 @@ static bool load_grid_pickup_layers(sdl3d_game_data_runtime *runtime, yyjson_val
                 set_error(error_buffer, error_buffer_size, "failed to allocate grid pickup kind data");
                 return false;
             }
+        }
+    }
+    return true;
+}
+
+static void strip_sector_level_lightmap(sdl3d_level *level)
+{
+    if (level == NULL)
+        return;
+
+    SDL_free(level->lightmap_pixels);
+    level->lightmap_pixels = NULL;
+    level->lightmap_width = 0;
+    level->lightmap_height = 0;
+    sdl3d_free_texture(&level->lightmap_texture);
+    for (int i = 0; i < level->model.mesh_count; ++i)
+    {
+        SDL_free(level->model.meshes[i].lightmap_uvs);
+        level->model.meshes[i].lightmap_uvs = NULL;
+    }
+}
+
+static bool json_float_array(yyjson_val *value, float *out_values, int count, const float *fallback)
+{
+    if (out_values == NULL || count <= 0)
+        return false;
+
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < (size_t)count)
+    {
+        if (fallback != NULL)
+            SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
+        return fallback != NULL;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, (size_t)i);
+        if (!yyjson_is_num(entry))
+        {
+            if (fallback != NULL)
+                SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
+            return fallback != NULL;
+        }
+        out_values[i] = (float)yyjson_get_num(entry);
+    }
+    return true;
+}
+
+static int sector_material_index(yyjson_val *materials, yyjson_val *ref, bool allow_none)
+{
+    if (allow_none && ref == NULL)
+        return -1;
+    if (yyjson_is_null(ref) && allow_none)
+        return -1;
+    if (yyjson_is_int(ref))
+    {
+        const int index = (int)yyjson_get_int(ref);
+        if (allow_none && index == -1)
+            return -1;
+        return (index >= 0 && index < (int)yyjson_arr_size(materials)) ? index : -2;
+    }
+    if (yyjson_is_str(ref))
+    {
+        const char *name = yyjson_get_str(ref);
+        if (allow_none && name != NULL && SDL_strcmp(name, "none") == 0)
+            return -1;
+        for (size_t i = 0; yyjson_is_arr(materials) && i < yyjson_arr_size(materials); ++i)
+        {
+            yyjson_val *material = yyjson_arr_get(materials, i);
+            if (SDL_strcmp(json_string(material, "name", ""), name != NULL ? name : "") == 0)
+                return (int)i;
+        }
+    }
+    return -2;
+}
+
+static bool load_sector_level_materials(sector_level_runtime *level, yyjson_val *materials, char *error_buffer,
+                                        int error_buffer_size)
+{
+    level->material_count = yyjson_is_arr(materials) ? (int)yyjson_arr_size(materials) : 0;
+    level->materials = (sdl3d_level_material *)SDL_calloc((size_t)level->material_count, sizeof(*level->materials));
+    if (level->materials == NULL && level->material_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector level materials");
+        return false;
+    }
+
+    static const float default_albedo[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    for (int i = 0; i < level->material_count; ++i)
+    {
+        yyjson_val *material_json = yyjson_arr_get(materials, (size_t)i);
+        yyjson_val *albedo = obj_get(material_json, "albedo");
+        sdl3d_level_material *material = &level->materials[i];
+        SDL_memcpy(material->albedo, default_albedo, sizeof(material->albedo));
+        if (yyjson_is_arr(albedo) && yyjson_arr_size(albedo) >= 3)
+        {
+            for (int channel = 0; channel < 4 && channel < (int)yyjson_arr_size(albedo); ++channel)
+            {
+                yyjson_val *value = yyjson_arr_get(albedo, (size_t)channel);
+                if (yyjson_is_num(value))
+                    material->albedo[channel] = (float)yyjson_get_num(value);
+            }
+        }
+        material->metallic = json_float(material_json, "metallic", 0.0f);
+        material->roughness = json_float(material_json, "roughness", 1.0f);
+        material->texture = json_string(material_json, "texture", NULL);
+        material->tex_scale = json_float(material_json, "tex_scale", 4.0f);
+    }
+    return true;
+}
+
+static bool load_sector_level_sectors(sector_level_runtime *level, yyjson_val *materials, yyjson_val *sectors,
+                                      char *error_buffer, int error_buffer_size)
+{
+    level->sector_count = yyjson_is_arr(sectors) ? (int)yyjson_arr_size(sectors) : 0;
+    level->sectors = (sdl3d_sector *)SDL_calloc((size_t)level->sector_count, sizeof(*level->sectors));
+    level->sector_names = (const char **)SDL_calloc((size_t)level->sector_count, sizeof(*level->sector_names));
+    if ((level->sectors == NULL || level->sector_names == NULL) && level->sector_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector level sectors");
+        return false;
+    }
+
+    for (int sector_index = 0; sector_index < level->sector_count; ++sector_index)
+    {
+        yyjson_val *sector_json = yyjson_arr_get(sectors, (size_t)sector_index);
+        yyjson_val *points = obj_get(sector_json, "points");
+        sdl3d_sector *sector = &level->sectors[sector_index];
+
+        level->sector_names[sector_index] = json_string(sector_json, "name", NULL);
+        sector->num_points = yyjson_is_arr(points) ? (int)yyjson_arr_size(points) : 0;
+        for (int point_index = 0; point_index < sector->num_points; ++point_index)
+        {
+            yyjson_val *point = yyjson_arr_get(points, (size_t)point_index);
+            json_vec2_value(point, 0.0f, 0.0f, &sector->points[point_index][0], &sector->points[point_index][1]);
+        }
+
+        sector->floor_y = json_float(sector_json, "floor_y", 0.0f);
+        sector->ceil_y = json_float(sector_json, "ceil_y", sector->floor_y + 4.0f);
+        sector->floor_material = sector_material_index(materials, obj_get(sector_json, "floor_material"), true);
+        sector->ceil_material = sector_material_index(materials, obj_get(sector_json, "ceil_material"), true);
+        sector->wall_material = sector_material_index(materials, obj_get(sector_json, "wall_material"), false);
+        json_float_array(obj_get(sector_json, "floor_normal"), sector->floor_normal, 3, NULL);
+        json_float_array(obj_get(sector_json, "ceil_normal"), sector->ceil_normal, 3, NULL);
+        sector->ambient_sound_id = json_int(sector_json, "ambient_sound_id", 0);
+        json_float_array(obj_get(sector_json, "push_velocity"), sector->push_velocity, 3, NULL);
+        sector->damage_per_second = json_float(sector_json, "damage_per_second", 0.0f);
+    }
+    return true;
+}
+
+static bool load_sector_level_lights(sector_level_runtime *level, yyjson_val *lights, char *error_buffer,
+                                     int error_buffer_size)
+{
+    level->light_count = yyjson_is_arr(lights) ? (int)yyjson_arr_size(lights) : 0;
+    if (level->light_count <= 0)
+        return true;
+
+    level->lights = (sdl3d_level_light *)SDL_calloc((size_t)level->light_count, sizeof(*level->lights));
+    if (level->lights == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector level lights");
+        return false;
+    }
+
+    static const float default_color[3] = {1.0f, 1.0f, 1.0f};
+    for (int i = 0; i < level->light_count; ++i)
+    {
+        yyjson_val *light_json = yyjson_arr_get(lights, (size_t)i);
+        sdl3d_level_light *light = &level->lights[i];
+        json_float_array(obj_get(light_json, "position"), light->position, 3, NULL);
+        json_float_array(obj_get(light_json, "color"), light->color, 3, default_color);
+        light->intensity = json_float(light_json, "intensity", 1.0f);
+        light->range = json_float(light_json, "range", 8.0f);
+    }
+    return true;
+}
+
+static bool build_sector_level_variants(sector_level_runtime *level, char *error_buffer, int error_buffer_size)
+{
+    if (!sdl3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, level->lights,
+                           level->light_count, &level->lightmapped))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' lightmapped build failed: %s", level->name,
+                   SDL_GetError());
+        return false;
+    }
+    if (!sdl3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, level->lights,
+                           level->light_count, &level->vertex_baked))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' vertex-baked build failed: %s", level->name,
+                   SDL_GetError());
+        return false;
+    }
+    strip_sector_level_lightmap(&level->vertex_baked);
+    if (!sdl3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, NULL, 0,
+                           &level->unlit))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' unlit build failed: %s", level->name,
+                   SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+static bool load_sector_levels(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                               int error_buffer_size)
+{
+    yyjson_val *levels = obj_get(root, "sector_levels");
+    if (levels == NULL)
+        return true;
+    if (!yyjson_is_arr(levels))
+    {
+        set_error(error_buffer, error_buffer_size, "sector_levels must be an array");
+        return false;
+    }
+
+    runtime->sector_level_count = (int)yyjson_arr_size(levels);
+    runtime->sector_levels =
+        (sector_level_runtime *)SDL_calloc((size_t)runtime->sector_level_count, sizeof(*runtime->sector_levels));
+    if (runtime->sector_levels == NULL && runtime->sector_level_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector levels");
+        return false;
+    }
+
+    for (int i = 0; i < runtime->sector_level_count; ++i)
+    {
+        yyjson_val *level_json = yyjson_arr_get(levels, (size_t)i);
+        sector_level_runtime *level = &runtime->sector_levels[i];
+        level->name = SDL_strdup(json_string(level_json, "name", ""));
+        if (level->name == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate sector level name");
+            return false;
+        }
+
+        yyjson_val *materials = obj_get(level_json, "materials");
+        yyjson_val *sectors = obj_get(level_json, "sectors");
+        yyjson_val *lights = obj_get(level_json, "lights");
+        if (!load_sector_level_materials(level, materials, error_buffer, error_buffer_size) ||
+            !load_sector_level_sectors(level, materials, sectors, error_buffer, error_buffer_size) ||
+            !load_sector_level_lights(level, lights, error_buffer, error_buffer_size) ||
+            !build_sector_level_variants(level, error_buffer, error_buffer_size))
+        {
+            return false;
         }
     }
     return true;
@@ -5423,6 +5687,36 @@ sdl3d_properties *sdl3d_game_data_mutable_scene_state(sdl3d_game_data_runtime *r
 const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? runtime->scene_state : NULL;
+}
+
+bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
+                                      sdl3d_game_data_sector_level *out_level)
+{
+    if (out_level != NULL)
+        SDL_zero(*out_level);
+    if (runtime == NULL || name == NULL || out_level == NULL)
+        return false;
+
+    for (int i = 0; i < runtime->sector_level_count; ++i)
+    {
+        const sector_level_runtime *level = &runtime->sector_levels[i];
+        if (level->name == NULL || SDL_strcmp(level->name, name) != 0)
+            continue;
+
+        out_level->name = level->name;
+        out_level->sectors = level->sectors;
+        out_level->sector_names = level->sector_names;
+        out_level->sector_count = level->sector_count;
+        out_level->materials = level->materials;
+        out_level->material_count = level->material_count;
+        out_level->lights = level->lights;
+        out_level->light_count = level->light_count;
+        out_level->lightmapped = &level->lightmapped;
+        out_level->vertex_baked = &level->vertex_baked;
+        out_level->unlit = &level->unlit;
+        return true;
+    }
+    return false;
 }
 
 void sdl3d_game_data_ui_state_init(sdl3d_game_data_ui_state *state)
@@ -14780,6 +15074,7 @@ bool sdl3d_game_data_load_asset_with_options(sdl3d_asset_resolver *assets, const
               load_entities(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_maps(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_pickup_layers(runtime, root, error_buffer, error_buffer_size) &&
+              load_sector_levels(runtime, root, error_buffer, error_buffer_size) &&
               load_actor_pools(runtime, root, error_buffer, error_buffer_size) &&
               load_input(runtime, root, error_buffer, error_buffer_size) &&
               load_timers(runtime, logic, error_buffer, error_buffer_size) && load_sensors(runtime, logic) &&
@@ -16910,6 +17205,17 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
         SDL_free(runtime->grid_pickup_layers[i].cells);
         SDL_free(runtime->grid_pickup_layers[i].render_positions);
     }
+    for (int i = 0; i < runtime->sector_level_count; ++i)
+    {
+        SDL_free(runtime->sector_levels[i].name);
+        SDL_free(runtime->sector_levels[i].sectors);
+        SDL_free(runtime->sector_levels[i].sector_names);
+        SDL_free(runtime->sector_levels[i].materials);
+        SDL_free(runtime->sector_levels[i].lights);
+        sdl3d_free_level(&runtime->sector_levels[i].lightmapped);
+        sdl3d_free_level(&runtime->sector_levels[i].vertex_baked);
+        sdl3d_free_level(&runtime->sector_levels[i].unlit);
+    }
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {
         SDL_free(runtime->actor_pools[i].name);
@@ -16965,6 +17271,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_maps);
     SDL_free(runtime->grid_actor_indices);
     SDL_free(runtime->grid_pickup_layers);
+    SDL_free(runtime->sector_levels);
     SDL_free(runtime->actor_pools);
     SDL_free(runtime->direct_connect_sessions);
     SDL_free(runtime->host_sessions);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -13,6 +13,7 @@
 #include "game_data_standard_options.h"
 #include "network_replication_schema.h"
 #include "sdl3d/input.h"
+#include "sdl3d/level.h"
 #include "sdl3d_crypto.h"
 
 #define PATH_BUFFER_SIZE 256
@@ -72,6 +73,7 @@ typedef struct validation_names
     name_table actor_pool_actors;
     name_table grid_maps;
     name_table grid_pickup_layers;
+    name_table sector_levels;
     name_table signals;
     name_table scripts;
     name_table script_modules;
@@ -1875,10 +1877,10 @@ static bool import_path_is_safe_relative(const char *path)
 static bool import_section_name_allowed(const char *name)
 {
     static const char *const allowed[] = {
-        "storage",          "persistence",  "profiles",     "assets",   "scripts",   "input",
-        "render",           "transitions",  "ui",           "entities", "grid_maps", "grid_pickup_layers",
-        "actor_archetypes", "actor_pools",  "signals",      "logic",    "adapters",  "network",
-        "haptics",          "presentation", "update_phases"};
+        "storage",       "persistence",      "profiles",     "assets",       "scripts",   "input",
+        "render",        "transitions",      "ui",           "entities",     "grid_maps", "grid_pickup_layers",
+        "sector_levels", "actor_archetypes", "actor_pools",  "signals",      "logic",     "adapters",
+        "network",       "haptics",          "presentation", "update_phases"};
     for (size_t i = 0; name != NULL && i < SDL_arraysize(allowed); ++i)
     {
         if (SDL_strcmp(name, allowed[i]) == 0)
@@ -2507,6 +2509,11 @@ static bool is_vec_array(yyjson_val *value, size_t min_count)
     return true;
 }
 
+static bool is_exact_vec_array(yyjson_val *value, size_t count)
+{
+    return yyjson_is_arr(value) && yyjson_arr_size(value) == count && is_vec_array(value, count);
+}
+
 static bool is_wave_axis_value(yyjson_val *value)
 {
     if (value == NULL || yyjson_is_num(value))
@@ -2661,6 +2668,27 @@ static bool collect_grid_pickup_layers(validation_context *ctx, yyjson_val *root
             return validation_error(ctx, path, "grid pickup layer entries must be objects");
         if (!require_unique_name(ctx, &names->grid_pickup_layers, "grid pickup layer", json_string(layer, "name"),
                                  path))
+            return false;
+    }
+    return true;
+}
+
+static bool collect_sector_levels(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *levels = obj_get(root, "sector_levels");
+    if (levels == NULL)
+        return true;
+    if (!yyjson_is_arr(levels))
+        return validation_error(ctx, "$.sector_levels", "sector_levels must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(levels); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.sector_levels[%zu]", i);
+        yyjson_val *level = yyjson_arr_get(levels, i);
+        if (!yyjson_is_obj(level))
+            return validation_error(ctx, path, "sector level entries must be objects");
+        if (!require_unique_name(ctx, &names->sector_levels, "sector level", json_string(level, "name"), path))
             return false;
     }
     return true;
@@ -3181,14 +3209,14 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_grid_maps(ctx, root, names) && collect_grid_pickup_layers(ctx, root, names) &&
-           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
-           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
-           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
-           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
-           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
-           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
-           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
-           collect_sensors(ctx, root, names);
+           collect_sector_levels(ctx, root, names) && collect_actor_archetypes(ctx, root, names) &&
+           collect_actor_pools(ctx, root, names) && collect_scripts(ctx, root, names) &&
+           collect_adapters(ctx, root, names) && collect_input_actions(ctx, root, names) &&
+           collect_input_assignment_sets(ctx, root, names) && collect_input_profiles(ctx, root, names) &&
+           collect_network_input_channels(ctx, root, names) && collect_cameras(ctx, root, names) &&
+           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
+           collect_images(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -3691,6 +3719,235 @@ static bool validate_grid_pickup_layers(validation_context *ctx, yyjson_val *roo
             }
         }
         name_table_destroy(&glyphs);
+        if (!ok)
+            return false;
+    }
+    return true;
+}
+
+static bool sector_level_material_ref_valid(yyjson_val *materials, const name_table *material_names, yyjson_val *ref,
+                                            bool allow_none)
+{
+    if (allow_none && (ref == NULL || yyjson_is_null(ref)))
+        return true;
+    if (yyjson_is_int(ref))
+    {
+        const int index = (int)yyjson_get_int(ref);
+        return index >= (allow_none ? -1 : 0) && index < (int)yyjson_arr_size(materials);
+    }
+    if (yyjson_is_str(ref))
+    {
+        const char *name = yyjson_get_str(ref);
+        if (allow_none && SDL_strcmp(name != NULL ? name : "", "none") == 0)
+            return true;
+        return name_table_contains(material_names, name);
+    }
+    return false;
+}
+
+static bool validate_sector_levels(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *levels = obj_get(root, "sector_levels");
+    if (levels == NULL)
+        return true;
+    if (!yyjson_is_arr(levels))
+        return validation_error(ctx, "$.sector_levels", "sector_levels must be an array");
+
+    for (size_t level_index = 0; level_index < yyjson_arr_size(levels); ++level_index)
+    {
+        char level_path[PATH_BUFFER_SIZE];
+        format_path(level_path, sizeof(level_path), "$.sector_levels[%zu]", level_index);
+        yyjson_val *level = yyjson_arr_get(levels, level_index);
+        yyjson_val *materials = obj_get(level, "materials");
+        yyjson_val *sectors = obj_get(level, "sectors");
+        yyjson_val *lights = obj_get(level, "lights");
+        name_table material_names;
+        name_table sector_names;
+        SDL_zero(material_names);
+        SDL_zero(sector_names);
+        bool ok = true;
+
+        if (!yyjson_is_obj(level))
+        {
+            ok = validation_error(ctx, level_path, "sector level entries must be objects");
+            goto done;
+        }
+        if (!yyjson_is_arr(materials) || yyjson_arr_size(materials) <= 0)
+        {
+            ok = validation_error(ctx, level_path, "sector level materials must be a non-empty array");
+            goto done;
+        }
+        if (!yyjson_is_arr(sectors) || yyjson_arr_size(sectors) <= 0)
+        {
+            ok = validation_error(ctx, level_path, "sector level sectors must be a non-empty array");
+            goto done;
+        }
+
+        for (size_t material_index = 0; ok && material_index < yyjson_arr_size(materials); ++material_index)
+        {
+            char material_path[PATH_BUFFER_SIZE];
+            format_path(material_path, sizeof(material_path), "%s.materials[%zu]", level_path, material_index);
+            yyjson_val *material = yyjson_arr_get(materials, material_index);
+            if (!yyjson_is_obj(material))
+            {
+                ok = validation_error(ctx, material_path, "sector material entries must be objects");
+                break;
+            }
+            if (!require_unique_name(ctx, &material_names, "sector material", json_string(material, "name"),
+                                     material_path))
+            {
+                ok = false;
+                break;
+            }
+            yyjson_val *albedo = obj_get(material, "albedo");
+            if (albedo != NULL && !is_vec_array(albedo, 3))
+            {
+                ok = validation_error(ctx, material_path, "sector material albedo must be a vec3 or vec4");
+                break;
+            }
+            yyjson_val *metallic = obj_get(material, "metallic");
+            yyjson_val *roughness = obj_get(material, "roughness");
+            yyjson_val *tex_scale = obj_get(material, "tex_scale");
+            if ((metallic != NULL && !yyjson_is_num(metallic)) || (roughness != NULL && !yyjson_is_num(roughness)) ||
+                (tex_scale != NULL && !yyjson_is_num(tex_scale)))
+            {
+                ok = validation_error(ctx, material_path, "sector material numeric fields must be numbers");
+                break;
+            }
+            if (tex_scale != NULL && yyjson_get_num(tex_scale) <= 0.0)
+            {
+                ok = validation_error(ctx, material_path, "sector material tex_scale must be positive");
+                break;
+            }
+            const char *texture = json_string(material, "texture");
+            if (texture != NULL && texture[0] == '\0')
+            {
+                ok = validation_error(ctx, material_path, "sector material texture must be non-empty when present");
+                break;
+            }
+            if (texture != NULL && !asset_path_exists(ctx, texture, material_path, "sector material texture"))
+            {
+                ok = false;
+                break;
+            }
+        }
+
+        for (size_t sector_index = 0; ok && sector_index < yyjson_arr_size(sectors); ++sector_index)
+        {
+            char sector_path[PATH_BUFFER_SIZE];
+            format_path(sector_path, sizeof(sector_path), "%s.sectors[%zu]", level_path, sector_index);
+            yyjson_val *sector = yyjson_arr_get(sectors, sector_index);
+            yyjson_val *points = obj_get(sector, "points");
+            if (!yyjson_is_obj(sector))
+            {
+                ok = validation_error(ctx, sector_path, "sector entries must be objects");
+                break;
+            }
+            const char *sector_name = json_string(sector, "name");
+            if (sector_name != NULL && sector_name[0] != '\0' &&
+                !require_unique_name(ctx, &sector_names, "sector", sector_name, sector_path))
+            {
+                ok = false;
+                break;
+            }
+            if (!yyjson_is_arr(points) || yyjson_arr_size(points) < 3 ||
+                yyjson_arr_size(points) > SDL3D_SECTOR_MAX_POINTS)
+            {
+                ok = validation_error(ctx, sector_path, "sector points must contain 3..%d vec2 entries",
+                                      SDL3D_SECTOR_MAX_POINTS);
+                break;
+            }
+            for (size_t point_index = 0; point_index < yyjson_arr_size(points); ++point_index)
+            {
+                if (!is_exact_vec_array(yyjson_arr_get(points, point_index), 2))
+                {
+                    ok = validation_error(ctx, sector_path, "sector points must be vec2 arrays");
+                    break;
+                }
+            }
+            if (!ok)
+                break;
+            yyjson_val *floor_y = obj_get(sector, "floor_y");
+            yyjson_val *ceil_y = obj_get(sector, "ceil_y");
+            if (!yyjson_is_num(floor_y) || !yyjson_is_num(ceil_y))
+            {
+                ok = validation_error(ctx, sector_path, "sector floor_y and ceil_y must be numbers");
+                break;
+            }
+            if (yyjson_get_num(ceil_y) <= yyjson_get_num(floor_y))
+            {
+                ok = validation_error(ctx, sector_path, "sector ceil_y must be greater than floor_y");
+                break;
+            }
+            if (!sector_level_material_ref_valid(materials, &material_names, obj_get(sector, "floor_material"), true) ||
+                !sector_level_material_ref_valid(materials, &material_names, obj_get(sector, "ceil_material"), true) ||
+                !sector_level_material_ref_valid(materials, &material_names, obj_get(sector, "wall_material"), false))
+            {
+                ok = validation_error(ctx, sector_path, "sector material refs must reference a declared material");
+                break;
+            }
+            yyjson_val *floor_normal = obj_get(sector, "floor_normal");
+            yyjson_val *ceil_normal = obj_get(sector, "ceil_normal");
+            yyjson_val *push_velocity = obj_get(sector, "push_velocity");
+            if ((floor_normal != NULL && !is_exact_vec_array(floor_normal, 3)) ||
+                (ceil_normal != NULL && !is_exact_vec_array(ceil_normal, 3)) ||
+                (push_velocity != NULL && !is_exact_vec_array(push_velocity, 3)))
+            {
+                ok = validation_error(ctx, sector_path, "sector normals and push_velocity must be vec3 arrays");
+                break;
+            }
+            yyjson_val *ambient = obj_get(sector, "ambient_sound_id");
+            if (ambient != NULL && (!yyjson_is_int(ambient) || yyjson_get_int(ambient) < 0))
+            {
+                ok = validation_error(ctx, sector_path, "sector ambient_sound_id must be a non-negative integer");
+                break;
+            }
+            yyjson_val *damage = obj_get(sector, "damage_per_second");
+            if (damage != NULL && (!yyjson_is_num(damage) || yyjson_get_num(damage) < 0.0))
+            {
+                ok = validation_error(ctx, sector_path, "sector damage_per_second must be non-negative");
+                break;
+            }
+        }
+
+        if (ok && lights != NULL)
+        {
+            if (!yyjson_is_arr(lights))
+            {
+                ok = validation_error(ctx, level_path, "sector level lights must be an array");
+                goto done;
+            }
+            for (size_t light_index = 0; ok && light_index < yyjson_arr_size(lights); ++light_index)
+            {
+                char light_path[PATH_BUFFER_SIZE];
+                format_path(light_path, sizeof(light_path), "%s.lights[%zu]", level_path, light_index);
+                yyjson_val *light = yyjson_arr_get(lights, light_index);
+                if (!yyjson_is_obj(light) || !is_exact_vec_array(obj_get(light, "position"), 3))
+                {
+                    ok = validation_error(ctx, light_path, "sector light requires position vec3");
+                    break;
+                }
+                yyjson_val *color = obj_get(light, "color");
+                if (color != NULL && !is_exact_vec_array(color, 3))
+                {
+                    ok = validation_error(ctx, light_path, "sector light color must be a vec3");
+                    break;
+                }
+                yyjson_val *intensity = obj_get(light, "intensity");
+                yyjson_val *range = obj_get(light, "range");
+                if ((intensity != NULL && (!yyjson_is_num(intensity) || yyjson_get_num(intensity) < 0.0)) ||
+                    (range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) <= 0.0)))
+                {
+                    ok = validation_error(ctx, light_path,
+                                          "sector light intensity must be non-negative and range positive");
+                    break;
+                }
+            }
+        }
+
+    done:
+        name_table_destroy(&material_names);
+        name_table_destroy(&sector_names);
         if (!ok)
             return false;
     }
@@ -6137,7 +6394,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
            validate_input_bindings(ctx, root) && validate_input_assignment_sets(ctx, root) &&
            validate_input_profiles(ctx, root, names) && validate_grid_maps(ctx, root) &&
-           validate_grid_pickup_layers(ctx, root, names) && validate_components(ctx, root, names) &&
+           validate_grid_pickup_layers(ctx, root, names) && validate_sector_levels(ctx, root) &&
+           validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
@@ -6162,6 +6420,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->actor_pool_actors);
     name_table_destroy(&names->grid_maps);
     name_table_destroy(&names->grid_pickup_layers);
+    name_table_destroy(&names->sector_levels);
     name_table_destroy(&names->signals);
     name_table_destroy(&names->scripts);
     name_table_destroy(&names->script_modules);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7314,6 +7314,176 @@ return rules
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_levels");
+    write_text(dir / "sector_level.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Level Test" },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [
+        { "name": "floor", "albedo": [0.7, 0.7, 0.7, 1.0], "roughness": 0.9, "tex_scale": 2.0 },
+        { "name": "wall", "albedo": [0.2, 0.25, 0.35, 1.0], "metallic": 0.1, "roughness": 0.6 }
+      ],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "floor",
+          "ceil_material": "wall",
+          "wall_material": "wall",
+          "ambient_sound_id": 2,
+          "damage_per_second": 1.5
+        },
+        {
+          "name": "hall",
+          "points": [[4, 1], [7, 1], [7, 3], [4, 3]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "floor",
+          "ceil_material": -1,
+          "wall_material": "wall",
+          "push_velocity": [1.0, 0.0, 0.0]
+        }
+      ],
+      "lights": [
+        { "position": [2.0, 2.5, 2.0], "color": [1.0, 0.8, 0.6], "intensity": 2.0, "range": 6.0 }
+      ]
+    }
+  ]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_level.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_data_sector_level level{};
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
+    EXPECT_STREQ(level.name, "sector.test");
+    ASSERT_EQ(level.material_count, 2);
+    EXPECT_FLOAT_EQ(level.materials[0].tex_scale, 2.0f);
+    EXPECT_FLOAT_EQ(level.materials[1].metallic, 0.1f);
+    ASSERT_EQ(level.sector_count, 2);
+    ASSERT_NE(level.sector_names, nullptr);
+    EXPECT_STREQ(level.sector_names[0], "room");
+    EXPECT_STREQ(level.sector_names[1], "hall");
+    EXPECT_EQ(level.sectors[0].ambient_sound_id, 2);
+    EXPECT_FLOAT_EQ(sdl3d_sector_damage_per_second(&level.sectors[0]), 1.5f);
+    expect_vec3_near(sdl3d_sector_push_velocity(&level.sectors[1]), sdl3d_vec3_make(1.0f, 0.0f, 0.0f));
+    ASSERT_EQ(level.light_count, 1);
+    EXPECT_FLOAT_EQ(level.lights[0].intensity, 2.0f);
+
+    ASSERT_NE(level.lightmapped, nullptr);
+    ASSERT_NE(level.vertex_baked, nullptr);
+    ASSERT_NE(level.unlit, nullptr);
+    EXPECT_EQ(level.lightmapped->sector_count, 2);
+    EXPECT_GT(level.lightmapped->model.mesh_count, 0);
+    EXPECT_GT(level.lightmapped->portal_count, 0);
+    EXPECT_GT(level.lightmapped->lightmap_width, 0);
+    EXPECT_GT(level.lightmapped->lightmap_height, 0);
+    EXPECT_EQ(level.vertex_baked->lightmap_width, 0);
+    EXPECT_EQ(level.vertex_baked->lightmap_height, 0);
+    EXPECT_EQ(sdl3d_level_find_sector(level.lightmapped, level.sectors, 1.0f, 1.0f), 0);
+    EXPECT_EQ(sdl3d_level_find_sector(level.lightmapped, level.sectors, 5.0f, 2.0f), 1);
+
+    sdl3d_game_data_sector_level missing{};
+    EXPECT_FALSE(sdl3d_game_data_get_sector_level(runtime, "sector.missing", &missing));
+    EXPECT_EQ(missing.name, nullptr);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidAuthoredSectorLevels)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_level_invalid");
+    struct Case
+    {
+        const char *name;
+        const char *sector_json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "bad_material",
+            R"json({
+              "name": "sector.bad",
+              "materials": [{ "name": "floor" }],
+              "sectors": [{
+                "points": [[0,0], [2,0], [2,2], [0,2]],
+                "floor_y": 0,
+                "ceil_y": 3,
+                "floor_material": "floor",
+                "ceil_material": "floor",
+                "wall_material": "missing"
+              }]
+            })json",
+            "material refs",
+        },
+        {
+            "bad_points",
+            R"json({
+              "name": "sector.bad",
+              "materials": [{ "name": "floor" }],
+              "sectors": [{
+                "points": [[0,0], [2,0]],
+                "floor_y": 0,
+                "ceil_y": 3,
+                "wall_material": "floor"
+              }]
+            })json",
+            "points",
+        },
+        {
+            "bad_height",
+            R"json({
+              "name": "sector.bad",
+              "materials": [{ "name": "floor" }],
+              "sectors": [{
+                "points": [[0,0], [2,0], [2,2], [0,2]],
+                "floor_y": 4,
+                "ceil_y": 3,
+                "wall_material": "floor"
+              }]
+            })json",
+            "ceil_y",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path path = dir / (std::string(test_case.name) + ".game.json");
+        const std::string json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Sector Level" },
+  "sector_levels": [
+)json") + test_case.sector_json +
+                                 R"json(
+  ]
+})json";
+        write_text(path, json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, PacmanDemoLoadsAndRunsMazeCollection)
 {
     const std::filesystem::path pacman_path = pacman_data_path();


### PR DESCRIPTION
## Summary

- Add a reusable `sector_levels` game-data section for authored sector/portal worlds.
- Validate sector materials, sector geometry, material references, sector metadata, and lights.
- Load sector levels into runtime-owned `sdl3d_level` variants: lightmapped, vertex-baked, and unlit.
- Add the current Doom level sector geometry as a JSON fragment for later runner-driven Doom migration phases.
- Document the new JSON schema and runtime behavior.

## Tests

- `clang-format -i include/sdl3d/game_data.h src/game_data.c src/game_data_validation.c tests/test_game_data.cpp`
- `cmake --build build/release --target sdl3d_game_data_test -j 8`
- `./build/release/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.LoadsAuthoredSectorLevels:GameDataRuntime.RejectsInvalidAuthoredSectorLevels'`
- `./build/release/tests/sdl3d_game_data_test`
- `cmake --build build/release -j 8`
- `python3 -m json.tool demos/doom_level/data/fragments/world/sector_levels.json >/dev/null`

Refs #251