### PR TITLE
Add data-authored sector hazard sensors

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -7,7 +7,8 @@
   },
   "imports": [
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
-    { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] }
+    { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
+    { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] }
   ],
   "app": {
     "title": "SDL3D Doom Level",
@@ -51,7 +52,9 @@
       "properties": {
         "yaw": { "type": "float", "value": 3.14159 },
         "pitch": { "type": "float", "value": 0.0 },
-        "current_sector": { "type": "int", "value": -1 }
+        "current_sector": { "type": "int", "value": -1 },
+        "damage_taken": { "type": "float", "value": 0.0 },
+        "last_damage_per_second": { "type": "float", "value": 0.0 }
       },
       "components": [
         {
@@ -72,6 +75,35 @@
           "step_height": 1.1,
           "ceiling_clearance": 0.1,
           "mouse_sensitivity": 0.002
+        }
+      ]
+    },
+    {
+      "name": "entity.effect.nukage.vapor",
+      "active": true,
+      "transform": { "position": [4.0, -0.35, 21.0] },
+      "components": [
+        {
+          "type": "particles.emitter",
+          "shape": "box",
+          "extents": [5.3, 0.05, 4.2],
+          "direction": [0.04, 1.0, -0.03],
+          "spread": 1.15,
+          "speed_min": 0.35,
+          "speed_max": 1.05,
+          "lifetime_min": 2.4,
+          "lifetime_max": 4.6,
+          "size_start": 0.045,
+          "size_end": 0.16,
+          "color_start": [35, 245, 45, 155],
+          "color_end": [0, 185, 55, 0],
+          "gravity": -0.16,
+          "max_particles": 360,
+          "emit_rate": 95.0,
+          "camera_facing": true,
+          "depth_test": true,
+          "additive_blend": true,
+          "draw_emissive": [0.25, 0.95, 0.25]
         }
       ]
     }

