### PR TITLE
Render authored sector levels from scene data

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -1,0 +1,43 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "SDL3D Doom Level",
+    "id": "demo.doom_level",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] }
+  ],
+  "app": {
+    "title": "SDL3D Doom Level",
+    "window": { "width": 1280, "height": 720, "renderer": "opengl", "vsync": true },
+    "audio": { "enabled": false }
+  },
+  "world": {
+    "name": "world.doom_level",
+    "kind": "sector",
+    "ambient_light": [0.18, 0.18, 0.2],
+    "cameras": [
+      {
+        "name": "camera.doom.fixed",
+        "type": "perspective",
+        "position": [5.0, 1.8, -3.0],
+        "target": [5.0, 1.5, 8.0],
+        "up": [0.0, 1.0, 0.0],
+        "fovy": 65.0,
+        "active": true
+      }
+    ]
+  },
+  "render": {
+    "clear_color": [8, 10, 14, 255],
+    "lighting": true,
+    "bloom": true,
+    "ssao": true,
+    "tonemap": "aces"
+  },
+  "scenes": {
+    "initial": "scene.doom_level.play",
+    "files": ["scenes/play.scene.json"]
+  }
+}

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -1,0 +1,31 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.doom_level.play",
+  "camera": "camera.doom.fixed",
+  "updates_game": false,
+  "renders_world": true,
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.doom.e1m1",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.doom_level.phase",
+        "text": "DATA-DRIVEN SECTOR LEVEL",
+        "x": 0.5,
+        "y": 0.06,
+        "scale": 1.0,
+        "centered": true,
+        "normalized": true,
+        "color": [220, 230, 255, 230]
+      }
+    ]
+  }
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -327,7 +327,33 @@ At load time SDL3D builds three runtime variants per sector level:
 - `vertex_baked`: baked vertex lighting without a lightmap atlas
 - `unlit`: raw material color/texture without baked lights
 
-Later renderer and controller phases should consume these runtime descriptors
+Scenes render sector levels by declaring instances under `world.sector_levels`:
+
+```json
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.level_1",
+  "camera": "camera.level_1",
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.e1m1",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  }
+}
+```
+
+`level` references a top-level sector level. `variant` defaults to
+`lightmapped` and may be `lightmapped`, `vertex_baked`, or `unlit`.
+`position` defaults to the origin and translates the level as a whole.
+`portal_culling` defaults to `true`; when enabled, generic presentation
+computes visibility from the active camera before drawing the level.
+
+Renderer, controller, and editor phases should consume runtime descriptors
 instead of parsing JSON directly. `world.kind` remains a high-level statement
 of spatial intent; `sector_levels` is the concrete sector-world data.
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -249,6 +249,52 @@ extern "C"
         const sdl3d_level *unlit;
     } sdl3d_game_data_sector_level;
 
+    /** @brief Runtime mesh variant selected for an authored sector level instance. */
+    typedef enum sdl3d_game_data_sector_level_variant
+    {
+        /** @brief Baked lightmap atlas variant. */
+        SDL3D_GAME_DATA_SECTOR_LEVEL_LIGHTMAPPED = 1,
+        /** @brief Baked per-vertex lighting variant without a lightmap atlas. */
+        SDL3D_GAME_DATA_SECTOR_LEVEL_VERTEX_BAKED = 2,
+        /** @brief Unlit material variant. */
+        SDL3D_GAME_DATA_SECTOR_LEVEL_UNLIT = 3,
+    } sdl3d_game_data_sector_level_variant;
+
+    /**
+     * @brief Active-scene instance of an authored sector level.
+     *
+     * Scene files declare sector level instances under `world.sector_levels`.
+     * The runtime resolves the authored level name to built level data and
+     * supplies the selected render variant. Pointers are runtime-owned.
+     */
+    typedef struct sdl3d_game_data_sector_level_instance
+    {
+        /** @brief Authored sector level name. */
+        const char *level_name;
+        /** @brief Authored variant name, such as `lightmapped`. */
+        const char *variant_name;
+        /** @brief Selected built level variant. */
+        sdl3d_game_data_sector_level_variant variant;
+        /** @brief Built level selected by @p variant. */
+        const sdl3d_level *level;
+        /** @brief Runtime sector definitions parallel to @p level. */
+        const sdl3d_sector *sectors;
+        /** @brief Number of entries in @p sectors. */
+        int sector_count;
+        /** @brief World-space translation applied before drawing. */
+        sdl3d_vec3 position;
+        /** @brief Whether renderers should compute portal visibility for this instance. */
+        bool portal_culling;
+    } sdl3d_game_data_sector_level_instance;
+
+    /**
+     * @brief Callback for active authored sector level instances.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*sdl3d_game_data_sector_level_instance_fn)(void *userdata,
+                                                             const sdl3d_game_data_sector_level_instance *instance);
+
     /**
      * @brief Runtime metrics used when evaluating data-authored UI bindings.
      *
@@ -822,6 +868,18 @@ extern "C"
      */
     bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
                                           sdl3d_game_data_sector_level *out_level);
