### PR TITLE
Add generic interactable primitives

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -602,6 +602,60 @@ If no door is in range and in front of the actor, the interaction is treated as
 a successful no-op so use-button bindings can be authored without extra guard
 conditions.
 
+Generic actor interaction uses an `interactable` component and the
+`interaction.use` action. Prefer this for switches, levers, consoles, pickup
+stations, keyed locks, and actor-driven world triggers. Sector doors can still
+use `sector_door.*` actions inside the interactable's action list:
+
+```json
+{
+  "name": "entity.security_switch",
+  "tags": ["usable"],
+  "transform": { "position": [4.0, 1.0, 8.0] },
+  "properties": {
+    "interaction_cooldown": { "type": "float", "value": 0.0 }
+  },
+  "components": [
+    {
+      "type": "interactable",
+      "prompt_key": "prompt.use.security_switch",
+      "range": 2.0,
+      "min_dot": 0.2,
+      "cooldown_property": "interaction_cooldown",
+      "cooldown": 0.25,
+      "requires": { "property": "blue_key", "amount": 1, "consume": false },
+      "actions": [
+        { "type": "sector_door.open", "target": "door.security" }
+      ],
+      "locked_actions": [
+        { "type": "scene_state.set", "key": "prompt", "value": "Needs blue key" }
+      ],
+      "cooldown_actions": [
+        { "type": "scene_state.set", "key": "prompt", "value": "Wait..." }
+      ]
+    }
+  ]
+}
+```
+
+```json
+{ "type": "interaction.use", "actor": "entity.player", "target_tag": "usable" }
+```
+
+`interaction.use` finds the nearest active actor with an `interactable`
+component in range and in front of the source actor. Yaw defaults to the
+source actor's `yaw` property; override it with `yaw_property`. `range` and
+`min_dot` on the action override component defaults for that use attempt. If no
+target is found, `miss_actions` may run; otherwise the action is a successful
+no-op.
+
+Interaction payloads include `actor_name`, `source_actor_name`,
+`interactable_actor_name`, `target_actor_name`, `prompt_key`,
+`interaction_status`, `locked`, and `distance`. Requirements read numeric
+properties from the source actor. Use `consume: true` for one-shot keys,
+currency, or charges. `cooldown_property` is stored on the interactable and is
+decremented by the component while the actor is active.
+
 `sector_platforms` move authored sector floors over time and rebuild sector
 render/collision variants when the movement exceeds `rebuild_min_delta`. Use
 them for elevators, lifts, moving bridges, and other deterministic sector

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -157,6 +157,11 @@ typedef struct sensor_actor_list
     int capacity;
 } sensor_actor_list;
 
+static bool sensor_actor_list_add(sensor_actor_list *list, sdl3d_registered_actor *actor);
+static void sensor_actor_list_free(sensor_actor_list *list);
+static bool collect_sensor_endpoint_actors(sdl3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
+                                           sensor_actor_list *out_list);
+
 typedef struct input_binding_spec
 {
     const char *action;
@@ -15027,6 +15032,278 @@ static bool execute_grid_pickup_layer_reset_action(sdl3d_game_data_runtime *runt
     return true;
 }
 
+static yyjson_val *actor_component_json(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor,
+                                        const char *type)
+{
+    if (runtime == NULL || actor == NULL || type == NULL)
+        return NULL;
+
+    yyjson_val *entity = find_entity_json(runtime, actor->name);
+    if (entity == NULL)
+    {
+        int actor_index = -1;
+        const actor_pool_runtime *pool = find_actor_pool_for_actor_const(runtime, actor->name, &actor_index);
+        if (pool != NULL && actor_index >= 0)
+            entity = pool->archetype_json;
+    }
+
+    yyjson_val *components = obj_get(entity, "components");
+    for (size_t i = 0; yyjson_is_arr(components) && i < yyjson_arr_size(components); ++i)
+    {
+        yyjson_val *component = yyjson_arr_get(components, i);
+        if (SDL_strcmp(json_string(component, "type", ""), type) != 0)
+            continue;
+        yyjson_val *enabled_if = obj_get(component, "enabled_if");
+        if (enabled_if != NULL && !eval_data_condition(runtime, enabled_if, NULL))
+            continue;
+        return component;
+    }
+    return NULL;
+}
+
+static float json_float_override(yyjson_val *primary, yyjson_val *fallback_json, const char *key, float fallback)
+{
+    yyjson_val *value = obj_get(primary, key);
+    if (yyjson_is_num(value))
+        return (float)yyjson_get_num(value);
+    return json_float(fallback_json, key, fallback);
+}
+
+static bool actor_has_authored_tag(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor,
+                                   const char *tag)
+{
+    if (tag == NULL || tag[0] == '\0')
+        return true;
+    yyjson_val *entity = find_entity_json(runtime, actor != NULL ? actor->name : NULL);
+    if (entity_json_has_tags(entity, &tag, 1))
+        return true;
+    int actor_index = -1;
+    const actor_pool_runtime *pool =
+        find_actor_pool_for_actor_const(runtime, actor != NULL ? actor->name : NULL, &actor_index);
+    return pool != NULL && actor_index >= 0 && entity_json_has_tags(pool->archetype_json, &tag, 1);
+}
+
+static bool interaction_actor_in_front(const sdl3d_registered_actor *source, const sdl3d_registered_actor *target,
+                                       yyjson_val *action, yyjson_val *component)
+{
+    if (source == NULL || target == NULL)
+        return false;
+    const float min_dot = SDL_clamp(json_float_override(action, component, "min_dot", 0.15f), -1.0f, 1.0f);
+    if (min_dot <= -1.0f)
+        return true;
+
+    const char *yaw_property = json_string(action, "yaw_property", json_string(component, "yaw_property", "yaw"));
+    const float yaw = sdl3d_properties_get_float(source->props, yaw_property, 0.0f);
+    const sdl3d_vec3 forward = sdl3d_vec3_make(SDL_sinf(yaw), 0.0f, -SDL_cosf(yaw));
+    sdl3d_vec3 to_target =
+        sdl3d_vec3_make(target->position.x - source->position.x, 0.0f, target->position.z - source->position.z);
+    const float len_sq = sdl3d_vec3_length_squared(to_target);
+    if (len_sq <= 0.000001f)
+        return true;
+    to_target = sdl3d_vec3_normalize(to_target);
+    return forward.x * to_target.x + forward.z * to_target.z >= min_dot;
+}
+
+static sdl3d_registered_actor *find_interactable_actor(sdl3d_game_data_runtime *runtime, sdl3d_registered_actor *source,
+                                                       yyjson_val *action, yyjson_val **out_component,
+                                                       float *out_distance)
+{
+    if (out_component != NULL)
+        *out_component = NULL;
+    if (out_distance != NULL)
+        *out_distance = 0.0f;
+    if (runtime == NULL || source == NULL)
+        return NULL;
+
+    const char *tag = json_string(action, "target_tag", json_string(action, "interactable_tag", NULL));
+    sdl3d_registered_actor *best = NULL;
+    yyjson_val *best_component = NULL;
+    float best_distance_sq = 0.0f;
+
+    sensor_actor_list candidates;
+    SDL_zero(candidates);
+    if (!collect_sensor_endpoint_actors(runtime, NULL, tag, &candidates))
+    {
+        sensor_actor_list_free(&candidates);
+        return NULL;
+    }
+
+    if (tag == NULL)
+    {
+        sensor_actor_list_free(&candidates);
+        yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
+        for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
+        {
+            const char *entity_name = json_string(yyjson_arr_get(entities, i), "name", NULL);
+            if (!active_scene_has_entity_internal(runtime, entity_name))
+                continue;
+            sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
+            if (runtime_actor_is_active(runtime, actor) && !sensor_actor_list_add(&candidates, actor))
+            {
+                sensor_actor_list_free(&candidates);
+                return NULL;
+            }
+        }
+        for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
+        {
+            actor_pool_runtime *pool = &runtime->actor_pools[pool_index];
+            if (!actor_pool_in_scene(pool, sdl3d_game_data_active_scene(runtime)))
+                continue;
+            for (int actor_index = 0; actor_index < pool->capacity; ++actor_index)
+            {
+                sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
+                if (actor_pool_actor_is_active(pool, actor, actor_index) && !sensor_actor_list_add(&candidates, actor))
+                {
+                    sensor_actor_list_free(&candidates);
+                    return NULL;
+                }
+            }
+        }
+    }
+
+    for (int i = 0; i < candidates.count; ++i)
+    {
+        sdl3d_registered_actor *candidate = candidates.items[i];
+        if (candidate == source || !actor_has_authored_tag(runtime, candidate, tag))
+            continue;
+        yyjson_val *component = actor_component_json(runtime, candidate, "interactable");
+        if (component == NULL)
+            continue;
+        const float range = SDL_max(json_float_override(action, component, "range", 2.25f), 0.0f);
+        const float dx = candidate->position.x - source->position.x;
+        const float dy = candidate->position.y - source->position.y;
+        const float dz = candidate->position.z - source->position.z;
+        const float distance_sq = dx * dx + dy * dy + dz * dz;
+        if (distance_sq > range * range || !interaction_actor_in_front(source, candidate, action, component))
+            continue;
+        if (best == NULL || distance_sq < best_distance_sq)
+        {
+            best = candidate;
+            best_component = component;
+            best_distance_sq = distance_sq;
+        }
+    }
+
+    sensor_actor_list_free(&candidates);
+    if (out_component != NULL)
+        *out_component = best_component;
+    if (out_distance != NULL)
+        *out_distance = best != NULL ? SDL_sqrtf(best_distance_sq) : 0.0f;
+    return best;
+}
+
+static const char *interaction_prompt_key(yyjson_val *component)
+{
+    return json_string(component, "prompt_key", json_string(component, "prompt", ""));
+}
+
+static bool interaction_requirement_met(sdl3d_registered_actor *source, yyjson_val *component)
+{
+    yyjson_val *requirement = obj_get(component, "requires");
+    if (!yyjson_is_obj(requirement))
+        return true;
+    const char *property = json_string(requirement, "property", json_string(requirement, "resource", NULL));
+    if (source == NULL || property == NULL || property[0] == '\0')
+        return false;
+    const float amount = SDL_max(json_float(requirement, "amount", 1.0f), 0.0f);
+    return weapon_actor_numeric_property(source, property, 0.0f) + 0.0001f >= amount;
+}
+
+static void interaction_consume_requirement(sdl3d_registered_actor *source, yyjson_val *component)
+{
+    yyjson_val *requirement = obj_get(component, "requires");
+    if (!yyjson_is_obj(requirement) || !json_bool(requirement, "consume", false))
+        return;
+    const char *property = json_string(requirement, "property", json_string(requirement, "resource", NULL));
+    if (property == NULL || property[0] == '\0')
+        return;
+    const float amount = SDL_max(json_float(requirement, "amount", 1.0f), 0.0f);
+    const float current = weapon_actor_numeric_property(source, property, 0.0f);
+    weapon_set_actor_numeric_property(source, property, SDL_max(current - amount, 0.0f));
+}
+
+static sdl3d_properties *interaction_payload(const sdl3d_registered_actor *source,
+                                             const sdl3d_registered_actor *interactable, yyjson_val *component,
+                                             const char *status, float distance)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    sdl3d_properties_set_string(payload, "actor_name", source != NULL && source->name != NULL ? source->name : "");
+    sdl3d_properties_set_string(payload, "source_actor_name",
+                                source != NULL && source->name != NULL ? source->name : "");
+    sdl3d_properties_set_string(payload, "interactable_actor_name",
+                                interactable != NULL && interactable->name != NULL ? interactable->name : "");
+    sdl3d_properties_set_string(payload, "target_actor_name",
+                                interactable != NULL && interactable->name != NULL ? interactable->name : "");
+    sdl3d_properties_set_string(payload, "prompt_key", interaction_prompt_key(component));
+    sdl3d_properties_set_string(payload, "interaction_status", status != NULL ? status : "success");
+    sdl3d_properties_set_bool(payload, "locked", status != NULL && SDL_strcmp(status, "locked") == 0);
+    sdl3d_properties_set_float(payload, "distance", distance);
+    return payload;
+}
+
+static bool interaction_emit_or_run(sdl3d_game_data_runtime *runtime, yyjson_val *component, const char *actions_key,
+                                    const char *signal_key, const sdl3d_properties *payload)
+{
+    yyjson_val *actions = obj_get(component, actions_key);
+    if (yyjson_is_arr(actions))
+        return execute_action_array(runtime, actions, payload);
+    const int signal_id = action_signal_id(runtime, component, signal_key);
+    if (signal_id < 0)
+        return true;
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    if (bus == NULL)
+        return false;
+    sdl3d_signal_emit(bus, signal_id, payload);
+    return true;
+}
+
+static bool execute_interaction_use_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                           const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *source =
+        actor_from_payload_key(runtime, payload, json_string(action, "actor_from_payload", NULL));
+    if (source == NULL)
+        source = sdl3d_game_data_find_actor(runtime, json_string(action, "actor", NULL));
+    if (!runtime_actor_is_active(runtime, source))
+        return false;
+
+    yyjson_val *component = NULL;
+    float distance = 0.0f;
+    sdl3d_registered_actor *target = find_interactable_actor(runtime, source, action, &component, &distance);
+    if (target == NULL || component == NULL)
+        return execute_optional_action_array(runtime, obj_get(action, "miss_actions"), NULL);
+
+    const char *cooldown_property = json_string(component, "cooldown_property", NULL);
+    if (cooldown_property != NULL && cooldown_property[0] != '\0' &&
+        sdl3d_properties_get_float(target->props, cooldown_property, 0.0f) > 0.0f)
+    {
+        sdl3d_properties *event_payload = interaction_payload(source, target, component, "cooldown", distance);
+        const bool ok = interaction_emit_or_run(runtime, component, "cooldown_actions", "on_cooldown", event_payload);
+        sdl3d_properties_destroy(event_payload);
+        return ok;
+    }
+
+    if (!interaction_requirement_met(source, component))
+    {
+        sdl3d_properties *event_payload = interaction_payload(source, target, component, "locked", distance);
+        const bool ok = interaction_emit_or_run(runtime, component, "locked_actions", "on_locked", event_payload);
+        sdl3d_properties_destroy(event_payload);
+        return ok;
+    }
+
+    interaction_consume_requirement(source, component);
+    const float cooldown = SDL_max(json_float(component, "cooldown", 0.0f), 0.0f);
+    if (cooldown_property != NULL && cooldown_property[0] != '\0' && cooldown > 0.0f)
+        sdl3d_properties_set_float(target->props, cooldown_property, cooldown);
+
+    sdl3d_properties *event_payload = interaction_payload(source, target, component, "success", distance);
+    const bool ok = interaction_emit_or_run(runtime, component, "actions", "signal", event_payload);
+    sdl3d_properties_destroy(event_payload);
+    return ok;
+}
+
 static const char *sector_door_action_target_name(yyjson_val *action, const sdl3d_properties *payload)
 {
     const char *target_from_payload = json_string(action, "target_from_payload", NULL);
@@ -15466,6 +15743,8 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return execute_weapon_reload_action(runtime, action, payload);
     if (SDL_strcmp(type, "weapon.hitscan") == 0)
         return execute_weapon_hitscan_action(runtime, action, payload);
+    if (SDL_strcmp(type, "interaction.use") == 0)
+        return execute_interaction_use_action(runtime, action, payload);
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
@@ -16680,6 +16959,18 @@ static void update_weapon_state_component(yyjson_val *component, sdl3d_registere
     weapon_complete_reload(actor, component);
 }
 
+static void update_interactable_component(yyjson_val *component, sdl3d_registered_actor *actor, float dt)
+{
+    if (component == NULL || actor == NULL || !actor->active)
+        return;
+    const char *cooldown_property = json_string(component, "cooldown_property", NULL);
+    if (cooldown_property == NULL || cooldown_property[0] == '\0')
+        return;
+    const float cooldown = sdl3d_properties_get_float(actor->props, cooldown_property, 0.0f);
+    if (cooldown > 0.0f)
+        sdl3d_properties_set_float(actor->props, cooldown_property, SDL_max(cooldown - dt, 0.0f));
+}
+
 static void update_control_components(sdl3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     sdl3d_input_manager *input = runtime_input(runtime);
@@ -16799,6 +17090,8 @@ static void update_motion_components(sdl3d_game_data_runtime *runtime, yyjson_va
                 yyjson_val *component = yyjson_arr_get(components, c);
                 if (SDL_strcmp(json_string(component, "type", ""), "weapon.state") == 0)
                     update_weapon_state_component(component, actor, dt);
+                else if (SDL_strcmp(json_string(component, "type", ""), "interactable") == 0)
+                    update_interactable_component(component, actor, dt);
             }
             if (!sdl3d_properties_get_bool(actor->props, "active_motion", true))
             {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2812,16 +2812,16 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb",      "collision.circle",
-        "combat.health",      "control.axis_1d",     "controller.fps_sector",
-        "lifecycle.ttl",      "light.directional",   "light.point",
-        "light.spot",         "motion.grid_agent",   "motion.oscillate",
-        "motion.patrol",      "motion.scroll_wrap",  "motion.sector_velocity_3d",
-        "motion.spin",        "motion.velocity_2d",  "motion.velocity_3d",
-        "particles.emitter",  "pickup.respawn",      "property.decay",
-        "render.cube",        "render.model",        "render.sphere",
-        "render.sprite",      "status_effect.timer", "weapon.projectile",
-        "weapon.state",
+        "adapter.controller", "collision.aabb",     "collision.circle",
+        "combat.health",      "control.axis_1d",    "controller.fps_sector",
+        "lifecycle.ttl",      "light.directional",  "light.point",
+        "light.spot",         "motion.grid_agent",  "motion.oscillate",
+        "motion.patrol",      "motion.scroll_wrap", "motion.sector_velocity_3d",
+        "motion.spin",        "motion.velocity_2d", "motion.velocity_3d",
+        "interactable",       "particles.emitter",  "pickup.respawn",
+        "property.decay",     "render.cube",        "render.model",
+        "render.sphere",      "render.sprite",      "status_effect.timer",
+        "weapon.projectile",  "weapon.state",
     };
 
     if (type == NULL)
@@ -2969,6 +2969,71 @@ static bool validate_weapon_state_component(validation_context *ctx, yyjson_val 
     yyjson_val *consume_reserve = obj_get(component, "consume_reserve");
     if (consume_reserve != NULL && !yyjson_is_bool(consume_reserve))
         return validation_error(ctx, path, "weapon.state consume_reserve must be a boolean");
+    return true;
+}
+
+static bool validate_interactable_requires(validation_context *ctx, yyjson_val *requires, const char *path)
+{
+    if (requires == NULL)
+        return true;
+    if (!yyjson_is_obj(requires))
+        return validation_error(ctx, path, "interactable requires must be an object");
+    const char *property = json_string(requires, "property");
+    if (property == NULL)
+        property = json_string(requires, "resource");
+    if (property == NULL || property[0] == '\0')
+        return validation_error(ctx, path, "interactable requires needs a non-empty property or resource");
+    yyjson_val *amount = obj_get(requires, "amount");
+    if (amount != NULL && (!yyjson_is_num(amount) || yyjson_get_num(amount) < 0.0))
+        return validation_error(ctx, path, "interactable requires amount must be non-negative");
+    yyjson_val *consume = obj_get(requires, "consume");
+    if (consume != NULL && !yyjson_is_bool(consume))
+        return validation_error(ctx, path, "interactable requires consume must be a boolean");
+    return true;
+}
+
+static bool validate_interactable_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                            validation_names *names)
+{
+    yyjson_val *range = obj_get(component, "range");
+    yyjson_val *min_dot = obj_get(component, "min_dot");
+    yyjson_val *cooldown = obj_get(component, "cooldown");
+    if ((range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) < 0.0)) ||
+        (cooldown != NULL && (!yyjson_is_num(cooldown) || yyjson_get_num(cooldown) < 0.0)) ||
+        (min_dot != NULL &&
+         (!yyjson_is_num(min_dot) || yyjson_get_num(min_dot) < -1.0 || yyjson_get_num(min_dot) > 1.0)))
+    {
+        return validation_error(ctx, path, "interactable range, min_dot, and cooldown values are invalid");
+    }
+    const char *string_fields[] = {"prompt", "prompt_key", "yaw_property", "cooldown_property"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        if (!validate_non_empty_string_field(ctx, component, path, "interactable", string_fields[i]))
+            return false;
+    }
+    if (!validate_interactable_requires(ctx, obj_get(component, "requires"), path))
+        return false;
+    const char *signal_keys[] = {"signal", "on_locked", "on_cooldown"};
+    for (size_t i = 0; i < SDL_arraysize(signal_keys); ++i)
+    {
+        if (!validate_optional_signal_field(ctx, component, path, names, signal_keys[i]))
+            return false;
+    }
+    const char *action_keys[] = {"actions", "locked_actions", "cooldown_actions"};
+    for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
+    {
+        yyjson_val *actions = obj_get(component, action_keys[i]);
+        if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+            return false;
+    }
+    if (obj_get(component, "actions") == NULL && json_string(component, "signal") == NULL &&
+        obj_get(component, "locked_actions") == NULL && json_string(component, "on_locked") == NULL &&
+        obj_get(component, "cooldown_actions") == NULL && json_string(component, "on_cooldown") == NULL)
+    {
+        return validation_error(ctx, path,
+                                "interactable requires actions, signal, locked_actions, on_locked, cooldown_actions, "
+                                "or on_cooldown");
+    }
     return true;
 }
 
