### PR TITLE
Author Doom sector platforms

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -11,6 +11,7 @@
     { "path": "fragments/actors/projectiles.json", "sections": ["actor_archetypes", "actor_pools", "signals", "logic"] },
     { "path": "fragments/world/sector_levels.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/sector_doors.json", "sections": ["sector_doors", "signals", "logic"] },
+    { "path": "fragments/world/sector_platforms.json", "sections": ["sector_platforms"] },
     { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] },
     { "path": "fragments/world/player_triggers.json", "sections": ["logic"] },
     { "path": "fragments/world/surveillance.json", "sections": ["logic"] }

--- a/demos/doom_level/data/fragments/world/sector_platforms.json
+++ b/demos/doom_level/data/fragments/world/sector_platforms.json
@@ -1,0 +1,16 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_platforms": [
+    {
+      "name": "platform.doom.lift",
+      "scene": "scene.doom_level.play",
+      "sector_level": "sector.doom.e1m1",
+      "sector": "lift",
+      "min_floor_y": 0.0,
+      "max_floor_y": 2.5,
+      "ceil_y": 12.0,
+      "cycle_seconds": 6.0,
+      "rebuild_min_delta": 0.02
+    }
+  ]
+}

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -23,12 +23,6 @@
 #define SIG_AMBIENT_FEEDBACK 2004
 #define SIG_AMBIENT_FEEDBACK_SKIP 2005
 #define SIG_DAMAGE_FLOOR_TICK 2009
-#define LIFT_FLOOR_MIN_Y 0.0f
-#define LIFT_FLOOR_MAX_Y 2.5f
-#define LIFT_CEIL_Y 12.0f
-#define LIFT_CYCLE_SECONDS 6.0f
-#define LIFT_REBUILD_MIN_DELTA 0.02f
-#define LIFT_ENTITY_ID 1
 #define AMBIENT_FADE_SECONDS 1.0f
 #define AMBIENT_FEEDBACK_SECONDS 5.0f
 #define DAMAGE_FEEDBACK_REFERENCE_DPS 30.0f
@@ -52,7 +46,6 @@ typedef struct doom_state
     sdl3d_audio_engine *audio;
     sdl3d_logic_world *logic;
     sdl3d_logic_branch ambient_feedback_branch;
-    sdl3d_logic_sector_platform dynamic_lift;
     sdl3d_logic_sector_damage_sensor damage_sensor;
     sdl3d_sector_watcher sector_watcher;
     sdl3d_backend current_backend;
@@ -221,33 +214,6 @@ static bool doom_logic_trigger_feedback(void *userdata, const char *feedback_nam
     return false;
 }
 
-static bool doom_logic_set_sector_geometry(void *userdata, int sector_index, const sdl3d_sector_geometry *geometry,
-                                           const sdl3d_properties *payload)
-{
-    (void)payload;
-    doom_state *state = (doom_state *)userdata;
-    if (state == NULL || geometry == NULL)
-    {
-        return false;
-    }
-
-    if (!level_data_set_sector_geometry(&state->level, sector_index, geometry))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Dynamic sector geometry update failed: %s", SDL_GetError());
-        return false;
-    }
-    return true;
-}
-
-static void init_dynamic_lift(doom_state *state)
-{
-    sdl3d_logic_sector_platform_init(&state->dynamic_lift, LIFT_ENTITY_ID,
-                                     sdl3d_logic_target_sector_index(DOOM_DYNAMIC_LIFT_SECTOR), LIFT_FLOOR_MIN_Y,
-                                     LIFT_FLOOR_MAX_Y, LIFT_CEIL_Y, LIFT_CYCLE_SECONDS, LIFT_REBUILD_MIN_DELTA);
-    state->dynamic_lift.last_floor_y = g_sectors[DOOM_DYNAMIC_LIFT_SECTOR].floor_y;
-    state->dynamic_lift.has_last_floor_y = true;
-}
-
 static void init_damage_sensor(doom_state *state)
 {
     sdl3d_logic_sector_damage_sensor_init(&state->damage_sensor, 1, SIG_DAMAGE_FLOOR_TICK, 0.0f);
@@ -266,7 +232,6 @@ static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
     adapters.userdata = state;
     adapters.set_ambient = doom_logic_set_ambient;
     adapters.trigger_feedback = doom_logic_trigger_feedback;
-    adapters.set_sector_geometry = doom_logic_set_sector_geometry;
     sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
 
     sdl3d_logic_target_context target_context;
@@ -389,7 +354,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
         return false;
     }
     state->level_ready = true;
