### PR TITLE
Add reusable FPS data template

### DIFF
--- a/demos/templates/fps/README.md
+++ b/demos/templates/fps/README.md
@@ -1,0 +1,18 @@
+# SDL3D FPS Template
+
+This template is a data-only starter for sector/FPS projects. It is intended to
+be copied into a new game project and customized through JSON and Lua.
+
+Run it with:
+
+```sh
+./build/debug/sdl3d_runner --root demos/templates/fps/data --data asset://fps_template.game.json
+```
+
+The fragments demonstrate common project-agnostic conventions:
+
+- FPS keyboard/mouse input actions.
+- A sector-backed player controller.
+- A minimal sector room and navigation graph.
+- Reticle, FPS counter, resource/combat debug HUD, and pause overlay.
+- Projectile, pickup, and station archetypes with editor metadata.

--- a/demos/templates/fps/data/fps_template.game.json
+++ b/demos/templates/fps/data/fps_template.game.json
@@ -1,0 +1,51 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "SDL3D FPS Template",
+    "id": "template.fps",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/world/fps_room.json", "sections": ["sector_level_fragments", "sector_navigation"] },
+    { "path": "fragments/actors/fps_player.json", "sections": ["entities"] },
+    { "path": "fragments/actors/combat_pickups_projectiles.json", "sections": ["actor_archetypes", "actor_instances", "actor_pools"] },
+    { "path": "fragments/ui/fps_hud.json", "sections": ["assets", "ui"] },
+    { "path": "fragments/editor/fps_templates.json", "sections": ["editor"] }
+  ],
+  "app": {
+    "title": "SDL3D FPS Template",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "world": {
+    "name": "world.fps_template",
+    "kind": "sector",
+    "units": "meters",
+    "meters_per_unit": 1.0,
+    "ambient_light": [0.14, 0.14, 0.18],
+    "cameras": [
+      {
+        "name": "camera.fps.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fovy": 90.0,
+        "active": true
+      }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": true,
+    "clear_color": [0.018, 0.02, 0.028]
+  },
+  "scenes": {
+    "initial": "scene.fps.play",
+    "files": ["scenes/fps_play.scene.json"]
+  }
+}

--- a/demos/templates/fps/data/fragments/actors/combat_pickups_projectiles.json
+++ b/demos/templates/fps/data/fragments/actors/combat_pickups_projectiles.json
@@ -1,0 +1,98 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "actor_archetypes": [
+    {
+      "name": "archetype.fps.projectile",
+      "tags": ["projectile", "player_projectile"],
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] },
+        "age": { "type": "float", "value": 0.0 },
+        "ttl": { "type": "float", "value": 2.5 },
+        "damage": { "type": "int", "value": 12 }
+      },
+      "components": [
+        { "type": "render.sphere", "radius": 0.1, "slices": 8, "rings": 8, "color": [255, 210, 120, 255], "emissive": true, "lighting": false },
+        { "type": "motion.sector_velocity_3d", "property": "velocity", "sector_level": "sector.fps.template_room", "reason": "projectile impact" },
+        { "type": "lifecycle.ttl", "age_property": "age", "ttl_property": "ttl", "reason": "projectile expired" },
+        { "type": "light.point", "color": [1.0, 0.65, 0.25], "intensity": 3.5, "range": 4.5 }
+      ],
+      "editor": {
+        "display_name": "FPS Projectile",
+        "category": "mechanics/weapons",
+        "tags": ["projectile", "pooled"],
+        "preview": { "primitive": "sphere", "color": [1.0, 0.65, 0.25, 1.0] },
+        "bounds": { "radius": 0.15 },
+        "test_scene": "scene.fps.play"
+      }
+    },
+    {
+      "name": "archetype.fps.health_pickup",
+      "active": true,
+      "tags": ["pickup", "health_pickup"],
+      "properties": {
+        "pickup_available": { "type": "bool", "value": true },
+        "pickup_respawn_remaining": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "pickup.respawn" },
+        { "type": "render.sphere", "radius": 0.32, "color": [70, 255, 120, 240], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.25, 1.0, 0.45], "intensity": 1.8, "range": 5.0 },
+        { "type": "motion.spin", "property": "rotation_angle", "rate": 2.0 }
+      ],
+      "editor": {
+        "display_name": "Health Pickup",
+        "category": "mechanics/resources",
+        "tags": ["pickup", "health"],
+        "preview": { "primitive": "sphere", "color": [0.25, 1.0, 0.45, 1.0] },
+        "bounds": { "size": [0.8, 0.8, 0.8] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.fps.play"
+      }
+    },
+    {
+      "name": "archetype.fps.resource_station",
+      "active": true,
+      "tags": ["resource_station"],
+      "properties": {
+        "charges": { "type": "int", "value": 99 },
+        "cooldown": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        { "type": "property.decay", "property": "cooldown", "rate": 1.0, "target": 0.0, "min": 0.0 },
+        { "type": "render.cube", "size": [1.2, 1.4, 1.2], "color": [80, 220, 255, 230], "lighting": true, "emissive": true },
+        { "type": "light.point", "color": [0.2, 0.85, 1.0], "intensity": 2.0, "range": 6.0 }
+      ],
+      "editor": {
+        "display_name": "Resource Station",
+        "category": "mechanics/resources",
+        "tags": ["station", "resource"],
+        "preview": { "primitive": "cube", "color": [0.2, 0.85, 1.0, 1.0] },
+        "bounds": { "size": [1.2, 1.4, 1.2] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.fps.play"
+      }
+    }
+  ],
+  "actor_instances": [
+    {
+      "name": "entity.fps.health_pickup",
+      "archetype": "archetype.fps.health_pickup",
+      "transform": { "position": [16.0, 0.55, 5.0] }
+    },
+    {
+      "name": "entity.fps.resource_station",
+      "archetype": "archetype.fps.resource_station",
+      "transform": { "position": [20.0, 0.7, 5.0] }
+    }
+  ],
+  "actor_pools": [
+    {
+      "name": "pool.fps.player_projectiles",
+      "archetype": "archetype.fps.projectile",
+      "capacity": 16,
+      "scene": "scene.fps.play",
+      "exhaustion_policy": "reuse_oldest",
+      "on_scene_exit": "reset"
+    }
+  ]
+}

--- a/demos/templates/fps/data/fragments/actors/fps_player.json
+++ b/demos/templates/fps/data/fragments/actors/fps_player.json
@@ -1,0 +1,67 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["player", "fps_actor"],
+      "transform": { "position": [4.0, 1.6, 5.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 },
+        "health": { "type": "float", "value": 100.0 },
+        "max_health": { "type": "float", "value": 100.0 },
+        "armor": { "type": "float", "value": 0.0 },
+        "ammo": { "type": "int", "value": 24 },
+        "max_ammo": { "type": "int", "value": 48 },
+        "fire_timer": { "type": "float", "value": 0.0 },
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "alive": { "type": "bool", "value": true }
+      },
+      "components": [
+        { "type": "combat.health" },
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.fps.template_room",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 7.0,
+          "jump_velocity": 6.0,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.6,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        },
+        {
+          "type": "weapon.projectile",
+          "action": "action.fire",
+          "pool": "pool.fps.player_projectiles",
+          "cooldown": 0.16,
+          "cooldown_property": "fire_timer",
+          "speed": 22.0,
+          "offset": [0.0, -0.08, -0.35],
+          "velocity_from_property": "camera_forward",
+          "ammo_property": "ammo",
+          "ammo_per_shot": 1
+        }
+      ],
+      "editor": {
+        "display_name": "FPS Player",
+        "category": "actors/player",
+        "tags": ["player", "controller"],
+        "preview": { "primitive": "capsule", "color": [0.2, 0.8, 1.0, 1.0] },
+        "bounds": { "center": [0.0, -0.8, 0.0], "size": [0.7, 1.6, 0.7] },
+        "snap": { "grid": 0.25, "align_to_floor": true },
+        "test_scene": "scene.fps.play"
+      }
+    }
+  ]
+}

--- a/demos/templates/fps/data/fragments/editor/fps_templates.json
+++ b/demos/templates/fps/data/fragments/editor/fps_templates.json
@@ -1,0 +1,84 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "editor": {
+    "display_name": "FPS Starter Templates",
+    "description": "Project-agnostic sector/FPS authoring templates for controls, player setup, HUD, pickups, projectile pools, and common world mechanics.",
+    "category": "templates/fps",
+    "tags": ["fps", "sector", "template", "starter"],
+    "preview": { "primitive": "sector", "color": [0.25, 0.55, 1.0, 1.0] },
+    "snap": { "grid": [0.5, 0.25, 0.5], "rotation_degrees": 15.0, "align_to_floor": true },
+    "test_scene": "scene.fps.play",
+    "templates": [
+      {
+        "name": "template.fps.player_controller",
+        "display_name": "FPS Player Controller",
+        "category": "actors/player",
+        "tags": ["player", "controller", "camera"],
+        "source": "entity.player",
+        "source_kind": "entity",
+        "preview": { "primitive": "capsule", "color": [0.2, 0.8, 1.0, 1.0] },
+        "bounds": { "size": [0.7, 1.6, 0.7] },
+        "snap": { "grid": 0.25, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "move_speed", "type": "float", "display_name": "Move Speed", "min": 0.1, "default": 7.0 },
+          { "name": "jump_velocity", "type": "float", "display_name": "Jump Velocity", "min": 0.0, "default": 6.0 },
+          { "name": "mouse_sensitivity", "type": "float", "display_name": "Mouse Sensitivity", "min": 0.0, "default": 0.002 }
+        ],
+        "test_scene": "scene.fps.play"
+      },
+      {
+        "name": "template.fps.projectile_pool",
+        "display_name": "Projectile Pool",
+        "category": "mechanics/weapons",
+        "tags": ["projectile", "pool", "weapon"],
+        "source": "pool.fps.player_projectiles",
+        "source_kind": "actor_pool",
+        "preview": { "primitive": "sphere", "color": [1.0, 0.65, 0.25, 1.0] },
+        "bounds": { "radius": 0.15 },
+        "exposed_properties": [
+          { "name": "capacity", "type": "int", "display_name": "Pool Capacity", "min": 1, "default": 16 },
+          { "name": "damage", "type": "int", "display_name": "Damage", "min": 0, "default": 12 },
+          { "name": "ttl", "type": "float", "display_name": "Lifetime Seconds", "min": 0.1, "default": 2.5 }
+        ],
+        "test_scene": "scene.fps.play"
+      },
+      {
+        "name": "template.fps.health_pickup",
+        "display_name": "Health Pickup",
+        "category": "mechanics/resources",
+        "tags": ["pickup", "health", "respawn"],
+        "source": "archetype.fps.health_pickup",
+        "source_kind": "actor_archetype",
+        "preview": { "primitive": "sphere", "color": [0.25, 1.0, 0.45, 1.0] },
+        "bounds": { "size": [0.8, 0.8, 0.8] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "amount", "type": "float", "display_name": "Resource Amount", "min": 0.0, "default": 25.0 },
+          { "name": "respawn_seconds", "type": "float", "display_name": "Respawn Seconds", "min": 0.0, "default": 8.0 }
+        ],
+        "test_scene": "scene.fps.play"
+      },
+      {
+        "name": "template.fps.debug_hud",
+        "display_name": "FPS Debug HUD",
+        "category": "ui/hud",
+        "tags": ["hud", "reticle", "fps_counter", "resources"],
+        "source": "fragments/ui/fps_hud.json",
+        "source_kind": "fragment",
+        "preview": { "primitive": "none", "color": [1.0, 1.0, 1.0, 1.0] },
+        "test_scene": "scene.fps.play"
+      },
+      {
+        "name": "template.fps.sector_navigation",
+        "display_name": "Sector Navigation Graph",
+        "category": "mechanics/navigation",
+        "tags": ["navigation", "sector", "ai"],
+        "source": "nav.fps.template_room",
+        "source_kind": "sector_navigation",
+        "preview": { "primitive": "volume", "color": [0.25, 0.55, 1.0, 1.0] },
+        "bounds": { "size": [24.0, 1.0, 10.0] },
+        "test_scene": "scene.fps.play"
+      }
+    ]
+  }
+}

--- a/demos/templates/fps/data/fragments/input/fps_controls.json
+++ b/demos/templates/fps/data/fragments/input/fps_controls.json
@@ -1,0 +1,24 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "input": {
+    "contexts": [
+      {
+        "name": "input.fps.standard",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
+          { "name": "action.interact", "bindings": [{ "device": "keyboard", "key": "E" }] },
+          { "name": "action.fire", "bindings": [{ "device": "mouse", "button": "LEFT" }] },
+          { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] },
+          { "name": "action.menu.up", "bindings": [{ "device": "keyboard", "key": "UP" }] },
+          { "name": "action.menu.down", "bindings": [{ "device": "keyboard", "key": "DOWN" }] },
+          { "name": "action.menu.select", "bindings": [{ "device": "keyboard", "key": "RETURN" }] }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/templates/fps/data/fragments/ui/fps_hud.json
+++ b/demos/templates/fps/data/fragments/ui/fps_hud.json
@@ -1,0 +1,60 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "assets": {
+    "fonts": [
+      { "id": "font.fps.hud", "builtin": "Inter", "size": 22 },
+      { "id": "font.fps.title", "builtin": "Inter", "size": 34 }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.fps.reticle",
+        "font": "font.fps.hud",
+        "text": "+",
+        "x": 0.5,
+        "y": 0.5,
+        "scale": 1.1,
+        "centered": true,
+        "normalized": true,
+        "color": [255, 255, 255, 210]
+      },
+      {
+        "name": "ui.fps.fps_counter",
+        "font": "font.fps.hud",
+        "format": "FPS %.0f",
+        "bindings": [{ "type": "metric", "metric": "fps" }],
+        "x": 0.985,
+        "y": 0.035,
+        "scale": 0.8,
+        "align": "right",
+        "normalized": true,
+        "color": [180, 235, 190, 230]
+      },
+      {
+        "name": "ui.fps.resources",
+        "font": "font.fps.hud",
+        "text": "HP {target.entity.player.health}/{target.entity.player.max_health}  Armor {target.entity.player.armor}  Ammo {target.entity.player.ammo}/{target.entity.player.max_ammo}",
+        "x": 0.02,
+        "y": 0.93,
+        "scale": 0.8,
+        "align": "left",
+        "normalized": true,
+        "color": [215, 245, 225, 235]
+      },
+      {
+        "name": "ui.fps.pause.title",
+        "font": "font.fps.title",
+        "text": "PAUSED",
+        "x": 0.5,
+        "y": 0.42,
+        "scale": 1.2,
+        "centered": true,
+        "normalized": true,
+        "color": [245, 248, 255, 255],
+        "pulse_alpha": true,
+        "visible_if": { "type": "app.paused", "equals": true }
+      }
+    ]
+  }
+}

--- a/demos/templates/fps/data/fragments/world/fps_room.json
+++ b/demos/templates/fps/data/fragments/world/fps_room.json
@@ -1,0 +1,52 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_level_fragments": [
+    {
+      "level": "sector.fps.template_room",
+      "materials": [
+        { "name": "floor", "albedo": [0.26, 0.28, 0.32, 1.0], "roughness": 0.85, "tex_scale": 4.0 },
+        { "name": "wall", "albedo": [0.34, 0.38, 0.46, 1.0], "roughness": 0.7, "tex_scale": 4.0 },
+        { "name": "ceiling", "albedo": [0.18, 0.20, 0.24, 1.0], "roughness": 0.9, "tex_scale": 3.0 }
+      ],
+      "sectors": [
+        {
+          "name": "spawn_room",
+          "points": [[0, 0], [12, 0], [12, 10], [0, 10]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor",
+          "ceil_material": "ceiling",
+          "wall_material": "wall"
+        },
+        {
+          "name": "test_lane",
+          "points": [[12, 3], [24, 3], [24, 7], [12, 7]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor",
+          "ceil_material": "ceiling",
+          "wall_material": "wall"
+        }
+      ],
+      "lights": [
+        { "position": [5.5, 3.0, 5.0], "color": [0.35, 0.65, 1.0], "intensity": 2.2, "range": 10.0 },
+        { "position": [18.0, 2.8, 5.0], "color": [1.0, 0.45, 0.2], "intensity": 2.0, "range": 9.0 }
+      ]
+    }
+  ],
+  "sector_navigation": [
+    {
+      "name": "nav.fps.template_room",
+      "sector_level": "sector.fps.template_room",
+      "nodes": [
+        { "name": "spawn.center", "sector": "spawn_room", "position": [5.5, 1.0, 5.0] },
+        { "name": "lane.entry", "sector": "test_lane", "position": [14.0, 1.0, 5.0] },
+        { "name": "lane.end", "sector": "test_lane", "position": [22.0, 1.0, 5.0] }
+      ],
+      "links": [
+        { "from": "spawn.center", "to": "lane.entry" },
+        { "from": "lane.entry", "to": "lane.end" }
+      ]
+    }
+  ]
+}