--- a/demos/doom_level/data/fragments/world/sector_hazards.json
+++ b/demos/doom_level/data/fragments/world/sector_hazards.json
@@ -1,0 +1,45 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.nukage.damage",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.doom.e1m1",
+        "sector": "nukage_basin",
+        "edge": "stay",
+        "actions": [
+          {
+            "type": "property.add",
+            "target_from_payload": "actor_name",
+            "key": "damage_taken",
+            "value_from_payload": "sector_damage_delta"
+          },
+          {
+            "type": "property.set",
+            "target_from_payload": "actor_name",
+            "key": "last_damage_per_second",
+            "value_from_payload": "sector_damage_per_second"
+          }
+        ]
+      },
+      {
+        "name": "sensor.nukage.exit",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.doom.e1m1",
+        "sector": "nukage_basin",
+        "edge": "exit",
+        "actions": [
+          {
+            "type": "property.set",
+            "target_from_payload": "actor_name",
+            "key": "last_damage_per_second",
+            "value": 0.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -4,7 +4,7 @@
   "camera": "camera.doom.player",
   "updates_game": true,
   "renders_world": true,
-  "entities": ["entity.player"],
+  "entities": ["entity.player", "entity.effect.nukage.vapor"],
   "input": {
     "actions": [
       "action.move.forward",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -835,7 +835,8 @@ game-specific calculations or policy that is not a reusable engine primitive.
 
 Use `target_from_payload` when a sensor or previous action supplies the actor
 name. Use `value_from_payload` when the amount should come from sensor payload
-data:
+data. When `property.add` combines an integer with a float, the result is stored
+as a float so fractional damage, timers, and meters can accumulate correctly:
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -827,6 +827,25 @@ Logic connects sensors, timers, signals, conditions, and actions:
 Use JSON actions for ordinary composition. Use Lua adapters only for
 game-specific calculations or policy that is not a reusable engine primitive.
 
+`property.set` and `property.add` normally target a fixed actor:
+
+```json
+{ "type": "property.add", "target": "entity.player", "key": "health", "value": -1 }
+```
+
+Use `target_from_payload` when a sensor or previous action supplies the actor
+name. Use `value_from_payload` when the amount should come from sensor payload
+data:
+
+```json
+{
+  "type": "property.add",
+  "target_from_payload": "actor_name",
+  "key": "damage_taken",
+  "value_from_payload": "sector_damage_delta"
+}
+```
+
 `collision.on_overlap` is a data-action variant of the 2D contact sensor. It
 matches actors by fixed actor names or tags, publishes `actor_name` and
 `other_actor_name` in the action payload, and runs actions when overlap occurs.
@@ -849,6 +868,37 @@ matches actors by fixed actor names or tags, publishes `actor_name` and
 
 `edge` may be `enter` for first contact only or `stay` / `overlap` for every
 update while actors overlap.
+
+`sensor.sector` detects when an actor is inside an authored sector from a
+`sector_levels` entry. It can fire on `enter`, `stay` / `overlap`, or `exit`;
+authors can use separate sensors for different edges. The payload includes
+`actor_name`, `sector_level`, `sector_name`, `sector_index`,
+`sector_damage_per_second`, `sector_damage_delta`, and `ambient_sound_id`.
+`sector_damage_delta` is `damage_per_second * dt`, so damage-over-time sectors
+can be authored without Lua:
+
+```json
+{
+  "name": "sensor.nukage.damage",
+  "type": "sensor.sector",
+  "actor": "entity.player",
+  "sector_level": "sector.doom.e1m1",
+  "sector": "nukage_basin",
+  "edge": "stay",
+  "actions": [
+    {
+      "type": "property.add",
+      "target_from_payload": "actor_name",
+      "key": "damage_taken",
+      "value_from_payload": "sector_damage_delta"
+    }
+  ]
+}
+```
+
+Use `actor_tag` instead of `actor` to apply a sector sensor to every active
+actor with a matching tag. `sector_index` may be used instead of `sector` when
+the authored sector order is deliberate and stable.
 
 `logic.wave_schedules` spawn actors from pools over time:
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -23,6 +23,7 @@
 #include "sdl3d/door.h"
 #include "sdl3d/fps_mover.h"
 #include "sdl3d/input.h"
+#include "sdl3d/level.h"
 #include "sdl3d/math.h"
 #include "sdl3d/network.h"
 #include "sdl3d/script.h"
@@ -49,6 +50,7 @@ typedef enum game_data_sensor_type
     GAME_DATA_SENSOR_BOUNDS_REFLECT,
     GAME_DATA_SENSOR_CONTACT_2D,
     GAME_DATA_SENSOR_INPUT_PRESSED,
+    GAME_DATA_SENSOR_SECTOR,
 } game_data_sensor_type;
 
 typedef struct named_signal
@@ -117,6 +119,10 @@ typedef struct sensor_entry
     const char *other;
     const char *entity_tag;
     const char *other_tag;
+    const char *sector_level;
+    const char *sector;
+    const char *sector_property;
+    int sector_index;
     const char *action;
     const char *axis;
     const char *side;
@@ -5957,6 +5963,18 @@ static const sector_level_runtime *find_sector_level_runtime(const sdl3d_game_da
     return NULL;
 }
 
+static int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name)
+{
+    if (level == NULL || sector_name == NULL)
+        return -1;
+    for (int i = 0; i < level->sector_count; ++i)
+    {
+        if (level->sector_names[i] != NULL && SDL_strcmp(level->sector_names[i], sector_name) == 0)
+            return i;
+    }
+    return -1;
+}
+
 bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
                                       sdl3d_game_data_sector_level *out_level)
 {
@@ -6633,6 +6651,8 @@ static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime
 }
 
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload);
+static sdl3d_registered_actor *actor_from_payload_key(sdl3d_game_data_runtime *runtime, const sdl3d_properties *payload,
+                                                      const char *key);
 
 void sdl3d_game_data_timeline_state_init(sdl3d_game_data_timeline_state *state)
 {
@@ -12022,6 +12042,15 @@ static const char *persistence_property_key(yyjson_val *property)
     return json_string(property, "key", NULL);
 }
 
+static sdl3d_registered_actor *action_target_actor(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   const sdl3d_properties *payload)
+{
+    const char *target_from_payload = json_string(action, "target_from_payload", NULL);
+    if (target_from_payload != NULL)
+        return actor_from_payload_key(runtime, payload, target_from_payload);
+    return sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+}
+
 static bool json_add_property_value(yyjson_mut_doc *doc, yyjson_mut_val *object, const char *key,
                                     const sdl3d_value *value)
 {
@@ -13372,21 +13401,44 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "property.set") == 0 || SDL_strcmp(type, "property.add") == 0)
     {
-        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+        sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
         const char *key = json_string(action, "key", NULL);
         yyjson_val *value = obj_get(action, "value");
-        if (actor == NULL || key == NULL || value == NULL)
+        const char *value_from_payload = json_string(action, "value_from_payload", NULL);
+        const sdl3d_value *payload_value = value_from_payload != NULL && payload != NULL
+                                               ? sdl3d_properties_get_value(payload, value_from_payload)
+                                               : NULL;
+        if (actor == NULL || key == NULL || (value == NULL && payload_value == NULL))
             return false;
 
         if (SDL_strcmp(type, "property.add") == 0)
         {
             const sdl3d_value *existing = sdl3d_properties_get_value(actor->props, key);
-            if (existing != NULL && existing->type == SDL3D_VALUE_INT && yyjson_is_num(value))
+            if (existing != NULL && existing->type == SDL3D_VALUE_INT && payload_value != NULL &&
+                payload_value->type == SDL3D_VALUE_INT)
+            {
+                sdl3d_properties_set_int(actor->props, key, existing->as_int + payload_value->as_int);
+            }
+            else if (existing != NULL && existing->type == SDL3D_VALUE_FLOAT && payload_value != NULL &&
+                     payload_value->type == SDL3D_VALUE_FLOAT)
+            {
+                sdl3d_properties_set_float(actor->props, key, existing->as_float + payload_value->as_float);
+            }
+            else if (existing != NULL && existing->type == SDL3D_VALUE_FLOAT && payload_value != NULL &&
+                     payload_value->type == SDL3D_VALUE_INT)
+            {
+                sdl3d_properties_set_float(actor->props, key, existing->as_float + (float)payload_value->as_int);
+            }
+            else if (existing != NULL && existing->type == SDL3D_VALUE_INT && yyjson_is_num(value))
                 sdl3d_properties_set_int(actor->props, key, existing->as_int + (int)yyjson_get_int(value));
             else if (existing != NULL && existing->type == SDL3D_VALUE_FLOAT && yyjson_is_num(value))
                 sdl3d_properties_set_float(actor->props, key, existing->as_float + (float)yyjson_get_real(value));
             else
                 return false;
+        }
+        else if (payload_value != NULL)
+        {
+            copy_property_value(actor->props, key, payload_value);
         }
         else
         {
@@ -13958,11 +14010,21 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
             entry->type = GAME_DATA_SENSOR_CONTACT_2D;
         else if (SDL_strcmp(type, "sensor.input_pressed") == 0)
             entry->type = GAME_DATA_SENSOR_INPUT_PRESSED;
+        else if (SDL_strcmp(type, "sensor.sector") == 0)
+            entry->type = GAME_DATA_SENSOR_SECTOR;
 
         entry->entity = json_string(sensor, "entity", json_string(sensor, "a", NULL));
+        if (entry->entity == NULL)
+            entry->entity = json_string(sensor, "actor", NULL);
         entry->other = json_string(sensor, "b", NULL);
         entry->entity_tag = json_string(sensor, "a_tag", NULL);
+        if (entry->entity_tag == NULL)
+            entry->entity_tag = json_string(sensor, "actor_tag", NULL);
         entry->other_tag = json_string(sensor, "b_tag", NULL);
+        entry->sector_level = json_string(sensor, "sector_level", NULL);
+        entry->sector = json_string(sensor, "sector", NULL);
+        entry->sector_property = json_string(sensor, "sector_property", "current_sector");
+        entry->sector_index = json_int(sensor, "sector_index", -1);
         entry->action = json_string(sensor, "action", NULL);
         entry->axis = json_string(sensor, "axis", NULL);
         entry->side = json_string(sensor, "side", NULL);
@@ -13971,9 +14033,13 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
         entry->threshold = json_float(sensor, "threshold", 0.0f);
         entry->actions = obj_get(sensor, "actions");
         entry->edge = json_string(sensor, "edge", "enter");
-        entry->signal_id = sdl3d_game_data_find_signal(
-            runtime, json_string(sensor, "on_enter",
-                                 json_string(sensor, "on_pressed", json_string(sensor, "on_reflect", NULL))));
+        const char *signal_name =
+            json_string(sensor, "on_enter", json_string(sensor, "on_pressed", json_string(sensor, "on_reflect", NULL)));
+        if (SDL_strcmp(entry->edge, "stay") == 0 || SDL_strcmp(entry->edge, "overlap") == 0)
+            signal_name = json_string(sensor, "on_stay", signal_name);
+        else if (SDL_strcmp(entry->edge, "exit") == 0)
+            signal_name = json_string(sensor, "on_exit", signal_name);
+        entry->signal_id = sdl3d_game_data_find_signal(runtime, signal_name);
     }
     return true;
 }