-    init_dynamic_lift(state);
 
     if (!entities_init(&state->ent, &state->level.unlit, ctx_registry(ctx), ctx_bus(ctx)))
     {
@@ -512,34 +476,6 @@ static void apply_doom_profile_actions(sdl3d_game_context *ctx, doom_state *stat
     }
 }
 
-static void update_dynamic_lift(doom_state *state, float dt)
-{
-    static bool checked_disable_lift = false;
-    static bool disable_lift = false;
-
-    if (!checked_disable_lift)
-    {
-        disable_lift = SDL_getenv("DOOM_DISABLE_DYNAMIC_LIFT") != NULL;
-        checked_disable_lift = true;
-    }
-    if (disable_lift)
-    {
-        return;
-    }
-
-    if (state == NULL || !state->level_ready || state->logic == NULL)
-    {
-        return;
-    }
-
-    const sdl3d_logic_sector_platform_result result =
-        sdl3d_logic_sector_platform_update(state->logic, &state->dynamic_lift, dt);
-    if (result.attempted && !result.applied)
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Dynamic lift logic action failed: %s", SDL_GetError());
-    }
-}
-
 static float clamp01(float value)
 {
     if (value < 0.0f)
@@ -584,7 +520,6 @@ typedef struct doom_tick_profile
     Uint64 last_counter;
     double actions_ms;
     double transition_ms;
-    double lift_ms;
     double entities_ms;
     double player_ms;
     double sensors_ms;
@@ -608,13 +543,12 @@ static double doom_profile_elapsed_ms(Uint64 start, Uint64 end)
     return (double)(end - start) * 1000.0 / (double)SDL_GetPerformanceFrequency();
 }
 
-static void doom_tick_profile_record(double actions_ms, double transition_ms, double lift_ms, double entities_ms,
-                                     double player_ms, double sensors_ms, double frame_ms)
+static void doom_tick_profile_record(double actions_ms, double transition_ms, double entities_ms, double player_ms,
+                                     double sensors_ms, double frame_ms)
 {
     const Uint64 now = SDL_GetPerformanceCounter();
     g_tick_profile.actions_ms += actions_ms;
     g_tick_profile.transition_ms += transition_ms;
-    g_tick_profile.lift_ms += lift_ms;
     g_tick_profile.entities_ms += entities_ms;
     g_tick_profile.player_ms += player_ms;
     g_tick_profile.sensors_ms += sensors_ms;
@@ -633,16 +567,14 @@ static void doom_tick_profile_record(double actions_ms, double transition_ms, do
 
     const double ticks = g_tick_profile.ticks > 0 ? (double)g_tick_profile.ticks : 1.0;
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "Doom tick profile: tick=%.2fms actions=%.2f transition=%.2f lift=%.2f entities=%.2f player=%.2f "
+                "Doom tick profile: tick=%.2fms actions=%.2f transition=%.2f entities=%.2f player=%.2f "
                 "sensors=%.2f ticks=%d",
                 g_tick_profile.frame_ms / ticks, g_tick_profile.actions_ms / ticks,
-                g_tick_profile.transition_ms / ticks, g_tick_profile.lift_ms / ticks,
-                g_tick_profile.entities_ms / ticks, g_tick_profile.player_ms / ticks, g_tick_profile.sensors_ms / ticks,
-                g_tick_profile.ticks);
+                g_tick_profile.transition_ms / ticks, g_tick_profile.entities_ms / ticks,
+                g_tick_profile.player_ms / ticks, g_tick_profile.sensors_ms / ticks, g_tick_profile.ticks);
     g_tick_profile.last_counter = now;
     g_tick_profile.actions_ms = 0.0;
     g_tick_profile.transition_ms = 0.0;
-    g_tick_profile.lift_ms = 0.0;
     g_tick_profile.entities_ms = 0.0;
     g_tick_profile.player_ms = 0.0;
     g_tick_profile.sensors_ms = 0.0;
@@ -658,7 +590,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     Uint64 section_start = 0;
     double actions_ms = 0.0;
     double transition_ms = 0.0;
-    double lift_ms = 0.0;
     double entities_ms = 0.0;
     double player_ms = 0.0;
     double sensors_ms = 0.0;
@@ -695,13 +626,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     {
         Uint64 now = SDL_GetPerformanceCounter();
         transition_ms = doom_profile_elapsed_ms(section_start, now);
-        section_start = now;
-    }
-    update_dynamic_lift(state, dt);
-    if (profile_tick)
-    {
-        Uint64 now = SDL_GetPerformanceCounter();
-        lift_ms = doom_profile_elapsed_ms(section_start, now);
         section_start = now;
     }
     entities_update(&state->ent, &state->level.unlit, dt, state->player.mover.position);
