### PR TITLE
Add FPS mechanics dojo editor metadata

### DIFF
--- a/demos/fps_mechanics_dojo/README.md
+++ b/demos/fps_mechanics_dojo/README.md
@@ -1,0 +1,22 @@
+# FPS Mechanics Dojo
+
+This is a data-only testbed for reusable FPS world mechanics. It intentionally
+uses mock geometry, authored lights, and simple trigger volumes instead of
+finished media assets.
+
+Run it with the generic runner:
+
+```sh
+./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json
+```
+
+The first scene demonstrates existing data-authored primitives:
+
+- `controller.fps_sector` movement
+- `controller.fps_sector.launch` for jump-pad style movement
+- `controller.fps_sector.teleport` for teleport pads
+- `sensor.volume` and `sensor.sector`
+- `sector_doors` and `sector_platforms`
+- actor archetype/instance mockups with optional `editor` metadata
+
+The dojo is meant to grow alongside reusable mechanics from issue #282.

--- a/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
+++ b/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
@@ -1,0 +1,50 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "SDL3D FPS Mechanics Dojo",
+    "id": "demo.fps_mechanics_dojo",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/world/arena.json", "sections": ["sector_level_fragments", "sector_doors", "sector_platforms", "signals", "logic"] },
+    { "path": "fragments/actors/player.json", "sections": ["entities"] },
+    { "path": "fragments/actors/mechanic_markers.json", "sections": ["actor_archetypes", "actor_instances"] },
+    { "path": "fragments/editor/metadata.json", "sections": ["editor"] }
+  ],
+  "app": {
+    "title": "SDL3D FPS Mechanics Dojo",
+    "window": { "width": 1280, "height": 720, "renderer": "opengl", "vsync": true },
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "world": {
+    "name": "world.fps_mechanics_dojo",
+    "kind": "sector",
+    "ambient_light": [0.16, 0.16, 0.2],
+    "cameras": [
+      {
+        "name": "camera.dojo.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fovy": 68.0,
+        "active": true
+      }
+    ]
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.dojo.hud", "builtin": "Inter", "size": 22 }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": true,
+    "clear_color": [0.02, 0.025, 0.04]
+  },
+  "scenes": {
+    "initial": "scene.dojo.fps_world",
+    "files": ["scenes/fps_world.scene.json"]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
@@ -1,0 +1,82 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "actor_archetypes": [
+    {
+      "name": "archetype.dojo.marker.pad",
+      "active": true,
+      "tags": ["dojo_marker", "mechanic_marker"],
+      "components": [
+        { "type": "render.cube", "size": [2.0, 0.12, 2.0], "color": [50, 170, 230, 210], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.2, 0.8, 1.0], "intensity": 1.8, "range": 5.0 }
+      ],
+      "editor": {
+        "display_name": "Mechanic Marker Pad",
+        "category": "mechanics/markers",
+        "tags": ["marker", "mockup"],
+        "preview": { "primitive": "cube", "color": [0.2, 0.8, 1.0, 1.0] },
+        "bounds": { "size": [2.0, 0.12, 2.0] },
+        "snap": { "grid": [0.5, 0.25, 0.5], "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "label", "type": "string", "display_name": "Label" }
+        ],
+        "test_scene": "scene.dojo.fps_world"
+      }
+    }
+  ],
+  "actor_instances": [
+    {
+      "name": "entity.dojo.launch_pad",
+      "archetype": "archetype.dojo.marker.pad",
+      "transform": { "position": [6.0, 0.08, 6.0] },
+      "properties": { "label": { "type": "string", "value": "Launch Pad" } },
+      "components": [
+        { "type": "render.cube", "size": [2.0, 0.12, 2.0], "color": [60, 190, 255, 230], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.25, 0.85, 1.0], "intensity": 2.0, "range": 6.0 }
+      ],
+      "editor": {
+        "display_name": "Launch Pad Mockup",
+        "category": "mechanics/movement",
+        "tags": ["jump_pad", "launch"],
+        "preview": { "primitive": "cube", "color": [0.25, 0.85, 1.0, 1.0] },
+        "bounds": { "size": [2.0, 0.12, 2.0] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.teleporter_pad",
+      "archetype": "archetype.dojo.marker.pad",
+      "transform": { "position": [13.0, 0.08, 5.0] },
+      "properties": { "label": { "type": "string", "value": "Teleporter" } },
+      "components": [
+        { "type": "render.cube", "size": [2.0, 0.12, 2.0], "color": [180, 70, 255, 230], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.8, 0.25, 1.0], "intensity": 2.2, "range": 6.0 }
+      ],
+      "editor": {
+        "display_name": "Teleporter Pad Mockup",
+        "category": "mechanics/movement",
+        "tags": ["teleporter"],
+        "preview": { "primitive": "cube", "color": [0.8, 0.25, 1.0, 1.0] },
+        "bounds": { "size": [2.0, 0.12, 2.0] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.teleporter_destination",
+      "archetype": "archetype.dojo.marker.pad",
+      "transform": { "position": [22.0, 0.08, 10.0] },
+      "properties": { "label": { "type": "string", "value": "Destination" } },
+      "components": [
+        { "type": "render.cube", "size": [1.2, 0.1, 1.2], "color": [220, 190, 50, 230], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [1.0, 0.75, 0.2], "intensity": 1.6, "range": 4.0 }
+      ],
+      "editor": {
+        "display_name": "Teleporter Destination Mockup",
+        "category": "mechanics/movement",
+        "tags": ["teleporter", "destination"],
+        "preview": { "primitive": "cube", "color": [1.0, 0.75, 0.2, 1.0] },
+        "bounds": { "size": [1.2, 0.1, 1.2] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    }
+  ]
+}

--- a/demos/fps_mechanics_dojo/data/fragments/actors/player.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/player.json
@@ -1,0 +1,47 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["player", "fps_actor"],
+      "transform": { "position": [3.0, 1.6, 4.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 },
+        "dojo_hazard_damage": { "type": "float", "value": 0.0 }
+      },
+      "editor": {
+        "display_name": "FPS Player",
+        "category": "actors/player",
+        "tags": ["player", "controller"],
+        "preview": { "primitive": "capsule", "color": [0.2, 0.8, 1.0, 1.0] },
+        "bounds": { "center": [0.0, -0.8, 0.0], "size": [0.7, 1.6, 0.7] },
+        "snap": { "grid": 0.25, "align_to_floor": true },
+        "test_scene": "scene.dojo.fps_world"
+      },
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.dojo.arena",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 8.0,
+          "jump_velocity": 6.5,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.65,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ]
+}

--- a/demos/fps_mechanics_dojo/data/fragments/editor/metadata.json
+++ b/demos/fps_mechanics_dojo/data/fragments/editor/metadata.json
@@ -1,0 +1,45 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "editor": {
+    "display_name": "FPS Mechanics Dojo",
+    "description": "Data-only testbed for reusable FPS movement and world mechanics.",
+    "category": "dojos/fps",
+    "tags": ["fps", "sector", "mechanics", "dojo"],
+    "preview": { "primitive": "sector", "color": [0.2, 0.45, 1.0, 1.0] },
+    "snap": { "grid": [0.5, 0.25, 0.5], "rotation_degrees": 15.0, "align_to_floor": true },
+    "test_scene": "scene.dojo.fps_world",
+    "templates": [
+      {
+        "name": "template.fps.launch_pad",
+        "display_name": "Launch Pad Trigger",
+        "category": "mechanics/movement",
+        "tags": ["launch", "jump_pad", "trigger"],
+        "source": "sensor.dojo.launch.enter",
+        "source_kind": "sensor",
+        "preview": { "primitive": "cube", "color": [0.25, 0.85, 1.0, 1.0] },
+        "bounds": { "size": [2.0, 0.2, 2.0] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "vertical_velocity", "type": "float", "display_name": "Launch Velocity", "min": 0.1, "default": 12.0 }
+        ],
+        "test_scene": "scene.dojo.fps_world"
+      },
+      {
+        "name": "template.fps.teleporter",
+        "display_name": "Teleporter Trigger",
+        "category": "mechanics/movement",
+        "tags": ["teleport", "trigger"],
+        "source": "sensor.dojo.teleporter.enter",
+        "source_kind": "sensor",
+        "preview": { "primitive": "cube", "color": [0.8, 0.25, 1.0, 1.0] },
+        "bounds": { "size": [2.0, 0.2, 2.0] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "position", "type": "vec3", "display_name": "Destination", "default": [22.0, 1.6, 10.0] },
+          { "name": "yaw", "type": "float", "display_name": "Facing Yaw", "default": -1.5707964 }
+        ],
+        "test_scene": "scene.dojo.fps_world"
+      }
+    ]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/fragments/input/fps_controls.json
+++ b/demos/fps_mechanics_dojo/data/fragments/input/fps_controls.json
@@ -1,0 +1,20 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "input": {
+    "contexts": [
+      {
+        "name": "input.fps_mechanics_dojo",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
+          { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
+          { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/fragments/world/arena.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/arena.json
@@ -1,0 +1,98 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_level_fragments": [
+    {
+      "level": "sector.dojo.arena",
+      "materials": [
+        { "name": "floor", "albedo": [0.28, 0.30, 0.34, 1.0], "roughness": 0.85, "tex_scale": 4.0 },
+        { "name": "wall", "albedo": [0.35, 0.39, 0.48, 1.0], "roughness": 0.75, "tex_scale": 4.0 },
+        { "name": "hazard", "albedo": [0.25, 0.05, 0.02, 1.0], "roughness": 0.6, "tex_scale": 3.0 },
+        { "name": "upper", "albedo": [0.22, 0.26, 0.32, 1.0], "roughness": 0.8, "tex_scale": 3.0 }
+      ],
+      "sectors": [
+        { "name": "start", "points": [[0, 0], [10, 0], [10, 10], [0, 10]], "floor_y": 0.0, "ceil_y": 4.0, "floor_material": "floor", "ceil_material": "upper", "wall_material": "wall" },
+        { "name": "teleporter_room", "points": [[10, 0], [18, 0], [18, 10], [10, 10]], "floor_y": 0.0, "ceil_y": 4.0, "floor_material": "floor", "ceil_material": "upper", "wall_material": "wall" },
+        { "name": "hazard_lane", "points": [[18, 0], [28, 0], [28, 10], [18, 10]], "floor_y": 0.0, "ceil_y": 4.0, "floor_material": "hazard", "ceil_material": "upper", "wall_material": "wall", "damage_per_second": 6.0 },
+        { "name": "lift_room", "points": [[0, 10], [10, 10], [10, 18], [0, 18]], "floor_y": 0.0, "ceil_y": 6.0, "floor_material": "floor", "ceil_material": "upper", "wall_material": "wall" }
+      ],
+      "lights": [
+        { "position": [5.0, 2.8, 5.0], "color": [0.2, 0.55, 1.0], "intensity": 2.2, "range": 12.0 },
+        { "position": [14.0, 2.8, 5.0], "color": [0.75, 0.25, 1.0], "intensity": 2.0, "range": 10.0 },
+        { "position": [23.0, 2.6, 5.0], "color": [1.0, 0.24, 0.08], "intensity": 2.4, "range": 11.0 }
+      ]
+    }
+  ],
+  "sector_doors": [
+    {
+      "name": "door.dojo.hazard_gate",
+      "scene": "scene.dojo.fps_world",
+      "panels": [
+        { "bounds": { "min": [17.75, 0.0, 3.4], "max": [18.25, 3.2, 6.6] }, "open_offset": [0.0, 3.4, 0.0] }
+      ],
+      "open_seconds": 1.0,
+      "close_seconds": 1.0,
+      "render": { "color": [190, 80, 50, 230], "lighting": true }
+    }
+  ],
+  "sector_platforms": [
+    {
+      "name": "platform.dojo.lift",
+      "scene": "scene.dojo.fps_world",
+      "sector_level": "sector.dojo.arena",
+      "sector": "lift_room",
+      "min_floor_y": 0.0,
+      "max_floor_y": 2.25,
+      "ceil_y": 6.0,
+      "cycle_seconds": 5.0,
+      "rebuild_min_delta": 0.02
+    }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.dojo.launch.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [5.0, 0.0, 5.0],
+        "max": [7.0, 2.2, 7.0],
+        "edge": "enter",
+        "actions": [
+          { "type": "controller.fps_sector.launch", "target": "entity.player", "vertical_velocity": 12.0 }
+        ]
+      },
+      {
+        "name": "sensor.dojo.teleporter.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [12.0, 0.0, 4.0],
+        "max": [14.0, 2.2, 6.0],
+        "edge": "enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [22.0, 1.6, 10.0], "yaw": -1.5707964, "pitch": 0.0 }
+        ]
+      },
+      {
+        "name": "sensor.dojo.hazard.damage",
+        "type": "sensor.sector",
+        "actor": "entity.player",
+        "sector_level": "sector.dojo.arena",
+        "sector": "hazard_lane",
+        "edge": "stay",
+        "actions": [
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "dojo_hazard_damage", "value_from_payload": "sector_damage_delta" }
+        ]
+      }
+    ],
+    "bindings": [
+      {
+        "signal": "signal.dojo.open_hazard_gate",
+        "actions": [
+          { "type": "sector_door.open", "target": "door.dojo.hazard_gate" }
+        ]
+      }
+    ]
+  },
+  "signals": [
+    "signal.dojo.open_hazard_gate"
+  ]
+}

