### PR TITLE
Codify display and world defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ targets. The generic `sdl3d_runner` can launch games from:
 The demo games are compatibility proofs for engine capabilities. New demo work
 should strengthen reusable systems instead of adding one-off host code.
 
+Default authored display and world conventions are intentionally simple:
+SDL3D games target a 1280x720 logical canvas that is letterboxed to preserve
+aspect ratio on the user's display, one world unit represents one meter, and
+perspective/FPS cameras default to a 90 degree vertical field of view unless a
+game authors a different value.
+
 ## Repository Layout
 
 - `include/`: public C headers

--- a/demos/doom_level/data/doom_level.game.json
+++ b/demos/doom_level/data/doom_level.game.json
@@ -26,7 +26,10 @@
   ],
   "app": {
     "title": "SDL3D Doom Level",
-    "window": { "width": 1280, "height": 720, "renderer": "opengl", "vsync": true },
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
     "audio": { "enabled": true },
     "startup_transition": "startup",
     "pause": { "action": "action.pause" },
@@ -38,13 +41,15 @@
   "world": {
     "name": "world.doom_level",
     "kind": "sector",
+    "units": "meters",
+    "meters_per_unit": 1.0,
     "ambient_light": [0.18, 0.18, 0.2],
     "cameras": [
       {
         "name": "camera.doom.player",
         "type": "fps",
         "target_entity": "entity.player",
-        "fovy": 65.0,
+        "fovy": 90.0,
         "active": true
       },
       {
@@ -52,7 +57,7 @@
         "type": "perspective",
         "position": [4.0, 3.25, 25.2],
         "target": [4.0, 0.15, 18.4],
-        "fovy": 70.0
+        "fovy": 90.0
       }
     ]
   },

--- a/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
+++ b/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
@@ -14,7 +14,10 @@
   ],
   "app": {
     "title": "SDL3D FPS Mechanics Dojo",
-    "window": { "width": 1280, "height": 720, "renderer": "opengl", "vsync": true },
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
     "pause": { "action": "action.pause" },
     "quit": { "action": "action.exit" },
     "input_policy": { "global_actions": ["action.exit"] }
@@ -22,13 +25,15 @@
   "world": {
     "name": "world.fps_mechanics_dojo",
     "kind": "sector",
+    "units": "meters",
+    "meters_per_unit": 1.0,
     "ambient_light": [0.16, 0.16, 0.2],
     "cameras": [
       {
         "name": "camera.dojo.player",
         "type": "fps",
         "target_entity": "entity.player",
-        "fovy": 68.0,
+        "fovy": 90.0,
         "active": true
       }
     ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -270,6 +270,14 @@ The optional `app` object configures the managed loop before the window exists:
 }
 ```
 
+The standard authored virtual resolution is 1280x720. The managed window path
+presents the logical resolution with letterboxing, so the game scales up or down
+to the user's display while preserving the authored 16:9 aspect ratio. Prefer
+root-level `logical_width` and `logical_height` for this virtual canvas. The
+optional `app.window.width` and `app.window.height` fields describe an initial
+desktop window size; they do not change the authored layout scale unless
+`app.window.logical_width` and `app.window.logical_height` are also set.
+
 `pause.action` toggles the managed runtime pause state when the active scene
 allows the action and `pause.allowed_if` is absent or true. `quit.action`
 requests shutdown through the managed app flow; when `quit.transition` names an
@@ -333,18 +341,21 @@ camera with their `camera` field, and logic actions can switch cameras with
 Camera types:
 
 - `orthographic`: fixed position/target/up with `size`.
-- `perspective`: fixed position/target/up with `fovy`.
+- `perspective`: fixed position/target/up with `fovy`. If omitted, the
+  vertical field of view defaults to 90 degrees.
 - `chase`: follows an actor named by `target_entity`. The forward vector comes
   from a Vec3 actor property such as `velocity` or an authored
   `camera_forward`, with `fallback_forward` used when that property is near
   zero. Use `chase_distance: 0` for actor-perspective cameras and larger
-  values for behind-the-actor chase cameras.
+  values for behind-the-actor chase cameras. If omitted, `fovy` defaults to 90
+  degrees.
 - `fps`: reads a first-person sector controller from `target_entity` and
   renders from that actor's eye position. If the controller has not updated
   yet, the camera falls back to the actor's `yaw`, `pitch`, and `view_smooth`
   properties. The controller also publishes a normalized view direction to
   `camera_forward` by default; override this with `forward_property` when a
-  game wants a different property name for projectile or camera logic.
+  game wants a different property name for projectile or camera logic. If
+  omitted, `fovy` defaults to 90 degrees.
 - `adapter`: delegates camera ownership to a native or Lua adapter.
 
 ## Storage And Persistence
@@ -393,7 +404,8 @@ any other specific world type.
   "world": {
     "name": "world.main",
     "kind": "fixed_screen",
-    "units": "world_units",
+    "units": "meters",
+    "meters_per_unit": 1.0,
     "axes": { "horizontal": "x", "vertical": "y", "depth": "z" },
     "bounds": { "min": [-9.0, -5.0, -1.0], "max": [9.0, 5.0, 2.0] },
     "cameras": [],
@@ -401,6 +413,11 @@ any other specific world type.
   }
 }
 ```
+
+SDL3D's default world convention is one authored world unit equals one meter
+(`units: "meters"`, `meters_per_unit: 1.0`). Author these fields explicitly in
+new games and demos so editors, physics tuning, movement speeds, and level
+metrics share the same scale vocabulary.
 
 World kinds may include fixed-screen playfields, tile grids, room graphs,
 sector/portal maps, brush worlds, or general 3D scenes as engine support

--- a/include/sdl3d/game.h
+++ b/include/sdl3d/game.h
@@ -30,6 +30,17 @@ extern "C"
 {
 #endif
 
+/**
+ * @brief Default authored virtual resolution for SDL3D games.
+ *
+ * The managed loop presents this logical resolution with letterboxing by
+ * default so games can scale to user displays while preserving aspect ratio.
+ */
+#define SDL3D_GAME_DEFAULT_LOGICAL_WIDTH 1280
+
+/** @brief Default authored virtual height for SDL3D games. */
+#define SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT 720
+
     /** @brief Opaque game-session container for genre-neutral runtime services. */
     typedef struct sdl3d_game_session sdl3d_game_session;
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -48,6 +48,15 @@ extern "C"
     /** @brief Maximum bytes stored for one dynamic menu row label or value, including room for terminator. */
 #define SDL3D_GAME_DATA_MENU_DYNAMIC_TEXT_CAPACITY 256U
 
+    /** @brief Default vertical field-of-view for authored perspective, chase, and FPS cameras. */
+#define SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES 90.0f
+
+    /** @brief Default world unit label. SDL3D convention is one authored world unit equals one meter. */
+#define SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS "meters"
+
+    /** @brief Default scale from authored world units to real-world meters. */
+#define SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT 1.0f
+
     /** @brief Opaque runtime created from one game JSON document. */
     typedef struct sdl3d_game_data_runtime sdl3d_game_data_runtime;
 
@@ -2093,6 +2102,17 @@ extern "C"
      */
     bool sdl3d_game_data_get_camera_float(const sdl3d_game_data_runtime *runtime, const char *camera_name,
                                           const char *property_name, float *out_value);
+
+    /**
+     * @brief Read the authored world unit convention.
+     *
+     * Games may omit these fields; SDL3D then reports the engine default:
+     * units="meters" and meters_per_unit=1.0. This is metadata for tools,
+     * editors, physics tuning, and documentation. The renderer interprets all
+     * authored positions consistently as world units.
+     */
+    bool sdl3d_game_data_get_world_units(const sdl3d_game_data_runtime *runtime, const char **out_units,
+                                         float *out_meters_per_unit);
 
     /** @brief Return the number of authored world lights. */
     int sdl3d_game_data_world_light_count(const sdl3d_game_data_runtime *runtime);

--- a/src/game.c
+++ b/src/game.c
@@ -9,8 +9,6 @@
 #include "sdl3d/logic.h"
 #include "sdl3d/time.h"
 
-#define SDL3D_GAME_DEFAULT_WIDTH 1280
-#define SDL3D_GAME_DEFAULT_HEIGHT 720
 #define SDL3D_GAME_DEFAULT_FIXED_DT (1.0f / 60.0f)
 #define SDL3D_GAME_DEFAULT_MAX_TICKS 8
 
@@ -389,9 +387,9 @@ static bool sdl3d_game_create_context(const sdl3d_game_config *config, sdl3d_gam
     sdl3d_window_config window_config;
     sdl3d_game_session_desc session_desc;
     const int logical_width =
-        (config != NULL && config->logical_width > 0) ? config->logical_width : SDL3D_GAME_DEFAULT_WIDTH;
+        (config != NULL && config->logical_width > 0) ? config->logical_width : SDL3D_GAME_DEFAULT_LOGICAL_WIDTH;
     const int logical_height =
-        (config != NULL && config->logical_height > 0) ? config->logical_height : SDL3D_GAME_DEFAULT_HEIGHT;
+        (config != NULL && config->logical_height > 0) ? config->logical_height : SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT;
 
     sdl3d_init_window_config(&window_config);
     window_config.width = (config != NULL && config->width > 0) ? config->width : logical_width;

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -5431,7 +5431,7 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
         if (target == NULL)
             return false;
 
-        const float fovy = json_float(camera_json, "fovy", 65.0f);
+        const float fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
         const fps_controller_runtime *controller = find_fps_controller_const(runtime, target->name);
         if (controller != NULL && controller->initialized)
         {
@@ -5494,7 +5494,7 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
         out_camera->target = sdl3d_vec3_make(anchor.x + velocity.x * lookahead, anchor.y + velocity.y * lookahead,
                                              anchor.z + target_z_offset);
         out_camera->up = json_vec3(camera_json, "up", sdl3d_vec3_make(0.0f, 0.0f, 1.0f));
-        out_camera->fovy = json_float(camera_json, "fovy", 60.0f);
+        out_camera->fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
         out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
         return true;
     }
@@ -5510,7 +5510,7 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
     else
     {
         out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
-        out_camera->fovy = json_float(camera_json, "fovy", 60.0f);
+        out_camera->fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
     }
     return true;
 }
@@ -5532,6 +5532,22 @@ bool sdl3d_game_data_get_camera_float(const sdl3d_game_data_runtime *runtime, co
 
     *out_value = (float)yyjson_get_num(value);
     return true;
+}
+
+bool sdl3d_game_data_get_world_units(const sdl3d_game_data_runtime *runtime, const char **out_units,
+                                     float *out_meters_per_unit)
+{
+    if (out_units != NULL)
+        *out_units = NULL;
+    if (out_meters_per_unit != NULL)
+        *out_meters_per_unit = 0.0f;
+    if (runtime == NULL || out_units == NULL || out_meters_per_unit == NULL)
+        return false;
+
+    yyjson_val *world = obj_get(runtime_root(runtime), "world");
+    *out_units = json_string(world, "units", SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    *out_meters_per_unit = json_float(world, "meters_per_unit", SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
+    return *out_units != NULL && (*out_units)[0] != '\0' && *out_meters_per_unit > 0.0f;
 }
 
 int sdl3d_game_data_world_light_count(const sdl3d_game_data_runtime *runtime)
@@ -19163,6 +19179,10 @@ static bool apply_app_config_from_root(yyjson_val *root, sdl3d_game_config *out_
             SDL_snprintf(title_buffer, (size_t)title_buffer_size, "%s", window_title);
             out_config->title = title_buffer;
         }
+        out_config->width = json_int(window, "window_width", json_int(window, "width", out_config->width));
+        out_config->height = json_int(window, "window_height", json_int(window, "height", out_config->height));
+        out_config->logical_width = json_int(window, "logical_width", out_config->logical_width);
+        out_config->logical_height = json_int(window, "logical_height", out_config->logical_height);
 #if defined(SDL3D_PRODUCTION_BUILD)
         const char *mode = json_string(window, "production_display_mode", json_string(window, "display_mode", NULL));
 #else

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7723,6 +7723,18 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     yyjson_val *app = obj_get(root, "app");
     if (!yyjson_is_obj(app))
         return true;
+    static const char *const app_dimension_fields[] = {"width",         "height",        "window_width",
+                                                       "window_height", "logical_width", "logical_height"};
+    for (size_t i = 0; i < SDL_arraysize(app_dimension_fields); ++i)
+    {
+        yyjson_val *dimension = obj_get(app, app_dimension_fields[i]);
+        if (dimension != NULL && (!yyjson_is_int(dimension) || yyjson_get_int(dimension) <= 0))
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.app.%s", app_dimension_fields[i]);
+            return validation_error(ctx, path, "app dimensions must be positive integers");
+        }
+    }
     const char *start_signal = json_string(app, "start_signal");
     if (start_signal != NULL && !require_ref(ctx, &names->signals, "signal", start_signal, "$.app.start_signal"))
         return false;
@@ -7742,6 +7754,16 @@ static bool validate_app_refs(validation_context *ctx, yyjson_val *root, validat
     yyjson_val *window = obj_get(app, "window");
     if (window != NULL && !yyjson_is_obj(window))
         return validation_error(ctx, "$.app.window", "window must be an object");
+    for (size_t i = 0; i < SDL_arraysize(app_dimension_fields); ++i)
+    {
+        yyjson_val *dimension = obj_get(window, app_dimension_fields[i]);
+        if (dimension != NULL && (!yyjson_is_int(dimension) || yyjson_get_int(dimension) <= 0))
+        {
+            char path[PATH_BUFFER_SIZE];
+            format_path(path, sizeof(path), "$.app.window.%s", app_dimension_fields[i]);
+            return validation_error(ctx, path, "app window dimensions must be positive integers");
+        }
+    }
     const char *window_apply_signal = json_string(window, "apply_signal");
     if (window_apply_signal != NULL &&
         !require_ref(ctx, &names->signals, "signal", window_apply_signal, "$.app.window.apply_signal"))
@@ -7895,6 +7917,12 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
         format_path(path, sizeof(path), "$.world.cameras[%zu]", i);
         yyjson_val *camera = yyjson_arr_get(cameras, i);
         const char *type = json_string(camera, "type");
+        yyjson_val *fovy = obj_get(camera, "fovy");
+        if (fovy != NULL && (!yyjson_is_num(fovy) || yyjson_get_num(fovy) <= 0.0 || yyjson_get_num(fovy) >= 180.0))
+            return validation_error(ctx, path, "camera fovy must be in the range (0, 180)");
+        yyjson_val *size = obj_get(camera, "size");
+        if (size != NULL && (!yyjson_is_num(size) || yyjson_get_num(size) <= 0.0))
+            return validation_error(ctx, path, "camera size must be positive");
         if (SDL_strcmp(type != NULL ? type : "", "adapter") == 0)
         {
             const char *adapter = json_string(camera, "adapter");
@@ -7917,6 +7945,23 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
                 return false;
         }
     }
+    return true;
+}
+
+static bool validate_world_metadata(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *world = obj_get(root, "world");
+    if (world == NULL)
+        return true;
+    if (!yyjson_is_obj(world))
+        return validation_error(ctx, "$.world", "world must be an object");
+
+    yyjson_val *units = obj_get(world, "units");
+    if (units != NULL && (!yyjson_is_str(units) || yyjson_get_str(units)[0] == '\0'))
+        return validation_error(ctx, "$.world.units", "world units must be a non-empty string");
+    yyjson_val *meters_per_unit = obj_get(world, "meters_per_unit");
+    if (meters_per_unit != NULL && (!yyjson_is_num(meters_per_unit) || yyjson_get_num(meters_per_unit) <= 0.0))
+        return validation_error(ctx, "$.world.meters_per_unit", "world meters_per_unit must be positive");
     return true;
 }
 
@@ -9181,10 +9226,10 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
 static bool validate_details(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     return validate_storage(ctx, root) && validate_persistence(ctx, root, names) && validate_factions(ctx, root) &&
-           validate_input_bindings(ctx, root) && validate_input_assignment_sets(ctx, root) &&
-           validate_input_profiles(ctx, root, names) && validate_grid_maps(ctx, root) &&
-           validate_grid_pickup_layers(ctx, root, names) && validate_sector_levels(ctx, root) &&
-           validate_components(ctx, root, names) &&
+           validate_world_metadata(ctx, root) && validate_input_bindings(ctx, root) &&
+           validate_input_assignment_sets(ctx, root) && validate_input_profiles(ctx, root, names) &&
+           validate_grid_maps(ctx, root) && validate_grid_pickup_layers(ctx, root, names) &&
+           validate_sector_levels(ctx, root) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6844,6 +6844,17 @@ TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
     const std::filesystem::path dojo_path = fps_mechanics_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
 
+    sdl3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(dojo_path.string().c_str(), &config, title, sizeof(title),
+                                                     app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "SDL3D FPS Mechanics Dojo");
+    EXPECT_EQ(config.logical_width, SDL3D_GAME_DEFAULT_LOGICAL_WIDTH);
+    EXPECT_EQ(config.logical_height, SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_OPENGL);
+
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
     char error[512]{};
@@ -6857,12 +6868,125 @@ TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_pad"), nullptr);
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_destination"), nullptr);
 
+    const char *units = nullptr;
+    float meters_per_unit = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_units(runtime, &units, &meters_per_unit));
+    EXPECT_STREQ(units, SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    EXPECT_FLOAT_EQ(meters_per_unit, SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
+    sdl3d_camera3d camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.dojo.player", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_FLOAT_EQ(camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+
     RenderPrimitiveCapture render{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &render));
     EXPECT_GE(render.cubes, 3);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, UsesDefaultWorldUnitsAndPerspectiveFovy)
+{
+    const std::filesystem::path dir = unique_test_dir("world_camera_defaults");
+    write_text(dir / "game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "World Camera Defaults" },
+  "world": {
+    "name": "world.defaults",
+    "kind": "3d",
+    "cameras": [
+      {
+        "name": "camera.default",
+        "type": "perspective",
+        "position": [0.0, 0.0, 2.0],
+        "target": [0.0, 0.0, 0.0]
+      }
+    ]
+  }
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(
+        sdl3d_game_data_load_file((dir / "game.json").string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char *units = nullptr;
+    float meters_per_unit = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_units(runtime, &units, &meters_per_unit));
+    EXPECT_STREQ(units, SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    EXPECT_FLOAT_EQ(meters_per_unit, SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
+    sdl3d_camera3d camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.default", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_FLOAT_EQ(camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidWorldDisplayAndCameraConventions)
+{
+    const std::filesystem::path dir = unique_test_dir("world_display_camera_validation");
+    struct Case
+    {
+        const char *name;
+        const char *json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "bad_logical_width",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Logical Width" },
+  "app": { "logical_width": 0 },
+  "world": { "name": "world.bad", "kind": "3d" }
+})json",
+            "app dimensions must be positive integers",
+        },
+        {
+            "bad_world_scale",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad World Scale" },
+  "world": { "name": "world.bad", "kind": "3d", "units": "meters", "meters_per_unit": 0.0 }
+})json",
+            "world meters_per_unit must be positive",
+        },
+        {
+            "bad_fovy",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad FOV" },
+  "world": {
+    "name": "world.bad",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.bad", "type": "perspective", "fovy": 180.0 }
+    ]
+  }
+})json",
+            "camera fovy must be in the range",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path path = dir / (std::string(test_case.name) + ".game.json");
+        write_text(path, test_case.json);
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+    remove_test_dir(dir);
 }
 
 TEST(GameDataRuntime, RejectsInvalidEditorMetadata)
@@ -10537,6 +10661,17 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
         sdl3d_free_image(&image);
     }
 
+    sdl3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(doom_path.string().c_str(), &config, title, sizeof(title),
+                                                     app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "SDL3D Doom Level");
+    EXPECT_EQ(config.logical_width, SDL3D_GAME_DEFAULT_LOGICAL_WIDTH);
+    EXPECT_EQ(config.logical_height, SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_OPENGL);
+
     sdl3d_game_session *session = nullptr;
     ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
     char error[512]{};
@@ -10546,6 +10681,11 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     ASSERT_NE(runtime, nullptr);
 
     ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.doom_level.play"));
+    const char *units = nullptr;
+    float meters_per_unit = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_units(runtime, &units, &meters_per_unit));
+    EXPECT_STREQ(units, SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    EXPECT_FLOAT_EQ(meters_per_unit, SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
     sdl3d_game_data_scene_skybox skybox{};
     ASSERT_TRUE(sdl3d_game_data_get_active_scene_skybox(runtime, &skybox));
     EXPECT_STREQ(skybox.pos_x, "image.doom.skybox.px");
@@ -10751,8 +10891,13 @@ TEST(GameDataRuntime, DoomLevelDataLoadsAuthoredSectorDoors)
     EXPECT_TRUE(damage_rect_visible);
     EXPECT_GT(resolved_damage_rect.color.a, 90);
     EXPECT_LT(resolved_damage_rect.color.a, 120);
+    sdl3d_camera3d player_camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.doom.player", &player_camera));
+    EXPECT_EQ(player_camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_FLOAT_EQ(player_camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
     sdl3d_camera3d surveillance_camera{};
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.doom.surveillance", &surveillance_camera));
+    EXPECT_FLOAT_EQ(surveillance_camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
     EXPECT_STREQ(sdl3d_game_data_active_camera(runtime), "camera.doom.player");
     player->position = sdl3d_vec3_make(43.0f, 0.5f, 89.0f);
     ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));


### PR DESCRIPTION
## Summary
- expose default SDL3D display/world conventions: 1280x720 logical canvas, meters as world units, and 90 degree perspective/FPS camera FOV
- parse and validate authored app/window dimensions, world units, world scale, and camera FOV/size metadata
- update Doom level and FPS mechanics dojo data to author 1280x720, meter units, and 90 degree cameras
- document the display/world conventions in README and game-data docs

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/debug --target sdl3d_game_data_test -j8
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug -j8
- ctest --test-dir build/debug --output-on-failure