### PR TITLE
Author Doom render controls

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -15,7 +15,8 @@
     { "path": "fragments/world/sector_ambient.json", "sections": ["assets", "logic"] },
     { "path": "fragments/world/sector_hazards.json", "sections": ["logic"] },
     { "path": "fragments/world/player_triggers.json", "sections": ["logic"] },
-    { "path": "fragments/world/surveillance.json", "sections": ["logic"] }
+    { "path": "fragments/world/surveillance.json", "sections": ["logic"] },
+    { "path": "fragments/world/render_controls.json", "sections": ["signals", "logic"] }
   ],
   "app": {
     "title": "SDL3D Doom Level",
@@ -54,6 +55,15 @@
           { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
           { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
+          { "name": "action.render.lighting.toggle", "bindings": [{ "device": "keyboard", "key": "L" }] },
+          { "name": "action.render.variant.cycle", "bindings": [{ "device": "keyboard", "key": "M" }] },
+          { "name": "action.render.portal_culling.toggle", "bindings": [{ "device": "keyboard", "key": "F2" }] },
+          { "name": "action.render.profile.cycle", "bindings": [{ "device": "keyboard", "key": "TAB" }] },
+          { "name": "action.render.profile.modern", "bindings": [{ "device": "keyboard", "key": "1" }] },
+          { "name": "action.render.profile.ps1", "bindings": [{ "device": "keyboard", "key": "2" }] },
+          { "name": "action.render.profile.n64", "bindings": [{ "device": "keyboard", "key": "3" }] },
+          { "name": "action.render.profile.dos", "bindings": [{ "device": "keyboard", "key": "4" }] },
+          { "name": "action.render.profile.snes", "bindings": [{ "device": "keyboard", "key": "5" }] },
           {
             "name": "action.fire",
             "bindings": [
@@ -142,9 +152,11 @@
   "render": {
     "clear_color": [8, 10, 14, 255],
     "lighting": true,
+    "lighting_key": "doom.render.lighting",
     "bloom": true,
     "ssao": true,
-    "tonemap": "aces"
+    "profile": "modern",
+    "profile_key": "doom.render.profile"
   },
   "scenes": {
     "initial": "scene.doom_level.play",

--- a/demos/doom_level/data/fragments/world/render_controls.json
+++ b/demos/doom_level/data/fragments/world/render_controls.json
@@ -1,0 +1,119 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "signals": [
+    "signal.render.lighting.toggle",
+    "signal.render.variant.cycle",
+    "signal.render.portal_culling.toggle",
+    "signal.render.profile.cycle",
+    "signal.render.profile.modern",
+    "signal.render.profile.ps1",
+    "signal.render.profile.n64",
+    "signal.render.profile.dos",
+    "signal.render.profile.snes"
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.lighting.toggle",
+        "on_pressed": "signal.render.lighting.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.variant.cycle",
+        "on_pressed": "signal.render.variant.cycle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.portal_culling.toggle",
+        "on_pressed": "signal.render.portal_culling.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.cycle",
+        "on_pressed": "signal.render.profile.cycle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.modern",
+        "on_pressed": "signal.render.profile.modern"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.ps1",
+        "on_pressed": "signal.render.profile.ps1"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.n64",
+        "on_pressed": "signal.render.profile.n64"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.dos",
+        "on_pressed": "signal.render.profile.dos"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.render.profile.snes",
+        "on_pressed": "signal.render.profile.snes"
+      }
+    ],
+    "bindings": [
+      {
+        "signal": "signal.render.lighting.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "doom.render.lighting", "default": true }
+        ]
+      },
+      {
+        "signal": "signal.render.variant.cycle",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "doom.sector.variant",
+            "default": "lightmapped",
+            "values": ["lightmapped", "vertex_baked", "unlit"]
+          }
+        ]
+      },
+      {
+        "signal": "signal.render.portal_culling.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "doom.sector.portal_culling", "default": true }
+        ]
+      },
+      {
+        "signal": "signal.render.profile.cycle",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "doom.render.profile",
+            "default": "modern",
+            "values": ["modern", "ps1", "n64", "dos", "snes"]
+          }
+        ]
+      },
+      {
+        "signal": "signal.render.profile.modern",
+        "actions": [{ "type": "scene_state.set", "key": "doom.render.profile", "value": "modern" }]
+      },
+      {
+        "signal": "signal.render.profile.ps1",
+        "actions": [{ "type": "scene_state.set", "key": "doom.render.profile", "value": "ps1" }]
+      },
+      {
+        "signal": "signal.render.profile.n64",
+        "actions": [{ "type": "scene_state.set", "key": "doom.render.profile", "value": "n64" }]
+      },
+      {
+        "signal": "signal.render.profile.dos",
+        "actions": [{ "type": "scene_state.set", "key": "doom.render.profile", "value": "dos" }]
+      },
+      {
+        "signal": "signal.render.profile.snes",
+        "actions": [{ "type": "scene_state.set", "key": "doom.render.profile", "value": "snes" }]
+      }
+    ]
+  }
+}

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -48,6 +48,15 @@
       "action.move.right",
       "action.jump",
       "action.interact",
+      "action.render.lighting.toggle",
+      "action.render.variant.cycle",
+      "action.render.portal_culling.toggle",
+      "action.render.profile.cycle",
+      "action.render.profile.modern",
+      "action.render.profile.ps1",
+      "action.render.profile.n64",
+      "action.render.profile.dos",
+      "action.render.profile.snes",
       "action.fire"
     ]
   },
@@ -56,8 +65,10 @@
       {
         "level": "sector.doom.e1m1",
         "variant": "lightmapped",
+        "variant_key": "doom.sector.variant",
         "position": [0.0, 0.0, 0.0],
-        "portal_culling": true
+        "portal_culling": true,
+        "portal_culling_key": "doom.sector.portal_culling"
       }
     ]
   },

--- a/demos/doom_level/main.c
+++ b/demos/doom_level/main.c
@@ -31,16 +31,9 @@ typedef struct doom_state
     sdl3d_font debug_font;
     sdl3d_ui_context *ui;
     sdl3d_demo_player *demo_player;
-    sdl3d_backend current_backend;
     doom_render_profile render_profile;
     int action_pause;
     int action_menu;
-    int action_toggle_lighting;
-    int action_toggle_lightmaps;
-    int action_toggle_debug_stats;
-    int action_toggle_portal_culling;
-    int action_switch_backend;
-    int action_render_profile[DOOM_RENDER_PROFILE_COUNT];
     float pause_flash_timer;
     bool has_font;
     bool level_ready;
@@ -139,39 +132,17 @@ static void toggle_pause(sdl3d_game_context *ctx, doom_state *state)
     state->pause_flash_timer = 0.0f;
 }
 
-static int bind_doom_key_action(sdl3d_input_manager *input, const char *name, SDL_Scancode key)
-{
-    int action = sdl3d_input_register_action(input, name);
-    sdl3d_input_bind_key(input, action, key);
-    return action;
-}
-
 static void bind_doom_actions(sdl3d_input_manager *input, doom_state *state)
 {
-    static const SDL_Scancode profile_keys[DOOM_RENDER_PROFILE_COUNT] = {
-        SDL_SCANCODE_1, SDL_SCANCODE_2, SDL_SCANCODE_3, SDL_SCANCODE_4, SDL_SCANCODE_5,
-    };
     sdl3d_input_bind_fps_defaults(input);
     state->action_pause = sdl3d_input_find_action(input, "pause");
     state->action_menu = sdl3d_input_find_action(input, "menu");
-    state->action_toggle_lighting = bind_doom_key_action(input, "toggle_lighting", SDL_SCANCODE_L);
-    state->action_toggle_lightmaps = bind_doom_key_action(input, "toggle_lightmaps", SDL_SCANCODE_M);
-    state->action_toggle_debug_stats = bind_doom_key_action(input, "toggle_debug_stats", SDL_SCANCODE_F1);
-    state->action_toggle_portal_culling = bind_doom_key_action(input, "toggle_portal_culling", SDL_SCANCODE_F2);
-    state->action_switch_backend = bind_doom_key_action(input, "switch_backend", SDL_SCANCODE_TAB);
-    for (int i = 0; i < DOOM_RENDER_PROFILE_COUNT; ++i)
-    {
-        char action_name[SDL3D_INPUT_ACTION_NAME_MAX];
-        SDL_snprintf(action_name, sizeof(action_name), "render_profile_%d", i + 1);
-        state->action_render_profile[i] = bind_doom_key_action(input, action_name, profile_keys[i]);
-    }
 }
 
 static bool game_init(sdl3d_game_context *ctx, void *userdata)
 {
     doom_state *state = (doom_state *)userdata;
 
-    state->current_backend = sdl3d_get_render_context_backend(ctx->renderer);
     state->render_profile = DOOM_RENDER_PROFILE_MODERN;
     bind_doom_actions(ctx_input(ctx), state);
     apply_window_defaults(ctx, state);
@@ -215,29 +186,6 @@ static bool game_init(sdl3d_game_context *ctx, void *userdata)
     return true;
 }
 
-static bool switch_demo_backend(sdl3d_game_context *ctx, doom_state *state)
-{
-    sdl3d_backend next =
-        (state->current_backend == SDL3D_BACKEND_OPENGL) ? SDL3D_BACKEND_SOFTWARE : SDL3D_BACKEND_OPENGL;
-
-    if (sdl3d_switch_backend(&ctx->window, &ctx->renderer, next))
-    {
-        state->current_backend = next;
-        apply_window_defaults(ctx, state);
-        return true;
-    }
-
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Backend switch failed: %s", SDL_GetError());
-    if (!sdl3d_switch_backend(&ctx->window, &ctx->renderer, state->current_backend))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not restore previous backend: %s", SDL_GetError());
-        return false;
-    }
-
-    apply_window_defaults(ctx, state);
-    return true;
-}
-
 static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event *event)
 {
     doom_state *state = (doom_state *)userdata;
@@ -261,52 +209,6 @@ static bool game_event(sdl3d_game_context *ctx, void *userdata, const SDL_Event 
 
     sdl3d_ui_process_event(state->ui, event);
     return true;
-}
-
-static void apply_doom_debug_actions(sdl3d_game_context *ctx, doom_state *state)
-{
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_toggle_lighting))
-    {
-        state->level.use_lit = !state->level.use_lit;
-    }
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_toggle_lightmaps))
-    {
-        state->level.use_lightmaps = !state->level.use_lightmaps;
-    }
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_toggle_debug_stats))
-    {
-        state->render.show_debug = !state->render.show_debug;
-    }
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_toggle_portal_culling))
-    {
-        state->render.portal_culling = !state->render.portal_culling;
-    }
-    if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_switch_backend) && !switch_demo_backend(ctx, state))
-    {
-        ctx->quit_requested = true;
-    }
-}
-
-static void apply_doom_profile_actions(sdl3d_game_context *ctx, doom_state *state)
-{
-    for (int i = 0; i < DOOM_RENDER_PROFILE_COUNT; ++i)
-    {
-        if (!sdl3d_input_is_pressed(ctx_input(ctx), state->action_render_profile[i]))
-        {
-            continue;
-        }
-
-        doom_render_profile next = (doom_render_profile)i;
-        if (backend_apply_profile(ctx->renderer, next))
-        {
-            state->render_profile = next;
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Render profile: %s", backend_profile_name(next));
-        }
-        else
-        {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Render profile switch failed: %s", SDL_GetError());
-        }
-    }
 }
 
 typedef struct doom_tick_profile
@@ -395,15 +297,11 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
         section_start = tick_start;
     }
 
-    apply_doom_profile_actions(ctx, state);
-
     if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_pause))
     {
         toggle_pause(ctx, state);
         return;
     }
-
-    apply_doom_debug_actions(ctx, state);
 
     if (state->demo_player != NULL && sdl3d_demo_playback_finished(state->demo_player))
     {
@@ -463,8 +361,6 @@ static void game_tick(sdl3d_game_context *ctx, void *userdata, float dt)
 static void game_pause_tick(sdl3d_game_context *ctx, void *userdata, float real_dt)
 {
     doom_state *state = (doom_state *)userdata;
-
-    apply_doom_profile_actions(ctx, state);
 
     if (sdl3d_input_is_pressed(ctx_input(ctx), state->action_pause))
     {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -73,6 +73,31 @@ Names are stable authored handles. Use namespaces that reveal ownership:
 Loaders reject duplicate names inside namespaces and report the source file and
 JSON path when validation fails.
 
+## Render
+
+The root `render` object configures frame-level presentation defaults:
+
+```json
+{
+  "render": {
+    "clear_color": [8, 10, 14, 255],
+    "lighting": true,
+    "lighting_key": "render_lighting_enabled",
+    "bloom": true,
+    "ssao": true,
+    "profile": "modern",
+    "profile_key": "render_profile"
+  }
+}
+```
+
+`profile` may be `modern`, `ps1`, `n64`, `dos`, or `snes`. If `tonemap` is not
+authored, the selected profile supplies its tonemap mode. `tonemap` may be
+`none`, `reinhard`, or `aces` when a game wants to override the profile.
+Optional `*_key` fields read scene-state values at draw time and override the
+authored defaults. This lets games author debug/profile toggles through sensors
+and logic actions while keeping the runner game-agnostic.
+
 ## Structured Imports
 
 Imports are structured composition, not textual includes. Each imported file is
@@ -429,8 +454,10 @@ Scenes render sector levels by declaring instances under `world.sector_levels`:
       {
         "level": "sector.e1m1",
         "variant": "lightmapped",
+        "variant_key": "render_sector_variant",
         "position": [0.0, 0.0, 0.0],
-        "portal_culling": true
+        "portal_culling": true,
+        "portal_culling_key": "render_portal_culling"
       }
     ]
   }
@@ -442,6 +469,9 @@ Scenes render sector levels by declaring instances under `world.sector_levels`:
 `position` defaults to the origin and translates the level as a whole.
 `portal_culling` defaults to `true`; when enabled, generic presentation
 computes visibility from the active camera before drawing the level.
+`variant_key` and `portal_culling_key` are optional scene-state keys. When
+present, they override `variant` and `portal_culling` at runtime. This supports
+data-authored debug/profile controls without custom host-side input code.
 
 Renderer, controller, and editor phases should consume runtime descriptors
 instead of parsing JSON directly. `world.kind` remains a high-level statement
@@ -993,6 +1023,23 @@ Logic connects sensors, timers, signals, conditions, and actions:
 
 Use JSON actions for ordinary composition. Use Lua adapters only for
 game-specific calculations or policy that is not a reusable engine primitive.
+
+Scene-state actions write transient values that UI, render settings, sector
+instances, and conditions can read:
+
+```json
+{ "type": "scene_state.set", "key": "render_profile", "value": "ps1" }
+{ "type": "scene_state.toggle", "key": "render_lighting_enabled", "default": true }
+{
+  "type": "scene_state.cycle",
+  "key": "sector_variant",
+  "default": "lightmapped",
+  "values": ["lightmapped", "vertex_baked", "unlit"]
+}
+```
+
+Use `set` for fixed values, `toggle` for booleans, and `cycle` for small
+ordered sets such as render profiles or debug variants.
 
 `property.set` and `property.add` normally target a fixed actor:
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -433,6 +433,12 @@ extern "C"
     {
         /** @brief Clear color for the frame. */
         sdl3d_color clear_color;
+        /** @brief True when a render profile was authored or selected through scene state. */
+        bool has_profile;
+        /** @brief Render profile selected by authored data or scene state. */
+        sdl3d_render_profile profile;
+        /** @brief Name of the selected render profile, or NULL. */
+        const char *profile_name;
         /** @brief Whether 3D lighting should be enabled. */
         bool lighting_enabled;
         /** @brief Whether bloom post-processing should be enabled. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3885,6 +3885,51 @@ static sdl3d_tonemap_mode parse_tonemap(const char *value, sdl3d_tonemap_mode fa
     return fallback;
 }
 
+static bool parse_render_profile(const char *value, sdl3d_render_profile *out_profile)
+{
+    if (value == NULL || out_profile == NULL)
+        return false;
+    if (SDL_strcasecmp(value, "modern") == 0)
+        *out_profile = sdl3d_profile_modern();
+    else if (SDL_strcasecmp(value, "ps1") == 0)
+        *out_profile = sdl3d_profile_ps1();
+    else if (SDL_strcasecmp(value, "n64") == 0)
+        *out_profile = sdl3d_profile_n64();
+    else if (SDL_strcasecmp(value, "dos") == 0)
+        *out_profile = sdl3d_profile_dos();
+    else if (SDL_strcasecmp(value, "snes") == 0)
+        *out_profile = sdl3d_profile_snes();
+    else
+        return false;
+    return true;
+}
+
+static const char *scene_state_string(const sdl3d_game_data_runtime *runtime, const char *key, const char *fallback)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0')
+        return fallback;
+    return sdl3d_properties_get_string(runtime->scene_state, key, fallback);
+}
+
+static bool scene_state_bool(const sdl3d_game_data_runtime *runtime, const char *key, bool fallback)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0')
+        return fallback;
+    const sdl3d_value *value = sdl3d_properties_get_value(runtime->scene_state, key);
+    if (value == NULL)
+        return fallback;
+    if (value->type == SDL3D_VALUE_BOOL)
+        return value->as_bool;
+    if (value->type == SDL3D_VALUE_INT)
+        return value->as_int != 0;
+    if (value->type == SDL3D_VALUE_STRING && value->as_string != NULL)
+    {
+        return SDL_strcasecmp(value->as_string, "true") == 0 || SDL_strcmp(value->as_string, "1") == 0 ||
+               SDL_strcasecmp(value->as_string, "on") == 0 || SDL_strcasecmp(value->as_string, "yes") == 0;
+    }
+    return fallback;
+}
+
 static sdl3d_transition_type parse_transition_type(const char *value, sdl3d_transition_type fallback)
 {
     if (value == NULL)
@@ -6206,10 +6251,27 @@ bool sdl3d_game_data_get_render_settings(const sdl3d_game_data_runtime *runtime,
         return true;
 
     out_settings->clear_color = json_color(render, "clear_color", out_settings->clear_color);
-    out_settings->lighting_enabled = json_bool(render, "lighting", out_settings->lighting_enabled);
-    out_settings->bloom_enabled = json_bool(render, "bloom", out_settings->bloom_enabled);
-    out_settings->ssao_enabled = json_bool(render, "ssao", out_settings->ssao_enabled);
-    out_settings->tonemap = parse_tonemap(json_string(render, "tonemap", NULL), out_settings->tonemap);
+    out_settings->lighting_enabled = scene_state_bool(runtime, json_string(render, "lighting_key", NULL),
+                                                      json_bool(render, "lighting", out_settings->lighting_enabled));
+    out_settings->bloom_enabled = scene_state_bool(runtime, json_string(render, "bloom_key", NULL),
+                                                   json_bool(render, "bloom", out_settings->bloom_enabled));
+    out_settings->ssao_enabled = scene_state_bool(runtime, json_string(render, "ssao_key", NULL),
+                                                  json_bool(render, "ssao", out_settings->ssao_enabled));
+    const char *tonemap_name =
+        scene_state_string(runtime, json_string(render, "tonemap_key", NULL), json_string(render, "tonemap", NULL));
+    out_settings->tonemap = parse_tonemap(tonemap_name, out_settings->tonemap);
+
+    const char *profile_name =
+        scene_state_string(runtime, json_string(render, "profile_key", NULL), json_string(render, "profile", NULL));
+    sdl3d_render_profile profile;
+    if (parse_render_profile(profile_name, &profile))
+    {
+        out_settings->has_profile = true;
+        out_settings->profile = profile;
+        out_settings->profile_name = profile_name;
+        if (tonemap_name == NULL)
+            out_settings->tonemap = profile.tonemap;
+    }
     return true;
 }
 
@@ -6375,7 +6437,8 @@ bool sdl3d_game_data_for_each_sector_level_instance(const sdl3d_game_data_runtim
     {
         yyjson_val *entry = yyjson_arr_get(instances, i);
         const char *level_name = json_string(entry, "level", NULL);
-        const char *variant_name = json_string(entry, "variant", "lightmapped");
+        const char *variant_name = scene_state_string(runtime, json_string(entry, "variant_key", NULL),
+                                                      json_string(entry, "variant", "lightmapped"));
         const sector_level_runtime *level_runtime = find_sector_level_runtime(runtime, level_name);
         const sdl3d_level *level = NULL;
         const sdl3d_game_data_sector_level_variant variant =
@@ -6392,7 +6455,8 @@ bool sdl3d_game_data_for_each_sector_level_instance(const sdl3d_game_data_runtim
         instance.sectors = level_runtime->sectors;
         instance.sector_count = level_runtime->sector_count;
         instance.position = json_vec3(entry, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
-        instance.portal_culling = json_bool(entry, "portal_culling", true);
+        instance.portal_culling = scene_state_bool(runtime, json_string(entry, "portal_culling_key", NULL),
+                                                   json_bool(entry, "portal_culling", true));
         if (!callback(userdata, &instance))
             return true;
     }
@@ -14109,6 +14173,42 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0' || value == NULL)
             return false;
         return set_property_from_json_with_payload(runtime->scene_state, key, value, payload);
+    }
+
+    if (SDL_strcmp(type, "scene_state.toggle") == 0)
+    {
+        const char *key = json_string(action, "key", NULL);
+        if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0')
+            return false;
+        const bool current = scene_state_bool(runtime, key, json_bool(action, "default", false));
+        sdl3d_properties_set_bool(runtime->scene_state, key, !current);
+        return true;
+    }
+
+    if (SDL_strcmp(type, "scene_state.cycle") == 0)
+    {
+        const char *key = json_string(action, "key", NULL);
+        yyjson_val *values = obj_get(action, "values");
+        const size_t count = yyjson_is_arr(values) ? yyjson_arr_size(values) : 0U;
+        if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0' || count == 0U)
+            return false;
+
+        const sdl3d_value *current = sdl3d_properties_get_value(runtime->scene_state, key);
+        sdl3d_value fallback;
+        if (current == NULL && json_scalar_to_value(obj_get(action, "default"), &fallback))
+            current = &fallback;
+        size_t next = 0U;
+        for (size_t i = 0; i < count; ++i)
+        {
+            yyjson_val *value = yyjson_arr_get(values, i);
+            if (json_value_matches_property(value, current))
+            {
+                next = (i + 1U) % count;
+                break;
+            }
+        }
+
+        return set_property_from_json(runtime->scene_state, key, yyjson_arr_get(values, next));
     }
 
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5238,6 +5238,34 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "scene_state.set requires a scalar value");
         return true;
     }
+    if (SDL_strcmp(type, "scene_state.toggle") == 0)
+    {
+        if (!is_non_empty_string(action, "key"))
+            return validation_error(ctx, json_path, "scene_state.toggle requires a non-empty key");
+        yyjson_val *default_value = obj_get(action, "default");
+        if (default_value != NULL && !yyjson_is_bool(default_value))
+            return validation_error(ctx, json_path, "scene_state.toggle default must be a boolean");
+        return true;
+    }
+    if (SDL_strcmp(type, "scene_state.cycle") == 0)
+    {
+        if (!is_non_empty_string(action, "key"))
+            return validation_error(ctx, json_path, "scene_state.cycle requires a non-empty key");
+        yyjson_val *values = obj_get(action, "values");
+        if (!yyjson_is_arr(values) || yyjson_arr_size(values) == 0)
+            return validation_error(ctx, json_path, "scene_state.cycle requires a non-empty values array");
+        for (size_t i = 0; i < yyjson_arr_size(values); ++i)
+        {
+            yyjson_val *value = yyjson_arr_get(values, i);
+            if (!(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value)))
+                return validation_error(ctx, json_path, "scene_state.cycle values must be scalar");
+        }
+        yyjson_val *default_value = obj_get(action, "default");
+        if (default_value != NULL &&
+            !(yyjson_is_bool(default_value) || yyjson_is_num(default_value) || yyjson_is_str(default_value)))
+            return validation_error(ctx, json_path, "scene_state.cycle default must be scalar");
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))
@@ -6794,12 +6822,18 @@ static bool validate_scene_sector_levels(validation_context *ctx, yyjson_val *sc
             return validation_error(ctx, entry_path,
                                     "scene sector level variant must be lightmapped, vertex_baked, or unlit");
         }
+        yyjson_val *variant_key = obj_get(entry, "variant_key");
+        if (variant_key != NULL && !is_non_empty_string(entry, "variant_key"))
+            return validation_error(ctx, entry_path, "scene sector level variant_key must be non-empty");
         yyjson_val *position = obj_get(entry, "position");
         if (position != NULL && !is_exact_vec_array(position, 3))
             return validation_error(ctx, entry_path, "scene sector level position must be a vec3 array");
         yyjson_val *portal_culling = obj_get(entry, "portal_culling");
         if (portal_culling != NULL && !yyjson_is_bool(portal_culling))
             return validation_error(ctx, entry_path, "scene sector level portal_culling must be a boolean");
+        yyjson_val *portal_culling_key = obj_get(entry, "portal_culling_key");
+        if (portal_culling_key != NULL && !is_non_empty_string(entry, "portal_culling_key"))
+            return validation_error(ctx, entry_path, "scene sector level portal_culling_key must be non-empty");
     }
     return true;
 }
@@ -7247,6 +7281,51 @@ static bool warn_unused(validation_context *ctx, const name_table *declared, con
     return true;
 }
 
+static bool valid_render_profile_name(const char *name)
+{
+    return name != NULL &&
+           (SDL_strcasecmp(name, "modern") == 0 || SDL_strcasecmp(name, "ps1") == 0 ||
+            SDL_strcasecmp(name, "n64") == 0 || SDL_strcasecmp(name, "dos") == 0 || SDL_strcasecmp(name, "snes") == 0);
+}
+
+static bool valid_tonemap_name(const char *name)
+{
+    return name != NULL && (SDL_strcasecmp(name, "none") == 0 || SDL_strcasecmp(name, "reinhard") == 0 ||
+                            SDL_strcasecmp(name, "aces") == 0);
+}
+
+static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *render = obj_get(root, "render");
+    if (render == NULL)
+        return true;
+    if (!yyjson_is_obj(render))
+        return validation_error(ctx, "$.render", "render must be an object");
+
+    yyjson_val *lighting = obj_get(render, "lighting");
+    yyjson_val *bloom = obj_get(render, "bloom");
+    yyjson_val *ssao = obj_get(render, "ssao");
+    if ((lighting != NULL && !yyjson_is_bool(lighting)) || (bloom != NULL && !yyjson_is_bool(bloom)) ||
+        (ssao != NULL && !yyjson_is_bool(ssao)))
+        return validation_error(ctx, "$.render", "render lighting, bloom, and ssao must be booleans");
+    if (obj_get(render, "clear_color") != NULL && !is_vec_array(obj_get(render, "clear_color"), 3))
+        return validation_error(ctx, "$.render.clear_color", "render clear_color must be a vec3 or vec4 color");
+    const char *tonemap = json_string(render, "tonemap");
+    if (tonemap != NULL && !valid_tonemap_name(tonemap))
+        return validation_error(ctx, "$.render.tonemap", "render tonemap must be none, reinhard, or aces");
+    const char *profile = json_string(render, "profile");
+    if (profile != NULL && !valid_render_profile_name(profile))
+        return validation_error(ctx, "$.render.profile", "render profile is unknown");
+
+    const char *key_fields[] = {"lighting_key", "bloom_key", "ssao_key", "tonemap_key", "profile_key"};
+    for (size_t i = 0; i < SDL_arraysize(key_fields); ++i)
+    {
+        if (obj_get(render, key_fields[i]) != NULL && !is_non_empty_string(render, key_fields[i]))
+            return validation_error(ctx, "$.render", "render scene-state key fields must be non-empty strings");
+    }
+    return true;
+}
+
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
@@ -7259,9 +7338,10 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
            validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
-           validate_presentation(ctx, root, names) && validate_render_effects(ctx, root, names) &&
-           validate_lights(ctx, root, names) && validate_haptics(ctx, root, names) &&
-           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
+           validate_presentation(ctx, root, names) && validate_render_settings(ctx, root) &&
+           validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
+           validate_haptics(ctx, root, names) && validate_logic(ctx, root, names) &&
+           validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -172,6 +172,8 @@ static bool apply_render_settings(const sdl3d_game_data_runtime *runtime, sdl3d_
 
     bool ok = true;
     ok = sdl3d_clear_render_context(renderer, settings.clear_color) && ok;
+    if (settings.has_profile)
+        ok = sdl3d_set_render_profile(renderer, &settings.profile) && ok;
     ok = sdl3d_set_lighting_enabled(renderer, settings.lighting_enabled) && ok;
     ok = sdl3d_set_bloom_enabled(renderer, settings.bloom_enabled) && ok;
     ok = sdl3d_set_ssao_enabled(renderer, settings.ssao_enabled) && ok;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8505,6 +8505,46 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     ASSERT_NE(runtime, nullptr);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.doom_level.play"));
+    sdl3d_game_data_render_settings render_settings{};
+    ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_TRUE(render_settings.has_profile);
+    EXPECT_STREQ(render_settings.profile_name, "modern");
+    EXPECT_TRUE(render_settings.lighting_enabled);
+
+    const int lighting_toggle_signal = sdl3d_game_data_find_signal(runtime, "signal.render.lighting.toggle");
+    ASSERT_GE(lighting_toggle_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), lighting_toggle_signal, nullptr);
+    ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_FALSE(render_settings.lighting_enabled);
+
+    const int profile_ps1_signal = sdl3d_game_data_find_signal(runtime, "signal.render.profile.ps1");
+    ASSERT_GE(profile_ps1_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), profile_ps1_signal, nullptr);
+    ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_STREQ(render_settings.profile_name, "ps1");
+    EXPECT_TRUE(render_settings.profile.vertex_snap);
+    EXPECT_EQ(render_settings.tonemap, SDL3D_TONEMAP_NONE);
+
+    SectorLevelInstanceCapture sector_capture{};
+    ASSERT_TRUE(
+        sdl3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &sector_capture));
+    EXPECT_EQ(sector_capture.variant, SDL3D_GAME_DATA_SECTOR_LEVEL_LIGHTMAPPED);
+    EXPECT_TRUE(sector_capture.portal_culling);
+    const int variant_cycle_signal = sdl3d_game_data_find_signal(runtime, "signal.render.variant.cycle");
+    ASSERT_GE(variant_cycle_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), variant_cycle_signal, nullptr);
+    sector_capture = {};
+    ASSERT_TRUE(
+        sdl3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &sector_capture));
+    EXPECT_EQ(sector_capture.variant, SDL3D_GAME_DATA_SECTOR_LEVEL_VERTEX_BAKED);
+    const int portal_toggle_signal = sdl3d_game_data_find_signal(runtime, "signal.render.portal_culling.toggle");
+    ASSERT_GE(portal_toggle_signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), portal_toggle_signal, nullptr);
+    sector_capture = {};
+    ASSERT_TRUE(
+        sdl3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &sector_capture));
+    EXPECT_FALSE(sector_capture.portal_culling);
+
     DoorPrefixRenderCapture capture{};
     capture.prefix = "door.";
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_door_prefix_render_primitive, &capture));


### PR DESCRIPTION
## Summary
- add generic scene-state toggle/cycle actions for data-authored runtime switches
- let render settings and sector-level instances read scene-state overrides for profiles, lighting, variants, and portal culling
- author Doom render/debug controls in JSON and remove the matching native host key plumbing
- document render profile overrides, scene-state actions, and sector-level runtime keys

## Verification
- `git diff --check`
- `cmake --build build/debug --target sdl3d_game_data_test doom_level sdl3d_runner --parallel 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter="GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.ResolvesActiveSceneSectorLevelInstances"`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --parallel 8`
- `./build/debug/sdl3d_runner --root demos/doom_level/data --data asset://doom_level.game.json --scene scene.doom_level.play` startup smoke, stopped after successful load