--- a/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
@@ -1,0 +1,66 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.dojo.fps_world",
+  "camera": "camera.dojo.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.dojo.launch_pad",
+    "entity.dojo.teleporter_pad",
+    "entity.dojo.teleporter_destination"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.interact",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.dojo.arena",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.dojo.title",
+        "text": "FPS Mechanics Dojo",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.03],
+        "anchor": "top_left",
+        "color": [220, 235, 255, 230],
+        "scale": 0.9
+      },
+      {
+        "name": "ui.dojo.damage",
+        "text": "Hazard damage {target.entity.player.dojo_hazard_damage}",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.07],
+        "anchor": "top_left",
+        "color": [255, 150, 120, 220],
+        "scale": 0.75
+      },
+      {
+        "name": "ui.dojo.reticle",
+        "text": "+",
+        "font": "font.dojo.hud",
+        "position": [0.5, 0.5],
+        "anchor": "center",
+        "color": [255, 255, 255, 210],
+        "scale": 1.0
+      }
+    ]
+  }
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -38,6 +38,7 @@ Every root game file is a JSON object.
 | `render` | no | Renderer setup and global render policy. |
 | `transitions` | no | Named transition descriptors. |
 | `ui` | no | Reusable UI descriptors. |
+| `editor` | no | Optional authoring metadata for tools, templates, previews, and dojos. Ignored by runtime gameplay. |
 | `entities` | no | Named actors with tags, transforms, properties, and components. |
 | `grid_maps` | no | Authored tile grids for maze, board, and grid-locked games. |
 | `grid_pickup_layers` | no | Dense grid-indexed pickup layers rendered and collected without one actor per pickup. |
