### PR TITLE
Author Doom launch and teleport triggers

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -12,6 +12,7 @@
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
     { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] },
+    { "path": "fragments/world/player_triggers.json", "sections": ["logic"] },
     { "path": "fragments/world/surveillance.json", "sections": ["logic"] }
   ],
   "app": {

--- a/demos/doom_level/data/fragments/world/player_triggers.json
+++ b/demos/doom_level/data/fragments/world/player_triggers.json
@@ -1,0 +1,39 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.launcher.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [36.5, 0.0, 66.5],
+        "max": [39.5, 2.4, 69.5],
+        "edge": "enter",
+        "actions": [
+          {
+            "type": "controller.fps_sector.launch",
+            "target": "entity.player",
+            "vertical_velocity": 15.0
+          }
+        ]
+      },
+      {
+        "name": "sensor.teleporter.dragon.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [22.5, 0.0, 86.5],
+        "max": [25.5, 2.4, 89.5],
+        "edge": "enter",
+        "actions": [
+          {
+            "type": "controller.fps_sector.teleport",
+            "target": "entity.player",
+            "position": [72.0, 4.1, 63.0],
+            "yaw": -1.5707964,
+            "pitch": 0.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -22,8 +22,6 @@
 #define SIG_FADE_OUT_DONE 2001
 #define SIG_AMBIENT_FEEDBACK 2004
 #define SIG_AMBIENT_FEEDBACK_SKIP 2005
-#define SIG_LAUNCHER_ENTER 2007
-#define SIG_DRAGON_TELEPORT_ENTER 2008
 #define SIG_DAMAGE_FLOOR_TICK 2009
 #define LIFT_FLOOR_MIN_Y 0.0f
 #define LIFT_FLOOR_MAX_Y 2.5f
@@ -33,17 +31,11 @@
 #define LIFT_ENTITY_ID 1
 #define AMBIENT_FADE_SECONDS 1.0f
 #define AMBIENT_FEEDBACK_SECONDS 5.0f
-#define TELEPORT_FEEDBACK_SECONDS 2.0f
-#define LAUNCHER_FEEDBACK_SECONDS 1.25f
-#define LAUNCHER_VERTICAL_VELOCITY 15.0f
-#define DRAGON_TELEPORTER_ID 1
 #define DAMAGE_FEEDBACK_REFERENCE_DPS 30.0f
 #define DAMAGE_FEEDBACK_MIN_STRENGTH 0.35f
 #define DAMAGE_FEEDBACK_ATTACK_RATE 10.0f
 #define DAMAGE_FEEDBACK_DECAY_RATE 4.0f
 #define DAMAGE_FEEDBACK_PULSE_HZ 2.8f
-#define LAUNCHER_PAD_X 38.0f
-#define LAUNCHER_PAD_Z 68.0f
 #define FEEDBACK_AMBIENT_ZONE "ambient_zone"
 #define FEEDBACK_DAMAGE_FLOOR "damage_floor"
 
@@ -62,14 +54,10 @@ typedef struct doom_state
     sdl3d_logic_branch ambient_feedback_branch;
     sdl3d_logic_sector_platform dynamic_lift;
     sdl3d_logic_sector_damage_sensor damage_sensor;
-    sdl3d_logic_contact_sensor launcher_sensor;
-    sdl3d_logic_contact_sensor dragon_teleport_sensor;
     sdl3d_sector_watcher sector_watcher;
     sdl3d_backend current_backend;
     doom_render_profile render_profile;
     float ambient_feedback_timer;
-    float teleport_feedback_timer;
-    float launcher_feedback_timer;
     float damage_feedback_strength;
     float damage_feedback_target_strength;
     float damage_pulse_timer;
@@ -251,65 +239,6 @@ static bool doom_logic_set_sector_geometry(void *userdata, int sector_index, con
     return true;
 }
 
-static bool doom_logic_launch_player(void *userdata, sdl3d_vec3 velocity, const sdl3d_properties *payload)
-{
-    (void)payload;
-    doom_state *state = (doom_state *)userdata;
-    if (state == NULL || velocity.y <= 0.0f)
-    {
-        return false;
-    }
-
-    sdl3d_fps_mover_launch(&state->player.mover, velocity.y);
-    state->launcher_feedback_timer = LAUNCHER_FEEDBACK_SECONDS;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Launcher applied vertical velocity %.1f", velocity.y);
-    return true;
-}
-
-static bool doom_logic_teleport_player(void *userdata, const sdl3d_teleport_destination *destination,
-                                       const sdl3d_properties *payload)
-{
-    doom_state *state = (doom_state *)userdata;
-
-    if (state == NULL || destination == NULL)
-    {
-        return false;
-    }
-
-    sdl3d_fps_mover_teleport(&state->player.mover, destination->position, destination->use_yaw, destination->yaw,
-                             destination->use_pitch, destination->pitch);
-    state->teleport_feedback_timer = TELEPORT_FEEDBACK_SECONDS;
-    const int trigger_id =
-        payload != NULL
-            ? sdl3d_properties_get_int(payload, "teleporter_id", sdl3d_properties_get_int(payload, "sensor_id", -1))
-            : -1;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Teleport trigger %d moved player to %.1f %.1f %.1f", trigger_id,
-                destination->position.x, destination->position.y, destination->position.z);
-    return true;
-}
-
-static sdl3d_teleport_destination dragon_teleport_destination(void)
-{
-    sdl3d_teleport_destination destination;
-    SDL_zero(destination);
-    destination.position = sdl3d_vec3_make(72.0f, 2.5f + PLAYER_HEIGHT, 63.0f);
-    destination.yaw = -SDL_PI_F * 0.5f;
-    destination.pitch = 0.0f;
-    destination.use_yaw = true;
-    destination.use_pitch = true;
-    return destination;
-}
-
-static void init_dragon_teleport_sensor(doom_state *state)
-{
-    const sdl3d_bounding_box source = {
-        sdl3d_vec3_make(22.5f, 0.0f, 86.5f),
-        sdl3d_vec3_make(25.5f, 2.4f, 89.5f),
-    };
-    sdl3d_logic_contact_sensor_init(&state->dragon_teleport_sensor, DRAGON_TELEPORTER_ID, source,
-                                    SIG_DRAGON_TELEPORT_ENTER, SDL3D_TRIGGER_EDGE_ENTER);
-}
-
 static void init_dynamic_lift(doom_state *state)
 {
     sdl3d_logic_sector_platform_init(&state->dynamic_lift, LIFT_ENTITY_ID,
@@ -317,15 +246,6 @@ static void init_dynamic_lift(doom_state *state)
                                      LIFT_FLOOR_MAX_Y, LIFT_CEIL_Y, LIFT_CYCLE_SECONDS, LIFT_REBUILD_MIN_DELTA);
     state->dynamic_lift.last_floor_y = g_sectors[DOOM_DYNAMIC_LIFT_SECTOR].floor_y;
     state->dynamic_lift.has_last_floor_y = true;
-}
-
-static void init_launcher_sensor(doom_state *state)
-{
-    const sdl3d_bounding_box bounds = {
-        sdl3d_vec3_make(LAUNCHER_PAD_X - 1.5f, -0.15f, LAUNCHER_PAD_Z - 1.5f),
-        sdl3d_vec3_make(LAUNCHER_PAD_X + 1.5f, 0.45f, LAUNCHER_PAD_Z + 1.5f),
-    };
-    sdl3d_logic_contact_sensor_init(&state->launcher_sensor, 1, bounds, SIG_LAUNCHER_ENTER, SDL3D_TRIGGER_EDGE_ENTER);
 }
 
 static void init_damage_sensor(doom_state *state)
@@ -344,11 +264,9 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     sdl3d_logic_game_adapters adapters;
     SDL_zero(adapters);
     adapters.userdata = state;
-    adapters.teleport_player = doom_logic_teleport_player;
     adapters.set_ambient = doom_logic_set_ambient;
     adapters.trigger_feedback = doom_logic_trigger_feedback;
     adapters.set_sector_geometry = doom_logic_set_sector_geometry;
-    adapters.launch_player = doom_logic_launch_player;
     sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
 
     sdl3d_logic_target_context target_context;
@@ -379,25 +297,6 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     sdl3d_logic_action ambient_feedback_action =
         sdl3d_logic_action_make_trigger_feedback(FEEDBACK_AMBIENT_ZONE, AMBIENT_FEEDBACK_SECONDS);
     if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_AMBIENT_FEEDBACK, &ambient_feedback_action) == 0)
-    {
-        return false;
-    }
-
-    sdl3d_logic_action teleport_action = sdl3d_logic_action_make_teleport_player_from_payload();
-    if (sdl3d_logic_world_bind_logic_action(state->logic, SDL3D_SIGNAL_TELEPORT, &teleport_action) == 0)
-    {
-        return false;
-    }
-
-    sdl3d_logic_action dragon_teleport_action = sdl3d_logic_action_make_teleport_player(dragon_teleport_destination());
-    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_DRAGON_TELEPORT_ENTER, &dragon_teleport_action) == 0)
-    {
-        return false;
-    }
-
-    sdl3d_logic_action launcher_action =
-        sdl3d_logic_action_make_launch_player(sdl3d_vec3_make(0.0f, LAUNCHER_VERTICAL_VELOCITY, 0.0f));
-    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_LAUNCHER_ENTER, &launcher_action) == 0)
     {
         return false;
     }
@@ -501,8 +400,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     state->entities_ready = true;
 
     player_init(&state->player, ctx_input(ctx));
-    init_dragon_teleport_sensor(state);
-    init_launcher_sensor(state);
     init_damage_sensor(state);
     if (!bind_doom_logic(ctx, state))
     {
@@ -826,10 +723,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
             player_ms = doom_profile_elapsed_ms(section_start, now);
             section_start = now;
         }
-        sdl3d_logic_contact_sensor_update(&state->launcher_sensor, state->logic,
-                                          sdl3d_vec3_make(state->player.mover.position.x,
-                                                          state->player.mover.position.y - PLAYER_HEIGHT,
-                                                          state->player.mover.position.z));
         player_apply_sector_damage(&state->player, g_sectors, g_sector_count, dt);
         sdl3d_logic_sector_damage_sensor_update(&state->damage_sensor, state->logic,
                                                 sdl3d_vec3_make(state->player.mover.position.x,
@@ -853,28 +746,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
             state->ambient_feedback_timer = 0.0f;
         }
     }
-    if (state->teleport_feedback_timer > 0.0f)
-    {
-        state->teleport_feedback_timer -= dt;
-        if (state->teleport_feedback_timer < 0.0f)
-        {
-            state->teleport_feedback_timer = 0.0f;
-        }
-    }
-    if (state->launcher_feedback_timer > 0.0f)
-    {
-        state->launcher_feedback_timer -= dt;
-        if (state->launcher_feedback_timer < 0.0f)
-        {
-            state->launcher_feedback_timer = 0.0f;
-        }
-    }
-
-    sdl3d_logic_contact_sensor_update(&state->dragon_teleport_sensor, state->logic,
-                                      sdl3d_vec3_make(state->player.mover.position.x,
-                                                      state->player.mover.position.y - PLAYER_HEIGHT,
-                                                      state->player.mover.position.z));
-
     sdl3d_sector_watcher_update(&state->sector_watcher, &state->level.unlit, g_sectors,
                                 sdl3d_vec3_make(state->player.mover.position.x,
                                                 state->player.mover.position.y - PLAYER_HEIGHT,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -474,6 +474,35 @@ defaults are `yaw`, `pitch`, `view_smooth`, `vertical_velocity`, `on_ground`,
 and `current_sector`. Use an `fps` camera targeting the same actor for the
 player view.
 
+FPS sector controllers also expose reusable actions for trigger volumes and
+scripted events:
+
+```json
+{
+  "type": "controller.fps_sector.launch",
+  "target": "entity.player",
+  "vertical_velocity": 15.0
+}
+```
+
+`controller.fps_sector.launch` applies an upward impulse to the controller and
+requires a positive `vertical_velocity`.
+
+```json
+{
+  "type": "controller.fps_sector.teleport",
+  "target": "entity.player",
+  "position": [72.0, 4.1, 63.0],
+  "yaw": -1.5707964,
+  "pitch": 0.0
+}
+```
+
+`controller.fps_sector.teleport` moves the controller and actor to the given
+eye-position. `yaw` and `pitch` are optional; omitted angles preserve the
+current orientation. Both actions also support `target_from_payload` instead of
+`target` when a sensor payload supplies the actor name.
+
 ## Scenes
 
 `scenes` defines the initial scene and scene files or packages:

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6791,6 +6791,10 @@ static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime
 }
 
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload);
+static bool execute_fps_controller_launch_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                 const sdl3d_properties *payload);
+static bool execute_fps_controller_teleport_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   const sdl3d_properties *payload);
 static sdl3d_registered_actor *actor_from_payload_key(sdl3d_game_data_runtime *runtime, const sdl3d_properties *payload,
                                                       const char *key);
 
