### PR TITLE
Add sector perception sensors

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1754,6 +1754,40 @@ Use `actor_tag` instead of `actor` to apply a sector sensor to every active
 actor with a matching tag. `sector_index` may be used instead of `sector` when
 the authored sector order is deliberate and stable.
 
+`sensor.perception` detects whether an observer can see one or more targets
+inside a sector level. It combines range, field-of-view, sector line-of-sight,
+and the standard `target_filter` object, so faction-aware AI perception can be
+authored without game-specific C. Use exactly one of `observer` or
+`observer_tag`, exactly one of `target` or `target_tag`, and a `sector_level`.
+The sensor supports `enter`, `stay` / `overlap`, and `exit` edges.
+
+```json
+{
+  "name": "sensor.guard.sees_enemy",
+  "type": "sensor.perception",
+  "observer": "entity.guard",
+  "target_tag": "actor",
+  "sector_level": "sector.dungeon",
+  "range": 18.0,
+  "fov_degrees": 120.0,
+  "observer_eye_height": 1.5,
+  "target_eye_height": 1.0,
+  "target_filter": { "relationship": "hostile" },
+  "edge": "stay",
+  "actions": [
+    { "type": "property.set", "target": "entity.guard", "key": "alerted", "value": true },
+    { "type": "property.set", "target_from_payload": "target_actor_name", "key": "was_seen", "value": true }
+  ]
+}
+```
+
+Use `min_dot` instead of `fov_degrees` when you want to author the dot-product
+threshold directly; `-1.0` means omnidirectional. `yaw_property` defaults to
+`yaw` and is used for field-of-view checks. The payload includes `actor_name`
+and `observer_actor_name` for the observer, `target_actor_name` and
+`other_actor_name` for the seen target, `sector_level`, `distance`,
+`perception_distance`, `range`, `origin`, and `target_position`.
+
 `sensor.volume` detects whether an actor is inside an authored axis-aligned 3D
 box. It supports the same `enter`, `stay` / `overlap`, and `exit` edges and
 publishes `actor_name` to actions or signals. Use it for trigger volumes such

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -51,6 +51,7 @@ typedef enum game_data_sensor_type
     GAME_DATA_SENSOR_BOUNDS_REFLECT,
     GAME_DATA_SENSOR_CONTACT_2D,
     GAME_DATA_SENSOR_INPUT_PRESSED,
+    GAME_DATA_SENSOR_PERCEPTION,
     GAME_DATA_SENSOR_SECTOR,
     GAME_DATA_SENSOR_VOLUME,
 } game_data_sensor_type;
@@ -133,6 +134,11 @@ typedef struct sensor_entry
     float min_value;
     float max_value;
     float threshold;
+    float range;
+    float min_dot;
+    float observer_eye_height;
+    float target_eye_height;
+    const char *yaw_property;
     sdl3d_vec3 volume_min;
     sdl3d_vec3 volume_max;
     int signal_id;
@@ -16474,20 +16480,22 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
             entry->type = GAME_DATA_SENSOR_CONTACT_2D;
         else if (SDL_strcmp(type, "sensor.input_pressed") == 0)
             entry->type = GAME_DATA_SENSOR_INPUT_PRESSED;
+        else if (SDL_strcmp(type, "sensor.perception") == 0)
+            entry->type = GAME_DATA_SENSOR_PERCEPTION;
         else if (SDL_strcmp(type, "sensor.sector") == 0)
             entry->type = GAME_DATA_SENSOR_SECTOR;
         else if (SDL_strcmp(type, "sensor.volume") == 0)
             entry->type = GAME_DATA_SENSOR_VOLUME;
 
         entry->name = json_string(sensor, "name", NULL);
-        entry->entity = json_string(sensor, "entity", json_string(sensor, "a", NULL));
+        entry->entity = json_string(sensor, "observer", json_string(sensor, "entity", json_string(sensor, "a", NULL)));
         if (entry->entity == NULL)
             entry->entity = json_string(sensor, "actor", NULL);
-        entry->other = json_string(sensor, "b", NULL);
-        entry->entity_tag = json_string(sensor, "a_tag", NULL);
+        entry->other = json_string(sensor, "target", json_string(sensor, "b", NULL));
+        entry->entity_tag = json_string(sensor, "observer_tag", json_string(sensor, "a_tag", NULL));
         if (entry->entity_tag == NULL)
             entry->entity_tag = json_string(sensor, "actor_tag", NULL);
-        entry->other_tag = json_string(sensor, "b_tag", NULL);
+        entry->other_tag = json_string(sensor, "target_tag", json_string(sensor, "b_tag", NULL));
         entry->sector_level = json_string(sensor, "sector_level", NULL);
         entry->sector = json_string(sensor, "sector", NULL);
         entry->sector_property = json_string(sensor, "sector_property", "current_sector");
@@ -16498,6 +16506,14 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
         entry->min_value = json_float(sensor, "min", 0.0f);
         entry->max_value = json_float(sensor, "max", 0.0f);
         entry->threshold = json_float(sensor, "threshold", 0.0f);
+        entry->range = json_float(sensor, "range", 64.0f);
+        entry->min_dot = SDL_clamp(json_float(sensor, "min_dot", -1.0f), -1.0f, 1.0f);
+        yyjson_val *fov_degrees = obj_get(sensor, "fov_degrees");
+        if (yyjson_is_num(fov_degrees))
+            entry->min_dot = SDL_cosf(SDL_clamp((float)yyjson_get_num(fov_degrees), 0.0f, 360.0f) * SDL_PI_F / 360.0f);
+        entry->observer_eye_height = json_float(sensor, "observer_eye_height", json_float(sensor, "eye_height", 0.0f));
+        entry->target_eye_height = json_float(sensor, "target_eye_height", entry->observer_eye_height);
+        entry->yaw_property = json_string(sensor, "yaw_property", "yaw");
         entry->volume_min = json_vec3(sensor, "min", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
         entry->volume_max = json_vec3(sensor, "max", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
         entry->actions = obj_get(sensor, "actions");
@@ -18322,6 +18338,170 @@ static void update_volume_sensor(sdl3d_game_data_runtime *runtime, sensor_entry 
     sensor_actor_list_free(&actors);
 }
 
+static bool perception_actor_in_field_of_view(const sensor_entry *sensor, const sdl3d_registered_actor *observer,
+                                              const sdl3d_registered_actor *target)
+{
+    if (sensor == NULL || observer == NULL || target == NULL)
+        return false;
+    if (sensor->min_dot <= -1.0f)
+        return true;
+
+    const float yaw = sdl3d_properties_get_float(observer->props, sensor->yaw_property, 0.0f);
+    const sdl3d_vec3 forward = sdl3d_vec3_make(SDL_sinf(yaw), 0.0f, -SDL_cosf(yaw));
+    sdl3d_vec3 to_target =
+        sdl3d_vec3_make(target->position.x - observer->position.x, 0.0f, target->position.z - observer->position.z);
+    if (sdl3d_vec3_length_squared(to_target) <= 0.000001f)
+        return true;
+    to_target = sdl3d_vec3_normalize(to_target);
+    return sdl3d_vec3_dot(forward, to_target) >= sensor->min_dot;
+}
+
+static bool perception_sensor_has_line_of_sight(const sensor_entry *sensor, const sector_level_runtime *level,
+                                                const sdl3d_registered_actor *observer,
+                                                const sdl3d_registered_actor *target, float *out_distance,
+                                                sdl3d_vec3 *out_origin, sdl3d_vec3 *out_target)
+{
+    if (sensor == NULL || level == NULL || observer == NULL || target == NULL)
+        return false;
+
+    const sdl3d_vec3 origin =
+        sdl3d_vec3_make(observer->position.x, observer->position.y + sensor->observer_eye_height, observer->position.z);
+    const sdl3d_vec3 target_point =
+        sdl3d_vec3_make(target->position.x, target->position.y + sensor->target_eye_height, target->position.z);
+    const sdl3d_vec3 delta = sdl3d_vec3_sub(target_point, origin);
+    const float distance = sdl3d_vec3_length(delta);
+    if (distance <= 0.000001f || distance > sensor->range)
+        return false;
+
+    if (out_distance != NULL)
+        *out_distance = distance;
+    if (out_origin != NULL)
+        *out_origin = origin;
+    if (out_target != NULL)
+        *out_target = target_point;
+
+    const sdl3d_vec3 direction = sdl3d_vec3_scale(delta, 1.0f / distance);
+    const sdl3d_level_trace_result trace =
+        sdl3d_level_trace_point(&level->lightmapped, level->sectors, origin, direction, distance);
+    return !trace.hit || SDL_clamp(trace.fraction, 0.0f, 1.0f) >= 0.995f;
+}
+
+static sdl3d_properties *create_perception_sensor_payload(const sensor_entry *sensor, const sector_level_runtime *level,
+                                                          const sdl3d_registered_actor *observer,
+                                                          const sdl3d_registered_actor *target, float distance,
+                                                          sdl3d_vec3 origin, sdl3d_vec3 target_point)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    sdl3d_properties_set_string(payload, "actor_name",
+                                observer != NULL && observer->name != NULL ? observer->name : "");
+    sdl3d_properties_set_string(payload, "observer_actor_name",
+                                observer != NULL && observer->name != NULL ? observer->name : "");
+    sdl3d_properties_set_string(payload, "target_actor_name",
+                                target != NULL && target->name != NULL ? target->name : "");
+    sdl3d_properties_set_string(payload, "other_actor_name",
+                                target != NULL && target->name != NULL ? target->name : "");
+    sdl3d_properties_set_string(payload, "sector_level", level != NULL && level->name != NULL ? level->name : "");
+    sdl3d_properties_set_float(payload, "distance", distance);
+    sdl3d_properties_set_float(payload, "perception_distance", distance);
+    sdl3d_properties_set_float(payload, "range", sensor != NULL ? sensor->range : 0.0f);
+    sdl3d_properties_set_vec3(payload, "origin", origin);
+    sdl3d_properties_set_vec3(payload, "target_position", target_point);
+    return payload;
+}
+
+static void emit_perception_sensor_signal(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                          const sector_level_runtime *level, sdl3d_registered_actor *observer,
+                                          sdl3d_registered_actor *target, float distance, sdl3d_vec3 origin,
+                                          sdl3d_vec3 target_point)
+{
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    if (bus == NULL || sensor == NULL || sensor->signal_id < 0)
+        return;
+
+    sdl3d_properties *payload =
+        create_perception_sensor_payload(sensor, level, observer, target, distance, origin, target_point);
+    sdl3d_signal_emit(bus, sensor->signal_id, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void execute_perception_sensor_actions(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                              const sector_level_runtime *level, sdl3d_registered_actor *observer,
+                                              sdl3d_registered_actor *target, float distance, sdl3d_vec3 origin,
+                                              sdl3d_vec3 target_point)
+{
+    if (runtime == NULL || sensor == NULL || !yyjson_is_arr(sensor->actions))
+        return;
+
+    sdl3d_properties *payload =
+        create_perception_sensor_payload(sensor, level, observer, target, distance, origin, target_point);
+    if (payload != NULL)
+        (void)execute_action_array(runtime, sensor->actions, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void update_perception_sensor_pair(sdl3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                          const sector_level_runtime *level, sdl3d_registered_actor *observer,
+                                          sdl3d_registered_actor *target)
+{
+    if (!runtime_actor_is_active(runtime, observer) || !runtime_actor_is_active(runtime, target) || observer == target)
+        return;
+
+    sensor_contact_pair_state *state = sensor_contact_pair_state_for(sensor, observer->name, target->name);
+    if (state == NULL)
+        return;
+
+    float distance = 0.0f;
+    sdl3d_vec3 origin = observer->position;
+    sdl3d_vec3 target_point = target->position;
+    bool active =
+        actor_matches_target_filter(runtime, target, observer, sensor->json, NULL, sensor->other_tag, true) &&
+        perception_actor_in_field_of_view(sensor, observer, target) &&
+        perception_sensor_has_line_of_sight(sensor, level, observer, target, &distance, &origin, &target_point);
+
+    const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                             : sensor_edge_is_stay(sensor) ? active
+                                                           : (active && !state->active);
+    if (should_emit)
+    {
+        emit_perception_sensor_signal(runtime, sensor, level, observer, target, distance, origin, target_point);
+        execute_perception_sensor_actions(runtime, sensor, level, observer, target, distance, origin, target_point);
+    }
+    state->active = active;
+    state->seen = true;
+}
+
+static void update_perception_sensor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    const sector_level_runtime *level = find_sector_level_runtime(runtime, sensor->sector_level);
+    if (level == NULL)
+        return;
+
+    sensor_actor_list observers;
+    sensor_actor_list targets;
+    SDL_zero(observers);
+    SDL_zero(targets);
+
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &observers) &&
+        collect_sensor_endpoint_actors(runtime, sensor->other, sensor->other_tag, &targets))
+    {
+        for (int observer_index = 0; observer_index < observers.count; ++observer_index)
+        {
+            for (int target_index = 0; target_index < targets.count; ++target_index)
+            {
+                update_perception_sensor_pair(runtime, sensor, level, observers.items[observer_index],
+                                              targets.items[target_index]);
+            }
+        }
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&observers);
+    sensor_actor_list_free(&targets);
+}
+
 static void update_sensors(sdl3d_game_data_runtime *runtime)
 {
     for (int i = 0; i < runtime->sensor_count; ++i)
@@ -18340,6 +18520,11 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
         if (sensor->type == GAME_DATA_SENSOR_VOLUME)
         {
             update_volume_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_PERCEPTION)
+        {
+            update_perception_sensor(runtime, sensor);
             continue;
         }
 

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7314,6 +7314,91 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
                 return false;
             continue;
         }
+        if (SDL_strcmp(type, "sensor.perception") == 0)
+        {
+            const char *observer = json_string(sensor, "observer");
+            if (observer == NULL)
+                observer = json_string(sensor, "entity");
+            if (observer == NULL)
+                observer = json_string(sensor, "actor");
+            const char *observer_tag = json_string(sensor, "observer_tag");
+            if (observer_tag == NULL)
+                observer_tag = json_string(sensor, "actor_tag");
+            const char *target = json_string(sensor, "target");
+            if (target == NULL)
+                target = json_string(sensor, "b");
+            const char *target_tag = json_string(sensor, "target_tag");
+            if (target_tag == NULL)
+                target_tag = json_string(sensor, "b_tag");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((observer == NULL && observer_tag == NULL) || (observer != NULL && observer_tag != NULL))
+                return validation_error(ctx, path,
+                                        "sensor.perception requires exactly one of observer or observer_tag");
+            if ((target == NULL && target_tag == NULL) || (target != NULL && target_tag != NULL))
+                return validation_error(ctx, path, "sensor.perception requires exactly one of target or target_tag");
+            if (observer != NULL && !require_actor_ref(ctx, names, observer, path))
+                return false;
+            if (target != NULL && !require_actor_ref(ctx, names, target, path))
+                return false;
+            if (observer_tag != NULL && observer_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.perception observer_tag must be non-empty");
+            if (target_tag != NULL && target_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.perception target_tag must be non-empty");
+            if (!require_ref(ctx, &names->sector_levels, "sector level", json_string(sensor, "sector_level"), path))
+                return false;
+            yyjson_val *range = obj_get(sensor, "range");
+            if (range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) <= 0.0))
+                return validation_error(ctx, path, "sensor.perception range must be positive");
+            yyjson_val *min_dot = obj_get(sensor, "min_dot");
+            if (min_dot != NULL &&
+                (!yyjson_is_num(min_dot) || yyjson_get_num(min_dot) < -1.0 || yyjson_get_num(min_dot) > 1.0))
+            {
+                return validation_error(ctx, path, "sensor.perception min_dot must be between -1 and 1");
+            }
+            yyjson_val *fov_degrees = obj_get(sensor, "fov_degrees");
+            if (fov_degrees != NULL && (!yyjson_is_num(fov_degrees) || yyjson_get_num(fov_degrees) <= 0.0 ||
+                                        yyjson_get_num(fov_degrees) > 360.0))
+            {
+                return validation_error(ctx, path, "sensor.perception fov_degrees must be in the range (0, 360]");
+            }
+            yyjson_val *observer_eye_height = obj_get(sensor, "observer_eye_height");
+            yyjson_val *target_eye_height = obj_get(sensor, "target_eye_height");
+            yyjson_val *eye_height = obj_get(sensor, "eye_height");
+            if ((observer_eye_height != NULL && !yyjson_is_num(observer_eye_height)) ||
+                (target_eye_height != NULL && !yyjson_is_num(target_eye_height)) ||
+                (eye_height != NULL && !yyjson_is_num(eye_height)))
+            {
+                return validation_error(ctx, path, "sensor.perception eye heights must be numeric");
+            }
+            yyjson_val *yaw_property = obj_get(sensor, "yaw_property");
+            if (yaw_property != NULL && (!yyjson_is_str(yaw_property) || yyjson_get_str(yaw_property)[0] == '\0'))
+                return validation_error(ctx, path, "sensor.perception yaw_property must be a non-empty string");
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path, "sensor.perception edge must be enter, stay, overlap, or exit");
+            }
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.perception"))
+                return false;
+            continue;
+        }
         if (SDL_strcmp(type, "sensor.sector") == 0)
         {
             const char *actor = json_string(sensor, "actor");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -11010,6 +11010,151 @@ TEST(GameDataRuntime, RunsAuthoredSectorHazardSensors)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredPerceptionSensorsWithSectorLineOfSightAndTargetFilters)