@@ -755,7 +679,7 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
     {
         Uint64 now = SDL_GetPerformanceCounter();
         sensors_ms += doom_profile_elapsed_ms(section_start, now);
-        doom_tick_profile_record(actions_ms, transition_ms, lift_ms, entities_ms, player_ms, sensors_ms,
+        doom_tick_profile_record(actions_ms, transition_ms, entities_ms, player_ms, sensors_ms,
                                  doom_profile_elapsed_ms(tick_start, now));
     }
 }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -43,6 +43,7 @@ Every root game file is a JSON object.
 | `grid_pickup_layers` | no | Dense grid-indexed pickup layers rendered and collected without one actor per pickup. |
 | `sector_levels` | no | Authored sector/portal worlds for Doom/Quake-style indoor levels. |
 | `sector_doors` | no | Runtime sliding doors for sector/FPS worlds. |
+| `sector_platforms` | no | Runtime moving floor/ceiling sectors for lifts, elevators, and oscillating platforms. |
 | `actor_archetypes` | no | Templates used by runtime actor pools. |
 | `actor_pools` | no | Preallocated spawn/despawn pools. |
 | `signals` | no | Authored signal names. |
@@ -85,6 +86,7 @@ a JSON object with schema `sdl3d.fragment.v0`.
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/world/e1m1.sectors.json", "sections": ["sector_levels"] },
     { "path": "fragments/world/e1m1.doors.json", "sections": ["sector_doors", "signals", "logic"] },
+    { "path": "fragments/world/e1m1.platforms.json", "sections": ["sector_platforms"] },
     { "path": "fragments/input/profiles.json", "sections": ["input"] },
     { "path": "fragments/network/replication.json", "sections": ["network"] }
   ]
@@ -426,6 +428,35 @@ actor and either emits a signal or runs nested actions with `actor_name`,
 If no door is in range and in front of the actor, the interaction is treated as
 a successful no-op so use-button bindings can be authored without extra guard
 conditions.
+
+`sector_platforms` move authored sector floors over time and rebuild sector
+render/collision variants when the movement exceeds `rebuild_min_delta`. Use
+them for elevators, lifts, moving bridges, and other deterministic sector
+geometry motion:
+
+```json
+{
+  "sector_platforms": [
+    {
+      "name": "platform.lift",
+      "scene": "scene.level_1",
+      "sector_level": "sector.level_1",
+      "sector": "lift",
+      "min_floor_y": 0.0,
+      "max_floor_y": 2.5,
+      "ceil_y": 12.0,
+      "cycle_seconds": 6.0,
+      "rebuild_min_delta": 0.02
+    }
+  ]
+}
+```
+
+Use either `sector` or `sector_index` to choose the sector. `ceil_y` must stay
+above `max_floor_y`, `cycle_seconds` must be positive, and `scene` may be
+omitted for a platform that updates in every scene. The platform follows a
+smooth sine cycle that starts at `min_floor_y`, rises to `max_floor_y`, and
+returns to `min_floor_y`.
 
 Use `controller.fps_sector` on an actor to drive first-person movement through
 a sector level:

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -358,6 +358,23 @@ typedef struct sector_door_runtime
     sdl3d_door door;
 } sector_door_runtime;
 
