### PR TITLE
Add noise events and hearing sensors

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1788,6 +1788,51 @@ and `observer_actor_name` for the observer, `target_actor_name` and
 `other_actor_name` for the seen target, `sector_level`, `distance`,
 `perception_distance`, `range`, `origin`, and `target_position`.
 
+`noise.emit` creates a short-lived runtime noise event. It does not play audio
+by itself; pair it with `audio.play_sfx` when the game should also make an
+audible sound. A noise can come from `source`, `actor`, `target`, the matching
+`*_from_payload` fields, `from`, `from_payload`, or a literal `position` plus
+optional `offset`.
+
+```json
+{
+  "type": "noise.emit",
+  "source": "entity.imp",
+  "radius": 14.0,
+  "loudness": 1.0,
+  "duration": 0.25
+}
+```
+
+`sensor.hearing` lets actors react to those noise events. Use exactly one of
+`actor` or `actor_tag` to select listeners. `range` caps the listener's hearing
+range; the effective hearing radius is the smaller of the sensor range and the
+noise radius. Use `target_filter` to restrict the source actor by tag, owner, or
+faction relationship.
+
+```json
+{
+  "name": "sensor.guard.hears_hostile",
+  "type": "sensor.hearing",
+  "actor": "entity.guard",
+  "target_tag": "noisy",
+  "range": 18.0,
+  "target_filter": { "relationship": "hostile" },
+  "edge": "enter",
+  "actions": [
+    { "type": "property.set", "target": "entity.guard", "key": "alerted", "value": true },
+    { "type": "property.set", "target": "entity.guard", "key": "last_noise", "value_from_payload": "noise_position" }
+  ]
+}
+```
+
+The hearing payload includes `actor_name` and `listener_actor_name` for the
+listener, `source_actor_name`, `target_actor_name` when the noise source is an
+actor, `noise_id`, `noise_position`, `noise_radius`, `noise_loudness`,
+`distance`, `hearing_distance`, `audibility`, and `range`. `audibility` is
+linearly attenuated from the event loudness at the source to zero at the
+effective radius.
+
 `sensor.volume` detects whether an actor is inside an authored axis-aligned 3D
 box. It supports the same `enter`, `stay` / `overlap`, and `exit` edges and
 publishes `actor_name` to actions or signals. Use it for trigger volumes such

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -50,6 +50,7 @@ typedef enum game_data_sensor_type
     GAME_DATA_SENSOR_BOUNDS_EXIT,
     GAME_DATA_SENSOR_BOUNDS_REFLECT,
     GAME_DATA_SENSOR_CONTACT_2D,
+    GAME_DATA_SENSOR_HEARING,
     GAME_DATA_SENSOR_INPUT_PRESSED,
     GAME_DATA_SENSOR_PERCEPTION,
     GAME_DATA_SENSOR_SECTOR,
@@ -111,6 +112,8 @@ typedef struct sensor_contact_pair_state
 {
     const char *actor_name;
     const char *other_actor_name;
+    bool owns_actor_name;
+    bool owns_other_actor_name;
     bool active;
     bool seen;
 } sensor_contact_pair_state;
@@ -156,6 +159,17 @@ typedef struct wave_schedule_entry
     float elapsed;
     bool initialized;
 } wave_schedule_entry;
+
+typedef struct noise_event_runtime
+{
+    unsigned int id;
+    char key[32];
+    const char *source_actor_name;
+    sdl3d_vec3 position;
+    float radius;
+    float loudness;
+    float remaining_seconds;
+} noise_event_runtime;
 
 typedef struct sensor_actor_list
 {
@@ -517,6 +531,10 @@ typedef struct sdl3d_game_data_runtime
     int sensor_count;
     wave_schedule_entry *wave_schedules;
     int wave_schedule_count;
+    noise_event_runtime *noise_events;
+    int noise_event_count;
+    int noise_event_capacity;
+    unsigned int next_noise_event_id;
     input_binding_spec *input_bindings;
     int input_binding_count;
     int input_binding_capacity;
@@ -15770,6 +15788,68 @@ static bool execute_sector_door_interact_action(sdl3d_game_data_runtime *runtime
     return ok;
 }
 
+static sdl3d_registered_actor *noise_source_actor(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                                  const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *source =
+        actor_from_payload_key(runtime, payload, json_string(action, "source_from_payload", NULL));
+    if (source == NULL)
+        source = actor_from_payload_key(runtime, payload, json_string(action, "actor_from_payload", NULL));
+    if (source == NULL)
+        source = actor_from_payload_key(runtime, payload, json_string(action, "target_from_payload", NULL));
+    if (source == NULL)
+        source = sdl3d_game_data_find_actor(runtime, json_string(action, "source", NULL));
+    if (source == NULL)
+        source = sdl3d_game_data_find_actor(runtime, json_string(action, "actor", NULL));
+    if (source == NULL)
+        source = sdl3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+    return source;
+}
+
+static bool runtime_add_noise_event(sdl3d_game_data_runtime *runtime, const char *source_actor_name,
+                                    sdl3d_vec3 position, float radius, float loudness, float duration)
+{
+    if (runtime == NULL || radius <= 0.0f || duration <= 0.0f)
+        return false;
+    if (runtime->noise_event_count >= runtime->noise_event_capacity)
+    {
+        const int new_capacity = runtime->noise_event_capacity > 0 ? runtime->noise_event_capacity * 2 : 16;
+        noise_event_runtime *events =
+            (noise_event_runtime *)SDL_realloc(runtime->noise_events, (size_t)new_capacity * sizeof(*events));
+        if (events == NULL)
+            return false;
+        SDL_memset(events + runtime->noise_event_capacity, 0,
+                   (size_t)(new_capacity - runtime->noise_event_capacity) * sizeof(*events));
+        runtime->noise_events = events;
+        runtime->noise_event_capacity = new_capacity;
+    }
+
+    noise_event_runtime *event = &runtime->noise_events[runtime->noise_event_count++];
+    SDL_zero(*event);
+    event->id = ++runtime->next_noise_event_id;
+    if (event->id == 0U)
+        event->id = ++runtime->next_noise_event_id;
+    SDL_snprintf(event->key, sizeof(event->key), "noise.%u", event->id);
+    event->source_actor_name = source_actor_name;
+    event->position = position;
+    event->radius = radius;
+    event->loudness = loudness;
+    event->remaining_seconds = duration;
+    return true;
+}
+
+static bool execute_noise_emit_action(sdl3d_game_data_runtime *runtime, yyjson_val *action,
+                                      const sdl3d_properties *payload)
+{
+    sdl3d_registered_actor *source = noise_source_actor(runtime, action, payload);
+    const sdl3d_vec3 fallback = source != NULL ? source->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const sdl3d_vec3 position = actor_spawn_position_from_action(runtime, action, payload, fallback);
+    const float radius = SDL_max(json_float(action, "radius", json_float(action, "range", 16.0f)), 0.0f);
+    const float loudness = SDL_max(json_float(action, "loudness", 1.0f), 0.0f);
+    const float duration = SDL_max(json_float(action, "duration", json_float(action, "duration_seconds", 0.1f)), 0.0f);
+    return runtime_add_noise_event(runtime, source != NULL ? source->name : NULL, position, radius, loudness, duration);
+}
+
 static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *action, const sdl3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
@@ -16116,6 +16196,8 @@ static bool execute_one_action(sdl3d_game_data_runtime *runtime, yyjson_val *act
         return execute_interaction_use_action(runtime, action, payload);
     if (SDL_strcmp(type, "effect.explosion") == 0)
         return execute_effect_explosion_action(runtime, action, payload);
+    if (SDL_strcmp(type, "noise.emit") == 0)
+        return execute_noise_emit_action(runtime, action, payload);
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
@@ -16478,6 +16560,8 @@ static bool load_sensors(sdl3d_game_data_runtime *runtime, yyjson_val *logic)
             entry->type = GAME_DATA_SENSOR_CONTACT_2D;
         else if (SDL_strcmp(type, "collision.on_overlap") == 0)
             entry->type = GAME_DATA_SENSOR_CONTACT_2D;
+        else if (SDL_strcmp(type, "sensor.hearing") == 0)
+            entry->type = GAME_DATA_SENSOR_HEARING;
         else if (SDL_strcmp(type, "sensor.input_pressed") == 0)
             entry->type = GAME_DATA_SENSOR_INPUT_PRESSED;
         else if (SDL_strcmp(type, "sensor.perception") == 0)
@@ -17996,6 +18080,22 @@ static bool collect_sensor_endpoint_actors(sdl3d_game_data_runtime *runtime, con
     return true;
 }
 
+static bool sensor_contact_name_is_transient(const char *name)
+{
+    return name != NULL && SDL_strncmp(name, "noise.", 6) == 0;
+}
+
+static void sensor_contact_pair_destroy(sensor_contact_pair_state *state)
+{
+    if (state == NULL)
+        return;
+    if (state->owns_actor_name)
+        SDL_free((char *)state->actor_name);
+    if (state->owns_other_actor_name)
+        SDL_free((char *)state->other_actor_name);
+    SDL_zero(*state);
+}
+
 static sensor_contact_pair_state *sensor_contact_pair_state_for(sensor_entry *sensor, const char *actor_name,
                                                                 const char *other_actor_name)
 {
@@ -18027,8 +18127,31 @@ static sensor_contact_pair_state *sensor_contact_pair_state_for(sensor_entry *se
 
     sensor_contact_pair_state *state = &sensor->contact_pairs[sensor->contact_pair_count++];
     SDL_zero(*state);
-    state->actor_name = actor_name;
-    state->other_actor_name = other_actor_name;
+    if (sensor_contact_name_is_transient(actor_name))
+    {
+        state->actor_name = SDL_strdup(actor_name);
+        state->owns_actor_name = true;
+    }
+    else
+    {
+        state->actor_name = actor_name;
+    }
+    if (sensor_contact_name_is_transient(other_actor_name))
+    {
+        state->other_actor_name = SDL_strdup(other_actor_name);
+        state->owns_other_actor_name = true;
+    }
+    else
+    {
+        state->other_actor_name = other_actor_name;
+    }
+    if ((state->owns_actor_name && state->actor_name == NULL) ||
+        (state->owns_other_actor_name && state->other_actor_name == NULL))
+    {
+        sensor_contact_pair_destroy(state);
+        --sensor->contact_pair_count;
+        return NULL;
+    }
     return state;
 }
 
@@ -18084,12 +18207,26 @@ static void sensor_contact_states_end(sensor_entry *sensor)
     if (sensor == NULL)
         return;
     bool any_active = false;
+    int write_index = 0;
     for (int i = 0; i < sensor->contact_pair_count; ++i)
     {
-        if (!sensor->contact_pairs[i].seen)
-            sensor->contact_pairs[i].active = false;
-        any_active = any_active || sensor->contact_pairs[i].active;
+        sensor_contact_pair_state *state = &sensor->contact_pairs[i];
+        if (!state->seen)
+        {
+            if (sensor_contact_name_is_transient(state->actor_name) ||
+                sensor_contact_name_is_transient(state->other_actor_name))
+            {
+                sensor_contact_pair_destroy(state);
+                continue;
+            }
+            state->active = false;
+        }
+        any_active = any_active || state->active;
+        if (write_index != i)
+            sensor->contact_pairs[write_index] = *state;
+        ++write_index;
     }
+    sensor->contact_pair_count = write_index;
     sensor->was_active = any_active;
 }
 
@@ -18502,6 +18639,130 @@ static void update_perception_sensor(sdl3d_game_data_runtime *runtime, sensor_en
     sensor_actor_list_free(&targets);
 }
 
+static float noise_event_audibility(const sensor_entry *sensor, const noise_event_runtime *event,
+                                    const sdl3d_registered_actor *listener, float *out_distance)
+{
+    if (sensor == NULL || event == NULL || listener == NULL)
+        return 0.0f;
+    const sdl3d_vec3 delta = sdl3d_vec3_sub(event->position, listener->position);
+    const float distance = sdl3d_vec3_length(delta);
+    if (out_distance != NULL)
+        *out_distance = distance;
+    const float radius = SDL_min(sensor->range, event->radius);
+    if (radius <= 0.0f || distance > radius)
+        return 0.0f;
+    return event->loudness * SDL_clamp(1.0f - distance / radius, 0.0f, 1.0f);
+}
+
+static sdl3d_properties *create_hearing_sensor_payload(const sensor_entry *sensor, const noise_event_runtime *event,
+                                                       const sdl3d_registered_actor *listener,
+                                                       const sdl3d_registered_actor *source, float distance,
+                                                       float audibility)
+{
+    sdl3d_properties *payload = sdl3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    sdl3d_properties_set_string(payload, "actor_name",
+                                listener != NULL && listener->name != NULL ? listener->name : "");
+    sdl3d_properties_set_string(payload, "listener_actor_name",
+                                listener != NULL && listener->name != NULL ? listener->name : "");
+    sdl3d_properties_set_string(payload, "source_actor_name",
+                                event != NULL && event->source_actor_name != NULL ? event->source_actor_name : "");
+    sdl3d_properties_set_string(payload, "target_actor_name",
+                                source != NULL && source->name != NULL ? source->name : "");
+    sdl3d_properties_set_int(payload, "noise_id", event != NULL ? (int)event->id : 0);
+    sdl3d_properties_set_vec3(payload, "noise_position",
+                              event != NULL ? event->position : sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    sdl3d_properties_set_float(payload, "noise_radius", event != NULL ? event->radius : 0.0f);
+    sdl3d_properties_set_float(payload, "noise_loudness", event != NULL ? event->loudness : 0.0f);
+    sdl3d_properties_set_float(payload, "distance", distance);
+    sdl3d_properties_set_float(payload, "hearing_distance", distance);
+    sdl3d_properties_set_float(payload, "audibility", audibility);
+    sdl3d_properties_set_float(payload, "range", sensor != NULL ? sensor->range : 0.0f);
+    return payload;
+}
+
+static void emit_hearing_sensor_signal(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                       const noise_event_runtime *event, sdl3d_registered_actor *listener,
+                                       sdl3d_registered_actor *source, float distance, float audibility)
+{
+    sdl3d_signal_bus *bus = runtime_bus(runtime);
+    if (bus == NULL || sensor == NULL || sensor->signal_id < 0)
+        return;
+
+    sdl3d_properties *payload = create_hearing_sensor_payload(sensor, event, listener, source, distance, audibility);
+    sdl3d_signal_emit(bus, sensor->signal_id, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void execute_hearing_sensor_actions(sdl3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                           const noise_event_runtime *event, sdl3d_registered_actor *listener,
+                                           sdl3d_registered_actor *source, float distance, float audibility)
+{
+    if (runtime == NULL || sensor == NULL || !yyjson_is_arr(sensor->actions))
+        return;
+
+    sdl3d_properties *payload = create_hearing_sensor_payload(sensor, event, listener, source, distance, audibility);
+    if (payload != NULL)
+        (void)execute_action_array(runtime, sensor->actions, payload);
+    sdl3d_properties_destroy(payload);
+}
+
+static void update_hearing_sensor_listener(sdl3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                           sdl3d_registered_actor *listener)
+{
+    if (!runtime_actor_is_active(runtime, listener))
+        return;
+
+    for (int event_index = 0; event_index < runtime->noise_event_count; ++event_index)
+    {
+        const noise_event_runtime *event = &runtime->noise_events[event_index];
+        if (event->remaining_seconds <= 0.0f)
+            continue;
+
+        sdl3d_registered_actor *source = sdl3d_game_data_find_actor(runtime, event->source_actor_name);
+        if (event->source_actor_name != NULL &&
+            !actor_matches_target_filter(runtime, source, listener, sensor->json, NULL, sensor->other_tag, true))
+        {
+            continue;
+        }
+
+        float distance = 0.0f;
+        const float audibility = noise_event_audibility(sensor, event, listener, &distance);
+        const bool active = audibility > 0.0f;
+        sensor_contact_pair_state *state = sensor_contact_pair_state_for(sensor, listener->name, event->key);
+        if (state == NULL)
+            continue;
+
+        const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                                 : sensor_edge_is_stay(sensor) ? active
+                                                               : (active && !state->active);
+        if (should_emit)
+        {
+            emit_hearing_sensor_signal(runtime, sensor, event, listener, source, distance, audibility);
+            execute_hearing_sensor_actions(runtime, sensor, event, listener, source, distance, audibility);
+        }
+        state->active = active;
+        state->seen = true;
+    }
+}
+
+static void update_hearing_sensor(sdl3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    sensor_actor_list listeners;
+    SDL_zero(listeners);
+
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &listeners))
+    {
+        for (int i = 0; i < listeners.count; ++i)
+            update_hearing_sensor_listener(runtime, sensor, listeners.items[i]);
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&listeners);
+}
+
 static void update_sensors(sdl3d_game_data_runtime *runtime)
 {
     for (int i = 0; i < runtime->sensor_count; ++i)
@@ -18525,6 +18786,11 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
         if (sensor->type == GAME_DATA_SENSOR_PERCEPTION)
         {
             update_perception_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_HEARING)
+        {
+            update_hearing_sensor(runtime, sensor);
             continue;
         }
 
@@ -18571,6 +18837,26 @@ static void update_sensors(sdl3d_game_data_runtime *runtime)
             }
         }
     }
+}
+
+static void update_noise_events(sdl3d_game_data_runtime *runtime, float dt)
+{
+    if (runtime == NULL || runtime->noise_event_count <= 0)
+        return;
+
+    int write_index = 0;
+    for (int read_index = 0; read_index < runtime->noise_event_count; ++read_index)
+    {
+        noise_event_runtime event = runtime->noise_events[read_index];
+        event.remaining_seconds -= dt;
+        if (event.remaining_seconds > 0.0f)
+        {
+            if (write_index != read_index)
+                runtime->noise_events[write_index] = event;
+            ++write_index;
+        }
+    }
+    runtime->noise_event_count = write_index;
 }
 
 static float json_random_axis(sdl3d_game_data_runtime *runtime, yyjson_val *value, float fallback)
