### PR TITLE
Author Doom presentation props

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -7,6 +7,7 @@
   },
   "imports": [
     { "path": "fragments/actors/props.json", "sections": ["assets", "entities"] },
+    { "path": "fragments/actors/presentation_props.json", "sections": ["entities"] },
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
     { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] }

--- a/demos/doom_level/data/fragments/actors/presentation_props.json
+++ b/demos/doom_level/data/fragments/actors/presentation_props.json
@@ -1,0 +1,203 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.doom.presentation.ambient_feedback",
+      "active": true,
+      "tags": ["presentation", "feedback"],
+      "transform": { "position": [73.0, 3.0, 63.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.7, 0.7, 0.7],
+          "color": [40, 210, 70, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [220, 40, 30, 255], "emissive_base": [0.05, 0.4, 0.1], "emissive_add": [0.35, 0.04, 0.02], "rate": 1.4 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.teleporter.source_pad",
+      "active": true,
+      "tags": ["presentation", "teleporter"],
+      "transform": { "position": [24.0, 0.05, 88.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [3.0, 0.1, 3.0],
+          "color": [40, 190, 230, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [255, 210, 60, 255], "emissive_base": [0.0, 0.14, 0.2], "emissive_add": [0.45, 0.34, 0.03], "rate": 2.1 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.teleporter.destination_beacon",
+      "active": true,
+      "tags": ["presentation", "teleporter"],
+      "transform": { "position": [72.0, 2.85, 63.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.8, 0.7, 0.8],
+          "color": [80, 120, 255, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [255, 210, 60, 255], "emissive_base": [0.05, 0.08, 0.4], "emissive_add": [0.42, 0.3, 0.05], "rate": 1.8 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.launcher.base",
+      "active": true,
+      "tags": ["presentation", "launcher"],
+      "transform": { "position": [38.0, 0.05, 68.0] },
+      "components": [
+        { "type": "render.cube", "size": [3.2, 0.1, 3.2], "color": [35, 38, 46, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.launcher.pad",
+      "active": true,
+      "tags": ["presentation", "launcher"],
+      "transform": { "position": [38.0, 0.18, 68.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [2.2, 0.16, 2.2],
+          "color": [70, 175, 255, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [255, 245, 90, 255], "emissive_base": [0.04, 0.18, 0.36], "emissive_add": [0.5, 0.45, 0.08], "rate": 2.4 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.launcher.post",
+      "active": true,
+      "tags": ["presentation", "launcher"],
+      "transform": { "position": [38.0, 0.55, 68.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.35, 0.7, 0.35],
+          "color": [90, 215, 255, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [255, 255, 160, 255], "emissive_base": [0.04, 0.2, 0.32], "emissive_add": [0.45, 0.45, 0.12], "rate": 2.4 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.conveyor.deck",
+      "active": true,
+      "tags": ["presentation", "conveyor"],
+      "transform": { "position": [19.0, 0.04, 51.0] },
+      "components": [
+        { "type": "render.cube", "size": [21.0, 0.08, 12.0], "color": [30, 35, 40, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.conveyor.center_line",
+      "active": true,
+      "tags": ["presentation", "conveyor"],
+      "transform": { "position": [19.0, 0.12, 51.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [13.0, 0.08, 0.8],
+          "color": [70, 210, 230, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "emissive_base": [0.0, 0.18, 0.2], "emissive_add": [0.04, 0.18, 0.22], "rate": 1.2 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.conveyor.arrow_top",
+      "active": true,
+      "tags": ["presentation", "conveyor"],
+      "transform": { "position": [26.0, 0.13, 49.4] },
+      "components": [
+        { "type": "render.cube", "size": [3.0, 0.1, 0.8], "color": [70, 210, 230, 255], "lighting": true, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.conveyor.arrow_bottom",
+      "active": true,
+      "tags": ["presentation", "conveyor"],
+      "transform": { "position": [26.0, 0.13, 52.6] },
+      "components": [
+        { "type": "render.cube", "size": [3.0, 0.1, 0.8], "color": [70, 210, 230, 255], "lighting": true, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.surveillance.base",
+      "active": true,
+      "tags": ["presentation", "surveillance"],
+      "transform": { "position": [43.0, 0.18, 89.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.4, 0.25, 1.4], "color": [45, 48, 55, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.surveillance.button",
+      "active": true,
+      "tags": ["presentation", "surveillance"],
+      "transform": { "position": [43.0, 0.42, 89.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.9, 0.25, 0.9],
+          "color": [235, 45, 45, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [45, 235, 90, 255], "emissive_base": [0.3, 0.04, 0.04], "emissive_add": [0.03, 0.35, 0.08], "rate": 1.5 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.surveillance.post",
+      "active": true,
+      "tags": ["presentation", "surveillance"],
+      "transform": { "position": [43.0, 1.35, 89.0] },
+      "components": [
+        { "type": "render.cube", "size": [0.18, 1.6, 0.18], "color": [50, 60, 75, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.doom.presentation.surveillance.camera_body",
+      "active": true,
+      "tags": ["presentation", "surveillance"],
+      "transform": { "position": [43.0, 2.2, 89.0] },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.8, 0.45, 0.45],
+          "color": [70, 90, 120, 255],
+          "lighting": true,
+          "emissive": true,
+          "effects": [
+            { "type": "pulse", "color": [40, 180, 90, 255], "emissive_base": [0.03, 0.04, 0.08], "emissive_add": [0.02, 0.24, 0.08], "rate": 1.5 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -24,7 +24,21 @@
     "entity.doom.crate.entry.3",
     "entity.doom.crate.storage.0",
     "entity.doom.crate.storage.1",
-    "entity.doom.crate.storage.2"
+    "entity.doom.crate.storage.2",
+    "entity.doom.presentation.ambient_feedback",
+    "entity.doom.presentation.teleporter.source_pad",
+    "entity.doom.presentation.teleporter.destination_beacon",
+    "entity.doom.presentation.launcher.base",
+    "entity.doom.presentation.launcher.pad",
+    "entity.doom.presentation.launcher.post",
+    "entity.doom.presentation.conveyor.deck",
+    "entity.doom.presentation.conveyor.center_line",
+    "entity.doom.presentation.conveyor.arrow_top",
+    "entity.doom.presentation.conveyor.arrow_bottom",
+    "entity.doom.presentation.surveillance.base",
+    "entity.doom.presentation.surveillance.button",
+    "entity.doom.presentation.surveillance.post",
+    "entity.doom.presentation.surveillance.camera_body"
   ],
   "input": {
     "actions": [

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -1176,9 +1176,7 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 
     render_draw_frame(&state->render, ctx->renderer, state->has_font ? &state->debug_font : NULL, state->ui,
                       &state->level, &state->ent, &state->hazards, &state->doors, &state->surveillance, &state->player,
-                      WINDOW_W, WINDOW_H, frame_dt, backend_profile_name(state->render_profile),
-                      state->ambient_feedback_timer > 0.0f, state->teleport_feedback_timer > 0.0f,
-                      state->launcher_feedback_timer > 0.0f);
+                      WINDOW_W, WINDOW_H, frame_dt, backend_profile_name(state->render_profile));
     sdl3d_transition_draw(&state->transition, ctx->renderer);
     draw_damage_overlay(ctx, state);
     if (ctx->paused && !state->quit_pending)

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -14,8 +14,6 @@
 #define ROCKET_LIGHT_B 0.2f
 #define ROCKET_LIGHT_INTENSITY 4.0f
 #define ROCKET_LIGHT_RANGE 4.0f
-#define LAUNCHER_PAD_X 38.0f
-#define LAUNCHER_PAD_Z 68.0f
 
 static sdl3d_vec3 camera_forward(const sdl3d_camera3d *camera)
 {
@@ -30,12 +28,6 @@ static sdl3d_vec3 camera_forward(const sdl3d_camera3d *camera)
         return sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
     }
     return sdl3d_vec3_normalize(forward);
-}
-
-static sdl3d_vec3 bounds_center(sdl3d_bounding_box bounds)
-{
-    return sdl3d_vec3_make((bounds.min.x + bounds.max.x) * 0.5f, (bounds.min.y + bounds.max.y) * 0.5f,
-                           (bounds.min.z + bounds.max.z) * 0.5f);
 }
 
 void render_state_init(render_state *rs)
@@ -80,8 +72,7 @@ static bool render_state_ensure_sector_capacity(render_state *rs, int sector_cou
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
                        level_data *ld, entities *ent, const doom_hazard_particles *hazards, const doom_doors *doors,
                        const doom_surveillance_camera *surveillance, const player_state *player, int backbuffer_w,
-                       int backbuffer_h, float dt, const char *render_profile_name, bool ambient_feedback_active,
-                       bool teleport_feedback_active, bool launcher_feedback_active)
+                       int backbuffer_h, float dt, const char *render_profile_name)
 {
     const sdl3d_fps_mover *mover = &player->mover;
     sdl3d_level *active = level_data_active(ld);
@@ -160,49 +151,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
             sdl3d_actor_set_sector(a, sdl3d_level_find_sector(active, g_sectors, ap.x, ap.z));
         }
         sdl3d_draw_scene_with_visibility(ctx, ent->scene, rs->portal_culling ? &rs->vis : NULL);
-    }
-
-    /* Ambient-zone feedback beacon. */
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(73.0f, 3.0f, 63.0f), sdl3d_vec3_make(0.7f, 0.7f, 0.7f),
-                    ambient_feedback_active ? (sdl3d_color){220, 40, 30, 255} : (sdl3d_color){40, 210, 70, 255});
-
-    /* Dragon-room teleporter source pad and destination beacon. */
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(24.0f, 0.05f, 88.0f), sdl3d_vec3_make(3.0f, 0.1f, 3.0f),
-                    teleport_feedback_active ? (sdl3d_color){255, 210, 60, 255} : (sdl3d_color){40, 190, 230, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(72.0f, 2.85f, 63.0f), sdl3d_vec3_make(0.8f, 0.7f, 0.8f),
-                    teleport_feedback_active ? (sdl3d_color){255, 210, 60, 255} : (sdl3d_color){80, 120, 255, 255});
-
-    /* Player launcher pad in the dragon room. */
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(LAUNCHER_PAD_X, 0.05f, LAUNCHER_PAD_Z), sdl3d_vec3_make(3.2f, 0.1f, 3.2f),
-                    (sdl3d_color){35, 38, 46, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(LAUNCHER_PAD_X, 0.18f, LAUNCHER_PAD_Z), sdl3d_vec3_make(2.2f, 0.16f, 2.2f),
-                    launcher_feedback_active ? (sdl3d_color){255, 245, 90, 255} : (sdl3d_color){70, 175, 255, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(LAUNCHER_PAD_X, 0.55f, LAUNCHER_PAD_Z), sdl3d_vec3_make(0.35f, 0.7f, 0.35f),
-                    launcher_feedback_active ? (sdl3d_color){255, 255, 160, 255} : (sdl3d_color){90, 215, 255, 255});
-
-    /* Conveyor direction marker in the dragon room. */
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(19.0f, 0.04f, 51.0f), sdl3d_vec3_make(21.0f, 0.08f, 12.0f),
-                    (sdl3d_color){30, 35, 40, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(19.0f, 0.12f, 51.0f), sdl3d_vec3_make(13.0f, 0.08f, 0.8f),
-                    (sdl3d_color){70, 210, 230, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(26.0f, 0.13f, 49.4f), sdl3d_vec3_make(3.0f, 0.1f, 0.8f),
-                    (sdl3d_color){70, 210, 230, 255});
-    sdl3d_draw_cube(ctx, sdl3d_vec3_make(26.0f, 0.13f, 52.6f), sdl3d_vec3_make(3.0f, 0.1f, 0.8f),
-                    (sdl3d_color){70, 210, 230, 255});
-
-    /* Surveillance camera button in the dragon room. */
-    if (surveillance != NULL)
-    {
-        const sdl3d_vec3 c = bounds_center(surveillance->button_bounds);
-        const bool active_button = doom_surveillance_is_active(surveillance);
-        sdl3d_draw_cube(ctx, sdl3d_vec3_make(c.x, 0.18f, c.z), sdl3d_vec3_make(1.4f, 0.25f, 1.4f),
-                        (sdl3d_color){45, 48, 55, 255});
-        sdl3d_draw_cube(ctx, sdl3d_vec3_make(c.x, 0.42f, c.z), sdl3d_vec3_make(0.9f, 0.25f, 0.9f),
-                        active_button ? (sdl3d_color){45, 235, 90, 255} : (sdl3d_color){235, 45, 45, 255});
-        sdl3d_draw_cube(ctx, sdl3d_vec3_make(c.x, 1.35f, c.z), sdl3d_vec3_make(0.18f, 1.6f, 0.18f),
-                        (sdl3d_color){50, 60, 75, 255});
-        sdl3d_draw_cube(ctx, sdl3d_vec3_make(c.x, 2.2f, c.z), sdl3d_vec3_make(0.8f, 0.45f, 0.45f),
-                        active_button ? (sdl3d_color){40, 180, 90, 255} : (sdl3d_color){70, 90, 120, 255});
     }
 
     /* Sector hazard particles */

--- a/demos/doom_level/renderer.h
+++ b/demos/doom_level/renderer.h
@@ -31,7 +31,6 @@ void render_state_free(render_state *rs);
 void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_font *font, sdl3d_ui_context *ui,
                        level_data *ld, entities *ent, const doom_hazard_particles *hazards, const doom_doors *doors,
                        const doom_surveillance_camera *surveillance, const player_state *player, int backbuffer_w,
-                       int backbuffer_h, float dt, const char *render_profile_name, bool ambient_feedback_active,
-                       bool teleport_feedback_active, bool launcher_feedback_active);
+                       int backbuffer_h, float dt, const char *render_profile_name);
 
 #endif

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -114,6 +114,7 @@ struct RenderPrimitiveCapture
     int doom_robot_sprites = 0;
     int doom_health_sprites = 0;
     int doom_crates = 0;
+    int doom_presentation_cubes = 0;
 };
 
 struct SectorLevelInstanceCapture
@@ -1346,6 +1347,8 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         capture->doom_health_sprites++;
     if (entity_name.rfind("entity.doom.crate.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
         capture->doom_crates++;
+    if (entity_name.rfind("entity.doom.presentation.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
+        capture->doom_presentation_cubes++;
     if (entity_name == "entity.doom.robot.entry")
     {
         capture->saw_doom_robot_sprite = true;
@@ -8074,6 +8077,7 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_EQ(authored_props.doom_robot_sprites, 5);
     EXPECT_EQ(authored_props.doom_health_sprites, 5);
     EXPECT_EQ(authored_props.doom_crates, 8);
+    EXPECT_EQ(authored_props.doom_presentation_cubes, 14);
     EXPECT_GE(authored_props.sprites, 10);
     sdl3d_game_data_sprite_asset robot_sprite{};
     ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.doom.robot.walk", &robot_sprite));


### PR DESCRIPTION
## Summary
- add a Doom presentation prop fragment for beacons, pads, conveyor markers, and surveillance button geometry
- include those authored entities in the Doom play scene
- remove matching hard-coded cube draws from the native Doom renderer
- update runtime coverage to assert the authored presentation primitive count

## Tests
- cmake --build build/debug --target doom_level sdl3d_game_data_test --parallel
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors'
- ./build/debug/tests/sdl3d_game_data_test
- git diff --check

Part of #251