### PR TITLE
Add data-authored weapon primitives

### DIFF
--- a/demos/fps_mechanics_dojo/data/fragments/world/arena.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/arena.json
@@ -160,12 +160,22 @@
         "signal": "signal.dojo.damage_dummy",
         "actions": [
           {
-            "type": "combat.damage",
-            "target": "entity.dojo.combat_dummy",
-            "source": "entity.player",
-            "amount": 25.0,
-            "damage_type": "dojo",
-            "on_death": "signal.dojo.dummy_dead"
+            "type": "weapon.hitscan",
+            "target": "entity.player",
+            "sector_level": "sector.dojo.arena",
+            "target_tag": "combat_target",
+            "range": 40.0,
+            "cooldown": 0.15,
+            "actions": [
+              {
+                "type": "combat.damage",
+                "target_from_payload": "actor_name",
+                "source_from_payload": "source_actor_name",
+                "amount": 25.0,
+                "damage_type": "dojo_hitscan",
+                "on_death": "signal.dojo.dummy_dead"
+              }
+            ]
           }
         ]
       }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -956,6 +956,79 @@ not accept `target` or `target_from_payload`. This is the preferred shape for
 FPS and shooter player weapons because it keeps input-to-projectile behavior
 declarative.
 
+Projectiles can also participate in the generic weapon state convention. Add
+`clip_property` to consume from a magazine, or `ammo_resource` / `ammo_property`
+to consume directly from a numeric resource. `ammo_per_shot` defaults to `1`.
+`reload_timer_property` prevents firing while a reload is pending.
+`cooldown_property` defaults to `fire_timer`, preserving the older projectile
+cooldown behavior. Optional `on_fire`, `on_empty`, `on_cooldown`, and
+`on_reloading` signals receive `actor_name`, `source_actor_name`,
+`weapon_status`, and `ammo_per_shot`.
+
+`weapon.state` completes data-authored reloads and can decay a weapon cooldown:
+
+```json
+{
+  "type": "weapon.state",
+  "clip_property": "clip",
+  "clip_size_property": "clip_size",
+  "reserve_property": "ammo_reserve",
+  "reload_timer_property": "reload_timer",
+  "reload_pending_property": "reload_pending",
+  "cooldown_property": "fire_timer",
+  "cooldown_rate": 1.0
+}
+```
+
+Start a reload with `weapon.reload`:
+
+```json
+{
+  "type": "weapon.reload",
+  "target": "entity.player",
+  "clip_property": "clip",
+  "clip_size_property": "clip_size",
+  "reserve_property": "ammo_reserve",
+  "reload_seconds": 0.8
+}
+```
+
+When the timer reaches zero, `weapon.state` fills the clip from the reserve and
+clears `reload_pending`. If `consume_reserve` is `false`, the clip fills
+without reducing reserve ammo, which is useful for energy weapons or prototypes.
+
+`weapon.hitscan` traces instantly from an actor. It can trace against sector
+geometry through `sector_level`, select the nearest active actor with
+`target_tag`, consume the same clip/ammo fields as projectiles, and run authored
+actions with a payload:
+
+```json
+{
+  "type": "weapon.hitscan",
+  "target": "entity.player",
+  "sector_level": "sector.e1m1",
+  "direction_from_property": "camera_forward",
+  "target_tag": "enemy",
+  "range": 64.0,
+  "clip_property": "clip",
+  "actions": [
+    {
+      "type": "combat.damage",
+      "target_from_payload": "actor_name",
+      "source_from_payload": "source_actor_name",
+      "amount": 15.0,
+      "damage_type": "hitscan"
+    }
+  ]
+}
+```
+
+Hitscan payloads include `source_actor_name`, `actor_name` / `hit_actor_name`,
+`origin`, `direction`, `hit_position`, `hit_distance`, `hit_actor`, and
+`hit_wall`. Use these fields for damage, particles, lights, sounds, decals, or
+debug UI. Actor hit tests use a target actor's `hit_radius` or `radius`
+property, falling back to the action's `hit_radius` value.
+
 ## Sector Level Fragments
 
 Large sector worlds can be split by authoring concern without duplicating a

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7088,6 +7088,8 @@ static yyjson_val *active_timeline_events(const sdl3d_game_data_runtime *runtime
 }
 
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload);
+static bool execute_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *actions,
+                                 const sdl3d_properties *payload);
 static bool execute_fps_controller_launch_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
                                                  const sdl3d_properties *payload);
 static bool execute_fps_controller_teleport_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
@@ -11667,6 +11669,8 @@ static int action_signal_id(sdl3d_game_data_runtime *runtime, yyjson_val *action
 
 static bool execute_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *actions,
                                  const sdl3d_properties *payload);
+static bool execute_optional_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *actions,
+                                          const sdl3d_properties *payload);
 static float sector_door_distance_sq_xz(const sdl3d_door *door, sdl3d_vec3 point);
 static bool sector_door_is_in_front(const sdl3d_door *door, sdl3d_vec3 point, float yaw, float min_dot);
 
@@ -13720,6 +13724,169 @@ static bool execute_actor_despawn_by_tag_action(sdl3d_game_data_runtime *runtime
     return true;
 }
 