@@ -163,6 +164,8 @@ Import rules:
 - `actor_instances` and `sector_level_fragments` are composition-time authoring
   helpers; they are expanded into normal `entities` and `sector_levels` before
   ordinary validation and runtime loading
+- `editor` metadata is mergeable so templates and future editor palettes can
+  live beside the fragments they describe
 
 See [Project Layout Guidance](project-layout.md) for recommended fragment
 organization.
@@ -831,6 +834,54 @@ Runtime spawning uses preallocated pools:
 Pools support deterministic spawn/despawn, scene-exit policy, lifecycle safety,
 metrics, and Lua helpers.
 
+`entities`, `actor_archetypes`, `actor_instances`, and `actor_pools` may carry
+an optional `editor` object. The runtime ignores this metadata during gameplay;
+it exists for editors, dojos, palette browsers, prefab previews, and validation.
+
+```json
+{
+  "name": "archetype.jump_pad",
+  "tags": ["mechanic", "jump_pad"],
+  "editor": {
+    "display_name": "Jump Pad",
+    "category": "mechanics/movement",
+    "tags": ["launch", "trigger"],
+    "preview": { "primitive": "cube", "color": [0.25, 0.85, 1.0, 1.0] },
+    "bounds": { "size": [2.0, 0.2, 2.0] },
+    "snap": { "grid": 0.5, "align_to_floor": true },
+    "exposed_properties": [
+      { "name": "vertical_velocity", "type": "float", "display_name": "Launch Velocity", "min": 0.1 }
+    ],
+    "test_scene": "scene.dojo.fps_world"
+  }
+}
+```
+
+Supported editor fields:
+
+- `display_name`, `description`, `category`, `icon`, and `preview_asset`:
+  non-empty strings when present
+- `tags`: array of non-empty strings
+- `preview`: object with optional `primitive`, `asset`, and `color`; primitive
+  may be `none`, `cube`, `sphere`, `capsule`, `sprite`, `model`, `light`,
+  `volume`, or `sector`
+- `bounds`: optional `center`, positive `size`, positive `half_extents`, or
+  positive `radius`
+- `snap`: optional positive `grid` number or vec3, positive
+  `rotation_degrees`, and boolean `align_to_floor`
+- `exposed_properties`: tool-facing property controls with unique `name`,
+  optional display text, optional `type` (`bool`, `int`, `float`, `string`,
+  `vec2`, `vec3`, `color`, or `enum`), numeric `min`/`max`, and scalar/vector
+  default
+- `test_scene`: optional scene reference that tools can launch through the
+  runner for isolated tuning
+
+The root `editor` object may also declare reusable `templates`. Template
+entries use the same fields plus required `name`, and optional `source` /
+`source_kind` strings that identify the authored object or fragment a tool
+should copy or instantiate. This is intentionally metadata only; copying,
+placement, and editing behavior belongs to tools.
+
 Common projectile archetype conventions:
 
 - tag projectile actors with a broad tag such as `projectile` and a role tag
