### PR TITLE
Author Doom reticle UI

### DIFF
--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -71,6 +71,16 @@
         "centered": true,
         "normalized": true,
         "color": [220, 230, 255, 230]
+      },
+      {
+        "name": "ui.doom_level.reticle",
+        "text": "+",
+        "x": 0.5,
+        "y": 0.5,
+        "scale": 1.2,
+        "centered": true,
+        "normalized": true,
+        "color": [255, 255, 255, 220]
       }
     ]
   }

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -15,21 +15,6 @@
 #define ROCKET_LIGHT_INTENSITY 4.0f
 #define ROCKET_LIGHT_RANGE 4.0f
 
-static sdl3d_vec3 camera_forward(const sdl3d_camera3d *camera)
-{
-    if (camera == NULL)
-    {
-        return sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
-    }
-
-    sdl3d_vec3 forward = sdl3d_vec3_sub(camera->target, camera->position);
-    if (sdl3d_vec3_length_squared(forward) <= 0.000001f)
-    {
-        return sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
-    }
-    return sdl3d_vec3_normalize(forward);
-}
-
 void render_state_init(render_state *rs)
 {
     SDL_zerop(rs);
@@ -83,7 +68,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
 
     float px = mover->position.x, py = mover->position.y;
     float pz = mover->position.z;
-    const sdl3d_vec3 forward = camera_forward(&cam);
 
     int current_sector = sdl3d_level_find_sector_at(&ld->unlit, g_sectors, px, pz, py - PLAYER_HEIGHT);
     if (current_sector < 0)
@@ -166,17 +150,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
         sdl3d_set_emissive(ctx, 5.0f, 3.0f, 1.0f);
         sdl3d_draw_sphere(ctx, sdl3d_vec3_make(player->proj_x, player->proj_y, player->proj_z), 0.1f, 8, 8,
                           (sdl3d_color){255, 200, 100, 255});
-        sdl3d_set_emissive(ctx, 0, 0, 0);
-    }
-
-    /* Crosshair */
-    {
-        float chx = cam.position.x + forward.x * 0.4f;
-        float chy = cam.position.y + forward.y * 0.4f;
-        float chz = cam.position.z + forward.z * 0.4f;
-        sdl3d_set_emissive(ctx, 8, 8, 8);
-        sdl3d_draw_cube(ctx, sdl3d_vec3_make(chx, chy, chz), sdl3d_vec3_make(0.003f, 0.003f, 0.003f),
-                        (sdl3d_color){255, 255, 255, 255});
         sdl3d_set_emissive(ctx, 0, 0, 0);
     }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -161,6 +161,7 @@ struct UiTextCapture
     bool saw_score = false;
     bool saw_pause = false;
     bool saw_network_match_terminated = false;
+    bool saw_doom_reticle = false;
 };
 
 struct UiImageCapture
@@ -1446,6 +1447,15 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
         capture->saw_network_match_terminated = true;
         EXPECT_TRUE(text->centered);
         EXPECT_TRUE(text->normalized);
+    }
+    if (std::string(text->name) == "ui.doom_level.reticle")
+    {
+        capture->saw_doom_reticle = true;
+        EXPECT_STREQ(text->text, "+");
+        EXPECT_TRUE(text->centered);
+        EXPECT_TRUE(text->normalized);
+        EXPECT_NEAR(text->x, 0.5f, 0.0001f);
+        EXPECT_NEAR(text->y, 0.5f, 0.0001f);
     }
     return true;
 }
@@ -8079,6 +8089,9 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_EQ(authored_props.doom_crates, 8);
     EXPECT_EQ(authored_props.doom_presentation_cubes, 14);
     EXPECT_GE(authored_props.sprites, 10);
+    UiTextCapture ui_text{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui_text));
+    EXPECT_TRUE(ui_text.saw_doom_reticle);
     sdl3d_game_data_sprite_asset robot_sprite{};
     ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.doom.robot.walk", &robot_sprite));
     EXPECT_EQ(robot_sprite.source_kind, SDL3D_SPRITE_ASSET_SOURCE_FILES);


### PR DESCRIPTION
## Summary
- move the Doom level reticle into authored scene UI data
- remove the native hard-coded 3D crosshair cube from the Doom renderer
- extend the Doom data runtime test to verify the reticle is present in JSON-authored UI

## Verification
- cmake --build build/debug --target sdl3d_game_data_test doom_level
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors