### PR TITLE
Add generic combat health actions

### DIFF
--- a/demos/fps_mechanics_dojo/README.md
+++ b/demos/fps_mechanics_dojo/README.md
@@ -17,6 +17,7 @@ The first scene demonstrates existing data-authored primitives:
 - `controller.fps_sector.teleport` for teleport pads
 - `sensor.volume` and `sensor.sector`
 - `sector_doors` and `sector_platforms`
+- `combat.health` plus `combat.damage` against a mock target dummy
 - actor archetype/instance mockups with optional `editor` metadata
 
 The dojo is meant to grow alongside reusable mechanics from issue #282.

--- a/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
@@ -21,6 +21,36 @@
         ],
         "test_scene": "scene.dojo.fps_world"
       }
+    },
+    {
+      "name": "archetype.dojo.combat_dummy",
+      "active": true,
+      "tags": ["dojo_marker", "combat_target"],
+      "properties": {
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 },
+        "armor": { "type": "float", "value": 30.0 },
+        "armor_absorb": { "type": "float", "value": 0.5 },
+        "alive": { "type": "bool", "value": true }
+      },
+      "components": [
+        { "type": "combat.health" },
+        { "type": "render.cube", "size": [1.2, 1.8, 1.2], "color": [230, 80, 70, 255], "lighting": true },
+        { "type": "light.point", "color": [1.0, 0.25, 0.15], "intensity": 1.4, "range": 4.0 }
+      ],
+      "editor": {
+        "display_name": "Combat Dummy",
+        "category": "mechanics/combat",
+        "tags": ["combat", "health", "mockup"],
+        "preview": { "primitive": "cube", "color": [1.0, 0.25, 0.15, 1.0] },
+        "bounds": { "size": [1.2, 1.8, 1.2] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "health", "type": "float", "display_name": "Health", "min": 0.0, "default": 100.0 },
+          { "name": "armor", "type": "float", "display_name": "Armor", "min": 0.0, "default": 30.0 }
+        ],
+        "test_scene": "scene.dojo.fps_world"
+      }
     }
   ],
   "actor_instances": [
@@ -75,6 +105,19 @@
         "tags": ["teleporter", "destination"],
         "preview": { "primitive": "cube", "color": [1.0, 0.75, 0.2, 1.0] },
         "bounds": { "size": [1.2, 0.1, 1.2] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.combat_dummy",
+      "archetype": "archetype.dojo.combat_dummy",
+      "transform": { "position": [24.0, 0.9, 6.0] },
+      "editor": {
+        "display_name": "Combat Dummy Instance",
+        "category": "mechanics/combat",
+        "tags": ["combat", "health"],
+        "preview": { "primitive": "cube", "color": [1.0, 0.25, 0.15, 1.0] },
+        "bounds": { "size": [1.2, 1.8, 1.2] },
         "test_scene": "scene.dojo.fps_world"
       }
     }

--- a/demos/fps_mechanics_dojo/data/fragments/input/fps_controls.json
+++ b/demos/fps_mechanics_dojo/data/fragments/input/fps_controls.json
@@ -11,6 +11,7 @@
           { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
           { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
+          { "name": "action.fire", "bindings": [{ "device": "mouse", "button": "LEFT" }] },
           { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
           { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] }
         ]

--- a/demos/fps_mechanics_dojo/data/fragments/world/arena.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/arena.json
@@ -81,6 +81,12 @@
         "actions": [
           { "type": "property.add", "target_from_payload": "actor_name", "key": "dojo_hazard_damage", "value_from_payload": "sector_damage_delta" }
         ]
+      },
+      {
+        "name": "sensor.dojo.combat.fire",
+        "type": "sensor.input_pressed",
+        "action": "action.fire",
+        "on_pressed": "signal.dojo.damage_dummy"
       }
     ],
     "bindings": [
@@ -89,10 +95,25 @@
         "actions": [
           { "type": "sector_door.open", "target": "door.dojo.hazard_gate" }
         ]
+      },
+      {
+        "signal": "signal.dojo.damage_dummy",
+        "actions": [
+          {
+            "type": "combat.damage",
+            "target": "entity.dojo.combat_dummy",
+            "source": "entity.player",
+            "amount": 25.0,
+            "damage_type": "dojo",
+            "on_death": "signal.dojo.dummy_dead"
+          }
+        ]
       }
     ]
   },
   "signals": [
-    "signal.dojo.open_hazard_gate"
+    "signal.dojo.open_hazard_gate",
+    "signal.dojo.damage_dummy",
+    "signal.dojo.dummy_dead"
   ]
 }

--- a/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
@@ -8,7 +8,8 @@
     "entity.player",
     "entity.dojo.launch_pad",
     "entity.dojo.teleporter_pad",
-    "entity.dojo.teleporter_destination"
+    "entity.dojo.teleporter_destination",
+    "entity.dojo.combat_dummy"
   ],
   "input": {
     "mouse_capture": "unpaused",
@@ -19,6 +20,7 @@
       "action.move.right",
       "action.jump",
       "action.interact",
+      "action.fire",
       "action.pause"
     ]
   },
@@ -50,6 +52,15 @@
         "position": [0.02, 0.07],
         "anchor": "top_left",
         "color": [255, 150, 120, 220],
+        "scale": 0.75
+      },
+      {
+        "name": "ui.dojo.dummy",
+        "text": "Dummy HP {target.entity.dojo.combat_dummy.health}  Armor {target.entity.dojo.combat_dummy.armor}  Alive {target.entity.dojo.combat_dummy.alive}",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.11],
+        "anchor": "top_left",
+        "color": [255, 210, 180, 220],
         "scale": 0.75
       },
       {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1138,6 +1138,11 @@ Reusable components include:
 - `controller.fps_sector`: first-person movement through a sector level using
   authored input actions, sector collision, jumping, gravity, stair stepping,
   and mouse-look.
+- `combat.health`: declares that an actor participates in generic combat
+  health/armor actions. The actual runtime state remains ordinary actor
+  properties so UI, Lua, replication, saves, and data actions can read the same
+  values. Use properties such as `health`, `max_health`, `armor`,
+  `armor_absorb`, and `alive` for defaults.
 - `motion.scroll_wrap`: scrolls an actor along one axis and wraps to the
   opposite bound. This is intended for parallax panels, repeating stars, clouds,
   conveyor belts, and similar backgrounds.
@@ -1284,6 +1289,50 @@ as a float so fractional damage, timers, and meters can accumulate correctly:
   "value_from_payload": "sector_damage_delta"
 }
 ```
+
+Generic combat actions provide reusable health, armor, death, and revival
+behavior without writing game-specific C:
+
+```json
+{
+  "type": "combat.damage",
+  "target": "entity.enemy",
+  "source": "entity.player",
+  "amount": 35.0,
+  "damage_type": "slash",
+  "on_damage": "signal.enemy.damaged",
+  "on_death": "signal.enemy.killed"
+}
+```
+
+`combat.damage` reads `health`, `max_health`, `armor`, `armor_absorb`, and
+`alive` by default. `armor_absorb` is clamped to 0..1; absorbed damage depletes
+armor first, and the remainder reduces health. Health is clamped at zero. The
+death signal is emitted only when the action transitions an actor from alive to
+dead. Set `deactivate_on_death: true` when the actor should stop rendering and
+updating immediately.
+
+`combat.heal`, `combat.kill`, and `combat.revive` use the same target and
+property conventions:
+
+```json
+{ "type": "combat.heal", "target": "entity.player", "amount": 25.0 }
+{ "type": "combat.kill", "target_from_payload": "actor_name", "on_death": "signal.actor.killed" }
+{ "type": "combat.revive", "target": "entity.player", "health": 50.0, "on_revive": "signal.player.revived" }
+```
+
+All combat actions support `target_from_payload`, optional `source` or
+`source_from_payload`, and property-name overrides such as `health_property`,
+`max_health_property`, `armor_property`, `armor_absorb_property`, and
+`alive_property`. Damage/heal amount can come from `amount_from_payload`, and
+revive health can come from `health_from_payload`. Combat event payloads include
+`actor_name`, `source_actor_name`, `damage_type`, `amount`, `armor_delta`,
+`health_delta`, `health`, `max_health`, `armor`, `alive`, and `dead`.
+
+Prefer combat actions over raw `property.add` for gameplay health because they
+centralize armor absorption, clamping, alive/dead state, and signal emission.
+Raw property actions remain useful for simple meters, counters, and diagnostic
+state.
 
 `collision.on_overlap` is a data-action variant of the 2D contact sensor. It
 matches actors by fixed actor names or tags, publishes `actor_name` and

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -13766,6 +13766,254 @@ static bool execute_projectile_fire_action_for_actor(sdl3d_game_data_runtime *ru
     return true;
 }
 
+static bool value_as_float(const sdl3d_value *value, float *out_value)
+{
+    if (value == NULL || out_value == NULL)
+        return false;
+    if (value->type == SDL3D_VALUE_INT)
+    {
+        *out_value = (float)value->as_int;
+        return true;
+    }
+    if (value->type == SDL3D_VALUE_FLOAT)
+    {
+        *out_value = value->as_float;
+        return true;
+    }
+    return false;
+}
+
+static bool action_float_value(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload,
+                               const char *key, const char *payload_key, float *out_value)
+{
+    (void)runtime;
+    if (action == NULL || out_value == NULL)
+        return false;
+
+    yyjson_val *value = obj_get(action, key);
+    if (yyjson_is_num(value))
+    {
+        *out_value = (float)yyjson_get_num(value);
+        return true;
+    }
+
+    const char *payload_field = json_string(action, payload_key, NULL);
+    if (payload_field != NULL && payload != NULL)
+        return value_as_float(sdl3d_properties_get_value(payload, payload_field), out_value);
+    return false;
+}
+
+static void set_actor_numeric_property(sdl3d_registered_actor *actor, const char *key, float value)
+{
+    if (actor == NULL || actor->props == NULL || key == NULL)
+        return;
+
+    const sdl3d_value *existing = sdl3d_properties_get_value(actor->props, key);
+    const float rounded = SDL_roundf(value);
+    if (existing != NULL && existing->type == SDL3D_VALUE_INT && SDL_fabsf(value - rounded) <= 0.0001f)
+        sdl3d_properties_set_int(actor->props, key, (int)rounded);
+    else
+        sdl3d_properties_set_float(actor->props, key, value);
+}
+
+static float actor_numeric_property(const sdl3d_registered_actor *actor, const char *key, float fallback)
+{
+    float value = fallback;
+    return actor != NULL && actor->props != NULL &&
+                   value_as_float(sdl3d_properties_get_value(actor->props, key), &value)
+               ? value
+               : fallback;
+}
+
+static const char *combat_action_property(yyjson_val *action, const char *key, const char *fallback)
+{
+    const char *value = json_string(action, key, NULL);
+    return value != NULL && value[0] != '\0' ? value : fallback;
+}
+
+static sdl3d_properties *combat_event_payload(sdl3d_registered_actor *target, yyjson_val *action,
+                                              const sdl3d_properties *source_payload, float amount, float armor_delta,
+                                              float health_delta, float health, float max_health, float armor,
+                                              bool alive)
+{
+    sdl3d_properties *event_payload = sdl3d_properties_create();
+    if (event_payload == NULL)
+        return NULL;
+
+    sdl3d_properties_set_string(event_payload, "actor_name",
+                                target != NULL && target->name != NULL ? target->name : "");
+    const char *source = json_string(action, "source", NULL);
+    const char *source_from_payload = json_string(action, "source_from_payload", NULL);
+    if (source_from_payload != NULL && source_payload != NULL)
+        source = sdl3d_properties_get_string(source_payload, source_from_payload, source);
+    sdl3d_properties_set_string(event_payload, "source_actor_name", source != NULL ? source : "");
+    sdl3d_properties_set_string(event_payload, "damage_type", json_string(action, "damage_type", ""));
+    sdl3d_properties_set_float(event_payload, "amount", amount);
+    sdl3d_properties_set_float(event_payload, "armor_delta", armor_delta);
+    sdl3d_properties_set_float(event_payload, "health_delta", health_delta);
+    sdl3d_properties_set_float(event_payload, "health", health);
+    sdl3d_properties_set_float(event_payload, "max_health", max_health);
+    sdl3d_properties_set_float(event_payload, "armor", armor);
+    sdl3d_properties_set_bool(event_payload, "alive", alive);
+    sdl3d_properties_set_bool(event_payload, "dead", !alive);
+    return event_payload;
+}
+
+static void emit_combat_signal(sdl3d_game_data_runtime *runtime, yyjson_val *action, const char *signal_key,
+                               const sdl3d_properties *payload)
+{
+    const int signal_id = action_signal_id(runtime, action, signal_key);
+    if (signal_id >= 0 && runtime_bus(runtime) != NULL)
+        sdl3d_signal_emit(runtime_bus(runtime), signal_id, payload);
+}
+
+static bool execute_combat_damage_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                         const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
+    float amount = 0.0f;
+    if (actor == NULL || !action_float_value(runtime, action, payload, "amount", "amount_from_payload", &amount))
+        return false;
+    amount = SDL_max(amount, 0.0f);
+
+    const char *health_key = combat_action_property(action, "health_property", "health");
+    const char *max_health_key = combat_action_property(action, "max_health_property", "max_health");
+    const char *armor_key = combat_action_property(action, "armor_property", "armor");
+    const char *armor_absorb_key = combat_action_property(action, "armor_absorb_property", "armor_absorb");
+    const char *alive_key = combat_action_property(action, "alive_property", "alive");
+
+    const float max_health = SDL_max(actor_numeric_property(actor, max_health_key, 100.0f), 0.0f);
+    const float old_health = SDL_clamp(actor_numeric_property(actor, health_key, max_health), 0.0f, max_health);
+    const float old_armor = SDL_max(actor_numeric_property(actor, armor_key, 0.0f), 0.0f);
+    const float authored_absorb =
+        json_float(action, "armor_absorb", actor_numeric_property(actor, armor_absorb_key, 1.0f));
+    const float armor_absorb = old_armor > 0.0f ? SDL_clamp(authored_absorb, 0.0f, 1.0f) : 0.0f;
+    const float armor_delta = SDL_min(old_armor, amount * armor_absorb);
+    const float health_delta = SDL_max(amount - armor_delta, 0.0f);
+    const float health = SDL_max(old_health - health_delta, 0.0f);
+    const float armor = SDL_max(old_armor - armor_delta, 0.0f);
+    const bool was_alive = sdl3d_properties_get_bool(actor->props, alive_key, old_health > 0.0f);
+    const bool alive = health > 0.0f;
+
+    set_actor_numeric_property(actor, health_key, health);
+    set_actor_numeric_property(actor, armor_key, armor);
+    sdl3d_properties_set_bool(actor->props, alive_key, alive);
+    if (!alive && json_bool(action, "deactivate_on_death", false))
+        actor->active = false;
+
+    sdl3d_properties *event_payload = combat_event_payload(actor, action, payload, amount, armor_delta, health_delta,
+                                                           health, max_health, armor, alive);
+    if (event_payload != NULL)
+    {
+        emit_combat_signal(runtime, action, "on_damage", event_payload);
+        if (was_alive && !alive)
+            emit_combat_signal(runtime, action, "on_death", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
+static bool execute_combat_heal_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                       const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
+    float amount = 0.0f;
+    if (actor == NULL || !action_float_value(runtime, action, payload, "amount", "amount_from_payload", &amount))
+        return false;
+    amount = SDL_max(amount, 0.0f);
+
+    const char *health_key = combat_action_property(action, "health_property", "health");
+    const char *max_health_key = combat_action_property(action, "max_health_property", "max_health");
+    const char *alive_key = combat_action_property(action, "alive_property", "alive");
+    const float max_health = SDL_max(actor_numeric_property(actor, max_health_key, 100.0f), 0.0f);
+    const float old_health = SDL_clamp(actor_numeric_property(actor, health_key, max_health), 0.0f, max_health);
+    const bool was_alive = sdl3d_properties_get_bool(actor->props, alive_key, old_health > 0.0f);
+    const bool can_revive = json_bool(action, "revive", false);
+    const float health = SDL_min(old_health + amount, max_health);
+    const bool alive = (was_alive || can_revive) && health > 0.0f;
+
+    set_actor_numeric_property(actor, health_key, health);
+    sdl3d_properties_set_bool(actor->props, alive_key, alive);
+
+    sdl3d_properties *event_payload = combat_event_payload(
+        actor, action, payload, amount, 0.0f, -amount, health, max_health,
+        actor_numeric_property(actor, combat_action_property(action, "armor_property", "armor"), 0.0f), alive);
+    if (event_payload != NULL)
+    {
+        emit_combat_signal(runtime, action, "on_heal", event_payload);
+        if (!was_alive && alive)
+            emit_combat_signal(runtime, action, "on_revive", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
+static bool execute_combat_kill_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                       const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
+    if (actor == NULL)
+        return false;
+
+    const char *health_key = combat_action_property(action, "health_property", "health");
+    const char *max_health_key = combat_action_property(action, "max_health_property", "max_health");
+    const char *armor_key = combat_action_property(action, "armor_property", "armor");
+    const char *alive_key = combat_action_property(action, "alive_property", "alive");
+    const float old_health =
+        actor_numeric_property(actor, health_key, actor_numeric_property(actor, max_health_key, 100.0f));
+    const bool was_alive = sdl3d_properties_get_bool(actor->props, alive_key, old_health > 0.0f);
+
+    set_actor_numeric_property(actor, health_key, 0.0f);
+    sdl3d_properties_set_bool(actor->props, alive_key, false);
+    if (json_bool(action, "deactivate", json_bool(action, "deactivate_on_death", false)))
+        actor->active = false;
+
+    if (was_alive)
+    {
+        sdl3d_properties *event_payload =
+            combat_event_payload(actor, action, payload, old_health, 0.0f, old_health, 0.0f,
+                                 actor_numeric_property(actor, max_health_key, 100.0f),
+                                 actor_numeric_property(actor, armor_key, 0.0f), false);
+        if (event_payload != NULL)
+        {
+            emit_combat_signal(runtime, action, "on_death", event_payload);
+            sdl3d_properties_destroy(event_payload);
+        }
+    }
+    return true;
+}
+
+static bool execute_combat_revive_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                         const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
+    if (actor == NULL)
+        return false;
+
+    const char *health_key = combat_action_property(action, "health_property", "health");
+    const char *max_health_key = combat_action_property(action, "max_health_property", "max_health");
+    const char *armor_key = combat_action_property(action, "armor_property", "armor");
+    const char *alive_key = combat_action_property(action, "alive_property", "alive");
+    const float max_health = SDL_max(actor_numeric_property(actor, max_health_key, 100.0f), 0.0f);
+    float health = max_health;
+    (void)action_float_value(runtime, action, payload, "health", "health_from_payload", &health);
+    health = SDL_clamp(health, 0.0f, max_health);
+
+    set_actor_numeric_property(actor, health_key, health);
+    sdl3d_properties_set_bool(actor->props, alive_key, health > 0.0f);
+    actor->active = true;
+
+    sdl3d_properties *event_payload =
+        combat_event_payload(actor, action, payload, health, 0.0f, -health, health, max_health,
+                             actor_numeric_property(actor, armor_key, 0.0f), health > 0.0f);
+    if (event_payload != NULL)
+    {
+        emit_combat_signal(runtime, action, "on_revive", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
 static bool execute_projectile_fire_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
                                            const sdl3d_properties *payload)
 {
@@ -14446,6 +14694,15 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
 
     if (SDL_strcmp(type, "actor.despawn_by_tag") == 0)
         return execute_actor_despawn_by_tag_action(runtime, action);
+
+    if (SDL_strcmp(type, "combat.damage") == 0)
+        return execute_combat_damage_action(runtime, action, payload);
+    if (SDL_strcmp(type, "combat.heal") == 0)
+        return execute_combat_heal_action(runtime, action, payload);
+    if (SDL_strcmp(type, "combat.kill") == 0)
+        return execute_combat_kill_action(runtime, action, payload);
+    if (SDL_strcmp(type, "combat.revive") == 0)
+        return execute_combat_revive_action(runtime, action, payload);
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2812,29 +2812,14 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller",
-        "collision.aabb",
-        "collision.circle",
-        "control.axis_1d",
-        "controller.fps_sector",
-        "lifecycle.ttl",
-        "light.directional",
-        "light.point",
-        "light.spot",
-        "motion.grid_agent",
-        "motion.oscillate",
-        "motion.patrol",
-        "motion.scroll_wrap",
-        "motion.sector_velocity_3d",
-        "motion.spin",
-        "motion.velocity_2d",
-        "motion.velocity_3d",
-        "particles.emitter",
-        "property.decay",
-        "render.cube",
-        "render.model",
-        "render.sphere",
-        "render.sprite",
+        "adapter.controller", "collision.aabb",     "collision.circle",
+        "combat.health",      "control.axis_1d",    "controller.fps_sector",
+        "lifecycle.ttl",      "light.directional",  "light.point",
+        "light.spot",         "motion.grid_agent",  "motion.oscillate",
+        "motion.patrol",      "motion.scroll_wrap", "motion.sector_velocity_3d",
+        "motion.spin",        "motion.velocity_2d", "motion.velocity_3d",
+        "particles.emitter",  "property.decay",     "render.cube",
+        "render.model",       "render.sphere",      "render.sprite",
         "weapon.projectile",
     };
 
@@ -2899,6 +2884,35 @@ static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *c
     if ((spawn_yaw != NULL && !yyjson_is_num(spawn_yaw)) || (spawn_pitch != NULL && !yyjson_is_num(spawn_pitch)))
     {
         return validation_error(ctx, path, "controller.fps_sector spawn yaw and pitch values must be numbers");
+    }
+    return true;
+}
+
+static bool validate_combat_health_component(validation_context *ctx, yyjson_val *component, const char *path)
+{
+    const char *property_keys[] = {"health_property", "max_health_property", "armor_property", "armor_absorb_property",
+                                   "alive_property"};
+    for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, property_keys[i]);
+        if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+            return validation_error(ctx, path, "combat.health property names must be non-empty strings");
+    }
+
+    yyjson_val *health = obj_get(component, "health");
+    yyjson_val *max_health = obj_get(component, "max_health");
+    yyjson_val *armor = obj_get(component, "armor");
+    yyjson_val *armor_absorb = obj_get(component, "armor_absorb");
+    if ((health != NULL && (!yyjson_is_num(health) || yyjson_get_num(health) < 0.0)) ||
+        (max_health != NULL && (!yyjson_is_num(max_health) || yyjson_get_num(max_health) < 0.0)) ||
+        (armor != NULL && (!yyjson_is_num(armor) || yyjson_get_num(armor) < 0.0)))
+    {
+        return validation_error(ctx, path, "combat.health numeric values must be non-negative");
+    }
+    if (armor_absorb != NULL &&
+        (!yyjson_is_num(armor_absorb) || yyjson_get_num(armor_absorb) < 0.0 || yyjson_get_num(armor_absorb) > 1.0))
+    {
+        return validation_error(ctx, path, "combat.health armor_absorb must be in 0..1");
     }
     return true;
 }
@@ -4652,6 +4666,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_fps_sector_component(ctx, component, path, names))
                     return false;
             }
+            else if (SDL_strcmp(type, "combat.health") == 0)
+            {
+                if (!validate_combat_health_component(ctx, component, path))
+                    return false;
+            }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
             {
                 if (!require_ref(ctx, &names->actions, "input action", json_string(component, "action"), path) ||
@@ -4996,6 +5015,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             {
                 return validation_error(ctx, component_path,
                                         "controller.fps_sector is only supported on static entities");
+            }
+            else if (SDL_strcmp(type, "combat.health") == 0)
+            {
+                if (!validate_combat_health_component(ctx, component, component_path))
+                    return false;
             }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
             {
@@ -5587,6 +5611,101 @@ static bool validate_audio_action(validation_context *ctx, yyjson_val *action, c
     return true;
 }
 
+static bool validate_combat_target_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                          validation_names *names, const char *type)
+{
+    yyjson_val *target_value = obj_get(action, "target");
+    yyjson_val *target_from_payload_value = obj_get(action, "target_from_payload");
+    const char *target = json_string(action, "target");
+    const char *target_from_payload = json_string(action, "target_from_payload");
+    if ((target == NULL && target_from_payload == NULL) || (target != NULL && target_from_payload != NULL))
+        return validation_error(ctx, json_path, "%s requires exactly one of target or target_from_payload", type);
+    if (target_value != NULL && !yyjson_is_str(target_value))
+        return validation_error(ctx, json_path, "%s target must be a string", type);
+    if (target_from_payload_value != NULL && !yyjson_is_str(target_from_payload_value))
+        return validation_error(ctx, json_path, "%s target_from_payload must be a string", type);
+    if (target != NULL && target[0] == '\0')
+        return validation_error(ctx, json_path, "%s target must be non-empty", type);
+    if (target_from_payload != NULL && target_from_payload[0] == '\0')
+        return validation_error(ctx, json_path, "%s target_from_payload must be non-empty", type);
+    if (target != NULL && !name_table_contains(&names->entities, target) &&
+        !name_table_contains(&names->actor_pool_actors, target))
+    {
+        return validation_error(ctx, json_path, "unknown %s target '%s'", type, target);
+    }
+
+    const char *source = json_string(action, "source");
+    if (source != NULL && source[0] == '\0')
+        return validation_error(ctx, json_path, "%s source must be non-empty", type);
+    if (source != NULL && !name_table_contains(&names->entities, source) &&
+        !name_table_contains(&names->actor_pool_actors, source))
+    {
+        return validation_error(ctx, json_path, "unknown %s source '%s'", type, source);
+    }
+    yyjson_val *source_from_payload = obj_get(action, "source_from_payload");
+    if (source_from_payload != NULL &&
+        (!yyjson_is_str(source_from_payload) || yyjson_get_str(source_from_payload)[0] == '\0'))
+        return validation_error(ctx, json_path, "%s source_from_payload must be a non-empty string", type);
+
+    const char *property_keys[] = {"health_property", "max_health_property", "armor_property", "armor_absorb_property",
+                                   "alive_property"};
+    for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
+    {
+        yyjson_val *value = obj_get(action, property_keys[i]);
+        if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+            return validation_error(ctx, json_path, "%s property names must be non-empty strings", type);
+    }
+
+    const char *signal_keys[] = {"on_damage", "on_death", "on_heal", "on_revive"};
+    for (size_t i = 0; i < SDL_arraysize(signal_keys); ++i)
+    {
+        const char *signal = json_string(action, signal_keys[i]);
+        if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, json_path))
+            return false;
+    }
+
+    yyjson_val *deactivate_on_death = obj_get(action, "deactivate_on_death");
+    yyjson_val *deactivate = obj_get(action, "deactivate");
+    yyjson_val *revive = obj_get(action, "revive");
+    if ((deactivate_on_death != NULL && !yyjson_is_bool(deactivate_on_death)) ||
+        (deactivate != NULL && !yyjson_is_bool(deactivate)) || (revive != NULL && !yyjson_is_bool(revive)))
+    {
+        return validation_error(ctx, json_path, "%s boolean fields must be booleans", type);
+    }
+
+    yyjson_val *armor_absorb = obj_get(action, "armor_absorb");
+    if (armor_absorb != NULL &&
+        (!yyjson_is_num(armor_absorb) || yyjson_get_num(armor_absorb) < 0.0 || yyjson_get_num(armor_absorb) > 1.0))
+    {
+        return validation_error(ctx, json_path, "%s armor_absorb must be in 0..1", type);
+    }
+    yyjson_val *damage_type = obj_get(action, "damage_type");
+    if (damage_type != NULL && !yyjson_is_str(damage_type))
+        return validation_error(ctx, json_path, "%s damage_type must be a string", type);
+    return true;
+}
+
+static bool validate_combat_amount_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                          validation_names *names, const char *type, const char *field,
+                                          const char *payload_field)
+{
+    if (!validate_combat_target_action(ctx, action, json_path, names, type))
+        return false;
+    yyjson_val *amount = obj_get(action, field);
+    yyjson_val *amount_from_payload_value = obj_get(action, payload_field);
+    const char *amount_from_payload = json_string(action, payload_field);
+    if ((amount == NULL && amount_from_payload == NULL) || (amount != NULL && amount_from_payload != NULL))
+        return validation_error(ctx, json_path, "%s requires exactly one of %s or %s", type, field, payload_field);
+    if (amount != NULL && (!yyjson_is_num(amount) || yyjson_get_num(amount) < 0.0))
+        return validation_error(ctx, json_path, "%s %s must be a non-negative number", type, field);
+    if (amount_from_payload_value != NULL &&
+        (!yyjson_is_str(amount_from_payload_value) || yyjson_get_str(amount_from_payload_value)[0] == '\0'))
+    {
+        return validation_error(ctx, json_path, "%s %s must be a non-empty string", type, payload_field);
+    }
+    return true;
+}
+
 static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                 validation_names *names)
 {
@@ -5719,6 +5838,31 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *reason = obj_get(action, "reason");
         if (reason != NULL && !yyjson_is_str(reason))
             return validation_error(ctx, json_path, "actor.despawn_by_tag reason must be a string");
+        return true;
+    }
+    if (SDL_strcmp(type, "combat.damage") == 0)
+        return validate_combat_amount_action(ctx, action, json_path, names, type, "amount", "amount_from_payload");
+    if (SDL_strcmp(type, "combat.heal") == 0)
+        return validate_combat_amount_action(ctx, action, json_path, names, type, "amount", "amount_from_payload");
+    if (SDL_strcmp(type, "combat.kill") == 0)
+        return validate_combat_target_action(ctx, action, json_path, names, type);
+    if (SDL_strcmp(type, "combat.revive") == 0)
+    {
+        if (!validate_combat_target_action(ctx, action, json_path, names, type))
+            return false;
+        yyjson_val *health = obj_get(action, "health");
+        yyjson_val *health_from_payload_value = obj_get(action, "health_from_payload");
+        const char *health_from_payload = json_string(action, "health_from_payload");
+        if (health != NULL && health_from_payload != NULL)
+            return validation_error(ctx, json_path,
+                                    "combat.revive requires at most one of health or health_from_payload");
+        if (health != NULL && (!yyjson_is_num(health) || yyjson_get_num(health) < 0.0))
+            return validation_error(ctx, json_path, "combat.revive health must be a non-negative number");
+        if (health_from_payload_value != NULL &&
+            (!yyjson_is_str(health_from_payload_value) || yyjson_get_str(health_from_payload_value)[0] == '\0'))
+        {
+            return validation_error(ctx, json_path, "combat.revive health_from_payload must be a non-empty string");
+        }
         return true;
     }
     if (SDL_strcmp(type, "sector_door.open") == 0 || SDL_strcmp(type, "sector_door.close") == 0 ||

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -222,6 +222,19 @@ struct SensorSignalCapture
     std::string other_actor_name;
 };
 
+struct CombatSignalCapture
+{
+    int calls = 0;
+    std::string actor_name;
+    std::string source_actor_name;
+    float amount = 0.0f;
+    float armor_delta = 0.0f;
+    float health_delta = 0.0f;
+    float health = 0.0f;
+    float armor = 0.0f;
+    bool alive = true;
+};
+
 bool serve_adapter(void *userdata, sdl3d_game_data_runtime *runtime, const char *adapter_name,
                    sdl3d_registered_actor *target, const sdl3d_properties *payload)
 {
@@ -311,6 +324,25 @@ void capture_sensor_signal(void *userdata, int signal_id, const sdl3d_properties
     capture->calls++;
     capture->actor_name = sdl3d_properties_get_string(payload, "actor_name", "");
     capture->other_actor_name = sdl3d_properties_get_string(payload, "other_actor_name", "");
+}
+
+void capture_combat_signal(void *userdata, int signal_id, const sdl3d_properties *payload)
+{
+    auto *capture = static_cast<CombatSignalCapture *>(userdata);
+    (void)signal_id;
+    if (capture == nullptr)
+    {
+        return;
+    }
+    capture->calls++;
+    capture->actor_name = sdl3d_properties_get_string(payload, "actor_name", "");
+    capture->source_actor_name = sdl3d_properties_get_string(payload, "source_actor_name", "");
+    capture->amount = sdl3d_properties_get_float(payload, "amount", 0.0f);
+    capture->armor_delta = sdl3d_properties_get_float(payload, "armor_delta", 0.0f);
+    capture->health_delta = sdl3d_properties_get_float(payload, "health_delta", 0.0f);
+    capture->health = sdl3d_properties_get_float(payload, "health", 0.0f);
+    capture->armor = sdl3d_properties_get_float(payload, "armor", 0.0f);
+    capture->alive = sdl3d_properties_get_bool(payload, "alive", true);
 }
 
 std::string fixture_path(const char *filename)
@@ -6882,6 +6914,263 @@ TEST(GameDataRuntime, RejectsInvalidEditorMetadata)
     EXPECT_NE(std::string(error).find("editor exposed property default does not match its type"), std::string::npos)
         << error;
 
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, CombatActionsApplyHealthArmorDeathAndRevive)
+{
+    const std::filesystem::path dir = unique_test_dir("combat_actions");
+    write_text(dir / "combat.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Combat Actions", "id": "test.combat_actions", "version": "0.1.0" },
+  "world": { "name": "world.combat_actions", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.hero",
+      "tags": ["player"]
+    },
+    {
+      "name": "entity.monster",
+      "tags": ["enemy"],
+      "properties": {
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 },
+        "armor": { "type": "float", "value": 20.0 },
+        "armor_absorb": { "type": "float", "value": 0.5 },
+        "alive": { "type": "bool", "value": true }
+      },
+      "components": [
+        { "type": "combat.health" }
+      ]
+    }
+  ],
+  "signals": [
+    "signal.damage",
+    "signal.damage.lethal",
+    "signal.damage.after_death",
+    "signal.heal",
+    "signal.revive",
+    "signal.kill",
+    "signal.damaged",
+    "signal.dead",
+    "signal.healed",
+    "signal.revived"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.damage",
+        "actions": [
+          {
+            "type": "combat.damage",
+            "target": "entity.monster",
+            "source": "entity.hero",
+            "amount": 30.0,
+            "damage_type": "slash",
+            "on_damage": "signal.damaged",
+            "on_death": "signal.dead"
+          }
+        ]
+      },
+      {
+        "signal": "signal.damage.lethal",
+        "actions": [
+          {
+            "type": "combat.damage",
+            "target": "entity.monster",
+            "source": "entity.hero",
+            "amount": 200.0,
+            "on_damage": "signal.damaged",
+            "on_death": "signal.dead"
+          }
+        ]
+      },
+      {
+        "signal": "signal.damage.after_death",
+        "actions": [
+          {
+            "type": "combat.damage",
+            "target": "entity.monster",
+            "source": "entity.hero",
+            "amount": 1.0,
+            "on_damage": "signal.damaged",
+            "on_death": "signal.dead"
+          }
+        ]
+      },
+      {
+        "signal": "signal.heal",
+        "actions": [
+          { "type": "combat.heal", "target": "entity.monster", "amount": 25.0, "on_heal": "signal.healed" }
+        ]
+      },
+      {
+        "signal": "signal.revive",
+        "actions": [
+          { "type": "combat.revive", "target": "entity.monster", "health": 50.0, "on_revive": "signal.revived" }
+        ]
+      },
+      {
+        "signal": "signal.kill",
+        "actions": [
+          { "type": "combat.kill", "target": "entity.monster", "source": "entity.hero", "on_death": "signal.dead" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(
+        dir / "scenes" / "play.scene.json",
+        R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.hero", "entity.monster"] })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(
+        sdl3d_game_data_load_file((dir / "combat.game.json").string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    sdl3d_registered_actor *monster = sdl3d_game_data_find_actor(runtime, "entity.monster");
+    ASSERT_NE(monster, nullptr);
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+
+    CombatSignalCapture damaged{};
+    CombatSignalCapture dead{};
+    CombatSignalCapture healed{};
+    CombatSignalCapture revived{};
+    ASSERT_NE(sdl3d_signal_connect(bus, sdl3d_game_data_find_signal(runtime, "signal.damaged"), capture_combat_signal,
+                                   &damaged),
+              0);
+    ASSERT_NE(
+        sdl3d_signal_connect(bus, sdl3d_game_data_find_signal(runtime, "signal.dead"), capture_combat_signal, &dead),
+        0);
+    ASSERT_NE(sdl3d_signal_connect(bus, sdl3d_game_data_find_signal(runtime, "signal.healed"), capture_combat_signal,
+                                   &healed),
+              0);
+    ASSERT_NE(sdl3d_signal_connect(bus, sdl3d_game_data_find_signal(runtime, "signal.revived"), capture_combat_signal,
+                                   &revived),
+              0);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.damage"), nullptr);
+    EXPECT_EQ(damaged.calls, 1);
+    EXPECT_EQ(dead.calls, 0);
+    EXPECT_EQ(damaged.actor_name, "entity.monster");
+    EXPECT_EQ(damaged.source_actor_name, "entity.hero");
+    EXPECT_NEAR(damaged.amount, 30.0f, 0.001f);
+    EXPECT_NEAR(damaged.armor_delta, 15.0f, 0.001f);
+    EXPECT_NEAR(damaged.health_delta, 15.0f, 0.001f);
+    EXPECT_NEAR(damaged.health, 85.0f, 0.001f);
+    EXPECT_NEAR(damaged.armor, 5.0f, 0.001f);
+    EXPECT_TRUE(damaged.alive);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "health", 0.0f), 85.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "armor", 0.0f), 5.0f, 0.001f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(monster->props, "alive", false));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.damage.lethal"), nullptr);
+    EXPECT_EQ(damaged.calls, 2);
+    EXPECT_EQ(dead.calls, 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "health", 1.0f), 0.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "armor", 1.0f), 0.0f, 0.001f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(monster->props, "alive", true));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.damage.after_death"), nullptr);
+    EXPECT_EQ(damaged.calls, 3);
+    EXPECT_EQ(dead.calls, 1);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.heal"), nullptr);
+    EXPECT_EQ(healed.calls, 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "health", 0.0f), 25.0f, 0.001f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(monster->props, "alive", true));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.revive"), nullptr);
+    EXPECT_EQ(revived.calls, 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "health", 0.0f), 50.0f, 0.001f);
+    EXPECT_TRUE(sdl3d_properties_get_bool(monster->props, "alive", false));
+    EXPECT_TRUE(monster->active);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.kill"), nullptr);
+    EXPECT_EQ(dead.calls, 2);
+    EXPECT_NEAR(sdl3d_properties_get_float(monster->props, "health", 1.0f), 0.0f, 0.001f);
+    EXPECT_FALSE(sdl3d_properties_get_bool(monster->props, "alive", true));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidCombatActionsAndComponents)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_combat");
+    write_text(dir / "invalid_combat.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Combat", "id": "test.invalid_combat", "version": "0.1.0" },
+  "world": { "name": "world.invalid_combat", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.actor",
+      "components": [
+        { "type": "combat.health", "armor_absorb": 1.5 }
+      ]
+    }
+  ],
+  "signals": ["signal.damage"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.damage",
+        "actions": [
+          { "type": "combat.damage", "target": "entity.actor", "amount": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.actor"] })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_combat.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("combat.health armor_absorb must be in 0..1"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_combat_action.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Combat Action", "id": "test.invalid_combat_action", "version": "0.1.0" },
+  "world": { "name": "world.invalid_combat_action", "kind": "fixed_screen" },
+  "entities": [{ "name": "entity.actor" }],
+  "signals": ["signal.damage"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.damage",
+        "actions": [
+          { "type": "combat.damage", "target": "entity.actor", "amount": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_combat_action.game.json").string().c_str(), session,
+                                           &runtime, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("combat.damage amount must be a non-negative number"), std::string::npos)
+        << error;
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary

- Adds reusable data-authored combat primitives: `combat.damage`, `combat.heal`, `combat.kill`, and `combat.revive`.
- Adds `combat.health` as a validated component convention for actors that participate in generic health/armor logic.
- Supports armor absorption, health clamping, alive/dead state, optional deactivation on death, payload-driven targets/amounts, and combat event signals.
- Extends the FPS mechanics dojo with a mock combat dummy that can be damaged through authored JSON.
- Documents combat properties, actions, event payloads, and when to prefer combat actions over raw property mutation.

## Issue

Second work slice of #282.

## Validation

- `find demos/fps_mechanics_dojo/data -name '*.json' -print0 | xargs -0 jq empty`
- `cmake --build build/debug --target sdl3d_game_data_test -j 8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.CombatActionsApplyHealthArmorDeathAndRevive:GameDataRuntime.RejectsInvalidCombatActionsAndComponents:GameDataRuntime.EditorMetadataValidatesAndFpsMechanicsDojoLoads'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug --target game_data_json_test sdl3d_runner -j 8`
- `./build/debug/tests/game_data_json_test`
- `./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json --scene scene.dojo.fps_world` smoke-tested for startup