@@ -1458,6 +1509,8 @@ JSON path. It checks:
 - script ids, modules, dependencies, dependency cycles, and file existence
 - input binding structure
 - component, sensor, timer, action, app, UI, render, and camera payloads
+- editor metadata shape, preview hints, exposed properties, and test-scene
+  references
 - network protocol, replication fields, control messages, runtime bindings,
   directions, schema hash shape, and managed session-flow metadata
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -872,7 +872,7 @@ Supported editor fields:
 - `exposed_properties`: tool-facing property controls with unique `name`,
   optional display text, optional `type` (`bool`, `int`, `float`, `string`,
   `vec2`, `vec3`, `color`, or `enum`), numeric `min`/`max`, and scalar/vector
-  default
+  default matching the declared type; `color` defaults may be RGB or RGBA
 - `test_scene`: optional scene reference that tools can launch through the
   runner for isolated tuning
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -24,6 +24,8 @@ data/
       actions.json
       device_assignments.json
       profiles.json
+    editor/
+      metadata.json
     logic/
       gameplay.json
       menus.json
@@ -84,6 +86,8 @@ fragments by editing purpose:
   platforms define this level?"
 - Grid fragments answer "what tile, maze, or board layout drives this level?"
 - Input fragments answer "what can the player do and with which devices?"