@@ -13814,6 +13818,10 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
+    if (SDL_strcmp(type, "controller.fps_sector.launch") == 0)
+        return execute_fps_controller_launch_action(runtime, action, payload);
+    if (SDL_strcmp(type, "controller.fps_sector.teleport") == 0)
+        return execute_fps_controller_teleport_action(runtime, action, payload);
     if (SDL_strcmp(type, "grid.spawn_from_glyphs") == 0)
         return execute_grid_spawn_from_glyphs_action(runtime, action);
     if (SDL_strcmp(type, "grid.spawn_runs_from_glyphs") == 0)
@@ -14655,6 +14663,93 @@ static void fps_controller_publish_actor_state(const fps_controller_runtime *con
                              controller->mover.current_sector);
 }
 
+static bool initialize_fps_controller_runtime(sdl3d_game_data_runtime *runtime, fps_controller_runtime *controller,
+                                              yyjson_val *component, sdl3d_registered_actor *actor)
+{
+    (void)runtime;
+    if (controller == NULL || component == NULL || actor == NULL)
+        return false;
+    if (controller->initialized)
+        return true;
+
+    sdl3d_fps_mover_config config;
+    SDL_zero(config);
+    config.move_speed = json_float(component, "move_speed", 12.0f);
+    config.jump_velocity = json_float(component, "jump_velocity", 6.0f);
+    config.gravity = json_float(component, "gravity", 14.0f);
+    config.player_height = json_float(component, "player_height", 1.6f);
+    config.player_radius = json_float(component, "player_radius", 0.35f);
+    config.step_height = json_float(component, "step_height", 1.1f);
+    config.ceiling_clearance = json_float(component, "ceiling_clearance", 0.1f);
+    const float yaw = sdl3d_properties_get_float(actor->props, json_string(component, "yaw_property", "yaw"),
+                                                 json_float(component, "spawn_yaw", 0.0f));
+    sdl3d_fps_mover_init(&controller->mover, &config, actor->position, yaw);
+    controller->mover.pitch = sdl3d_properties_get_float(
+        actor->props, json_string(component, "pitch_property", "pitch"), json_float(component, "spawn_pitch", 0.0f));
+    controller->initialized = true;
+    fps_controller_publish_actor_state(controller, component, actor);
+    return true;
+}
+
+static fps_controller_runtime *fps_controller_for_actor_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                               const sdl3d_properties *payload,
+                                                               sdl3d_registered_actor **out_actor,
+                                                               yyjson_val **out_component)
+{
+    const char *target = json_string(action, "target", NULL);
+    const char *target_from_payload = json_string(action, "target_from_payload", NULL);
+    if ((target == NULL || target[0] == '\0') && target_from_payload != NULL && payload != NULL)
+        target = sdl3d_properties_get_string(payload, target_from_payload, NULL);
+
+    sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, target);
+    yyjson_val *entity = find_entity_json(runtime, target);
+    yyjson_val *component = find_component_json(entity, "controller.fps_sector");
+    fps_controller_runtime *controller =
+        actor != NULL && component != NULL ? find_or_add_fps_controller(runtime, target, component) : NULL;
+    if (controller == NULL || !initialize_fps_controller_runtime(runtime, controller, component, actor))
+        return NULL;
+
+    if (out_actor != NULL)
+        *out_actor = actor;
+    if (out_component != NULL)
+        *out_component = component;
+    return controller;
+}
+
+static bool execute_fps_controller_launch_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                 const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = NULL;
+    yyjson_val *component = NULL;
+    fps_controller_runtime *controller = fps_controller_for_actor_action(runtime, action, payload, &actor, &component);
+    const float vertical_velocity = json_float(action, "vertical_velocity", 0.0f);
+    if (controller == NULL || vertical_velocity <= 0.0f)
+        return false;
+
+    sdl3d_fps_mover_launch(&controller->mover, vertical_velocity);
+    fps_controller_publish_actor_state(controller, component, actor);
+    return true;
+}
+
+static bool execute_fps_controller_teleport_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = NULL;
+    yyjson_val *component = NULL;
+    fps_controller_runtime *controller = fps_controller_for_actor_action(runtime, action, payload, &actor, &component);
+    yyjson_val *position = obj_get(action, "position");
+    if (controller == NULL || !yyjson_is_arr(position) || yyjson_arr_size(position) != 3)
+        return false;
+
+    yyjson_val *yaw = obj_get(action, "yaw");
+    yyjson_val *pitch = obj_get(action, "pitch");
+    sdl3d_fps_mover_teleport(&controller->mover, json_vec3_value(position, actor->position), yyjson_is_num(yaw),
+                             json_float(action, "yaw", controller->mover.yaw), yyjson_is_num(pitch),
+                             json_float(action, "pitch", controller->mover.pitch));
+    fps_controller_publish_actor_state(controller, component, actor);
+    return true;
+}
+
 static sdl3d_bounding_box sector_door_closed_bounds(const sdl3d_door *door)
 {
     if (door == NULL || door->panel_count <= 0)
@@ -14750,25 +14845,8 @@ static void update_fps_sector_controller(sdl3d_game_data_runtime *runtime, yyjso
     if (controller == NULL)
         return;
 
-    if (!controller->initialized)
-    {
-        sdl3d_fps_mover_config config;
-        SDL_zero(config);
-        config.move_speed = json_float(component, "move_speed", 12.0f);
-        config.jump_velocity = json_float(component, "jump_velocity", 6.0f);
-        config.gravity = json_float(component, "gravity", 14.0f);
-        config.player_height = json_float(component, "player_height", 1.6f);
-        config.player_radius = json_float(component, "player_radius", 0.35f);
-        config.step_height = json_float(component, "step_height", 1.1f);
-        config.ceiling_clearance = json_float(component, "ceiling_clearance", 0.1f);
-        const float yaw = sdl3d_properties_get_float(actor->props, json_string(component, "yaw_property", "yaw"),
-                                                     json_float(component, "spawn_yaw", 0.0f));
-        sdl3d_fps_mover_init(&controller->mover, &config, actor->position, yaw);
-        controller->mover.pitch =
-            sdl3d_properties_get_float(actor->props, json_string(component, "pitch_property", "pitch"),
-                                       json_float(component, "spawn_pitch", 0.0f));
-        controller->initialized = true;
-    }
+    if (!initialize_fps_controller_runtime(runtime, controller, component, actor))
+        return;
 
     const int forward_action = fps_controller_action_id(runtime, component, "forward");
     const int back_action = fps_controller_action_id(runtime, component, "back");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -4955,6 +4955,39 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "projectile.fire properties must be an object");
         return true;
     }