@@ -18692,6 +18978,7 @@ bool sdl3d_game_data_update(sdl3d_game_data_runtime *runtime, float dt)
     update_motion_components(runtime, root, dt);
     update_wave_schedules(runtime, dt);
     update_sensors(runtime);
+    update_noise_events(runtime, dt);
     actor_lifecycle_defer_end(runtime);
     return true;
 }
@@ -21273,9 +21560,14 @@ void sdl3d_game_data_destroy(sdl3d_game_data_runtime *runtime)
     SDL_free(runtime->adapters);
     SDL_free(runtime->bindings);
     for (int i = 0; i < runtime->sensor_count; ++i)
+    {
+        for (int pair_index = 0; pair_index < runtime->sensors[i].contact_pair_count; ++pair_index)
+            sensor_contact_pair_destroy(&runtime->sensors[i].contact_pairs[pair_index]);
         SDL_free(runtime->sensors[i].contact_pairs);
+    }
     SDL_free(runtime->sensors);
     SDL_free(runtime->wave_schedules);
+    SDL_free(runtime->noise_events);
     SDL_free(runtime->input_bindings);
     SDL_free(runtime->ui_states);
     SDL_free(runtime->animations);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -6666,6 +6666,56 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         return validate_interaction_use_action(ctx, action, json_path, names);
     if (SDL_strcmp(type, "effect.explosion") == 0)
         return validate_effect_explosion_action(ctx, action, json_path, names);
+    if (SDL_strcmp(type, "noise.emit") == 0)
+    {
+        const char *source = json_string(action, "source");
+        const char *actor = json_string(action, "actor");
+        const char *target = json_string(action, "target");
+        if (source != NULL && !require_actor_ref(ctx, names, source, json_path))
+            return false;
+        if (actor != NULL && !require_actor_ref(ctx, names, actor, json_path))
+            return false;
+        if (target != NULL && !require_actor_ref(ctx, names, target, json_path))
+            return false;
+
+        const char *payload_fields[] = {"source_from_payload", "actor_from_payload", "target_from_payload",
+                                        "from_payload"};
+        for (size_t i = 0; i < SDL_arraysize(payload_fields); ++i)
+        {
+            yyjson_val *value = obj_get(action, payload_fields[i]);
+            if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+                return validation_error(ctx, json_path, "noise.emit %s must be a non-empty string", payload_fields[i]);
+        }
+
+        yyjson_val *from = obj_get(action, "from");
+        if (from != NULL && (!yyjson_is_str(from) || yyjson_get_str(from)[0] == '\0'))
+            return validation_error(ctx, json_path, "noise.emit from must be a non-empty actor reference");
+        const char *from_actor = json_string(action, "from");
+        if (from_actor != NULL && !require_actor_ref(ctx, names, from_actor, json_path))
+            return false;
+        yyjson_val *position = obj_get(action, "position");
+        yyjson_val *offset = obj_get(action, "offset");
+        if (position != NULL && !is_vec_array(position, 3))
+            return validation_error(ctx, json_path, "noise.emit position must be a vec3");
+        if (offset != NULL && !is_vec_array(offset, 3))
+            return validation_error(ctx, json_path, "noise.emit offset must be a vec3");
+        yyjson_val *radius = obj_get(action, "radius");
+        yyjson_val *range = obj_get(action, "range");
+        yyjson_val *loudness = obj_get(action, "loudness");
+        yyjson_val *duration = obj_get(action, "duration");
+        yyjson_val *duration_seconds = obj_get(action, "duration_seconds");
+        if (radius != NULL && (!yyjson_is_num(radius) || yyjson_get_num(radius) <= 0.0))
+            return validation_error(ctx, json_path, "noise.emit radius must be positive");
+        if (range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) <= 0.0))
+            return validation_error(ctx, json_path, "noise.emit range must be positive");
+        if (loudness != NULL && (!yyjson_is_num(loudness) || yyjson_get_num(loudness) < 0.0))
+            return validation_error(ctx, json_path, "noise.emit loudness must be non-negative");
+        if (duration != NULL && (!yyjson_is_num(duration) || yyjson_get_num(duration) <= 0.0))
+            return validation_error(ctx, json_path, "noise.emit duration must be positive");
+        if (duration_seconds != NULL && (!yyjson_is_num(duration_seconds) || yyjson_get_num(duration_seconds) <= 0.0))
+            return validation_error(ctx, json_path, "noise.emit duration_seconds must be positive");
+        return true;
+    }
     if (SDL_strcmp(type, "sector_door.open") == 0 || SDL_strcmp(type, "sector_door.close") == 0 ||
         SDL_strcmp(type, "sector_door.toggle") == 0)
     {
@@ -7311,6 +7361,53 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
         {
             if (!require_ref(ctx, &names->actions, "input action", json_string(sensor, "action"), path) ||
                 !require_ref(ctx, &names->signals, "signal", json_string(sensor, "on_pressed"), path))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.hearing") == 0)
+        {
+            const char *actor = json_string(sensor, "actor");
+            if (actor == NULL)
+                actor = json_string(sensor, "entity");
+            const char *actor_tag = json_string(sensor, "actor_tag");
+            if (actor_tag == NULL)
+                actor_tag = json_string(sensor, "observer_tag");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((actor == NULL && actor_tag == NULL) || (actor != NULL && actor_tag != NULL))
+                return validation_error(ctx, path, "sensor.hearing requires exactly one of actor or actor_tag");
+            if (actor != NULL && !require_actor_ref(ctx, names, actor, path))
+                return false;
+            if (actor_tag != NULL && actor_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.hearing actor_tag must be non-empty");
+            yyjson_val *target_tag = obj_get(sensor, "target_tag");
+            if (target_tag != NULL && (!yyjson_is_str(target_tag) || yyjson_get_str(target_tag)[0] == '\0'))
+                return validation_error(ctx, path, "sensor.hearing target_tag must be non-empty");
+            yyjson_val *range = obj_get(sensor, "range");
+            if (range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) <= 0.0))
+                return validation_error(ctx, path, "sensor.hearing range must be positive");
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path, "sensor.hearing edge must be enter, stay, overlap, or exit");
+            }
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.hearing"))
                 return false;
             continue;
         }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -11155,6 +11155,133 @@ TEST(GameDataRuntime, RunsAuthoredPerceptionSensorsWithSectorLineOfSightAndTarge
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredHearingSensorsForNoiseEventsAndTargetFilters)
+{
+    const std::filesystem::path dir = unique_test_dir("hearing_sensors");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.listener", "entity.enemy", "entity.friend", "entity.far_enemy"]
+})json");
+    write_text(dir / "hearing_sensors.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Hearing Sensor Test" },
+  "world": { "name": "world.test", "kind": "sector" },
+  "signals": ["signal.enemy.noise", "signal.friend.noise", "signal.far.noise"],
+  "factions": {
+    "player": { "enemy": "hostile", "civilian": "friendly" },
+    "enemy": { "player": "hostile" },
+    "civilian": { "player": "friendly" }
+  },
+  "entities": [
+    {
+      "name": "entity.listener",
+      "active": true,
+      "transform": { "position": [0.0, 0.0, 0.0] },
+      "properties": {
+        "faction": { "type": "string", "value": "player" },
+        "heard_count": { "type": "int", "value": 0 },
+        "last_source": { "type": "string", "value": "" },
+        "last_audibility": { "type": "float", "value": 0.0 }
+      }
+    },
+    {
+      "name": "entity.enemy",
+      "active": true,
+      "tags": ["noisy"],
+      "transform": { "position": [2.0, 0.0, 0.0] },
+      "properties": { "faction": { "type": "string", "value": "enemy" } }
+    },
+    {
+      "name": "entity.friend",
+      "active": true,
+      "tags": ["noisy"],
+      "transform": { "position": [1.0, 0.0, 0.0] },
+      "properties": { "faction": { "type": "string", "value": "civilian" } }
+    },
+    {
+      "name": "entity.far_enemy",
+      "active": true,
+      "tags": ["noisy"],
+      "transform": { "position": [12.0, 0.0, 0.0] },
+      "properties": { "faction": { "type": "string", "value": "enemy" } }
+    }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.enemy.noise",
+        "actions": [{ "type": "noise.emit", "source": "entity.enemy", "radius": 6.0, "duration": 0.25 }]
+      },
+      {
+        "signal": "signal.friend.noise",
+        "actions": [{ "type": "noise.emit", "source": "entity.friend", "radius": 6.0, "duration": 0.25 }]
+      },
+      {
+        "signal": "signal.far.noise",
+        "actions": [{ "type": "noise.emit", "source": "entity.far_enemy", "radius": 6.0, "duration": 0.25 }]
+      }
+    ],
+    "sensors": [
+      {
+        "name": "sensor.listener.hears_hostile",
+        "type": "sensor.hearing",
+        "actor": "entity.listener",
+        "target_tag": "noisy",
+        "range": 8.0,
+        "edge": "enter",
+        "target_filter": { "relationship": "hostile" },
+        "actions": [
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "heard_count", "value": 1 },
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "last_source", "value_from_payload": "source_actor_name" },
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "last_audibility", "value_from_payload": "audibility" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "hearing_sensors.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+    sdl3d_registered_actor *listener = sdl3d_game_data_find_actor(runtime, "entity.listener");
+    ASSERT_NE(listener, nullptr);
+    sdl3d_signal_bus *bus = sdl3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.enemy.noise"), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(listener->props, "heard_count", 0), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(listener->props, "last_source", ""), "entity.enemy");
+    EXPECT_GT(sdl3d_properties_get_float(listener->props, "last_audibility", 0.0f), 0.0f);
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.friend.noise"), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(listener->props, "heard_count", 0), 1);
+    EXPECT_STREQ(sdl3d_properties_get_string(listener->props, "last_source", ""), "entity.enemy");
+
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.far.noise"), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(listener->props, "heard_count", 0), 1);
+
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.25f));
+    sdl3d_signal_emit(bus, sdl3d_game_data_find_signal(runtime, "signal.enemy.noise"), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(sdl3d_properties_get_int(listener->props, "heard_count", 0), 2);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
 {
     const std::filesystem::path dir = unique_test_dir("sector_doors_invalid");
@@ -11239,6 +11366,36 @@ TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
               ]
             })json",
             "sensor.perception fov_degrees",
