### PR TITLE
Add data-authored FPS sector controller

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -19,16 +19,61 @@
     "ambient_light": [0.18, 0.18, 0.2],
     "cameras": [
       {
-        "name": "camera.doom.fixed",
-        "type": "perspective",
-        "position": [5.0, 1.8, -3.0],
-        "target": [5.0, 1.5, 8.0],
-        "up": [0.0, 1.0, 0.0],
+        "name": "camera.doom.player",
+        "type": "fps",
+        "target_entity": "entity.player",
         "fovy": 65.0,
         "active": true
       }
     ]
   },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.doom_level",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] }
+        ]
+      }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [5.0, 1.6, 4.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 3.14159 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.doom.e1m1",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 12.0,
+          "jump_velocity": 6.0,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 1.1,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ],
   "render": {
     "clear_color": [8, 10, 14, 255],
     "lighting": true,

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -1,9 +1,19 @@
 {
   "schema": "sdl3d.scene.v0",
   "name": "scene.doom_level.play",
-  "camera": "camera.doom.fixed",
-  "updates_game": false,
+  "camera": "camera.doom.player",
+  "updates_game": true,
   "renders_world": true,
+  "entities": ["entity.player"],
+  "input": {
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump"
+    ]
+  },
   "world": {
     "sector_levels": [
       {
@@ -18,7 +28,7 @@
     "text": [
       {
         "name": "ui.doom_level.phase",
-        "text": "DATA-DRIVEN SECTOR LEVEL",
+        "text": "DATA-DRIVEN SECTOR LEVEL - WASD + MOUSE",
         "x": 0.5,
         "y": 0.06,
         "scale": 1.0,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -179,6 +179,10 @@ Camera types:
   `camera_forward`, with `fallback_forward` used when that property is near
   zero. Use `chase_distance: 0` for actor-perspective cameras and larger
   values for behind-the-actor chase cameras.
+- `fps`: reads a first-person sector controller from `target_entity` and
+  renders from that actor's eye position. If the controller has not updated
+  yet, the camera falls back to the actor's `yaw`, `pitch`, and `view_smooth`
+  properties.
 - `adapter`: delegates camera ownership to a native or Lua adapter.
 
 ## Storage And Persistence
@@ -356,6 +360,53 @@ computes visibility from the active camera before drawing the level.
 Renderer, controller, and editor phases should consume runtime descriptors
 instead of parsing JSON directly. `world.kind` remains a high-level statement
 of spatial intent; `sector_levels` is the concrete sector-world data.
+
+Use `controller.fps_sector` on an actor to drive first-person movement through
+a sector level:
+
+```json
+{
+  "name": "entity.player",
+  "active": true,
+  "transform": { "position": [5.0, 1.6, 4.0] },
+  "properties": {
+    "yaw": { "type": "float", "value": 3.14159 },
+    "pitch": { "type": "float", "value": 0.0 },
+    "current_sector": { "type": "int", "value": -1 }
+  },
+  "components": [
+    {
+      "type": "controller.fps_sector",
+      "sector_level": "sector.e1m1",
+      "actions": {
+        "forward": "action.move.forward",
+        "back": "action.move.back",
+        "left": "action.move.left",
+        "right": "action.move.right",
+        "jump": "action.jump"
+      },
+      "move_speed": 12.0,
+      "jump_velocity": 6.0,
+      "gravity": 14.0,
+      "player_height": 1.6,
+      "player_radius": 0.35,
+      "step_height": 1.1,
+      "ceiling_clearance": 0.1,
+      "mouse_sensitivity": 0.002
+    }
+  ]
+}
+```
+
+The actor transform is the player's eye position; feet are
+`position.y - player_height`. The controller applies sector collision, stair
+stepping, wall sliding, gravity, jumping, and mouse-look. It writes the actor's
+position plus diagnostic properties each frame. Property names can be customized
+with `yaw_property`, `pitch_property`, `view_smooth_property`,
+`vertical_velocity_property`, `on_ground_property`, and `sector_property`; the
+defaults are `yaw`, `pitch`, `view_smooth`, `vertical_velocity`, `on_ground`,
+and `current_sector`. Use an `fps` camera targeting the same actor for the
+player view.
 
 ## Scenes
 
@@ -629,6 +680,9 @@ Reusable components include:
   effects instead of scanning active actors in Lua.
 - `motion.grid_agent`: moves an actor along an authored `grid_maps` maze with
   queued turns, walkability checks, center snapping, and optional map wrapping.
+- `controller.fps_sector`: first-person movement through a sector level using
+  authored input actions, sector collision, jumping, gravity, stair stepping,
+  and mouse-look.
 - `motion.scroll_wrap`: scrolls an actor along one axis and wraps to the
   opposite bound. This is intended for parallax panels, repeating stars, clouds,
   conveyor belts, and similar backgrounds.

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -20,6 +20,7 @@
 #include "network_replication_schema.h"
 #include "script_internal.h"
 #include "sdl3d/asset.h"
+#include "sdl3d/fps_mover.h"
 #include "sdl3d/input.h"
 #include "sdl3d/math.h"
 #include "sdl3d/network.h"
@@ -339,6 +340,14 @@ typedef struct sector_level_runtime
     sdl3d_level unlit;
 } sector_level_runtime;
 
+typedef struct fps_controller_runtime
+{
+    const char *entity_name;
+    yyjson_val *component;
+    sdl3d_fps_mover mover;
+    bool initialized;
+} fps_controller_runtime;
+
 typedef enum actor_pool_exhaustion_policy
 {
     ACTOR_POOL_EXHAUST_FAIL,
@@ -494,6 +503,9 @@ typedef struct sdl3d_game_data_runtime
     int grid_pickup_layer_count;
     sector_level_runtime *sector_levels;
     int sector_level_count;
+    fps_controller_runtime *fps_controllers;
+    int fps_controller_count;
+    int fps_controller_capacity;
     actor_pool_runtime *actor_pools;
     int actor_pool_count;
     runtime_direct_connect_session *direct_connect_sessions;
@@ -3439,6 +3451,66 @@ static yyjson_val *find_camera_json(const sdl3d_game_data_runtime *runtime, cons
     return NULL;
 }
 
+static fps_controller_runtime *find_fps_controller(sdl3d_game_data_runtime *runtime, const char *entity_name)
+{
+    if (runtime == NULL || entity_name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->fps_controller_count; ++i)
+    {
+        fps_controller_runtime *controller = &runtime->fps_controllers[i];
+        if (controller->entity_name != NULL && SDL_strcmp(controller->entity_name, entity_name) == 0)
+            return controller;
+    }
+    return NULL;
+}
+
+static const fps_controller_runtime *find_fps_controller_const(const sdl3d_game_data_runtime *runtime,
+                                                               const char *entity_name)
+{
+    if (runtime == NULL || entity_name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->fps_controller_count; ++i)
+    {
+        const fps_controller_runtime *controller = &runtime->fps_controllers[i];
+        if (controller->entity_name != NULL && SDL_strcmp(controller->entity_name, entity_name) == 0)
+            return controller;
+    }
+    return NULL;
+}
+
+static fps_controller_runtime *find_or_add_fps_controller(sdl3d_game_data_runtime *runtime, const char *entity_name,
+                                                          yyjson_val *component)
+{
+    fps_controller_runtime *controller = find_fps_controller(runtime, entity_name);
+    if (controller != NULL)
+    {
+        if (component != NULL && controller->component != component)
+        {
+            controller->component = component;
+            controller->initialized = false;
+        }
+        return controller;
+    }
+    if (runtime == NULL || entity_name == NULL || component == NULL)
+        return NULL;
+    if (runtime->fps_controller_count >= runtime->fps_controller_capacity)
+    {
+        const int next_capacity = runtime->fps_controller_capacity > 0 ? runtime->fps_controller_capacity * 2 : 4;
+        fps_controller_runtime *controllers = (fps_controller_runtime *)SDL_realloc(
+            runtime->fps_controllers, (size_t)next_capacity * sizeof(*controllers));
+        if (controllers == NULL)
+            return NULL;
+        runtime->fps_controllers = controllers;
+        runtime->fps_controller_capacity = next_capacity;
+    }
+
+    controller = &runtime->fps_controllers[runtime->fps_controller_count++];
+    SDL_zero(*controller);
+    controller->entity_name = entity_name;
+    controller->component = component;
+    return controller;
+}
+
 static sdl3d_backend parse_backend(const char *value, sdl3d_backend fallback)
 {
     if (value == NULL)
@@ -4813,6 +4885,34 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
     const char *type = json_string(camera_json, "type", "perspective");
     if (SDL_strcmp(type, "adapter") == 0)
         return false;
+
+    if (SDL_strcmp(type, "fps") == 0)
+    {
+        sdl3d_registered_actor *target =
+            sdl3d_game_data_find_actor(runtime, json_string(camera_json, "target_entity", NULL));
+        if (target == NULL)
+            return false;
+
+        const float fovy = json_float(camera_json, "fovy", 65.0f);
+        const fps_controller_runtime *controller = find_fps_controller_const(runtime, target->name);
+        if (controller != NULL && controller->initialized)
+        {
+            *out_camera = sdl3d_fps_mover_camera(&controller->mover, fovy);
+            return true;
+        }
+
+        sdl3d_fps_mover fallback_mover;
+        SDL_zero(fallback_mover);
+        fallback_mover.position = target->position;
+        fallback_mover.yaw = sdl3d_properties_get_float(target->props, json_string(camera_json, "yaw_property", "yaw"),
+                                                        json_float(camera_json, "yaw", 0.0f));
+        fallback_mover.pitch = sdl3d_properties_get_float(
+            target->props, json_string(camera_json, "pitch_property", "pitch"), json_float(camera_json, "pitch", 0.0f));
+        fallback_mover.view_smooth = sdl3d_properties_get_float(
+            target->props, json_string(camera_json, "view_smooth_property", "view_smooth"), 0.0f);
+        *out_camera = sdl3d_fps_mover_camera(&fallback_mover, fovy);
+        return true;
+    }
 
     if (SDL_strcmp(type, "chase") == 0)
     {
@@ -13948,6 +14048,112 @@ static bool load_scenes(sdl3d_game_data_runtime *runtime, yyjson_val *root, cons
     return true;
 }
 
+static int fps_controller_action_id(const sdl3d_game_data_runtime *runtime, yyjson_val *component, const char *name)
+{
+    yyjson_val *actions = obj_get(component, "actions");
+    const char *action = json_string(actions, name, NULL);
+    return sdl3d_game_data_find_action(runtime, action);
+}
+
+static float fps_controller_action_value(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                         int action_id)
+{
+    if (input == NULL || action_id < 0 || !sdl3d_game_data_active_scene_allows_action(runtime, action_id))
+        return 0.0f;
+    return sdl3d_input_get_value(input, action_id);
+}
+
+static bool fps_controller_action_pressed(const sdl3d_game_data_runtime *runtime, const sdl3d_input_manager *input,
+                                          int action_id)
+{
+    return input != NULL && action_id >= 0 && sdl3d_game_data_active_scene_allows_action(runtime, action_id) &&
+           sdl3d_input_is_pressed(input, action_id);
+}
+
+static void fps_controller_publish_actor_state(const fps_controller_runtime *controller, yyjson_val *component,
+                                               sdl3d_registered_actor *actor)
+{
+    if (controller == NULL || component == NULL || actor == NULL)
+        return;
+    actor_set_position(actor, controller->mover.position);
+    sdl3d_properties_set_float(actor->props, json_string(component, "yaw_property", "yaw"), controller->mover.yaw);
+    sdl3d_properties_set_float(actor->props, json_string(component, "pitch_property", "pitch"),
+                               controller->mover.pitch);
+    sdl3d_properties_set_float(actor->props, json_string(component, "view_smooth_property", "view_smooth"),
+                               controller->mover.view_smooth);
+    sdl3d_properties_set_float(actor->props, json_string(component, "vertical_velocity_property", "vertical_velocity"),
+                               controller->mover.vertical_velocity);
+    sdl3d_properties_set_bool(actor->props, json_string(component, "on_ground_property", "on_ground"),
+                              controller->mover.on_ground);
+    sdl3d_properties_set_int(actor->props, json_string(component, "sector_property", "current_sector"),
+                             controller->mover.current_sector);
+}
+
+static void update_fps_sector_controller(sdl3d_game_data_runtime *runtime, yyjson_val *component,
+                                         sdl3d_registered_actor *actor, const sdl3d_input_manager *input, float dt)
+{
+    if (runtime == NULL || component == NULL || actor == NULL)
+        return;
+
+    const sector_level_runtime *sector_level =
+        find_sector_level_runtime(runtime, json_string(component, "sector_level", NULL));
+    if (sector_level == NULL)
+        return;
+
+    fps_controller_runtime *controller = find_or_add_fps_controller(runtime, actor->name, component);
+    if (controller == NULL)
+        return;
+
+    if (!controller->initialized)
+    {
+        sdl3d_fps_mover_config config;
+        SDL_zero(config);
+        config.move_speed = json_float(component, "move_speed", 12.0f);
+        config.jump_velocity = json_float(component, "jump_velocity", 6.0f);
+        config.gravity = json_float(component, "gravity", 14.0f);
+        config.player_height = json_float(component, "player_height", 1.6f);
+        config.player_radius = json_float(component, "player_radius", 0.35f);
+        config.step_height = json_float(component, "step_height", 1.1f);
+        config.ceiling_clearance = json_float(component, "ceiling_clearance", 0.1f);
+        const float yaw = sdl3d_properties_get_float(actor->props, json_string(component, "yaw_property", "yaw"),
+                                                     json_float(component, "spawn_yaw", 0.0f));
+        sdl3d_fps_mover_init(&controller->mover, &config, actor->position, yaw);
+        controller->mover.pitch =
+            sdl3d_properties_get_float(actor->props, json_string(component, "pitch_property", "pitch"),
+                                       json_float(component, "spawn_pitch", 0.0f));
+        controller->initialized = true;
+    }
+
+    const int forward_action = fps_controller_action_id(runtime, component, "forward");
+    const int back_action = fps_controller_action_id(runtime, component, "back");
+    const int left_action = fps_controller_action_id(runtime, component, "left");
+    const int right_action = fps_controller_action_id(runtime, component, "right");
+    const int jump_action = fps_controller_action_id(runtime, component, "jump");
+
+    if (fps_controller_action_pressed(runtime, input, jump_action))
+        sdl3d_fps_mover_jump(&controller->mover);
+
+    const float forward = fps_controller_action_value(runtime, input, forward_action) -
+                          fps_controller_action_value(runtime, input, back_action);
+    const float side = fps_controller_action_value(runtime, input, right_action) -
+                       fps_controller_action_value(runtime, input, left_action);
+    const float fwd_x = SDL_sinf(controller->mover.yaw);
+    const float fwd_z = -SDL_cosf(controller->mover.yaw);
+    const float right_x = SDL_cosf(controller->mover.yaw);
+    const float right_z = SDL_sinf(controller->mover.yaw);
+    const sdl3d_vec2 wish = {
+        fwd_x * forward + right_x * side,
+        fwd_z * forward + right_z * side,
+    };
+
+    const bool mouse_look = json_bool(component, "mouse_look", true);
+    const float mouse_dx = mouse_look && input != NULL ? sdl3d_input_get_mouse_dx(input) : 0.0f;
+    const float mouse_dy = mouse_look && input != NULL ? sdl3d_input_get_mouse_dy(input) : 0.0f;
+    sdl3d_fps_mover_update(&controller->mover, &sector_level->lightmapped, sector_level->sectors, wish, mouse_dx,
+                           mouse_dy, json_float(component, "mouse_sensitivity", 0.002f), dt);
+    fps_controller_publish_actor_state(controller, component, actor);
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -14008,6 +14214,10 @@ static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_v
                     invoke_adapter(runtime, adapter, actor, payload);
                     sdl3d_properties_destroy(payload);
                 }
+            }
+            else if (SDL_strcmp(type, "controller.fps_sector") == 0)
+            {
+                update_fps_sector_controller(runtime, component, actor, input, dt);
             }
         }
     }
@@ -17353,6 +17563,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_actor_indices);
     SDL_free(runtime->grid_pickup_layers);
     SDL_free(runtime->sector_levels);
+    SDL_free(runtime->fps_controllers);
     SDL_free(runtime->actor_pools);
     SDL_free(runtime->direct_connect_sessions);
     SDL_free(runtime->host_sessions);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -4198,8 +4198,8 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             }
             if (SDL_strcmp(type, "controller.fps_sector") == 0)
             {
-                if (!validate_fps_sector_component(ctx, component, component_path, names))
-                    return false;
+                return validation_error(ctx, component_path,
+                                        "controller.fps_sector is only supported on static entities");
             }
             else if (SDL_strcmp(type, "motion.grid_agent") == 0)
             {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2526,10 +2526,10 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb", "collision.circle",   "control.axis_1d",    "lifecycle.ttl",
-        "light.directional",  "light.point",    "light.spot",         "motion.grid_agent",  "motion.oscillate",
-        "motion.scroll_wrap", "motion.spin",    "motion.velocity_2d", "motion.velocity_3d", "particles.emitter",
-        "property.decay",     "render.cube",    "render.sphere",
+        "adapter.controller", "collision.aabb",     "collision.circle", "control.axis_1d",    "controller.fps_sector",
+        "lifecycle.ttl",      "light.directional",  "light.point",      "light.spot",         "motion.grid_agent",
+        "motion.oscillate",   "motion.scroll_wrap", "motion.spin",      "motion.velocity_2d", "motion.velocity_3d",
+        "particles.emitter",  "property.decay",     "render.cube",      "render.sphere",
     };
 
     if (type == NULL)
@@ -2540,6 +2540,57 @@ static bool is_supported_component_type(const char *type)
             return true;
     }
     return false;
+}
+
+static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                          validation_names *names)
+{
+    const char *level = json_string(component, "sector_level");
+    if (!require_ref(ctx, &names->sector_levels, "sector level", level, path))
+        return false;
+
+    yyjson_val *actions = obj_get(component, "actions");
+    if (!yyjson_is_obj(actions))
+        return validation_error(ctx, path, "controller.fps_sector requires an actions object");
+    const char *action_keys[] = {"forward", "back", "left", "right"};
+    for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
+    {
+        const char *action = json_string(actions, action_keys[i]);
+        if (!require_ref(ctx, &names->actions, "input action", action, path))
+            return false;
+    }
+    const char *jump = json_string(actions, "jump");
+    if (jump != NULL && !require_ref(ctx, &names->actions, "input action", jump, path))
+        return false;
+
+    const char *property_keys[] = {"yaw_property",         "pitch_property",
+                                   "view_smooth_property", "vertical_velocity_property",
+                                   "on_ground_property",   "sector_property"};
+    for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, property_keys[i]);
+        if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+            return validation_error(ctx, path, "controller.fps_sector property names must be non-empty strings");
+    }
+
+    const char *non_negative[] = {"move_speed",    "jump_velocity", "gravity",           "player_height",
+                                  "player_radius", "step_height",   "ceiling_clearance", "mouse_sensitivity"};
+    for (size_t i = 0; i < SDL_arraysize(non_negative); ++i)
+    {
+        yyjson_val *value = obj_get(component, non_negative[i]);
+        if (value != NULL && (!yyjson_is_num(value) || yyjson_get_num(value) < 0.0))
+            return validation_error(ctx, path, "controller.fps_sector numeric tuning values must be non-negative");
+    }
+    yyjson_val *mouse_look = obj_get(component, "mouse_look");
+    if (mouse_look != NULL && !yyjson_is_bool(mouse_look))
+        return validation_error(ctx, path, "controller.fps_sector mouse_look must be a boolean");
+    yyjson_val *spawn_yaw = obj_get(component, "spawn_yaw");
+    yyjson_val *spawn_pitch = obj_get(component, "spawn_pitch");
+    if ((spawn_yaw != NULL && !yyjson_is_num(spawn_yaw)) || (spawn_pitch != NULL && !yyjson_is_num(spawn_pitch)))
+    {
+        return validation_error(ctx, path, "controller.fps_sector spawn yaw and pitch values must be numbers");
+    }
+    return true;
 }
 
 static bool validate_script_cycle(validation_context *ctx, validation_names *names, script_manifest *script);