@@ -4759,6 +4824,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_weapon_state_component(ctx, component, path))
                     return false;
             }
+            else if (SDL_strcmp(type, "interactable") == 0)
+            {
+                if (!validate_interactable_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
             {
                 if (!require_ref(ctx, &names->actions, "input action", json_string(component, "action"), path) ||
@@ -5122,6 +5192,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             else if (SDL_strcmp(type, "weapon.state") == 0)
             {
                 if (!validate_weapon_state_component(ctx, component, component_path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "interactable") == 0)
+            {
+                if (!validate_interactable_component(ctx, component, component_path, names))
                     return false;
             }
             else if (SDL_strcmp(type, "weapon.projectile") == 0)
@@ -6119,6 +6194,42 @@ static bool validate_weapon_hitscan_action(validation_context *ctx, yyjson_val *
            (miss_actions == NULL || validate_action_array(ctx, miss_actions, json_path, names));
 }
 
+static bool validate_interaction_use_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                            validation_names *names)
+{
+    yyjson_val *actor_value = obj_get(action, "actor");
+    yyjson_val *actor_from_payload_value = obj_get(action, "actor_from_payload");
+    const char *actor = json_string(action, "actor");
+    const char *actor_from_payload = json_string(action, "actor_from_payload");
+    if ((actor == NULL && actor_from_payload == NULL) || (actor != NULL && actor_from_payload != NULL))
+        return validation_error(ctx, json_path, "interaction.use requires exactly one of actor or actor_from_payload");
+    if (actor_value != NULL && !yyjson_is_str(actor_value))
+        return validation_error(ctx, json_path, "interaction.use actor must be a string");
+    if (actor_from_payload_value != NULL && !yyjson_is_str(actor_from_payload_value))
+        return validation_error(ctx, json_path, "interaction.use actor_from_payload must be a string");
+    if (actor != NULL && !require_actor_ref(ctx, names, actor, json_path))
+        return false;
+    if (actor_from_payload != NULL && actor_from_payload[0] == '\0')
+        return validation_error(ctx, json_path, "interaction.use actor_from_payload must be non-empty");
+
+    yyjson_val *range = obj_get(action, "range");
+    yyjson_val *min_dot = obj_get(action, "min_dot");
+    if ((range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) < 0.0)) ||
+        (min_dot != NULL &&
+         (!yyjson_is_num(min_dot) || yyjson_get_num(min_dot) < -1.0 || yyjson_get_num(min_dot) > 1.0)))
+    {
+        return validation_error(ctx, json_path, "interaction.use range/min_dot are invalid");
+    }
+    if (!validate_non_empty_string_field(ctx, action, json_path, "interaction.use", "yaw_property") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "interaction.use", "target_tag") ||
+        !validate_non_empty_string_field(ctx, action, json_path, "interaction.use", "interactable_tag"))
+    {
+        return false;
+    }
+    yyjson_val *miss_actions = obj_get(action, "miss_actions");
+    return miss_actions == NULL || validate_action_array(ctx, miss_actions, json_path, names);
+}
+
 static bool validate_one_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                 validation_names *names)
 {
@@ -6294,6 +6405,8 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return validate_weapon_reload_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "weapon.hitscan") == 0)
         return validate_weapon_hitscan_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "interaction.use") == 0)
