### PR TITLE
Author Doom projectile firing data

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -8,6 +8,7 @@
   "imports": [
     { "path": "fragments/actors/props.json", "sections": ["assets", "entities"] },
     { "path": "fragments/actors/presentation_props.json", "sections": ["entities"] },
+    { "path": "fragments/actors/projectiles.json", "sections": ["actor_archetypes", "actor_pools", "signals", "logic"] },
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
     { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] }
@@ -41,7 +42,14 @@
           { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
           { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
-          { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] }
+          { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
+          {
+            "name": "action.fire",
+            "bindings": [
+              { "device": "mouse", "button": "LEFT" },
+              { "device": "keyboard", "key": "F" }
+            ]
+          }
         ]
       }
     ]
@@ -54,7 +62,10 @@
       "properties": {
         "yaw": { "type": "float", "value": 3.14159 },
         "pitch": { "type": "float", "value": 0.0 },
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
         "current_sector": { "type": "int", "value": -1 },
+        "fire_timer": { "type": "float", "value": 0.0 },
+        "fire_cooldown": { "type": "float", "value": 0.2 },
         "damage_taken": { "type": "float", "value": 0.0 },
         "last_damage_per_second": { "type": "float", "value": 0.0 }
       },
@@ -77,6 +88,13 @@
           "step_height": 1.1,
           "ceiling_clearance": 0.1,
           "mouse_sensitivity": 0.002
+        },
+        {
+          "type": "property.decay",
+          "property": "fire_timer",
+          "rate": 1.0,
+          "target": 0.0,
+          "min": 0.0
         }
       ]
     },