+typedef struct sector_platform_runtime
+{
+    yyjson_val *json;
+    const char *name;
+    sector_level_runtime *level;
+    int sector_index;
+    float min_floor_y;
+    float max_floor_y;
+    float ceil_y;
+    float cycle_seconds;
+    float rebuild_min_delta;
+    float time;
+    float last_floor_y;
+    bool has_last_floor_y;
+    bool enabled;
+} sector_platform_runtime;
+
 typedef struct fps_controller_runtime
 {
     const char *entity_name;
@@ -531,6 +548,8 @@ typedef struct sdl3d_game_data_runtime
     int sector_level_count;
     sector_door_runtime *sector_doors;
     int sector_door_count;
+    sector_platform_runtime *sector_platforms;
+    int sector_platform_count;
     fps_controller_runtime *fps_controllers;
     int fps_controller_count;
     int fps_controller_capacity;
@@ -619,6 +638,8 @@ static bool set_action_gamepad_button_binding(sdl3d_game_data_runtime *runtime, 
 static bool eval_data_condition(const sdl3d_game_data_runtime *runtime, yyjson_val *condition,
                                 const sdl3d_game_data_ui_metrics *metrics);
 static bool runtime_actor_is_active(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor);
+static sector_level_runtime *find_sector_level_runtime_mutable(sdl3d_game_data_runtime *runtime, const char *name);
+static int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name);
 static int menu_runtime_item_count(const sdl3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(sdl3d_game_data_runtime *runtime, scene_menu_state *menu);
 
@@ -3134,6 +3155,46 @@ static bool build_sector_level_variants(sector_level_runtime *level, char *error
     return true;
 }
 
+static bool set_sector_level_geometry(sector_level_runtime *level, int sector_index,
+                                      const sdl3d_sector_geometry *geometry, char *error_buffer, int error_buffer_size)
+{
+    if (level == NULL || geometry == NULL || sector_index < 0 || sector_index >= level->sector_count)
+    {
+        set_error(error_buffer, error_buffer_size, "sector platform geometry target is invalid");
+        return false;
+    }
+    if (geometry->ceil_y <= geometry->floor_y)
+    {
+        set_error(error_buffer, error_buffer_size, "sector platform ceiling must be above floor");
+        return false;
+    }
+
+    if (!sdl3d_level_set_sector_geometry(&level->lightmapped, level->sectors, level->sector_count, sector_index,
+                                         geometry, level->materials, level->material_count, level->lights,
+                                         level->light_count))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' lightmapped geometry update failed: %s",
+                   level->name, SDL_GetError());
+        return false;
+    }
+    if (!sdl3d_level_set_sector_geometry(&level->vertex_baked, level->sectors, level->sector_count, sector_index,
+                                         geometry, level->materials, level->material_count, level->lights,
+                                         level->light_count))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' vertex-baked geometry update failed: %s",
+                   level->name, SDL_GetError());
+        return false;
+    }
+    if (!sdl3d_level_set_sector_geometry(&level->unlit, level->sectors, level->sector_count, sector_index, geometry,
+                                         level->materials, level->material_count, NULL, 0))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' unlit geometry update failed: %s", level->name,
+                   SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
 static bool load_sector_levels(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                                int error_buffer_size)
 {
@@ -3249,6 +3310,72 @@ static bool load_sector_doors(sdl3d_game_data_runtime *runtime, yyjson_val *root
     return true;
 }
 
+static bool load_sector_platforms(sdl3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                                  int error_buffer_size)
+{
+    yyjson_val *platforms = obj_get(root, "sector_platforms");
+    if (platforms == NULL)
+        return true;
+    if (!yyjson_is_arr(platforms))
+    {
+        set_error(error_buffer, error_buffer_size, "sector_platforms must be an array");
+        return false;
+    }
+
+    runtime->sector_platform_count = (int)yyjson_arr_size(platforms);
+    runtime->sector_platforms = (sector_platform_runtime *)SDL_calloc((size_t)runtime->sector_platform_count,
+                                                                      sizeof(*runtime->sector_platforms));
+    if (runtime->sector_platforms == NULL && runtime->sector_platform_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector platforms");
+        return false;
+    }
+
+    for (int i = 0; i < runtime->sector_platform_count; ++i)
+    {
+        yyjson_val *platform_json = yyjson_arr_get(platforms, (size_t)i);
+        sector_platform_runtime *platform = &runtime->sector_platforms[i];
+        platform->json = platform_json;
+        platform->name = json_string(platform_json, "name", "");
+        platform->level = find_sector_level_runtime_mutable(runtime, json_string(platform_json, "sector_level", NULL));
+        if (platform->level == NULL)
+        {
+            set_errorf(error_buffer, error_buffer_size, "sector platform '%s' references an unknown sector level",
+                       platform->name);
+            return false;
+        }
+
+        const char *sector_name = json_string(platform_json, "sector", NULL);
+        yyjson_val *sector_index_value = obj_get(platform_json, "sector_index");
+        platform->sector_index =
+            sector_name != NULL ? sector_level_find_sector_name(platform->level, sector_name)
+                                : (yyjson_is_int(sector_index_value) ? (int)yyjson_get_int(sector_index_value) : -1);
+        if (platform->sector_index < 0 || platform->sector_index >= platform->level->sector_count)
+        {
+            set_errorf(error_buffer, error_buffer_size, "sector platform '%s' references an unknown sector",
+                       platform->name);
+            return false;
+        }
+
+        const sdl3d_sector *sector = &platform->level->sectors[platform->sector_index];
+        platform->min_floor_y = json_float(platform_json, "min_floor_y", sector->floor_y);
+        platform->max_floor_y = json_float(platform_json, "max_floor_y", sector->floor_y);
+        if (platform->min_floor_y > platform->max_floor_y)
+        {
+            const float temp = platform->min_floor_y;
+            platform->min_floor_y = platform->max_floor_y;
+            platform->max_floor_y = temp;
+        }
+        platform->ceil_y = json_float(platform_json, "ceil_y", sector->ceil_y);
+        platform->cycle_seconds = json_float(platform_json, "cycle_seconds", 1.0f);
+        platform->rebuild_min_delta = SDL_max(json_float(platform_json, "rebuild_min_delta", 0.02f), 0.0f);
+        platform->last_floor_y = sector->floor_y;
+        platform->has_last_floor_y = true;
+        platform->enabled = json_bool(platform_json, "enabled", true);
+    }
+    return true;
+}
+
 static yyjson_val *runtime_root(const sdl3d_game_data_runtime *runtime)
 {
     return runtime != NULL && runtime->doc != NULL ? yyjson_doc_get_root(runtime->doc) : NULL;
@@ -3319,6 +3446,23 @@ static bool sector_door_in_active_scene(const sdl3d_game_data_runtime *runtime, 
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
     return sector_door_in_scene(door, scene != NULL ? scene->name : NULL);
+}
+
+static bool sector_platform_in_scene(const sector_platform_runtime *platform, const char *scene_name)
+{
+    if (platform == NULL)
+        return false;
+    const char *scene = json_string(platform->json, "scene", NULL);
+    if (scene == NULL || scene[0] == '\0')
+        return true;
+    return scene_name != NULL && SDL_strcmp(scene, scene_name) == 0;
+}
+
+static bool sector_platform_in_active_scene(const sdl3d_game_data_runtime *runtime,
+                                            const sector_platform_runtime *platform)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    return sector_platform_in_scene(platform, scene != NULL ? scene->name : NULL);
 }
 
 static scene_menu_state *find_scene_menu(scene_entry *scene, const char *name)
@@ -6090,17 +6234,22 @@ const sdl3d_properties *sdl3d_game_data_scene_state(const sdl3d_game_data_runtim
     return runtime != NULL ? runtime->scene_state : NULL;
 }
 
-static const sector_level_runtime *find_sector_level_runtime(const sdl3d_game_data_runtime *runtime, const char *name)
+static sector_level_runtime *find_sector_level_runtime_mutable(sdl3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;
     for (int i = 0; i < runtime->sector_level_count; ++i)
     {
-        const sector_level_runtime *level = &runtime->sector_levels[i];
+        sector_level_runtime *level = &runtime->sector_levels[i];
         if (level->name != NULL && SDL_strcmp(level->name, name) == 0)
             return level;
     }
     return NULL;
+}
+
+static const sector_level_runtime *find_sector_level_runtime(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    return find_sector_level_runtime_mutable((sdl3d_game_data_runtime *)runtime, name);
 }
 
 static int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name)
@@ -14888,6 +15037,50 @@ static void update_sector_doors(sdl3d_game_data_runtime *runtime, float dt)
     }
 }
 
+static bool update_sector_platforms(sdl3d_game_data_runtime *runtime, float dt)
+{
+    if (runtime == NULL)
+        return false;
+    if (dt < 0.0f)
+        dt = 0.0f;
+
+    for (int i = 0; i < runtime->sector_platform_count; ++i)
+    {
+        sector_platform_runtime *platform = &runtime->sector_platforms[i];
+        if (!platform->enabled || platform->cycle_seconds <= 0.0f ||
+            !sector_platform_in_active_scene(runtime, platform))
+            continue;
+
+        platform->time += dt;
+        while (platform->time >= platform->cycle_seconds)
+            platform->time -= platform->cycle_seconds;
+
+        const float phase = platform->time / platform->cycle_seconds;
+        const float wave = (SDL_sinf(phase * SDL_PI_F * 2.0f - SDL_PI_F * 0.5f) + 1.0f) * 0.5f;
+        const float floor_y = platform->min_floor_y + (platform->max_floor_y - platform->min_floor_y) * wave;
+        if (platform->has_last_floor_y && SDL_fabsf(floor_y - platform->last_floor_y) < platform->rebuild_min_delta)
+            continue;
+
+        sdl3d_sector_geometry geometry;
+        SDL_zero(geometry);
+        geometry.floor_y = floor_y;
+        geometry.ceil_y = platform->ceil_y;
+        geometry.floor_normal[1] = 1.0f;
+        geometry.ceil_normal[1] = -1.0f;
+
+        char error[256];
+        if (!set_sector_level_geometry(platform->level, platform->sector_index, &geometry, error, (int)sizeof(error)))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D sector platform '%s' update failed: %s",
+                        platform->name != NULL ? platform->name : "<unnamed>", error);
+            return false;
+        }
+        platform->last_floor_y = floor_y;
+        platform->has_last_floor_y = true;
+    }
+    return true;
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -15928,6 +16121,11 @@ bool sdl3d_game_data_update(sdl3d_game_data_runtime *runtime, float dt)
     yyjson_val *root = yyjson_doc_get_root(runtime->doc);
     actor_lifecycle_defer_begin(runtime);
     update_sector_doors(runtime, dt);
+    if (!update_sector_platforms(runtime, dt))
+    {
+        actor_lifecycle_defer_end(runtime);
+        return false;
+    }
     update_control_components(runtime, root, dt);
     update_motion_components(runtime, root, dt);
     update_wave_schedules(runtime, dt);
@@ -16328,6 +16526,7 @@ bool sdl3d_game_data_load_asset_with_options(sdl3d_asset_resolver *assets, const
               load_grid_pickup_layers(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_levels(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_doors(runtime, root, error_buffer, error_buffer_size) &&
+              load_sector_platforms(runtime, root, error_buffer, error_buffer_size) &&
               load_actor_pools(runtime, root, error_buffer, error_buffer_size) &&
               load_input(runtime, root, error_buffer, error_buffer_size) &&
               load_timers(runtime, logic, error_buffer, error_buffer_size) && load_sensors(runtime, logic) &&
@@ -18526,6 +18725,7 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_pickup_layers);
     SDL_free(runtime->sector_levels);
     SDL_free(runtime->sector_doors);
+    SDL_free(runtime->sector_platforms);
     SDL_free(runtime->fps_controllers);
     SDL_free(runtime->patrol_controllers);
     SDL_free(runtime->actor_pools);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -78,6 +78,7 @@ typedef struct validation_names
     name_table grid_pickup_layers;
     name_table sector_levels;
     name_table sector_doors;
+    name_table sector_platforms;
     name_table signals;
     name_table scripts;
     name_table script_modules;
@@ -1880,14 +1881,30 @@ static bool import_path_is_safe_relative(const char *path)
 
 static bool import_section_name_allowed(const char *name)
 {
-    static const char *const allowed[] = {"storage",       "persistence",  "profiles",
-                                          "assets",        "scripts",      "input",
-                                          "render",        "transitions",  "ui",
-                                          "entities",      "grid_maps",    "grid_pickup_layers",
-                                          "sector_levels", "sector_doors", "actor_archetypes",
-                                          "actor_pools",   "signals",      "logic",
-                                          "adapters",      "network",      "haptics",
-                                          "presentation",  "update_phases"};
+    static const char *const allowed[] = {"storage",
+                                          "persistence",
+                                          "profiles",
+                                          "assets",
+                                          "scripts",
+                                          "input",
+                                          "render",
+                                          "transitions",
+                                          "ui",
+                                          "entities",
+                                          "grid_maps",
+                                          "grid_pickup_layers",
+                                          "sector_levels",
+                                          "sector_doors",
+                                          "sector_platforms",
+                                          "actor_archetypes",
+                                          "actor_pools",
+                                          "signals",
+                                          "logic",
+                                          "adapters",
+                                          "network",
+                                          "haptics",
+                                          "presentation",
+                                          "update_phases"};
     for (size_t i = 0; name != NULL && i < SDL_arraysize(allowed); ++i)
     {
         if (SDL_strcmp(name, allowed[i]) == 0)
@@ -2795,6 +2812,27 @@ static bool collect_sector_doors(validation_context *ctx, yyjson_val *root, vali
     return true;
 }
 
+static bool collect_sector_platforms(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *platforms = obj_get(root, "sector_platforms");
+    if (platforms == NULL)
+        return true;
+    if (!yyjson_is_arr(platforms))
+        return validation_error(ctx, "$.sector_platforms", "sector_platforms must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(platforms); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.sector_platforms[%zu]", i);
+        yyjson_val *platform = yyjson_arr_get(platforms, i);
+        if (!yyjson_is_obj(platform))
+            return validation_error(ctx, path, "sector platform entries must be objects");
+        if (!require_unique_name(ctx, &names->sector_platforms, "sector platform", json_string(platform, "name"), path))
+            return false;
+    }
+    return true;
+}
+
 static bool collect_actor_archetypes(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *archetypes = obj_get(root, "actor_archetypes");
@@ -3362,14 +3400,14 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_grid_maps(ctx, root, names) && collect_grid_pickup_layers(ctx, root, names) &&
            collect_sector_levels(ctx, root, names) && collect_sector_doors(ctx, root, names) &&
-           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
-           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
-           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
-           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
-           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
-           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
-           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
-           collect_sensors(ctx, root, names);
+           collect_sector_platforms(ctx, root, names) && collect_actor_archetypes(ctx, root, names) &&
+           collect_actor_pools(ctx, root, names) && collect_scripts(ctx, root, names) &&
+           collect_adapters(ctx, root, names) && collect_input_actions(ctx, root, names) &&
+           collect_input_assignment_sets(ctx, root, names) && collect_input_profiles(ctx, root, names) &&
+           collect_network_input_channels(ctx, root, names) && collect_cameras(ctx, root, names) &&
+           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
+           collect_images(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -4454,6 +4492,68 @@ static bool sector_level_has_sector_index(yyjson_val *root, const char *level_na
     yyjson_val *level = find_sector_level_json(root, level_name);
     yyjson_val *sectors = obj_get(level, "sectors");
     return yyjson_is_arr(sectors) && sector_index >= 0 && (size_t)sector_index < yyjson_arr_size(sectors);
+}
+
+static bool validate_sector_platforms(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *platforms = obj_get(root, "sector_platforms");
+    if (platforms == NULL)
+        return true;
+    if (!yyjson_is_arr(platforms))
+        return validation_error(ctx, "$.sector_platforms", "sector_platforms must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(platforms); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.sector_platforms[%zu]", i);
+        yyjson_val *platform = yyjson_arr_get(platforms, i);
+        if (!yyjson_is_obj(platform))
+            return validation_error(ctx, path, "sector platform entries must be objects");
+
+        const char *scene = json_string(platform, "scene");
+        if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, path))
+            return false;
+        const char *sector_level = json_string(platform, "sector_level");
+        if (!require_ref(ctx, &names->sector_levels, "sector level", sector_level, path))
+            return false;
+
+        const char *sector = json_string(platform, "sector");
+        yyjson_val *sector_index = obj_get(platform, "sector_index");
+        if ((sector == NULL && sector_index == NULL) || (sector != NULL && sector_index != NULL))
+            return validation_error(ctx, path, "sector platform requires exactly one of sector or sector_index");
+        if (sector != NULL && !sector_level_has_sector_name(root, sector_level, sector))
+            return validation_error(ctx, path, "unknown sector platform sector '%s'", sector);
+        if (sector_index != NULL &&
+            (!yyjson_is_int(sector_index) ||
+             !sector_level_has_sector_index(root, sector_level, (int)yyjson_get_int(sector_index))))
+        {
+            return validation_error(ctx, path, "sector platform sector_index must reference a sector in sector_level");
+        }
+
+        yyjson_val *min_floor_y = obj_get(platform, "min_floor_y");
+        yyjson_val *max_floor_y = obj_get(platform, "max_floor_y");
+        yyjson_val *ceil_y = obj_get(platform, "ceil_y");
+        yyjson_val *cycle_seconds = obj_get(platform, "cycle_seconds");
+        yyjson_val *rebuild_min_delta = obj_get(platform, "rebuild_min_delta");
+        if (!yyjson_is_num(min_floor_y) || !yyjson_is_num(max_floor_y) || !yyjson_is_num(ceil_y))
+            return validation_error(ctx, path, "sector platform requires numeric min_floor_y, max_floor_y, and ceil_y");
+        const double min_y = yyjson_get_num(min_floor_y);
+        const double max_y = yyjson_get_num(max_floor_y);
+        const double ceiling = yyjson_get_num(ceil_y);
+        if (max_y < min_y)
+            return validation_error(ctx, path,
+                                    "sector platform max_floor_y must be greater than or equal to min_floor_y");
+        if (ceiling <= max_y)
+            return validation_error(ctx, path, "sector platform ceil_y must be greater than max_floor_y");
+        if (!yyjson_is_num(cycle_seconds) || yyjson_get_num(cycle_seconds) <= 0.0)
+            return validation_error(ctx, path, "sector platform cycle_seconds must be positive");
+        if (rebuild_min_delta != NULL && (!yyjson_is_num(rebuild_min_delta) || yyjson_get_num(rebuild_min_delta) < 0.0))
+            return validation_error(ctx, path, "sector platform rebuild_min_delta must be non-negative");
+        yyjson_val *enabled = obj_get(platform, "enabled");
+        if (enabled != NULL && !yyjson_is_bool(enabled))
+            return validation_error(ctx, path, "sector platform enabled must be a boolean");
+    }
+    return true;
 }
 
 static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_val *root, validation_names *names)
@@ -7041,9 +7141,9 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
-           validate_sector_doors(ctx, root, names) && validate_actor_archetypes_and_pools(ctx, root, names) &&
-           validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
-           validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
+           validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
+           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
            validate_lights(ctx, root, names) && validate_haptics(ctx, root, names) &&
            validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
@@ -7066,6 +7166,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->grid_pickup_layers);
     name_table_destroy(&names->sector_levels);
     name_table_destroy(&names->sector_doors);