@@ -15155,6 +15221,147 @@ static void update_contact_sensor(sdl3d_game_data_runtime *runtime, sensor_entry
     sensor_actor_list_free(&others);
 }
 
+static bool sensor_edge_is_stay(const sensor_entry *sensor)
+{
+    return sensor != NULL && sensor->edge != NULL &&
+           (SDL_strcmp(sensor->edge, "stay") == 0 || SDL_strcmp(sensor->edge, "overlap") == 0);
+}
+
+static bool sensor_edge_is_exit(const sensor_entry *sensor)
+{
+    return sensor != NULL && sensor->edge != NULL && SDL_strcmp(sensor->edge, "exit") == 0;
+}
+
+static int sensor_target_sector_index(const sector_level_runtime *level, const sensor_entry *sensor)
+{
+    if (level == NULL || sensor == NULL)
+        return -1;
+    if (sensor->sector_index >= 0)
+        return sensor->sector_index < level->sector_count ? sensor->sector_index : -1;
+    return sector_level_find_sector_name(level, sensor->sector);
+}
+
+static int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
+                                         const sdl3d_registered_actor *actor)
+{
+    if (level == NULL || actor == NULL)
+        return -1;
+
+    const char *sector_property =
+        sensor != NULL && sensor->sector_property != NULL ? sensor->sector_property : "current_sector";
+    const sdl3d_value *current_sector = sdl3d_properties_get_value(actor->props, sector_property);
+    if (current_sector != NULL && current_sector->type == SDL3D_VALUE_INT && current_sector->as_int >= 0 &&
+        current_sector->as_int < level->sector_count)
+    {
+        return current_sector->as_int;
+    }
+
+    return sdl3d_level_find_sector_at(&level->lightmapped, level->sectors, actor->position.x, actor->position.z,
+                                      actor->position.y);
+}
+
+static sdl3d_properties *create_sector_sensor_payload(const sdl3d_game_data_runtime *runtime,
+                                                      const sensor_entry *sensor, const sector_level_runtime *level,
+                                                      const sdl3d_registered_actor *actor, int sector_index)
+{
+    (void)sensor;
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    sdl3d_properties_set_string(payload, "actor_name", actor != NULL && actor->name != NULL ? actor->name : "");
+    sdl3d_properties_set_string(payload, "sector_level", level != NULL && level->name != NULL ? level->name : "");
+    sdl3d_properties_set_int(payload, "sector_index", sector_index);
+    sdl3d_properties_set_string(payload, "sector_name",
+                                level != NULL && sector_index >= 0 && sector_index < level->sector_count &&
+                                        level->sector_names[sector_index] != NULL
+                                    ? level->sector_names[sector_index]
+                                    : "");
+    const sdl3d_sector *sector =
+        level != NULL && sector_index >= 0 && sector_index < level->sector_count ? &level->sectors[sector_index] : NULL;
+    const float damage_per_second = sdl3d_sector_damage_per_second(sector);
+    sdl3d_properties_set_float(payload, "sector_damage_per_second", damage_per_second);
+    sdl3d_properties_set_float(payload, "sector_damage_delta",
+                               sdl3d_sector_damage_for_delta(sector, runtime != NULL ? runtime->current_dt : 0.0f));
+    sdl3d_properties_set_int(payload, "ambient_sound_id", sector != NULL ? sector->ambient_sound_id : -1);
+    return payload;
+}
+
+static void emit_sector_sensor_signal(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                      const sector_level_runtime *level, sdl3d_registered_actor *actor,
+                                      int sector_index)
+{
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    if (bus == NULL || sensor == NULL || sensor->signal_id < 0)
+        return;
+
+    sdl3d_properties *payload = create_sector_sensor_payload(runtime, sensor, level, actor, sector_index);
+    sdl3d_signal_emit(bus, sensor->signal_id, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void execute_sector_sensor_actions(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                          const sector_level_runtime *level, sdl3d_registered_actor *actor,
+                                          int sector_index)
+{
+    if (runtime == NULL || sensor == NULL || !yyjson_is_arr(sensor->actions))
+        return;
+
+    sdl3d_properties *payload = create_sector_sensor_payload(runtime, sensor, level, actor, sector_index);
+    if (payload != NULL)
+        (void)execute_action_array(runtime, sensor->actions, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void update_sector_sensor_actor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                       const sector_level_runtime *level, int target_sector,
+                                       sdl3d_registered_actor *actor)
+{
+    if (!runtime_actor_is_active(runtime, actor))
+        return;
+
+    const int current_sector = actor_sector_index_for_sensor(level, sensor, actor);
+    const bool active = current_sector == target_sector;
+    const char *sector_name = "";
+    if (target_sector >= 0 && target_sector < level->sector_count && level->sector_names[target_sector] != NULL)
+        sector_name = level->sector_names[target_sector];
+    sensor_contact_pair_state *state =
+        sensor_contact_pair_state_for(sensor, actor != NULL ? actor->name : NULL, sector_name);
+    if (state == NULL)
+        return;
+
+    const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                             : sensor_edge_is_stay(sensor) ? active
+                                                           : (active && !state->active);
+    if (should_emit)
+    {
+        const int event_sector = active ? current_sector : target_sector;
+        emit_sector_sensor_signal(runtime, sensor, level, actor, event_sector);
+        execute_sector_sensor_actions(runtime, sensor, level, actor, event_sector);
+    }
+    state->active = active;
+    state->seen = true;
+}
+
+static void update_sector_sensor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    const sector_level_runtime *level = find_sector_level_runtime(runtime, sensor->sector_level);
+    const int target_sector = sensor_target_sector_index(level, sensor);
+    if (level == NULL || target_sector < 0)
+        return;
+
+    sensor_actor_list actors;
+    SDL_zero(actors);
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &actors))
+    {
+        for (int i = 0; i < actors.count; ++i)
+            update_sector_sensor_actor(runtime, sensor, level, target_sector, actors.items[i]);
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&actors);
+}
+
 static void update_sensors(sdl3d_game_data_runtime *runtime)
 {
     for (int i = 0; i < runtime->sensor_count; ++i)
@@ -15163,6 +15370,11 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
         if (sensor->type == GAME_DATA_SENSOR_CONTACT_2D)
         {
             update_contact_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_SECTOR)
+        {
+            update_sector_sensor(runtime, sensor);
             continue;
         }
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -13429,6 +13429,11 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
             {
                 sdl3d_properties_set_float(actor->props, key, existing->as_float + (float)payload_value->as_int);
             }
+            else if (existing != NULL && existing->type == SDL3D_VALUE_INT && payload_value != NULL &&
+                     payload_value->type == SDL3D_VALUE_FLOAT)
+            {
+                sdl3d_properties_set_float(actor->props, key, (float)existing->as_int + payload_value->as_float);
+            }
             else if (existing != NULL && existing->type == SDL3D_VALUE_INT && yyjson_is_num(value))
                 sdl3d_properties_set_int(actor->props, key, existing->as_int + (int)yyjson_get_int(value));
             else if (existing != NULL && existing->type == SDL3D_VALUE_FLOAT && yyjson_is_num(value))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -4275,6 +4275,39 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
     return true;
 }
 