+        },
+        {
+            "invalid_hearing_sensor",
+            R"json([])json",
+            R"json({
+              "sensors": [
+                {
+                  "type": "sensor.hearing",
+                  "actor": "entity.player",
+                  "range": 0,
+                  "actions": [
+                    { "type": "property.set", "target_from_payload": "actor_name", "key": "alert", "value": true }
+                  ]
+                }
+              ]
+            })json",
+            "sensor.hearing range",
+        },
+        {
+            "invalid_noise_action",
+            R"json([])json",
+            R"json({
+              "bindings": [
+                {
+                  "signal": "signal.run",
+                  "actions": [{ "type": "noise.emit", "source": "entity.player", "radius": 0 }]
+                }
+              ]
+            })json",
+            "noise.emit radius",
         },
     };
 


### PR DESCRIPTION
## Summary
- add generic `noise.emit` actions for short-lived runtime noise events
- add `sensor.hearing` with listener selection, range attenuation, edge behavior, and target-filter/faction support
- document the authored noise/hearing contract and payload fields
- add focused runtime and validation coverage, including transient noise key lifecycle handling

Continues #282 slice 9.

## Tests
- `cmake --build build/debug --target sdl3d_game_data_test -j8`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.RunsAuthoredHearingSensorsForNoiseEventsAndTargetFilters:GameDataRuntime.RejectsInvalidSectorDoorsAndActions'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j8`
- `ctest --test-dir build/debug --output-on-failure`