+- Editor fragments answer "how should tools preview, categorize, place, and
+  test reusable authored objects?"
 - Logic fragments answer "what happens when a signal, timer, or sensor fires?"
 - Network fragments answer "what is replicated and how sessions flow?"
 - Presentation fragments answer "how does reusable visual/audio polish behave?"
@@ -147,6 +151,20 @@ Use templates as starting points, then rename ids to match the game. Prefer
 templates for reusable primitives such as FPS controls, render profile toggles,
 pause/HUD widgets, reticles, and sector interactions. Keep game-specific rules
 in the game project's fragments and Lua scripts.
+
+## Dojos And Editor Metadata
+
+Mechanic dojos are small data-only projects or scenes used to tune reusable
+primitives in isolation. Prefer mock geometry, colored lights, particles, and
+clear UI indicators over finished media while the mechanic is still evolving.
+Launch dojos through `sdl3d_runner` and direct scene selection so mechanics can
+be tested without walking through splash, title, or campaign flow.
+
+Use optional `editor` metadata beside the authored object it describes. This
+keeps future editor palettes and prefab browsers grounded in the same JSON that
+runtime validation sees. Metadata should describe categories, previews, bounds,
+snap hints, exposed properties, and recommended test scenes; it should not
+encode gameplay rules.
 
 ## Lua Placement
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5218,6 +5218,32 @@ static bool editor_exposed_property_type_valid(const char *type)
     return false;
 }
 
+static bool editor_exposed_property_default_valid(yyjson_val *value, const char *type)
+{
+    if (value == NULL)
+        return true;
+    if (type == NULL)
+    {
+        return yyjson_is_str(value) || yyjson_is_int(value) || yyjson_is_real(value) || yyjson_is_bool(value) ||
+               is_exact_vec_array(value, 2) || is_exact_vec_array(value, 3) || is_exact_vec_array(value, 4);
+    }
+    if (SDL_strcmp(type, "bool") == 0)
+        return yyjson_is_bool(value);
+    if (SDL_strcmp(type, "int") == 0)
+        return yyjson_is_int(value);
+    if (SDL_strcmp(type, "float") == 0)
+        return yyjson_is_num(value);
+    if (SDL_strcmp(type, "string") == 0 || SDL_strcmp(type, "enum") == 0)
+        return yyjson_is_str(value);
+    if (SDL_strcmp(type, "vec2") == 0)
+        return is_exact_vec_array(value, 2);
+    if (SDL_strcmp(type, "vec3") == 0)
+        return is_exact_vec_array(value, 3);
+    if (SDL_strcmp(type, "color") == 0)
+        return is_exact_vec_array(value, 3) || is_exact_vec_array(value, 4);
+    return false;
+}
+
 static bool validate_editor_preview(validation_context *ctx, yyjson_val *preview, const char *json_path)
 {
     if (preview == NULL)
@@ -5317,11 +5343,8 @@ static bool validate_editor_exposed_properties(validation_context *ctx, yyjson_v
             ((min_value != NULL && !yyjson_is_num(min_value)) || (max_value != NULL && !yyjson_is_num(max_value))))
             ok = validation_error(ctx, path, "editor exposed property min and max must be numbers");
         yyjson_val *default_value = obj_get(property, "default");
-        if (ok && default_value != NULL && !yyjson_is_str(default_value) && !yyjson_is_int(default_value) &&
-            !yyjson_is_real(default_value) && !yyjson_is_bool(default_value) && !is_vec_array(default_value, 2))
-        {
-            ok = validation_error(ctx, path, "editor exposed property default must be scalar or vector");
-        }
+        if (ok && !editor_exposed_property_default_valid(default_value, type))
+            ok = validation_error(ctx, path, "editor exposed property default does not match its type");
     }
     name_table_destroy(&names);
     return ok;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1892,6 +1892,7 @@ static bool import_section_name_allowed(const char *name)
                                           "render",
                                           "transitions",
                                           "ui",
+                                          "editor",
                                           "entities",
                                           "grid_maps",
                                           "grid_pickup_layers",
@@ -5154,6 +5155,277 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
     return true;
 }
 
+static bool editor_string_field_valid(validation_context *ctx, yyjson_val *metadata, const char *key,
+                                      const char *json_path)
+{
+    yyjson_val *value = obj_get(metadata, key);
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0')
+        return validation_error(ctx, json_path, "editor %s must be a non-empty string", key);
+    return true;
+}
+
+static bool editor_tags_valid(validation_context *ctx, yyjson_val *tags, const char *json_path)
+{
+    if (tags == NULL)
+        return true;
+    if (!yyjson_is_arr(tags))
+        return validation_error(ctx, json_path, "editor tags must be an array");
+    for (size_t i = 0; i < yyjson_arr_size(tags); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *tag = yyjson_arr_get(tags, i);
+        if (!yyjson_is_str(tag) || yyjson_get_str(tag)[0] == '\0')
+            return validation_error(ctx, path, "editor tag entries must be non-empty strings");
+    }
+    return true;
+}
+
+static bool editor_vec_positive(yyjson_val *value)
+{
+    if (!is_vec_array(value, 3))
+        return false;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        if (yyjson_get_num(yyjson_arr_get(value, i)) <= 0.0)
+            return false;
+    }
+    return true;
+}
+
+static bool editor_preview_primitive_valid(const char *primitive)
+{
+    static const char *const valid[] = {"none",  "cube",  "sphere", "capsule", "sprite",
+                                        "model", "light", "volume", "sector"};
+    for (size_t i = 0; primitive != NULL && i < SDL_arraysize(valid); ++i)
+    {
+        if (SDL_strcmp(primitive, valid[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool editor_exposed_property_type_valid(const char *type)
+{
+    static const char *const valid[] = {"bool", "int", "float", "string", "vec2", "vec3", "color", "enum"};
+    for (size_t i = 0; type != NULL && i < SDL_arraysize(valid); ++i)
+    {
+        if (SDL_strcmp(type, valid[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool validate_editor_preview(validation_context *ctx, yyjson_val *preview, const char *json_path)
+{
+    if (preview == NULL)
+        return true;
+    if (!yyjson_is_obj(preview))
+        return validation_error(ctx, json_path, "editor preview must be an object");
+
+    const char *primitive = json_string(preview, "primitive");
+    if (primitive != NULL && !editor_preview_primitive_valid(primitive))
+        return validation_error(ctx, json_path, "editor preview primitive is unknown");
+    yyjson_val *asset = obj_get(preview, "asset");
+    if (asset != NULL && (!yyjson_is_str(asset) || yyjson_get_str(asset)[0] == '\0'))
+        return validation_error(ctx, json_path, "editor preview asset must be a non-empty string");
+    yyjson_val *color = obj_get(preview, "color");
+    if (color != NULL && !is_vec_array(color, 3))
+        return validation_error(ctx, json_path, "editor preview color must be a vec3 or vec4");
+    return true;
+}
+
+static bool validate_editor_bounds(validation_context *ctx, yyjson_val *bounds, const char *json_path)
+{
+    if (bounds == NULL)
+        return true;
+    if (!yyjson_is_obj(bounds))
+        return validation_error(ctx, json_path, "editor bounds must be an object");
+    yyjson_val *center = obj_get(bounds, "center");
+    if (center != NULL && !is_vec_array(center, 3))
+        return validation_error(ctx, json_path, "editor bounds center must be a vec3");
+    yyjson_val *size = obj_get(bounds, "size");
+    if (size != NULL && !editor_vec_positive(size))
+        return validation_error(ctx, json_path, "editor bounds size must be a positive vec3");
+    yyjson_val *half_extents = obj_get(bounds, "half_extents");
+    if (half_extents != NULL && !editor_vec_positive(half_extents))
+        return validation_error(ctx, json_path, "editor bounds half_extents must be a positive vec3");
+    yyjson_val *radius = obj_get(bounds, "radius");
+    if (radius != NULL && (!yyjson_is_num(radius) || yyjson_get_num(radius) <= 0.0))
+        return validation_error(ctx, json_path, "editor bounds radius must be positive");
+    return true;
+}
+
+static bool validate_editor_snap(validation_context *ctx, yyjson_val *snap, const char *json_path)
+{
+    if (snap == NULL)
+        return true;
+    if (!yyjson_is_obj(snap))
+        return validation_error(ctx, json_path, "editor snap must be an object");
+    yyjson_val *grid = obj_get(snap, "grid");
+    if (grid != NULL)
+    {
+        if (yyjson_is_num(grid))
+        {
+            if (yyjson_get_num(grid) <= 0.0)
+                return validation_error(ctx, json_path, "editor snap grid must be positive");
+        }
+        else if (!editor_vec_positive(grid))
+        {
+            return validation_error(ctx, json_path, "editor snap grid must be a positive number or vec3");
+        }
+    }
+    yyjson_val *rotation = obj_get(snap, "rotation_degrees");
+    if (rotation != NULL && (!yyjson_is_num(rotation) || yyjson_get_num(rotation) <= 0.0))
+        return validation_error(ctx, json_path, "editor snap rotation_degrees must be positive");
+    yyjson_val *align = obj_get(snap, "align_to_floor");
+    if (align != NULL && !yyjson_is_bool(align))
+        return validation_error(ctx, json_path, "editor snap align_to_floor must be a boolean");
+    return true;
+}
+
+static bool validate_editor_exposed_properties(validation_context *ctx, yyjson_val *properties, const char *json_path)
+{
+    if (properties == NULL)
+        return true;
+    if (!yyjson_is_arr(properties))
+        return validation_error(ctx, json_path, "editor exposed_properties must be an array");
+    name_table names;
+    SDL_zero(names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(properties); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s[%zu]", json_path, i);
+        yyjson_val *property = yyjson_arr_get(properties, i);
+        if (!yyjson_is_obj(property))
+        {
+            ok = validation_error(ctx, path, "editor exposed property entries must be objects");
+            break;
+        }
+        ok = require_unique_name(ctx, &names, "editor exposed property", json_string(property, "name"), path) &&
+             editor_string_field_valid(ctx, property, "display_name", path) &&
+             editor_string_field_valid(ctx, property, "description", path);
+        const char *type = json_string(property, "type");
+        if (ok && type != NULL && !editor_exposed_property_type_valid(type))
+            ok = validation_error(ctx, path, "editor exposed property type is unknown");
+        yyjson_val *min_value = obj_get(property, "min");
+        yyjson_val *max_value = obj_get(property, "max");
+        if (ok &&
+            ((min_value != NULL && !yyjson_is_num(min_value)) || (max_value != NULL && !yyjson_is_num(max_value))))
+            ok = validation_error(ctx, path, "editor exposed property min and max must be numbers");
+        yyjson_val *default_value = obj_get(property, "default");
+        if (ok && default_value != NULL && !yyjson_is_str(default_value) && !yyjson_is_int(default_value) &&
+            !yyjson_is_real(default_value) && !yyjson_is_bool(default_value) && !is_vec_array(default_value, 2))
+        {
+            ok = validation_error(ctx, path, "editor exposed property default must be scalar or vector");
+        }
+    }
+    name_table_destroy(&names);
+    return ok;
+}
+
+static bool validate_editor_metadata(validation_context *ctx, yyjson_val *metadata, const char *json_path,
+                                     validation_names *names, bool allow_templates)
+{
+    if (metadata == NULL)
+        return true;
+    if (!yyjson_is_obj(metadata))
+        return validation_error(ctx, json_path, "editor metadata must be an object");
+
+    if (!editor_string_field_valid(ctx, metadata, "display_name", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "description", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "category", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "icon", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "preview_asset", json_path) ||
+        !editor_tags_valid(ctx, obj_get(metadata, "tags"), json_path) ||
+        !validate_editor_preview(ctx, obj_get(metadata, "preview"), json_path) ||
+        !validate_editor_bounds(ctx, obj_get(metadata, "bounds"), json_path) ||
+        !validate_editor_snap(ctx, obj_get(metadata, "snap"), json_path) ||
+        !validate_editor_exposed_properties(ctx, obj_get(metadata, "exposed_properties"), json_path))
+    {
+        return false;
+    }
+
+    const char *test_scene = json_string(metadata, "test_scene");
+    if (test_scene != NULL && !require_ref(ctx, &names->scenes, "scene", test_scene, json_path))
+        return false;
+
+    yyjson_val *templates = obj_get(metadata, "templates");
+    if (templates == NULL)
+        return true;
+    if (!allow_templates)
+        return validation_error(ctx, json_path, "editor templates are only allowed on root editor metadata");
+    if (!yyjson_is_arr(templates))
+        return validation_error(ctx, json_path, "editor templates must be an array");
+
+    name_table template_names;
+    SDL_zero(template_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(templates); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s.templates[%zu]", json_path, i);
+        yyjson_val *entry = yyjson_arr_get(templates, i);
+        if (!yyjson_is_obj(entry))
+        {
+            ok = validation_error(ctx, path, "editor template entries must be objects");
+            break;
+        }
+        ok = require_unique_name(ctx, &template_names, "editor template", json_string(entry, "name"), path) &&
+             editor_string_field_valid(ctx, entry, "source", path) &&
+             editor_string_field_valid(ctx, entry, "source_kind", path) &&
+             validate_editor_metadata(ctx, entry, path, names, false);
+    }
+    name_table_destroy(&template_names);
+    return ok;
+}
+
+static bool validate_editor_metadata_tree(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    if (!validate_editor_metadata(ctx, obj_get(root, "editor"), "$.editor", names, true))
+        return false;
+
+    yyjson_val *entities = obj_get(root, "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.entities[%zu].editor", i);
+        if (!validate_editor_metadata(ctx, obj_get(yyjson_arr_get(entities, i), "editor"), path, names, false))
+            return false;
+    }
+
+    yyjson_val *archetypes = obj_get(root, "actor_archetypes");
+    for (size_t i = 0; yyjson_is_arr(archetypes) && i < yyjson_arr_size(archetypes); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_archetypes[%zu].editor", i);
+        if (!validate_editor_metadata(ctx, obj_get(yyjson_arr_get(archetypes, i), "editor"), path, names, false))
+            return false;
+    }
+
+    yyjson_val *instances = obj_get(root, "actor_instances");
+    for (size_t i = 0; yyjson_is_arr(instances) && i < yyjson_arr_size(instances); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_instances[%zu].editor", i);
+        if (!validate_editor_metadata(ctx, obj_get(yyjson_arr_get(instances, i), "editor"), path, names, false))
+            return false;
+    }
+
+    yyjson_val *pools = obj_get(root, "actor_pools");
+    for (size_t i = 0; yyjson_is_arr(pools) && i < yyjson_arr_size(pools); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.actor_pools[%zu].editor", i);
+        if (!validate_editor_metadata(ctx, obj_get(yyjson_arr_get(pools, i), "editor"), path, names, false))
+            return false;
+    }
+    return true;
+}
+
 static bool is_tween_easing(const char *easing)
 {
     return easing == NULL || SDL_strcmp(easing, "linear") == 0 || SDL_strcmp(easing, "in_quad") == 0 ||
@@ -7764,8 +8036,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_settings(ctx, root) &&
            validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
-           validate_haptics(ctx, root, names) && validate_logic(ctx, root, names) &&
-           validate_adapters(ctx, root, names) &&
+           validate_haptics(ctx, root, names) && validate_editor_metadata_tree(ctx, root, names) &&
+           validate_logic(ctx, root, names) && validate_adapters(ctx, root, names) &&
            warn_unused(ctx, &names->adapters, &names->used_adapters, "adapter") &&
            warn_unused(ctx, &names->scripts, &names->used_scripts, "script");
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6860,6 +6860,30 @@ TEST(GameDataRuntime, RejectsInvalidEditorMetadata)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+
+    write_text(dir / "bad_editor_default.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Editor Default", "id": "test.bad_editor_default", "version": "0.1.0" },
+  "world": { "name": "world.bad_editor_default", "kind": "fixed_screen" },
+  "editor": {
+    "display_name": "Bad Editor Default",
+    "exposed_properties": [
+      { "name": "position", "type": "vec3", "default": [1.0, 2.0, 3.0, 4.0] }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "bad_editor_default.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("editor exposed property default does not match its type"), std::string::npos)
+        << error;
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
     remove_test_dir(dir);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -338,6 +338,11 @@ std::filesystem::path doom_level_data_path()
     return demo_data_path("doom_level", "doom_level.game.json");
 }
 
+std::filesystem::path fps_mechanics_dojo_data_path()
+{
+    return demo_data_path("fps_mechanics_dojo", "fps_mechanics_dojo.game.json");
+}
+
 std::string read_fixture_file(const char *filename)
 {
     std::ifstream in(fixture_path(filename), std::ios::binary);
@@ -6797,6 +6802,62 @@ TEST(GameDataRuntime, ActorInstancesExpandArchetypesBeforeValidation)
     EXPECT_FALSE(sdl3d_game_data_load_file((dir / "bad_instances.game.json").string().c_str(), session, &runtime, error,
                                            sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown actor archetype"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
+{
+    const std::filesystem::path dojo_path = fps_mechanics_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.dojo.fps_world"));
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.player"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.launch_pad"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_pad"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_destination"), nullptr);
+
+    RenderPrimitiveCapture render{};
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &render));
+    EXPECT_GE(render.cubes, 3);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, RejectsInvalidEditorMetadata)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_metadata");
+    write_text(dir / "bad_editor.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Editor Metadata", "id": "test.bad_editor", "version": "0.1.0" },
+  "world": { "name": "world.bad_editor", "kind": "fixed_screen" },
+  "editor": {
+    "display_name": "Bad Metadata",
+    "tags": ["valid", ""],
+    "snap": { "grid": 0.0 }
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json", R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play" })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "bad_editor.game.json").string().c_str(), session, &runtime, error,
+                                           sizeof(error)));
+    EXPECT_NE(std::string(error).find("editor tag entries must be non-empty strings"), std::string::npos) << error;
+
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary

- Adds optional `editor` metadata validation for root/fragments and actor-facing authored objects (`entities`, `actor_archetypes`, `actor_instances`, `actor_pools`).
- Allows `editor` as a structured import section so tool metadata can live beside reusable fragments.
- Adds a data-only `fps_mechanics_dojo` demo with mock geometry for FPS controller movement, launch pads, teleporters, sector hazards, doors, and platforms.
- Documents editor metadata and dojo/project-layout guidance.

## Issue

First work slice of #282.

## Validation

- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target game_data_json_test -j 8`
- `./build/debug/tests/game_data_json_test`
- `find demos/fps_mechanics_dojo/data -name '*.json' -print0 | xargs -0 jq empty`