+{
+    const std::filesystem::path dir = unique_test_dir("perception_sensors");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.player", "entity.enemy.visible", "entity.enemy.blocked", "entity.friend"]
+})json");
+    write_text(dir / "perception_sensors.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Perception Sensor Test" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "factions": {
+    "player": { "enemy": "hostile", "civilian": "friendly" },
+    "enemy": { "player": "hostile" },
+    "civilian": { "player": "friendly" }
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [2.0, 1.0, 2.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "faction": { "type": "string", "value": "player" }
+      }
+    },
+    {
+      "name": "entity.enemy.visible",
+      "active": true,
+      "tags": ["npc"],
+      "transform": { "position": [2.0, 1.0, 0.75] },
+      "properties": {
+        "faction": { "type": "string", "value": "enemy" },
+        "spotted": { "type": "int", "value": 0 },
+        "last_distance": { "type": "float", "value": 0.0 },
+        "lost": { "type": "bool", "value": false }
+      }
+    },
+    {
+      "name": "entity.enemy.blocked",
+      "active": true,
+      "tags": ["npc"],
+      "transform": { "position": [6.0, 1.0, 2.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "enemy" },
+        "spotted": { "type": "int", "value": 0 }
+      }
+    },
+    {
+      "name": "entity.friend",
+      "active": true,
+      "tags": ["npc"],
+      "transform": { "position": [2.5, 1.0, 0.75] },
+      "properties": {
+        "faction": { "type": "string", "value": "civilian" },
+        "spotted": { "type": "int", "value": 0 }
+      }
+    }
+  ],
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [{ "name": "floor" }],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "wall_material": "floor"
+        }
+      ]
+    }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.enemy.visible",
+        "type": "sensor.perception",
+        "observer": "entity.player",
+        "target_tag": "npc",
+        "sector_level": "sector.test",
+        "range": 8.0,
+        "fov_degrees": 120.0,
+        "edge": "stay",
+        "target_filter": { "relationship": "hostile" },
+        "actions": [
+          { "type": "property.add", "target_from_payload": "target_actor_name", "key": "spotted", "value": 1 },
+          { "type": "property.set", "target_from_payload": "target_actor_name", "key": "last_distance", "value_from_payload": "distance" }
+        ]
+      },
+      {
+        "name": "sensor.enemy.lost",
+        "type": "sensor.perception",
+        "observer": "entity.player",
+        "target": "entity.enemy.visible",
+        "sector_level": "sector.test",
+        "range": 8.0,
+        "fov_degrees": 120.0,
+        "edge": "exit",
+        "target_filter": { "relationship": "hostile" },
+        "actions": [
+          { "type": "property.set", "target_from_payload": "target_actor_name", "key": "lost", "value": true }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "perception_sensors.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+    sdl3d_registered_actor *visible = sdl3d_game_data_find_actor(runtime, "entity.enemy.visible");
+    ASSERT_NE(visible, nullptr);
+    sdl3d_registered_actor *blocked = sdl3d_game_data_find_actor(runtime, "entity.enemy.blocked");
+    ASSERT_NE(blocked, nullptr);
+    sdl3d_registered_actor *friendly = sdl3d_game_data_find_actor(runtime, "entity.friend");
+    ASSERT_NE(friendly, nullptr);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(visible->props, "spotted", 0), 1);
+    EXPECT_GT(sdl3d_properties_get_float(visible->props, "last_distance", 0.0f), 1.0f);
+    EXPECT_EQ(sdl3d_properties_get_int(blocked->props, "spotted", 0), 0);
+    EXPECT_EQ(sdl3d_properties_get_int(friendly->props, "spotted", 0), 0);
+    EXPECT_FALSE(sdl3d_properties_get_bool(visible->props, "lost", false));
+
+    visible->position = sdl3d_vec3_make(2.0f, 1.0f, 3.5f);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(visible->props, "spotted", 0), 1);
+    EXPECT_TRUE(sdl3d_properties_get_bool(visible->props, "lost", false));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
 {
     const std::filesystem::path dir = unique_test_dir("sector_doors_invalid");
@@ -11075,6 +11220,25 @@ TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
               ]
             })json",
             "unknown sensor.sector sector",
+        },
+        {
+            "invalid_perception_sensor",
+            R"json([])json",
+            R"json({
+              "sensors": [
+                {
+                  "type": "sensor.perception",
+                  "observer": "entity.player",
+                  "target_tag": "enemy",
+                  "sector_level": "sector.test",
+                  "fov_degrees": 0,
+                  "actions": [
+                    { "type": "property.set", "target_from_payload": "target_actor_name", "key": "alert", "value": true }
+                  ]
+                }
+              ]
+            })json",
+            "sensor.perception fov_degrees",
         },
     };
 


### PR DESCRIPTION
## Summary
- add a generic `sensor.perception` primitive for sector line-of-sight, range, field-of-view, and target-filter based perception
- validate authored perception sensors and document their payload/JSON shape
- add focused game-data runtime and validation coverage for hostile-only perception, blocked line-of-sight, FOV exit behavior

Continues #282.

## Tests
- `cmake --build build/debug --target sdl3d_game_data_test -j8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.RunsAuthoredPerceptionSensorsWithSectorLineOfSightAndTargetFilters:GameDataRuntime.RejectsInvalidSectorDoorsAndActions'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j8`
- `ctest --test-dir build/debug --output-on-failure`