--- a/demos/templates/fps/data/scenes/fps_play.scene.json
+++ b/demos/templates/fps/data/scenes/fps_play.scene.json
@@ -1,0 +1,77 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.fps.play",
+  "camera": "camera.fps.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.fps.health_pickup",
+    "entity.fps.resource_station"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.interact",
+      "action.fire",
+      "action.pause",
+      "action.menu.up",
+      "action.menu.down",
+      "action.menu.select"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.fps.template_room",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "menus": [
+    {
+      "name": "menu.fps.pause",
+      "active_if": { "type": "app.paused", "equals": true },
+      "up_action": "action.menu.up",
+      "down_action": "action.menu.down",
+      "select_action": "action.menu.select",
+      "selected": 0,
+      "items": [
+        { "label": "Resume", "pause": "resume" },
+        { "label": "Quit", "quit": true }
+      ]
+    }
+  ],
+  "ui": {
+    "menus": [
+      {
+        "name": "ui.fps.pause.menu",
+        "menu": "menu.fps.pause",
+        "visible_if": { "type": "app.paused", "equals": true },
+        "font": "font.fps.hud",
+        "x": 0.5,
+        "y": 0.5,
+        "gap": 0.07,
+        "normalized": true,
+        "align": "center",
+        "color": [225, 236, 255, 245],
+        "selected_color": [255, 245, 208, 255],
+        "selected_pulse_alpha": true,
+        "cursor": {
+          "text": ">",
+          "offset_x": -0.08,
+          "align": "center",
+          "color": [255, 222, 140, 255],
+          "pulse_alpha": true
+        }
+      }
+    ]
+  }
+}

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -125,6 +125,25 @@ Demo targets may compile the same runner source with embedded assets and a
 default root data path. That wrapper should only supply build-time defaults; it
 should not contain game rules.
 
+## FPS Starter Template
+
+`demos/templates/fps` is a project-agnostic starter for sector/FPS games. It is
+designed to be copied into a new project rather than imported as a hidden engine
+dependency. The template loads through the generic runner:
+
+```sh
+build/debug/sdl3d_runner \
+  --root demos/templates/fps/data \
+  --data asset://fps_template.game.json
+```
+
+The starter proves the data-only shape for common FPS primitives: WASD/mouse
+input, an FPS sector controller, a 90-degree FOV camera, a sector room,
+navigation graph, reticle/FPS/resource HUD text, pause menu, projectile weapon,
+projectile pool, pickup archetype, resource-station archetype, and editor
+palette metadata. It uses colored geometry and built-in fonts so it remains
+lightweight and game-agnostic.
+
 ## Data-Only Parity Checklist
 
 Before treating a game as data-only, validate the runner-backed game path:

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -152,6 +152,26 @@ templates for reusable primitives such as FPS controls, render profile toggles,
 pause/HUD widgets, reticles, and sector interactions. Keep game-specific rules
 in the game project's fragments and Lua scripts.
 
+The repository includes a data-only FPS starter at `demos/templates/fps`. It
+demonstrates the expected split for a small sector/FPS game:
+
+- `fragments/input/fps_controls.json` for reusable movement, interaction, fire,
+  pause, and menu actions.
+- `fragments/world/fps_room.json` for a mock sector room plus sector navigation
+  graph.
+- `fragments/actors/fps_player.json` for a controller-equipped player and
+  data-authored projectile weapon.
+- `fragments/actors/combat_pickups_projectiles.json` for projectile, pickup,
+  and resource-station archetypes, instances, and pools.
+- `fragments/ui/fps_hud.json` for reticle, FPS counter, resource text, and
+  pause overlay text.
+- `fragments/editor/fps_templates.json` for project-agnostic editor palette
+  metadata.
+
+The template is intentionally mock-media only. A real game should copy the
+shape, rename ids, and replace geometry/colors/assets without introducing a
+custom C host.
+
 ## Dojos And Editor Metadata
 
 Mechanic dojos are small data-only projects or scenes used to tune reusable

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -375,6 +375,11 @@ std::filesystem::path fps_mechanics_dojo_data_path()
     return demo_data_path("fps_mechanics_dojo", "fps_mechanics_dojo.game.json");
 }
 
+std::filesystem::path fps_template_data_path()
+{
+    return demo_data_path("templates/fps", "fps_template.game.json");
+}
+
 std::string read_fixture_file(const char *filename)
 {
     std::ifstream in(fixture_path(filename), std::ios::binary);
@@ -9708,6 +9713,106 @@ return nav
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
     remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, FpsTemplateLoadsDataOnlyStarter)
+{
+    const std::filesystem::path template_path = fps_template_data_path();
+    ASSERT_TRUE(std::filesystem::exists(template_path)) << template_path;
+
+    char validate_error[512]{};
+    ASSERT_TRUE(
+        sdl3d_game_data_validate_file(template_path.string().c_str(), nullptr, validate_error, sizeof(validate_error)))
+        << validate_error;
+
+    sdl3d_game_config config{};
+    char title[128]{};
+    char config_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(template_path.string().c_str(), &config, title, sizeof(title),
+                                                     config_error, sizeof(config_error)))
+        << config_error;
+    EXPECT_STREQ(config.title, "SDL3D FPS Template");
+    EXPECT_EQ(config.logical_width, SDL3D_GAME_DEFAULT_LOGICAL_WIDTH);
+    EXPECT_EQ(config.logical_height, SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(template_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_NE(runtime, nullptr);
+
+    EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), "scene.fps.play");
+    const char *units = nullptr;
+    float meters_per_unit = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_units(runtime, &units, &meters_per_unit));
+    EXPECT_STREQ(units, SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    EXPECT_FLOAT_EQ(meters_per_unit, SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
+
+    sdl3d_game_data_sector_level level{};
+    ASSERT_TRUE(sdl3d_game_data_get_sector_level(runtime, "sector.fps.template_room", &level));
+    ASSERT_EQ(level.sector_count, 2);
+    ASSERT_NE(level.sector_names, nullptr);
+    EXPECT_STREQ(level.sector_names[0], "spawn_room");
+    EXPECT_STREQ(level.sector_names[1], "test_lane");
+    EXPECT_EQ(level.light_count, 2);
+    EXPECT_TRUE(sdl3d_game_data_sector_nav_path_available(
+        runtime, "nav.fps.template_room", sdl3d_vec3_make(4.0f, 1.0f, 5.0f), sdl3d_vec3_make(22.0f, 1.0f, 5.0f)));
+
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    sdl3d_registered_actor *pickup = sdl3d_game_data_find_actor(runtime, "entity.fps.health_pickup");
+    sdl3d_registered_actor *station = sdl3d_game_data_find_actor(runtime, "entity.fps.resource_station");
+    sdl3d_registered_actor *projectile = sdl3d_game_data_find_actor(runtime, "pool.fps.player_projectiles.0");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(pickup, nullptr);
+    ASSERT_NE(station, nullptr);
+    ASSERT_NE(projectile, nullptr);
+    EXPECT_TRUE(player->active);
+    EXPECT_TRUE(pickup->active);
+    EXPECT_TRUE(station->active);
+    EXPECT_FALSE(projectile->active);
+
+    struct FpsTemplateUiCapture
+    {
+        bool saw_reticle = false;
+        bool saw_fps = false;
+        bool saw_resources = false;
+        bool saw_pause = false;
+    } ui_capture;
+    auto capture_fps_template_ui = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *capture = static_cast<FpsTemplateUiCapture *>(userdata);
+        if (std::string(text->name) == "ui.fps.reticle")
+            capture->saw_reticle = true;
+        else if (std::string(text->name) == "ui.fps.fps_counter")
+            capture->saw_fps = true;
+        else if (std::string(text->name) == "ui.fps.resources")
+            capture->saw_resources = true;
+        else if (std::string(text->name) == "ui.fps.pause.title")
+            capture->saw_pause = true;
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_fps_template_ui, &ui_capture));
+    EXPECT_TRUE(ui_capture.saw_reticle);
+    EXPECT_TRUE(ui_capture.saw_fps);
+    EXPECT_TRUE(ui_capture.saw_resources);
+    EXPECT_TRUE(ui_capture.saw_pause);
+
+    const int fire_action = sdl3d_game_data_find_action(runtime, "action.fire");
+    ASSERT_GE(fire_action, 0);
+    sdl3d_input_manager *input = sdl3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    sdl3d_input_set_action_override(input, fire_action, 1.0f);
+    ASSERT_NE(sdl3d_input_update(input, 1), nullptr);
+    ASSERT_TRUE(sdl3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(projectile->active);
+    EXPECT_EQ(sdl3d_properties_get_int(player->props, "ammo", -1), 23);
+    const sdl3d_vec3 projectile_velocity =
+        sdl3d_properties_get_vec3(projectile->props, "velocity", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(sdl3d_vec3_length(projectile_velocity), 22.0f, 0.001f);
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
 }
 
 TEST(GameDataRuntime, ResolvesActiveSceneSectorLevelInstances)


### PR DESCRIPTION
## Summary
- add a data-only sector/FPS starter template under demos/templates/fps
- include reusable FPS controls, player controller, projectile pool, pickup/resource archetypes, HUD, pause menu, sector room, navigation graph, and editor template metadata
- document the FPS starter in the data-only games and project layout guidance

## Tests
- cmake --build build/debug --target sdl3d_game_data_test -j4
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.FpsTemplateLoadsDataOnlyStarter
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug -j4

Part of #282