### PR TITLE
Add sector-traced velocity motion

### DIFF
--- a/demos/doom_level/data/fragments/actors/projectiles.json
+++ b/demos/doom_level/data/fragments/actors/projectiles.json
@@ -21,8 +21,10 @@
           "lighting": false
         },
         {
-          "type": "motion.velocity_3d",
-          "property": "velocity"
+          "type": "motion.sector_velocity_3d",
+          "property": "velocity",
+          "sector_level": "sector.doom.e1m1",
+          "reason": "projectile impact"
         },
         {
           "type": "lifecycle.ttl",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -745,6 +745,10 @@ Reusable components include:
 - `motion.velocity_3d`: moves an actor by a `vec3` velocity property on all
   axes. This is useful for effect actors, projectiles, particles represented as
   pooled actors, and other simple kinematic objects.
+- `motion.sector_velocity_3d`: moves an actor by a `vec3` velocity property
+  through an authored `sector_level`, tracing against sector volumes and
+  despawning on impact by default. Use this for data-authored projectiles in
+  FPS/sector worlds.
 - `motion.patrol`: moves an actor through an authored list of 3D waypoints.
   Use `speed`, `wait_time`, `arrival_radius`, `mode` (`loop` or `ping_pong`),
   and optional `yaw_property` to expose movement direction to rendering or Lua

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -14921,6 +14921,30 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
                                                               actor->position.y + velocity.y * dt,
                                                               actor->position.z + velocity.z * dt));
                 }
+                else if (SDL_strcmp(type, "motion.sector_velocity_3d") == 0)
+                {
+                    const sector_level_runtime *level =
+                        find_sector_level_runtime(runtime, json_string(component, "sector_level", NULL));
+                    const char *property = json_string(component, "property", "velocity");
+                    const sdl3d_vec3 velocity = actor_vec_property(actor, property);
+                    const float speed = sdl3d_vec3_length(velocity);
+                    if (level == NULL || speed <= 0.000001f)
+                        continue;
+
+                    const sdl3d_vec3 direction = sdl3d_vec3_scale(velocity, 1.0f / speed);
+                    const sdl3d_level_trace_result trace = sdl3d_level_trace_point(
+                        &level->lightmapped, level->sectors, actor->position, direction, speed * dt);
+                    actor_set_position(actor, trace.end_point);
+                    if (trace.hit && json_bool(component, "despawn_on_hit", true))
+                    {
+                        if (actor_id > 0)
+                            (void)actor_pool_request_despawn(runtime, &runtime->actor_pools[pool_index], actor, i,
+                                                             json_string(component, "reason", "sector impact"));
+                        else
+                            actor->active = false;
+                        break;
+                    }
+                }
                 else if (SDL_strcmp(type, "motion.scroll_wrap") == 0)
                 {
                     const int axis = axis_index(json_string(component, "axis", "x"));

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2533,10 +2533,27 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb",    "collision.circle",   "control.axis_1d", "controller.fps_sector",
-        "lifecycle.ttl",      "light.directional", "light.point",        "light.spot",      "motion.grid_agent",
-        "motion.oscillate",   "motion.patrol",     "motion.scroll_wrap", "motion.spin",     "motion.velocity_2d",
-        "motion.velocity_3d", "particles.emitter", "property.decay",     "render.cube",     "render.sphere",
+        "adapter.controller",
+        "collision.aabb",
+        "collision.circle",
+        "control.axis_1d",
+        "controller.fps_sector",
+        "lifecycle.ttl",
+        "light.directional",
+        "light.point",
+        "light.spot",
+        "motion.grid_agent",
+        "motion.oscillate",
+        "motion.patrol",
+        "motion.scroll_wrap",
+        "motion.sector_velocity_3d",
+        "motion.spin",
+        "motion.velocity_2d",
+        "motion.velocity_3d",
+        "particles.emitter",
+        "property.decay",
+        "render.cube",
+        "render.sphere",
         "render.sprite",
     };
 
@@ -4332,6 +4349,21 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (rate != NULL && !yyjson_is_num(rate))
                     return validation_error(ctx, path, "motion.spin rate must be a number");
             }
