### PR TITLE
Add data-driven resources pickups and powerups

### DIFF
--- a/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/mechanic_markers.json
@@ -51,6 +51,72 @@
         ],
         "test_scene": "scene.dojo.fps_world"
       }
+    },
+    {
+      "name": "archetype.dojo.pickup",
+      "active": true,
+      "tags": ["dojo_marker", "pickup"],
+      "properties": {
+        "pickup_available": { "type": "bool", "value": true },
+        "pickup_respawn_remaining": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "pickup.respawn" },
+        { "type": "render.sphere", "radius": 0.35, "color": [70, 255, 120, 240], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.25, 1.0, 0.45], "intensity": 1.8, "range": 5.0 },
+        { "type": "motion.spin", "property": "rotation_angle", "rate": 2.0 }
+      ],
+      "editor": {
+        "display_name": "Resource Pickup",
+        "category": "mechanics/resources",
+        "tags": ["pickup", "resource", "mockup"],
+        "preview": { "primitive": "sphere", "color": [0.25, 1.0, 0.45, 1.0] },
+        "bounds": { "size": [0.8, 0.8, 0.8] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "archetype.dojo.resource_station",
+      "active": true,
+      "tags": ["dojo_marker", "resource_station"],
+      "properties": {
+        "charges": { "type": "int", "value": 99 },
+        "cooldown": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "property.decay", "property": "cooldown", "rate": 1.0, "target": 0.0, "min": 0.0 },
+        { "type": "render.cube", "size": [1.2, 1.4, 1.2], "color": [80, 220, 255, 230], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.2, 0.85, 1.0], "intensity": 2.0, "range": 6.0 }
+      ],
+      "editor": {
+        "display_name": "Resource Station",
+        "category": "mechanics/resources",
+        "tags": ["station", "resource", "mockup"],
+        "preview": { "primitive": "cube", "color": [0.2, 0.85, 1.0, 1.0] },
+        "bounds": { "size": [1.2, 1.4, 1.2] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "archetype.dojo.powerup",
+      "active": true,
+      "tags": ["dojo_marker", "powerup"],
+      "components": [
+        { "type": "render.sphere", "radius": 0.42, "color": [255, 210, 60, 245], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [1.0, 0.75, 0.1], "intensity": 2.2, "range": 6.0 },
+        { "type": "motion.oscillate", "amplitude": [0.0, 0.2, 0.0], "rate": 2.5 }
+      ],
+      "editor": {
+        "display_name": "Temporary Power-Up",
+        "category": "mechanics/resources",
+        "tags": ["powerup", "status", "mockup"],
+        "preview": { "primitive": "sphere", "color": [1.0, 0.75, 0.1, 1.0] },
+        "bounds": { "size": [0.9, 0.9, 0.9] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.dojo.fps_world"
+      }
     }
   ],
   "actor_instances": [
@@ -118,6 +184,45 @@
         "tags": ["combat", "health"],
         "preview": { "primitive": "cube", "color": [1.0, 0.25, 0.15, 1.0] },
         "bounds": { "size": [1.2, 1.8, 1.2] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.health_pickup",
+      "archetype": "archetype.dojo.pickup",
+      "transform": { "position": [4.0, 0.6, 14.0] },
+      "editor": {
+        "display_name": "Health/Ammo Pickup",
+        "category": "mechanics/resources",
+        "tags": ["pickup", "resource"],
+        "preview": { "primitive": "sphere", "color": [0.25, 1.0, 0.45, 1.0] },
+        "bounds": { "size": [0.8, 0.8, 0.8] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.health_station",
+      "archetype": "archetype.dojo.resource_station",
+      "transform": { "position": [7.0, 0.7, 14.0] },
+      "editor": {
+        "display_name": "Health Station",
+        "category": "mechanics/resources",
+        "tags": ["station", "resource"],
+        "preview": { "primitive": "cube", "color": [0.2, 0.85, 1.0, 1.0] },
+        "bounds": { "size": [1.2, 1.4, 1.2] },
+        "test_scene": "scene.dojo.fps_world"
+      }
+    },
+    {
+      "name": "entity.dojo.powerup",
+      "archetype": "archetype.dojo.powerup",
+      "transform": { "position": [13.5, 0.7, 14.0] },
+      "editor": {
+        "display_name": "Quad Damage Power-Up",
+        "category": "mechanics/resources",
+        "tags": ["powerup", "status"],
+        "preview": { "primitive": "sphere", "color": [1.0, 0.75, 0.1, 1.0] },
+        "bounds": { "size": [0.9, 0.9, 0.9] },
         "test_scene": "scene.dojo.fps_world"
       }
     }

--- a/demos/fps_mechanics_dojo/data/fragments/actors/player.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/player.json
@@ -10,7 +10,14 @@
         "yaw": { "type": "float", "value": 0.0 },
         "pitch": { "type": "float", "value": 0.0 },
         "current_sector": { "type": "int", "value": -1 },
-        "dojo_hazard_damage": { "type": "float", "value": 0.0 }
+        "dojo_hazard_damage": { "type": "float", "value": 0.0 },
+        "health": { "type": "float", "value": 65.0 },
+        "max_health": { "type": "float", "value": 100.0 },
+        "ammo": { "type": "int", "value": 2 },
+        "max_ammo": { "type": "int", "value": 12 },
+        "quad_damage": { "type": "bool", "value": false },
+        "quad_damage_remaining": { "type": "float", "value": 0.0 },
+        "quad_damage_active": { "type": "bool", "value": false }
       },
       "editor": {
         "display_name": "FPS Player",
@@ -40,6 +47,13 @@
           "step_height": 0.65,
           "ceiling_clearance": 0.1,
           "mouse_sensitivity": 0.002
+        },
+        {
+          "type": "status_effect.timer",
+          "property": "quad_damage",
+          "duration_property": "quad_damage_remaining",
+          "active_property": "quad_damage_active",
+          "expired_value": false
         }
       ]
     }

--- a/demos/fps_mechanics_dojo/data/fragments/world/arena.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/arena.json
@@ -87,6 +87,66 @@
         "type": "sensor.input_pressed",
         "action": "action.fire",
         "on_pressed": "signal.dojo.damage_dummy"
+      },
+      {
+        "name": "sensor.dojo.pickup.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [3.4, 0.0, 13.4],
+        "max": [4.6, 2.0, 14.6],
+        "edge": "enter",
+        "actions": [
+          {
+            "type": "pickup.collect",
+            "target_from_payload": "actor_name",
+            "pickup": "entity.dojo.health_pickup",
+            "respawn_seconds": 8.0,
+            "resources": [
+              { "resource": "health", "amount": 20.0 },
+              { "resource": "ammo", "amount": 4.0 }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "sensor.dojo.station.stay",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [6.3, 0.0, 13.3],
+        "max": [7.7, 2.0, 14.7],
+        "edge": "stay",
+        "actions": [
+          {
+            "type": "resource.station.use",
+            "target_from_payload": "actor_name",
+            "station": "entity.dojo.health_station",
+            "cooldown": 1.5,
+            "consume_charge": false,
+            "resources": [
+              { "resource": "health", "amount": 8.0 }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "sensor.dojo.powerup.enter",
+        "type": "sensor.volume",
+        "actor": "entity.player",
+        "min": [12.8, 0.0, 13.3],
+        "max": [14.2, 2.0, 14.7],
+        "edge": "enter",
+        "actions": [
+          {
+            "type": "status_effect.apply",
+            "target_from_payload": "actor_name",
+            "property": "quad_damage",
+            "value": true,
+            "duration": 10.0,
+            "duration_property": "quad_damage_remaining",
+            "active_property": "quad_damage_active"
+          },
+          { "type": "entity.set_active", "target": "entity.dojo.powerup", "active": false }
+        ]
       }
     ],
     "bindings": [

--- a/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
@@ -9,7 +9,10 @@
     "entity.dojo.launch_pad",
     "entity.dojo.teleporter_pad",
     "entity.dojo.teleporter_destination",
-    "entity.dojo.combat_dummy"
+    "entity.dojo.combat_dummy",
+    "entity.dojo.health_pickup",
+    "entity.dojo.health_station",
+    "entity.dojo.powerup"
   ],
   "input": {
     "mouse_capture": "unpaused",
@@ -61,6 +64,15 @@
         "position": [0.02, 0.11],
         "anchor": "top_left",
         "color": [255, 210, 180, 220],
+        "scale": 0.75
+      },
+      {
+        "name": "ui.dojo.resources",
+        "text": "HP {target.entity.player.health}/{target.entity.player.max_health}  Ammo {target.entity.player.ammo}/{target.entity.player.max_ammo}  Quad {target.entity.player.quad_damage_active}",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.15],
+        "anchor": "top_left",
+        "color": [190, 255, 210, 230],
         "scale": 0.75
       },
       {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1143,6 +1143,12 @@ Reusable components include:
   properties so UI, Lua, replication, saves, and data actions can read the same
   values. Use properties such as `health`, `max_health`, `armor`,
   `armor_absorb`, and `alive` for defaults.
+- `pickup.respawn`: reactivates an inactive pickup actor after a respawn timer
+  reaches zero. By default it reads `pickup_respawn_remaining` and writes
+  `pickup_available`.
+- `status_effect.timer`: expires a temporary property-driven status effect.
+  It decrements a duration property such as `quad_damage_remaining`, writes an
+  `expired_value` when the timer reaches zero, and can clear an active flag.
 - `motion.scroll_wrap`: scrolls an actor along one axis and wraps to the
   opposite bound. This is intended for parallax panels, repeating stars, clouds,
   conveyor belts, and similar backgrounds.
@@ -1333,6 +1339,96 @@ Prefer combat actions over raw `property.add` for gameplay health because they
 centralize armor absorption, clamping, alive/dead state, and signal emission.
 Raw property actions remain useful for simple meters, counters, and diagnostic
 state.
+
+### Resources, Pickups, Stations, And Status Effects
+
+Generic resource actions manage numeric meters such as ammo, mana, keys, fuel,
+stamina, shields, or currency. They operate on ordinary actor properties so UI,
+Lua, persistence, and networking see the same state.
+
+```json
+{ "type": "resource.add", "target": "entity.player", "resource": "ammo", "amount": 12 }
+{ "type": "resource.consume", "target": "entity.player", "resource": "ammo", "amount": 1 }
+{ "type": "resource.set", "target": "entity.player", "resource": "stamina", "value": 100 }
+```
+
+By default, `resource: "ammo"` reads and writes the `ammo` property and clamps
+against `max_ammo` when present. Override names with `property` and
+`max_property` when a project uses different naming. `amount_from_payload` and
+`value_from_payload` allow sensors or other actions to drive the value. Consume
+actions are non-destructive on failure unless `allow_partial: true`; use
+`on_success` and `on_failure` to emit authored feedback signals.
+
+`pickup.collect` grants one or more resources to a collector actor, optionally
+deactivates the pickup, and can start a respawn timer:
+
+```json
+{
+  "type": "pickup.collect",
+  "target_from_payload": "actor_name",
+  "pickup_from_payload": "other_actor_name",
+  "respawn_seconds": 15.0,
+  "resources": [
+    { "resource": "health", "amount": 25.0 },
+    { "resource": "ammo", "amount": 8.0 }
+  ],
+  "on_collected": "signal.pickup.collected"
+}
+```
+
+Author a `pickup.respawn` component on the pickup actor when it should become
+active again after `pickup_respawn_remaining` reaches zero. This component runs
+for inactive actors in the active scene, so respawned pickups do not require Lua
+polling.
+
+Resource stations are reusable actors such as health fountains, ammo terminals,
+and recharge pads. `resource.station.use` grants resources if the station has
+charges and is off cooldown:
+
+```json
+{
+  "type": "resource.station.use",
+  "target": "entity.player",
+  "station": "entity.health_station",
+  "cooldown": 2.0,
+  "resources": [{ "resource": "health", "amount": 20.0 }]
+}
+```
+
+The station reads `charges` and `cooldown` by default. Add a `property.decay`
+component for the cooldown property so it counts down over time. Set
+`consume_charge: false` for infinite stations.
+
+Temporary power-ups can be modeled with `status_effect.apply` and
+`status_effect.timer`:
+
+```json
+{
+  "type": "status_effect.apply",
+  "target": "entity.player",
+  "property": "quad_damage",
+  "value": true,
+  "duration": 10.0,
+  "duration_property": "quad_damage_remaining",
+  "active_property": "quad_damage_active"
+}
+```
+
+The matching component resets the property when the timer expires:
+
+```json
+{
+  "type": "status_effect.timer",
+  "property": "quad_damage",
+  "duration_property": "quad_damage_remaining",
+  "active_property": "quad_damage_active",
+  "expired_value": false
+}
+```
+
+Use these primitives for reusable mechanics. Put game-specific policy, such as
+which pickups spawn in a level or how a power-up changes enemy AI, in JSON and
+Lua.
 
 `collision.on_overlap` is a data-action variant of the 2D contact sensor. It
 matches actors by fixed actor names or tags, publishes `actor_name` and

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -11743,6 +11743,34 @@ static bool json_scalar_to_value(yyjson_val *json, sdl3d_value *out_value)
     return false;
 }
 
+static bool set_property_from_value(sdl3d_properties *props, const char *key, const sdl3d_value *value)
+{
+    if (props == NULL || key == NULL || key[0] == '\0' || value == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SDL3D_VALUE_BOOL:
+        sdl3d_properties_set_bool(props, key, value->as_bool);
+        return true;
+    case SDL3D_VALUE_INT:
+        sdl3d_properties_set_int(props, key, value->as_int);
+        return true;
+    case SDL3D_VALUE_FLOAT:
+        sdl3d_properties_set_float(props, key, value->as_float);
+        return true;
+    case SDL3D_VALUE_STRING:
+        sdl3d_properties_set_string(props, key, value->as_string != NULL ? value->as_string : "");
+        return true;
+    case SDL3D_VALUE_VEC3:
+        sdl3d_properties_set_vec3(props, key, value->as_vec3);
+        return true;
+    case SDL3D_VALUE_COLOR:
+        return false;
+    }
+    return false;
+}
+
 static yyjson_val *find_ui_text_json(const sdl3d_game_data_runtime *runtime, const char *name)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
@@ -14014,6 +14042,324 @@ static bool execute_combat_revive_action(sdl3d_game_data_runtime *runtime, yyjso
     return true;
 }
 
+static const char *resource_name(yyjson_val *action)
+{
+    const char *resource = json_string(action, "resource", NULL);
+    return resource != NULL && resource[0] != '\0' ? resource : NULL;
+}
+
+static const char *resource_property_name(yyjson_val *json, const char *fallback_resource)
+{
+    const char *property = json_string(json, "property", NULL);
+    if (property != NULL && property[0] != '\0')
+        return property;
+    return fallback_resource;
+}
+
+static const char *resource_max_property_name(yyjson_val *json, const char *resource, char *buffer, size_t buffer_size)
+{
+    const char *property = json_string(json, "max_property", NULL);
+    if (property != NULL && property[0] != '\0')
+        return property;
+    if (resource == NULL || resource[0] == '\0' || buffer == NULL || buffer_size == 0U)
+        return NULL;
+    SDL_snprintf(buffer, buffer_size, "max_%s", resource);
+    return buffer;
+}
+
+static bool resource_numeric_value(yyjson_val *json, const sdl3d_properties *payload, const char *value_key,
+                                   const char *payload_key, float *out_value)
+{
+    return action_float_value(NULL, json, payload, value_key, payload_key, out_value);
+}
+
+static sdl3d_properties *resource_event_payload(sdl3d_registered_actor *target, yyjson_val *json, const char *resource,
+                                                float old_value, float value, float max_value, float amount,
+                                                bool success)
+{
+    sdl3d_properties *event_payload = sdl3d_properties_create();
+    if (event_payload == NULL)
+        return NULL;
+    sdl3d_properties_set_string(event_payload, "actor_name",
+                                target != NULL && target->name != NULL ? target->name : "");
+    sdl3d_properties_set_string(event_payload, "resource", resource != NULL ? resource : "");
+    sdl3d_properties_set_string(event_payload, "resource_property",
+                                resource_property_name(json, resource) != NULL ? resource_property_name(json, resource)
+                                                                               : "");
+    sdl3d_properties_set_float(event_payload, "old_value", old_value);
+    sdl3d_properties_set_float(event_payload, "value", value);
+    sdl3d_properties_set_float(event_payload, "max_value", max_value);
+    sdl3d_properties_set_float(event_payload, "amount", amount);
+    sdl3d_properties_set_bool(event_payload, "success", success);
+    return event_payload;
+}
+
+static void emit_optional_signal(sdl3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,
+                                 const sdl3d_properties *payload)
+{
+    const int signal_id = action_signal_id(runtime, json, signal_key);
+    if (signal_id >= 0 && runtime_bus(runtime) != NULL)
+        sdl3d_signal_emit(runtime_bus(runtime), signal_id, payload);
+}
+
+static bool apply_resource_delta_to_actor(sdl3d_game_data_runtime *runtime, sdl3d_registered_actor *target,
+                                          yyjson_val *json, const sdl3d_properties *payload, float amount, bool consume)
+{
+    const char *resource = resource_name(json);
+    const char *property = resource_property_name(json, resource);
+    char max_property_buffer[128];
+    const char *max_property =
+        resource_max_property_name(json, resource, max_property_buffer, sizeof(max_property_buffer));
+    if (target == NULL || resource == NULL || property == NULL)
+        return false;
+
+    const float old_value = actor_numeric_property(target, property, 0.0f);
+    const float min_value = json_float(json, "min", 0.0f);
+    float max_value = 0.0f;
+    const bool has_authored_max = yyjson_is_num(obj_get(json, "max"));
+    const bool has_max_property =
+        max_property != NULL && sdl3d_properties_get_value(target->props, max_property) != NULL;
+    if (has_authored_max)
+        max_value = json_float(json, "max", old_value);
+    else if (has_max_property)
+        max_value = actor_numeric_property(target, max_property, old_value);
+
+    bool success = true;
+    float applied = SDL_max(amount, 0.0f);
+    float value = old_value;
+    if (consume)
+    {
+        const bool allow_partial = json_bool(json, "allow_partial", false);
+        if (old_value + 0.0001f < applied && !allow_partial)
+        {
+            success = false;
+            applied = 0.0f;
+        }
+        else
+        {
+            applied = SDL_min(applied, SDL_max(old_value - min_value, 0.0f));
+            value = old_value - applied;
+        }
+    }
+    else
+    {
+        value = old_value + applied;
+    }
+
+    if (success && json_bool(json, "clamp", true))
+    {
+        value = SDL_max(value, min_value);
+        if (has_authored_max || has_max_property)
+            value = SDL_min(value, max_value);
+    }
+
+    if (success)
+        set_actor_numeric_property(target, property, value);
+
+    sdl3d_properties *event_payload =
+        resource_event_payload(target, json, resource, old_value, success ? value : old_value,
+                               (has_authored_max || has_max_property) ? max_value : old_value, applied, success);
+    if (event_payload != NULL)
+    {
+        emit_optional_signal(runtime, json, success ? "on_success" : "on_failure", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    (void)payload;
+    return true;
+}
+
+static bool execute_resource_amount_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                           const sdl3d_properties *payload, bool consume)
+{
+    sdl3d_registered_actor *target = action_target_actor(runtime, action, payload);
+    float amount = 0.0f;
+    if (target == NULL || !resource_numeric_value(action, payload, "amount", "amount_from_payload", &amount))
+        return false;
+    return apply_resource_delta_to_actor(runtime, target, action, payload, amount, consume);
+}
+
+static bool execute_resource_set_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                        const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *target = action_target_actor(runtime, action, payload);
+    const char *resource = resource_name(action);
+    const char *property = resource_property_name(action, resource);
+    float value = 0.0f;
+    if (target == NULL || resource == NULL || property == NULL ||
+        !resource_numeric_value(action, payload, "value", "value_from_payload", &value))
+    {
+        return false;
+    }
+
+    char max_property_buffer[128];
+    const char *max_property =
+        resource_max_property_name(action, resource, max_property_buffer, sizeof(max_property_buffer));
+    const bool has_authored_max = yyjson_is_num(obj_get(action, "max"));
+    const bool has_max_property =
+        max_property != NULL && sdl3d_properties_get_value(target->props, max_property) != NULL;
+    const float max_value = has_authored_max   ? json_float(action, "max", value)
+                            : has_max_property ? actor_numeric_property(target, max_property, value)
+                                               : value;
+    const float min_value = json_float(action, "min", 0.0f);
+    const float old_value = actor_numeric_property(target, property, 0.0f);
+    if (json_bool(action, "clamp", true))
+    {
+        value = SDL_max(value, min_value);
+        if (has_authored_max || has_max_property)
+            value = SDL_min(value, max_value);
+    }
+    set_actor_numeric_property(target, property, value);
+
+    sdl3d_properties *event_payload =
+        resource_event_payload(target, action, resource, old_value, value,
+                               (has_authored_max || has_max_property) ? max_value : value, value - old_value, true);
+    if (event_payload != NULL)
+    {
+        emit_optional_signal(runtime, action, "on_success", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
+static bool apply_resource_grants(sdl3d_game_data_runtime *runtime, sdl3d_registered_actor *target, yyjson_val *grants,
+                                  const sdl3d_properties *payload)
+{
+    if (runtime == NULL || target == NULL || !yyjson_is_arr(grants))
+        return false;
+
+    bool ok = true;
+    for (size_t i = 0; i < yyjson_arr_size(grants); ++i)
+    {
+        yyjson_val *grant = yyjson_arr_get(grants, i);
+        float amount = 0.0f;
+        if (!resource_numeric_value(grant, payload, "amount", "amount_from_payload", &amount) ||
+            !apply_resource_delta_to_actor(runtime, target, grant, payload, amount, false))
+        {
+            ok = false;
+        }
+    }
+    return ok;
+}
+
+static bool execute_pickup_collect_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                          const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *collector = action_target_actor(runtime, action, payload);
+    sdl3d_registered_actor *pickup = sdl3d_game_data_find_actor(runtime, json_string(action, "pickup", NULL));
+    const char *pickup_from_payload = json_string(action, "pickup_from_payload", NULL);
+    if (pickup == NULL && pickup_from_payload != NULL)
+        pickup = actor_from_payload_key(runtime, payload, pickup_from_payload);
+    if (collector == NULL || pickup == NULL || !pickup->active)
+        return false;
+
+    if (!apply_resource_grants(runtime, collector, obj_get(action, "resources"), payload))
+        return false;
+
+    if (json_bool(action, "deactivate", true))
+    {
+        pickup->active = false;
+        sdl3d_properties_set_bool(pickup->props, json_string(action, "available_property", "pickup_available"), false);
+        const float respawn_seconds = json_float(action, "respawn_seconds", 0.0f);
+        if (respawn_seconds > 0.0f)
+        {
+            sdl3d_properties_set_float(pickup->props, json_string(action, "timer_property", "pickup_respawn_remaining"),
+                                       respawn_seconds);
+        }
+    }
+
+    sdl3d_properties *event_payload = sdl3d_properties_create();
+    if (event_payload != NULL)
+    {
+        sdl3d_properties_set_string(event_payload, "actor_name", collector->name != NULL ? collector->name : "");
+        sdl3d_properties_set_string(event_payload, "pickup_actor_name", pickup->name != NULL ? pickup->name : "");
+        emit_optional_signal(runtime, action, "on_collected", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
+static bool execute_resource_station_use_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *target = action_target_actor(runtime, action, payload);
+    sdl3d_registered_actor *station = sdl3d_game_data_find_actor(runtime, json_string(action, "station", NULL));
+    const char *station_from_payload = json_string(action, "station_from_payload", NULL);
+    if (station == NULL && station_from_payload != NULL)
+        station = actor_from_payload_key(runtime, payload, station_from_payload);
+    if (target == NULL || station == NULL)
+        return false;
+
+    const char *cooldown_property = json_string(action, "cooldown_property", "cooldown");
+    const char *charges_property = json_string(action, "charges_property", "charges");
+    const float cooldown = sdl3d_properties_get_float(station->props, cooldown_property, 0.0f);
+    const float charges = actor_numeric_property(station, charges_property, 1.0f);
+    const bool use_charge = json_bool(action, "consume_charge", true);
+    const bool success = cooldown <= 0.0f && (!use_charge || charges > 0.0f);
+    if (success)
+    {
+        if (!apply_resource_grants(runtime, target, obj_get(action, "resources"), payload))
+            return false;
+        if (use_charge)
+            set_actor_numeric_property(station, charges_property, SDL_max(charges - 1.0f, 0.0f));
+        sdl3d_properties_set_float(station->props, cooldown_property, json_float(action, "cooldown", cooldown));
+    }
+
+    sdl3d_properties *event_payload = sdl3d_properties_create();
+    if (event_payload != NULL)
+    {
+        sdl3d_properties_set_string(event_payload, "actor_name", target->name != NULL ? target->name : "");
+        sdl3d_properties_set_string(event_payload, "station_actor_name", station->name != NULL ? station->name : "");
+        sdl3d_properties_set_float(event_payload, "charges", actor_numeric_property(station, charges_property, 0.0f));
+        sdl3d_properties_set_float(event_payload, "cooldown",
+                                   sdl3d_properties_get_float(station->props, cooldown_property, 0.0f));
+        sdl3d_properties_set_bool(event_payload, "success", success);
+        emit_optional_signal(runtime, action, success ? "on_success" : "on_failure", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
+static bool execute_status_effect_apply_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *target = action_target_actor(runtime, action, payload);
+    const char *property = json_string(action, "property", NULL);
+    const char *duration_property = json_string(action, "duration_property", NULL);
+    char duration_buffer[128];
+    if (duration_property == NULL && property != NULL)
+    {
+        SDL_snprintf(duration_buffer, sizeof(duration_buffer), "%s_remaining", property);
+        duration_property = duration_buffer;
+    }
+
+    sdl3d_value value;
+    float duration = 0.0f;
+    if (target == NULL || property == NULL || property[0] == '\0' ||
+        !json_scalar_to_value(obj_get(action, "value"), &value) ||
+        !resource_numeric_value(action, payload, "duration", "duration_from_payload", &duration))
+    {
+        return false;
+    }
+
+    if (!set_property_from_value(target->props, property, &value))
+        return false;
+    sdl3d_properties_set_float(target->props, duration_property, SDL_max(duration, 0.0f));
+    const char *active_property = json_string(action, "active_property", NULL);
+    if (active_property != NULL && active_property[0] != '\0')
+        sdl3d_properties_set_bool(target->props, active_property, duration > 0.0f);
+
+    sdl3d_properties *event_payload = sdl3d_properties_create();
+    if (event_payload != NULL)
+    {
+        sdl3d_properties_set_string(event_payload, "actor_name", target->name != NULL ? target->name : "");
+        sdl3d_properties_set_string(event_payload, "property", property);
+        sdl3d_properties_set_float(event_payload, "duration", duration);
+        emit_optional_signal(runtime, action, "on_apply", event_payload);
+        sdl3d_properties_destroy(event_payload);
+    }
+    return true;
+}
+
 static bool execute_projectile_fire_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
                                            const sdl3d_properties *payload)
 {
@@ -14703,6 +15049,18 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return execute_combat_kill_action(runtime, action, payload);
     if (SDL_strcmp(type, "combat.revive") == 0)
         return execute_combat_revive_action(runtime, action, payload);
+    if (SDL_strcmp(type, "resource.add") == 0)
+        return execute_resource_amount_action(runtime, action, payload, false);
+    if (SDL_strcmp(type, "resource.consume") == 0)
+        return execute_resource_amount_action(runtime, action, payload, true);
+    if (SDL_strcmp(type, "resource.set") == 0)
+        return execute_resource_set_action(runtime, action, payload);
+    if (SDL_strcmp(type, "pickup.collect") == 0)
+        return execute_pickup_collect_action(runtime, action, payload);
+    if (SDL_strcmp(type, "resource.station.use") == 0)
+        return execute_resource_station_use_action(runtime, action, payload);
+    if (SDL_strcmp(type, "status_effect.apply") == 0)
+        return execute_status_effect_apply_action(runtime, action, payload);
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
@@ -15820,6 +16178,73 @@ static bool update_sector_platforms(sdl3d_game_data_runtime *runtime, float dt)
     return true;
 }
 
+static void update_pickup_respawn_component(yyjson_val *component, sdl3d_registered_actor *actor, float dt)
+{
+    if (component == NULL || actor == NULL || actor->active)
+        return;
+
+    const char *timer_property = json_string(component, "timer_property", "pickup_respawn_remaining");
+    const char *available_property = json_string(component, "available_property", "pickup_available");
+    const float remaining = sdl3d_properties_get_float(actor->props, timer_property, 0.0f);
+    if (remaining <= 0.0f)
+        return;
+
+    const float next = SDL_max(remaining - dt, 0.0f);
+    sdl3d_properties_set_float(actor->props, timer_property, next);
+    if (next <= 0.0f)
+    {
+        actor->active = true;
+        sdl3d_properties_set_bool(actor->props, available_property, true);
+    }
+}
+
+static void update_status_effect_timer_component(sdl3d_game_data_runtime *runtime, yyjson_val *component,
+                                                 sdl3d_registered_actor *actor, float dt)
+{
+    if (runtime == NULL || component == NULL || actor == NULL || !actor->active)
+        return;
+
+    const char *property = json_string(component, "property", NULL);
+    const char *duration_property = json_string(component, "duration_property", NULL);
+    char duration_buffer[128];
+    if (duration_property == NULL && property != NULL)
+    {
+        SDL_snprintf(duration_buffer, sizeof(duration_buffer), "%s_remaining", property);
+        duration_property = duration_buffer;
+    }
+    if (property == NULL || duration_property == NULL)
+        return;
+
+    const float remaining = sdl3d_properties_get_float(actor->props, duration_property, 0.0f);
+    if (remaining <= 0.0f)
+        return;
+
+    const float next = SDL_max(remaining - dt, 0.0f);
+    sdl3d_properties_set_float(actor->props, duration_property, next);
+    if (next > 0.0f)
+        return;
+
+    sdl3d_value expired;
+    if (json_scalar_to_value(obj_get(component, "expired_value"), &expired))
+        (void)set_property_from_value(actor->props, property, &expired);
+    const char *active_property = json_string(component, "active_property", NULL);
+    if (active_property != NULL && active_property[0] != '\0')
+        sdl3d_properties_set_bool(actor->props, active_property, false);
+
+    const int signal_id = action_signal_id(runtime, component, "on_expire");
+    if (signal_id >= 0 && runtime_bus(runtime) != NULL)
+    {
+        sdl3d_properties *payload = sdl3d_properties_create();
+        if (payload != NULL)
+        {
+            sdl3d_properties_set_string(payload, "actor_name", actor->name != NULL ? actor->name : "");
+            sdl3d_properties_set_string(payload, "property", property);
+        }
+        sdl3d_signal_emit(runtime_bus(runtime), signal_id, payload);
+        sdl3d_properties_destroy(payload);
+    }
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -15922,7 +16347,17 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
                 continue;
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
             yyjson_val *components = obj_get(entity, "components");
-            if (actor == NULL || !runtime_actor_is_active(runtime, actor) || !yyjson_is_arr(components))
+            if (actor == NULL || !yyjson_is_arr(components))
+                continue;
+
+            for (size_t c = 0; c < yyjson_arr_size(components); ++c)
+            {
+                yyjson_val *component = yyjson_arr_get(components, c);
+                if (SDL_strcmp(json_string(component, "type", ""), "pickup.respawn") == 0)
+                    update_pickup_respawn_component(component, actor, dt);
+            }
+
+            if (!runtime_actor_is_active(runtime, actor))
                 continue;
             if (!sdl3d_properties_get_bool(actor->props, "active_motion", true))
             {
@@ -16137,6 +16572,10 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
                     if (angle > two_pi || angle < -two_pi)
                         angle = SDL_fmodf(angle, two_pi);
                     sdl3d_properties_set_float(actor->props, property, angle);
+                }
+                else if (SDL_strcmp(type, "status_effect.timer") == 0)
+                {
+                    update_status_effect_timer_component(runtime, component, actor, dt);
                 }
                 else if (SDL_strcmp(type, "lifecycle.ttl") == 0)
                 {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2812,15 +2812,15 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb",     "collision.circle",
-        "combat.health",      "control.axis_1d",    "controller.fps_sector",
-        "lifecycle.ttl",      "light.directional",  "light.point",
-        "light.spot",         "motion.grid_agent",  "motion.oscillate",
-        "motion.patrol",      "motion.scroll_wrap", "motion.sector_velocity_3d",
-        "motion.spin",        "motion.velocity_2d", "motion.velocity_3d",
-        "particles.emitter",  "property.decay",     "render.cube",
-        "render.model",       "render.sphere",      "render.sprite",
-        "weapon.projectile",
+        "adapter.controller", "collision.aabb",      "collision.circle",
+        "combat.health",      "control.axis_1d",     "controller.fps_sector",
+        "lifecycle.ttl",      "light.directional",   "light.point",
+        "light.spot",         "motion.grid_agent",   "motion.oscillate",
+        "motion.patrol",      "motion.scroll_wrap",  "motion.sector_velocity_3d",
+        "motion.spin",        "motion.velocity_2d",  "motion.velocity_3d",
+        "particles.emitter",  "pickup.respawn",      "property.decay",
+        "render.cube",        "render.model",        "render.sphere",
+        "render.sprite",      "status_effect.timer", "weapon.projectile",
     };
 
     if (type == NULL)
@@ -2832,6 +2832,11 @@ static bool is_supported_component_type(const char *type)
     }
     return false;
 }
+
+static bool validate_non_empty_string_field(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                            const char *type, const char *field);
+static bool validate_optional_signal_field(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                           validation_names *names, const char *field);
 
 static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *component, const char *path,
                                           validation_names *names)
@@ -2915,6 +2920,33 @@ static bool validate_combat_health_component(validation_context *ctx, yyjson_val
         return validation_error(ctx, path, "combat.health armor_absorb must be in 0..1");
     }
     return true;
+}
+
+static bool validate_pickup_respawn_component(validation_context *ctx, yyjson_val *component, const char *path)
+{
+    if (!validate_non_empty_string_field(ctx, component, path, "pickup.respawn", "timer_property") ||
+        !validate_non_empty_string_field(ctx, component, path, "pickup.respawn", "available_property"))
+    {
+        return false;
+    }
+    return true;
+}
+
+static bool validate_status_effect_timer_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                                   validation_names *names)
+{
+    (void)names;
+    if (!is_non_empty_string(component, "property"))
+        return validation_error(ctx, path, "status_effect.timer requires a non-empty property");
+    if (!validate_non_empty_string_field(ctx, component, path, "status_effect.timer", "duration_property") ||
+        !validate_non_empty_string_field(ctx, component, path, "status_effect.timer", "active_property"))
+    {
+        return false;
+    }
+    yyjson_val *expired = obj_get(component, "expired_value");
+    if (expired != NULL && !(yyjson_is_bool(expired) || yyjson_is_num(expired) || yyjson_is_str(expired)))
+        return validation_error(ctx, path, "status_effect.timer expired_value must be scalar");
+    return validate_optional_signal_field(ctx, component, path, names, "on_expire");
 }
 
 static bool validate_projectile_fire_shape(validation_context *ctx, yyjson_val *value, const char *path,
@@ -4671,6 +4703,16 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_combat_health_component(ctx, component, path))
                     return false;
             }
+            else if (SDL_strcmp(type, "pickup.respawn") == 0)
+            {
+                if (!validate_pickup_respawn_component(ctx, component, path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "status_effect.timer") == 0)
+            {
+                if (!validate_status_effect_timer_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
             {
                 if (!require_ref(ctx, &names->actions, "input action", json_string(component, "action"), path) ||
@@ -5019,6 +5061,16 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             else if (SDL_strcmp(type, "combat.health") == 0)
             {
                 if (!validate_combat_health_component(ctx, component, component_path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "pickup.respawn") == 0)
+            {
+                if (!validate_pickup_respawn_component(ctx, component, component_path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "status_effect.timer") == 0)
+            {
+                if (!validate_status_effect_timer_component(ctx, component, component_path, names))
                     return false;
             }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
@@ -5706,6 +5758,221 @@ static bool validate_combat_amount_action(validation_context *ctx, yyjson_val *a
     return true;
 }
 
+static bool validate_actor_target_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                         validation_names *names, const char *type, const char *target_key,
+                                         const char *payload_key)
+{
+    yyjson_val *target_value = obj_get(action, target_key);
+    yyjson_val *target_from_payload_value = obj_get(action, payload_key);
+    const char *target = json_string(action, target_key);
+    const char *target_from_payload = json_string(action, payload_key);
+    if ((target == NULL && target_from_payload == NULL) || (target != NULL && target_from_payload != NULL))
+        return validation_error(ctx, json_path, "%s requires exactly one of %s or %s", type, target_key, payload_key);
+    if (target_value != NULL && !yyjson_is_str(target_value))
+        return validation_error(ctx, json_path, "%s %s must be a string", type, target_key);
+    if (target_from_payload_value != NULL && !yyjson_is_str(target_from_payload_value))
+        return validation_error(ctx, json_path, "%s %s must be a string", type, payload_key);
+    if (target != NULL && target[0] == '\0')
+        return validation_error(ctx, json_path, "%s %s must be non-empty", type, target_key);
+    if (target_from_payload != NULL && target_from_payload[0] == '\0')
+        return validation_error(ctx, json_path, "%s %s must be non-empty", type, payload_key);
+    if (target != NULL && !name_table_contains(&names->entities, target) &&
+        !name_table_contains(&names->actor_pool_actors, target))
+    {
+        return validation_error(ctx, json_path, "unknown %s %s '%s'", type, target_key, target);
+    }
+    return true;
+}
+
+static bool validate_non_empty_string_field(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                            const char *type, const char *field)
+{
+    yyjson_val *value = obj_get(json, field);
+    if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+        return validation_error(ctx, json_path, "%s %s must be a non-empty string", type, field);
+    return true;
+}
+
+static bool validate_optional_signal_field(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                           validation_names *names, const char *field)
+{
+    const char *signal = json_string(json, field);
+    return signal == NULL || require_ref(ctx, &names->signals, "signal", signal, json_path);
+}
+
+static bool validate_resource_grant(validation_context *ctx, yyjson_val *grant, const char *json_path,
+                                    validation_names *names, const char *owner_type)
+{
+    (void)names;
+    if (!yyjson_is_obj(grant))
+        return validation_error(ctx, json_path, "%s resources entries must be objects", owner_type);
+    if (!is_non_empty_string(grant, "resource"))
+        return validation_error(ctx, json_path, "%s resource grants require a non-empty resource", owner_type);
+    if (!validate_non_empty_string_field(ctx, grant, json_path, owner_type, "property") ||
+        !validate_non_empty_string_field(ctx, grant, json_path, owner_type, "max_property"))
+    {
+        return false;
+    }
+
+    yyjson_val *amount = obj_get(grant, "amount");
+    yyjson_val *amount_from_payload_value = obj_get(grant, "amount_from_payload");
+    const char *amount_from_payload = json_string(grant, "amount_from_payload");
+    if ((amount == NULL && amount_from_payload == NULL) || (amount != NULL && amount_from_payload != NULL))
+        return validation_error(ctx, json_path,
+                                "%s resource grants require exactly one of amount or amount_from_payload", owner_type);
+    if (amount != NULL && (!yyjson_is_num(amount) || yyjson_get_num(amount) < 0.0))
+        return validation_error(ctx, json_path, "%s resource grant amount must be a non-negative number", owner_type);
+    if (amount_from_payload_value != NULL &&
+        (!yyjson_is_str(amount_from_payload_value) || yyjson_get_str(amount_from_payload_value)[0] == '\0'))
+    {
+        return validation_error(ctx, json_path, "%s amount_from_payload must be a non-empty string", owner_type);
+    }
+    yyjson_val *max = obj_get(grant, "max");
+    yyjson_val *min = obj_get(grant, "min");
+    yyjson_val *clamp = obj_get(grant, "clamp");
+    if ((max != NULL && !yyjson_is_num(max)) || (min != NULL && !yyjson_is_num(min)))
+        return validation_error(ctx, json_path, "%s resource grant min/max must be numbers", owner_type);
+    if (clamp != NULL && !yyjson_is_bool(clamp))
+        return validation_error(ctx, json_path, "%s resource grant clamp must be a boolean", owner_type);
+    return true;
+}
+
+static bool validate_resource_grants(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                     validation_names *names, const char *type)
+{
+    yyjson_val *resources = obj_get(action, "resources");
+    if (!yyjson_is_arr(resources) || yyjson_arr_size(resources) == 0)
+        return validation_error(ctx, json_path, "%s requires a non-empty resources array", type);
+    for (size_t i = 0; i < yyjson_arr_size(resources); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "%s.resources[%zu]", json_path, i);
+        if (!validate_resource_grant(ctx, yyjson_arr_get(resources, i), path, names, type))
+            return false;
+    }
+    return true;
+}
+
+static bool validate_resource_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                     validation_names *names, const char *type, const char *value_key,
+                                     const char *payload_key)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, type, "target", "target_from_payload"))
+        return false;
+    if (!is_non_empty_string(action, "resource"))
+        return validation_error(ctx, json_path, "%s requires a non-empty resource", type);
+    if (!validate_non_empty_string_field(ctx, action, json_path, type, "property") ||
+        !validate_non_empty_string_field(ctx, action, json_path, type, "max_property"))
+    {
+        return false;
+    }
+
+    yyjson_val *value = obj_get(action, value_key);
+    yyjson_val *value_from_payload_value = obj_get(action, payload_key);
+    const char *value_from_payload = json_string(action, payload_key);
+    if ((value == NULL && value_from_payload == NULL) || (value != NULL && value_from_payload != NULL))
+        return validation_error(ctx, json_path, "%s requires exactly one of %s or %s", type, value_key, payload_key);
+    if (value != NULL && (!yyjson_is_num(value) || yyjson_get_num(value) < 0.0))
+        return validation_error(ctx, json_path, "%s %s must be a non-negative number", type, value_key);
+    if (value_from_payload_value != NULL &&
+        (!yyjson_is_str(value_from_payload_value) || yyjson_get_str(value_from_payload_value)[0] == '\0'))
+    {
+        return validation_error(ctx, json_path, "%s %s must be a non-empty string", type, payload_key);
+    }
+
+    yyjson_val *max = obj_get(action, "max");
+    yyjson_val *min = obj_get(action, "min");
+    yyjson_val *clamp = obj_get(action, "clamp");
+    yyjson_val *allow_partial = obj_get(action, "allow_partial");
+    if ((max != NULL && !yyjson_is_num(max)) || (min != NULL && !yyjson_is_num(min)))
+        return validation_error(ctx, json_path, "%s min/max must be numbers", type);
+    if ((clamp != NULL && !yyjson_is_bool(clamp)) || (allow_partial != NULL && !yyjson_is_bool(allow_partial)))
+        return validation_error(ctx, json_path, "%s boolean fields must be booleans", type);
+    return validate_optional_signal_field(ctx, action, json_path, names, "on_success") &&
+           validate_optional_signal_field(ctx, action, json_path, names, "on_failure");
+}
+
+static bool validate_pickup_collect_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                           validation_names *names)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, "pickup.collect", "target", "target_from_payload"))
+        return false;
+    if (!validate_actor_target_action(ctx, action, json_path, names, "pickup.collect", "pickup", "pickup_from_payload"))
+        return false;
+    yyjson_val *deactivate = obj_get(action, "deactivate");
+    yyjson_val *respawn = obj_get(action, "respawn_seconds");
+    if (deactivate != NULL && !yyjson_is_bool(deactivate))
+        return validation_error(ctx, json_path, "pickup.collect deactivate must be a boolean");
+    if (respawn != NULL && (!yyjson_is_num(respawn) || yyjson_get_num(respawn) < 0.0))
+        return validation_error(ctx, json_path, "pickup.collect respawn_seconds must be non-negative");
+    if (!validate_non_empty_string_field(ctx, action, json_path, "pickup.collect", "timer_property") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "pickup.collect", "available_property"))
+    {
+        return false;
+    }
+    return validate_resource_grants(ctx, action, json_path, names, "pickup.collect") &&
+           validate_optional_signal_field(ctx, action, json_path, names, "on_collected");
+}
+
+static bool validate_resource_station_use_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                 validation_names *names)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, "resource.station.use", "target",
+                                      "target_from_payload"))
+        return false;
+    if (!validate_actor_target_action(ctx, action, json_path, names, "resource.station.use", "station",
+                                      "station_from_payload"))
+        return false;
+    yyjson_val *cooldown = obj_get(action, "cooldown");
+    yyjson_val *consume_charge = obj_get(action, "consume_charge");
+    if (cooldown != NULL && (!yyjson_is_num(cooldown) || yyjson_get_num(cooldown) < 0.0))
+        return validation_error(ctx, json_path, "resource.station.use cooldown must be non-negative");
+    if (consume_charge != NULL && !yyjson_is_bool(consume_charge))
+        return validation_error(ctx, json_path, "resource.station.use consume_charge must be a boolean");
+    if (!validate_non_empty_string_field(ctx, action, json_path, "resource.station.use", "cooldown_property") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "resource.station.use", "charges_property"))
+    {
+        return false;
+    }
+    return validate_resource_grants(ctx, action, json_path, names, "resource.station.use") &&
+           validate_optional_signal_field(ctx, action, json_path, names, "on_success") &&
+           validate_optional_signal_field(ctx, action, json_path, names, "on_failure");
+}
+
+static bool validate_status_effect_apply_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                validation_names *names)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, "status_effect.apply", "target",
+                                      "target_from_payload"))
+        return false;
+    if (!is_non_empty_string(action, "property"))
+        return validation_error(ctx, json_path, "status_effect.apply requires a non-empty property");
+    if (!validate_non_empty_string_field(ctx, action, json_path, "status_effect.apply", "duration_property") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "status_effect.apply", "active_property"))
+    {
+        return false;
+    }
+    yyjson_val *value = obj_get(action, "value");
+    if (!(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value)))
+        return validation_error(ctx, json_path, "status_effect.apply value must be scalar");
+    yyjson_val *duration = obj_get(action, "duration");
+    yyjson_val *duration_from_payload_value = obj_get(action, "duration_from_payload");
+    const char *duration_from_payload = json_string(action, "duration_from_payload");
+    if ((duration == NULL && duration_from_payload == NULL) || (duration != NULL && duration_from_payload != NULL))
+    {
+        return validation_error(ctx, json_path,
+                                "status_effect.apply requires exactly one of duration or duration_from_payload");
+    }
+    if (duration != NULL && (!yyjson_is_num(duration) || yyjson_get_num(duration) < 0.0))
+        return validation_error(ctx, json_path, "status_effect.apply duration must be non-negative");
+    if (duration_from_payload_value != NULL &&
+        (!yyjson_is_str(duration_from_payload_value) || yyjson_get_str(duration_from_payload_value)[0] == '\0'))
+    {
+        return validation_error(ctx, json_path, "status_effect.apply duration_from_payload must be non-empty");
+    }
+    return validate_optional_signal_field(ctx, action, json_path, names, "on_apply");
+}
+
 static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                 validation_names *names)
 {
@@ -5865,6 +6132,18 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "resource.add") == 0)
+        return validate_resource_action(ctx, action, json_path, names, type, "amount", "amount_from_payload");
+    if (SDL_strcmp(type, "resource.consume") == 0)
+        return validate_resource_action(ctx, action, json_path, names, type, "amount", "amount_from_payload");
+    if (SDL_strcmp(type, "resource.set") == 0)
+        return validate_resource_action(ctx, action, json_path, names, type, "value", "value_from_payload");
+    if (SDL_strcmp(type, "pickup.collect") == 0)
+        return validate_pickup_collect_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "resource.station.use") == 0)
+        return validate_resource_station_use_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "status_effect.apply") == 0)
+        return validate_status_effect_apply_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "sector_door.open") == 0 || SDL_strcmp(type, "sector_door.close") == 0 ||
         SDL_strcmp(type, "sector_door.toggle") == 0)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7176,6 +7176,314 @@ TEST(GameDataRuntime, RejectsInvalidCombatActionsAndComponents)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, ResourcesPickupsStationsAndStatusEffectsAreDataDriven)