+static yyjson_val *find_sector_level_json(yyjson_val *root, const char *level_name)
+{
+    yyjson_val *levels = obj_get(root, "sector_levels");
+    for (size_t i = 0; level_name != NULL && yyjson_is_arr(levels) && i < yyjson_arr_size(levels); ++i)
+    {
+        yyjson_val *level = yyjson_arr_get(levels, i);
+        const char *name = json_string(level, "name");
+        if (name != NULL && SDL_strcmp(name, level_name) == 0)
+            return level;
+    }
+    return NULL;
+}
+
+static bool sector_level_has_sector_name(yyjson_val *root, const char *level_name, const char *sector_name)
+{
+    yyjson_val *level = find_sector_level_json(root, level_name);
+    yyjson_val *sectors = obj_get(level, "sectors");
+    for (size_t i = 0; sector_name != NULL && yyjson_is_arr(sectors) && i < yyjson_arr_size(sectors); ++i)
+    {
+        const char *name = json_string(yyjson_arr_get(sectors, i), "name");
+        if (name != NULL && SDL_strcmp(name, sector_name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool sector_level_has_sector_index(yyjson_val *root, const char *level_name, int sector_index)
+{
+    yyjson_val *level = find_sector_level_json(root, level_name);
+    yyjson_val *sectors = obj_get(level, "sectors");
+    return yyjson_is_arr(sectors) && sector_index >= 0 && (size_t)sector_index < yyjson_arr_size(sectors);
+}
+
 static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *archetypes = obj_get(root, "actor_archetypes");
@@ -4533,12 +4566,31 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return require_ref(ctx, &names->timers, "timer", json_string(action, "timer"), json_path);
     if (SDL_strcmp(type, "property.set") == 0 || SDL_strcmp(type, "property.add") == 0)
     {
-        if (!require_ref(ctx, &names->entities, "entity", json_string(action, "target"), json_path))
+        yyjson_val *target_value = obj_get(action, "target");
+        yyjson_val *target_from_payload_value = obj_get(action, "target_from_payload");
+        const char *target = json_string(action, "target");
+        const char *target_from_payload = json_string(action, "target_from_payload");
+        if ((target == NULL && target_from_payload == NULL) || (target != NULL && target_from_payload != NULL))
+            return validation_error(ctx, json_path, "%s requires exactly one of target or target_from_payload", type);
+        if (target_value != NULL && !yyjson_is_str(target_value))
+            return validation_error(ctx, json_path, "%s target must be a string", type);
+        if (target_from_payload_value != NULL && !yyjson_is_str(target_from_payload_value))
+            return validation_error(ctx, json_path, "%s target_from_payload must be a string", type);
+        if (target != NULL && !require_ref(ctx, &names->entities, "entity", target, json_path))
             return false;
+        if (target_from_payload != NULL && target_from_payload[0] == '\0')
+            return validation_error(ctx, json_path, "%s target_from_payload must be non-empty", type);
         if (!is_non_empty_string(action, "key"))
             return validation_error(ctx, json_path, "%s requires a non-empty key", type);
-        if (obj_get(action, "value") == NULL)
-            return validation_error(ctx, json_path, "%s requires a value", type);
+        yyjson_val *value = obj_get(action, "value");
+        yyjson_val *value_from_payload_value = obj_get(action, "value_from_payload");
+        const char *value_from_payload = json_string(action, "value_from_payload");
+        if ((value == NULL && value_from_payload == NULL) || (value != NULL && value_from_payload != NULL))
+            return validation_error(ctx, json_path, "%s requires exactly one of value or value_from_payload", type);
+        if (value_from_payload_value != NULL && !yyjson_is_str(value_from_payload_value))
+            return validation_error(ctx, json_path, "%s value_from_payload must be a string", type);
+        if (value_from_payload != NULL && value_from_payload[0] == '\0')
+            return validation_error(ctx, json_path, "%s value_from_payload must be non-empty", type);
         return true;
     }
     if (SDL_strcmp(type, "property.snapshot") == 0 || SDL_strcmp(type, "property.restore_snapshot") == 0)
@@ -5247,6 +5299,65 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
         {
             if (!require_ref(ctx, &names->actions, "input action", json_string(sensor, "action"), path) ||
                 !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_pressed"), path))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.sector") == 0)
+        {
+            const char *actor = json_string(sensor, "actor");
+            if (actor == NULL)
+                actor = json_string(sensor, "entity");
+            const char *actor_tag = json_string(sensor, "actor_tag");
+            if (actor_tag == NULL)
+                actor_tag = json_string(sensor, "a_tag");
+            const char *sector_level = json_string(sensor, "sector_level");
+            const char *sector = json_string(sensor, "sector");
+            yyjson_val *sector_index = obj_get(sensor, "sector_index");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((actor == NULL && actor_tag == NULL) || (actor != NULL && actor_tag != NULL))
+                return validation_error(ctx, path, "sensor.sector requires exactly one of actor or actor_tag");
+            if (actor != NULL && !require_actor_ref(ctx, names, actor, path))
+                return false;
+            if (actor_tag != NULL && actor_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.sector actor_tag must be non-empty");
+            if (!require_ref(ctx, &names->sector_levels, "sector level", sector_level, path))
+                return false;
+            if ((sector == NULL && sector_index == NULL) || (sector != NULL && sector_index != NULL))
+                return validation_error(ctx, path, "sensor.sector requires exactly one of sector or sector_index");
+            if (sector != NULL && !sector_level_has_sector_name(root, sector_level, sector))
+                return validation_error(ctx, path, "unknown sensor.sector sector '%s'", sector);
+            if (sector_index != NULL &&
+                (!yyjson_is_int(sector_index) ||
+                 !sector_level_has_sector_index(root, sector_level, (int)yyjson_get_int(sector_index))))
+            {
+                return validation_error(ctx, path,
+                                        "sensor.sector sector_index must reference a sector in sector_level");
+            }
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path, "sensor.sector edge must be enter, stay, overlap, or exit");
+            }
+            yyjson_val *sector_property = obj_get(sensor, "sector_property");
+            if (sector_property != NULL &&
+                (!yyjson_is_str(sector_property) || yyjson_get_str(sector_property)[0] == '\0'))
+                return validation_error(ctx, path, "sensor.sector sector_property must be a non-empty string");
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
                 return false;
             continue;
         }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8033,7 +8033,7 @@ TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
   "schema": "sdl3d.scene.v0",
   "name": "scene.play",
   "updates_game": true,
-  "entities": ["entity.player"],
+  "entities": ["entity.player", "entity.bot"],
   "world": { "sector_levels": [{ "level": "sector.test", "variant": "unlit" }] }
 })json");
     write_text(dir / "sector_hazard_sensors.game.json",
@@ -8048,9 +8048,18 @@ TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
       "transform": { "position": [1.0, 1.0, 1.0] },
       "properties": {
         "current_sector": { "type": "int", "value": 0 },
-        "damage_taken": { "type": "float", "value": 0.0 },
+        "damage_taken": { "type": "int", "value": 0 },
         "last_damage_per_second": { "type": "float", "value": 0.0 },
         "entered_hazard": { "type": "bool", "value": false }
+      }
+    },
+    {
+      "name": "entity.bot",
+      "active": true,
+      "tags": ["hazard_subject"],
+      "transform": { "position": [3.0, 1.0, 1.0] },
+      "properties": {
+        "tag_damage": { "type": "int", "value": 0 }
       }
     }
   ],
@@ -8104,6 +8113,17 @@ TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
         ]
       },
       {
+        "name": "sensor.hazard.tag_stay",
+        "type": "sensor.sector",
+        "actor_tag": "hazard_subject",
+        "sector_level": "sector.test",
+        "sector": "hazard",
+        "edge": "stay",
+        "actions": [
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "tag_damage", "value_from_payload": "sector_damage_delta" }
+        ]
+      },
+      {
         "name": "sensor.hazard.exit",
         "type": "sensor.sector",
         "actor": "entity.player",
@@ -8129,10 +8149,13 @@ TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
         << error;
     sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
     ASSERT_NE(player, nullptr);
+    sdl3d_registered_actor *bot = sdl3d_game_data_find_actor(runtime, "entity.bot");
+    ASSERT_NE(bot, nullptr);
 
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
     EXPECT_FALSE(sdl3d_properties_get_bool(player->props, "entered_hazard", true));
-    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "damage_taken", -1.0f), 0.0f, 0.0001f);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "damage_taken", -1), 0);
+    EXPECT_NEAR(sdl3d_properties_get_float(bot->props, "tag_damage", 0.0f), 2.5f, 0.0001f);
 
     sdl3d_properties_set_int(player->props, "current_sector", 1);
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -167,6 +167,7 @@ struct ParticleCapture
     bool saw_ambient = false;
     bool saw_options_flow = false;
     bool saw_pooled_emitter = false;