+        return validate_interaction_use_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "sector_door.open") == 0 || SDL_strcmp(type, "sector_door.close") == 0 ||
         SDL_strcmp(type, "sector_door.toggle") == 0)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7916,6 +7916,186 @@ TEST(GameDataRuntime, RejectsInvalidWeaponPrimitives)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, GenericInteractionUseRunsLockedCooldownAndSuccessActions)
+{
+    const std::filesystem::path dir = unique_test_dir("generic_interaction_use");
+    write_text(dir / "interaction.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Interaction", "id": "test.interaction", "version": "0.1.0" },
+  "world": { "name": "world.interaction", "kind": "sector" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 0.0, 0.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "keycard": { "type": "int", "value": 0 },
+        "locked_feedback": { "type": "bool", "value": false },
+        "cooldown_feedback": { "type": "bool", "value": false }
+      }
+    },
+    {
+      "name": "entity.switch",
+      "active": true,
+      "tags": ["usable"],
+      "transform": { "position": [0.0, 0.0, -1.0] },
+      "properties": {
+        "use_count": { "type": "int", "value": 0 },
+        "interaction_cooldown": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "interactable",
+          "prompt_key": "prompt.open",
+          "range": 2.0,
+          "min_dot": 0.5,
+          "cooldown_property": "interaction_cooldown",
+          "cooldown": 0.25,
+          "requires": { "property": "keycard", "amount": 1.0 },
+          "actions": [
+            { "type": "property.add", "target": "entity.switch", "key": "use_count", "value": 1 }
+          ],
+          "locked_actions": [
+            { "type": "property.set", "target": "entity.player", "key": "locked_feedback", "value": true }
+          ],
+          "cooldown_actions": [
+            { "type": "property.set", "target": "entity.player", "key": "cooldown_feedback", "value": true }
+          ]
+        }
+      ]
+    }
+  ],
+  "signals": ["signal.use"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.use",
+        "actions": [
+          { "type": "interaction.use", "actor": "entity.player", "target_tag": "usable" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player", "entity.switch"]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "interaction.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int use = sdl3d_game_data_find_signal(runtime, "signal.use");
+    ASSERT_GE(use, 0);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *sw = sdl3d_game_data_find_actor(runtime, "entity.switch");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(sw, nullptr);
+
+    sdl3d_signal_emit(bus, use, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "locked_feedback", false));
+    EXPECT_EQ(sdl3d_properties_get_int(sw->props, "use_count", -1), 0);
+
+    sdl3d_properties_set_bool(player->props, "locked_feedback", false);
+    sdl3d_properties_set_int(player->props, "keycard", 1);
+    sdl3d_signal_emit(bus, use, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(sw->props, "use_count", -1), 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(sw->props, "interaction_cooldown", 0.0f), 0.25f, 0.0001f);
+
+    sdl3d_signal_emit(bus, use, nullptr);
+    EXPECT_TRUE(sdl3d_properties_get_bool(player->props, "cooldown_feedback", false));
+    EXPECT_EQ(sdl3d_properties_get_int(sw->props, "use_count", -1), 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    sdl3d_signal_emit(bus, use, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(sw->props, "use_count", -1), 2);
+
+    sdl3d_properties_set_float(player->props, "yaw", 3.14159f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    sdl3d_signal_emit(bus, use, nullptr);
+    EXPECT_EQ(sdl3d_properties_get_int(sw->props, "use_count", -1), 2);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidInteractionPrimitives)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_interaction");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.player"] })json");
+    write_text(dir / "invalid_interactable.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Interaction", "id": "test.invalid_interaction", "version": "0.1.0" },
+  "world": { "name": "world.invalid_interaction", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "components": [
+        { "type": "interactable", "range": -1.0, "actions": [] }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_interactable.game.json").string().c_str(), session, &runtime,
+                                           error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("interactable range, min_dot, and cooldown values are invalid"),
+              std::string::npos)
+        << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_use.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Use", "id": "test.invalid_use", "version": "0.1.0" },
+  "world": { "name": "world.invalid_use", "kind": "fixed_screen" },
+  "entities": [{ "name": "entity.player" }],
+  "signals": ["signal.use"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.use",
+        "actions": [
+          { "type": "interaction.use", "actor": "entity.player", "min_dot": 2.0 }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_load_file((dir / "invalid_use.game.json").string().c_str(), session, &runtime, error,
+                                           sizeof(error)));
+    EXPECT_NE(std::string(error).find("interaction.use range/min_dot are invalid"), std::string::npos) << error;
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ActivePooledActorsRenderAndEmitParticles)
 {
     const std::filesystem::path dir = unique_test_dir("actor_pool_render");


### PR DESCRIPTION
## Summary

Implements slice 5 of #282: generic interactables, switches, keys, and locks.

- adds reusable `interactable` components for actor-based use targets
- adds `interaction.use` to select the nearest active interactable in range and in front of the source actor
- supports lock requirements against source actor properties, optional consumption, cooldowns, success/locked/cooldown action paths, and signal hooks
- publishes generic interaction payload fields for downstream actions, Lua, UI, and effects
- validates the new component/action shapes and documents the authoring pattern

## Tests

- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.GenericInteractionUseRunsLockedCooldownAndSuccessActions:GameDataRuntime.RejectsInvalidInteractionPrimitives'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j 8`
- `ctest --test-dir build/debug --output-on-failure -j 8`

CTest: 1142 passed, 0 failed; 1 existing OpenGL availability skip.

Next slice should be #282 slice 6: explosives, area effects, and chain reactions.