### PR TITLE
Add sector navigation substrate

### DIFF
--- a/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
+++ b/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
@@ -8,6 +8,7 @@
   "imports": [
     { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
     { "path": "fragments/world/arena.json", "sections": ["sector_level_fragments", "sector_doors", "sector_platforms", "signals", "logic"] },
+    { "path": "fragments/world/navigation.json", "sections": ["sector_navigation"] },
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/actors/mechanic_markers.json", "sections": ["actor_archetypes", "actor_instances"] },
     { "path": "fragments/editor/metadata.json", "sections": ["editor"] }

--- a/demos/fps_mechanics_dojo/data/fragments/world/navigation.json
+++ b/demos/fps_mechanics_dojo/data/fragments/world/navigation.json
@@ -1,0 +1,20 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_navigation": [
+    {
+      "name": "nav.dojo.arena",
+      "sector_level": "sector.dojo.arena",
+      "nodes": [
+        { "name": "start.center", "sector": "start", "position": [5.0, 1.0, 5.0] },
+        { "name": "teleporter.center", "sector": "teleporter_room", "position": [14.0, 1.0, 5.0] },
+        { "name": "hazard.center", "sector": "hazard_lane", "position": [23.0, 1.0, 5.0] },
+        { "name": "lift.center", "sector": "lift_room", "position": [5.0, 1.0, 14.0] }
+      ],
+      "links": [
+        { "from": "start.center", "to": "teleporter.center" },
+        { "from": "teleporter.center", "to": "hazard.center" },
+        { "from": "start.center", "to": "lift.center" }
+      ]
+    }
+  ]
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -44,6 +44,7 @@ Every root game file is a JSON object.
 | `grid_pickup_layers` | no | Dense grid-indexed pickup layers rendered and collected without one actor per pickup. |
 | `sector_levels` | no | Authored sector/portal worlds for Doom/Quake-style indoor levels. |
 | `sector_level_fragments` | no | Composition-only material/sector/light fragments merged into named sector levels before validation. |
+| `sector_navigation` | no | Authored sector navigation graphs for AI/path queries in sector worlds. |
 | `sector_doors` | no | Runtime sliding doors for sector/FPS worlds. |
 | `sector_platforms` | no | Runtime moving floor/ceiling sectors for lifts, elevators, and oscillating platforms. |
 | `actor_archetypes` | no | Templates used by placed actor instances and runtime actor pools. |
@@ -558,6 +559,47 @@ data-authored debug/profile controls without custom host-side input code.
 Renderer, controller, and editor phases should consume runtime descriptors
 instead of parsing JSON directly. `world.kind` remains a high-level statement
 of spatial intent; `sector_levels` is the concrete sector-world data.
+
+## Sector Navigation
+
+`sector_navigation` declares reusable navigation graphs over authored
+`sector_levels`. The graph is intentionally explicit: authors decide which
+sector anchors are connected, which keeps AI pathing structurally correct even
+when the rendered sector mesh is complex.
+
+```json
+{
+  "sector_navigation": [
+    {
+      "name": "nav.level_1",
+      "sector_level": "sector.level_1",
+      "nodes": [
+        { "name": "start", "sector": "start_room", "position": [5.0, 1.0, 4.0] },
+        { "name": "hall", "sector": "north_hall", "position": [12.0, 1.0, 4.0] },
+        { "name": "arena", "sector": "arena", "position": [22.0, 1.0, 10.0] }
+      ],
+      "links": [
+        { "from": "start", "to": "hall" },
+        { "from": "hall", "to": "arena", "cost": 3.5 }
+      ]
+    }
+  ]
+}
+```
+
+Validation requires unique graph and node names, a valid `sector_level`, a
+non-empty `nodes` array, exact vec3 node `position` values, exactly one of
+`sector` or `sector_index` per node, link endpoints that reference declared
+nodes, optional boolean `bidirectional`, and positive optional `cost`. Links are
+bidirectional by default. When `cost` is omitted, runtime path queries use the
+world-space distance between linked nodes.
+
+Lua and C runtime helpers can query the nearest node, path availability, full
+node paths, or the next node toward a goal. Nearest-node lookup first prefers
+nodes in the sector containing the query position, then falls back to the
+nearest graph node. Keep dense per-frame steering in engine components or
+lightweight Lua; use sector navigation for high-level decisions such as patrol
+routes, chase goals, retreat points, and encounter scripting.
 
 `sector_doors` add dynamic, collidable door panels to sector/FPS scenes without
 hard-coding them in a demo host. A door has one or two axis-aligned panels,

--- a/docs/game-data-lua.md
+++ b/docs/game-data-lua.md
@@ -185,6 +185,10 @@ The runtime installs a small `sdl3d` table for low-level access and utility help
 - `sdl3d.grid_walkable(map, col, row)`
 - `sdl3d.grid_neighbors(map, col, row)`
 - `sdl3d.grid_next_step(map, start_col, start_row, goal_col, goal_row)`
+- `sdl3d.sector_nav_nearest(graph, x, y, z)`
+- `sdl3d.sector_nav_path_available(graph, sx, sy, sz, gx, gy, gz)`
+- `sdl3d.sector_nav_next_node(graph, sx, sy, sz, gx, gy, gz)`
+- `sdl3d.sector_nav_path(graph, sx, sy, sz, gx, gy, gz)`
 - `sdl3d.log(message)`
 - `sdl3d.storage.*`
 - `sdl3d.json.*`
@@ -215,6 +219,36 @@ game-specific decisions such as ghost target selection, spawn point selection,
 tile-trigger behavior, and authored maze debugging. Keep frequent movement
 integration in `motion.grid_agent`; use Lua to choose desired directions and
 high-level policy.
+
+## Sector Navigation
+
+Lua can query JSON-authored `sector_navigation` graphs for sector/FPS AI and
+encounter scripting:
+
+```lua
+local enemy = ctx:actor("entity.orc")
+local player = ctx:actor("entity.player")
+local next_node = ctx:sector_nav_next_node("nav.level_1", enemy, player)
+
+if next_node ~= nil then
+  enemy:set_vec3("desired_position", Vec3(next_node.x, next_node.y, next_node.z))
+end
+```
+
+Context helpers accept an actor wrapper, a `Vec3`, or a table with `x`, `y`,
+and `z` fields:
+
+- `ctx:sector_nav_nearest(graph, position)` returns a node table or `nil`
+- `ctx:sector_nav_path_available(graph, start, goal)` returns a boolean
+- `ctx:sector_nav_next_node(graph, start, goal)` returns the next node table or `nil`
+- `ctx:sector_nav_path(graph, start, goal)` returns an array of node tables with a `cost` field, or `nil`
+
+Node tables include `name`, `sector_index`, `x`, `y`, `z`, and numeric array
+entries `[1]`, `[2]`, `[3]`. Path queries anchor the start and goal positions
+to the nearest graph nodes, preferring nodes in the same sector when possible,
+then run Dijkstra over authored links. This is intended for high-level routing;
+avoid running many full path queries every frame for large actor crowds. Cache
+route intent in Lua or move dense steering into a reusable engine component.
 
 ## Actor Pools
 

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -1001,6 +1001,55 @@ extern "C"
     bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,
                                           sdl3d_game_data_sector_level *out_level);
 
+    /** @brief Runtime-owned node resolved from an authored sector navigation graph. */
+    typedef struct sdl3d_game_data_sector_nav_node
+    {
+        /** @brief Authored node name. */
+        const char *name;
+        /** @brief Sector index in the graph's sector level, or -1 when unresolved. */
+        int sector_index;
+        /** @brief World-space navigation anchor position. */
+        sdl3d_vec3 position;
+    } sdl3d_game_data_sector_nav_node;
+
+    /**
+     * @brief Find the nearest authored navigation node in a sector navigation graph.
+     *
+     * If @p position is inside the graph's sector level, nodes in that sector
+     * are preferred. If no same-sector node exists, the nearest node in the
+     * graph is returned. The returned node name is runtime-owned.
+     */
+    bool sdl3d_game_data_sector_nav_nearest_node(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                                 sdl3d_vec3 position, sdl3d_game_data_sector_nav_node *out_node);
+
+    /**
+     * @brief Resolve an authored sector navigation path between two world positions.
+     *
+     * The start and goal positions are first anchored to nearest nodes in the
+     * graph, then Dijkstra search is run across authored links. @p out_nodes
+     * may be NULL when the caller only needs @p out_node_count or @p out_cost.
+     * When @p out_nodes is non-NULL, @p max_nodes must be large enough for the
+     * full path or the function returns false.
+     */
+    bool sdl3d_game_data_sector_nav_path(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                         sdl3d_vec3 start, sdl3d_vec3 goal, sdl3d_game_data_sector_nav_node *out_nodes,
+                                         int max_nodes, int *out_node_count, float *out_cost);
+
+    /**
+     * @brief Return whether an authored sector navigation path exists between two positions.
+     */
+    bool sdl3d_game_data_sector_nav_path_available(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                                   sdl3d_vec3 start, sdl3d_vec3 goal);
+
+    /**
+     * @brief Resolve the next node after the start anchor on a sector navigation path.
+     *
+     * If the start and goal anchor to the same node, that node is returned.
+     */
+    bool sdl3d_game_data_sector_nav_next_node(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                              sdl3d_vec3 start, sdl3d_vec3 goal,
+                                              sdl3d_game_data_sector_nav_node *out_node);
+
     /**
      * @brief Iterate sector levels declared by the active scene.
      *

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -2012,6 +2012,112 @@ static int lua_grid_next_step(lua_State *lua)
     return 2;
 }
 
+static void lua_push_sector_nav_node(lua_State *lua, const sdl3d_game_data_sector_nav_node *node)
+{
+    if (node == NULL || node->name == NULL)
+    {
+        lua_pushnil(lua);
+        return;
+    }
+    lua_newtable(lua);
+    lua_pushstring(lua, node->name);
+    lua_setfield(lua, -2, "name");
+    lua_pushinteger(lua, node->sector_index);
+    lua_setfield(lua, -2, "sector_index");
+    lua_pushnumber(lua, (lua_Number)node->position.x);
+    lua_setfield(lua, -2, "x");
+    lua_pushnumber(lua, (lua_Number)node->position.y);
+    lua_setfield(lua, -2, "y");
+    lua_pushnumber(lua, (lua_Number)node->position.z);
+    lua_setfield(lua, -2, "z");
+    lua_pushnumber(lua, (lua_Number)node->position.x);
+    lua_rawseti(lua, -2, 1);
+    lua_pushnumber(lua, (lua_Number)node->position.y);
+    lua_rawseti(lua, -2, 2);
+    lua_pushnumber(lua, (lua_Number)node->position.z);
+    lua_rawseti(lua, -2, 3);
+}
+
+static sdl3d_vec3 lua_vec3_args(lua_State *lua, int first_index)
+{
+    return sdl3d_vec3_make((float)luaL_checknumber(lua, first_index), (float)luaL_checknumber(lua, first_index + 1),
+                           (float)luaL_checknumber(lua, first_index + 2));
+}
+
+static int lua_sector_nav_nearest(lua_State *lua)
+{
+    sdl3d_game_data_sector_nav_node node;
+    const char *graph = luaL_checkstring(lua, 1);
+    const sdl3d_vec3 position = lua_vec3_args(lua, 2);
+    if (!sdl3d_game_data_sector_nav_nearest_node(lua_runtime(lua), graph, position, &node))
+    {
+        lua_pushnil(lua);
+        return 1;
+    }
+    lua_push_sector_nav_node(lua, &node);
+    return 1;
+}
+
+static int lua_sector_nav_path_available(lua_State *lua)
+{
+    const char *graph = luaL_checkstring(lua, 1);
+    const sdl3d_vec3 start = lua_vec3_args(lua, 2);
+    const sdl3d_vec3 goal = lua_vec3_args(lua, 5);
+    lua_pushboolean(lua, sdl3d_game_data_sector_nav_path_available(lua_runtime(lua), graph, start, goal));
+    return 1;
+}
+
+static int lua_sector_nav_next_node(lua_State *lua)
+{
+    sdl3d_game_data_sector_nav_node node;
+    const char *graph = luaL_checkstring(lua, 1);
+    const sdl3d_vec3 start = lua_vec3_args(lua, 2);
+    const sdl3d_vec3 goal = lua_vec3_args(lua, 5);
+    if (!sdl3d_game_data_sector_nav_next_node(lua_runtime(lua), graph, start, goal, &node))
+    {
+        lua_pushnil(lua);
+        return 1;
+    }
+    lua_push_sector_nav_node(lua, &node);
+    return 1;
+}
+
+static int lua_sector_nav_path(lua_State *lua)
+{
+    const char *graph = luaL_checkstring(lua, 1);
+    const sdl3d_vec3 start = lua_vec3_args(lua, 2);
+    const sdl3d_vec3 goal = lua_vec3_args(lua, 5);
+    int node_count = 0;
+    float cost = 0.0f;
+    if (!sdl3d_game_data_sector_nav_path(lua_runtime(lua), graph, start, goal, NULL, 0, &node_count, &cost) ||
+        node_count <= 0)
+    {
+        lua_pushnil(lua);
+        return 1;
+    }
+
+    sdl3d_game_data_sector_nav_node *nodes =
+        (sdl3d_game_data_sector_nav_node *)SDL_malloc(sizeof(sdl3d_game_data_sector_nav_node) * (size_t)node_count);
+    if (nodes == NULL ||
+        !sdl3d_game_data_sector_nav_path(lua_runtime(lua), graph, start, goal, nodes, node_count, &node_count, &cost))
+    {
+        SDL_free(nodes);
+        lua_pushnil(lua);
+        return 1;
+    }
+
+    lua_newtable(lua);
+    for (int i = 0; i < node_count; ++i)
+    {
+        lua_push_sector_nav_node(lua, &nodes[i]);
+        lua_rawseti(lua, -2, i + 1);
+    }
+    lua_pushnumber(lua, (lua_Number)cost);
+    lua_setfield(lua, -2, "cost");
+    SDL_free(nodes);
+    return 1;
+}
+
 static void install_lua_helpers(lua_State *lua)
 {
     static const char *source_parts[] = {
@@ -2259,6 +2365,53 @@ static void install_lua_helpers(lua_State *lua)
         "        grid_pickup_count = function(self_or_layer, maybe_layer)\n"
         "            return sdl3d.grid_pickup_count(maybe_layer or self_or_layer)\n"
         "        end,\n",
+        "        sector_nav_nearest = function(self_or_graph, maybe_graph, maybe_position)\n"
+        "            local graph, position\n"
+        "            if type(self_or_graph) == 'table' and self_or_graph.adapter ~= nil then\n"
+        "                graph, position = maybe_graph, maybe_position\n"
+        "            else\n"
+        "                graph, position = self_or_graph, maybe_graph\n"
+        "            end\n"
+        "            if type(position) == 'table' and position.position ~= nil then position = position.position end\n"
+        "            position = as_vec3(position)\n"
+        "            return sdl3d.sector_nav_nearest(graph, position.x, position.y, position.z)\n"
+        "        end,\n"
+        "        sector_nav_path_available = function(self_or_graph, maybe_graph, maybe_start, maybe_goal)\n"
+        "            local graph, start, goal\n"
+        "            if type(self_or_graph) == 'table' and self_or_graph.adapter ~= nil then\n"
+        "                graph, start, goal = maybe_graph, maybe_start, maybe_goal\n"
+        "            else\n"
+        "                graph, start, goal = self_or_graph, maybe_graph, maybe_start\n"
+        "            end\n"
+        "            if type(start) == 'table' and start.position ~= nil then start = start.position end\n"
+        "            if type(goal) == 'table' and goal.position ~= nil then goal = goal.position end\n"
+        "            start, goal = as_vec3(start), as_vec3(goal)\n"
+        "            return sdl3d.sector_nav_path_available(graph, start.x, start.y, start.z, goal.x, goal.y, goal.z)\n"
+        "        end,\n"
+        "        sector_nav_next_node = function(self_or_graph, maybe_graph, maybe_start, maybe_goal)\n"
+        "            local graph, start, goal\n"
+        "            if type(self_or_graph) == 'table' and self_or_graph.adapter ~= nil then\n"
+        "                graph, start, goal = maybe_graph, maybe_start, maybe_goal\n"
+        "            else\n"
+        "                graph, start, goal = self_or_graph, maybe_graph, maybe_start\n"
+        "            end\n"
+        "            if type(start) == 'table' and start.position ~= nil then start = start.position end\n"
+        "            if type(goal) == 'table' and goal.position ~= nil then goal = goal.position end\n"
+        "            start, goal = as_vec3(start), as_vec3(goal)\n"
+        "            return sdl3d.sector_nav_next_node(graph, start.x, start.y, start.z, goal.x, goal.y, goal.z)\n"
+        "        end,\n"
+        "        sector_nav_path = function(self_or_graph, maybe_graph, maybe_start, maybe_goal)\n"
+        "            local graph, start, goal\n"
+        "            if type(self_or_graph) == 'table' and self_or_graph.adapter ~= nil then\n"
+        "                graph, start, goal = maybe_graph, maybe_start, maybe_goal\n"
+        "            else\n"
+        "                graph, start, goal = self_or_graph, maybe_graph, maybe_start\n"
+        "            end\n"
+        "            if type(start) == 'table' and start.position ~= nil then start = start.position end\n"
+        "            if type(goal) == 'table' and goal.position ~= nil then goal = goal.position end\n"
+        "            start, goal = as_vec3(start), as_vec3(goal)\n"
+        "            return sdl3d.sector_nav_path(graph, start.x, start.y, start.z, goal.x, goal.y, goal.z)\n"
+        "        end,\n",
         "        state_get = function(self_or_key, maybe_key, fallback)\n"
         "            if type(self_or_key) == 'table' and self_or_key.adapter ~= nil then\n"
         "                return sdl3d.state_get(maybe_key, fallback)\n"
@@ -2382,6 +2535,10 @@ static void register_lua_api(sdl3d_game_data_runtime *runtime, sdl3d_script_engi
     SDL3D_LUA_BIND("grid_pickup_at", lua_grid_pickup_at);
     SDL3D_LUA_BIND("grid_collect_at", lua_grid_collect_at);
     SDL3D_LUA_BIND("grid_pickup_count", lua_grid_pickup_count);
+    SDL3D_LUA_BIND("sector_nav_nearest", lua_sector_nav_nearest);
+    SDL3D_LUA_BIND("sector_nav_path_available", lua_sector_nav_path_available);
+    SDL3D_LUA_BIND("sector_nav_next_node", lua_sector_nav_next_node);
+    SDL3D_LUA_BIND("sector_nav_path", lua_sector_nav_path);
     SDL3D_LUA_BIND("log", lua_log);
     SDL3D_LUA_BIND("storage_read", lua_storage_read);
     SDL3D_LUA_BIND("storage_write", lua_storage_write);
@@ -6460,6 +6617,286 @@ static int sector_level_find_sector_name(const sector_level_runtime *level, cons
             return i;
     }
     return -1;
+}
+
+static yyjson_val *find_sector_navigation_graph(const sdl3d_game_data_runtime *runtime, const char *graph_name)
+{
+    yyjson_val *graphs = obj_get(runtime_root(runtime), "sector_navigation");
+    for (size_t i = 0; graph_name != NULL && yyjson_is_arr(graphs) && i < yyjson_arr_size(graphs); ++i)
+    {
+        yyjson_val *graph = yyjson_arr_get(graphs, i);
+        const char *name = json_string(graph, "name", NULL);
+        if (name != NULL && SDL_strcmp(name, graph_name) == 0)
+            return graph;
+    }
+    return NULL;
+}
+
+static const sector_level_runtime *sector_navigation_level(const sdl3d_game_data_runtime *runtime, yyjson_val *graph)
+{
+    return find_sector_level_runtime(runtime, json_string(graph, "sector_level", NULL));
+}
+
+static int sector_navigation_node_count(yyjson_val *graph)
+{
+    yyjson_val *nodes = obj_get(graph, "nodes");
+    return yyjson_is_arr(nodes) ? (int)yyjson_arr_size(nodes) : 0;
+}
+
+static yyjson_val *sector_navigation_node_at(yyjson_val *graph, int index)
+{
+    yyjson_val *nodes = obj_get(graph, "nodes");
+    return index >= 0 && yyjson_is_arr(nodes) && index < (int)yyjson_arr_size(nodes)
+               ? yyjson_arr_get(nodes, (size_t)index)
+               : NULL;
+}
+
+static int sector_navigation_node_sector_index(const sector_level_runtime *level, yyjson_val *node)
+{
+    if (level == NULL || node == NULL)
+        return -1;
+    const int authored_index = json_int(node, "sector_index", -1);
+    if (authored_index >= 0 && authored_index < level->sector_count)
+        return authored_index;
+    return sector_level_find_sector_name(level, json_string(node, "sector", NULL));
+}
+
+static bool sector_navigation_read_node(const sdl3d_game_data_runtime *runtime, yyjson_val *graph, int index,
+                                        sdl3d_game_data_sector_nav_node *out_node)
+{
+    const sector_level_runtime *level = sector_navigation_level(runtime, graph);
+    yyjson_val *node = sector_navigation_node_at(graph, index);
+    if (level == NULL || node == NULL || out_node == NULL)
+        return false;
+
+    out_node->name = json_string(node, "name", NULL);
+    out_node->sector_index = sector_navigation_node_sector_index(level, node);
+    out_node->position = json_vec3(node, "position", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return out_node->name != NULL && out_node->sector_index >= 0;
+}
+
+static int sector_navigation_find_node_index(yyjson_val *graph, const char *node_name)
+{
+    const int node_count = sector_navigation_node_count(graph);
+    for (int i = 0; node_name != NULL && i < node_count; ++i)
+    {
+        yyjson_val *node = sector_navigation_node_at(graph, i);
+        const char *name = json_string(node, "name", NULL);
+        if (name != NULL && SDL_strcmp(name, node_name) == 0)
+            return i;
+    }
+    return -1;
+}
+
+static float sector_navigation_distance_squared(sdl3d_vec3 a, sdl3d_vec3 b)
+{
+    const float dx = a.x - b.x;
+    const float dy = a.y - b.y;
+    const float dz = a.z - b.z;
+    return dx * dx + dy * dy + dz * dz;
+}
+
+static float sector_navigation_link_default_cost(const sdl3d_game_data_runtime *runtime, yyjson_val *graph, int from,
+                                                 int to)
+{
+    sdl3d_game_data_sector_nav_node from_node;
+    sdl3d_game_data_sector_nav_node to_node;
+    if (!sector_navigation_read_node(runtime, graph, from, &from_node) ||
+        !sector_navigation_read_node(runtime, graph, to, &to_node))
+    {
+        return 1.0f;
+    }
+    return SDL_sqrtf(sector_navigation_distance_squared(from_node.position, to_node.position));
+}
+
+static int sector_navigation_nearest_index(const sdl3d_game_data_runtime *runtime, yyjson_val *graph,
+                                           sdl3d_vec3 position)
+{
+    const sector_level_runtime *level = sector_navigation_level(runtime, graph);
+    const int node_count = sector_navigation_node_count(graph);
+    if (level == NULL || node_count <= 0)
+        return -1;
+
+    const int containing_sector =
+        sdl3d_level_find_sector_at(&level->lightmapped, level->sectors, position.x, position.z, position.y);
+    int best_index = -1;
+    float best_distance = 1.0e30f;
+    for (int pass = 0; pass < 2 && best_index < 0; ++pass)
+    {
+        const bool same_sector_only = pass == 0 && containing_sector >= 0;
+        for (int i = 0; i < node_count; ++i)
+        {
+            sdl3d_game_data_sector_nav_node node;
+            if (!sector_navigation_read_node(runtime, graph, i, &node))
+                continue;
+            if (same_sector_only && node.sector_index != containing_sector)
+                continue;
+            const float distance = sector_navigation_distance_squared(position, node.position);
+            if (best_index < 0 || distance < best_distance)
+            {
+                best_index = i;
+                best_distance = distance;
+            }
+        }
+    }
+    return best_index;
+}
+
+bool sdl3d_game_data_sector_nav_nearest_node(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                             sdl3d_vec3 position, sdl3d_game_data_sector_nav_node *out_node)
+{
+    yyjson_val *graph = find_sector_navigation_graph(runtime, graph_name);
+    const int index = sector_navigation_nearest_index(runtime, graph, position);
+    return index >= 0 && sector_navigation_read_node(runtime, graph, index, out_node);
+}
+
+bool sdl3d_game_data_sector_nav_path(const sdl3d_game_data_runtime *runtime, const char *graph_name, sdl3d_vec3 start,
+                                     sdl3d_vec3 goal, sdl3d_game_data_sector_nav_node *out_nodes, int max_nodes,
+                                     int *out_node_count, float *out_cost)
+{
+    if (out_node_count != NULL)
+        *out_node_count = 0;
+    if (out_cost != NULL)
+        *out_cost = 0.0f;
+
+    yyjson_val *graph = find_sector_navigation_graph(runtime, graph_name);
+    const int node_count = sector_navigation_node_count(graph);
+    const int start_index = sector_navigation_nearest_index(runtime, graph, start);
+    const int goal_index = sector_navigation_nearest_index(runtime, graph, goal);
+    if (graph == NULL || node_count <= 0 || start_index < 0 || goal_index < 0)
+        return false;
+
+    float *distances = (float *)SDL_malloc(sizeof(float) * (size_t)node_count);
+    int *previous = (int *)SDL_malloc(sizeof(int) * (size_t)node_count);
+    bool *visited = (bool *)SDL_calloc((size_t)node_count, sizeof(bool));
+    int *reverse_path = (int *)SDL_malloc(sizeof(int) * (size_t)node_count);
+    if (distances == NULL || previous == NULL || visited == NULL || reverse_path == NULL)
+    {
+        SDL_free(distances);
+        SDL_free(previous);
+        SDL_free(visited);
+        SDL_free(reverse_path);
+        return false;
+    }
+
+    for (int i = 0; i < node_count; ++i)
+    {
+        distances[i] = 1.0e30f;
+        previous[i] = -1;
+    }
+    distances[start_index] = 0.0f;
+
+    for (;;)
+    {
+        int current = -1;
+        float current_distance = 1.0e30f;
+        for (int i = 0; i < node_count; ++i)
+        {
+            if (!visited[i] && distances[i] < current_distance)
+            {
+                current = i;
+                current_distance = distances[i];
+            }
+        }
+        if (current < 0 || current == goal_index)
+            break;
+        visited[current] = true;
+
+        yyjson_val *links = obj_get(graph, "links");
+        for (size_t link_index = 0; yyjson_is_arr(links) && link_index < yyjson_arr_size(links); ++link_index)
+        {
+            yyjson_val *link = yyjson_arr_get(links, link_index);
+            const int from = sector_navigation_find_node_index(graph, json_string(link, "from", NULL));
+            const int to = sector_navigation_find_node_index(graph, json_string(link, "to", NULL));
+            const bool bidirectional = json_bool(link, "bidirectional", true);
+            int neighbor = -1;
+            if (from == current)
+                neighbor = to;
+            else if (bidirectional && to == current)
+                neighbor = from;
+            if (neighbor < 0 || neighbor >= node_count || visited[neighbor])
+                continue;
+
+            const float cost = SDL_max(
+                json_float(link, "cost", sector_navigation_link_default_cost(runtime, graph, current, neighbor)),
+                0.0001f);
+            const float candidate = distances[current] + cost;
+            if (candidate < distances[neighbor])
+            {
+                distances[neighbor] = candidate;
+                previous[neighbor] = current;
+            }
+        }
+    }
+
+    bool ok = start_index == goal_index || previous[goal_index] >= 0;
+    int path_count = 0;
+    if (ok)
+    {
+        for (int node = goal_index; node >= 0 && path_count < node_count; node = previous[node])
+            reverse_path[path_count++] = node;
+        if (path_count <= 0 || reverse_path[path_count - 1] != start_index)
+            ok = false;
+    }
+
+    if (ok)
+    {
+        if (out_node_count != NULL)
+            *out_node_count = path_count;
+        if (out_cost != NULL)
+            *out_cost = distances[goal_index];
+        if (out_nodes != NULL)
+        {
+            if (max_nodes < path_count)
+            {
+                ok = false;
+            }
+            else
+            {
+                for (int i = 0; i < path_count; ++i)
+                {
+                    const int source_index = reverse_path[path_count - 1 - i];
+                    if (!sector_navigation_read_node(runtime, graph, source_index, &out_nodes[i]))
+                    {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    SDL_free(distances);
+    SDL_free(previous);
+    SDL_free(visited);
+    SDL_free(reverse_path);
+    return ok;
+}
+
+bool sdl3d_game_data_sector_nav_path_available(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                               sdl3d_vec3 start, sdl3d_vec3 goal)
+{
+    return sdl3d_game_data_sector_nav_path(runtime, graph_name, start, goal, NULL, 0, NULL, NULL);
+}
+
+bool sdl3d_game_data_sector_nav_next_node(const sdl3d_game_data_runtime *runtime, const char *graph_name,
+                                          sdl3d_vec3 start, sdl3d_vec3 goal, sdl3d_game_data_sector_nav_node *out_node)
+{
+    int node_count = 0;
+    if (!sdl3d_game_data_sector_nav_path(runtime, graph_name, start, goal, NULL, 0, &node_count, NULL) ||
+        node_count <= 0)
+        return false;
+
+    sdl3d_game_data_sector_nav_node *nodes =
+        (sdl3d_game_data_sector_nav_node *)SDL_malloc(sizeof(sdl3d_game_data_sector_nav_node) * (size_t)node_count);
+    if (nodes == NULL)
+        return false;
+    const bool ok =
+        sdl3d_game_data_sector_nav_path(runtime, graph_name, start, goal, nodes, node_count, &node_count, NULL);
+    if (ok && out_node != NULL)
+        *out_node = nodes[node_count > 1 ? 1 : 0];
+    SDL_free(nodes);
+    return ok;
 }
 
 bool sdl3d_game_data_get_sector_level(const sdl3d_game_data_runtime *runtime, const char *name,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -77,6 +77,7 @@ typedef struct validation_names
     name_table grid_maps;
     name_table grid_pickup_layers;
     name_table sector_levels;
+    name_table sector_navigation;
     name_table sector_doors;
     name_table sector_platforms;
     name_table signals;
@@ -1901,6 +1902,7 @@ static bool import_section_name_allowed(const char *name)
                                           "grid_pickup_layers",
                                           "sector_levels",
                                           "sector_level_fragments",
+                                          "sector_navigation",
                                           "sector_doors",
                                           "sector_platforms",
                                           "actor_archetypes",
@@ -3270,6 +3272,23 @@ static bool collect_sector_levels(validation_context *ctx, yyjson_val *root, val
     return true;
 }
 
+static bool collect_sector_navigation(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *graphs = obj_get(root, "sector_navigation");
+    for (size_t i = 0; yyjson_is_arr(graphs) && i < yyjson_arr_size(graphs); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.sector_navigation[%zu]", i);
+        yyjson_val *graph = yyjson_arr_get(graphs, i);
+        if (!require_unique_name(ctx, &names->sector_navigation, "sector navigation graph", json_string(graph, "name"),
+                                 path))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool collect_sector_doors(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *doors = obj_get(root, "sector_doors");
@@ -3931,16 +3950,16 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_grid_maps(ctx, root, names) && collect_grid_pickup_layers(ctx, root, names) &&
-           collect_sector_levels(ctx, root, names) && collect_sector_doors(ctx, root, names) &&
-           collect_sector_platforms(ctx, root, names) && collect_actor_archetypes(ctx, root, names) &&
-           collect_actor_pools(ctx, root, names) && collect_scripts(ctx, root, names) &&
-           collect_adapters(ctx, root, names) && collect_input_actions(ctx, root, names) &&
-           collect_input_assignment_sets(ctx, root, names) && collect_input_profiles(ctx, root, names) &&
-           collect_network_input_channels(ctx, root, names) && collect_cameras(ctx, root, names) &&
-           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
-           collect_images(ctx, root, names) && collect_models(ctx, root, names) &&
-           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
-           collect_sensors(ctx, root, names);
+           collect_sector_levels(ctx, root, names) && collect_sector_navigation(ctx, root, names) &&
+           collect_sector_doors(ctx, root, names) && collect_sector_platforms(ctx, root, names) &&
+           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
+           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
+           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
+           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
+           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
+           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
+           collect_models(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -5084,6 +5103,127 @@ static bool sector_level_has_sector_index(yyjson_val *root, const char *level_na
     yyjson_val *level = find_sector_level_json(root, level_name);
     yyjson_val *sectors = obj_get(level, "sectors");
     return yyjson_is_arr(sectors) && sector_index >= 0 && (size_t)sector_index < yyjson_arr_size(sectors);
+}
+
+static bool validate_sector_navigation(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *graphs = obj_get(root, "sector_navigation");
+    if (graphs == NULL)
+        return true;
+    if (!yyjson_is_arr(graphs))
+        return validation_error(ctx, "$.sector_navigation", "sector_navigation must be an array");
+
+    for (size_t graph_index = 0; graph_index < yyjson_arr_size(graphs); ++graph_index)
+    {
+        char graph_path[PATH_BUFFER_SIZE];
+        format_path(graph_path, sizeof(graph_path), "$.sector_navigation[%zu]", graph_index);
+        yyjson_val *graph = yyjson_arr_get(graphs, graph_index);
+        yyjson_val *nodes = obj_get(graph, "nodes");
+        yyjson_val *links = obj_get(graph, "links");
+        name_table node_names;
+        SDL_zero(node_names);
+        bool ok = true;
+
+        if (!yyjson_is_obj(graph))
+        {
+            ok = validation_error(ctx, graph_path, "sector navigation graph entries must be objects");
+            goto done;
+        }
+        const char *level = json_string(graph, "sector_level");
+        if (!require_ref(ctx, &names->sector_levels, "sector level", level, graph_path))
+        {
+            ok = false;
+            goto done;
+        }
+        if (!yyjson_is_arr(nodes) || yyjson_arr_size(nodes) <= 0 || yyjson_arr_size(nodes) > 1024)
+        {
+            ok = validation_error(ctx, graph_path, "sector navigation nodes must be a non-empty array of <=1024 nodes");
+            goto done;
+        }
+        if (links != NULL && !yyjson_is_arr(links))
+        {
+            ok = validation_error(ctx, graph_path, "sector navigation links must be an array");
+            goto done;
+        }
+
+        for (size_t node_index = 0; ok && node_index < yyjson_arr_size(nodes); ++node_index)
+        {
+            char node_path[PATH_BUFFER_SIZE];
+            format_path(node_path, sizeof(node_path), "%s.nodes[%zu]", graph_path, node_index);
+            yyjson_val *node = yyjson_arr_get(nodes, node_index);
+            if (!yyjson_is_obj(node))
+            {
+                ok = validation_error(ctx, node_path, "sector navigation nodes must be objects");
+                break;
+            }
+            if (!require_unique_name(ctx, &node_names, "sector navigation node", json_string(node, "name"), node_path))
+            {
+                ok = false;
+                break;
+            }
+            if (!is_exact_vec_array(obj_get(node, "position"), 3))
+            {
+                ok = validation_error(ctx, node_path, "sector navigation node position must be a vec3");
+                break;
+            }
+            const char *sector = json_string(node, "sector");
+            yyjson_val *sector_index = obj_get(node, "sector_index");
+            if ((sector == NULL && sector_index == NULL) || (sector != NULL && sector_index != NULL))
+            {
+                ok = validation_error(ctx, node_path,
+                                      "sector navigation node requires exactly one of sector or sector_index");
+                break;
+            }
+            if (sector != NULL && !sector_level_has_sector_name(root, level, sector))
+            {
+                ok = validation_error(ctx, node_path, "unknown sector navigation node sector '%s'", sector);
+                break;
+            }
+            if (sector_index != NULL &&
+                (!yyjson_is_int(sector_index) ||
+                 !sector_level_has_sector_index(root, level, (int)yyjson_get_int(sector_index))))
+            {
+                ok = validation_error(ctx, node_path, "sector navigation node sector_index is out of range");
+                break;
+            }
+        }
+
+        for (size_t link_index = 0; ok && yyjson_is_arr(links) && link_index < yyjson_arr_size(links); ++link_index)
+        {
+            char link_path[PATH_BUFFER_SIZE];
+            format_path(link_path, sizeof(link_path), "%s.links[%zu]", graph_path, link_index);
+            yyjson_val *link = yyjson_arr_get(links, link_index);
+            if (!yyjson_is_obj(link))
+            {
+                ok = validation_error(ctx, link_path, "sector navigation links must be objects");
+                break;
+            }
+            if (!require_ref(ctx, &node_names, "sector navigation node", json_string(link, "from"), link_path) ||
+                !require_ref(ctx, &node_names, "sector navigation node", json_string(link, "to"), link_path))
+            {
+                ok = false;
+                break;
+            }
+            yyjson_val *bidirectional = obj_get(link, "bidirectional");
+            yyjson_val *cost = obj_get(link, "cost");
+            if (bidirectional != NULL && !yyjson_is_bool(bidirectional))
+            {
+                ok = validation_error(ctx, link_path, "sector navigation link bidirectional must be a boolean");
+                break;
+            }
+            if (cost != NULL && (!yyjson_is_num(cost) || yyjson_get_num(cost) <= 0.0))
+            {
+                ok = validation_error(ctx, link_path, "sector navigation link cost must be positive");
+                break;
+            }
+        }
+
+    done:
+        name_table_destroy(&node_names);
+        if (!ok)
+            return false;
+    }
+    return true;
 }
 
 static bool validate_sector_platforms(validation_context *ctx, yyjson_val *root, validation_names *names)
@@ -9229,7 +9369,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_world_metadata(ctx, root) && validate_input_bindings(ctx, root) &&
            validate_input_assignment_sets(ctx, root) && validate_input_profiles(ctx, root, names) &&
            validate_grid_maps(ctx, root) && validate_grid_pickup_layers(ctx, root, names) &&
-           validate_sector_levels(ctx, root) && validate_components(ctx, root, names) &&
+           validate_sector_levels(ctx, root) && validate_sector_navigation(ctx, root, names) &&
+           validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
@@ -9257,6 +9398,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->grid_maps);
     name_table_destroy(&names->grid_pickup_layers);
     name_table_destroy(&names->sector_levels);
+    name_table_destroy(&names->sector_navigation);
     name_table_destroy(&names->sector_doors);
     name_table_destroy(&names->sector_platforms);
     name_table_destroy(&names->signals);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -9598,6 +9598,118 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredSectorNavigationQueries)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_navigation");
+    write_text(dir / "scripts" / "nav.lua",
+               R"lua(
+local nav = {}
+function nav.inspect(_, _, ctx)
+    local start = Vec3(1.0, 1.0, 1.0)
+    local goal = Vec3(9.0, 1.0, 1.0)
+    local next_node = ctx:sector_nav_next_node("nav.test", start, goal)
+    ctx:state_set("lua_path_available", ctx:sector_nav_path_available("nav.test", start, goal))
+    ctx:state_set("lua_next_node", next_node ~= nil and next_node.name or "none")
+    local path = ctx:sector_nav_path("nav.test", start, goal)
+    ctx:state_set("lua_path_count", path ~= nil and #path or 0)
+end
+return nav
+)lua");
+    write_text(dir / "sector_navigation.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Sector Navigation Test" },
+  "scripts": [
+    { "id": "script.nav", "path": "scripts/nav.lua", "module": "test.nav" }
+  ],
+  "adapters": [
+    { "name": "adapter.nav.inspect", "kind": "action", "script": "script.nav", "function": "inspect" }
+  ],
+  "signals": ["signal.nav.inspect"],
+  "logic": {
+    "bindings": [
+      { "signal": "signal.nav.inspect", "actions": [{ "type": "adapter.invoke", "adapter": "adapter.nav.inspect" }] }
+    ]
+  },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [
+        { "name": "floor", "albedo": [0.7, 0.7, 0.7, 1.0] },
+        { "name": "wall", "albedo": [0.2, 0.25, 0.35, 1.0] }
+      ],
+      "sectors": [
+        { "name": "room", "points": [[0, 0], [4, 0], [4, 4], [0, 4]], "floor_y": 0.0, "ceil_y": 3.0, "floor_material": "floor", "ceil_material": "wall", "wall_material": "wall" },
+        { "name": "hall", "points": [[4, 0], [8, 0], [8, 4], [4, 4]], "floor_y": 0.0, "ceil_y": 3.0, "floor_material": "floor", "ceil_material": "wall", "wall_material": "wall" },
+        { "name": "goal", "points": [[8, 0], [12, 0], [12, 4], [8, 4]], "floor_y": 0.0, "ceil_y": 3.0, "floor_material": "floor", "ceil_material": "wall", "wall_material": "wall" },
+        { "name": "isolated", "points": [[20, 0], [24, 0], [24, 4], [20, 4]], "floor_y": 0.0, "ceil_y": 3.0, "floor_material": "floor", "ceil_material": "wall", "wall_material": "wall" }
+      ]
+    }
+  ],
+  "sector_navigation": [
+    {
+      "name": "nav.test",
+      "sector_level": "sector.test",
+      "nodes": [
+        { "name": "room.center", "sector": "room", "position": [2.0, 1.0, 2.0] },
+        { "name": "hall.center", "sector": "hall", "position": [6.0, 1.0, 2.0] },
+        { "name": "goal.center", "sector": "goal", "position": [10.0, 1.0, 2.0] },
+        { "name": "isolated.center", "sector": "isolated", "position": [22.0, 1.0, 2.0] }
+      ],
+      "links": [
+        { "from": "room.center", "to": "hall.center" },
+        { "from": "hall.center", "to": "goal.center" }
+      ]
+    }
+  ]
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "sector_navigation.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    sdl3d_game_data_sector_nav_node nearest{};
+    ASSERT_TRUE(
+        sdl3d_game_data_sector_nav_nearest_node(runtime, "nav.test", sdl3d_vec3_make(1.0f, 1.0f, 1.0f), &nearest));
+    EXPECT_STREQ(nearest.name, "room.center");
+    EXPECT_EQ(nearest.sector_index, 0);
+
+    sdl3d_game_data_sector_nav_node path[4]{};
+    int node_count = 0;
+    float cost = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_sector_nav_path(runtime, "nav.test", sdl3d_vec3_make(1.0f, 1.0f, 1.0f),
+                                                sdl3d_vec3_make(9.0f, 1.0f, 1.0f), path, 4, &node_count, &cost));
+    ASSERT_EQ(node_count, 3);
+    EXPECT_STREQ(path[0].name, "room.center");
+    EXPECT_STREQ(path[1].name, "hall.center");
+    EXPECT_STREQ(path[2].name, "goal.center");
+    EXPECT_GT(cost, 0.0f);
+
+    sdl3d_game_data_sector_nav_node next{};
+    ASSERT_TRUE(sdl3d_game_data_sector_nav_next_node(runtime, "nav.test", sdl3d_vec3_make(1.0f, 1.0f, 1.0f),
+                                                     sdl3d_vec3_make(9.0f, 1.0f, 1.0f), &next));
+    EXPECT_STREQ(next.name, "hall.center");
+    EXPECT_FALSE(sdl3d_game_data_sector_nav_path_available(runtime, "nav.test", sdl3d_vec3_make(1.0f, 1.0f, 1.0f),
+                                                           sdl3d_vec3_make(22.0f, 1.0f, 2.0f)));
+
+    const int signal = sdl3d_game_data_find_signal(runtime, "signal.nav.inspect");
+    ASSERT_GE(signal, 0);
+    sdl3d_signal_emit(sdl3d_game_session_get_signal_bus(session), signal, nullptr);
+    const sdl3d_properties *scene_state = sdl3d_game_data_scene_state(runtime);
+    EXPECT_TRUE(sdl3d_properties_get_bool(scene_state, "lua_path_available", false));
+    EXPECT_STREQ(sdl3d_properties_get_string(scene_state, "lua_next_node", ""), "hall.center");
+    EXPECT_EQ(sdl3d_properties_get_int(scene_state, "lua_path_count", 0), 3);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ResolvesActiveSceneSectorLevelInstances)
 {
     const std::filesystem::path dir = unique_test_dir("sector_level_scene");
@@ -9683,6 +9795,79 @@ TEST(GameDataRuntime, ResolvesActiveSceneSectorLevelInstances)
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidSectorNavigationGraphs)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_navigation_invalid");
+    struct InvalidSectorNavigationCase
+    {
+        const char *name;
+        const char *navigation_json;
+        const char *error_substring;
+    };
+    const InvalidSectorNavigationCase cases[] = {
+        {"unknown_sector",
+         R"json([{
+           "name": "nav.bad",
+           "sector_level": "sector.test",
+           "nodes": [{ "name": "a", "sector": "missing", "position": [1.0, 1.0, 1.0] }]
+         }])json",
+         "unknown sector navigation node sector"},
+        {"unknown_link_node",
+         R"json([{
+           "name": "nav.bad",
+           "sector_level": "sector.test",
+           "nodes": [{ "name": "a", "sector": "room", "position": [1.0, 1.0, 1.0] }],
+           "links": [{ "from": "a", "to": "missing" }]
+         }])json",
+         "unknown sector navigation node reference"},
+        {"bad_cost",
+         R"json([{
+           "name": "nav.bad",
+           "sector_level": "sector.test",
+           "nodes": [
+             { "name": "a", "sector": "room", "position": [1.0, 1.0, 1.0] },
+             { "name": "b", "sector": "room", "position": [2.0, 1.0, 1.0] }
+           ],
+           "links": [{ "from": "a", "to": "b", "cost": 0.0 }]
+         }])json",
+         "sector navigation link cost must be positive"},
+    };
+
+    for (const auto &test_case : cases)
+    {
+        const std::string game_json = std::string(R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Invalid Sector Navigation" },
+  "sector_levels": [
+    {
+      "name": "sector.test",
+      "materials": [
+        { "name": "floor", "albedo": [0.7, 0.7, 0.7, 1.0] },
+        { "name": "wall", "albedo": [0.2, 0.25, 0.35, 1.0] }
+      ],
+      "sectors": [{
+        "name": "room",
+        "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+        "floor_y": 0.0,
+        "ceil_y": 3.0,
+        "floor_material": "floor",
+        "ceil_material": "wall",
+        "wall_material": "wall"
+      }]
+    }
+  ],
+  "sector_navigation": )json") + test_case.navigation_json +
+                                      "\n}\n";
+        write_text(dir / (std::string(test_case.name) + ".game.json"), game_json.c_str());
+        char error[512]{};
+        EXPECT_FALSE(sdl3d_game_data_validate_file(
+            (dir / (std::string(test_case.name) + ".game.json")).string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.error_substring), std::string::npos) << error;
+    }
     remove_test_dir(dir);
 }
 


### PR DESCRIPTION
## Summary
- add authored `sector_navigation` graphs with validation, import support, and public C runtime query helpers
- expose nearest/path/path-available/next-node sector nav helpers to Lua and document the JSON/Lua APIs
- add an FPS mechanics dojo nav graph fragment and focused runtime/validation tests

## Verification
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j4`

Part of #282.