+typedef enum weapon_fire_status
+{
+    WEAPON_FIRE_READY = 0,
+    WEAPON_FIRE_COOLDOWN,
+    WEAPON_FIRE_RELOADING,
+    WEAPON_FIRE_EMPTY
+} weapon_fire_status;
+
+static bool weapon_value_as_float(const sdl3d_value *value, float *out_value)
+{
+    if (value == NULL || out_value == NULL)
+        return false;
+    if (value->type == SDL3D_VALUE_INT)
+    {
+        *out_value = (float)value->as_int;
+        return true;
+    }
+    if (value->type == SDL3D_VALUE_FLOAT)
+    {
+        *out_value = value->as_float;
+        return true;
+    }
+    return false;
+}
+
+static float weapon_actor_numeric_property(const sdl3d_registered_actor *actor, const char *key, float fallback)
+{
+    float value = fallback;
+    return actor != NULL && actor->props != NULL &&
+                   weapon_value_as_float(sdl3d_properties_get_value(actor->props, key), &value)
+               ? value
+               : fallback;
+}
+
+static void weapon_set_actor_numeric_property(sdl3d_registered_actor *actor, const char *key, float value)
+{
+    if (actor == NULL || actor->props == NULL || key == NULL || key[0] == '\0')
+        return;
+    const sdl3d_value *existing = sdl3d_properties_get_value(actor->props, key);
+    const float rounded = SDL_roundf(value);
+    if (existing != NULL && existing->type == SDL3D_VALUE_INT && SDL_fabsf(value - rounded) <= 0.0001f)
+        sdl3d_properties_set_int(actor->props, key, (int)rounded);
+    else
+        sdl3d_properties_set_float(actor->props, key, value);
+}
+
+static sdl3d_properties *weapon_event_payload(const sdl3d_registered_actor *source, yyjson_val *action,
+                                              weapon_fire_status status)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    sdl3d_properties_set_string(payload, "actor_name", source != NULL && source->name != NULL ? source->name : "");
+    sdl3d_properties_set_string(payload, "source_actor_name",
+                                source != NULL && source->name != NULL ? source->name : "");
+    const char *status_text = "ready";
+    if (status == WEAPON_FIRE_COOLDOWN)
+        status_text = "cooldown";
+    else if (status == WEAPON_FIRE_RELOADING)
+        status_text = "reloading";
+    else if (status == WEAPON_FIRE_EMPTY)
+        status_text = "empty";
+    sdl3d_properties_set_string(payload, "weapon_status", status_text);
+    sdl3d_properties_set_float(payload, "ammo_per_shot", json_float(action, "ammo_per_shot", 1.0f));
+    return payload;
+}
+
+static void weapon_emit_signal(sdl3d_game_data_runtime *runtime, yyjson_val *action, const char *signal_key,
+                               const sdl3d_registered_actor *source, weapon_fire_status status)
+{
+    const int signal_id = action_signal_id(runtime, action, signal_key);
+    if (signal_id < 0 || runtime_bus(runtime) == NULL)
+        return;
+    sdl3d_properties *payload = weapon_event_payload(source, action, status);
+    sdl3d_signal_emit(runtime_bus(runtime), signal_id, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static weapon_fire_status weapon_fire_status_for_actor(const sdl3d_registered_actor *actor, yyjson_val *action)
+{
+    if (actor == NULL || action == NULL)
+        return WEAPON_FIRE_EMPTY;
+
+    const char *cooldown_property = json_string(action, "cooldown_property", "fire_timer");
+    if (cooldown_property != NULL && cooldown_property[0] != '\0' &&
+        sdl3d_properties_get_float(actor->props, cooldown_property, 0.0f) > 0.0f)
+    {
+        return WEAPON_FIRE_COOLDOWN;
+    }
+
+    const char *reload_timer_property = json_string(action, "reload_timer_property", NULL);
+    if (reload_timer_property != NULL && reload_timer_property[0] != '\0' &&
+        sdl3d_properties_get_float(actor->props, reload_timer_property, 0.0f) > 0.0f)
+    {
+        return WEAPON_FIRE_RELOADING;
+    }
+
+    const float ammo_per_shot = SDL_max(json_float(action, "ammo_per_shot", 1.0f), 0.0f);
+    const char *clip_property = json_string(action, "clip_property", NULL);
+    if (clip_property != NULL && clip_property[0] != '\0' &&
+        weapon_actor_numeric_property(actor, clip_property, 0.0f) + 0.0001f < ammo_per_shot)
+    {
+        return WEAPON_FIRE_EMPTY;
+    }
+
+    const char *ammo_resource = json_string(action, "ammo_resource", NULL);
+    const char *ammo_property = json_string(action, "ammo_property", ammo_resource);
+    if (clip_property == NULL && ammo_property != NULL && ammo_property[0] != '\0' &&
+        weapon_actor_numeric_property(actor, ammo_property, 0.0f) + 0.0001f < ammo_per_shot)
+    {
+        return WEAPON_FIRE_EMPTY;
+    }
+    return WEAPON_FIRE_READY;
+}
+
+static bool weapon_fire_prepare(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                const sdl3d_registered_actor *actor)
+{
+    const weapon_fire_status status = weapon_fire_status_for_actor(actor, action);
+    if (status == WEAPON_FIRE_READY)
+        return true;
+    if (status == WEAPON_FIRE_COOLDOWN)
+        weapon_emit_signal(runtime, action, "on_cooldown", actor, status);
+    else if (status == WEAPON_FIRE_RELOADING)
+        weapon_emit_signal(runtime, action, "on_reloading", actor, status);
+    else
+        weapon_emit_signal(runtime, action, "on_empty", actor, status);
+    return false;
+}
+
+static void weapon_fire_commit(sdl3d_game_data_runtime *runtime, yyjson_val *action, sdl3d_registered_actor *actor)
+{
+    if (actor == NULL || action == NULL)
+        return;
+
+    const float ammo_per_shot = SDL_max(json_float(action, "ammo_per_shot", 1.0f), 0.0f);
+    const char *clip_property = json_string(action, "clip_property", NULL);
+    if (clip_property != NULL && clip_property[0] != '\0')
+    {
+        const float clip = weapon_actor_numeric_property(actor, clip_property, 0.0f);
+        weapon_set_actor_numeric_property(actor, clip_property, SDL_max(clip - ammo_per_shot, 0.0f));
+    }
+    else
+    {
+        const char *ammo_resource = json_string(action, "ammo_resource", NULL);
+        const char *ammo_property = json_string(action, "ammo_property", ammo_resource);
+        if (ammo_property != NULL && ammo_property[0] != '\0')
+        {
+            const float ammo = weapon_actor_numeric_property(actor, ammo_property, 0.0f);
+            weapon_set_actor_numeric_property(actor, ammo_property, SDL_max(ammo - ammo_per_shot, 0.0f));
+        }
+    }
+
+    const char *cooldown_property = json_string(action, "cooldown_property", "fire_timer");
+    if (cooldown_property != NULL && cooldown_property[0] != '\0')
+    {
+        const float cooldown =
+            json_float(action, "cooldown", sdl3d_properties_get_float(actor->props, "fire_cooldown", 0.0f));
+        sdl3d_properties_set_float(actor->props, cooldown_property, cooldown);
+    }
+    weapon_emit_signal(runtime, action, "on_fire", actor, WEAPON_FIRE_READY);
+}
+
 static bool execute_projectile_fire_action_for_actor(sdl3d_game_data_runtime *runtime, yyjson_val *action,
                                                      const sdl3d_properties *payload,
                                                      sdl3d_registered_actor *source_actor)
@@ -13732,12 +13899,8 @@ static bool execute_projectile_fire_action_for_actor(sdl3d_game_data_runtime *ru
     if (target == NULL || !runtime_actor_is_active(runtime, target))
         return false;
 
-    const char *cooldown_property = json_string(action, "cooldown_property", "fire_timer");
-    if (cooldown_property != NULL && cooldown_property[0] != '\0' &&
-        sdl3d_properties_get_float(target->props, cooldown_property, 0.0f) > 0.0f)
-    {
+    if (!weapon_fire_prepare(runtime, action, target))
         return true;
-    }
 
     actor_pool_runtime *pool = find_actor_pool(runtime, json_string(action, "pool", NULL));
     actor_pool_note_spawn_attempt(pool);
@@ -13784,13 +13947,7 @@ static bool execute_projectile_fire_action_for_actor(sdl3d_game_data_runtime *ru
         sdl3d_properties_set_vec3(actor->props, "velocity", projectile_velocity);
     }
     actor_pool_note_spawn_success(runtime, pool);
-
-    if (cooldown_property != NULL && cooldown_property[0] != '\0')
-    {
-        const float cooldown =
-            json_float(action, "cooldown", sdl3d_properties_get_float(target->props, "fire_cooldown", 0.0f));
-        sdl3d_properties_set_float(target->props, cooldown_property, cooldown);
-    }
+    weapon_fire_commit(runtime, action, target);
     return true;
 }
 
@@ -14357,6 +14514,250 @@ static bool execute_status_effect_apply_action(sdl3d_game_data_runtime *runtime,
         emit_optional_signal(runtime, action, "on_apply", event_payload);
         sdl3d_properties_destroy(event_payload);
     }
+    return true;
+}
+
+static bool actor_matches_weapon_target(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor,
+                                        const sdl3d_registered_actor *source, const char *tag, bool exclude_source)
+{
+    if (actor == NULL || !actor->active)
+        return false;
+    if (exclude_source && source != NULL && actor == source)
+        return false;
+    if (tag == NULL || tag[0] == '\0')
+        return true;
+
+    yyjson_val *entity = find_entity_json(runtime, actor->name);
+    if (entity_json_has_tags(entity, &tag, 1))
+        return true;
+
+    int actor_index = -1;
+    const actor_pool_runtime *pool = find_actor_pool_for_actor_const(runtime, actor->name, &actor_index);
+    return pool != NULL && actor_index >= 0 && entity_json_has_tags(pool->archetype_json, &tag, 1);
+}
+
+static bool ray_sphere_intersection(sdl3d_vec3 origin, sdl3d_vec3 direction, sdl3d_vec3 center, float radius,
+                                    float max_distance, float *out_distance)
+{
+    const sdl3d_vec3 oc = sdl3d_vec3_make(origin.x - center.x, origin.y - center.y, origin.z - center.z);
+    const float b = oc.x * direction.x + oc.y * direction.y + oc.z * direction.z;
+    const float c = sdl3d_vec3_length_squared(oc) - radius * radius;
+    const float discriminant = b * b - c;
+    if (discriminant < 0.0f)
+        return false;
+    const float sqrt_discriminant = SDL_sqrtf(discriminant);
+    float t = -b - sqrt_discriminant;
+    if (t < 0.0f)
+        t = -b + sqrt_discriminant;
+    if (t < 0.0f || t > max_distance)
+        return false;
+    if (out_distance != NULL)
+        *out_distance = t;
+    return true;
+}
+
+static sdl3d_registered_actor *find_hitscan_actor_target(sdl3d_game_data_runtime *runtime,
+                                                         const sdl3d_registered_actor *source, yyjson_val *action,
+                                                         sdl3d_vec3 origin, sdl3d_vec3 direction, float max_distance,
+                                                         float *out_distance)
+{
+    const char *tag = json_string(action, "target_tag", json_string(action, "hit_tag", NULL));
+    const bool exclude_source = json_bool(action, "exclude_source", true);
+    float best_distance = max_distance;
+    sdl3d_registered_actor *best = NULL;
+
+    yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+    for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+    {
+        yyjson_val *entity = yyjson_arr_get(entities, i);
+        const char *entity_name = json_string(entity, "name", NULL);
+        if (!active_scene_has_entity_internal(runtime, entity_name))
+            continue;
+        sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+        if (!actor_matches_weapon_target(runtime, actor, source, tag, exclude_source))
+            continue;
+        const float radius =
+            SDL_max(weapon_actor_numeric_property(
+                        actor, "hit_radius",
+                        weapon_actor_numeric_property(actor, "radius", json_float(action, "hit_radius", 0.5f))),
+                    0.001f);
+        float distance = 0.0f;
+        if (ray_sphere_intersection(origin, direction, actor->position, radius, best_distance, &distance))
+        {
+            best = actor;
+            best_distance = distance;
+        }
+    }
+
+    for (int pool_index = 0; runtime != NULL && pool_index < runtime->actor_pool_count; ++pool_index)
+    {
+        actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+        if (!actor_pool_in_scene(pool, sdl3d_game_data_active_scene(runtime)))
+            continue;
+        for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+        {
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+            if (!actor_pool_actor_is_active(pool, actor, actor_index) ||
+                !actor_matches_weapon_target(runtime, actor, source, tag, exclude_source))
+            {
+                continue;
+            }
+            const float radius =
+                SDL_max(weapon_actor_numeric_property(
+                            actor, "hit_radius",
+                            weapon_actor_numeric_property(actor, "radius", json_float(action, "hit_radius", 0.5f))),
+                        0.001f);
+            float distance = 0.0f;
+            if (ray_sphere_intersection(origin, direction, actor->position, radius, best_distance, &distance))
+            {
+                best = actor;
+                best_distance = distance;
+            }
+        }
+    }
+
+    if (out_distance != NULL)
+        *out_distance = best_distance;
+    return best;
+}
+
+static sdl3d_vec3 weapon_direction_from_action(const sdl3d_registered_actor *source, yyjson_val *action)
+{
+    const sdl3d_vec3 fallback = json_vec3_value(obj_get(action, "direction"), sdl3d_vec3_make(0.0f, 0.0f, -1.0f));
+    const char *direction_property = json_string(action, "direction_from_property", "camera_forward");
+    sdl3d_vec3 direction = direction_property != NULL && source != NULL
+                               ? sdl3d_properties_get_vec3(source->props, direction_property, fallback)
+                               : fallback;
+    if (sdl3d_vec3_length_squared(direction) <= 0.000001f)
+        direction = sdl3d_vec3_make(0.0f, 0.0f, -1.0f);
+    return sdl3d_vec3_normalize(direction);
+}
+
+static sdl3d_properties *weapon_hitscan_payload(const sdl3d_registered_actor *source, const sdl3d_registered_actor *hit,
+                                                sdl3d_vec3 origin, sdl3d_vec3 direction, sdl3d_vec3 hit_position,
+                                                float distance, bool wall_hit)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    sdl3d_properties_set_string(payload, "source_actor_name",
+                                source != NULL && source->name != NULL ? source->name : "");
+    sdl3d_properties_set_string(payload, "actor_name", hit != NULL && hit->name != NULL ? hit->name : "");
+    sdl3d_properties_set_string(payload, "hit_actor_name", hit != NULL && hit->name != NULL ? hit->name : "");
+    sdl3d_properties_set_vec3(payload, "origin", origin);
+    sdl3d_properties_set_vec3(payload, "direction", direction);
+    sdl3d_properties_set_vec3(payload, "hit_position", hit_position);
+    sdl3d_properties_set_float(payload, "hit_distance", distance);
+    sdl3d_properties_set_bool(payload, "hit_actor", hit != NULL);
+    sdl3d_properties_set_bool(payload, "hit_wall", wall_hit);
+    return payload;
+}
+
+static bool execute_weapon_hitscan_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                          const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *source = action_target_actor(runtime, action, payload);
+    if (source == NULL || !runtime_actor_is_active(runtime, source))
+        return false;
+    if (!weapon_fire_prepare(runtime, action, source))
+        return true;
+
+    const float range = SDL_max(json_float(action, "range", 64.0f), 0.0f);
+    sdl3d_vec3 origin = actor_spawn_position_from_action(runtime, action, payload, source->position);
+    sdl3d_vec3 direction = weapon_direction_from_action(source, action);
+    float wall_distance = range;
+    bool wall_hit = false;
+    sdl3d_vec3 hit_position =
+        sdl3d_vec3_make(origin.x + direction.x * range, origin.y + direction.y * range, origin.z + direction.z * range);
+
+    const sector_level_runtime *level = find_sector_level_runtime(runtime, json_string(action, "sector_level", NULL));
+    if (level != NULL)
+    {
+        const sdl3d_level_trace_result trace =
+            sdl3d_level_trace_point(&level->lightmapped, level->sectors, origin, direction, range);
+        wall_distance = SDL_clamp(trace.fraction, 0.0f, 1.0f) * range;
+        wall_hit = trace.hit;
+        hit_position = trace.end_point;
+    }
+
+    float actor_distance = wall_distance;
+    sdl3d_registered_actor *hit_actor =
+        find_hitscan_actor_target(runtime, source, action, origin, direction, wall_distance, &actor_distance);
+    if (hit_actor != NULL)
+    {
+        hit_position = sdl3d_vec3_make(origin.x + direction.x * actor_distance, origin.y + direction.y * actor_distance,
+                                       origin.z + direction.z * actor_distance);
+        wall_hit = false;
+    }
+
+    weapon_fire_commit(runtime, action, source);
+    sdl3d_properties *hit_payload =
+        weapon_hitscan_payload(source, hit_actor, origin, direction, hit_position,
+                               hit_actor != NULL ? actor_distance : wall_distance, wall_hit);
+    const bool ok =
+        execute_optional_action_array(runtime,
+                                      hit_actor != NULL || wall_hit || json_bool(action, "run_actions_on_miss", false)
+                                          ? obj_get(action, "actions")
+                                          : obj_get(action, "miss_actions"),
+                                      hit_payload);
+    sdl3d_properties_destroy(hit_payload);
+    return ok;
+}
+
+static void weapon_complete_reload(sdl3d_registered_actor *actor, yyjson_val *json)
+{
+    if (actor == NULL || json == NULL)
+        return;
+
+    const char *clip_property = json_string(json, "clip_property", "clip");
+    const char *clip_size_property = json_string(json, "clip_size_property", "clip_size");
+    const char *reserve_property = json_string(json, "reserve_property", "ammo_reserve");
+    const char *pending_property = json_string(json, "reload_pending_property", "reload_pending");
+    const char *timer_property = json_string(json, "reload_timer_property", "reload_timer");
+    const float clip_size =
+        SDL_max(json_float(json, "clip_size", weapon_actor_numeric_property(actor, clip_size_property, 0.0f)), 0.0f);
+    const float clip = SDL_clamp(weapon_actor_numeric_property(actor, clip_property, 0.0f), 0.0f, clip_size);
+    const bool consume_reserve = json_bool(json, "consume_reserve", true);
+    const float reserve =
+        consume_reserve ? SDL_max(weapon_actor_numeric_property(actor, reserve_property, 0.0f), 0.0f) : clip_size;
+    const float needed = SDL_max(clip_size - clip, 0.0f);
+    const float loaded = consume_reserve ? SDL_min(needed, reserve) : needed;
+    weapon_set_actor_numeric_property(actor, clip_property, clip + loaded);
+    if (consume_reserve)
+        weapon_set_actor_numeric_property(actor, reserve_property, reserve - loaded);
+    sdl3d_properties_set_bool(actor->props, pending_property, false);
+    sdl3d_properties_set_float(actor->props, timer_property, 0.0f);
+}
+
+static bool execute_weapon_reload_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                         const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *actor = action_target_actor(runtime, action, payload);
+    if (actor == NULL)
+        return false;
+
+    const char *clip_property = json_string(action, "clip_property", "clip");
+    const char *clip_size_property = json_string(action, "clip_size_property", "clip_size");
+    const char *reserve_property = json_string(action, "reserve_property", "ammo_reserve");
+    const char *pending_property = json_string(action, "reload_pending_property", "reload_pending");
+    const char *timer_property = json_string(action, "reload_timer_property", "reload_timer");
+    const float clip_size =
+        SDL_max(json_float(action, "clip_size", weapon_actor_numeric_property(actor, clip_size_property, 0.0f)), 0.0f);
+    const float clip = SDL_clamp(weapon_actor_numeric_property(actor, clip_property, 0.0f), 0.0f, clip_size);
+    const bool consume_reserve = json_bool(action, "consume_reserve", true);
+    const float reserve = consume_reserve ? weapon_actor_numeric_property(actor, reserve_property, 0.0f) : clip_size;
+    if (clip >= clip_size || reserve <= 0.0f)
+    {
+        weapon_emit_signal(runtime, action, "on_failure", actor, WEAPON_FIRE_EMPTY);
+        return true;
+    }
+
+    const float reload_seconds = SDL_max(json_float(action, "reload_seconds", 0.0f), 0.0f);
+    sdl3d_properties_set_bool(actor->props, pending_property, true);
+    sdl3d_properties_set_float(actor->props, timer_property, reload_seconds);
+    weapon_emit_signal(runtime, action, "on_reload", actor, WEAPON_FIRE_RELOADING);
+    if (reload_seconds <= 0.0f)
+        weapon_complete_reload(actor, action);
     return true;
 }
 