+    if (SDL_strcmp(type, "controller.fps_sector.launch") == 0 ||
+        SDL_strcmp(type, "controller.fps_sector.teleport") == 0)
+    {
+        yyjson_val *target_value = obj_get(action, "target");
+        yyjson_val *target_from_payload_value = obj_get(action, "target_from_payload");
+        const char *target = json_string(action, "target");
+        const char *target_from_payload = json_string(action, "target_from_payload");
+        if ((target == NULL && target_from_payload == NULL) || (target != NULL && target_from_payload != NULL))
+            return validation_error(ctx, json_path, "%s requires exactly one of target or target_from_payload", type);
+        if (target_value != NULL && !yyjson_is_str(target_value))
+            return validation_error(ctx, json_path, "%s target must be a string", type);
+        if (target != NULL && !require_ref(ctx, &names->entities, "entity", target, json_path))
+            return false;
+        if (target_from_payload_value != NULL &&
+            (!yyjson_is_str(target_from_payload_value) || yyjson_get_str(target_from_payload_value)[0] == '\0'))
+            return validation_error(ctx, json_path, "%s target_from_payload must be a non-empty string", type);
+        if (SDL_strcmp(type, "controller.fps_sector.launch") == 0)
+        {
+            yyjson_val *vertical_velocity = obj_get(action, "vertical_velocity");
+            if (!yyjson_is_num(vertical_velocity) || yyjson_get_num(vertical_velocity) <= 0.0)
+                return validation_error(ctx, json_path,
+                                        "controller.fps_sector.launch requires positive vertical_velocity");
+            return true;
+        }
+
+        if (!is_vec_array(obj_get(action, "position"), 3))
+            return validation_error(ctx, json_path, "controller.fps_sector.teleport requires a vec3 position");
+        yyjson_val *yaw = obj_get(action, "yaw");
+        yyjson_val *pitch = obj_get(action, "pitch");
+        if ((yaw != NULL && !yyjson_is_num(yaw)) || (pitch != NULL && !yyjson_is_num(pitch)))
+            return validation_error(ctx, json_path, "controller.fps_sector.teleport yaw and pitch must be numeric");
+        return true;
+    }
     if (SDL_strcmp(type, "grid.spawn_from_glyphs") == 0 || SDL_strcmp(type, "grid.spawn_runs_from_glyphs") == 0)
     {
         if (!require_ref(ctx, &names->grid_maps, "grid map", json_string(action, "map"), json_path))

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7696,6 +7696,7 @@ TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
       }
     ]
   },