+
+    /**
+     * @brief Iterate sector levels declared by the active scene.
+     *
+     * The active scene owns placement and variant selection through
+     * `world.sector_levels`. This helper is renderer-agnostic so tests,
+     * editors, and custom hosts can inspect the same resolved instances that
+     * the generic presentation layer draws.
+     */
+    bool sdl3d_game_data_for_each_sector_level_instance(const sdl3d_game_data_runtime *runtime,
+                                                        sdl3d_game_data_sector_level_instance_fn callback,
+                                                        void *userdata);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum sdl3d_game_data_diagnostic_severity

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -287,6 +287,16 @@ extern "C"
                                                           const sdl3d_game_data_render_eval *eval);
 
     /**
+     * @brief Draw active-scene authored sector levels.
+     *
+     * Scene files declare sector level instances under `world.sector_levels`.
+     * Call inside an active 3D pass. When an instance enables portal culling,
+     * this helper computes visibility from @p camera before drawing.
+     */
+    bool sdl3d_game_data_draw_sector_levels(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                            const sdl3d_camera3d *camera);
+
+    /**
      * @brief Draw authored UI text for the active scene.
      *
      * Built-in font assets are loaded on demand through @p font_cache. Text is

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5689,6 +5689,19 @@ const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtim
     return runtime != NULL ? runtime->scene_state : NULL;
 }
 
+static const sector_level_runtime *find_sector_level_runtime(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->sector_level_count; ++i)
+    {
+        const sector_level_runtime *level = &runtime->sector_levels[i];
+        if (level->name != NULL && SDL_strcmp(level->name, name) == 0)
+            return level;
+    }
+    return NULL;
+}
+
 bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
                                       sdl3d_game_data_sector_level *out_level)
 {
@@ -5697,26 +5710,94 @@ bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, co
     if (runtime == NULL || name == NULL || out_level == NULL)
         return false;
 
-    for (int i = 0; i < runtime->sector_level_count; ++i)
-    {
-        const sector_level_runtime *level = &runtime->sector_levels[i];
-        if (level->name == NULL || SDL_strcmp(level->name, name) != 0)
-            continue;
+    const sector_level_runtime *level = find_sector_level_runtime(runtime, name);
+    if (level == NULL)
+        return false;
 
-        out_level->name = level->name;
-        out_level->sectors = level->sectors;
-        out_level->sector_names = level->sector_names;
-        out_level->sector_count = level->sector_count;
-        out_level->materials = level->materials;
-        out_level->material_count = level->material_count;
-        out_level->lights = level->lights;
-        out_level->light_count = level->light_count;
-        out_level->lightmapped = &level->lightmapped;
-        out_level->vertex_baked = &level->vertex_baked;
-        out_level->unlit = &level->unlit;
-        return true;
+    out_level->name = level->name;
+    out_level->sectors = level->sectors;
+    out_level->sector_names = level->sector_names;
+    out_level->sector_count = level->sector_count;
+    out_level->materials = level->materials;
+    out_level->material_count = level->material_count;
+    out_level->lights = level->lights;
+    out_level->light_count = level->light_count;
+    out_level->lightmapped = &level->lightmapped;
+    out_level->vertex_baked = &level->vertex_baked;
+    out_level->unlit = &level->unlit;
+    return true;
+}
+
+static sdl3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
+                                                                             const sdl3d_level **out_level,
+                                                                             const sector_level_runtime *level)
+{
+    if (out_level != NULL)
+        *out_level = NULL;
+    if (level == NULL)
+        return 0;
+
+    const char *name = variant != NULL ? variant : "lightmapped";
+    if (SDL_strcmp(name, "lightmapped") == 0)
+    {
+        if (out_level != NULL)
+            *out_level = &level->lightmapped;
+        return SDL3D_GAME_DATA_SECTOR_LEVEL_LIGHTMAPPED;
     }
-    return false;
+    if (SDL_strcmp(name, "vertex_baked") == 0)
+    {
+        if (out_level != NULL)
+            *out_level = &level->vertex_baked;
+        return SDL3D_GAME_DATA_SECTOR_LEVEL_VERTEX_BAKED;
+    }
+    if (SDL_strcmp(name, "unlit") == 0)
+    {
+        if (out_level != NULL)
+            *out_level = &level->unlit;
+        return SDL3D_GAME_DATA_SECTOR_LEVEL_UNLIT;
+    }
+    return 0;
+}
+
+bool sdl3d_game_data_for_each_sector_level_instance(const sdl3d_game_data_runtime *runtime,
+                                                    sdl3d_game_data_sector_level_instance_fn callback, void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *instances = obj_get(obj_get(scene != NULL ? scene->root : NULL, "world"), "sector_levels");
+    if (instances == NULL)
+        return true;
+    if (!yyjson_is_arr(instances))
+        return false;
+
+    for (size_t i = 0; i < yyjson_arr_size(instances); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(instances, i);
+        const char *level_name = json_string(entry, "level", NULL);
+        const char *variant_name = json_string(entry, "variant", "lightmapped");
+        const sector_level_runtime *level_runtime = find_sector_level_runtime(runtime, level_name);
+        const sdl3d_level *level = NULL;
+        const sdl3d_game_data_sector_level_variant variant =
+            sector_level_variant_from_string(variant_name, &level, level_runtime);
+        if (level_runtime == NULL || level == NULL || variant == 0)
+            return false;
+
+        sdl3d_game_data_sector_level_instance instance;
+        SDL_zero(instance);
+        instance.level_name = level_runtime->name;
+        instance.variant_name = variant_name;
+        instance.variant = variant;
+        instance.level = level;
+        instance.sectors = level_runtime->sectors;
+        instance.sector_count = level_runtime->sector_count;
+        instance.position = json_vec3(entry, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        instance.portal_culling = json_bool(entry, "portal_culling", true);
+        if (!callback(userdata, &instance))
+            return true;
+    }
+    return true;
 }
 
 void sdl3d_game_data_ui_state_init(sdl3d_game_data_ui_state *state)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5986,6 +5986,50 @@ static bool scene_has_menu_name(yyjson_val *scene_root, const char *name)
     return false;
 }
 
+static bool validate_scene_sector_levels(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
+                                         validation_names *names)
+{
+    yyjson_val *world = obj_get(scene_root, "world");
+    if (world == NULL)
+        return true;
+    if (!yyjson_is_obj(world))
+        return validation_error(ctx, json_path, "scene world must be an object");
+
+    yyjson_val *sector_levels = obj_get(world, "sector_levels");
+    if (sector_levels == NULL)
+        return true;
+    char levels_path[PATH_BUFFER_SIZE];
+    format_path(levels_path, sizeof(levels_path), "%s.world.sector_levels", json_path);
+    if (!yyjson_is_arr(sector_levels))
+        return validation_error(ctx, levels_path, "scene world.sector_levels must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(sector_levels); ++i)
+    {
+        char entry_path[PATH_BUFFER_SIZE];
+        format_path(entry_path, sizeof(entry_path), "%s[%zu]", levels_path, i);
+        yyjson_val *entry = yyjson_arr_get(sector_levels, i);
+        if (!yyjson_is_obj(entry))
+            return validation_error(ctx, entry_path, "scene sector level entries must be objects");
+        if (!require_ref(ctx, &names->sector_levels, "sector level", json_string(entry, "level"), entry_path))
+            return false;
+
+        const char *variant = json_string(entry, "variant");
+        if (variant != NULL && SDL_strcmp(variant, "lightmapped") != 0 && SDL_strcmp(variant, "vertex_baked") != 0 &&
+            SDL_strcmp(variant, "unlit") != 0)
+        {
+            return validation_error(ctx, entry_path,
+                                    "scene sector level variant must be lightmapped, vertex_baked, or unlit");
+        }
+        yyjson_val *position = obj_get(entry, "position");
+        if (position != NULL && !is_exact_vec_array(position, 3))
+            return validation_error(ctx, entry_path, "scene sector level position must be a vec3 array");
+        yyjson_val *portal_culling = obj_get(entry, "portal_culling");
+        if (portal_culling != NULL && !yyjson_is_bool(portal_culling))
+            return validation_error(ctx, entry_path, "scene sector level portal_culling must be a boolean");
+    }
+    return true;
+}
+
 static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yyjson_val *game_root,
                                    validation_names *names, const char *json_path)
 {
@@ -6009,6 +6053,9 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         return validation_error(ctx, json_path, "scene camera must be a string");
     const char *camera = json_string(root, "camera");
     if (camera != NULL && !require_ref(ctx, &names->cameras, "camera", camera, json_path))
+        return false;
+
+    if (!validate_scene_sector_levels(ctx, root, json_path, names))
         return false;
 
     char phases_path[PATH_BUFFER_SIZE];

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -25,6 +25,15 @@ typedef struct primitive_draw_context
     bool sphere_batch_active;
 } primitive_draw_context;
 
+typedef struct sector_level_draw_context
+{
+    sdl3d_render_context *renderer;
+    const sdl3d_camera3d *camera;
+    bool *sector_visible;
+    int sector_visible_capacity;
+    bool ok;
+} sector_level_draw_context;
+
 typedef struct ui_draw_context
 {
     const sdl3d_game_data_runtime *runtime;
@@ -960,6 +969,85 @@ static bool draw_render_primitives_evaluated_with_cache(const sdl3d_game_data_ru
     ok = flush_sphere_draw_batch(&context) && ok;
     SDL_free(context.sphere_batch_positions);
     return ok;
+}
+
+static bool draw_sector_level_instance(void *userdata, const sdl3d_game_data_sector_level_instance *instance)
+{
+    sector_level_draw_context *context = (sector_level_draw_context *)userdata;
+    if (context == NULL || context->renderer == NULL || instance == NULL || instance->level == NULL)
+        return false;
+
+    sdl3d_visibility_result vis;
+    SDL_zero(vis);
+    const sdl3d_visibility_result *vis_ptr = NULL;
+    if (instance->portal_culling && context->camera != NULL && instance->sectors != NULL && instance->sector_count > 0)
+    {
+        if (context->sector_visible_capacity < instance->sector_count)
+        {
+            bool *visible =
+                (bool *)SDL_realloc(context->sector_visible, (size_t)instance->sector_count * sizeof(*visible));
+            if (visible == NULL)
+            {
+                context->ok = false;
+                return false;
+            }
+            context->sector_visible = visible;
+            context->sector_visible_capacity = instance->sector_count;
+        }
+        vis.sector_visible = context->sector_visible;
+        sdl3d_camera3d local_camera = *context->camera;
+        local_camera.position.x -= instance->position.x;
+        local_camera.position.y -= instance->position.y;
+        local_camera.position.z -= instance->position.z;
+        local_camera.target.x -= instance->position.x;
+        local_camera.target.y -= instance->position.y;
+        local_camera.target.z -= instance->position.z;
+        sdl3d_level_compute_visibility_from_camera(
+            instance->level, instance->sectors, &local_camera, sdl3d_get_render_context_width(context->renderer),
+            sdl3d_get_render_context_height(context->renderer), 0.01f, 1000.0f, &vis);
+        vis_ptr = &vis;
+    }
+
+    bool pushed = false;
+    if (instance->position.x != 0.0f || instance->position.y != 0.0f || instance->position.z != 0.0f)
+    {
+        if (!sdl3d_push_matrix(context->renderer))
+        {
+            context->ok = false;
+            return false;
+        }
+        pushed = true;
+        if (!sdl3d_translate(context->renderer, instance->position.x, instance->position.y, instance->position.z))
+        {
+            context->ok = false;
+            if (pushed)
+                (void)sdl3d_pop_matrix(context->renderer);
+            return false;
+        }
+    }
+
+    const bool drawn = sdl3d_draw_level(context->renderer, instance->level, vis_ptr, (sdl3d_color){255, 255, 255, 255});
+    if (pushed && !sdl3d_pop_matrix(context->renderer))
+        context->ok = false;
+    if (!drawn)
+        context->ok = false;
+    return context->ok;
+}
+
+bool sdl3d_game_data_draw_sector_levels(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                        const sdl3d_camera3d *camera)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    sector_level_draw_context context;
+    SDL_zero(context);
+    context.renderer = renderer;
+    context.camera = camera;
+    context.ok = true;
+    const bool iterated = sdl3d_game_data_for_each_sector_level_instance(runtime, draw_sector_level_instance, &context);
+    SDL_free(context.sector_visible);
+    return iterated && context.ok;
 }
 
 bool sdl3d_game_data_draw_render_primitives(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer)
@@ -1991,6 +2079,7 @@ bool sdl3d_game_data_draw_frame(const sdl3d_game_data_frame_desc *frame)
         if (sdl3d_begin_mode_3d(frame->renderer, camera))
         {
             ok = run_frame_hook(frame, frame->before_world_3d) && ok;
+            ok = sdl3d_game_data_draw_sector_levels(frame->runtime, frame->renderer, &camera) && ok;
             if (frame->particle_cache != NULL)
                 ok = sdl3d_game_data_draw_particles(frame->runtime, frame->renderer, frame->particle_cache) && ok;
             ok = draw_render_primitives_evaluated_with_cache(frame->runtime, frame->renderer, frame->render_eval,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -109,6 +109,17 @@ struct RenderPrimitiveCapture
     int pickup_batch_instances = 0;
 };
 
+struct SectorLevelInstanceCapture
+{
+    int count = 0;
+    std::string level_name;
+    std::string variant_name;
+    sdl3d_game_data_sector_level_variant variant = static_cast<sdl3d_game_data_sector_level_variant>(0);
+    const sdl3d_level *level = nullptr;
+    sdl3d_vec3 position{};
+    bool portal_culling = true;
+};
+
 void capture_signal_payload(void *userdata, int signal_id, const sdl3d_properties *payload)
 {
     auto *capture = static_cast<NetworkSignalCapture *>(userdata);
@@ -1301,6 +1312,19 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_GT(primitive->instance_count, 0);
         EXPECT_NE(primitive->instances, nullptr);
     }
+    return true;
+}
+
+bool capture_sector_level_instance(void *userdata, const sdl3d_game_data_sector_level_instance *instance)
+{
+    auto *capture = static_cast<SectorLevelInstanceCapture *>(userdata);
+    capture->count++;
+    capture->level_name = instance->level_name != nullptr ? instance->level_name : "";
+    capture->variant_name = instance->variant_name != nullptr ? instance->variant_name : "";
+    capture->variant = instance->variant;
+    capture->level = instance->level;
+    capture->position = instance->position;
+    capture->portal_culling = instance->portal_culling;
     return true;
 }
 
@@ -7402,6 +7426,160 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, ResolvesActiveSceneSectorLevelInstances)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_level_scene");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.fixed",
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.test",
+        "variant": "unlit",
+        "position": [1.0, 2.0, 3.0],
+        "portal_culling": false
+      }
+    ]
+  }
+})json");
+    write_text(dir / "sector_scene.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Scene Test" },
+  "world": {
+    "name": "world.sector_scene",
+    "kind": "sector",
+    "cameras": [
+      {
+        "name": "camera.fixed",
+        "type": "perspective",
+        "position": [2.0, 1.5, -4.0],
+        "target": [2.0, 1.5, 2.0],
+        "up": [0.0, 1.0, 0.0],
+        "fovy": 60.0,
+        "active": true
+      }
+    ]
+  },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [
+        { "name": "floor", "albedo": [0.7, 0.7, 0.7, 1.0] },
+        { "name": "wall", "albedo": [0.2, 0.25, 0.35, 1.0] }
+      ],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "floor",
+          "ceil_material": "wall",
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_scene.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_game_data_sector_level level{};
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
+
+    SectorLevelInstanceCapture capture{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &capture));
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.level_name, "sector.test");
+    EXPECT_EQ(capture.variant_name, "unlit");
+    EXPECT_EQ(capture.variant, SDL3D_GAME_DATA_SECTOR_LEVEL_UNLIT);
+    EXPECT_EQ(capture.level, level.unlit);
+    expect_vec3_near(capture.position, sdl3d_vec3_make(1.0f, 2.0f, 3.0f));
+    EXPECT_FALSE(capture.portal_culling);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidSceneSectorLevelInstances)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_level_scene_invalid");
+    struct Case
+    {
+        const char *name;
+        const char *scene_world_json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "unknown_level",
+            R"json({ "sector_levels": [{ "level": "sector.missing" }] })json",
+            "unknown sector level",
+        },
+        {
+            "bad_variant",
+            R"json({ "sector_levels": [{ "level": "sector.test", "variant": "dynamic" }] })json",
+            "variant",
+        },
+        {
+            "bad_position",
+            R"json({ "sector_levels": [{ "level": "sector.test", "position": [1.0, 2.0] }] })json",
+            "position",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path game_path = dir / (std::string(test_case.name) + ".game.json");
+        write_text(dir / "scenes" / (std::string(test_case.name) + ".scene.json"), (std::string(R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "world": )json") + test_case.scene_world_json + R"json(
+})json")
+                                                                                       .c_str());
+        const std::string game_json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Sector Scene" },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [{
+        "points": [[0, 0], [2, 0], [2, 2], [0, 2]],
+        "floor_y": 0,
+        "ceil_y": 3,
+        "wall_material": "floor"
+      }]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/)json") +
+                                      test_case.name + R"json(.scene.json"] }
+})json";
+        write_text(game_path, game_json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(game_path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
     remove_test_dir(dir);
 }
 


### PR DESCRIPTION
## Summary

- add scene-authored `world.sector_levels` entries that resolve sector level instances by name, render variant, transform, and portal-culling policy
- draw active scene sector levels through the generic presentation frame path using `sdl3d_draw_level` and camera-based portal visibility
- add a minimal data-authored Doom level root + play scene that the generic runner can load
- document sector-level scene usage and validate bad scene references/variants/positions

## Validation

- `clang-format -i include/sdl3d/game_data.h include/sdl3d/game_presentation.h src/game_data.c src/game_data_validation.c src/game_presentation.c tests/test_game_data.cpp`
- `cmake --build build/release --target sdl3d_game_data_test -j 8`
- `./build/release/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.*Sector*'`
- `cmake --build build/release -j 8`
- `./build/release/tests/sdl3d_game_data_test`

Refs #251
