### PR TITLE
Add volume sensor camera triggers

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -11,7 +11,8 @@
     { "path": "fragments/actors/projectiles.json", "sections": ["actor_archetypes", "actor_pools", "signals", "logic"] },
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
-    { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] }
+    { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] },
+    { "path": "fragments/world/surveillance.json", "sections": ["logic"] }
   ],
   "app": {
     "title": "SDL3D Doom Level",
@@ -29,6 +30,13 @@
         "target_entity": "entity.player",
         "fovy": 65.0,
         "active": true
+      },
+      {
+        "name": "camera.doom.surveillance",
+        "type": "perspective",
+        "position": [4.0, 3.25, 25.2],
+        "target": [4.0, 0.15, 18.4],
+        "fovy": 70.0
       }
     ]
   },

--- a/demos/doom_level/data/fragments/world/surveillance.json
+++ b/demos/doom_level/data/fragments/world/surveillance.json
@@ -1,0 +1,29 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "logic": {
+    "sensors": [
+      {
+        "name": "logic.doom.surveillance.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [41.8, -0.1, 87.8],
+        "max": [44.2, 2.0, 90.2],
+        "edge": "enter",
+        "actions": [
+          { "type": "camera.set", "camera": "camera.doom.surveillance" }
+        ]
+      },
+      {
+        "name": "logic.doom.surveillance.exit",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [41.8, -0.1, 87.8],
+        "max": [44.2, 2.0, 90.2],
+        "edge": "exit",
+        "actions": [
+          { "type": "camera.set", "camera": "camera.doom.player" }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -928,6 +928,25 @@ Use `actor_tag` instead of `actor` to apply a sector sensor to every active
 actor with a matching tag. `sector_index` may be used instead of `sector` when
 the authored sector order is deliberate and stable.
 
+`sensor.volume` detects whether an actor is inside an authored axis-aligned 3D
+box. It supports the same `enter`, `stay` / `overlap`, and `exit` edges and
+publishes `actor_name` to actions or signals. Use it for trigger volumes such
+as camera zones, pickups, checkpoints, and area-specific effects:
+
+```json
+{
+  "name": "sensor.camera_zone.enter",
+  "type": "sensor.volume",
+  "actor": "entity.player",
+  "min": [41.8, -0.1, 87.8],
+  "max": [44.2, 2.0, 90.2],
+  "edge": "enter",
+  "actions": [
+    { "type": "camera.set", "camera": "camera.surveillance" }
+  ]
+}
+```
+
 `logic.wave_schedules` spawn actors from pools over time:
 
 ```json

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -52,6 +52,7 @@ typedef enum game_data_sensor_type
     GAME_DATA_SENSOR_CONTACT_2D,
     GAME_DATA_SENSOR_INPUT_PRESSED,
     GAME_DATA_SENSOR_SECTOR,
+    GAME_DATA_SENSOR_VOLUME,
 } game_data_sensor_type;
 
 typedef struct named_signal
@@ -116,6 +117,7 @@ typedef struct sensor_contact_pair_state
 typedef struct sensor_entry
 {
     game_data_sensor_type type;
+    const char *name;
     const char *entity;
     const char *other;
     const char *entity_tag;
@@ -130,6 +132,8 @@ typedef struct sensor_entry
     float min_value;
     float max_value;
     float threshold;
+    sdl3d_vec3 volume_min;
+    sdl3d_vec3 volume_max;
     int signal_id;
     yyjson_val *actions;
     const char *edge;
@@ -14168,7 +14172,10 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
             entry->type = GAME_DATA_SENSOR_INPUT_PRESSED;
         else if (SDL_strcmp(type, "sensor.sector") == 0)
             entry->type = GAME_DATA_SENSOR_SECTOR;
+        else if (SDL_strcmp(type, "sensor.volume") == 0)
+            entry->type = GAME_DATA_SENSOR_VOLUME;
 
+        entry->name = json_string(sensor, "name", NULL);
         entry->entity = json_string(sensor, "entity", json_string(sensor, "a", NULL));
         if (entry->entity == NULL)
             entry->entity = json_string(sensor, "actor", NULL);
@@ -14187,6 +14194,8 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
         entry->min_value = json_float(sensor, "min", 0.0f);
         entry->max_value = json_float(sensor, "max", 0.0f);
         entry->threshold = json_float(sensor, "threshold", 0.0f);
+        entry->volume_min = json_vec3(sensor, "min", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+        entry->volume_max = json_vec3(sensor, "max", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
         entry->actions = obj_get(sensor, "actions");
         entry->edge = json_string(sensor, "edge", "enter");
         const char *signal_name =
@@ -15618,6 +15627,53 @@ static void update_sector_sensor(sdl3d_game_data_runtime *runtime, sensor_entry 
     sensor_actor_list_free(&actors);
 }
 
+static bool point_in_sensor_volume(const sensor_entry *sensor, sdl3d_vec3 position)
+{
+    if (sensor == NULL)
+        return false;
+    return position.x >= sensor->volume_min.x && position.x <= sensor->volume_max.x &&
+           position.y >= sensor->volume_min.y && position.y <= sensor->volume_max.y &&
+           position.z >= sensor->volume_min.z && position.z <= sensor->volume_max.z;
+}
+
+static void update_volume_sensor_actor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                       sdl3d_registered_actor *actor)
+{
+    if (!runtime_actor_is_active(runtime, actor))
+        return;
+
+    sensor_contact_pair_state *state = sensor_contact_pair_state_for(sensor, actor != NULL ? actor->name : NULL,
+                                                                     sensor->name != NULL ? sensor->name : "volume");
+    if (state == NULL)
+        return;
+
+    const bool active = point_in_sensor_volume(sensor, actor->position);
+    const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                             : sensor_edge_is_stay(sensor) ? active
+                                                           : (active && !state->active);
+    if (should_emit)
+    {
+        emit_sensor_signal(runtime, sensor, actor, NULL);
+        execute_sensor_actions(runtime, sensor, actor, NULL);
+    }
+    state->active = active;
+    state->seen = true;
+}
+
+static void update_volume_sensor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    sensor_actor_list actors;
+    SDL_zero(actors);
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &actors))
+    {
+        for (int i = 0; i < actors.count; ++i)
+            update_volume_sensor_actor(runtime, sensor, actors.items[i]);
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&actors);
+}
+
 static void update_sensors(sdl3d_game_data_runtime *runtime)
 {
     for (int i = 0; i < runtime->sensor_count; ++i)
@@ -15631,6 +15687,11 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
         if (sensor->type == GAME_DATA_SENSOR_SECTOR)
         {
             update_sector_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_VOLUME)
+        {
+            update_volume_sensor(runtime, sensor);
             continue;
         }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5549,6 +5549,55 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
                 return false;
             continue;
         }
+        if (SDL_strcmp(type, "sensor.volume") == 0)
+        {
+            const char *actor = json_string(sensor, "actor");
+            if (actor == NULL)
+                actor = json_string(sensor, "entity");
+            const char *actor_tag = json_string(sensor, "actor_tag");
+            if (actor_tag == NULL)
+                actor_tag = json_string(sensor, "a_tag");
+            yyjson_val *min_value = obj_get(sensor, "min");
+            yyjson_val *max_value = obj_get(sensor, "max");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((actor == NULL && actor_tag == NULL) || (actor != NULL && actor_tag != NULL))
+                return validation_error(ctx, path, "sensor.volume requires exactly one of actor or actor_tag");
+            if (actor != NULL && !require_actor_ref(ctx, names, actor, path))
+                return false;
+            if (actor_tag != NULL && actor_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.volume actor_tag must be non-empty");
+            if (!is_vec_array(min_value, 3) || !is_vec_array(max_value, 3))
+                return validation_error(ctx, path, "sensor.volume min and max must be vec3 values");
+            if (yyjson_get_num(yyjson_arr_get(min_value, 0)) > yyjson_get_num(yyjson_arr_get(max_value, 0)) ||
+                yyjson_get_num(yyjson_arr_get(min_value, 1)) > yyjson_get_num(yyjson_arr_get(max_value, 1)) ||
+                yyjson_get_num(yyjson_arr_get(min_value, 2)) > yyjson_get_num(yyjson_arr_get(max_value, 2)))
+            {
+                return validation_error(ctx, path, "sensor.volume min must be less than or equal to max");
+            }
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path, "sensor.volume edge must be enter, stay, overlap, or exit");
+            }
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            continue;
+        }
         return validation_error(ctx, path, "unsupported sensor type '%s'", type);
     }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7904,6 +7904,100 @@ TEST(GameDataRuntime, SectorVelocityMotionDespawnsPooledActorsOnImpact)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, VolumeSensorsRunEnterAndExitActions)
+{
+    const std::filesystem::path dir = unique_test_dir("volume_sensor_actions");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.player",
+  "updates_game": true,
+  "entities": ["entity.player"]
+})json");
+    write_text(dir / "volume_sensor.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Volume Sensor Test" },
+  "world": {
+    "name": "world.volume",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.player", "type": "perspective", "position": [0.0, 2.0, 5.0], "target": [0.0, 0.0, 0.0], "active": true },
+      { "name": "camera.zone", "type": "perspective", "position": [4.0, 3.0, 2.0], "target": [0.0, 0.0, 0.0] }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 0.0, 0.0] },
+      "properties": {
+        "zone_entries": { "type": "int", "value": 0 },
+        "zone_exits": { "type": "int", "value": 0 }
+      }
+    }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.zone.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [1.0, -1.0, -1.0],
+        "max": [3.0, 1.0, 1.0],
+        "edge": "enter",
+        "actions": [
+          { "type": "camera.set", "camera": "camera.zone" },
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "zone_entries", "value": 1 }
+        ]
+      },
+      {
+        "name": "sensor.zone.exit",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [1.0, -1.0, -1.0],
+        "max": [3.0, 1.0, 1.0],
+        "edge": "exit",
+        "actions": [
+          { "type": "camera.set", "camera": "camera.player" },
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "zone_exits", "value": 1 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "volume_sensor.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.player");
+
+    player->position = sdl3d_vec3_make(2.0f, 0.0f, 0.0f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.zone");
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "zone_entries", 0), 1);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "zone_entries", 0), 1);
+
+    player->position = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.player");
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "zone_exits", 0), 1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RunsAuthoredSectorDoorInteractionRenderAndCollision)
 {
     const std::filesystem::path dir = unique_test_dir("sector_doors");
@@ -8224,6 +8318,14 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     RenderPrimitiveCapture projectile_capture{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &projectile_capture));
     EXPECT_EQ(projectile_capture.doom_projectile_spheres, 1);
+    sdl3d_camera3d surveillance_camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.doom.surveillance", &surveillance_camera));
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.doom.player");
+    player->position = sdl3d_vec3_make(43.0f, 0.5f, 89.0f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.doom.surveillance");
     sdl3d_game_data_sprite_asset robot_sprite{};
     ASSERT_TRUE(sdl3d_game_data_get_sprite_asset(runtime, "sprite.doom.robot.walk", &robot_sprite));
     EXPECT_EQ(robot_sprite.source_kind, SDL3D_SPRITE_ASSET_SOURCE_FILES);
@@ -9173,6 +9275,31 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "exactly one of a or a_tag",
+        },
+        {
+            "bad_volume_bounds",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "entities": [
+    { "name": "entity.player", "active": true }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [2.0, 0.0, 0.0],
+        "max": [1.0, 1.0, 1.0],
+        "actions": [
+          { "type": "property.add", "target": "entity.player", "key": "hits", "value": 1 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "min must be less than or equal to max",
         },
     };
 


### PR DESCRIPTION
## Summary
- add reusable sensor.volume trigger volumes with enter/stay/exit edges
- validate volume actor refs, bounds, edge values, and action lists
- author Doom surveillance camera switching with JSON cameras and volume sensors
- document volume sensors for camera zones, pickups, checkpoints, and effects

## Verification
- cmake --build build/debug --target sdl3d_game_data_test doom_level sdl3d_runner
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.VolumeSensorsRunEnterAndExitActions:GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions