### PR TITLE
Author Doom app lifecycle controls

### DIFF
--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -21,7 +21,13 @@
   "app": {
     "title": "SDL3D Doom Level",
     "window": { "width": 1280, "height": 720, "renderer": "opengl", "vsync": true },
-    "audio": { "enabled": true }
+    "audio": { "enabled": true },
+    "startup_transition": "startup",
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit", "transition": "quit" },
+    "input_policy": {
+      "global_actions": ["action.exit"]
+    }
   },
   "world": {
     "name": "world.doom_level",
@@ -54,6 +60,8 @@
           { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
           { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
+          { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] },
           { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
           { "name": "action.render.lighting.toggle", "bindings": [{ "device": "keyboard", "key": "L" }] },
           { "name": "action.render.variant.cycle", "bindings": [{ "device": "keyboard", "key": "M" }] },
@@ -157,6 +165,20 @@
     "ssao": true,
     "profile": "modern",
     "profile_key": "doom.render.profile"
+  },
+  "transitions": {
+    "startup": {
+      "type": "fade",
+      "direction": "in",
+      "color": [0, 0, 0, 255],
+      "duration": 0.35
+    },
+    "quit": {
+      "type": "fade",
+      "direction": "out",
+      "color": [0, 0, 0, 255],
+      "duration": 0.35
+    }
   },
   "scenes": {
     "initial": "scene.doom_level.play",

--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -47,6 +47,7 @@
       "action.move.left",
       "action.move.right",
       "action.jump",
+      "action.pause",
       "action.interact",
       "action.render.lighting.toggle",
       "action.render.variant.cycle",
@@ -181,6 +182,16 @@
         "pulse_rate": 2.8,
         "pulse_min": 0.45,
         "pulse_max": 1.0
+      },
+      {
+        "name": "ui.doom_level.pause.backdrop",
+        "x": 0.0,
+        "y": 0.0,
+        "w": 1.0,
+        "h": 1.0,
+        "normalized": true,
+        "color": [0, 0, 0, 120],
+        "visible_if": { "type": "app.paused", "equals": true }
       }
     ],
     "text": [
@@ -203,6 +214,29 @@
         "centered": true,
         "normalized": true,
         "color": [255, 255, 255, 220]
+      },
+      {
+        "name": "ui.doom_level.pause.title",
+        "text": "PAUSED",
+        "x": 0.5,
+        "y": 0.42,
+        "scale": 1.6,
+        "centered": true,
+        "normalized": true,
+        "color": [245, 248, 255, 255],
+        "pulse_alpha": true,
+        "visible_if": { "type": "app.paused", "equals": true }
+      },
+      {
+        "name": "ui.doom_level.pause.help",
+        "text": "Press P to resume - Esc exits",
+        "x": 0.5,
+        "y": 0.5,
+        "scale": 0.9,
+        "centered": true,
+        "normalized": true,
+        "color": [190, 205, 235, 220],
+        "visible_if": { "type": "app.paused", "equals": true }
       }
     ]
   }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -221,10 +221,22 @@ The optional `app` object configures the managed loop before the window exists:
     "backend": "opengl",
     "tick_rate": 60,
     "audio": { "enabled": true },
-    "pause": { "action": "action.pause" }
+    "startup_transition": "startup",
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit", "transition": "quit" },
+    "input_policy": {
+      "global_actions": ["action.exit"]
+    }
   }
 }
 ```
+
+`pause.action` toggles the managed runtime pause state when the active scene
+allows the action and `pause.allowed_if` is absent or true. `quit.action`
+requests shutdown through the managed app flow; when `quit.transition` names an
+authored transition, shutdown is delayed until that transition finishes. Use
+`app.input_policy.global_actions` for lifecycle actions such as quit that should
+work even when a scene restricts its local `input.actions` list.
 
 ## UI Rectangles
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8505,6 +8505,53 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     ASSERT_NE(runtime, nullptr);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.doom_level.play"));
+    sdl3d_game_data_app_control app{};
+    ASSERT_TRUE(sdl3d_game_data_get_app_control(runtime, &app));
+    EXPECT_EQ(app.start_signal_id, -1);
+    EXPECT_GE(app.pause_action_id, 0);
+    EXPECT_GE(app.quit_action_id, 0);
+    EXPECT_STREQ(app.startup_transition, "startup");
+    EXPECT_STREQ(app.quit_transition, "quit");
+
+    sdl3d_game_context ctx{};
+    ctx.session = session;
+    sdl3d_game_data_app_flow flow{};
+    sdl3d_game_data_app_flow_init(&flow);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_start(&flow, runtime));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_is_transitioning(&flow));
+
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_P;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 1);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_TRUE(ctx.paused);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 2);
+    key.type = SDL_EVENT_KEY_DOWN;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 3);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_FALSE(ctx.paused);
+
+    key.type = SDL_EVENT_KEY_UP;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 4);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    sdl3d_input_process_event(input, &key);
+    sdl3d_input_update(input, 5);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.0f));
+    EXPECT_TRUE(sdl3d_game_data_app_flow_quit_pending(&flow));
+    EXPECT_FALSE(ctx.quit_requested);
+    ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.36f));
+    EXPECT_TRUE(ctx.quit_requested);
+
     sdl3d_game_data_render_settings render_settings{};
     ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render_settings));
     EXPECT_TRUE(render_settings.has_profile);
@@ -8571,11 +8618,30 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     UiTextCapture ui_text{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui_text, &ui_text));
     EXPECT_TRUE(ui_text.saw_doom_reticle);
+    sdl3d_game_data_ui_text pause_text{};
+    bool saw_pause_text = false;
+    auto find_doom_pause_text = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        if (std::string(text->name) != "ui.doom_level.pause.title")
+            return true;
+        auto *args = static_cast<std::pair<sdl3d_game_data_ui_text *, bool *> *>(userdata);
+        *args->first = *text;
+        *args->second = true;
+        return false;
+    };
+    std::pair<sdl3d_game_data_ui_text *, bool *> pause_text_args{&pause_text, &saw_pause_text};
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_doom_pause_text, &pause_text_args));
+    ASSERT_TRUE(saw_pause_text);
+    sdl3d_game_data_ui_metrics ui_metrics{};
+    ui_metrics.paused = false;
+    EXPECT_FALSE(sdl3d_game_data_ui_text_is_visible(runtime, &pause_text, &ui_metrics));
+    ui_metrics.paused = true;
+    EXPECT_TRUE(sdl3d_game_data_ui_text_is_visible(runtime, &pause_text, &ui_metrics));
+
     sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
     ASSERT_NE(player, nullptr);
     UiRectCapture ui_rects{};
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_rect(runtime, capture_ui_rect, &ui_rects));
-    EXPECT_EQ(ui_rects.count, 4);
+    EXPECT_EQ(ui_rects.count, 5);
     EXPECT_TRUE(ui_rects.saw_doom_damage_feedback);
     sdl3d_game_data_ui_rect resolved_damage_rect{};
     bool damage_rect_visible = true;


### PR DESCRIPTION
## Summary
- Add data-authored Doom pause and quit actions using the generic managed app flow
- Add authored startup/quit transitions and an app-paused overlay for the Doom play scene
- Document managed pause/quit app lifecycle controls

## Verification
- cmake --build build/debug --target sdl3d_game_data_test
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug --target sdl3d_runner
- git diff --check