+    bool saw_nukage_vapor = false;
 };
 
 struct EvaluatedPrimitiveCapture
@@ -1431,6 +1432,13 @@ bool capture_particle(void *userdata, const sdl3d_game_data_particle_emitter *em
         EXPECT_EQ(emitter->config.max_particles, 12);
         EXPECT_NEAR(emitter->config.position.x, 2.0f, 0.0001f);
         EXPECT_NEAR(emitter->draw_emissive.y, 0.8f, 0.0001f);
+    }
+    if (std::string(emitter->entity_name) == "entity.effect.nukage.vapor")
+    {
+        capture->saw_nukage_vapor = true;
+        EXPECT_EQ(emitter->config.max_particles, 360);
+        EXPECT_TRUE(emitter->config.additive_blend);
+        EXPECT_NEAR(emitter->draw_emissive.y, 0.95f, 0.0001f);
     }
     return true;
 }
@@ -8009,9 +8017,140 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     capture.prefix = "door.";
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_door_prefix_render_primitive, &capture));
     EXPECT_EQ(capture.door_primitives, 5);
+    ParticleCapture particles{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_particle_emitter(runtime, capture_particle, &particles));
+    EXPECT_TRUE(particles.saw_nukage_vapor);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_hazard_sensors");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "world": { "sector_levels": [{ "level": "sector.test", "variant": "unlit" }] }
+})json");
+    write_text(dir / "sector_hazard_sensors.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Hazard Sensor Test" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [1.0, 1.0, 1.0] },
+      "properties": {
+        "current_sector": { "type": "int", "value": 0 },
+        "damage_taken": { "type": "float", "value": 0.0 },
+        "last_damage_per_second": { "type": "float", "value": 0.0 },
+        "entered_hazard": { "type": "bool", "value": false }
+      }
+    }
+  ],
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [
+        {
+          "name": "safe",
+          "points": [[0, 0], [2, 0], [2, 2], [0, 2]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "wall_material": "floor"
+        },
+        {
+          "name": "hazard",
+          "points": [[2, 0], [4, 0], [4, 2], [2, 2]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "wall_material": "floor",
+          "damage_per_second": 10.0,
+          "ambient_sound_id": 3
+        }
+      ]
+    }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.hazard.enter",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.test",
+        "sector": "hazard",
+        "edge": "enter",
+        "actions": [
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "entered_hazard", "value": true }
+        ]
+      },
+      {
+        "name": "sensor.hazard.stay",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.test",
+        "sector": "hazard",
+        "edge": "stay",
+        "actions": [
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "damage_taken", "value_from_payload": "sector_damage_delta" },
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "last_damage_per_second", "value_from_payload": "sector_damage_per_second" }
+        ]
+      },
+      {
+        "name": "sensor.hazard.exit",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.test",
+        "sector": "hazard",
+        "edge": "exit",
+        "actions": [
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "last_damage_per_second", "value": 0.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_hazard_sensors.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_FALSE(sdl3d_properties_get_bool(player->props, "entered_hazard", true));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "damage_taken", -1.0f), 0.0f, 0.0001f);
+
+    sdl3d_properties_set_int(player->props, "current_sector", 1);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "entered_hazard", false));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "damage_taken", 0.0f), 2.5f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "last_damage_per_second", 0.0f), 10.0f, 0.0001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "damage_taken", 0.0f), 3.5f, 0.0001f);
+
+    sdl3d_properties_set_int(player->props, "current_sector", 0);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "damage_taken", 0.0f), 3.5f, 0.0001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "last_damage_per_second", -1.0f), 0.0f, 0.0001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
@@ -8060,6 +8199,25 @@ TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
               ]
             })json",
             "unknown sector door reference",
+        },
+        {
+            "unknown_sector_sensor_sector",
+            R"json([])json",
+            R"json({
+              "sensors": [
+                {
+                  "type": "sensor.sector",
+                  "actor": "entity.player",
+                  "sector_level": "sector.test",
+                  "sector": "missing",
+                  "edge": "stay",
+                  "actions": [
+                    { "type": "property.add", "target_from_payload": "actor_name", "key": "damage_taken", "value_from_payload": "sector_damage_delta" }
+                  ]
+                }
+              ]
+            })json",
+            "unknown sensor.sector sector",
         },
     };
 


### PR DESCRIPTION
## Summary
- add reusable `sensor.sector` logic for sector enter/stay/exit detection
- allow property actions to read actor targets and values from action payloads
- migrate Doom nukage hazard damage and vapor particles into authored data
- document sector sensors and payload-driven property actions

## Tests
- `cmake --build build/debug --target sdl3d_game_data_test --parallel`
- `cmake --build build/debug --target sdl3d_runner --parallel`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.RunsAuthoredSectorHazardSensors:GameDataRuntime.RejectsInvalidSectorDoorsAndActions`
- `./build/debug/tests/sdl3d_game_data_test`

Part of #251.