### PR TITLE
Add faction target filters

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -164,6 +164,8 @@ Import rules:
 - `actor_instances` and `sector_level_fragments` are composition-time authoring
   helpers; they are expanded into normal `entities` and `sector_levels` before
   ordinary validation and runtime loading
+- `factions` is mergeable so combat relationship policy can live in shared
+  gameplay fragments
 - `editor` metadata is mergeable so templates and future editor palettes can
   live beside the fragments they describe
 
@@ -1495,6 +1497,56 @@ Prefer combat actions over raw `property.add` for gameplay health because they
 centralize armor absorption, clamping, alive/dead state, and signal emission.
 Raw property actions remain useful for simple meters, counters, and diagnostic
 state.
+
+### Factions And Target Filters
+
+Games can author a reusable faction relationship matrix at the root:
+
+```json
+{
+  "factions": {
+    "player": { "player": "friendly", "monster": "hostile", "neutral": "neutral" },
+    "monster": { "player": "hostile", "monster": "friendly", "neutral": "neutral" },
+    "neutral": { "player": "neutral", "monster": "neutral", "neutral": "friendly" }
+  }
+}
+```
+
+Actors participate by storing a string property, `faction` by default. If no
+matrix entry exists, actors in the same faction are treated as `friendly`,
+actors in different non-empty factions are treated as `hostile`, and missing
+factions are treated as `neutral`.
+
+Combat damage, hitscan weapons, explosions, contact/sector/volume sensors, and
+sector platform crush hazards accept `target_filter`:
+
+```json
+{
+  "type": "effect.explosion",
+  "source": "entity.player_rocket",
+  "radius": 4.0,
+  "damage": 45.0,
+  "target_filter": {
+    "relationship": "hostile",
+    "include_tags": ["combatant"],
+    "exclude_owner": true,
+    "owner_property": "owner",
+    "exclude_source": true
+  }
+}
+```
+
+Supported filters include `relationship` (`any`, `friendly`, `hostile`,
+`neutral`, or `ignored`), `target_faction`, `include_factions`,
+`exclude_factions`, `target_tag`, `include_tags`, `exclude_tags`,
+`exclude_source` / `exclude_self`, `exclude_owner`, `owner_property`,
+`faction_property`, `source_faction`, `source_faction_from_payload`, and
+`source_faction_property`. String-list fields accept either one string or an
+array of strings.
+
+Use filters instead of duplicating tag-only logic. They keep friendly fire,
+trap ownership, neutral NPCs, projectile owners, and world-owned hazards
+data-authored and consistent across combat, sensors, and effects.
 
 `effect.explosion` applies an authored radial effect around a position or actor.
 It is suitable for grenades, exploding barrels, blast spells, mines, traps, and

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -117,6 +117,7 @@ typedef struct sensor_contact_pair_state
 typedef struct sensor_entry
 {
     game_data_sensor_type type;
+    yyjson_val *json;
     const char *name;
     const char *entity;
     const char *other;
@@ -787,6 +788,12 @@ static bool actor_pool_request_despawn(sdl3d_game_data_runtime *runtime, actor_p
                                        sdl3d_registered_actor *actor, int index, const char *reason);
 static bool apply_actor_pool_scene_exit_policies(sdl3d_game_data_runtime *runtime, const char *from_scene,
                                                  const char *to_scene);
+static sdl3d_registered_actor *action_source_actor(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   const sdl3d_properties *payload);
+static bool actor_matches_target_filter(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *target,
+                                        const sdl3d_registered_actor *source, yyjson_val *json,
+                                        const sdl3d_properties *payload, const char *fallback_tag,
+                                        bool fallback_exclude_source);
 static void actor_lifecycle_defer_begin(sdl3d_game_data_runtime *runtime);
 static void actor_lifecycle_defer_end(sdl3d_game_data_runtime *runtime);
 static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
@@ -14079,6 +14086,9 @@ static bool apply_combat_damage_to_actor(sdl3d_game_data_runtime *runtime, yyjso
 {
     if (actor == NULL)
         return false;
+    sdl3d_registered_actor *source = action_source_actor(runtime, action, payload);
+    if (!actor_matches_target_filter(runtime, actor, source, action, payload, NULL, false))
+        return true;
     amount = SDL_max(amount, 0.0f);
 
     const char *health_key = combat_action_property(action, "health_property", "health");
@@ -14538,22 +14548,10 @@ static bool execute_status_effect_apply_action(sdl3d_game_data_runtime *runtime,
 }
 
 static bool actor_matches_weapon_target(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor,
-                                        const sdl3d_registered_actor *source, const char *tag, bool exclude_source)
+                                        const sdl3d_registered_actor *source, yyjson_val *action, const char *tag,
+                                        bool exclude_source)
 {
-    if (actor == NULL || !actor->active)
-        return false;
-    if (exclude_source && source != NULL && actor == source)
-        return false;
-    if (tag == NULL || tag[0] == '\0')
-        return true;
-
-    yyjson_val *entity = find_entity_json(runtime, actor->name);
-    if (entity_json_has_tags(entity, &tag, 1))
-        return true;
-
-    int actor_index = -1;
-    const actor_pool_runtime *pool = find_actor_pool_for_actor_const(runtime, actor->name, &actor_index);
-    return pool != NULL && actor_index >= 0 && entity_json_has_tags(pool->archetype_json, &tag, 1);
+    return actor_matches_target_filter(runtime, actor, source, action, NULL, tag, exclude_source);
 }
 
 static bool ray_sphere_intersection(sdl3d_vec3 origin, sdl3d_vec3 direction, sdl3d_vec3 center, float radius,
@@ -14594,7 +14592,7 @@ static sdl3d_registered_actor *find_hitscan_actor_target(sdl3d_game_data_runtime
         if (!active_scene_has_entity_internal(runtime, entity_name))
             continue;
         sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, entity_name);
-        if (!actor_matches_weapon_target(runtime, actor, source, tag, exclude_source))
+        if (!actor_matches_weapon_target(runtime, actor, source, action, tag, exclude_source))
             continue;
         const float radius =
             SDL_max(weapon_actor_numeric_property(
@@ -14618,7 +14616,7 @@ static sdl3d_registered_actor *find_hitscan_actor_target(sdl3d_game_data_runtime
         {
             sdl3d_registered_actor *actor = sdl3d_game_data_find_actor(runtime, pool->actor_names[actor_index]);
             if (!actor_pool_actor_is_active(pool, actor, actor_index) ||
-                !actor_matches_weapon_target(runtime, actor, source, tag, exclude_source))
+                !actor_matches_weapon_target(runtime, actor, source, action, tag, exclude_source))
             {
                 continue;
             }
@@ -15098,6 +15096,190 @@ static bool actor_has_authored_tag(const sdl3d_game_data_runtime *runtime, const
     return pool != NULL && actor_index >= 0 && entity_json_has_tags(pool->archetype_json, &tag, 1);
 }
 
+static yyjson_val *target_filter_json(yyjson_val *json)
+{
+    yyjson_val *filter = obj_get(json, "target_filter");
+    return yyjson_is_obj(filter) ? filter : json;
+}
+
+static const char *target_filter_string(yyjson_val *json, const char *key, const char *fallback)
+{
+    yyjson_val *filter = target_filter_json(json);
+    const char *value = json_string(filter, key, NULL);
+    if (value != NULL)
+        return value;
+    return filter != json ? json_string(json, key, fallback) : fallback;
+}
+
+static bool target_filter_bool(yyjson_val *json, const char *key, bool fallback)
+{
+    yyjson_val *filter = target_filter_json(json);
+    yyjson_val *value = obj_get(filter, key);
+    if (yyjson_is_bool(value))
+        return yyjson_get_bool(value);
+    return filter != json ? json_bool(json, key, fallback) : fallback;
+}
+
+static bool target_filter_string_array_contains(yyjson_val *json, const char *key, const char *value)
+{
+    if (value == NULL || value[0] == '\0')
+        return false;
+    yyjson_val *filter = target_filter_json(json);
+    yyjson_val *array = obj_get(filter, key);
+    if (array == NULL && filter != json)
+        array = obj_get(json, key);
+    if (yyjson_is_str(array))
+        return SDL_strcmp(yyjson_get_str(array), value) == 0;
+    for (size_t i = 0; yyjson_is_arr(array) && i < yyjson_arr_size(array); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(array, i);
+        if (yyjson_is_str(entry) && SDL_strcmp(yyjson_get_str(entry), value) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool target_filter_actor_has_any_tag(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *actor,
+                                            yyjson_val *json, const char *key)
+{
+    yyjson_val *filter = target_filter_json(json);
+    yyjson_val *tags = obj_get(filter, key);
+    if (tags == NULL && filter != json)
+        tags = obj_get(json, key);
+    if (yyjson_is_str(tags))
+        return actor_has_authored_tag(runtime, actor, yyjson_get_str(tags));
+    for (size_t i = 0; yyjson_is_arr(tags) && i < yyjson_arr_size(tags); ++i)
+    {
+        yyjson_val *tag = yyjson_arr_get(tags, i);
+        if (yyjson_is_str(tag) && actor_has_authored_tag(runtime, actor, yyjson_get_str(tag)))
+            return true;
+    }
+    return false;
+}
+
+static bool target_filter_actor_has_blocked_tag(const sdl3d_game_data_runtime *runtime,
+                                                const sdl3d_registered_actor *actor, yyjson_val *json, const char *key)
+{
+    yyjson_val *filter = target_filter_json(json);
+    yyjson_val *tags = obj_get(filter, key);
+    if (tags == NULL && filter != json)
+        tags = obj_get(json, key);
+    if (yyjson_is_str(tags))
+        return actor_has_authored_tag(runtime, actor, yyjson_get_str(tags));
+    for (size_t i = 0; yyjson_is_arr(tags) && i < yyjson_arr_size(tags); ++i)
+    {
+        yyjson_val *tag = yyjson_arr_get(tags, i);
+        if (yyjson_is_str(tag) && actor_has_authored_tag(runtime, actor, yyjson_get_str(tag)))
+            return true;
+    }
+    return false;
+}
+
+static const char *actor_faction(const sdl3d_registered_actor *actor, const char *property)
+{
+    return actor != NULL && property != NULL && property[0] != '\0'
+               ? sdl3d_properties_get_string(actor->props, property, "")
+               : "";
+}
+
+static const char *faction_relationship(const sdl3d_game_data_runtime *runtime, const char *source_faction,
+                                        const char *target_faction)
+{
+    if (source_faction == NULL || source_faction[0] == '\0' || target_faction == NULL || target_faction[0] == '\0')
+        return "neutral";
+
+    yyjson_val *factions = obj_get(runtime_root(runtime), "factions");
+    yyjson_val *source = obj_get(factions, source_faction);
+    const char *authored = json_string(source, target_faction, NULL);
+    if (authored != NULL)
+        return authored;
+    authored = json_string(source, "default", NULL);
+    if (authored != NULL)
+        return authored;
+    authored = json_string(factions, "default_relationship", NULL);
+    if (authored != NULL)
+        return authored;
+    return SDL_strcmp(source_faction, target_faction) == 0 ? "friendly" : "hostile";
+}
+
+static sdl3d_registered_actor *action_source_actor(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                   const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *source =
+        actor_from_payload_key(runtime, payload, target_filter_string(action, "source_from_payload", NULL));
+    if (source == NULL)
+        source = sdl3d_game_data_find_actor(runtime, target_filter_string(action, "source", NULL));
+    return source;
+}
+
+static bool actor_matches_target_filter(const sdl3d_game_data_runtime *runtime, const sdl3d_registered_actor *target,
+                                        const sdl3d_registered_actor *source, yyjson_val *json,
+                                        const sdl3d_properties *payload, const char *fallback_tag,
+                                        bool fallback_exclude_source)
+{
+    if (target == NULL || !target->active)
+        return false;
+    const char *tag = target_filter_string(json, "target_tag", fallback_tag);
+    if (tag == NULL)
+        tag = target_filter_string(json, "affected_tag", NULL);
+    if (tag == NULL)
+        tag = target_filter_string(json, "hit_tag", NULL);
+    if (tag != NULL && tag[0] != '\0' && !actor_has_authored_tag(runtime, target, tag))
+        return false;
+    if (target_filter_actor_has_any_tag(runtime, target, json, "include_tags") == false &&
+        (obj_get(target_filter_json(json), "include_tags") != NULL || obj_get(json, "include_tags") != NULL))
+        return false;
+    if (target_filter_actor_has_blocked_tag(runtime, target, json, "exclude_tags"))
+        return false;
+
+    const bool exclude_source =
+        target_filter_bool(json, "exclude_source", target_filter_bool(json, "exclude_self", fallback_exclude_source));
+    if (exclude_source && source != NULL && target == source)
+        return false;
+
+    const char *owner_property =
+        target_filter_string(json, "owner_property", target_filter_string(json, "owner_actor_property", "owner"));
+    const bool exclude_owner = target_filter_bool(json, "exclude_owner", false);
+    if (exclude_owner && source != NULL && owner_property != NULL && owner_property[0] != '\0')
+    {
+        const char *source_owner = sdl3d_properties_get_string(source->props, owner_property, NULL);
+        if (source_owner != NULL && target->name != NULL && SDL_strcmp(source_owner, target->name) == 0)
+            return false;
+        const char *target_owner = sdl3d_properties_get_string(target->props, owner_property, NULL);
+        if (target_owner != NULL && source->name != NULL && SDL_strcmp(target_owner, source->name) == 0)
+            return false;
+    }
+
+    const char *faction_property = target_filter_string(json, "faction_property", "faction");
+    const char *source_faction_property = target_filter_string(json, "source_faction_property", faction_property);
+    const char *target_faction = actor_faction(target, faction_property);
+    const char *source_faction = target_filter_string(json, "source_faction", NULL);
+    const char *source_faction_from_payload = target_filter_string(json, "source_faction_from_payload", NULL);
+    if (source_faction_from_payload != NULL && payload != NULL)
+        source_faction = sdl3d_properties_get_string(payload, source_faction_from_payload, source_faction);
+    if ((source_faction == NULL || source_faction[0] == '\0') && source != NULL)
+        source_faction = actor_faction(source, source_faction_property);
+
+    const char *required_target_faction = target_filter_string(json, "target_faction", NULL);
+    if (required_target_faction != NULL && required_target_faction[0] != '\0' &&
+        SDL_strcmp(target_faction, required_target_faction) != 0)
+        return false;
+    if (target_filter_string_array_contains(json, "include_factions", target_faction) == false &&
+        (obj_get(target_filter_json(json), "include_factions") != NULL || obj_get(json, "include_factions") != NULL))
+        return false;
+    if (target_filter_string_array_contains(json, "exclude_factions", target_faction))
+        return false;
+
+    const char *relationship = target_filter_string(json, "relationship", NULL);
+    if (relationship != NULL && relationship[0] != '\0' && SDL_strcmp(relationship, "any") != 0)
+    {
+        const char *actual = faction_relationship(runtime, source_faction, target_faction);
+        if (SDL_strcmp(actual, relationship) != 0)
+            return false;
+    }
+    return true;
+}
+
 static bool interaction_actor_in_front(const sdl3d_registered_actor *source, const sdl3d_registered_actor *target,
                                        yyjson_val *action, yyjson_val *component)
 {
@@ -15455,8 +15637,7 @@ static bool execute_effect_explosion_action(sdl3d_game_data_runtime *runtime, yy
     for (int i = 0; i < targets.count && affected < max_targets; ++i)
     {
         sdl3d_registered_actor *target = targets.items[i];
-        if (!runtime_actor_is_active(runtime, target) || (exclude_source && source != NULL && target == source) ||
-            !actor_has_authored_tag(runtime, target, tag))
+        if (!actor_matches_target_filter(runtime, target, source, action, payload, tag, exclude_source))
         {
             continue;
         }
@@ -16281,6 +16462,7 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
     {
         yyjson_val *sensor = yyjson_arr_get(sensors, (size_t)i);
         sensor_entry *entry = &runtime->sensors[i];
+        entry->json = sensor;
         const char *type = json_string(sensor, "type", "");
         if (SDL_strcmp(type, "sensor.bounds_exit") == 0)
             entry->type = GAME_DATA_SENSOR_BOUNDS_EXIT;
@@ -17053,14 +17235,17 @@ static bool sector_platform_apply_crush_policy(sdl3d_game_data_runtime *runtime,
     for (int i = 0; i < actors.count; ++i)
     {
         sdl3d_registered_actor *actor = actors.items[i];
-        if (!runtime_actor_is_active(runtime, actor) || !actor_has_authored_tag(runtime, actor, tag))
-            continue;
         if (actor_sector_index_for_sensor(platform->level, NULL, actor) != platform->sector_index)
             continue;
         if (actor->position.y > floor_y + clearance)
             continue;
 
         sdl3d_properties *payload = sector_platform_crush_payload(platform, actor, floor_y, floor_delta, damage);
+        if (!actor_matches_target_filter(runtime, actor, NULL, platform->json, payload, tag, false))
+        {
+            sdl3d_properties_destroy(payload);
+            continue;
+        }
         if (damage > 0.0f)
             ok = apply_combat_damage_to_actor(runtime, platform->json, payload, actor, damage) && ok;
         ok = execute_optional_action_array(runtime, actions, payload) && ok;
@@ -17903,6 +18088,12 @@ static void update_sensor_contact_pair(sdl3d_game_data_runtime *runtime, sensor_
         return;
 
     const bool active = actors_contact_2d(actor, other);
+    if (active && !actor_matches_target_filter(runtime, other, actor, sensor->json, NULL, sensor->other_tag, false))
+    {
+        state->active = false;
+        state->seen = true;
+        return;
+    }
     const bool stay =
         sensor->edge != NULL && (SDL_strcmp(sensor->edge, "stay") == 0 || SDL_strcmp(sensor->edge, "overlap") == 0);
     if (active && (stay || !state->active))
@@ -18039,7 +18230,9 @@ static void update_sector_sensor_actor(sdl3d_game_data_runtime *runtime, sensor_
         return;
 
     const int current_sector = actor_sector_index_for_sensor(level, sensor, actor);
-    const bool active = current_sector == target_sector;
+    const bool active =
+        current_sector == target_sector &&
+        actor_matches_target_filter(runtime, actor, NULL, sensor->json, NULL, sensor->entity_tag, false);
     const char *sector_name = "";
     if (target_sector >= 0 && target_sector < level->sector_count && level->sector_names[target_sector] != NULL)
         sector_name = level->sector_names[target_sector];
@@ -18100,7 +18293,9 @@ static void update_volume_sensor_actor(sdl3d_game_data_runtime *runtime, sensor_
     if (state == NULL)
         return;
 
-    const bool active = point_in_sensor_volume(sensor, actor->position);
+    const bool active =
+        point_in_sensor_volume(sensor, actor->position) &&
+        actor_matches_target_filter(runtime, actor, NULL, sensor->json, NULL, sensor->entity_tag, false);
     const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
                              : sensor_edge_is_stay(sensor) ? active
                                                            : (active && !state->active);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -124,6 +124,8 @@ static bool asset_path_exists(validation_context *ctx, const char *asset_path, c
                               const char *asset_kind);
 static void format_path(char *buffer, size_t buffer_size, const char *format, ...);
 static bool validation_error(validation_context *ctx, const char *json_path, const char *format, ...);
+static bool validate_target_filter_fields(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                          const char *type);
 static bool validate_imports_with_stack(validation_context *ctx, yyjson_val *root, import_validation_stack *stack);
 static bool validate_imports(validation_context *ctx, yyjson_val *root);
 static bool compose_document_into(validation_context *ctx, yyjson_val *root, yyjson_val *sections,
@@ -1893,6 +1895,7 @@ static bool import_section_name_allowed(const char *name)
                                           "transitions",
                                           "ui",
                                           "editor",
+                                          "factions",
                                           "entities",
                                           "grid_maps",
                                           "grid_pickup_layers",
@@ -5170,6 +5173,8 @@ static bool validate_sector_platforms(validation_context *ctx, yyjson_val *root,
         {
             return false;
         }
+        if (!validate_target_filter_fields(ctx, platform, path, "sector platform"))
+            return false;
         yyjson_val *actions = obj_get(platform, "crush_actions");
         if (actions != NULL && !validate_action_array(ctx, actions, path, names))
             return false;
@@ -5896,7 +5901,7 @@ static bool validate_combat_target_action(validation_context *ctx, yyjson_val *a
     yyjson_val *damage_type = obj_get(action, "damage_type");
     if (damage_type != NULL && !yyjson_is_str(damage_type))
         return validation_error(ctx, json_path, "%s damage_type must be a string", type);
-    return true;
+    return validate_target_filter_fields(ctx, action, json_path, type);
 }
 
 static bool validate_combat_amount_action(validation_context *ctx, yyjson_val *action, const char *json_path,
@@ -5960,6 +5965,136 @@ static bool validate_optional_signal_field(validation_context *ctx, yyjson_val *
 {
     const char *signal = json_string(json, field);
     return signal == NULL || require_ref(ctx, &names->signals, "signal", signal, json_path);
+}
+
+static bool faction_relationship_valid(const char *value)
+{
+    return value != NULL && (SDL_strcmp(value, "friendly") == 0 || SDL_strcmp(value, "hostile") == 0 ||
+                             SDL_strcmp(value, "neutral") == 0 || SDL_strcmp(value, "ignored") == 0);
+}
+
+static bool target_filter_relationship_valid(const char *value)
+{
+    return value != NULL && (SDL_strcmp(value, "any") == 0 || faction_relationship_valid(value));
+}
+
+static bool validate_string_or_string_array(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                            const char *type, const char *field)
+{
+    yyjson_val *value = obj_get(json, field);
+    if (value == NULL)
+        return true;
+    if (yyjson_is_str(value))
+        return yyjson_get_str(value)[0] != '\0' ||
+               validation_error(ctx, json_path, "%s %s must contain non-empty strings", type, field);
+    if (!yyjson_is_arr(value))
+        return validation_error(ctx, json_path, "%s %s must be a string or string array", type, field);
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (!yyjson_is_str(entry) || yyjson_get_str(entry)[0] == '\0')
+            return validation_error(ctx, json_path, "%s %s must contain non-empty strings", type, field);
+    }
+    return true;
+}
+
+static bool validate_target_filter_fields(validation_context *ctx, yyjson_val *json, const char *json_path,
+                                          const char *type)
+{
+    if (json == NULL)
+        return true;
+    yyjson_val *filter = obj_get(json, "target_filter");
+    if (filter != NULL && !yyjson_is_obj(filter))
+        return validation_error(ctx, json_path, "%s target_filter must be an object", type);
+    yyjson_val *sources[] = {json, filter};
+    for (size_t s = 0; s < SDL_arraysize(sources); ++s)
+    {
+        yyjson_val *source = sources[s];
+        if (source == NULL)
+            continue;
+        const char *string_fields[] = {"target_tag",       "affected_tag",
+                                       "hit_tag",          "target_faction",
+                                       "source_faction",   "source_faction_from_payload",
+                                       "faction_property", "source_faction_property",
+                                       "owner_property",   "owner_actor_property"};
+        for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+        {
+            if (!validate_non_empty_string_field(ctx, source, json_path, type, string_fields[i]))
+                return false;
+        }
+        const char *array_fields[] = {"include_tags", "exclude_tags", "include_factions", "exclude_factions"};
+        for (size_t i = 0; i < SDL_arraysize(array_fields); ++i)
+        {
+            if (!validate_string_or_string_array(ctx, source, json_path, type, array_fields[i]))
+                return false;
+        }
+        const char *bool_fields[] = {"exclude_source", "exclude_self", "exclude_owner"};
+        for (size_t i = 0; i < SDL_arraysize(bool_fields); ++i)
+        {
+            yyjson_val *value = obj_get(source, bool_fields[i]);
+            if (value != NULL && !yyjson_is_bool(value))
+                return validation_error(ctx, json_path, "%s %s must be a boolean", type, bool_fields[i]);
+        }
+        const char *relationship = json_string(source, "relationship");
+        if (relationship != NULL && !target_filter_relationship_valid(relationship))
+            return validation_error(ctx, json_path,
+                                    "%s relationship must be any, friendly, hostile, neutral, or ignored", type);
+    }
+    return true;
+}
+
+static bool validate_factions(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *factions = obj_get(root, "factions");
+    if (factions == NULL)
+        return true;
+    if (!yyjson_is_obj(factions))
+        return validation_error(ctx, "$.factions", "factions must be an object");
+    const char *default_relationship = json_string(factions, "default_relationship");
+    if (default_relationship != NULL && !faction_relationship_valid(default_relationship))
+    {
+        return validation_error(ctx, "$.factions",
+                                "factions default_relationship must be friendly, hostile, neutral, or ignored");
+    }
+
+    yyjson_val *key;
+    yyjson_val *value;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(factions, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        value = yyjson_obj_iter_get_val(key);
+        if (SDL_strcmp(name != NULL ? name : "", "default_relationship") == 0)
+            continue;
+        if (name == NULL || name[0] == '\0')
+            return validation_error(ctx, "$.factions", "faction names must be non-empty");
+        if (!yyjson_is_obj(value))
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.factions.%s", name);
+            return validation_error(ctx, path, "faction entries must be objects");
+        }
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.factions.%s", name);
+        yyjson_val *rel_key;
+        yyjson_val *rel_value;
+        yyjson_obj_iter rel_iter;
+        yyjson_obj_iter_init(value, &rel_iter);
+        while ((rel_key = yyjson_obj_iter_next(&rel_iter)) != NULL)
+        {
+            const char *target = yyjson_get_str(rel_key);
+            rel_value = yyjson_obj_iter_get_val(rel_key);
+            if (target == NULL || target[0] == '\0' || !yyjson_is_str(rel_value) ||
+                !faction_relationship_valid(yyjson_get_str(rel_value)))
+            {
+                return validation_error(
+                    ctx, path,
+                    "faction relationships must map non-empty faction names to friendly, hostile, neutral, or ignored");
+            }
+        }
+    }
+    return true;
 }
 
 static bool validate_resource_grant(validation_context *ctx, yyjson_val *grant, const char *json_path,
@@ -6226,7 +6361,8 @@ static bool validate_weapon_hitscan_action(validation_context *ctx, yyjson_val *
     }
     yyjson_val *actions = obj_get(action, "actions");
     yyjson_val *miss_actions = obj_get(action, "miss_actions");
-    return (actions == NULL || validate_action_array(ctx, actions, json_path, names)) &&
+    return validate_target_filter_fields(ctx, action, json_path, "weapon.hitscan") &&
+           (actions == NULL || validate_action_array(ctx, actions, json_path, names)) &&
            (miss_actions == NULL || validate_action_array(ctx, miss_actions, json_path, names));
 }
 
@@ -6346,7 +6482,8 @@ static bool validate_effect_explosion_action(validation_context *ctx, yyjson_val
         return validation_error(ctx, json_path, "effect.explosion max_targets must be a non-negative integer");
 
     yyjson_val *actions = obj_get(action, "actions");
-    return (actions == NULL || validate_action_array(ctx, actions, json_path, names)) &&
+    return validate_target_filter_fields(ctx, action, json_path, "effect.explosion") &&
+           (actions == NULL || validate_action_array(ctx, actions, json_path, names)) &&
            validate_optional_signal_field(ctx, action, json_path, names, "on_hit");
 }
 
@@ -7166,6 +7303,8 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
             {
                 return validation_error(ctx, path, "collision edge must be enter, stay, or overlap");
             }
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.contact_2d"))
+                return false;
             continue;
         }
         if (SDL_strcmp(type, "sensor.input_pressed") == 0)
@@ -7232,6 +7371,8 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
                 return false;
             if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
                 return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.sector"))
+                return false;
             continue;
         }
         if (SDL_strcmp(type, "sensor.volume") == 0)
@@ -7280,6 +7421,8 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
             if (actions != NULL && !validate_action_array(ctx, actions, path, names))
                 return false;
             if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.volume"))
                 return false;
             continue;
         }
@@ -8855,7 +8998,7 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
 
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
-    return validate_storage(ctx, root) && validate_persistence(ctx, root, names) &&
+    return validate_storage(ctx, root) && validate_persistence(ctx, root, names) && validate_factions(ctx, root) &&
            validate_input_bindings(ctx, root) && validate_input_assignment_sets(ctx, root) &&
            validate_input_profiles(ctx, root, names) && validate_grid_maps(ctx, root) &&
            validate_grid_pickup_layers(ctx, root, names) && validate_sector_levels(ctx, root) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7322,6 +7322,192 @@ TEST(GameDataRuntime, EffectExplosionAppliesRadialDamageImpulseAndActions)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, TargetFiltersApplyFactionAndOwnerRules)
+{
+    const std::filesystem::path dir = unique_test_dir("target_filters");
+    write_text(dir / "target_filters.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Target Filters", "id": "test.target_filters", "version": "0.1.0" },
+  "world": { "name": "world.target_filters", "kind": "fixed_screen" },
+  "factions": {
+    "player": { "player": "friendly", "monster": "hostile", "neutral": "neutral" },
+    "monster": { "player": "hostile", "monster": "friendly", "neutral": "neutral" },
+    "neutral": { "player": "neutral", "monster": "neutral", "neutral": "friendly" }
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["combatant"],
+      "transform": { "position": [0.0, 0.0, 0.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "player" },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 }
+      }
+    },
+    {
+      "name": "entity.projectile",
+      "active": true,
+      "tags": ["projectile"],
+      "transform": { "position": [0.0, 0.0, 0.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "player" },
+        "owner": { "type": "string", "value": "entity.player" }
+      }
+    },
+    {
+      "name": "entity.enemy",
+      "active": true,
+      "tags": ["combatant"],
+      "transform": { "position": [1.0, 0.0, 0.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "monster" },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 }
+      }
+    },
+    {
+      "name": "entity.ally",
+      "active": true,
+      "tags": ["combatant"],
+      "transform": { "position": [1.0, 0.0, 1.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "player" },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 }
+      }
+    },
+    {
+      "name": "entity.neutral",
+      "active": true,
+      "tags": ["combatant"],
+      "transform": { "position": [1.0, 0.0, -1.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "neutral" },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 }
+      }
+    }
+  ],
+  "signals": ["signal.blast", "signal.filtered_damage"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.blast",
+        "actions": [
+          {
+            "type": "effect.explosion",
+            "source": "entity.projectile",
+            "radius": 3.0,
+            "falloff": "constant",
+            "damage": 20.0,
+            "target_filter": {
+              "relationship": "hostile",
+              "include_tags": ["combatant"],
+              "exclude_owner": true,
+              "exclude_source": true
+            }
+          }
+        ]
+      },
+      {
+        "signal": "signal.filtered_damage",
+        "actions": [
+          {
+            "type": "combat.damage",
+            "source": "entity.player",
+            "target": "entity.ally",
+            "amount": 20.0,
+            "target_filter": { "relationship": "hostile" }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player", "entity.projectile", "entity.enemy", "entity.ally", "entity.neutral"]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "target_filters.game.json").string().c_str(), session, &runtime, error,
+                                          sizeof(error)))
+        << error;
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.blast"), nullptr);
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.filtered_damage"), nullptr);
+
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *enemy = sdl3d_game_data_find_actor(runtime, "entity.enemy");
+    sdl3d_registered_actor *ally = sdl3d_game_data_find_actor(runtime, "entity.ally");
+    sdl3d_registered_actor *neutral = sdl3d_game_data_find_actor(runtime, "entity.neutral");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(enemy, nullptr);
+    ASSERT_NE(ally, nullptr);
+    ASSERT_NE(neutral, nullptr);
+
+    EXPECT_NEAR(sdl3d_properties_get_float(player->props, "health", 0.0f), 100.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(enemy->props, "health", 0.0f), 80.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(ally->props, "health", 0.0f), 100.0f, 0.001f);
+    EXPECT_NEAR(sdl3d_properties_get_float(neutral->props, "health", 0.0f), 100.0f, 0.001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidFactionAndTargetFilterData)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_target_filters");
+    write_text(dir / "invalid_target_filters.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Target Filters", "id": "test.invalid_target_filters", "version": "0.1.0" },
+  "world": { "name": "world.invalid_target_filters", "kind": "fixed_screen" },
+  "factions": {
+    "player": { "monster": "very_hostile" }
+  },
+  "entities": [{ "name": "entity.actor", "active": true }],
+  "signals": ["signal.test"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.test",
+        "actions": [
+          {
+            "type": "effect.explosion",
+            "source": "entity.actor",
+            "radius": 1.0,
+            "target_filter": { "relationship": "hostile" }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "sdl3d.scene.v0", "name": "scene.play", "entities": ["entity.actor"] })json");
+
+    char error[512]{};
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "invalid_target_filters.game.json").string().c_str(), nullptr,
+                                               error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("faction relationships"), std::string::npos) << error;
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, EffectExplosionSupportsBoundedChainReactions)
 {
     const std::filesystem::path dir = unique_test_dir("effect_explosion_chain");


### PR DESCRIPTION
## Summary
- add a reusable faction relationship matrix and target_filter support for combat, hitscan, explosions, sensors, and sector platform crush hazards
- support faction/tag include-exclude filters plus source/self/owner exclusion policy
- validate faction relationships and target filter shapes, and document authoring guidance

## Tests
- cmake --build build/debug --target sdl3d_game_data_test -j8
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.TargetFiltersApplyFactionAndOwnerRules:GameDataRuntime.RejectsInvalidFactionAndTargetFilterData'
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug -j8
- ctest --test-dir build/debug --output-on-failure

Continues #282.