### PR TITLE
Add sector platform crush hazards

### DIFF
--- a/demos/fps_mechanics_dojo/data/fragments/actors/player.json
+++ b/demos/fps_mechanics_dojo/data/fragments/actors/player.json
@@ -11,6 +11,7 @@
         "pitch": { "type": "float", "value": 0.0 },
         "current_sector": { "type": "int", "value": -1 },
         "dojo_hazard_damage": { "type": "float", "value": 0.0 },
+        "dojo_crush_damage": { "type": "float", "value": 0.0 },
         "health": { "type": "float", "value": 65.0 },
         "max_health": { "type": "float", "value": 100.0 },
         "ammo": { "type": "int", "value": 2 },

--- a/demos/fps_mechanics_dojo/data/fragments/world/arena.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/arena.json
@@ -44,7 +44,14 @@
       "max_floor_y": 2.25,
       "ceil_y": 6.0,
       "cycle_seconds": 5.0,
-      "rebuild_min_delta": 0.02
+      "rebuild_min_delta": 0.02,
+      "crush_damage_per_second": 8.0,
+      "crush_clearance": 0.8,
+      "crush_actor_tag": "player",
+      "damage_type": "dojo_crusher",
+      "crush_actions": [
+        { "type": "property.add", "target_from_payload": "actor_name", "key": "dojo_crush_damage", "value_from_payload": "amount" }
+      ]
     }
   ],
   "logic": {

--- a/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/fps_world.scene.json
@@ -50,7 +50,7 @@
       },
       {
         "name": "ui.dojo.damage",
-        "text": "Hazard damage {target.entity.player.dojo_hazard_damage}",
+        "text": "Hazard {target.entity.player.dojo_hazard_damage}  Crush {target.entity.player.dojo_crush_damage}",
         "font": "font.dojo.hud",
         "position": [0.02, 0.07],
         "anchor": "top_left",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -673,7 +673,19 @@ geometry motion:
       "max_floor_y": 2.5,
       "ceil_y": 12.0,
       "cycle_seconds": 6.0,
-      "rebuild_min_delta": 0.02
+      "rebuild_min_delta": 0.02,
+      "crush_damage_per_second": 20.0,
+      "crush_clearance": 1.6,
+      "crush_actor_tag": "player",
+      "damage_type": "crush",
+      "crush_actions": [
+        {
+          "type": "property.set",
+          "target_from_payload": "actor_name",
+          "key": "last_hazard",
+          "value_from_payload": "sector_platform"
+        }
+      ]
     }
   ]
 }
@@ -684,6 +696,23 @@ above `max_floor_y`, `cycle_seconds` must be positive, and `scene` may be
 omitted for a platform that updates in every scene. The platform follows a
 smooth sine cycle that starts at `min_floor_y`, rises to `max_floor_y`, and
 returns to `min_floor_y`.
+
+Platforms can also act as moving world hazards. `crush_damage_per_second`
+applies generic combat damage while the platform moves upward into an actor's
+`crush_clearance` inside the platform sector. Use `crush_actor_tag` (or
+`actor_tag`) to limit affected actors. Without a tag, every active actor in the
+active scene is eligible. By default, damage only applies while the platform is
+rising; set `crush_when_descending: true` for moving ceilings, crushers, or
+other authored setups that should also damage on downward motion.
+
+Crush damage uses the same property conventions as `combat.damage`, including
+`health_property`, `max_health_property`, `armor_property`,
+`armor_absorb_property`, `alive_property`, `damage_type`, `on_damage`, and
+`on_death`. `crush_actions` run for each crushed actor with payload fields:
+`actor_name`, `target_actor_name`, `sector_platform`, `sector_level`,
+`sector_index`, `sector_platform_floor_y`, `sector_platform_floor_delta`,
+`sector_platform_crush_damage`, and `amount`. This is intended for feedback
+such as sparks, warning lights, sounds, or diagnostic UI.
 
 Use `controller.fps_sector` on an actor to drive first-person movement through
 a sector level:

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -11676,6 +11676,8 @@ static bool execute_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *a
                                  const sdl3d_properties *payload);
 static bool execute_optional_action_array(sdl3d_game_data_runtime *runtime, yyjson_val *actions,
                                           const sdl3d_properties *payload);
+static int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
+                                         const sdl3d_registered_actor *actor);
 static float sector_door_distance_sq_xz(const sdl3d_door *door, sdl3d_vec3 point);
 static bool sector_door_is_in_front(const sdl3d_door *door, sdl3d_vec3 point, float yaw, float min_dot);
 
@@ -17000,6 +17002,76 @@ static void update_sector_doors(sdl3d_game_data_runtime *runtime, float dt)
     }
 }
 
+static sdl3d_properties *sector_platform_crush_payload(const sector_platform_runtime *platform,
+                                                       const sdl3d_registered_actor *actor, float floor_y,
+                                                       float floor_delta, float damage)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    sdl3d_properties_set_string(payload, "actor_name", actor != NULL && actor->name != NULL ? actor->name : "");
+    sdl3d_properties_set_string(payload, "target_actor_name", actor != NULL && actor->name != NULL ? actor->name : "");
+    sdl3d_properties_set_string(payload, "sector_platform",
+                                platform != NULL && platform->name != NULL ? platform->name : "");
+    sdl3d_properties_set_string(
+        payload, "sector_level",
+        platform != NULL && platform->level != NULL && platform->level->name != NULL ? platform->level->name : "");
+    sdl3d_properties_set_int(payload, "sector_index", platform != NULL ? platform->sector_index : -1);
+    sdl3d_properties_set_float(payload, "sector_platform_floor_y", floor_y);
+    sdl3d_properties_set_float(payload, "sector_platform_floor_delta", floor_delta);
+    sdl3d_properties_set_float(payload, "sector_platform_crush_damage", damage);
+    sdl3d_properties_set_float(payload, "amount", damage);
+    return payload;
+}
+
+static bool sector_platform_apply_crush_policy(sdl3d_game_data_runtime *runtime, sector_platform_runtime *platform,
+                                               float floor_y, float previous_floor_y, float dt)
+{
+    const float damage_per_second = SDL_max(json_float(platform->json, "crush_damage_per_second", 0.0f), 0.0f);
+    yyjson_val *actions = obj_get(platform->json, "crush_actions");
+    const int signal_id = action_signal_id(runtime, platform->json, "on_crush");
+    if (damage_per_second <= 0.0f && !yyjson_is_arr(actions) && signal_id < 0)
+        return true;
+
+    const float floor_delta = floor_y - previous_floor_y;
+    if (floor_delta <= 0.0f && !json_bool(platform->json, "crush_when_descending", false))
+        return true;
+
+    const char *tag = json_string(platform->json, "crush_actor_tag", json_string(platform->json, "actor_tag", NULL));
+    sensor_actor_list actors;
+    SDL_zero(actors);
+    if (!collect_effect_targets(runtime, tag, &actors))
+    {
+        sensor_actor_list_free(&actors);
+        return false;
+    }
+
+    bool ok = true;
+    const float clearance = SDL_max(json_float(platform->json, "crush_clearance", 1.8f), 0.0f);
+    const float damage = damage_per_second * SDL_max(dt, 0.0f);
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    for (int i = 0; i < actors.count; ++i)
+    {
+        sdl3d_registered_actor *actor = actors.items[i];
+        if (!runtime_actor_is_active(runtime, actor) || !actor_has_authored_tag(runtime, actor, tag))
+            continue;
+        if (actor_sector_index_for_sensor(platform->level, NULL, actor) != platform->sector_index)
+            continue;
+        if (actor->position.y > floor_y + clearance)
+            continue;
+
+        sdl3d_properties *payload = sector_platform_crush_payload(platform, actor, floor_y, floor_delta, damage);
+        if (damage > 0.0f)
+            ok = apply_combat_damage_to_actor(runtime, platform->json, payload, actor, damage) && ok;
+        ok = execute_optional_action_array(runtime, actions, payload) && ok;
+        if (bus != NULL && signal_id >= 0)
+            sdl3d_signal_emit(bus, signal_id, payload);
+        sdl3d_properties_destroy(payload);
+    }
+    sensor_actor_list_free(&actors);
+    return ok;
+}
+
 static bool update_sector_platforms(sdl3d_game_data_runtime *runtime, float dt)
 {
     if (runtime == NULL)
@@ -17021,25 +17093,32 @@ static bool update_sector_platforms(sdl3d_game_data_runtime *runtime, float dt)
         const float phase = platform->time / platform->cycle_seconds;
         const float wave = (SDL_sinf(phase * SDL_PI_F * 2.0f - SDL_PI_F * 0.5f) + 1.0f) * 0.5f;
         const float floor_y = platform->min_floor_y + (platform->max_floor_y - platform->min_floor_y) * wave;
-        if (platform->has_last_floor_y && SDL_fabsf(floor_y - platform->last_floor_y) < platform->rebuild_min_delta)
-            continue;
+        const float previous_floor_y = platform->last_floor_y;
+        const bool should_rebuild =
+            !platform->has_last_floor_y || SDL_fabsf(floor_y - platform->last_floor_y) >= platform->rebuild_min_delta;
 
-        sdl3d_sector_geometry geometry;
-        SDL_zero(geometry);
-        geometry.floor_y = floor_y;
-        geometry.ceil_y = platform->ceil_y;
-        geometry.floor_normal[1] = 1.0f;
-        geometry.ceil_normal[1] = -1.0f;
-
-        char error[256];
-        if (!set_sector_level_geometry(platform->level, platform->sector_index, &geometry, error, (int)sizeof(error)))
+        if (should_rebuild)
         {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D sector platform '%s' update failed: %s",
-                        platform->name != NULL ? platform->name : "<unnamed>", error);
-            return false;
+            sdl3d_sector_geometry geometry;
+            SDL_zero(geometry);
+            geometry.floor_y = floor_y;
+            geometry.ceil_y = platform->ceil_y;
+            geometry.floor_normal[1] = 1.0f;
+            geometry.ceil_normal[1] = -1.0f;
+
+            char error[256];
+            if (!set_sector_level_geometry(platform->level, platform->sector_index, &geometry, error,
+                                           (int)sizeof(error)))
+            {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SDL3D sector platform '%s' update failed: %s",
+                            platform->name != NULL ? platform->name : "<unnamed>", error);
+                return false;
+            }
+            platform->last_floor_y = floor_y;
+            platform->has_last_floor_y = true;
         }
-        platform->last_floor_y = floor_y;
-        platform->has_last_floor_y = true;
+        if (!sector_platform_apply_crush_policy(runtime, platform, floor_y, previous_floor_y, dt))
+            return false;
     }
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5124,6 +5124,8 @@ static bool validate_sector_platforms(validation_context *ctx, yyjson_val *root,
         yyjson_val *ceil_y = obj_get(platform, "ceil_y");
         yyjson_val *cycle_seconds = obj_get(platform, "cycle_seconds");
         yyjson_val *rebuild_min_delta = obj_get(platform, "rebuild_min_delta");
+        yyjson_val *crush_damage = obj_get(platform, "crush_damage_per_second");
+        yyjson_val *crush_clearance = obj_get(platform, "crush_clearance");
         if (!yyjson_is_num(min_floor_y) || !yyjson_is_num(max_floor_y) || !yyjson_is_num(ceil_y))
             return validation_error(ctx, path, "sector platform requires numeric min_floor_y, max_floor_y, and ceil_y");
         const double min_y = yyjson_get_num(min_floor_y);
@@ -5138,9 +5140,43 @@ static bool validate_sector_platforms(validation_context *ctx, yyjson_val *root,
             return validation_error(ctx, path, "sector platform cycle_seconds must be positive");
         if (rebuild_min_delta != NULL && (!yyjson_is_num(rebuild_min_delta) || yyjson_get_num(rebuild_min_delta) < 0.0))
             return validation_error(ctx, path, "sector platform rebuild_min_delta must be non-negative");
+        if (crush_damage != NULL && (!yyjson_is_num(crush_damage) || yyjson_get_num(crush_damage) < 0.0))
+            return validation_error(ctx, path, "sector platform crush_damage_per_second must be non-negative");
+        if (crush_clearance != NULL && (!yyjson_is_num(crush_clearance) || yyjson_get_num(crush_clearance) < 0.0))
+            return validation_error(ctx, path, "sector platform crush_clearance must be non-negative");
         yyjson_val *enabled = obj_get(platform, "enabled");
         if (enabled != NULL && !yyjson_is_bool(enabled))
             return validation_error(ctx, path, "sector platform enabled must be a boolean");
+        yyjson_val *crush_when_descending = obj_get(platform, "crush_when_descending");
+        if (crush_when_descending != NULL && !yyjson_is_bool(crush_when_descending))
+            return validation_error(ctx, path, "sector platform crush_when_descending must be a boolean");
+        yyjson_val *deactivate_on_death = obj_get(platform, "deactivate_on_death");
+        if (deactivate_on_death != NULL && !yyjson_is_bool(deactivate_on_death))
+            return validation_error(ctx, path, "sector platform deactivate_on_death must be a boolean");
+        yyjson_val *armor_absorb = obj_get(platform, "armor_absorb");
+        if (armor_absorb != NULL &&
+            (!yyjson_is_num(armor_absorb) || yyjson_get_num(armor_absorb) < 0.0 || yyjson_get_num(armor_absorb) > 1.0))
+        {
+            return validation_error(ctx, path, "sector platform armor_absorb must be in 0..1");
+        }
+        if (!validate_non_empty_string_field(ctx, platform, path, "sector platform", "crush_actor_tag") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "actor_tag") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "damage_type") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "health_property") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "max_health_property") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "armor_property") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "armor_absorb_property") ||
+            !validate_non_empty_string_field(ctx, platform, path, "sector platform", "alive_property"))
+        {
+            return false;
+        }
+        yyjson_val *actions = obj_get(platform, "crush_actions");
+        if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+            return false;
+        if (!validate_optional_signal_field(ctx, platform, path, names, "on_crush") ||
+            !validate_optional_signal_field(ctx, platform, path, names, "on_damage") ||
+            !validate_optional_signal_field(ctx, platform, path, names, "on_death"))
+            return false;
     }
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -10029,6 +10029,7 @@ TEST(GameDataRuntime, RunsAuthoredSectorPlatform)
   "schema": "sdl3d.scene.v0",
   "name": "scene.play",
   "updates_game": true,
+  "entities": ["entity.player"],
   "world": { "sector_levels": [{ "level": "sector.test", "variant": "unlit" }] }
 })json");
     write_text(dir / "sector_platforms.game.json",
@@ -10036,6 +10037,19 @@ TEST(GameDataRuntime, RunsAuthoredSectorPlatform)
   "schema": "sdl3d.game.v0",
   "metadata": { "name": "Sector Platform Test" },
   "world": { "name": "world.test", "kind": "sector" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["player"],
+      "transform": { "position": [2.0, 1.2, 2.0] },
+      "properties": {
+        "current_sector": { "type": "int", "value": 0 },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 }
+      }
+    }
+  ],
   "sector_levels": [
     {
       "name": "sector.test",
@@ -10063,7 +10077,19 @@ TEST(GameDataRuntime, RunsAuthoredSectorPlatform)
       "max_floor_y": 2.0,
       "ceil_y": 4.0,
       "cycle_seconds": 4.0,
-      "rebuild_min_delta": 0.0
+      "rebuild_min_delta": 0.0,
+      "crush_damage_per_second": 10.0,
+      "crush_clearance": 0.5,
+      "crush_actor_tag": "player",
+      "damage_type": "crusher",
+      "crush_actions": [
+        {
+          "type": "property.set",
+          "target_from_payload": "actor_name",
+          "key": "last_platform",
+          "value_from_payload": "sector_platform"
+        }
+      ]
     }
   ],
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
@@ -10082,16 +10108,22 @@ TEST(GameDataRuntime, RunsAuthoredSectorPlatform)
     ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
     ASSERT_EQ(level.sector_count, 1);
     EXPECT_NEAR(level.sectors[0].floor_y, 0.0f, 0.001f);
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 100.0f, 0.001f);
 
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
     ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
     EXPECT_NEAR(level.sectors[0].floor_y, 1.0f, 0.001f);
     ASSERT_NE(level.unlit, nullptr);
     ASSERT_EQ(level.unlit->sector_count, 1);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 90.0f, 0.001f);
+    EXPECT_STREQ(sdl3d_properties_get_string(player->props, "last_platform", ""), "platform.test");
 
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 1.0f));
     ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.test", &level));
     EXPECT_NEAR(level.sectors[0].floor_y, 2.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 80.0f, 0.001f);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -10139,6 +10171,22 @@ TEST(GameDataRuntime, RejectsInvalidSectorPlatforms)
               }
             ])json",
             "cycle_seconds must be positive",
+        },
+        {
+            "bad_crush_damage",
+            R"json([
+              {
+                "name": "platform.bad",
+                "sector_level": "sector.test",
+                "sector": "lift",
+                "min_floor_y": 0.0,
+                "max_floor_y": 2.0,
+                "ceil_y": 4.0,
+                "cycle_seconds": 4.0,
+                "crush_damage_per_second": -1.0
+              }
+            ])json",
+            "crush_damage_per_second must be non-negative",
         },
     };
 


### PR DESCRIPTION
## Summary
- extend authored sector_platforms with reusable crush-hazard policy, clearance checks, actor tag filtering, and per-actor payload/actions
- validate crush damage, clearance, combat property names, combat signals, and nested crush actions
- wire the FPS mechanics dojo lift to demonstrate authored platform crush damage in HUD state

## Tests
- cmake --build build/debug --target sdl3d_game_data_test -j8
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.RunsAuthoredSectorPlatform:GameDataRuntime.RejectsInvalidSectorPlatforms:GameDataRuntime.EditorMetadataValidatesAndFpsMechanicsDojoLoads'
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug -j8
- ctest --test-dir build/debug --output-on-failure

Continues #282.