### PR TITLE
Add authored scene mouse capture policy

### DIFF
--- a/demos/doom_level/data/scenes/play.scene.json
+++ b/demos/doom_level/data/scenes/play.scene.json
@@ -41,6 +41,7 @@
     "entity.doom.presentation.surveillance.camera_body"
   ],
   "input": {
+    "mouse_capture": "unpaused",
     "actions": [
       "action.move.forward",
       "action.move.back",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -682,6 +682,22 @@ loaded scene directly and may inject scene state before that scene's enter
 signal runs. Authored data should still define a valid `scenes.initial` so the
 game has a complete production startup path.
 
+Scene `input` can restrict allowed actions and request relative mouse capture:
+
+```json
+{
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": ["action.move.forward", "action.look", "action.pause"]
+  }
+}
+```
+
+`input.mouse_capture` accepts `never`, `unpaused`, or `always`. Missing policy
+defaults to `never`. FPS-style scenes should normally use `unpaused` so the
+generic runtime captures relative mouse motion during play and releases it
+while authored pause/menu overlays are active.
+
 ## Actors
 
 Actors describe runtime objects:

--- a/include/sdl3d/data_game.h
+++ b/include/sdl3d/data_game.h
@@ -105,6 +105,15 @@ extern "C"
      */
     void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime);
 
+    /**
+     * @brief Release any relative mouse capture applied by the runtime.
+     *
+     * Generic hosts should call this during shutdown before destroying the
+     * runtime when a window is still available. It is safe to call with NULL
+     * arguments or when no capture policy has been applied.
+     */
+    void sdl3d_data_game_runtime_release_mouse_capture(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx);
+
     /** @brief Return the runtime-owned asset resolver, or NULL. */
     sdl3d_asset_resolver *sdl3d_data_game_runtime_assets(const sdl3d_data_game_runtime *runtime);
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -2243,6 +2243,16 @@ extern "C"
     bool sdl3d_game_data_active_scene_allows_action(const sdl3d_game_data_runtime *runtime, int action_id);
 
     /**
+     * @brief Return whether the active scene requests relative mouse capture.
+     *
+     * Scenes may author `input.mouse_capture` as `never`, `unpaused`, or
+     * `always`. Missing policy defaults to `never`. The @p paused argument lets
+     * generic hosts release the cursor while an authored pause/menu overlay is
+     * active.
+     */
+    bool sdl3d_game_data_active_scene_mouse_capture(const sdl3d_game_data_runtime *runtime, bool paused);
+
+    /**
      * @brief Read authored scene transition policy.
      *
      * Missing fields use stable defaults: same-scene requests and interrupting

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -3,6 +3,7 @@
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_timer.h>
+#include <SDL3/SDL_video.h>
 
 #include "sdl3d/game_presentation.h"
 #include "sdl3d/input.h"
@@ -31,6 +32,8 @@ struct sdl3d_data_game_runtime
     int managed_network_camera_toggle_signal_id;
     bool managed_network_lobby_start_requested;
     float managed_network_termination_timer;
+    bool mouse_capture_applied;
+    bool mouse_capture_enabled;
 };
 
 static const char SDL3D_MANAGED_NETWORK_HOST_SESSION[] = "host";
@@ -79,6 +82,32 @@ static Uint32 data_game_input_tick(const sdl3d_data_game_runtime *runtime)
         runtime != NULL && runtime->session != NULL ? sdl3d_game_session_get_input(runtime->session) : NULL;
     const sdl3d_input_snapshot *snapshot = input != NULL ? sdl3d_input_get_snapshot(input) : NULL;
     return snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : (Uint32)SDL_GetTicks();
+}
+
+static void data_game_release_mouse_capture(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || ctx == NULL || ctx->window == NULL || !runtime->mouse_capture_applied ||
+        !runtime->mouse_capture_enabled)
+    {
+        return;
+    }
+
+    SDL_SetWindowRelativeMouseMode(ctx->window, false);
+    runtime->mouse_capture_enabled = false;
+}
+
+static void data_game_apply_scene_mouse_capture(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    if (runtime == NULL || runtime->data == NULL || ctx == NULL || ctx->window == NULL)
+        return;
+
+    const bool capture = sdl3d_game_data_active_scene_mouse_capture(runtime->data, ctx->paused);
+    if (runtime->mouse_capture_applied && runtime->mouse_capture_enabled == capture)
+        return;
+
+    SDL_SetWindowRelativeMouseMode(ctx->window, capture);
+    runtime->mouse_capture_applied = true;
+    runtime->mouse_capture_enabled = capture;
 }
 
 static bool data_game_binding_matches(const char *actual, const char *expected)
@@ -970,6 +999,11 @@ void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime)
     SDL_free(runtime);
 }
 
+void sdl3d_data_game_runtime_release_mouse_capture(sdl3d_data_game_runtime *runtime, sdl3d_game_context *ctx)
+{
+    data_game_release_mouse_capture(runtime, ctx);
+}
+
 sdl3d_asset_resolver *sdl3d_data_game_runtime_assets(const sdl3d_data_game_runtime *runtime)
 {
     return runtime != NULL ? runtime->assets : NULL;
@@ -1320,6 +1354,7 @@ bool sdl3d_data_game_runtime_update_frame(sdl3d_data_game_runtime *runtime, sdl3
         return false;
 
     managed_network_update_after_frame(runtime, ctx);
+    data_game_apply_scene_mouse_capture(runtime, ctx);
     return true;
 }
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7245,6 +7245,23 @@ bool sdl3d_game_data_active_scene_allows_action(const sdl3d_game_data_runtime *r
     return string_array_contains(actions, action);
 }
 
+bool sdl3d_game_data_active_scene_mouse_capture(const sdl3d_game_data_runtime *runtime, bool paused)
+{
+    if (runtime == NULL)
+        return false;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *input = obj_get(scene != NULL ? scene->root : NULL, "input");
+    const char *policy = json_string(input, "mouse_capture", "never");
+    if (policy == NULL || SDL_strcmp(policy, "never") == 0)
+        return false;
+    if (SDL_strcmp(policy, "always") == 0)
+        return true;
+    if (SDL_strcmp(policy, "unpaused") == 0)
+        return !paused;
+    return false;
+}
+
 bool sdl3d_game_data_get_scene_transition_policy(const sdl3d_game_data_runtime *runtime,
                                                  sdl3d_game_data_scene_transition_policy *out_policy)
 {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -6935,6 +6935,10 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     yyjson_val *scene_input = obj_get(root, "input");
     if (scene_input != NULL && !yyjson_is_obj(scene_input))
         return validation_error(ctx, json_path, "scene input must be an object");
+    const char *mouse_capture = json_string(scene_input, "mouse_capture");
+    if (mouse_capture != NULL && SDL_strcmp(mouse_capture, "never") != 0 &&
+        SDL_strcmp(mouse_capture, "unpaused") != 0 && SDL_strcmp(mouse_capture, "always") != 0)
+        return validation_error(ctx, json_path, "scene input.mouse_capture must be never, unpaused, or always");
     yyjson_val *scene_actions = obj_get(scene_input, "actions");
     if (scene_actions != NULL && !yyjson_is_arr(scene_actions))
         return validation_error(ctx, json_path, "scene input.actions must be an array");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8551,6 +8551,8 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_FALSE(ctx.quit_requested);
     ASSERT_TRUE(sdl3d_game_data_app_flow_update(&flow, &ctx, runtime, 0.36f));
     EXPECT_TRUE(ctx.quit_requested);
+    EXPECT_TRUE(sdl3d_game_data_active_scene_mouse_capture(runtime, false));
+    EXPECT_FALSE(sdl3d_game_data_active_scene_mouse_capture(runtime, true));
 
     sdl3d_game_data_render_settings render_settings{};
     ASSERT_TRUE(sdl3d_game_data_get_render_settings(runtime, &render_settings));
@@ -9104,6 +9106,31 @@ TEST(GameDataRuntime, RejectsInvalidSceneSectorLevelInstances)
         EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
             << test_case.name << ": " << error;
     }
+
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidSceneMouseCapturePolicy)
+{
+    const std::filesystem::path dir = unique_test_dir("scene_mouse_capture_invalid");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "input": { "mouse_capture": "relative" }
+})json");
+    write_text(dir / "game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Scene Mouse Capture" },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("scene input.mouse_capture must be never, unpaused, or always"),
+              std::string::npos)
+        << error;
 
     remove_test_dir(dir);
 }

--- a/tools/sdl3d_runner.c
+++ b/tools/sdl3d_runner.c
@@ -306,9 +306,9 @@ static void runner_render(sdl3d_game_context *ctx, void *userdata, float alpha)
 static void runner_shutdown(sdl3d_game_context *ctx, void *userdata)
 {
     runner_state *state = (runner_state *)userdata;
-    (void)ctx;
     if (state != NULL)
     {
+        sdl3d_data_game_runtime_release_mouse_capture(state->runtime, ctx);
         sdl3d_data_game_runtime_destroy(state->runtime);
         state->runtime = NULL;
     }


### PR DESCRIPTION
## Summary
- Add scene-level input.mouse_capture policy with never, unpaused, and always modes
- Apply authored mouse capture from the generic data-game runtime and release it on runner shutdown
- Opt the Doom sector play scene into unpaused relative mouse capture
- Document the policy and add validation/runtime coverage

## Verification
- cmake --build build/debug --target sdl3d_game_data_test sdl3d_runner
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.DoomLevelDataLoadsAuthoredSectorDoors:GameDataRuntime.RejectsInvalidSceneMouseCapturePolicy'
- ./build/debug/tests/sdl3d_game_data_test
- git diff --check