--- a/demos/doom_level/data/fragments/actors/projectiles.json
+++ b/demos/doom_level/data/fragments/actors/projectiles.json
@@ -1,0 +1,78 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "actor_archetypes": [
+    {
+      "name": "archetype.doom.projectile",
+      "tags": ["projectile", "player_projectile"],
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] },
+        "age": { "type": "float", "value": 0.0 },
+        "ttl": { "type": "float", "value": 3.0 },
+        "damage": { "type": "int", "value": 12 }
+      },
+      "components": [
+        {
+          "type": "render.sphere",
+          "radius": 0.1,
+          "slices": 8,
+          "rings": 8,
+          "color": [255, 200, 100, 255],
+          "emissive": true,
+          "lighting": false
+        },
+        {
+          "type": "motion.velocity_3d",
+          "property": "velocity"
+        },
+        {
+          "type": "lifecycle.ttl",
+          "age_property": "age",
+          "ttl_property": "ttl",
+          "reason": "projectile expired"
+        },
+        {
+          "type": "light.point",
+          "color": [1.0, 0.6, 0.2],
+          "intensity": 4.0,
+          "range": 4.0
+        }
+      ]
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.doom.projectiles",
+      "archetype": "archetype.doom.projectile",
+      "capacity": 12,
+      "scene": "scene.doom_level.play",
+      "exhaustion_policy": "reuse_oldest",
+      "on_scene_exit": "reset"
+    }
+  ],
+  "signals": ["signal.doom.fire"],
+  "logic": {
+    "sensors": [
+      {
+        "name": "logic.doom.fire_input",
+        "type": "sensor.input_pressed",
+        "action": "action.fire",
+        "on_pressed": "signal.doom.fire"
+      }
+    ],
+    "bindings": [
+      {
+        "signal": "signal.doom.fire",
+        "actions": [
+          {
+            "type": "projectile.fire",
+            "target": "entity.player",
+            "pool": "pool.doom.projectiles",
+            "velocity_from_property": "camera_forward",
+            "speed": 20.0,
+            "cooldown_property": "fire_timer"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -47,7 +47,8 @@
       "action.move.left",
       "action.move.right",
       "action.jump",
-      "action.interact"
+      "action.interact",
+      "action.fire"
     ]
   },
   "world": {
@@ -64,7 +65,7 @@
     "text": [
       {
         "name": "ui.doom_level.phase",
-        "text": "DATA-DRIVEN SECTOR LEVEL - WASD + MOUSE - E OPENS DOORS",
+        "text": "DATA-DRIVEN SECTOR LEVEL - WASD + MOUSE - E OPENS DOORS - CLICK/F FIRES",
         "x": 0.5,
         "y": 0.06,
         "scale": 1.0,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -184,7 +184,9 @@ Camera types:
 - `fps`: reads a first-person sector controller from `target_entity` and
   renders from that actor's eye position. If the controller has not updated
   yet, the camera falls back to the actor's `yaw`, `pitch`, and `view_smooth`
-  properties.
+  properties. The controller also publishes a normalized view direction to
+  `camera_forward` by default; override this with `forward_property` when a
+  game wants a different property name for projectile or camera logic.
 - `adapter`: delegates camera ownership to a native or Lua adapter.
 
 ## Storage And Persistence
@@ -588,7 +590,8 @@ Example:
   "target": "entity.player",
   "pool": "pool.player_shots",
   "offset": [0.6, 0.0, 0.1],
-  "velocity": [12.0, 0.0, 0.0],
+  "velocity_from_property": "camera_forward",
+  "speed": 12.0,
   "cooldown_property": "fire_timer",
   "properties": { "owner": 1, "damage": 1 }
 }
@@ -596,8 +599,11 @@ Example:
 
 The target actor may define `fire_cooldown`; otherwise the action's `cooldown`
 field is used. If the cooldown property is positive, no projectile is spawned.
-Use `target_from_payload` instead of `target` when the firing actor should come
-from a signal or collision payload.
+Use `velocity` for a literal projectile velocity, or
+`velocity_from_property` plus `speed` to fire along an actor-authored direction
+such as an FPS controller's `camera_forward`. Use `target_from_payload` instead
+of `target` when the firing actor should come from a signal or collision
+payload.
 
 `actor.spawn` and `actor.despawn` can also resolve actors from payload fields:
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -13140,9 +13140,24 @@ static bool execute_projectile_fire_action(sdl3d_game_data_runtime *runtime, yyj
     actor_set_position(actor, actor_spawn_position_from_action(runtime, action, payload, target->position));
     apply_actor_spawn_properties(actor, obj_get(action, "properties"));
     yyjson_val *velocity = obj_get(action, "velocity");
-    if (velocity != NULL)
-        sdl3d_properties_set_vec3(actor->props, "velocity",
-                                  json_vec3_value(velocity, sdl3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    const sdl3d_vec3 fallback_velocity = json_vec3_value(velocity, sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const char *velocity_property = json_string(action, "velocity_from_property", NULL);
+    if (velocity_property != NULL || velocity != NULL)
+    {
+        sdl3d_vec3 projectile_velocity =
+            velocity_property != NULL ? sdl3d_properties_get_vec3(target->props, velocity_property, fallback_velocity)
+                                      : fallback_velocity;
+        yyjson_val *speed_value = obj_get(action, "speed");
+        if (yyjson_is_num(speed_value))
+        {
+            const float speed = (float)yyjson_get_num(speed_value);
+            if (sdl3d_vec3_length_squared(projectile_velocity) > 0.000001f)
+                projectile_velocity = sdl3d_vec3_scale(sdl3d_vec3_normalize(projectile_velocity), speed);
+            else
+                projectile_velocity = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+        }
+        sdl3d_properties_set_vec3(actor->props, "velocity", projectile_velocity);
+    }
     actor_pool_note_spawn_success(runtime, pool);
 
     if (cooldown_property != NULL && cooldown_property[0] != '\0')
@@ -14612,10 +14627,15 @@ static void fps_controller_publish_actor_state(const fps_controller_runtime *con
 {
     if (controller == NULL || component == NULL || actor == NULL)
         return;
+    const float cos_pitch = SDL_cosf(controller->mover.pitch);
+    const sdl3d_vec3 forward =
+        sdl3d_vec3_make(SDL_sinf(controller->mover.yaw) * cos_pitch, SDL_sinf(controller->mover.pitch),
+                        -SDL_cosf(controller->mover.yaw) * cos_pitch);
     actor_set_position(actor, controller->mover.position);
     sdl3d_properties_set_float(actor->props, json_string(component, "yaw_property", "yaw"), controller->mover.yaw);
     sdl3d_properties_set_float(actor->props, json_string(component, "pitch_property", "pitch"),
                                controller->mover.pitch);
+    sdl3d_properties_set_vec3(actor->props, json_string(component, "forward_property", "camera_forward"), forward);
     sdl3d_properties_set_float(actor->props, json_string(component, "view_smooth_property", "view_smooth"),
                                controller->mover.view_smooth);
     sdl3d_properties_set_float(actor->props, json_string(component, "vertical_velocity_property", "vertical_velocity"),

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2571,9 +2571,13 @@ static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *c
     if (jump != NULL && !require_ref(ctx, &names->actions, "input action", jump, path))
         return false;
 
-    const char *property_keys[] = {"yaw_property",         "pitch_property",
-                                   "view_smooth_property", "vertical_velocity_property",
-                                   "on_ground_property",   "sector_property"};
+    const char *property_keys[] = {"yaw_property",
+                                   "pitch_property",
+                                   "forward_property",
+                                   "view_smooth_property",
+                                   "vertical_velocity_property",
+                                   "on_ground_property",
+                                   "sector_property"};
     for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
     {
         yyjson_val *value = obj_get(component, property_keys[i]);
@@ -4882,6 +4886,14 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *velocity = obj_get(action, "velocity");
         if (velocity != NULL && !is_vec_array(velocity, 3))
             return validation_error(ctx, json_path, "projectile.fire velocity must be a vec3");
+        yyjson_val *velocity_from_property = obj_get(action, "velocity_from_property");
+        if (velocity_from_property != NULL &&
+            (!yyjson_is_str(velocity_from_property) || yyjson_get_str(velocity_from_property)[0] == '\0'))
+            return validation_error(ctx, json_path,
+                                    "projectile.fire velocity_from_property must be a non-empty string");
+        yyjson_val *speed = obj_get(action, "speed");
+        if (speed != NULL && (!yyjson_is_num(speed) || yyjson_get_num(speed) < 0.0))
+            return validation_error(ctx, json_path, "projectile.fire speed must be non-negative");
         yyjson_val *cooldown = obj_get(action, "cooldown");
         if (cooldown != NULL && !yyjson_is_num(cooldown))
             return validation_error(ctx, json_path, "projectile.fire cooldown must be numeric");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -115,6 +115,7 @@ struct RenderPrimitiveCapture
     int doom_health_sprites = 0;
     int doom_crates = 0;
     int doom_presentation_cubes = 0;
+    int doom_projectile_spheres = 0;
 };
 
 struct SectorLevelInstanceCapture
@@ -1350,6 +1351,8 @@ bool capture_render_primitive(void *userdata, const sdl3d_game_data_render_primi
         capture->doom_crates++;
     if (entity_name.rfind("entity.doom.presentation.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
         capture->doom_presentation_cubes++;
+    if (entity_name.rfind("pool.doom.projectiles.", 0) == 0 && primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
+        capture->doom_projectile_spheres++;
     if (entity_name == "entity.doom.robot.entry")
     {
         capture->saw_doom_robot_sprite = true;
@@ -6984,6 +6987,7 @@ TEST(GameDataRuntime, ArcadeShooterPrimitivesAreDataDriven)
       "properties": {
         "fire_timer": { "type": "float", "value": 0.0 },
         "fire_cooldown": { "type": "float", "value": 0.5 },
+        "camera_forward": { "type": "vec3", "value": [1.0, 0.0, 0.0] },
         "half_width": { "type": "float", "value": 0.25 },
         "half_height": { "type": "float", "value": 0.25 }
       },
@@ -7096,7 +7100,8 @@ TEST(GameDataRuntime, ArcadeShooterPrimitivesAreDataDriven)
             "type": "projectile.fire",
             "target": "entity.player",
             "pool": "pool.player_shots",
-            "velocity": [2.0, 0.0, 0.0],
+            "velocity_from_property": "camera_forward",
+            "speed": 2.0,
             "cooldown_property": "fire_timer"
           }
         ]
@@ -7771,6 +7776,8 @@ TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
     EXPECT_NEAR(player->position.y, 1.6f, 0.001f);
     EXPECT_EQ(sdl3d_properties_get_int(player->props, "current_sector", -1), 0);
     EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "on_ground", false));
+    expect_vec3_near(sdl3d_properties_get_vec3(player->props, "camera_forward", sdl3d_vec3_make(0.0f, 0.0f, 0.0f)),
+                     sdl3d_vec3_make(0.0f, 0.0f, -1.0f));
 
     sdl3d_camera3d camera{};
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.player", &camera));
@@ -8092,6 +8099,19 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     UiTextCapture ui_text{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui_text));
     EXPECT_TRUE(ui_text.saw_doom_reticle);
+    sdl3d_registered_actor *projectile = sdl3d_game_data_find_actor(runtime, "pool.doom.projectiles.0");
+    ASSERT_NE(projectile, nullptr);
+    EXPECT_FALSE(projectile->active);
+    const int fire_signal = sdl3d_game_data_find_signal(runtime, "signal.doom.fire");
+    ASSERT_GE(fire_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), fire_signal, nullptr);
+    EXPECT_TRUE(projectile->active);
+    expect_vec3_near(sdl3d_properties_get_vec3(projectile->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f)),
+                     sdl3d_vec3_make(0.0f, 0.0f, -20.0f));
+    EXPECT_EQ(sdl3d_game_data_world_light_count(runtime), 1);
+    RenderPrimitiveCapture projectile_capture{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &projectile_capture));
+    EXPECT_EQ(projectile_capture.doom_projectile_spheres, 1);
     sdl3d_game_data_sprite_asset robot_sprite{};
     ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.doom.robot.walk", &robot_sprite));
     EXPECT_EQ(robot_sprite.source_kind, SDL3D_SPRITE_ASSET_SOURCE_FILES);
@@ -8854,6 +8874,41 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "unknown actor pool",
+        },
+        {
+            "bad_projectile_speed",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "entities": [
+    { "name": "entity.player", "active": true }
+  ],
+  "actor_archetypes": [
+    { "name": "archetype.shot" }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "projectile.fire",
+            "target": "entity.player",
+            "pool": "pool.shots",
+            "velocity_from_property": "camera_forward",
+            "speed": -1.0
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "speed must be non-negative",
         },
         {
             "bad_spawn_from",


### PR DESCRIPTION
## Summary
- add generic FPS controller forward-vector publication for data-authored projectile/camera logic
- extend projectile.fire with velocity_from_property + speed so authored actions can fire along actor directions
- add Doom level projectile archetype/pool, fire input sensor, and signal binding in JSON
- document the new projectile and FPS controller fields

## Verification
- cmake --build build/debug --target sdl3d_game_data_test doom_level sdl3d_runner
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.ArcadeShooterPrimitivesAreDataDriven:GameDataRuntime.RunsAuthoredFpsSectorController:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions:GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors