### PR TITLE
Author remaining Doom props in data

### DIFF
--- a/demos/doom_level/data/fragments/actors/props.json
+++ b/demos/doom_level/data/fragments/actors/props.json
@@ -191,6 +191,156 @@
       ]
     },
     {
+      "name": "entity.doom.health.north",
+      "active": true,
+      "tags": ["pickup", "health", "billboard"],
+      "transform": { "position": [24.0, 0.25, 4.5] },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.health_pack",
+          "size": [1.0, 1.0],
+          "lighting": true
+        },
+        {
+          "type": "motion.oscillate",
+          "origin": [24.0, 0.25, 4.5],
+          "amplitude": [0.0, 0.15, 0.0],
+          "rate": 1.5
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.health.side",
+      "active": true,
+      "tags": ["pickup", "health", "billboard"],
+      "transform": { "position": [35.5, 0.25, 27.0] },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.health_pack",
+          "size": [1.0, 1.0],
+          "lighting": true
+        },
+        {
+          "type": "motion.oscillate",
+          "origin": [35.5, 0.25, 27.0],
+          "amplitude": [0.0, 0.1, 0.0],
+          "rate": 1.7
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.health.dragon",
+      "active": true,
+      "tags": ["pickup", "health", "billboard"],
+      "transform": { "position": [10.0, 0.25, 84.0] },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.health_pack",
+          "size": [1.0, 1.0],
+          "lighting": true
+        },
+        {
+          "type": "motion.oscillate",
+          "origin": [10.0, 0.25, 84.0],
+          "amplitude": [0.0, 0.14, 0.0],
+          "rate": 1.6
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.robot.storage",
+      "active": true,
+      "tags": ["npc", "robot", "billboard"],
+      "transform": { "position": [24.0, 0.0, 19.0] },
+      "properties": {
+        "sprite_yaw": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.robot.walk",
+          "size": [3.6, 5.6],
+          "facing_yaw_property": "sprite_yaw"
+        },
+        {
+          "type": "motion.patrol",
+          "waypoints": [
+            [24.0, 0.0, 19.0],
+            [24.0, 0.0, 23.0]
+          ],
+          "speed": 0.8,
+          "wait_time": 1.2,
+          "arrival_radius": 0.08,
+          "mode": "ping_pong",
+          "start_idle": false,
+          "yaw_property": "sprite_yaw"
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.robot.hall",
+      "active": true,
+      "tags": ["npc", "robot", "billboard"],
+      "transform": { "position": [24.0, 0.0, 37.5] },
+      "properties": {
+        "sprite_yaw": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.robot.walk",
+          "size": [3.4, 5.2],
+          "facing_yaw_property": "sprite_yaw"
+        },
+        {
+          "type": "motion.patrol",
+          "waypoints": [
+            [24.0, 0.0, 37.5],
+            [24.0, 0.0, 41.5]
+          ],
+          "speed": 0.7,
+          "wait_time": 1.6,
+          "arrival_radius": 0.08,
+          "mode": "ping_pong",
+          "start_idle": false,
+          "yaw_property": "sprite_yaw"
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.robot.dragon",
+      "active": true,
+      "tags": ["npc", "robot", "billboard"],
+      "transform": { "position": [24.0, 0.0, 72.0] },
+      "properties": {
+        "sprite_yaw": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "render.sprite",
+          "sprite": "sprite.doom.robot.walk",
+          "size": [3.6, 5.6],
+          "facing_yaw_property": "sprite_yaw"
+        },
+        {
+          "type": "motion.patrol",
+          "waypoints": [
+            [24.0, 0.0, 72.0],
+            [32.0, 0.0, 72.0]
+          ],
+          "speed": 1.0,
+          "wait_time": 1.5,
+          "arrival_radius": 0.08,
+          "mode": "ping_pong",
+          "start_idle": false,
+          "yaw_property": "sprite_yaw"
+        }
+      ]
+    },
+    {
       "name": "entity.doom.crate.nukage",
       "active": true,
       "tags": ["prop", "crate"],
@@ -202,6 +352,69 @@
           "color": [78, 170, 72, 255],
           "lighting": true
         }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.entry.0",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [3.0, 0.5, 5.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.entry.1",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [7.0, 0.5, 5.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.entry.2",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [3.0, 0.5, 10.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.entry.3",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [7.0, 0.5, 10.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.storage.0",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [14.0, 0.5, 20.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.storage.1",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [14.0, 1.5, 20.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.crate.storage.2",
+      "active": true,
+      "tags": ["prop", "crate"],
+      "transform": { "position": [22.0, 0.5, 16.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [78, 170, 72, 255], "lighting": true }
       ]
     }
   ]

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -9,9 +9,22 @@
     "entity.effect.nukage.vapor",
     "entity.doom.robot.entry",
     "entity.doom.robot.nukage",
+    "entity.doom.robot.storage",
+    "entity.doom.robot.hall",
+    "entity.doom.robot.dragon",
     "entity.doom.health.entry",
     "entity.doom.health.hall",
-    "entity.doom.crate.nukage"
+    "entity.doom.health.north",
+    "entity.doom.health.side",
+    "entity.doom.health.dragon",
+    "entity.doom.crate.nukage",
+    "entity.doom.crate.entry.0",
+    "entity.doom.crate.entry.1",
+    "entity.doom.crate.entry.2",
+    "entity.doom.crate.entry.3",
+    "entity.doom.crate.storage.0",
+    "entity.doom.crate.storage.1",
+    "entity.doom.crate.storage.2"
   ],
   "input": {
     "actions": [

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -111,6 +111,9 @@ struct RenderPrimitiveCapture
     bool saw_doom_robot_sprite = false;
     bool saw_doom_health_sprite = false;
     bool saw_doom_crate = false;
+    int doom_robot_sprites = 0;
+    int doom_health_sprites = 0;
+    int doom_crates = 0;
 };
 
 struct SectorLevelInstanceCapture
@@ -1336,7 +1339,14 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_GT(primitive->instance_count, 0);
         EXPECT_NE(primitive->instances, nullptr);
     }
-    if (std::string(primitive->entity_name) == "entity.doom.robot.entry")
+    const std::string entity_name = primitive->entity_name != nullptr ? primitive->entity_name : "";
+    if (entity_name.rfind("entity.doom.robot.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_SPRITE)
+        capture->doom_robot_sprites++;
+    if (entity_name.rfind("entity.doom.health.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_SPRITE)
+        capture->doom_health_sprites++;
+    if (entity_name.rfind("entity.doom.crate.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+        capture->doom_crates++;
+    if (entity_name == "entity.doom.robot.entry")
     {
         capture->saw_doom_robot_sprite = true;
         EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_SPRITE);
@@ -1345,7 +1355,7 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_NEAR(primitive->sprite_size.y, 5.2f, 0.0001f);
         EXPECT_TRUE(primitive->lighting_enabled);
     }
-    if (std::string(primitive->entity_name) == "entity.doom.health.entry")
+    if (entity_name == "entity.doom.health.entry")
     {
         capture->saw_doom_health_sprite = true;
         EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_SPRITE);
@@ -1353,7 +1363,7 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         EXPECT_NEAR(primitive->sprite_size.x, 1.0f, 0.0001f);
         EXPECT_NEAR(primitive->sprite_size.y, 1.0f, 0.0001f);
     }
-    if (std::string(primitive->entity_name) == "entity.doom.crate.nukage")
+    if (entity_name == "entity.doom.crate.nukage")
     {
         capture->saw_doom_crate = true;
         EXPECT_EQ(primitive->type, SDL3D_GAME_DATA_RENDER_CUBE);
@@ -8061,7 +8071,10 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_TRUE(authored_props.saw_doom_robot_sprite);
     EXPECT_TRUE(authored_props.saw_doom_health_sprite);
     EXPECT_TRUE(authored_props.saw_doom_crate);
-    EXPECT_GE(authored_props.sprites, 4);
+    EXPECT_EQ(authored_props.doom_robot_sprites, 5);
+    EXPECT_EQ(authored_props.doom_health_sprites, 5);
+    EXPECT_EQ(authored_props.doom_crates, 8);
+    EXPECT_GE(authored_props.sprites, 10);
     sdl3d_game_data_sprite_asset robot_sprite{};
     ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.doom.robot.walk", &robot_sprite));
     EXPECT_EQ(robot_sprite.source_kind, SDL3D_SPRITE_ASSET_SOURCE_FILES);


### PR DESCRIPTION
## Summary
- add authored Doom robot, health pickup, and crate entities that mirror the remaining native prop placement
- include the authored props in the Doom play scene
- strengthen the Doom runtime test to assert authored prop counts

## Tests
- cmake --build build/debug --target sdl3d_game_data_test sdl3d_runner --parallel
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors'
- ./build/debug/tests/sdl3d_game_data_test
- git diff --check

Part of #251