+            else if (SDL_strcmp(type, "motion.sector_velocity_3d") == 0)
+            {
+                if (!require_ref(ctx, &names->sector_levels, "sector level", json_string(component, "sector_level"),
+                                 path))
+                    return false;
+                yyjson_val *property = obj_get(component, "property");
+                if (property != NULL && !is_non_empty_string(component, "property"))
+                    return validation_error(ctx, path, "motion.sector_velocity_3d property must be non-empty");
+                yyjson_val *despawn_on_hit = obj_get(component, "despawn_on_hit");
+                if (despawn_on_hit != NULL && !yyjson_is_bool(despawn_on_hit))
+                    return validation_error(ctx, path, "motion.sector_velocity_3d despawn_on_hit must be a boolean");
+                yyjson_val *reason = obj_get(component, "reason");
+                if (reason != NULL && !is_non_empty_string(component, "reason"))
+                    return validation_error(ctx, path, "motion.sector_velocity_3d reason must be non-empty");
+            }
             else if (SDL_strncmp(type, "light.", 6) == 0)
             {
                 yyjson_val *color = obj_get(component, "color");
@@ -4467,6 +4499,23 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
                 yyjson_val *property = obj_get(component, "property");
                 if (property != NULL && !is_non_empty_string(component, "property"))
                     return validation_error(ctx, component_path, "%s property must be non-empty", type);
+            }
+            else if (SDL_strcmp(type, "motion.sector_velocity_3d") == 0)
+            {
+                if (!require_ref(ctx, &names->sector_levels, "sector level", json_string(component, "sector_level"),
+                                 component_path))
+                    return false;
+                yyjson_val *property = obj_get(component, "property");
+                if (property != NULL && !is_non_empty_string(component, "property"))
+                    return validation_error(ctx, component_path,
+                                            "motion.sector_velocity_3d property must be non-empty");
+                yyjson_val *despawn_on_hit = obj_get(component, "despawn_on_hit");
+                if (despawn_on_hit != NULL && !yyjson_is_bool(despawn_on_hit))
+                    return validation_error(ctx, component_path,
+                                            "motion.sector_velocity_3d despawn_on_hit must be a boolean");
+                yyjson_val *reason = obj_get(component, "reason");
+                if (reason != NULL && !is_non_empty_string(component, "reason"))
+                    return validation_error(ctx, component_path, "motion.sector_velocity_3d reason must be non-empty");
             }
             else if (SDL_strcmp(type, "lifecycle.ttl") == 0)
             {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7792,6 +7792,118 @@ TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, SectorVelocityMotionDespawnsPooledActorsOnImpact)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_velocity_motion");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "world": {
+    "sector_levels": [
+      { "level": "sector.test", "variant": "unlit" }
+    ]
+  }
+})json");
+    write_text(dir / "sector_velocity.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Velocity Motion Test" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [2.0, 1.5, 2.0] },
+      "properties": {
+        "camera_forward": { "type": "vec3", "value": [1.0, 0.0, 0.0] },
+        "fire_timer": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] }
+      },
+      "components": [
+        {
+          "type": "motion.sector_velocity_3d",
+          "property": "velocity",
+          "sector_level": "sector.test",
+          "reason": "hit wall"
+        }
+      ]
+    }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1, "scene": "scene.play" }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "projectile.fire",
+            "target": "entity.player",
+            "pool": "pool.shots",
+            "velocity_from_property": "camera_forward",
+            "speed": 20.0
+          }
+        ]
+      }
+    ]
+  },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "wall" }],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_velocity.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_registered_actor *shot = sdl3d_game_data_find_actor(runtime, "pool.shots.0");
+    ASSERT_NE(shot, nullptr);
+    ASSERT_FALSE(shot->active);
+    const int fire_signal = sdl3d_game_data_find_signal(runtime, "signal.fire");
+    ASSERT_GE(fire_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), fire_signal, nullptr);
+    ASSERT_TRUE(shot->active);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.05f));
+    EXPECT_TRUE(shot->active);
+    EXPECT_NEAR(shot->position.x, 3.0f, 0.3f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+    EXPECT_FALSE(shot->active);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RunsAuthoredSectorDoorInteractionRenderAndCollision)
 {
     const std::filesystem::path dir = unique_test_dir("sector_doors");
@@ -8909,6 +9021,26 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "speed must be non-negative",
+        },
+        {
+            "bad_sector_velocity_level",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "components": [
+        { "type": "motion.sector_velocity_3d", "sector_level": "sector.missing" }
+      ]
+    }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "unknown sector level",
         },
         {
             "bad_spawn_from",


### PR DESCRIPTION
## Summary
- add reusable motion.sector_velocity_3d for velocity-driven actors in sector worlds
- trace sector velocity motion against authored sector volumes and despawn pooled actors on impact
- update Doom projectile data to use sector-traced motion instead of unconstrained velocity
- document and validate the new component

## Verification
- cmake --build build/debug --target sdl3d_game_data_test doom_level sdl3d_runner
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.SectorVelocityMotionDespawnsPooledActorsOnImpact:GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions