### PR TITLE
Remove native Doom projectile glue

### DIFF
--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -327,7 +327,6 @@ static bool doom_logic_teleport_player(void *userdata, const sdl3d_teleport_dest
 
     sdl3d_fps_mover_teleport(&state->player.mover, destination->position, destination->use_yaw, destination->yaw,
                              destination->use_pitch, destination->pitch);
-    state->player.proj_active = false;
     state->teleport_feedback_timer = TELEPORT_FEEDBACK_SECONDS;
     const int trigger_id =
         payload != NULL

--- a/demos/doom_level/player.c
+++ b/demos/doom_level/player.c
@@ -1,4 +1,4 @@
-/* Player controller: FPS mover, input, projectile. */
+/* Player controller: FPS mover and input. */
 #include "player.h"
 
 #include <SDL3/SDL_scancode.h>
@@ -9,27 +9,11 @@
 #define MOVE_SPEED 12.0f
 #define JUMP_VELOCITY 6.0f
 #define GRAVITY 14.0f
-#define PROJ_SPEED 20.0f
-#define PROJ_LIFETIME 3.0f
-
-static void player_fire_projectile(player_state *p)
-{
-    p->proj_active = true;
-    p->proj_x = p->mover.position.x;
-    p->proj_y = p->mover.position.y;
-    p->proj_z = p->mover.position.z;
-    p->proj_dx = SDL_sinf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
-    p->proj_dy = SDL_sinf(p->mover.pitch);
-    p->proj_dz = -SDL_cosf(p->mover.yaw) * SDL_cosf(p->mover.pitch);
-    p->proj_life = PROJ_LIFETIME;
-}
 
 static void player_reset(player_state *p)
 {
     sdl3d_fps_mover_init(&p->mover, &p->config, sdl3d_vec3_make(PLAYER_SPAWN_X, PLAYER_HEIGHT, PLAYER_SPAWN_Z),
                          PLAYER_SPAWN_YAW);
-    p->proj_active = false;
-    p->proj_life = 0.0f;
     p->damage_taken = 0.0f;
     p->last_damage_per_second = 0.0f;
 }
@@ -50,7 +34,6 @@ void player_init(player_state *p, sdl3d_input_manager *input)
     p->action_move_left = sdl3d_input_find_action(input, "move_left");
     p->action_move_right = sdl3d_input_find_action(input, "move_right");
     p->action_jump = sdl3d_input_find_action(input, "jump");
-    p->action_fire = sdl3d_input_find_action(input, "fire");
     p->action_menu = sdl3d_input_find_action(input, "menu");
     p->action_reset = sdl3d_input_register_action(input, "reset_player");
     sdl3d_input_bind_key(input, p->action_reset, SDL_SCANCODE_BACKSPACE);
@@ -77,11 +60,6 @@ bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3
         sdl3d_fps_mover_jump(&p->mover);
     }
 
-    if (sdl3d_input_is_pressed(input, p->action_fire))
-    {
-        player_fire_projectile(p);
-    }
-
     /* Action movement in world XZ space. */
     float fwd_x = SDL_sinf(p->mover.yaw);
     float fwd_z = -SDL_cosf(p->mover.yaw);
@@ -97,23 +75,6 @@ bool player_update(player_state *p, const sdl3d_input_manager *input, const sdl3
 
     sdl3d_fps_mover_update(&p->mover, level, sectors, wish, sdl3d_input_get_mouse_dx(input),
                            sdl3d_input_get_mouse_dy(input), MOUSE_SENS, dt);
-
-    /* Projectile trace. */
-    if (p->proj_active)
-    {
-        float travel = PROJ_SPEED * dt;
-        sdl3d_vec3 dir = sdl3d_vec3_make(p->proj_dx, p->proj_dy, p->proj_dz);
-        sdl3d_level_trace_result tr =
-            sdl3d_level_trace_point(level, sectors, sdl3d_vec3_make(p->proj_x, p->proj_y, p->proj_z), dir, travel);
-        p->proj_x = tr.end_point.x;
-        p->proj_y = tr.end_point.y;
-        p->proj_z = tr.end_point.z;
-        if (tr.hit)
-            p->proj_active = false;
-        p->proj_life -= dt;
-        if (p->proj_life <= 0.0f)
-            p->proj_active = false;
-    }
 
     return true;
 }

--- a/demos/doom_level/player.h
+++ b/demos/doom_level/player.h
@@ -1,4 +1,4 @@
-/* Player controller: FPS mover, input, projectile. */
+/* Player controller: FPS mover and input. */
 #ifndef DOOM_PLAYER_H
 #define DOOM_PLAYER_H
 
@@ -29,15 +29,8 @@ typedef struct player_state
     int action_move_left;
     int action_move_right;
     int action_jump;
-    int action_fire;
     int action_menu;
     int action_reset;
-
-    /* Projectile */
-    bool proj_active;
-    float proj_x, proj_y, proj_z;
-    float proj_dx, proj_dy, proj_dz;
-    float proj_life;
 
     /* Demonstration damage bookkeeping; death rules are intentionally omitted. */
     float damage_taken;

--- a/demos/doom_level/renderer.c
+++ b/demos/doom_level/renderer.c
@@ -9,12 +9,6 @@
 #include "sdl3d/lighting.h"
 #include "sdl3d/sdl3d.h"
 
-#define ROCKET_LIGHT_R 1.0f
-#define ROCKET_LIGHT_G 0.6f
-#define ROCKET_LIGHT_B 0.2f
-#define ROCKET_LIGHT_INTENSITY 4.0f
-#define ROCKET_LIGHT_RANGE 4.0f
-
 void render_state_init(render_state *rs)
 {
     SDL_zerop(rs);
@@ -74,18 +68,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
 
     /* Dynamic lights. */
     sdl3d_clear_lights(ctx);
-    if (player->proj_active)
-    {
-        sdl3d_light rocket = {0};
-        rocket.type = SDL3D_LIGHT_POINT;
-        rocket.position = sdl3d_vec3_make(player->proj_x, player->proj_y, player->proj_z);
-        rocket.color[0] = ROCKET_LIGHT_R;
-        rocket.color[1] = ROCKET_LIGHT_G;
-        rocket.color[2] = ROCKET_LIGHT_B;
-        rocket.intensity = ROCKET_LIGHT_INTENSITY;
-        rocket.range = ROCKET_LIGHT_RANGE;
-        sdl3d_add_light(ctx, &rocket);
-    }
 
     sdl3d_clear_render_context(ctx, (sdl3d_color){10, 10, 15, 255});
     sdl3d_begin_mode_3d(ctx, cam);
@@ -140,15 +122,6 @@ void render_draw_frame(render_state *rs, sdl3d_render_context *ctx, const sdl3d_
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Hazard particle draw failed: %s", SDL_GetError());
         SDL_ClearError();
-    }
-
-    /* Projectile */
-    if (player->proj_active)
-    {
-        sdl3d_set_emissive(ctx, 5.0f, 3.0f, 1.0f);
-        sdl3d_draw_sphere(ctx, sdl3d_vec3_make(player->proj_x, player->proj_y, player->proj_z), 0.1f, 8, 8,
-                          (sdl3d_color){255, 200, 100, 255});
-        sdl3d_set_emissive(ctx, 0, 0, 0);
     }
 
     sdl3d_end_mode_3d(ctx);


### PR DESCRIPTION
## Summary
- remove legacy projectile input, state, tracing, rendering, and point-light code from the native Doom host
- leave projectiles owned by the data-authored actor pool / projectile.fire / sector velocity path
- remove the teleport reset hook that only existed for native projectile state

## Verification
- cmake --build build/debug --target doom_level sdl3d_game_data_test sdl3d_runner
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.SectorVelocityMotionDespawnsPooledActorsOnImpact:GameDataRuntime.DoomLevelDataFiresAuthoredProjectile
- git diff --check