@@ -15061,6 +15462,10 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return execute_resource_station_use_action(runtime, action, payload);
     if (SDL_strcmp(type, "status_effect.apply") == 0)
         return execute_status_effect_apply_action(runtime, action, payload);
+    if (SDL_strcmp(type, "weapon.reload") == 0)
+        return execute_weapon_reload_action(runtime, action, payload);
+    if (SDL_strcmp(type, "weapon.hitscan") == 0)
+        return execute_weapon_hitscan_action(runtime, action, payload);
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
@@ -16245,6 +16650,36 @@ static void update_status_effect_timer_component(sdl3d_game_data_runtime *runtim
     }
 }
 
+static void update_weapon_state_component(yyjson_val *component, sdl3d_registered_actor *actor, float dt)
+{
+    if (component == NULL || actor == NULL || !actor->active)
+        return;
+
+    const char *cooldown_property = json_string(component, "cooldown_property", NULL);
+    if (cooldown_property != NULL && cooldown_property[0] != '\0')
+    {
+        const float cooldown_rate = json_float(component, "cooldown_rate", 1.0f);
+        const float cooldown = sdl3d_properties_get_float(actor->props, cooldown_property, 0.0f);
+        if (cooldown > 0.0f && cooldown_rate > 0.0f)
+            sdl3d_properties_set_float(actor->props, cooldown_property, SDL_max(cooldown - cooldown_rate * dt, 0.0f));
+    }
+
+    const char *timer_property = json_string(component, "reload_timer_property", "reload_timer");
+    const char *pending_property = json_string(component, "reload_pending_property", "reload_pending");
+    if (!sdl3d_properties_get_bool(actor->props, pending_property, false))
+        return;
+
+    const float timer = sdl3d_properties_get_float(actor->props, timer_property, 0.0f);
+    if (timer > 0.0f)
+    {
+        const float next = SDL_max(timer - dt, 0.0f);
+        sdl3d_properties_set_float(actor->props, timer_property, next);
+        if (next > 0.0f)
+            return;
+    }
+    weapon_complete_reload(actor, component);
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -16359,6 +16794,12 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
 
             if (!runtime_actor_is_active(runtime, actor))
                 continue;
+            for (size_t c = 0; c < yyjson_arr_size(components); ++c)
+            {
+                yyjson_val *component = yyjson_arr_get(components, c);
+                if (SDL_strcmp(json_string(component, "type", ""), "weapon.state") == 0)
+                    update_weapon_state_component(component, actor, dt);
+            }
             if (!sdl3d_properties_get_bool(actor->props, "active_motion", true))
             {
                 continue;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2821,6 +2821,7 @@ static bool is_supported_component_type(const char *type)
         "particles.emitter",  "pickup.respawn",      "property.decay",
         "render.cube",        "render.model",        "render.sphere",
         "render.sprite",      "status_effect.timer", "weapon.projectile",
+        "weapon.state",
     };
 
     if (type == NULL)
@@ -2949,6 +2950,28 @@ static bool validate_status_effect_timer_component(validation_context *ctx, yyjs
     return validate_optional_signal_field(ctx, component, path, names, "on_expire");
 }
 
+static bool validate_weapon_state_component(validation_context *ctx, yyjson_val *component, const char *path)
+{
+    const char *string_fields[] = {"clip_property",         "clip_size_property",      "reserve_property",
+                                   "reload_timer_property", "reload_pending_property", "cooldown_property"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        if (!validate_non_empty_string_field(ctx, component, path, "weapon.state", string_fields[i]))
+            return false;
+    }
+    yyjson_val *clip_size = obj_get(component, "clip_size");
+    yyjson_val *cooldown_rate = obj_get(component, "cooldown_rate");
+    if ((clip_size != NULL && (!yyjson_is_num(clip_size) || yyjson_get_num(clip_size) < 0.0)) ||
+        (cooldown_rate != NULL && (!yyjson_is_num(cooldown_rate) || yyjson_get_num(cooldown_rate) < 0.0)))
+    {
+        return validation_error(ctx, path, "weapon.state numeric values must be non-negative");
+    }
+    yyjson_val *consume_reserve = obj_get(component, "consume_reserve");
+    if (consume_reserve != NULL && !yyjson_is_bool(consume_reserve))
+        return validation_error(ctx, path, "weapon.state consume_reserve must be a boolean");
+    return true;
+}
+
 static bool validate_projectile_fire_shape(validation_context *ctx, yyjson_val *value, const char *path,
                                            validation_names *names, bool require_target)
 {
@@ -3002,6 +3025,24 @@ static bool validate_projectile_fire_shape(validation_context *ctx, yyjson_val *
         (!yyjson_is_str(cooldown_property) || yyjson_get_str(cooldown_property)[0] == '\0'))
     {
         return validation_error(ctx, path, "projectile cooldown_property must be a non-empty string");
+    }
+    const char *weapon_string_fields[] = {"clip_property", "ammo_resource", "ammo_property", "reload_timer_property",
+                                          "direction_from_property"};
+    for (size_t i = 0; i < SDL_arraysize(weapon_string_fields); ++i)
+    {
+        yyjson_val *field = obj_get(value, weapon_string_fields[i]);
+        if (field != NULL && (!yyjson_is_str(field) || yyjson_get_str(field)[0] == '\0'))
+            return validation_error(ctx, path, "projectile weapon fields must be non-empty strings");
+    }
+    yyjson_val *ammo_per_shot = obj_get(value, "ammo_per_shot");
+    if (ammo_per_shot != NULL && (!yyjson_is_num(ammo_per_shot) || yyjson_get_num(ammo_per_shot) < 0.0))
+        return validation_error(ctx, path, "projectile ammo_per_shot must be non-negative");
+    const char *signal_keys[] = {"on_fire", "on_empty", "on_cooldown", "on_reloading"};
+    for (size_t i = 0; i < SDL_arraysize(signal_keys); ++i)
+    {
+        const char *signal = json_string(value, signal_keys[i]);
+        if (signal != NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+            return false;
     }
     yyjson_val *properties = obj_get(value, "properties");
     if (properties != NULL && !yyjson_is_obj(properties))
@@ -4713,6 +4754,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_status_effect_timer_component(ctx, component, path, names))
                     return false;
             }
+            else if (SDL_strcmp(type, "weapon.state") == 0)
+            {
+                if (!validate_weapon_state_component(ctx, component, path))
+                    return false;
+            }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
             {
                 if (!require_ref(ctx, &names->actions, "input action", json_string(component, "action"), path) ||
@@ -5071,6 +5117,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             else if (SDL_strcmp(type, "status_effect.timer") == 0)
             {
                 if (!validate_status_effect_timer_component(ctx, component, component_path, names))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "weapon.state") == 0)
+            {
+                if (!validate_weapon_state_component(ctx, component, component_path))
                     return false;
             }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
@@ -5973,6 +6024,101 @@ static bool validate_status_effect_apply_action(validation_context *ctx, yyjson_
     return validate_optional_signal_field(ctx, action, json_path, names, "on_apply");
 }
 
+static bool validate_weapon_common_fire_fields(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                               validation_names *names, const char *type)
+{
+    const char *string_fields[] = {"cooldown_property", "reload_timer_property", "clip_property",
+                                   "ammo_resource",     "ammo_property",         "direction_from_property"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        if (!validate_non_empty_string_field(ctx, action, json_path, type, string_fields[i]))
+            return false;
+    }
+    yyjson_val *cooldown = obj_get(action, "cooldown");
+    yyjson_val *ammo_per_shot = obj_get(action, "ammo_per_shot");
+    if ((cooldown != NULL && (!yyjson_is_num(cooldown) || yyjson_get_num(cooldown) < 0.0)) ||
+        (ammo_per_shot != NULL && (!yyjson_is_num(ammo_per_shot) || yyjson_get_num(ammo_per_shot) < 0.0)))
+    {
+        return validation_error(ctx, json_path, "%s cooldown and ammo_per_shot must be non-negative", type);
+    }
+    const char *signal_keys[] = {"on_fire", "on_empty", "on_cooldown", "on_reloading"};
+    for (size_t i = 0; i < SDL_arraysize(signal_keys); ++i)
+    {
+        if (!validate_optional_signal_field(ctx, action, json_path, names, signal_keys[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool validate_weapon_reload_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                          validation_names *names)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, "weapon.reload", "target", "target_from_payload"))
+        return false;
+    const char *string_fields[] = {"clip_property", "clip_size_property", "reserve_property", "reload_timer_property",
+                                   "reload_pending_property"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        if (!validate_non_empty_string_field(ctx, action, json_path, "weapon.reload", string_fields[i]))
+            return false;
+    }
+    yyjson_val *clip_size = obj_get(action, "clip_size");
+    yyjson_val *reload_seconds = obj_get(action, "reload_seconds");
+    if ((clip_size != NULL && (!yyjson_is_num(clip_size) || yyjson_get_num(clip_size) < 0.0)) ||
+        (reload_seconds != NULL && (!yyjson_is_num(reload_seconds) || yyjson_get_num(reload_seconds) < 0.0)))
+    {
+        return validation_error(ctx, json_path, "weapon.reload numeric values must be non-negative");
+    }
+    yyjson_val *consume_reserve = obj_get(action, "consume_reserve");
+    if (consume_reserve != NULL && !yyjson_is_bool(consume_reserve))
+        return validation_error(ctx, json_path, "weapon.reload consume_reserve must be a boolean");
+    return validate_optional_signal_field(ctx, action, json_path, names, "on_reload") &&
+           validate_optional_signal_field(ctx, action, json_path, names, "on_failure");
+}
+
+static bool validate_weapon_hitscan_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                           validation_names *names)
+{
+    if (!validate_actor_target_action(ctx, action, json_path, names, "weapon.hitscan", "target",
+                                      "target_from_payload") ||
+        !validate_weapon_common_fire_fields(ctx, action, json_path, names, "weapon.hitscan"))
+    {
+        return false;
+    }
+    const char *sector_level = json_string(action, "sector_level");
+    if (sector_level != NULL && !require_ref(ctx, &names->sector_levels, "sector level", sector_level, json_path))
+        return false;
+    if (!validate_non_empty_string_field(ctx, action, json_path, "weapon.hitscan", "target_tag") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "weapon.hitscan", "hit_tag"))
+    {
+        return false;
+    }
+    yyjson_val *direction = obj_get(action, "direction");
+    yyjson_val *offset = obj_get(action, "offset");
+    if (direction != NULL && !is_vec_array(direction, 3))
+        return validation_error(ctx, json_path, "weapon.hitscan direction must be a vec3");
+    if (offset != NULL && !is_vec_array(offset, 3))
+        return validation_error(ctx, json_path, "weapon.hitscan offset must be a vec3");
+    yyjson_val *range = obj_get(action, "range");
+    yyjson_val *hit_radius = obj_get(action, "hit_radius");
+    if ((range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) < 0.0)) ||
+        (hit_radius != NULL && (!yyjson_is_num(hit_radius) || yyjson_get_num(hit_radius) < 0.0)))
+    {
+        return validation_error(ctx, json_path, "weapon.hitscan range and hit_radius must be non-negative");
+    }
+    yyjson_val *exclude_source = obj_get(action, "exclude_source");
+    yyjson_val *run_actions_on_miss = obj_get(action, "run_actions_on_miss");
+    if ((exclude_source != NULL && !yyjson_is_bool(exclude_source)) ||
+        (run_actions_on_miss != NULL && !yyjson_is_bool(run_actions_on_miss)))
+    {
+        return validation_error(ctx, json_path, "weapon.hitscan boolean fields must be booleans");
+    }
+    yyjson_val *actions = obj_get(action, "actions");
+    yyjson_val *miss_actions = obj_get(action, "miss_actions");
+    return (actions == NULL || validate_action_array(ctx, actions, json_path, names)) &&
+           (miss_actions == NULL || validate_action_array(ctx, miss_actions, json_path, names));
+}
+
 static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                 validation_names *names)
 {
@@ -6144,6 +6290,10 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return validate_resource_station_use_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "status_effect.apply") == 0)
         return validate_status_effect_apply_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "weapon.reload") == 0)