+{
+    const std::filesystem::path dir = unique_test_dir("resources_pickups_status");
+    write_text(dir / "resources.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Resources", "id": "test.resources", "version": "0.1.0" },
+  "world": { "name": "world.resources", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "properties": {
+        "health": { "type": "float", "value": 40.0 },
+        "max_health": { "type": "float", "value": 100.0 },
+        "ammo": { "type": "int", "value": 2 },
+        "max_ammo": { "type": "int", "value": 8 },
+        "quad_damage": { "type": "bool", "value": false },
+        "quad_damage_remaining": { "type": "float", "value": 0.0 },
+        "quad_damage_active": { "type": "bool", "value": false }
+      },
+      "components": [
+        {
+          "type": "status_effect.timer",
+          "property": "quad_damage",
+          "duration_property": "quad_damage_remaining",
+          "active_property": "quad_damage_active",
+          "expired_value": false
+        }
+      ]
+    },
+    {
+      "name": "entity.health_pickup",
+      "active": true,
+      "properties": {
+        "pickup_available": { "type": "bool", "value": true },
+        "pickup_respawn_remaining": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "pickup.respawn" }
+      ]
+    },
+    {
+      "name": "entity.heal_station",
+      "active": true,
+      "properties": {
+        "charges": { "type": "int", "value": 2 },
+        "cooldown": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "property.decay", "property": "cooldown", "rate": 10.0, "target": 0.0, "min": 0.0 }
+      ]
+    }
+  ],
+  "signals": [
+    "signal.resource.add",
+    "signal.resource.consume",
+    "signal.resource.consume_fail",
+    "signal.pickup.collect",
+    "signal.station.use",
+    "signal.status.apply"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.resource.add",
+        "actions": [
+          { "type": "resource.add", "target": "entity.player", "resource": "ammo", "amount": 12.0 }
+        ]
+      },
+      {
+        "signal": "signal.resource.consume",
+        "actions": [
+          { "type": "resource.consume", "target": "entity.player", "resource": "ammo", "amount": 3.0 }
+        ]
+      },
+      {
+        "signal": "signal.resource.consume_fail",
+        "actions": [
+          { "type": "resource.consume", "target": "entity.player", "resource": "ammo", "amount": 99.0 }
+        ]
+      },
+      {
+        "signal": "signal.pickup.collect",
+        "actions": [
+          {
+            "type": "pickup.collect",
+            "target": "entity.player",
+            "pickup": "entity.health_pickup",
+            "respawn_seconds": 0.5,
+            "resources": [
+              { "resource": "health", "amount": 25.0 },
+              { "resource": "ammo", "amount": 2.0 }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.station.use",
+        "actions": [
+          {
+            "type": "resource.station.use",
+            "target": "entity.player",
+            "station": "entity.heal_station",
+            "cooldown": 0.5,
+            "resources": [
+              { "resource": "health", "amount": 30.0 }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.status.apply",
+        "actions": [
+          {
+            "type": "status_effect.apply",
+            "target": "entity.player",
+            "property": "quad_damage",
+            "value": true,
+            "duration": 0.25,
+            "duration_property": "quad_damage_remaining",
+            "active_property": "quad_damage_active"
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player", "entity.health_pickup", "entity.heal_station"]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "resources.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *pickup = sdl3d_game_data_find_actor(runtime, "entity.health_pickup");
+    sdl3d_registered_actor *station = sdl3d_game_data_find_actor(runtime, "entity.heal_station");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(pickup, nullptr);
+    ASSERT_NE(station, nullptr);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.resource.add"), nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo", 0), 8);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.resource.consume"), nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo", 0), 5);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.resource.consume_fail"), nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo", 0), 5);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.pickup.collect"), nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 65.0f, 0.001f);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo", 0), 7);
+    EXPECT_FALSE(pickup->active);
+    EXPECT_FALSE(sdl3d_properties_get_bool(pickup->props, "pickup_available", true));
+    EXPECT_NEAR(sdl3d_properties_get_float(pickup->props, "pickup_respawn_remaining", 0.0f), 0.5f, 0.001f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_FALSE(pickup->active);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_TRUE(pickup->active);
+    EXPECT_TRUE(sdl3d_properties_get_bool(pickup->props, "pickup_available", false));
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.station.use"), nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 95.0f, 0.001f);
+    EXPECT_EQ(sdl3d_properties_get_int(station->props, "charges", 0), 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(station->props, "cooldown", 0.0f), 0.5f, 0.001f);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.station.use"), nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(station->props, "charges", 0), 1);
+    ASSERT_TRUE(sdl3d_game_data_update_property_effects(runtime, 0.05f));
+    EXPECT_NEAR(sdl3d_properties_get_float(station->props, "cooldown", 1.0f), 0.0f, 0.001f);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.station.use"), nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 100.0f, 0.001f);
+    EXPECT_EQ(sdl3d_properties_get_int(station->props, "charges", -1), 0);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.status.apply"), nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "quad_damage", false));
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "quad_damage_active", false));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "quad_damage_remaining", 0.0f), 0.25f, 0.001f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    EXPECT_FALSE(sdl3d_properties_get_bool(player->props, "quad_damage", true));
+    EXPECT_FALSE(sdl3d_properties_get_bool(player->props, "quad_damage_active", true));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "quad_damage_remaining", 1.0f), 0.0f, 0.001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidResourcePickupAndStatusActions)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_resources");
+    write_text(dir / "invalid_resources.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Resources", "id": "test.invalid_resources", "version": "0.1.0" },
+  "world": { "name": "world.invalid_resources", "kind": "fixed_screen" },
+  "entities": [
+    { "name": "entity.player" },
+    { "name": "entity.pickup" }
+  ],
+  "signals": ["signal.invalid"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.invalid",
+        "actions": [
+          { "type": "resource.add", "target": "entity.player", "resource": "ammo", "amount": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(
+        dir / "scenes" / "play.scene.json",
+        R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.player", "entity.pickup"] })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_resources.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("resource.add amount must be a non-negative number"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_pickup.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Pickup", "id": "test.invalid_pickup", "version": "0.1.0" },
+  "world": { "name": "world.invalid_pickup", "kind": "fixed_screen" },
+  "entities": [
+    { "name": "entity.player" },
+    { "name": "entity.pickup" }
+  ],
+  "signals": ["signal.invalid"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.invalid",
+        "actions": [
+          { "type": "pickup.collect", "target": "entity.player", "pickup": "entity.pickup", "resources": [] }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_pickup.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("pickup.collect requires a non-empty resources array"), std::string::npos)
+        << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_status.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Status", "id": "test.invalid_status", "version": "0.1.0" },
+  "world": { "name": "world.invalid_status", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "components": [
+        { "type": "status_effect.timer", "property": "haste", "expired_value": [1, 2, 3] }
+      ]
+    }
+  ],
+  "signals": ["signal.invalid"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.invalid",
+        "actions": [
+          { "type": "status_effect.apply", "target": "entity.player", "property": "haste", "value": true, "duration": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_status.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("status_effect.timer expired_value must be scalar"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, WeaponProjectileComponentFiresFromOwningActor)
 {
     const std::filesystem::path dir = unique_test_dir("weapon_projectile_component");


### PR DESCRIPTION
## Summary

- Adds generic resource actions: `resource.add`, `resource.consume`, and `resource.set` with caps, clamping, payload-driven values, and success/failure signals.
- Adds reusable pickup, station, and temporary status-effect primitives: `pickup.collect`, `pickup.respawn`, `resource.station.use`, `status_effect.apply`, and `status_effect.timer`.
- Updates the FPS mechanics dojo with a health/ammo pickup, recharge station, temporary power-up, and HUD readouts.
- Documents the new JSON primitives and validation behavior.

## Tests

- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.ResourcesPickupsStationsAndStatusEffectsAreDataDriven:GameDataRuntime.RejectsInvalidResourcePickupAndStatusActions:GameDataRuntime.CombatActionsApplyHealthArmorDeathAndRevive:GameDataRuntime.RejectsInvalidCombatActionsAndComponents'`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.EditorMetadataValidatesAndFpsMechanicsDojoLoads'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j 8`

Part of #282 slice 3.