+    name_table_destroy(&names->sector_platforms);
     name_table_destroy(&names->signals);
     name_table_destroy(&names->scripts);
     name_table_destroy(&names->script_modules);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8201,6 +8201,163 @@ TEST(GameDataRuntime, RunsAuthoredSectorDoorInteractionRenderAndCollision)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredSectorPlatform)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_platforms");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "world": { "sector_levels": [{ "level": "sector.test", "variant": "unlit" }] }
+})json");
+    write_text(dir / "sector_platforms.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Platform Test" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }, { "name": "wall" }],
+      "sectors": [
+        {
+          "name": "lift",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor",
+          "ceil_material": "wall",
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "sector_platforms": [
+    {
+      "name": "platform.test",
+      "scene": "scene.play",
+      "sector_level": "sector.test",
+      "sector": "lift",
+      "min_floor_y": 0.0,
+      "max_floor_y": 2.0,
+      "ceil_y": 4.0,
+      "cycle_seconds": 4.0,
+      "rebuild_min_delta": 0.0
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_platforms.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_game_data_sector_level level{};
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
+    ASSERT_EQ(level.sector_count, 1);
+    EXPECT_NEAR(level.sectors[0].floor_y, 0.0f, 0.001f);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
+    EXPECT_NEAR(level.sectors[0].floor_y, 1.0f, 0.001f);
+    ASSERT_NE(level.unlit, nullptr);
+    ASSERT_EQ(level.unlit->sector_count, 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
+    EXPECT_NEAR(level.sectors[0].floor_y, 2.0f, 0.001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidSectorPlatforms)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_platforms_invalid");
+    write_text(dir / "scenes" / "play.scene.json", R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play" })json");
+
+    struct Case
+    {
+        const char *name;
+        const char *platform_json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "unknown_sector",
+            R"json([
+              {
+                "name": "platform.bad",
+                "sector_level": "sector.test",
+                "sector": "missing",
+                "min_floor_y": 0.0,
+                "max_floor_y": 2.0,
+                "ceil_y": 4.0,
+                "cycle_seconds": 4.0
+              }
+            ])json",
+            "unknown sector platform sector",
+        },
+        {
+            "bad_timing",
+            R"json([
+              {
+                "name": "platform.bad",
+                "sector_level": "sector.test",
+                "sector": "lift",
+                "min_floor_y": 0.0,
+                "max_floor_y": 2.0,
+                "ceil_y": 4.0,
+                "cycle_seconds": 0.0
+              }
+            ])json",
+            "cycle_seconds must be positive",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path game_path = dir / (std::string(test_case.name) + ".game.json");
+        const std::string game_json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Sector Platform" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [{
+        "name": "lift",
+        "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+        "floor_y": 0,
+        "ceil_y": 4,
+        "wall_material": "floor"
+      }]
+    }
+  ],
+  "sector_platforms": )json") + test_case.platform_json +
+                                      R"json(,
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+        write_text(game_path, game_json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(game_path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidFpsSectorController)
 {
     const std::filesystem::path dir = unique_test_dir("fps_sector_controller_invalid");


### PR DESCRIPTION
## Summary
- add reusable `sector_platforms` data for oscillating moving sector floors/lifts
- validate sector platform names, scene refs, sector refs, timing, and geometry bounds
- update sector platform runtime through the existing transactional dirty-sector geometry rebuild path
- author the Doom lift as JSON and remove the native Doom lift setup/update glue
- document the new `sector_platforms` section

## Verification
- `cmake --build build/debug --target doom_level sdl3d_game_data_test sdl3d_runner`
- `./build/debug/tests/sdl3d_game_data_test`
- `git diff --check`