@@ -4002,6 +4053,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                     !require_ref(ctx, &names->entities, "entity", json_string(component, "target"), path))
                     return false;
             }
+            else if (SDL_strcmp(type, "controller.fps_sector") == 0)
+            {
+                if (!validate_fps_sector_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "property.decay") == 0)
             {
                 if (!is_non_empty_string(component, "property"))
@@ -4140,7 +4196,12 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             {
                 return false;
             }
-            if (SDL_strcmp(type, "motion.grid_agent") == 0)
+            if (SDL_strcmp(type, "controller.fps_sector") == 0)
+            {
+                if (!validate_fps_sector_component(ctx, component, component_path, names))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "motion.grid_agent") == 0)
             {
                 if (!require_ref(ctx, &names->grid_maps, "grid map", json_string(component, "map"), component_path))
                     return false;
@@ -5339,6 +5400,11 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
                 return false;
         }
         else if (SDL_strcmp(type != NULL ? type : "", "chase") == 0)
+        {
+            if (!require_ref(ctx, &names->entities, "entity", json_string(camera, "target_entity"), path))
+                return false;
+        }
+        else if (SDL_strcmp(type != NULL ? type : "", "fps") == 0)
         {
             if (!require_ref(ctx, &names->entities, "entity", json_string(camera, "target_entity"), path))
                 return false;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7517,6 +7517,265 @@ TEST(GameDataRuntime, ResolvesActiveSceneSectorLevelInstances)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
+{
+    const std::filesystem::path dir = unique_test_dir("fps_sector_controller");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.player",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "input": {
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      { "level": "sector.test", "variant": "unlit" }
+    ]
+  }
+})json");
+    write_text(dir / "fps_sector.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "FPS Sector Controller Test" },
+  "world": {
+    "name": "world.test",
+    "kind": "sector",
+    "cameras": [
+      {
+        "name": "camera.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fovy": 70.0,
+        "active": true
+      }
+    ]
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.play",
+        "actions": [
+          { "name": "action.move.forward" },
+          { "name": "action.move.back" },
+          { "name": "action.move.left" },
+          { "name": "action.move.right" },
+          { "name": "action.jump" }
+        ]
+      }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [2.0, 1.6, 2.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.test",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 4.0,
+          "jump_velocity": 4.0,
+          "gravity": 9.0,
+          "player_height": 1.6,
+          "player_radius": 0.25,
+          "step_height": 0.6,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.0
+        }
+      ]
+    }
+  ],
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [
+        { "name": "floor", "albedo": [0.6, 0.6, 0.6, 1.0] },
+        { "name": "wall", "albedo": [0.2, 0.2, 0.25, 1.0] }
+      ],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor",
+          "ceil_material": "wall",
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "fps_sector.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    const float initial_z = player->position.z;
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int forward = sdl3d_game_data_find_action(runtime, "action.move.forward");
+    ASSERT_GE(forward, 0);
+    sdl3d_input_set_action_override(input, forward, 1.0f);
+    ASSERT_NE(sdl3d_input_update(input, 1000), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+
+    EXPECT_LT(player->position.z, initial_z);
+    EXPECT_NEAR(player->position.y, 1.6f, 0.001f);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "current_sector", -1), 0);
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "on_ground", false));
+
+    sdl3d_camera3d camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.player", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_NEAR(camera.position.x, player->position.x, 0.001f);
+    EXPECT_NEAR(camera.position.y, player->position.y, 0.001f);
+    EXPECT_NEAR(camera.position.z, player->position.z, 0.001f);
+    EXPECT_LT(camera.target.z, camera.position.z);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidFpsSectorController)
+{
+    const std::filesystem::path dir = unique_test_dir("fps_sector_controller_invalid");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.player"]
+})json");
+
+    struct Case
+    {
+        const char *name;
+        const char *component_json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "unknown_level",
+            R"json({
+              "type": "controller.fps_sector",
+              "sector_level": "sector.missing",
+              "actions": {
+                "forward": "action.move.forward",
+                "back": "action.move.back",
+                "left": "action.move.left",
+                "right": "action.move.right"
+              }
+            })json",
+            "unknown sector level",
+        },
+        {
+            "missing_actions",
+            R"json({
+              "type": "controller.fps_sector",
+              "sector_level": "sector.test"
+            })json",
+            "requires an actions object",
+        },
+        {
+            "unknown_action",
+            R"json({
+              "type": "controller.fps_sector",
+              "sector_level": "sector.test",
+              "actions": {
+                "forward": "action.missing",
+                "back": "action.move.back",
+                "left": "action.move.left",
+                "right": "action.move.right"
+              }
+            })json",
+            "unknown input action",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path game_path = dir / (std::string(test_case.name) + ".game.json");
+        const std::string game_json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid FPS Sector Controller" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.play",
+        "actions": [
+          { "name": "action.move.forward" },
+          { "name": "action.move.back" },
+          { "name": "action.move.left" },
+          { "name": "action.move.right" }
+        ]
+      }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "components": [
+)json") + test_case.component_json +
+                                      R"json(
+      ]
+    }
+  ],
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [{
+        "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+        "floor_y": 0,
+        "ceil_y": 3,
+        "wall_material": "floor"
+      }]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+        write_text(game_path, game_json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(game_path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidSceneSectorLevelInstances)
 {
     const std::filesystem::path dir = unique_test_dir("sector_level_scene_invalid");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7776,6 +7776,65 @@ TEST(GameDataRuntime, RejectsInvalidFpsSectorController)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RejectsFpsSectorControllerOnArchetypes)
+{
+    const std::filesystem::path dir = unique_test_dir("fps_sector_controller_archetype_invalid");
+    write_text(dir / "fps_sector_archetype.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid FPS Sector Archetype Controller" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.play",
+        "actions": [
+          { "name": "action.move.forward" },
+          { "name": "action.move.back" },
+          { "name": "action.move.left" },
+          { "name": "action.move.right" }
+        ]
+      }
+    ]
+  },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [{
+        "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+        "floor_y": 0,
+        "ceil_y": 3,
+        "wall_material": "floor"
+      }]
+    }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.player",
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.test",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right"
+          }
+        }
+      ]
+    }
+  ]
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "fps_sector_archetype.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("only supported on static entities"), std::string::npos) << error;
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidSceneSectorLevelInstances)
 {
     const std::filesystem::path dir = unique_test_dir("sector_level_scene_invalid");


### PR DESCRIPTION
## Summary
- add a reusable JSON-authored controller.fps_sector component backed by the existing sector FPS mover
- add an fps camera type that follows the authored controller state
- migrate doom_level data to use an authored player entity, input actions, and fps camera
- document the FPS sector controller and add runtime/validation coverage

## Tests
- cmake --build build/release --target sdl3d_game_data_test -j 8
- ./build/release/tests/sdl3d_game_data_test
- cmake --build build/release -j 8
- ctest --test-dir build/release --output-on-failure

Refs #251