+  "signals": ["signal.launch", "signal.teleport"],
   "entities": [
     {
       "name": "entity.player",
@@ -7749,6 +7750,32 @@ TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
       ]
     }
   ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.launch",
+        "actions": [
+          {
+            "type": "controller.fps_sector.launch",
+            "target": "entity.player",
+            "vertical_velocity": 5.0
+          }
+        ]
+      },
+      {
+        "signal": "signal.teleport",
+        "actions": [
+          {
+            "type": "controller.fps_sector.teleport",
+            "target": "entity.player",
+            "position": [3.0, 1.8, 3.0],
+            "yaw": 1.25,
+            "pitch": -0.25
+          }
+        ]
+      }
+    ]
+  },
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json");
 
@@ -7786,6 +7813,18 @@ TEST(GameDataRuntime, RunsAuthoredFpsSectorController)
     EXPECT_NEAR(camera.position.y, player->position.y, 0.001f);
     EXPECT_NEAR(camera.position.z, player->position.z, 0.001f);
     EXPECT_LT(camera.target.z, camera.position.z);
+
+    const int launch_signal = sdl3d_game_data_find_signal(runtime, "signal.launch");
+    ASSERT_GE(launch_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), launch_signal, nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "vertical_velocity", 0.0f), 5.0f, 0.001f);
+
+    const int teleport_signal = sdl3d_game_data_find_signal(runtime, "signal.teleport");
+    ASSERT_GE(teleport_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), teleport_signal, nullptr);
+    expect_vec3_near(player->position, sdl3d_vec3_make(3.0f, 1.8f, 3.0f));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "yaw", 0.0f), 1.25f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "pitch", 0.0f), -0.25f, 0.001f);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -9300,6 +9339,33 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "min must be less than or equal to max",
+        },
+        {
+            "bad_fps_launch_velocity",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "entities": [
+    { "name": "entity.player", "active": true }
+  ],
+  "signals": ["signal.launch"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.launch",
+        "actions": [
+          {
+            "type": "controller.fps_sector.launch",
+            "target": "entity.player",
+            "vertical_velocity": 0.0
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "positive vertical_velocity",
         },
     };
 


### PR DESCRIPTION
## Summary
- add reusable `controller.fps_sector.launch` and `controller.fps_sector.teleport` data actions
- author the Doom launcher pad and dragon teleporter as `sensor.volume` triggers in JSON
- remove the native Doom launch/teleport contact sensors, adapters, and feedback timers from the old host
- document the new FPS-sector controller actions and add validation/test coverage

## Verification
- `cmake --build build/debug --target doom_level sdl3d_game_data_test sdl3d_runner`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.RunsAuthoredFpsSectorController:GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions`
- `git diff --check`
