### PR TITLE
Author Doom damage feedback UI rects

### DIFF
--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -62,6 +62,116 @@
     ]
   },
   "ui": {
+    "rects": [
+      {
+        "name": "ui.doom_level.damage_feedback.top",
+        "x": 0.0,
+        "y": 0.0,
+        "w": 1.0,
+        "h": 0.08,
+        "normalized": true,
+        "color": [220, 20, 20, 170],
+        "alpha_source": {
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "scale": 0.033333,
+          "min": 0.35,
+          "max": 1.0
+        },
+        "visible_if": {
+          "type": "property.compare",
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "op": ">",
+          "value": 0.0
+        },
+        "pulse_alpha": true,
+        "pulse_rate": 2.8,
+        "pulse_min": 0.45,
+        "pulse_max": 1.0
+      },
+      {
+        "name": "ui.doom_level.damage_feedback.bottom",
+        "x": 0.0,
+        "y": 0.92,
+        "w": 1.0,
+        "h": 0.08,
+        "normalized": true,
+        "color": [220, 20, 20, 170],
+        "alpha_source": {
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "scale": 0.033333,
+          "min": 0.35,
+          "max": 1.0
+        },
+        "visible_if": {
+          "type": "property.compare",
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "op": ">",
+          "value": 0.0
+        },
+        "pulse_alpha": true,
+        "pulse_rate": 2.8,
+        "pulse_min": 0.45,
+        "pulse_max": 1.0
+      },
+      {
+        "name": "ui.doom_level.damage_feedback.left",
+        "x": 0.0,
+        "y": 0.08,
+        "w": 0.06,
+        "h": 0.84,
+        "normalized": true,
+        "color": [220, 20, 20, 170],
+        "alpha_source": {
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "scale": 0.033333,
+          "min": 0.35,
+          "max": 1.0
+        },
+        "visible_if": {
+          "type": "property.compare",
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "op": ">",
+          "value": 0.0
+        },
+        "pulse_alpha": true,
+        "pulse_rate": 2.8,
+        "pulse_min": 0.45,
+        "pulse_max": 1.0
+      },
+      {
+        "name": "ui.doom_level.damage_feedback.right",
+        "x": 0.94,
+        "y": 0.08,
+        "w": 0.06,
+        "h": 0.84,
+        "normalized": true,
+        "color": [220, 20, 20, 170],
+        "alpha_source": {
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "scale": 0.033333,
+          "min": 0.35,
+          "max": 1.0
+        },
+        "visible_if": {
+          "type": "property.compare",
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "op": ">",
+          "value": 0.0
+        },
+        "pulse_alpha": true,
+        "pulse_rate": 2.8,
+        "pulse_min": 0.45,
+        "pulse_max": 1.0
+      }
+    ],
     "text": [
       {
         "name": "ui.doom_level.phase",

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -20,13 +20,6 @@
 #include "renderer.h"
 
 #define SIG_FADE_OUT_DONE 2001
-#define SIG_DAMAGE_FLOOR_TICK 2009
-#define DAMAGE_FEEDBACK_REFERENCE_DPS 30.0f
-#define DAMAGE_FEEDBACK_MIN_STRENGTH 0.35f
-#define DAMAGE_FEEDBACK_ATTACK_RATE 10.0f
-#define DAMAGE_FEEDBACK_DECAY_RATE 4.0f
-#define DAMAGE_FEEDBACK_PULSE_HZ 2.8f
-#define FEEDBACK_DAMAGE_FLOOR "damage_floor"
 
 typedef struct doom_state
 {
@@ -38,13 +31,8 @@ typedef struct doom_state
     sdl3d_font debug_font;
     sdl3d_ui_context *ui;
     sdl3d_demo_player *demo_player;
-    sdl3d_logic_world *logic;
-    sdl3d_logic_sector_damage_sensor damage_sensor;
     sdl3d_backend current_backend;
     doom_render_profile render_profile;
-    float damage_feedback_strength;
-    float damage_feedback_target_strength;
-    float damage_pulse_timer;
     int action_pause;
     int action_menu;
     int action_toggle_lighting;
@@ -59,8 +47,6 @@ typedef struct doom_state
     bool entities_ready;
     bool quit_pending;
 } doom_state;
-
-static float clamp01(float value);
 
 static sdl3d_actor_registry *ctx_registry(const sdl3d_game_context *ctx)
 {
@@ -77,14 +63,8 @@ static sdl3d_input_manager *ctx_input(const sdl3d_game_context *ctx)
     return sdl3d_game_session_get_input(ctx != NULL ? ctx->session : NULL);
 }
 
-static sdl3d_logic_world *ctx_logic(const sdl3d_game_context *ctx)
-{
-    return sdl3d_game_session_get_logic_world(ctx != NULL ? ctx->session : NULL);
-}
-
 static void doom_state_cleanup(doom_state *state)
 {
-    state->logic = NULL;
     render_state_free(&state->render);
     if (state->entities_ready)
     {
@@ -134,69 +114,6 @@ static void on_fade_out_done(void *userdata, int signal_id, const sdl3d_properti
     (void)payload;
     sdl3d_game_context *ctx = (sdl3d_game_context *)userdata;
     ctx->quit_requested = true;
-}
-
-static bool doom_logic_trigger_feedback(void *userdata, const char *feedback_name, float duration_seconds,
-                                        const sdl3d_properties *payload)
-{
-    doom_state *state = (doom_state *)userdata;
-    if (state == NULL || feedback_name == NULL)
-    {
-        return false;
-    }
-
-    if (SDL_strcmp(feedback_name, FEEDBACK_DAMAGE_FLOOR) == 0)
-    {
-        const float damage_per_second =
-            payload != NULL ? sdl3d_properties_get_float(payload, "damage_per_second", 0.0f) : 0.0f;
-        if (damage_per_second <= 0.0f)
-        {
-            state->damage_feedback_target_strength = 0.0f;
-            return true;
-        }
-
-        state->damage_feedback_target_strength =
-            DAMAGE_FEEDBACK_MIN_STRENGTH +
-            clamp01(damage_per_second / DAMAGE_FEEDBACK_REFERENCE_DPS) * (1.0f - DAMAGE_FEEDBACK_MIN_STRENGTH);
-        return true;
-    }
-
-    return false;
-}
-
-static void init_damage_sensor(doom_state *state)
-{
-    sdl3d_logic_sector_damage_sensor_init(&state->damage_sensor, 1, SIG_DAMAGE_FLOOR_TICK, 0.0f);
-}
-
-static bool bind_doom_logic(sdl3d_game_context *ctx, doom_state *state)
-{
-    state->logic = ctx_logic(ctx);
-    if (state->logic == NULL)
-    {
-        return false;
-    }
-
-    sdl3d_logic_game_adapters adapters;
-    SDL_zero(adapters);
-    adapters.userdata = state;
-    adapters.trigger_feedback = doom_logic_trigger_feedback;
-    sdl3d_logic_world_set_game_adapters(state->logic, &adapters);
-
-    sdl3d_logic_target_context target_context;
-    SDL_zero(target_context);
-    target_context.level = &state->level.unlit;
-    target_context.sectors = g_sectors;
-    target_context.sector_count = g_sector_count;
-    sdl3d_logic_world_set_target_context(state->logic, &target_context);
-
-    sdl3d_logic_action damage_feedback_action = sdl3d_logic_action_make_trigger_feedback(FEEDBACK_DAMAGE_FLOOR, 0.0f);
-    if (sdl3d_logic_world_bind_logic_action(state->logic, SIG_DAMAGE_FLOOR_TICK, &damage_feedback_action) == 0)
-    {
-        return false;
-    }
-
-    return true;
 }
 
 static void start_quit_fade(sdl3d_game_context *ctx, doom_state *state)
@@ -286,12 +203,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     state->entities_ready = true;
 
     player_init(&state->player, ctx_input(ctx));
-    init_damage_sensor(state);
-    if (!bind_doom_logic(ctx, state))
-    {
-        doom_state_cleanup(state);
-        return false;
-    }
     render_state_init(&state->render);
     sdl3d_transition_start(&state->transition, SDL3D_TRANSITION_FADE, SDL3D_TRANSITION_IN, (sdl3d_color){0, 0, 0, 255},
                            1.0f, -1);
@@ -396,44 +307,6 @@ static void apply_doom_profile_actions(sdl3d_game_context *ctx, doom_state *stat
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Render profile switch failed: %s", SDL_GetError());
         }
     }
-}
-
-static float clamp01(float value)
-{
-    if (value < 0.0f)
-    {
-        return 0.0f;
-    }
-    if (value > 1.0f)
-    {
-        return 1.0f;
-    }
-    return value;
-}
-
-static void update_damage_feedback(doom_state *state, float dt)
-{
-    const float target_strength = state->damage_feedback_target_strength;
-    const float rate =
-        target_strength > state->damage_feedback_strength ? DAMAGE_FEEDBACK_ATTACK_RATE : DAMAGE_FEEDBACK_DECAY_RATE;
-    const float blend = clamp01(rate * dt);
-    state->damage_feedback_strength += (target_strength - state->damage_feedback_strength) * blend;
-
-    if (state->damage_feedback_strength > 0.001f)
-    {
-        state->damage_pulse_timer += dt * DAMAGE_FEEDBACK_PULSE_HZ;
-        while (state->damage_pulse_timer >= 1.0f)
-        {
-            state->damage_pulse_timer -= 1.0f;
-        }
-    }
-    else
-    {
-        state->damage_feedback_strength = 0.0f;
-        state->damage_pulse_timer = 0.0f;
-    }
-
-    state->damage_feedback_target_strength = 0.0f;
 }
 
 typedef struct doom_tick_profile
@@ -570,12 +443,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
             section_start = now;
         }
         player_apply_sector_damage(&state->player, g_sectors, g_sector_count, dt);
-        sdl3d_logic_sector_damage_sensor_update(&state->damage_sensor, state->logic,
-                                                sdl3d_vec3_make(state->player.mover.position.x,
-                                                                state->player.mover.position.y - PLAYER_HEIGHT,
-                                                                state->player.mover.position.z),
-                                                dt);
-        update_damage_feedback(state, dt);
         if (profile_tick)
         {
             Uint64 now = SDL_GetPerformanceCounter();
@@ -621,43 +488,6 @@ static void game_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_
     }
 }
 
-static void draw_damage_overlay(sdl3d_game_context *ctx, const doom_state *state)
-{
-    const int width = sdl3d_get_render_context_width(ctx->renderer);
-    const int height = sdl3d_get_render_context_height(ctx->renderer);
-
-    if (width <= 0 || height <= 0 || state->damage_feedback_strength <= 0.001f)
-    {
-        return;
-    }
-
-    const float pulse = (SDL_sinf(state->damage_pulse_timer * SDL_PI_F * 2.0f) + 1.0f) * 0.5f;
-    const float alpha = (58.0f + pulse * 72.0f) * state->damage_feedback_strength;
-    const float max_band = SDL_min((float)width, (float)height) * 0.12f;
-    const int layers = 5;
-    const float band = max_band / (float)layers;
-
-    for (int i = 0; i < layers; ++i)
-    {
-        const float inset = (float)i * band;
-        const float layer_scale = 1.0f - ((float)i / (float)layers);
-        float layer_alpha_f = alpha * layer_scale;
-        if (layer_alpha_f > 180.0f)
-        {
-            layer_alpha_f = 180.0f;
-        }
-        const Uint8 layer_alpha = (Uint8)layer_alpha_f;
-        const sdl3d_color red = {220, 20, 20, layer_alpha};
-
-        sdl3d_draw_rect_overlay(ctx->renderer, inset, inset, (float)width - inset * 2.0f, band, red);
-        sdl3d_draw_rect_overlay(ctx->renderer, inset, (float)height - inset - band, (float)width - inset * 2.0f, band,
-                                red);
-        sdl3d_draw_rect_overlay(ctx->renderer, inset, inset + band, band, (float)height - (inset + band) * 2.0f, red);
-        sdl3d_draw_rect_overlay(ctx->renderer, (float)width - inset - band, inset + band, band,
-                                (float)height - (inset + band) * 2.0f, red);
-    }
-}
-
 static void draw_pause_overlay(sdl3d_game_context *ctx, doom_state *state)
 {
     const int width = sdl3d_get_render_context_width(ctx->renderer);
@@ -694,7 +524,6 @@ static void game_render(sdl3d_game_context *ctx, void *userdata, float alpha)
                       &state->level, &state->ent, &state->player, WINDOW_W, WINDOW_H, frame_dt,
                       backend_profile_name(state->render_profile));
     sdl3d_transition_draw(&state->transition, ctx->renderer);
-    draw_damage_overlay(ctx, state);
     if (ctx->paused && !state->quit_pending)
     {
         draw_pause_overlay(ctx, state);

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -201,6 +201,53 @@ The optional `app` object configures the managed loop before the window exists:
 }
 ```
 
+## UI Rectangles
+
+`ui.rects` draws solid overlay rectangles in the generic presentation path.
+Use them for reusable presentation feedback such as low-health tints, damage
+vignettes, shield flashes, letterbox bars, or panel backgrounds without adding
+host-specific drawing code.
+
+```json
+{
+  "ui": {
+    "rects": [
+      {
+        "name": "ui.damage.top",
+        "x": 0.0,
+        "y": 0.0,
+        "w": 1.0,
+        "h": 0.08,
+        "normalized": true,
+        "color": [220, 20, 20, 170],
+        "alpha_source": {
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "scale": 0.033333,
+          "min": 0.35,
+          "max": 1.0
+        },
+        "visible_if": {
+          "type": "property.compare",
+          "target": "entity.player",
+          "key": "last_damage_per_second",
+          "op": ">",
+          "value": 0.0
+        },
+        "pulse_alpha": true,
+        "pulse_rate": 2.8,
+        "pulse_min": 0.45,
+        "pulse_max": 1.0
+      }
+    ]
+  }
+}
+```
+
+`alpha_source` accepts integer or float properties and multiplies the authored
+color alpha by `clamp(value * scale, min, max)`. Pair it with `visible_if` when
+zero-valued feedback should disappear entirely.
+
 ## World Cameras
 
 `world.cameras` defines reusable render cameras by name. Scenes can select a

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -526,6 +526,51 @@ extern "C"
         float effect_speed;
     } sdl3d_game_data_ui_image;
 
+    /** @brief Authored UI rectangle descriptor. */
+    typedef struct sdl3d_game_data_ui_rect
+    {
+        /** @brief Stable UI item name. */
+        const char *name;
+        /** @brief Caller-defined visibility key. */
+        const char *visible;
+        /** @brief Horizontal position. */
+        float x;
+        /** @brief Vertical position. */
+        float y;
+        /** @brief Rectangle width. */
+        float w;
+        /** @brief Rectangle height. */
+        float h;
+        /** @brief Whether x/y/w/h are normalized to the current render size. */
+        bool normalized;
+        /** @brief Horizontal alignment of the rectangle around x. */
+        sdl3d_game_data_ui_align align;
+        /** @brief Vertical alignment of the rectangle around y. */
+        sdl3d_game_data_ui_valign valign;
+        /** @brief Runtime or authored scale multiplier applied around the rectangle anchor. */
+        float scale;
+        /** @brief Rectangle color. */
+        sdl3d_color color;
+        /** @brief Optional actor that supplies an alpha multiplier property. */
+        const char *alpha_source_target;
+        /** @brief Optional property on @ref alpha_source_target used as alpha source. */
+        const char *alpha_source_key;
+        /** @brief Multiplier applied to the alpha source property. */
+        float alpha_source_scale;
+        /** @brief Minimum alpha multiplier when an alpha source is authored. */
+        float alpha_source_min;
+        /** @brief Maximum alpha multiplier when an alpha source is authored. */
+        float alpha_source_max;
+        /** @brief True when alpha should pulse while visible. */
+        bool pulse_alpha;
+        /** @brief Pulse frequency in cycles per second. */
+        float pulse_rate;
+        /** @brief Minimum pulse alpha multiplier. */
+        float pulse_min;
+        /** @brief Maximum pulse alpha multiplier. */
+        float pulse_max;
+    } sdl3d_game_data_ui_rect;
+
     /** @brief Bit flags indicating which runtime UI state fields override authored descriptor values. */
     typedef enum sdl3d_game_data_ui_state_flags
     {
@@ -579,6 +624,13 @@ extern "C"
      * Return false to stop iteration early.
      */
     typedef bool (*sdl3d_game_data_ui_image_fn)(void *userdata, const sdl3d_game_data_ui_image *image);
+
+    /**
+     * @brief Callback for iterating authored UI rectangle descriptors.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*sdl3d_game_data_ui_rect_fn)(void *userdata, const sdl3d_game_data_ui_rect *rect);
 
     /** @brief Input mode used by a data-authored scene skip policy. */
     typedef enum sdl3d_game_data_skip_input
@@ -2636,6 +2688,16 @@ extern "C"
                                            void *userdata);
 
     /**
+     * @brief Iterate authored UI rectangles visible to the active scene.
+     *
+     * Iteration includes global `ui.rects` followed by active-scene
+     * `ui.rects`. Visibility is evaluated separately by
+     * sdl3d_game_data_ui_rect_is_visible().
+     */
+    bool sdl3d_game_data_for_each_ui_rect(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_rect_fn callback,
+                                          void *userdata);
+
+    /**
      * @brief Initialize runtime UI state to identity values.
      *
      * The initialized state has no override flags, zero offset, scale 1, alpha
@@ -2689,6 +2751,17 @@ extern "C"
                                           sdl3d_game_data_ui_image *out_image, bool *out_visible);
 
     /**
+     * @brief Resolve authored rectangle plus runtime UI state for presentation.
+     *
+     * @p out_visible receives the final visibility after authored conditions,
+     * property-driven alpha, and runtime overrides. @p out_rect may alias
+     * @p rect.
+     */
+    bool sdl3d_game_data_resolve_ui_rect(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_rect *rect,
+                                         const sdl3d_game_data_ui_metrics *metrics, sdl3d_game_data_ui_rect *out_rect,
+                                         bool *out_visible);
+
+    /**
      * @brief Evaluate a UI text descriptor's authored visibility condition.
      *
      * Supports camera-active checks, app pause checks, actor property
@@ -2702,6 +2775,12 @@ extern "C"
     bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime,
                                              const sdl3d_game_data_ui_image *image,
                                              const sdl3d_game_data_ui_metrics *metrics);
+
+    /**
+     * @brief Evaluate a UI rectangle descriptor's authored visibility condition.
+     */
+    bool sdl3d_game_data_ui_rect_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_rect *rect,
+                                            const sdl3d_game_data_ui_metrics *metrics);
 
     /**
      * @brief Read the active scene's authored skip policy.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -357,6 +357,16 @@ extern "C"
                                         const sdl3d_game_data_render_eval *render_eval);
 
     /**
+     * @brief Draw authored UI rectangles for the active scene.
+     *
+     * Rectangles are drawn on SDL3D's overlay path after world rendering.
+     * @p render_eval supplies the current presentation time for pulse effects.
+     */
+    bool sdl3d_game_data_draw_ui_rects(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                       const sdl3d_game_data_ui_metrics *metrics,
+                                       const sdl3d_game_data_render_eval *render_eval);
+
+    /**
      * @brief Initialize a particle emitter cache.
      */
     void sdl3d_game_data_particle_cache_init(sdl3d_game_data_particle_cache *cache);

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9704,6 +9704,38 @@ static void ui_image_from_json(yyjson_val *item, sdl3d_game_data_ui_image *image
     image->effect_speed = json_float(item, "effect_speed", 1.0f);
 }
 
+static void ui_rect_from_json(yyjson_val *item, sdl3d_game_data_ui_rect *rect)
+{
+    if (rect == NULL)
+        return;
+    SDL_zero(*rect);
+    rect->name = json_string(item, "name", NULL);
+    rect->visible = json_string(item, "visible", "always");
+    rect->x = json_float(item, "x", 0.0f);
+    rect->y = json_float(item, "y", 0.0f);
+    rect->w = json_float(item, "w", json_float(item, "width", 0.0f));
+    rect->h = json_float(item, "h", json_float(item, "height", 0.0f));
+    rect->normalized = json_bool(item, "normalized", false);
+    rect->align = parse_ui_align(json_string(item, "align", NULL), SDL3D_GAME_DATA_UI_ALIGN_LEFT);
+    rect->valign = parse_ui_valign(json_string(item, "valign", NULL), SDL3D_GAME_DATA_UI_VALIGN_TOP);
+    rect->scale = json_float(item, "scale", 1.0f);
+    rect->color = json_color(item, "color", (sdl3d_color){255, 255, 255, 255});
+    yyjson_val *alpha_source = obj_get(item, "alpha_source");
+    rect->alpha_source_target = json_string(alpha_source, "target", NULL);
+    rect->alpha_source_key = json_string(alpha_source, "key", NULL);
+    rect->alpha_source_scale = json_float(alpha_source, "scale", 1.0f);
+    rect->alpha_source_min = json_float(alpha_source, "min", 0.0f);
+    rect->alpha_source_max = json_float(alpha_source, "max", 1.0f);
+    if (rect->alpha_source_max < rect->alpha_source_min)
+        rect->alpha_source_max = rect->alpha_source_min;
+    rect->pulse_alpha = json_bool(item, "pulse_alpha", false);
+    rect->pulse_rate = json_float(item, "pulse_rate", 1.0f);
+    rect->pulse_min = json_float(item, "pulse_min", 0.5f);
+    rect->pulse_max = json_float(item, "pulse_max", 1.0f);
+    if (rect->pulse_max < rect->pulse_min)
+        rect->pulse_max = rect->pulse_min;
+}
+
 static bool for_each_authored_ui_image_root(yyjson_val *root, sdl3d_game_data_ui_image_fn callback, void *userdata)
 {
     yyjson_val *images = obj_get(obj_get(root, "ui"), "images");
@@ -9712,6 +9744,19 @@ static bool for_each_authored_ui_image_root(yyjson_val *root, sdl3d_game_data_ui
         sdl3d_game_data_ui_image image;
         ui_image_from_json(yyjson_arr_get(images, i), &image);
         if (!callback(userdata, &image))
+            return false;
+    }
+    return true;
+}
+
+static bool for_each_authored_ui_rect_root(yyjson_val *root, sdl3d_game_data_ui_rect_fn callback, void *userdata)
+{
+    yyjson_val *rects = obj_get(obj_get(root, "ui"), "rects");
+    for (size_t i = 0; yyjson_is_arr(rects) && i < yyjson_arr_size(rects); ++i)
+    {
+        sdl3d_game_data_ui_rect rect;
+        ui_rect_from_json(yyjson_arr_get(rects, i), &rect);
+        if (!callback(userdata, &rect))
             return false;
     }
     return true;
@@ -9730,6 +9775,23 @@ bool sdl3d_game_data_for_each_ui_image(const sdl3d_game_data_runtime *runtime, s
 
     for (int root_index = 0; root_index < 2; ++root_index)
         if (!for_each_authored_ui_image_root(roots[root_index], callback, userdata))
+            return true;
+    return true;
+}
+
+bool sdl3d_game_data_for_each_ui_rect(const sdl3d_game_data_runtime *runtime, sdl3d_game_data_ui_rect_fn callback,
+                                      void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    yyjson_val *roots[2];
+    roots[0] = runtime_root(runtime);
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    roots[1] = scene != NULL ? scene->root : NULL;
+
+    for (int root_index = 0; root_index < 2; ++root_index)
+        if (!for_each_authored_ui_rect_root(roots[root_index], callback, userdata))
             return true;
     return true;
 }
@@ -11591,6 +11653,29 @@ static yyjson_val *find_ui_image_json(const sdl3d_game_data_runtime *runtime, co
     return NULL;
 }
 
+static yyjson_val *find_ui_rect_json(const sdl3d_game_data_runtime *runtime, const char *name)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *scene_rects = obj_get(obj_get(scene != NULL ? scene->root : NULL, "ui"), "rects");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(scene_rects) && i < yyjson_arr_size(scene_rects); ++i)
+    {
+        yyjson_val *rect = yyjson_arr_get(scene_rects, i);
+        const char *rect_name = json_string(rect, "name", NULL);
+        if (rect_name != NULL && SDL_strcmp(rect_name, name) == 0)
+            return rect;
+    }
+
+    yyjson_val *rects = obj_get(obj_get(runtime_root(runtime), "ui"), "rects");
+    for (size_t i = 0; name != NULL && yyjson_is_arr(rects) && i < yyjson_arr_size(rects); ++i)
+    {
+        yyjson_val *rect = yyjson_arr_get(rects, i);
+        const char *rect_name = json_string(rect, "name", NULL);
+        if (rect_name != NULL && SDL_strcmp(rect_name, name) == 0)
+            return rect;
+    }
+    return NULL;
+}
+
 static bool value_equals_json_bool(const sdl3d_value *left, bool right)
 {
     return left != NULL && left->type == SDL3D_VALUE_BOOL && left->as_bool == right;
@@ -11699,6 +11784,18 @@ static bool ui_image_authored_is_visible(const sdl3d_game_data_runtime *runtime,
     return image->visible == NULL || SDL_strcmp(image->visible, "always") == 0;
 }
 
+static bool ui_rect_authored_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_rect *rect,
+                                        const sdl3d_game_data_ui_metrics *metrics)
+{
+    if (runtime == NULL || rect == NULL)
+        return false;
+    yyjson_val *rect_json = find_ui_rect_json(runtime, rect->name);
+    yyjson_val *condition = obj_get(rect_json, "visible_if");
+    if (condition != NULL)
+        return eval_data_condition(runtime, condition, metrics);
+    return rect->visible == NULL || SDL_strcmp(rect->visible, "always") == 0;
+}
+
 static float clamp_unit(float value)
 {
     return SDL_clamp(value, 0.0f, 1.0f);
@@ -11794,6 +11891,59 @@ bool sdl3d_game_data_resolve_ui_image(const sdl3d_game_data_runtime *runtime, co
     return true;
 }
 
+bool sdl3d_game_data_resolve_ui_rect(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_rect *rect,
+                                     const sdl3d_game_data_ui_metrics *metrics, sdl3d_game_data_ui_rect *out_rect,
+                                     bool *out_visible)
+{
+    if (out_visible != NULL)
+        *out_visible = false;
+    if (runtime == NULL || rect == NULL || out_rect == NULL)
+        return false;
+
+    sdl3d_game_data_ui_rect resolved = *rect;
+    bool visible = ui_rect_authored_is_visible(runtime, rect, metrics);
+
+    if (rect->alpha_source_target != NULL && rect->alpha_source_key != NULL)
+    {
+        const sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, rect->alpha_source_target);
+        const sdl3d_value *value =
+            actor != NULL ? sdl3d_properties_get_value(actor->props, rect->alpha_source_key) : NULL;
+        float source = 0.0f;
+        if (value != NULL && value->type == SDL3D_VALUE_FLOAT)
+            source = value->as_float;
+        else if (value != NULL && value->type == SDL3D_VALUE_INT)
+            source = (float)value->as_int;
+        else
+            visible = false;
+
+        const float alpha_scale =
+            SDL_clamp(source * rect->alpha_source_scale, rect->alpha_source_min, rect->alpha_source_max);
+        resolved.color.a = multiply_u8(resolved.color.a, alpha_scale);
+    }
+
+    sdl3d_game_data_ui_state state;
+    if (sdl3d_game_data_get_ui_state(runtime, rect->name, &state))
+    {
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_VISIBLE) != 0u)
+            visible = state.visible;
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_OFFSET) != 0u)
+        {
+            resolved.x += state.offset_x;
+            resolved.y += state.offset_y;
+        }
+        if ((state.flags & SDL3D_GAME_DATA_UI_STATE_SCALE) != 0u)
+            resolved.scale *= state.scale;
+        resolved.color = apply_ui_state_color(resolved.color, &state);
+    }
+
+    if (resolved.scale <= 0.0f || resolved.w <= 0.0f || resolved.h <= 0.0f || resolved.color.a == 0)
+        visible = false;
+    if (out_visible != NULL)
+        *out_visible = visible;
+    *out_rect = resolved;
+    return true;
+}
+
 bool sdl3d_game_data_ui_text_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_text *text,
                                         const sdl3d_game_data_ui_metrics *metrics)
 {
@@ -11808,6 +11958,14 @@ bool sdl3d_game_data_ui_image_is_visible(const sdl3d_game_data_runtime *runtime,
     bool visible = false;
     sdl3d_game_data_ui_image resolved;
     return sdl3d_game_data_resolve_ui_image(runtime, image, metrics, &resolved, &visible) && visible;
+}
+
+bool sdl3d_game_data_ui_rect_is_visible(const sdl3d_game_data_runtime *runtime, const sdl3d_game_data_ui_rect *rect,
+                                        const sdl3d_game_data_ui_metrics *metrics)
+{
+    bool visible = false;
+    sdl3d_game_data_ui_rect resolved;
+    return sdl3d_game_data_resolve_ui_rect(runtime, rect, metrics, &resolved, &visible) && visible;
 }
 
 bool sdl3d_game_data_app_pause_allowed(const sdl3d_game_data_runtime *runtime,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -6149,13 +6149,16 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
     yyjson_val *ui = obj_get(root, "ui");
     yyjson_val *texts = obj_get(ui, "text");
     yyjson_val *images = obj_get(ui, "images");
+    yyjson_val *rects = obj_get(ui, "rects");
     yyjson_val *menus = obj_get(ui, "menus");
-    if (texts == NULL && images == NULL && menus == NULL)
+    if (texts == NULL && images == NULL && rects == NULL && menus == NULL)
         return true;
     if (texts != NULL && !yyjson_is_arr(texts))
         return validation_error(ctx, "$.ui.text", "UI text must be an array");
     if (images != NULL && !yyjson_is_arr(images))
         return validation_error(ctx, "$.ui.images", "UI images must be an array");
+    if (rects != NULL && !yyjson_is_arr(rects))
+        return validation_error(ctx, "$.ui.rects", "UI rectangles must be an array");
     if (menus != NULL && !yyjson_is_arr(menus))
         return validation_error(ctx, "$.ui.menus", "UI menus must be an array");
 
@@ -6213,6 +6216,40 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
         if (!validate_data_condition(ctx, obj_get(image, "visible_if"), condition_path, names))
+            return false;
+    }
+
+    for (size_t i = 0; yyjson_is_arr(rects) && i < yyjson_arr_size(rects); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.ui.rects[%zu]", i);
+        yyjson_val *rect = yyjson_arr_get(rects, i);
+        if (!yyjson_is_obj(rect))
+            return validation_error(ctx, path, "UI rectangle entries must be objects");
+        if (!is_non_empty_string(rect, "name"))
+            return validation_error(ctx, path, "UI rectangle requires a non-empty name");
+        yyjson_val *alpha_source = obj_get(rect, "alpha_source");
+        if (alpha_source != NULL)
+        {
+            if (!yyjson_is_obj(alpha_source))
+                return validation_error(ctx, path, "UI rectangle alpha_source must be an object");
+            if (!require_ref(ctx, &names->entities, "entity", json_string(alpha_source, "target"), path))
+                return false;
+            if (!is_non_empty_string(alpha_source, "key"))
+                return validation_error(ctx, path, "UI rectangle alpha_source requires a non-empty key");
+            yyjson_val *min_value = obj_get(alpha_source, "min");
+            yyjson_val *max_value = obj_get(alpha_source, "max");
+            if (min_value != NULL && !yyjson_is_num(min_value))
+                return validation_error(ctx, path, "UI rectangle alpha_source min must be numeric");
+            if (max_value != NULL && !yyjson_is_num(max_value))
+                return validation_error(ctx, path, "UI rectangle alpha_source max must be numeric");
+            if (yyjson_is_num(min_value) && yyjson_is_num(max_value) &&
+                yyjson_get_real(max_value) < yyjson_get_real(min_value))
+                return validation_error(ctx, path, "UI rectangle alpha_source max must be >= min");
+        }
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", path);
+        if (!validate_data_condition(ctx, obj_get(rect, "visible_if"), condition_path, names))
             return false;
     }
 
@@ -6979,9 +7016,12 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
 
     yyjson_val *texts = obj_get(obj_get(root, "ui"), "text");
     yyjson_val *images = obj_get(obj_get(root, "ui"), "images");
+    yyjson_val *rects = obj_get(obj_get(root, "ui"), "rects");
     yyjson_val *ui_menus = obj_get(obj_get(root, "ui"), "menus");
     if (images != NULL && !yyjson_is_arr(images))
         return validation_error(ctx, json_path, "scene UI images must be an array");
+    if (rects != NULL && !yyjson_is_arr(rects))
+        return validation_error(ctx, json_path, "scene UI rectangles must be an array");
     if (ui_menus != NULL && !yyjson_is_arr(ui_menus))
         return validation_error(ctx, json_path, "scene UI menus must be an array");
     for (size_t i = 0; yyjson_is_arr(ui_menus) && i < yyjson_arr_size(ui_menus); ++i)
@@ -7035,6 +7075,40 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         char condition_path[PATH_BUFFER_SIZE];
         format_path(condition_path, sizeof(condition_path), "%s.visible_if", image_path);
         if (!validate_scene_ui_condition(ctx, obj_get(image, "visible_if"), condition_path, names))
+            return false;
+    }
+
+    for (size_t i = 0; yyjson_is_arr(rects) && i < yyjson_arr_size(rects); ++i)
+    {
+        char rect_path[PATH_BUFFER_SIZE];
+        format_path(rect_path, sizeof(rect_path), "%s.ui.rects[%zu]", json_path, i);
+        yyjson_val *rect = yyjson_arr_get(rects, i);
+        if (!yyjson_is_obj(rect))
+            return validation_error(ctx, rect_path, "scene UI rectangle entries must be objects");
+        if (!is_non_empty_string(rect, "name"))
+            return validation_error(ctx, rect_path, "scene UI rectangle requires a non-empty name");
+        yyjson_val *alpha_source = obj_get(rect, "alpha_source");
+        if (alpha_source != NULL)
+        {
+            if (!yyjson_is_obj(alpha_source))
+                return validation_error(ctx, rect_path, "scene UI rectangle alpha_source must be an object");
+            if (!require_ref(ctx, &names->entities, "entity", json_string(alpha_source, "target"), rect_path))
+                return false;
+            if (!is_non_empty_string(alpha_source, "key"))
+                return validation_error(ctx, rect_path, "scene UI rectangle alpha_source requires a non-empty key");
+            yyjson_val *min_value = obj_get(alpha_source, "min");
+            yyjson_val *max_value = obj_get(alpha_source, "max");
+            if (min_value != NULL && !yyjson_is_num(min_value))
+                return validation_error(ctx, rect_path, "scene UI rectangle alpha_source min must be numeric");
+            if (max_value != NULL && !yyjson_is_num(max_value))
+                return validation_error(ctx, rect_path, "scene UI rectangle alpha_source max must be numeric");
+            if (yyjson_is_num(min_value) && yyjson_is_num(max_value) &&
+                yyjson_get_real(max_value) < yyjson_get_real(min_value))
+                return validation_error(ctx, rect_path, "scene UI rectangle alpha_source max must be >= min");
+        }
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", rect_path);
+        if (!validate_scene_ui_condition(ctx, obj_get(rect, "visible_if"), condition_path, names))
             return false;
     }
 

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -57,6 +57,15 @@ typedef struct ui_image_draw_context
     bool ok;
 } ui_image_draw_context;
 
+typedef struct ui_rect_draw_context
+{
+    const sdl3d_game_data_runtime *runtime;
+    sdl3d_render_context *renderer;
+    const sdl3d_game_data_ui_metrics *metrics;
+    const sdl3d_game_data_render_eval *render_eval;
+    bool ok;
+} ui_rect_draw_context;
+
 static Uint32 ui_image_hash_string(const char *s)
 {
     Uint32 h = 2166136261u;
@@ -973,6 +982,71 @@ static bool draw_ui_image(void *userdata, const sdl3d_game_data_ui_image *image)
     return true;
 }
 
+static void resolve_ui_rect_rect(const sdl3d_game_data_ui_rect *rect, int width, int height, float *out_x, float *out_y,
+                                 float *out_w, float *out_h)
+{
+    float w = rect->normalized ? rect->w * (float)width : rect->w;
+    float h = rect->normalized ? rect->h * (float)height : rect->h;
+    const float scale = rect->scale > 0.0f ? rect->scale : 1.0f;
+    w *= scale;
+    h *= scale;
+
+    float x = rect->normalized ? rect->x * (float)width : rect->x;
+    float y = rect->normalized ? rect->y * (float)height : rect->y;
+    if (rect->align == SDL3D_GAME_DATA_UI_ALIGN_CENTER)
+        x -= w * 0.5f;
+    else if (rect->align == SDL3D_GAME_DATA_UI_ALIGN_RIGHT)
+        x -= w;
+    if (rect->valign == SDL3D_GAME_DATA_UI_VALIGN_CENTER)
+        y -= h * 0.5f;
+    else if (rect->valign == SDL3D_GAME_DATA_UI_VALIGN_BOTTOM)
+        y -= h;
+
+    *out_x = x;
+    *out_y = y;
+    *out_w = w;
+    *out_h = h;
+}
+
+static bool draw_ui_rect(void *userdata, const sdl3d_game_data_ui_rect *rect)
+{
+    ui_rect_draw_context *draw = (ui_rect_draw_context *)userdata;
+    if (draw == NULL || rect == NULL)
+        return false;
+
+    sdl3d_game_data_ui_rect resolved;
+    bool visible = false;
+    if (!sdl3d_game_data_resolve_ui_rect(draw->runtime, rect, draw->metrics, &resolved, &visible))
+    {
+        draw->ok = false;
+        return true;
+    }
+    if (!visible)
+        return true;
+
+    sdl3d_color color = resolved.color;
+    if (resolved.pulse_alpha)
+    {
+        const float time = draw->render_eval != NULL ? draw->render_eval->time : 0.0f;
+        const float pulse = 0.5f + 0.5f * SDL_sinf(time * SDL_max(resolved.pulse_rate, 0.0f) * SDL_PI_F * 2.0f);
+        const float alpha = resolved.pulse_min + (resolved.pulse_max - resolved.pulse_min) * pulse;
+        color.a = (Uint8)SDL_clamp((int)((float)color.a * SDL_clamp(alpha, 0.0f, 1.0f) + 0.5f), 0, 255);
+    }
+    if (color.a == 0)
+        return true;
+
+    const int width = sdl3d_get_render_context_width(draw->renderer);
+    const int height = sdl3d_get_render_context_height(draw->renderer);
+    float x = 0.0f;
+    float y = 0.0f;
+    float w = 0.0f;
+    float h = 0.0f;
+    resolve_ui_rect_rect(&resolved, width, height, &x, &y, &w, &h);
+    if (!sdl3d_draw_rect_overlay(draw->renderer, x, y, w, h, color))
+        draw->ok = false;
+    return true;
+}
+
 static bool update_particle(void *userdata, const sdl3d_game_data_particle_emitter *emitter)
 {
     particle_update_context *context = (particle_update_context *)userdata;
@@ -1208,6 +1282,24 @@ bool sdl3d_game_data_draw_ui_images(const sdl3d_game_data_runtime *runtime, sdl3
     context.ok = true;
 
     return sdl3d_game_data_for_each_ui_image(runtime, draw_ui_image, &context) && context.ok;
+}
+
+bool sdl3d_game_data_draw_ui_rects(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
+                                   const sdl3d_game_data_ui_metrics *metrics,
+                                   const sdl3d_game_data_render_eval *render_eval)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    ui_rect_draw_context context;
+    SDL_zero(context);
+    context.runtime = runtime;
+    context.renderer = renderer;
+    context.metrics = metrics;
+    context.render_eval = render_eval;
+    context.ok = true;
+
+    return sdl3d_game_data_for_each_ui_rect(runtime, draw_ui_rect, &context) && context.ok;
 }
 
 void sdl3d_game_data_particle_cache_init(sdl3d_game_data_particle_cache *cache)
@@ -2205,6 +2297,7 @@ bool sdl3d_game_data_draw_frame(const sdl3d_game_data_frame_desc *frame)
     }
 
     ok = run_frame_hook(frame, frame->before_ui) && ok;
+    ok = sdl3d_game_data_draw_ui_rects(frame->runtime, frame->renderer, frame->metrics, frame->render_eval) && ok;
     if (frame->image_cache != NULL)
         ok = sdl3d_game_data_draw_ui_images(frame->runtime, frame->renderer, frame->image_cache, frame->metrics,
                                             frame->render_eval) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -171,6 +171,13 @@ struct UiImageCapture
     bool saw_splash_logo = false;
 };
 
+struct UiRectCapture
+{
+    int count = 0;
+    bool saw_doom_damage_feedback = false;
+    sdl3d_game_data_ui_rect damage_rect{};
+};
+
 struct ParticleCapture
 {
     int count = 0;
@@ -1459,6 +1466,23 @@ bool capture_ui_text(void *userdata, const sdl3d_game_data_ui_text *text)
         EXPECT_TRUE(text->normalized);
         EXPECT_NEAR(text->x, 0.5f, 0.0001f);
         EXPECT_NEAR(text->y, 0.5f, 0.0001f);
+    }
+    return true;
+}
+
+bool capture_ui_rect(void *userdata, const sdl3d_game_data_ui_rect *rect)
+{
+    auto *capture = static_cast<UiRectCapture *>(userdata);
+    capture->count++;
+    if (std::string(rect->name) == "ui.doom_level.damage_feedback.top")
+    {
+        capture->saw_doom_damage_feedback = true;
+        capture->damage_rect = *rect;
+        EXPECT_TRUE(rect->normalized);
+        EXPECT_TRUE(rect->pulse_alpha);
+        EXPECT_STREQ(rect->alpha_source_target, "entity.player");
+        EXPECT_STREQ(rect->alpha_source_key, "last_damage_per_second");
+        EXPECT_GT(rect->alpha_source_scale, 0.0f);
     }
     return true;
 }
@@ -8507,6 +8531,23 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     UiTextCapture ui_text{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui_text));
     EXPECT_TRUE(ui_text.saw_doom_reticle);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    UiRectCapture ui_rects{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_rect(runtime, capture_ui_rect, &ui_rects));
+    EXPECT_EQ(ui_rects.count, 4);
+    EXPECT_TRUE(ui_rects.saw_doom_damage_feedback);
+    sdl3d_game_data_ui_rect resolved_damage_rect{};
+    bool damage_rect_visible = true;
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_rect(runtime, &ui_rects.damage_rect, nullptr, &resolved_damage_rect,
+                                                &damage_rect_visible));
+    EXPECT_FALSE(damage_rect_visible);
+    sdl3d_properties_set_float(player->props, "last_damage_per_second", 18.0f);
+    ASSERT_TRUE(sdl3d_game_data_resolve_ui_rect(runtime, &ui_rects.damage_rect, nullptr, &resolved_damage_rect,
+                                                &damage_rect_visible));
+    EXPECT_TRUE(damage_rect_visible);
+    EXPECT_GT(resolved_damage_rect.color.a, 90);
+    EXPECT_LT(resolved_damage_rect.color.a, 120);
     sdl3d_registered_actor *projectile = sdl3d_game_data_find_actor(runtime, "pool.doom.projectiles.0");
     ASSERT_NE(projectile, nullptr);
     EXPECT_FALSE(projectile->active);
@@ -8522,8 +8563,6 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_EQ(projectile_capture.doom_projectile_spheres, 1);
     sdl3d_camera3d surveillance_camera{};
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.doom.surveillance", &surveillance_camera));
-    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
-    ASSERT_NE(player, nullptr);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.doom.player");
     player->position = sdl3d_vec3_make(43.0f, 0.5f, 89.0f);
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));


### PR DESCRIPTION
## Summary
- add generic authored `ui.rects` descriptors with validation, runtime resolution, property-driven alpha, and pulse support
- draw authored UI rectangles in the generic presentation path
- move Doom damage feedback overlays into scene JSON and remove the native Doom damage-feedback sensor/adapter/overlay code
- document the `ui.rects` primitive and cover Doom damage feedback with game-data tests

## Verification
- `git diff --check`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --parallel 8`