### PR TITLE
Add focused FPS mechanics dojo scenes

### DIFF
--- a/demos/fps_mechanics_dojo/README.md
+++ b/demos/fps_mechanics_dojo/README.md
@@ -10,7 +10,16 @@ Run it with the generic runner:
 ./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json
 ```
 
-The first scene demonstrates existing data-authored primitives:
+Launch focused scenes directly while tuning a mechanic:
+
+```sh
+./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json --scene scene.dojo.movement
+./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json --scene scene.dojo.combat_resources
+./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json --scene scene.dojo.hazards
+./build/debug/sdl3d_runner --root demos/fps_mechanics_dojo/data --data asset://fps_mechanics_dojo.game.json --scene scene.dojo.navigation
+```
+
+The overview and focused scenes demonstrate existing data-authored primitives:
 
 - `controller.fps_sector` movement
 - `controller.fps_sector.launch` for jump-pad style movement
@@ -18,6 +27,8 @@ The first scene demonstrates existing data-authored primitives:
 - `sensor.volume` and `sensor.sector`
 - `sector_doors` and `sector_platforms`
 - `combat.health` plus `combat.damage` against a mock target dummy
+- `resource.station.use`, `pickup.collect`, and `status_effect.apply`
+- sector navigation graph data for future AI/path tooling
 - actor archetype/instance mockups with optional `editor` metadata
 
 The dojo is meant to grow alongside reusable mechanics from issue #282.

--- a/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
+++ b/demos/fps_mechanics_dojo/data/fps_mechanics_dojo.game.json
@@ -11,6 +11,7 @@
     { "path": "fragments/world/navigation.json", "sections": ["sector_navigation"] },
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/actors/mechanic_markers.json", "sections": ["actor_archetypes", "actor_instances"] },
+    { "path": "fragments/logic/scene_setup.json", "sections": ["signals", "logic"] },
     { "path": "fragments/editor/metadata.json", "sections": ["editor"] }
   ],
   "app": {
@@ -51,6 +52,12 @@
   },
   "scenes": {
     "initial": "scene.dojo.fps_world",
-    "files": ["scenes/fps_world.scene.json"]
+    "files": [
+      "scenes/fps_world.scene.json",
+      "scenes/movement.scene.json",
+      "scenes/combat_resources.scene.json",
+      "scenes/hazards.scene.json",
+      "scenes/navigation.scene.json"
+    ]
   }
 }

--- a/demos/fps_mechanics_dojo/data/fragments/editor/metadata.json
+++ b/demos/fps_mechanics_dojo/data/fragments/editor/metadata.json
@@ -39,6 +39,88 @@
           { "name": "yaw", "type": "float", "display_name": "Facing Yaw", "default": -1.5707964 }
         ],
         "test_scene": "scene.dojo.fps_world"
+      },
+      {
+        "name": "template.fps.hazard_sector",
+        "display_name": "Hazard Sector",
+        "category": "mechanics/hazards",
+        "tags": ["sector", "hazard", "damage"],
+        "source": "sensor.dojo.hazard.damage",
+        "source_kind": "sensor",
+        "preview": { "primitive": "volume", "color": [1.0, 0.2, 0.08, 1.0] },
+        "bounds": { "size": [10.0, 4.0, 10.0] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "damage_per_second", "type": "float", "display_name": "Damage Per Second", "min": 0.0, "default": 6.0 }
+        ],
+        "test_scene": "scene.dojo.hazards"
+      },
+      {
+        "name": "template.fps.platform_lift",
+        "display_name": "Sector Lift",
+        "category": "mechanics/world",
+        "tags": ["platform", "lift", "crusher"],
+        "source": "platform.dojo.lift",
+        "source_kind": "sector_platform",
+        "preview": { "primitive": "cube", "color": [0.4, 0.65, 1.0, 1.0] },
+        "bounds": { "size": [10.0, 2.25, 8.0] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "cycle_seconds", "type": "float", "display_name": "Cycle Seconds", "min": 0.1, "default": 5.0 },
+          { "name": "crush_damage_per_second", "type": "float", "display_name": "Crush Damage", "min": 0.0, "default": 8.0 }
+        ],
+        "test_scene": "scene.dojo.hazards"
+      },
+      {
+        "name": "template.fps.sector_door",
+        "display_name": "Sector Door",
+        "category": "mechanics/world",
+        "tags": ["door", "sector", "gate"],
+        "source": "door.dojo.hazard_gate",
+        "source_kind": "sector_door",
+        "preview": { "primitive": "cube", "color": [0.8, 0.25, 0.15, 1.0] },
+        "bounds": { "size": [0.5, 3.2, 3.2] },
+        "snap": { "grid": 0.25, "align_to_floor": true },
+        "test_scene": "scene.dojo.hazards"
+      },
+      {
+        "name": "template.fps.combat_dummy",
+        "display_name": "Combat Target Dummy",
+        "category": "mechanics/combat",
+        "tags": ["combat", "health", "armor"],
+        "source": "archetype.dojo.combat_dummy",
+        "source_kind": "actor_archetype",
+        "preview": { "primitive": "cube", "color": [1.0, 0.25, 0.15, 1.0] },
+        "bounds": { "size": [1.2, 1.8, 1.2] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "exposed_properties": [
+          { "name": "health", "type": "float", "display_name": "Health", "min": 0.0, "default": 100.0 },
+          { "name": "armor", "type": "float", "display_name": "Armor", "min": 0.0, "default": 30.0 }
+        ],
+        "test_scene": "scene.dojo.combat_resources"
+      },
+      {
+        "name": "template.fps.resource_pickup",
+        "display_name": "Resource Pickup",
+        "category": "mechanics/resources",
+        "tags": ["pickup", "resource", "respawn"],
+        "source": "archetype.dojo.pickup",
+        "source_kind": "actor_archetype",
+        "preview": { "primitive": "sphere", "color": [0.25, 1.0, 0.45, 1.0] },
+        "bounds": { "size": [0.8, 0.8, 0.8] },
+        "snap": { "grid": 0.5, "align_to_floor": true },
+        "test_scene": "scene.dojo.combat_resources"
+      },
+      {
+        "name": "template.fps.sector_navigation_graph",
+        "display_name": "Sector Navigation Graph",
+        "category": "mechanics/navigation",
+        "tags": ["navigation", "sector", "ai"],
+        "source": "nav.dojo.arena",
+        "source_kind": "sector_navigation",
+        "preview": { "primitive": "volume", "color": [0.25, 0.55, 1.0, 1.0] },
+        "bounds": { "size": [28.0, 1.0, 18.0] },
+        "test_scene": "scene.dojo.navigation"
       }
     ]
   }

--- a/demos/fps_mechanics_dojo/data/fragments/logic/scene_setup.json
+++ b/demos/fps_mechanics_dojo/data/fragments/logic/scene_setup.json
@@ -1,0 +1,63 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "signals": [
+    "signal.dojo.scene.overview.enter",
+    "signal.dojo.scene.movement.enter",
+    "signal.dojo.scene.combat_resources.enter",
+    "signal.dojo.scene.hazards.enter",
+    "signal.dojo.scene.navigation.enter"
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.dojo.scene.overview.enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [3.0, 1.6, 4.0], "yaw": 0.0, "pitch": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_scene", "value": "overview" },
+          { "type": "sector_door.close", "target": "door.dojo.hazard_gate" }
+        ]
+      },
+      {
+        "signal": "signal.dojo.scene.movement.enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [3.0, 1.6, 4.0], "yaw": 0.0, "pitch": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_scene", "value": "movement" },
+          { "type": "sector_door.close", "target": "door.dojo.hazard_gate" }
+        ]
+      },
+      {
+        "signal": "signal.dojo.scene.combat_resources.enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [21.0, 1.6, 5.0], "yaw": 1.5707964, "pitch": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_scene", "value": "combat_resources" },
+          { "type": "property.set", "target": "entity.player", "key": "health", "value": 65.0 },
+          { "type": "property.set", "target": "entity.player", "key": "ammo", "value": 2 },
+          { "type": "property.set", "target": "entity.dojo.combat_dummy", "key": "health", "value": 100.0 },
+          { "type": "property.set", "target": "entity.dojo.combat_dummy", "key": "armor", "value": 30.0 },
+          { "type": "property.set", "target": "entity.dojo.combat_dummy", "key": "alive", "value": true },
+          { "type": "entity.set_active", "target": "entity.dojo.health_pickup", "active": true },
+          { "type": "entity.set_active", "target": "entity.dojo.powerup", "active": true },
+          { "type": "sector_door.open", "target": "door.dojo.hazard_gate" }
+        ]
+      },
+      {
+        "signal": "signal.dojo.scene.hazards.enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [16.0, 1.6, 5.0], "yaw": 1.5707964, "pitch": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_scene", "value": "hazards" },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_hazard_damage", "value": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_crush_damage", "value": 0.0 },
+          { "type": "sector_door.open", "target": "door.dojo.hazard_gate" }
+        ]
+      },
+      {
+        "signal": "signal.dojo.scene.navigation.enter",
+        "actions": [
+          { "type": "controller.fps_sector.teleport", "target": "entity.player", "position": [4.0, 1.6, 14.0], "yaw": 0.0, "pitch": 0.0 },
+          { "type": "property.set", "target": "entity.player", "key": "dojo_scene", "value": "navigation" },
+          { "type": "sector_door.close", "target": "door.dojo.hazard_gate" }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/scenes/combat_resources.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/combat_resources.scene.json
@@ -1,15 +1,12 @@
 {
   "schema": "sdl3d.scene.v0",
-  "name": "scene.dojo.fps_world",
-  "on_enter_signal": "signal.dojo.scene.overview.enter",
+  "name": "scene.dojo.combat_resources",
+  "on_enter_signal": "signal.dojo.scene.combat_resources.enter",
   "camera": "camera.dojo.player",
   "updates_game": true,
   "renders_world": true,
   "entities": [
     "entity.player",
-    "entity.dojo.launch_pad",
-    "entity.dojo.teleporter_pad",
-    "entity.dojo.teleporter_destination",
     "entity.dojo.combat_dummy",
     "entity.dojo.health_pickup",
     "entity.dojo.health_station",
@@ -23,7 +20,6 @@
       "action.move.left",
       "action.move.right",
       "action.jump",
-      "action.interact",
       "action.fire",
       "action.pause"
     ]
@@ -41,43 +37,34 @@
   "ui": {
     "text": [
       {
-        "name": "ui.dojo.title",
-        "text": "FPS Mechanics Dojo",
+        "name": "ui.dojo.combat_resources.title",
+        "text": "Combat + Resources Dojo",
         "font": "font.dojo.hud",
         "position": [0.02, 0.03],
         "anchor": "top_left",
-        "color": [220, 235, 255, 230],
-        "scale": 0.9
+        "color": [255, 220, 190, 235],
+        "scale": 0.8
       },
       {
-        "name": "ui.dojo.damage",
-        "text": "Hazard {target.entity.player.dojo_hazard_damage}  Crush {target.entity.player.dojo_crush_damage}",
+        "name": "ui.dojo.combat_resources.dummy",
+        "text": "Dummy HP {target.entity.dojo.combat_dummy.health} Armor {target.entity.dojo.combat_dummy.armor} Alive {target.entity.dojo.combat_dummy.alive}",
         "font": "font.dojo.hud",
         "position": [0.02, 0.07],
         "anchor": "top_left",
-        "color": [255, 150, 120, 220],
-        "scale": 0.75
+        "color": [255, 210, 180, 220],
+        "scale": 0.7
       },
       {
-        "name": "ui.dojo.dummy",
-        "text": "Dummy HP {target.entity.dojo.combat_dummy.health}  Armor {target.entity.dojo.combat_dummy.armor}  Alive {target.entity.dojo.combat_dummy.alive}",
+        "name": "ui.dojo.combat_resources.player",
+        "text": "HP {target.entity.player.health}/{target.entity.player.max_health} Ammo {target.entity.player.ammo}/{target.entity.player.max_ammo} Quad {target.entity.player.quad_damage_active}",
         "font": "font.dojo.hud",
         "position": [0.02, 0.11],
         "anchor": "top_left",
-        "color": [255, 210, 180, 220],
-        "scale": 0.75
-      },
-      {
-        "name": "ui.dojo.resources",
-        "text": "HP {target.entity.player.health}/{target.entity.player.max_health}  Ammo {target.entity.player.ammo}/{target.entity.player.max_ammo}  Quad {target.entity.player.quad_damage_active}",
-        "font": "font.dojo.hud",
-        "position": [0.02, 0.15],
-        "anchor": "top_left",
         "color": [190, 255, 210, 230],
-        "scale": 0.75
+        "scale": 0.7
       },
       {
-        "name": "ui.dojo.reticle",
+        "name": "ui.dojo.combat_resources.reticle",
         "text": "+",
         "font": "font.dojo.hud",
         "position": [0.5, 0.5],

--- a/demos/fps_mechanics_dojo/data/scenes/hazards.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/hazards.scene.json
@@ -1,0 +1,63 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.dojo.hazards",
+  "on_enter_signal": "signal.dojo.scene.hazards.enter",
+  "camera": "camera.dojo.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.dojo.arena",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.dojo.hazards.title",
+        "text": "Hazards Dojo: toxic sector + lift crusher",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.03],
+        "anchor": "top_left",
+        "color": [255, 180, 150, 235],
+        "scale": 0.8
+      },
+      {
+        "name": "ui.dojo.hazards.damage",
+        "text": "Hazard {target.entity.player.dojo_hazard_damage} Crush {target.entity.player.dojo_crush_damage}",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.07],
+        "anchor": "top_left",
+        "color": [255, 150, 120, 220],
+        "scale": 0.75
+      },
+      {
+        "name": "ui.dojo.hazards.reticle",
+        "text": "+",
+        "font": "font.dojo.hud",
+        "position": [0.5, 0.5],
+        "anchor": "center",
+        "color": [255, 255, 255, 210],
+        "scale": 1.0
+      }
+    ]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/scenes/movement.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/movement.scene.json
@@ -1,0 +1,58 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.dojo.movement",
+  "on_enter_signal": "signal.dojo.scene.movement.enter",
+  "camera": "camera.dojo.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.dojo.launch_pad",
+    "entity.dojo.teleporter_pad",
+    "entity.dojo.teleporter_destination"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.interact",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.dojo.arena",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.dojo.movement.title",
+        "text": "Movement Dojo: launch pad + teleporter",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.03],
+        "anchor": "top_left",
+        "color": [220, 235, 255, 230],
+        "scale": 0.8
+      },
+      {
+        "name": "ui.dojo.movement.reticle",
+        "text": "+",
+        "font": "font.dojo.hud",
+        "position": [0.5, 0.5],
+        "anchor": "center",
+        "color": [255, 255, 255, 210],
+        "scale": 1.0
+      }
+    ]
+  }
+}

--- a/demos/fps_mechanics_dojo/data/scenes/navigation.scene.json
+++ b/demos/fps_mechanics_dojo/data/scenes/navigation.scene.json
@@ -1,0 +1,56 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.dojo.navigation",
+  "on_enter_signal": "signal.dojo.scene.navigation.enter",
+  "camera": "camera.dojo.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.dojo.teleporter_destination",
+    "entity.dojo.combat_dummy"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.dojo.arena",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.dojo.navigation.title",
+        "text": "Navigation Dojo: sector graph path substrate",
+        "font": "font.dojo.hud",
+        "position": [0.02, 0.03],
+        "anchor": "top_left",
+        "color": [210, 230, 255, 235],
+        "scale": 0.8
+      },
+      {
+        "name": "ui.dojo.navigation.reticle",
+        "text": "+",
+        "font": "font.dojo.hud",
+        "position": [0.5, 0.5],
+        "anchor": "center",
+        "color": [255, 255, 255, 210],
+        "scale": 1.0
+      }
+    ]
+  }
+}

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -180,6 +180,12 @@ clear UI indicators over finished media while the mechanic is still evolving.
 Launch dojos through `sdl3d_runner` and direct scene selection so mechanics can
 be tested without walking through splash, title, or campaign flow.
 
+`demos/fps_mechanics_dojo` is the reference shape for FPS/sector mechanics. It
+keeps an overview scene plus focused direct-launch scenes for movement,
+combat/resources, hazards, and navigation. New dojos should follow that pattern:
+one scene per editing question, with authored scene-enter setup that places the
+player near the mechanic under test.
+
 Use optional `editor` metadata beside the authored object it describes. This
 keeps future editor palettes and prefab browsers grounded in the same JSON that
 runtime validation sees. Metadata should describe categories, previews, bounds,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6872,6 +6872,10 @@ TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.launch_pad"), nullptr);
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_pad"), nullptr);
     EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.teleporter_destination"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.combat_dummy"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.health_pickup"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.health_station"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.dojo.powerup"), nullptr);
 
     const char *units = nullptr;
     float meters_per_unit = 0.0f;
@@ -6886,6 +6890,47 @@ TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
     RenderPrimitiveCapture render{};
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_render_primitive, &render));
     EXPECT_GE(render.cubes, 3);
+
+    sdl3d_registered_actor *player = sdl3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    struct DojoSceneCase
+    {
+        const char *scene;
+        const char *scene_key;
+        sdl3d_vec3 expected_position;
+        const char *ui_title;
+    };
+    const DojoSceneCase scenes[] = {
+        {"scene.dojo.movement", "movement", sdl3d_vec3_make(3.0f, 1.6f, 4.0f), "ui.dojo.movement.title"},
+        {"scene.dojo.combat_resources", "combat_resources", sdl3d_vec3_make(21.0f, 1.6f, 5.0f),
+         "ui.dojo.combat_resources.title"},
+        {"scene.dojo.hazards", "hazards", sdl3d_vec3_make(16.0f, 1.6f, 5.0f), "ui.dojo.hazards.title"},
+        {"scene.dojo.navigation", "navigation", sdl3d_vec3_make(4.0f, 1.6f, 14.0f), "ui.dojo.navigation.title"},
+    };
+    for (const DojoSceneCase &scene : scenes)
+    {
+        ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, scene.scene)) << scene.scene;
+        EXPECT_STREQ(sdl3d_game_data_active_scene(runtime), scene.scene);
+        EXPECT_STREQ(sdl3d_properties_get_string(player->props, "dojo_scene", ""), scene.scene_key);
+        expect_vec3_near(player->position, scene.expected_position);
+
+        bool saw_title = false;
+        auto find_dojo_scene_title = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+            auto *args = static_cast<std::pair<const char *, bool *> *>(userdata);
+            if (std::string(text->name) == args->first)
+            {
+                *args->second = true;
+                return false;
+            }
+            return true;
+        };
+        std::pair<const char *, bool *> title_args{scene.ui_title, &saw_title};
+        ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, find_dojo_scene_title, &title_args));
+        EXPECT_TRUE(saw_title) << scene.ui_title;
+    }
+
+    EXPECT_TRUE(sdl3d_game_data_sector_nav_path_available(runtime, "nav.dojo.arena", sdl3d_vec3_make(4.0f, 1.0f, 4.0f),
+                                                          sdl3d_vec3_make(24.0f, 1.0f, 6.0f)));
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add direct-launch FPS mechanics dojo scenes for movement, combat/resources, hazards, and navigation
- add authored scene-enter setup signals so each scene places the player near the mechanic under test
- expand editor metadata templates for hazards, doors, lifts, combat targets, pickups, and navigation
- update dojo and project-layout docs for focused dojo scene workflows

## Tests
- cmake --build build/debug --target sdl3d_game_data_test -j4
- ./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.EditorMetadataValidatesAndFpsMechanicsDojoLoads
- ./build/debug/tests/sdl3d_game_data_test
- cmake --build build/debug -j4

Part of #282