+        return validate_weapon_reload_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "weapon.hitscan") == 0)
+        return validate_weapon_hitscan_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "sector_door.open") == 0 || SDL_strcmp(type, "sector_door.close") == 0 ||
         SDL_strcmp(type, "sector_door.toggle") == 0)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7580,6 +7580,342 @@ TEST(GameDataRuntime, WeaponProjectileComponentFiresFromOwningActor)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, WeaponStateReloadsAndProjectileFireConsumesClips)
+{
+    const std::filesystem::path dir = unique_test_dir("weapon_state_projectile");
+    write_text(dir / "weapon_state.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Weapon State", "id": "test.weapon_state", "version": "0.1.0" },
+  "world": { "name": "world.weapon_state", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [1.0, 1.0, 1.0] },
+      "properties": {
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "clip": { "type": "int", "value": 1 },
+        "clip_size": { "type": "int", "value": 2 },
+        "ammo_reserve": { "type": "int", "value": 3 },
+        "reload_timer": { "type": "float", "value": 0.0 },
+        "reload_pending": { "type": "bool", "value": false },
+        "fire_timer": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "weapon.state",
+          "clip_property": "clip",
+          "clip_size_property": "clip_size",
+          "reserve_property": "ammo_reserve",
+          "reload_timer_property": "reload_timer",
+          "reload_pending_property": "reload_pending",
+          "cooldown_property": "fire_timer",
+          "cooldown_rate": 10.0
+        }
+      ]
+    }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] }
+      }
+    }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 2, "scene": "scene.play" }
+  ],
+  "signals": ["signal.fire", "signal.reload"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "projectile.fire",
+            "target": "entity.player",
+            "pool": "pool.shots",
+            "velocity_from_property": "camera_forward",
+            "speed": 10.0,
+            "clip_property": "clip",
+            "reload_timer_property": "reload_timer",
+            "cooldown": 0.1
+          }
+        ]
+      },
+      {
+        "signal": "signal.reload",
+        "actions": [
+          {
+            "type": "weapon.reload",
+            "target": "entity.player",
+            "clip_property": "clip",
+            "clip_size_property": "clip_size",
+            "reserve_property": "ammo_reserve",
+            "reload_timer_property": "reload_timer",
+            "reload_pending_property": "reload_pending",
+            "reload_seconds": 0.2
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(
+        dir / "scenes" / "play.scene.json",
+        R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "updates_game": true, "entities": ["entity.player"] })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "weapon_state.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int fire = sdl3d_game_data_find_signal(runtime, "signal.fire");
+    const int reload = sdl3d_game_data_find_signal(runtime, "signal.reload");
+    ASSERT_GE(fire, 0);
+    ASSERT_GE(reload, 0);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *shot0 = sdl3d_game_data_find_actor(runtime, "pool.shots.0");
+    sdl3d_registered_actor *shot1 = sdl3d_game_data_find_actor(runtime, "pool.shots.1");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(shot0, nullptr);
+    ASSERT_NE(shot1, nullptr);
+
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_TRUE(shot0->active);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "clip", -1), 0);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "fire_timer", 0.0f), 0.1f, 0.0001f);
+
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_FALSE(shot1->active);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "fire_timer", 1.0f), 0.0f, 0.0001f);
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_FALSE(shot1->active);
+
+    sdl3d_signal_emit(bus, reload, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "reload_pending", false));
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "reload_timer", 0.0f), 0.2f, 0.0001f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "clip", -1), 0);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.1f));
+    EXPECT_FALSE(sdl3d_properties_get_bool(player->props, "reload_pending", true));
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "clip", -1), 2);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo_reserve", -1), 1);
+
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_TRUE(shot1->active);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "clip", -1), 1);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, WeaponHitscanTracesSectorAndRunsImpactActions)
+{
+    const std::filesystem::path dir = unique_test_dir("weapon_hitscan");
+    write_text(dir / "weapon_hitscan.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Weapon Hitscan", "id": "test.weapon_hitscan", "version": "0.1.0" },
+  "world": { "name": "world.weapon_hitscan", "kind": "sector" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [2.0, 1.5, 8.0] },
+      "properties": {
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "energy": { "type": "int", "value": 1 },
+        "fire_timer": { "type": "float", "value": 0.0 }
+      }
+    },
+    {
+      "name": "entity.enemy",
+      "active": true,
+      "tags": ["enemy"],
+      "transform": { "position": [2.0, 1.5, 4.0] },
+      "properties": {
+        "hit_radius": { "type": "float", "value": 0.5 },
+        "health": { "type": "float", "value": 50.0 },
+        "max_health": { "type": "float", "value": 50.0 },
+        "alive": { "type": "bool", "value": true }
+      },
+      "components": [{ "type": "combat.health" }]
+    }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "weapon.hitscan",
+            "target": "entity.player",
+            "sector_level": "sector.test",
+            "target_tag": "enemy",
+            "range": 20.0,
+            "ammo_resource": "energy",
+            "cooldown": 0.0,
+            "actions": [
+              {
+                "type": "combat.damage",
+                "target_from_payload": "actor_name",
+                "source_from_payload": "source_actor_name",
+                "amount": 15.0,
+                "damage_type": "hitscan"
+              },
+              {
+                "type": "property.set",
+                "target": "entity.player",
+                "key": "last_hit_distance",
+                "value_from_payload": "hit_distance"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "wall" }],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 10], [0, 10]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player", "entity.enemy"],
+  "world": { "sector_levels": [{ "level": "sector.test", "variant": "unlit" }] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "weapon_hitscan.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int fire = sdl3d_game_data_find_signal(runtime, "signal.fire");
+    ASSERT_GE(fire, 0);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *enemy = sdl3d_game_data_find_actor(runtime, "entity.enemy");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(enemy, nullptr);
+
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "energy", -1), 0);
+    EXPECT_NEAR(sdl3d_properties_get_float(enemy->props, "health", 0.0f), 35.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "last_hit_distance", 0.0f), 3.5f, 0.251f);
+
+    sdl3d_signal_emit(bus, fire, nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(enemy->props, "health", 0.0f), 35.0f, 0.001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidWeaponPrimitives)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_weapon_primitives");
+    write_text(dir / "invalid_weapon.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Weapon", "id": "test.invalid_weapon", "version": "0.1.0" },
+  "world": { "name": "world.invalid_weapon", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "components": [
+        { "type": "weapon.state", "clip_size": -1.0 }
+      ]
+    }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          { "type": "weapon.hitscan", "target": "entity.player", "range": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.player"] })json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_weapon.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("weapon.state numeric values must be non-negative"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_hitscan.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Hitscan", "id": "test.invalid_hitscan", "version": "0.1.0" },
+  "world": { "name": "world.invalid_hitscan", "kind": "fixed_screen" },
+  "entities": [{ "name": "entity.player" }],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          { "type": "weapon.hitscan", "target": "entity.player", "range": -1.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_hitscan.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("weapon.hitscan range and hit_radius must be non-negative"), std::string::npos)
+        << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ActivePooledActorsRenderAndEmitParticles)
 {
     const std::filesystem::path dir = unique_test_dir("actor_pool_render");


### PR DESCRIPTION
## Summary

Implements slice 4 of #282: reusable weapon primitives beyond basic projectiles.

- adds generic weapon state support for clips, reserve ammo, reload timers, cooldown decay, and fire-state signals
- extends projectile firing to consume authored clip/ammo state without changing existing cooldown defaults
- adds `weapon.reload` and `weapon.hitscan` data actions with sector ray tracing, actor hit filters, impact payloads, and nested impact/miss actions
- validates the new component/action shapes and documents the weapon-state convention
- updates the FPS mechanics dojo combat dummy interaction to use `weapon.hitscan` instead of direct damage

## Tests

- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j 8`
- `ctest --test-dir build/debug --output-on-failure -j 8`

All 1140 CTest tests pass locally.

Next slice should be #282 slice 5: generic interactables, switches, keys, and locks.