### PR TITLE
Add mesh primitive render descriptors

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1380,6 +1380,18 @@ Reusable components include:
   face is UV-mapped to the full image and tinted by `color`. The property path
   is useful for grid wall runs and other pooled actors that need per-instance
   dimensions.
+- `render.mesh_primitive`: declares a procedural placeholder mesh descriptor.
+  The canonical `primitive` values are `cube`, `sphere`, `capsule`,
+  `cylinder`, `cone`, `torus`, `pyramid`, and `wedge`. These descriptors use
+  the same transform, `color`, `texture`, `lighting`, and `emissive` fields as
+  other render primitives where applicable, and add `draw_mode`: `solid`
+  (default), `wire`, or `solid_wire`. Dimension fields include `size`,
+  `radius`, `height`, `radius_top`, `radius_bottom`, `major_radius`,
+  `minor_radius`, `segments`/`slices`, `rings`, and `tube_segments`. This is the
+  stable data/runtime representation for procedural mesh primitives. Rendering
+  support for the full primitive set is provided by the procedural mesh
+  presentation path; until that path is enabled, existing `render.cube` and
+  `render.sphere` remain the production drawing components.
 - `render.model`: renders an authored `assets.models` entry with `model`,
   optional `scale`, axis-angle rotation, `color` tint, and optional skeletal
   animation playback via `animation_clip` and `animation_time_property`.

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -408,7 +408,43 @@ extern "C"
         SDL3D_GAME_DATA_RENDER_SPRITE = 4,
         /** @brief 3D model primitive backed by an authored model asset. */
         SDL3D_GAME_DATA_RENDER_MODEL = 5,
+        /** @brief Procedural mesh primitive selected by @ref sdl3d_game_data_mesh_primitive_kind. */
+        SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE = 6,
     } sdl3d_game_data_render_primitive_type;
+
+    /** @brief Procedural mesh shape selected by a `render.mesh_primitive` component. */
+    typedef enum sdl3d_game_data_mesh_primitive_kind
+    {
+        /** @brief Invalid or unknown procedural mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID = 0,
+        /** @brief Box/cube mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE = 1,
+        /** @brief Sphere mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_SPHERE = 2,
+        /** @brief Capsule mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_CAPSULE = 3,
+        /** @brief Cylinder mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_CYLINDER = 4,
+        /** @brief Cone mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE = 5,
+        /** @brief Torus mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS = 6,
+        /** @brief Square-pyramid mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID = 7,
+        /** @brief Wedge/ramp mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE = 8,
+    } sdl3d_game_data_mesh_primitive_kind;
+
+    /** @brief Draw mode selected by authored procedural mesh primitives. */
+    typedef enum sdl3d_game_data_render_draw_mode
+    {
+        /** @brief Draw a solid shaded primitive. */
+        SDL3D_GAME_DATA_RENDER_DRAW_SOLID = 0,
+        /** @brief Draw only primitive wire edges. */
+        SDL3D_GAME_DATA_RENDER_DRAW_WIRE = 1,
+        /** @brief Draw a solid shaded primitive with wire edges overlaid. */
+        SDL3D_GAME_DATA_RENDER_DRAW_SOLID_WIRE = 2,
+    } sdl3d_game_data_render_draw_mode;
 
     /**
      * @brief Read-only descriptor for an authored render primitive component.
@@ -423,6 +459,10 @@ extern "C"
         const char *entity_name;
         /** @brief Primitive type declared by the component. */
         sdl3d_game_data_render_primitive_type type;
+        /** @brief Procedural mesh kind for SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE. */
+        sdl3d_game_data_mesh_primitive_kind mesh_primitive;
+        /** @brief Draw mode for SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE. */
+        sdl3d_game_data_render_draw_mode draw_mode;
         /** @brief Current world-space position from the owning actor plus optional component offset. */
         sdl3d_vec3 position;
         /** @brief Optional world-space instance positions for batched primitives. */
@@ -441,8 +481,22 @@ extern "C"
         int slices;
         /** @brief Sphere latitudinal rings for SDL3D_GAME_DATA_RENDER_SPHERE. */
         int rings;
+        /** @brief Mesh primitive height for capsule, cylinder, cone, pyramid, and wedge primitives. */
+        float height;
+        /** @brief Mesh primitive top radius for cylinder/cone-style primitives. */
+        float radius_top;
+        /** @brief Mesh primitive bottom radius for cylinder/cone-style primitives. */
+        float radius_bottom;
+        /** @brief Torus major radius for SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS. */
+        float major_radius;
+        /** @brief Torus minor/tube radius for SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS. */
+        float minor_radius;
+        /** @brief Secondary tessellation count, such as torus tube segments. */
+        int tube_segments;
         /** @brief Authored tint color. */
         sdl3d_color color;
+        /** @brief Optional wire overlay color for mesh primitive wire draw modes. */
+        sdl3d_color wire_color;
         /** @brief Optional image asset id used as an albedo texture by primitives that support textures. */
         const char *texture_image;
         /** @brief Optional sprite asset id for SDL3D_GAME_DATA_RENDER_SPRITE. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6110,6 +6110,40 @@ static void apply_render_effects(const sdl3d_game_data_runtime *runtime, yyjson_
     }
 }
 
+static sdl3d_game_data_mesh_primitive_kind mesh_primitive_kind_from_string(const char *name)
+{
+    if (name == NULL)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID;
+    if (SDL_strcmp(name, "cube") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE;
+    if (SDL_strcmp(name, "sphere") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_SPHERE;
+    if (SDL_strcmp(name, "capsule") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_CAPSULE;
+    if (SDL_strcmp(name, "cylinder") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_CYLINDER;
+    if (SDL_strcmp(name, "cone") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE;
+    if (SDL_strcmp(name, "torus") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS;
+    if (SDL_strcmp(name, "pyramid") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID;
+    if (SDL_strcmp(name, "wedge") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE;
+    return SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID;
+}
+
+static sdl3d_game_data_render_draw_mode render_draw_mode_from_string(const char *name)
+{
+    if (name == NULL || SDL_strcmp(name, "solid") == 0)
+        return SDL3D_GAME_DATA_RENDER_DRAW_SOLID;
+    if (SDL_strcmp(name, "wire") == 0)
+        return SDL3D_GAME_DATA_RENDER_DRAW_WIRE;
+    if (SDL_strcmp(name, "solid_wire") == 0)
+        return SDL3D_GAME_DATA_RENDER_DRAW_SOLID_WIRE;
+    return SDL3D_GAME_DATA_RENDER_DRAW_SOLID;
+}
+
 static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
                                          const sdl3d_game_data_render_eval *eval, const sdl3d_registered_actor *actor,
                                          yyjson_val *components, sdl3d_game_data_render_primitive_fn callback,
@@ -6141,6 +6175,7 @@ static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
         primitive.emissive = json_bool(component, "emissive", false);
         primitive.emissive_color =
             primitive.emissive ? sdl3d_vec3_make(0.2f, 0.2f, 0.2f) : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+        primitive.wire_color = json_color(component, "wire_color", (sdl3d_color){0, 0, 0, 255});
 
         if (SDL_strcmp(type, "render.cube") == 0)
         {
@@ -6156,6 +6191,27 @@ static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
             primitive.radius = json_float(component, "radius", 0.5f);
             primitive.slices = json_int(component, "slices", 16);
             primitive.rings = json_int(component, "rings", 8);
+        }
+        else if (SDL_strcmp(type, "render.mesh_primitive") == 0)
+        {
+            primitive.type = SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE;
+            primitive.mesh_primitive = mesh_primitive_kind_from_string(json_string(component, "primitive", NULL));
+            primitive.draw_mode = render_draw_mode_from_string(json_string(component, "draw_mode", NULL));
+            primitive.size = json_vec3(component, "size", sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
+            const char *size_property = json_string(component, "size_property", NULL);
+            if (size_property != NULL)
+                primitive.size = sdl3d_properties_get_vec3(actor->props, size_property, primitive.size);
+            primitive.radius = json_float(component, "radius", 0.5f);
+            primitive.height = json_float(component, "height", primitive.size.y);
+            primitive.radius_top = json_float(component, "radius_top", primitive.radius);
+            primitive.radius_bottom = json_float(component, "radius_bottom", primitive.radius);
+            primitive.major_radius = json_float(component, "major_radius", 0.5f);
+            primitive.minor_radius = json_float(component, "minor_radius", 0.15f);
+            primitive.slices = SDL_max(json_int(component, "slices", json_int(component, "segments", 24)), 3);
+            primitive.rings = SDL_max(json_int(component, "rings", 8), 3);
+            primitive.tube_segments = SDL_max(json_int(component, "tube_segments", primitive.rings), 3);
+            if (primitive.mesh_primitive == SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE)
+                primitive.radius_top = json_float(component, "radius_top", 0.0f);
         }
         else if (SDL_strcmp(type, "render.sprite") == 0)
         {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2817,16 +2817,16 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller", "collision.aabb",     "collision.circle",
-        "combat.health",      "control.axis_1d",    "controller.fps_sector",
-        "lifecycle.ttl",      "light.directional",  "light.point",
-        "light.spot",         "motion.grid_agent",  "motion.oscillate",
-        "motion.patrol",      "motion.scroll_wrap", "motion.sector_velocity_3d",
-        "motion.spin",        "motion.velocity_2d", "motion.velocity_3d",
-        "interactable",       "particles.emitter",  "pickup.respawn",
-        "property.decay",     "render.cube",        "render.model",
-        "render.sphere",      "render.sprite",      "status_effect.timer",
-        "weapon.projectile",  "weapon.state",
+        "adapter.controller",  "collision.aabb",     "collision.circle",
+        "combat.health",       "control.axis_1d",    "controller.fps_sector",
+        "lifecycle.ttl",       "light.directional",  "light.point",
+        "light.spot",          "motion.grid_agent",  "motion.oscillate",
+        "motion.patrol",       "motion.scroll_wrap", "motion.sector_velocity_3d",
+        "motion.spin",         "motion.velocity_2d", "motion.velocity_3d",
+        "interactable",        "particles.emitter",  "pickup.respawn",
+        "property.decay",      "render.cube",        "render.mesh_primitive",
+        "render.model",        "render.sphere",      "render.sprite",
+        "status_effect.timer", "weapon.projectile",  "weapon.state",
     };
 
     if (type == NULL)
@@ -2837,6 +2837,80 @@ static bool is_supported_component_type(const char *type)
             return true;
     }
     return false;
+}
+
+static bool render_mesh_primitive_kind_valid(const char *primitive)
+{
+    const char *known[] = {"cube", "sphere", "capsule", "cylinder", "cone", "torus", "pyramid", "wedge"};
+    for (size_t i = 0; primitive != NULL && i < SDL_arraysize(known); ++i)
+    {
+        if (SDL_strcmp(primitive, known[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool render_draw_mode_valid(const char *draw_mode)
+{
+    return draw_mode != NULL && (SDL_strcmp(draw_mode, "solid") == 0 || SDL_strcmp(draw_mode, "wire") == 0 ||
+                                 SDL_strcmp(draw_mode, "solid_wire") == 0);
+}
+
+static bool validate_render_mesh_primitive_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                                     const validation_names *names)
+{
+    const char *primitive = json_string(component, "primitive");
+    if (!render_mesh_primitive_kind_valid(primitive))
+        return validation_error(ctx, path, "render.mesh_primitive primitive is unknown");
+    yyjson_val *draw_mode = obj_get(component, "draw_mode");
+    if (draw_mode != NULL && (!yyjson_is_str(draw_mode) || !render_draw_mode_valid(yyjson_get_str(draw_mode))))
+        return validation_error(ctx, path, "render.mesh_primitive draw_mode is unknown");
+    yyjson_val *texture_value = obj_get(component, "texture");
+    if (texture_value != NULL && !is_non_empty_string(component, "texture"))
+        return validation_error(ctx, path, "render.mesh_primitive texture must be a non-empty image asset id");
+    const char *texture = json_string(component, "texture");
+    if (texture != NULL && !require_ref(ctx, &names->images, "image asset", texture, path))
+        return false;
+    yyjson_val *wire_color = obj_get(component, "wire_color");
+    if (wire_color != NULL && !is_vec_array(wire_color, 3))
+        return validation_error(ctx, path, "render.mesh_primitive wire_color must be a vec3 or vec4");
+    yyjson_val *size = obj_get(component, "size");
+    if (size != NULL && !is_vec_array(size, 3))
+        return validation_error(ctx, path, "render.mesh_primitive size must be a vec3");
+    yyjson_val *size_property = obj_get(component, "size_property");
+    if (size_property != NULL && !is_non_empty_string(component, "size_property"))
+        return validation_error(ctx, path, "render.mesh_primitive size_property must be non-empty");
+    const char *positive_numbers[] = {"radius", "height", "major_radius", "minor_radius"};
+    for (size_t i = 0; i < SDL_arraysize(positive_numbers); ++i)
+    {
+        yyjson_val *value = obj_get(component, positive_numbers[i]);
+        if (value != NULL && (!yyjson_is_num(value) || yyjson_get_num(value) <= 0.0))
+            return validation_error(ctx, path, "render.mesh_primitive dimensions must be positive numbers");
+    }
+    const char *non_negative_numbers[] = {"radius_top", "radius_bottom"};
+    for (size_t i = 0; i < SDL_arraysize(non_negative_numbers); ++i)
+    {
+        yyjson_val *value = obj_get(component, non_negative_numbers[i]);
+        if (value != NULL && (!yyjson_is_num(value) || yyjson_get_num(value) < 0.0))
+            return validation_error(ctx, path, "render.mesh_primitive radii must be non-negative numbers");
+    }
+    const char *positive_ints[] = {"segments", "slices", "rings", "tube_segments"};
+    for (size_t i = 0; i < SDL_arraysize(positive_ints); ++i)
+    {
+        yyjson_val *value = obj_get(component, positive_ints[i]);
+        if (value != NULL && (!yyjson_is_int(value) || yyjson_get_int(value) < 3))
+            return validation_error(ctx, path, "render.mesh_primitive tessellation values must be integers >= 3");
+    }
+    yyjson_val *rotation_axis = obj_get(component, "rotation_axis");
+    if (rotation_axis != NULL && !is_vec_array(rotation_axis, 3))
+        return validation_error(ctx, path, "render.mesh_primitive rotation_axis must be a vec3");
+    yyjson_val *rotation_angle = obj_get(component, "rotation_angle");
+    if (rotation_angle != NULL && !yyjson_is_num(rotation_angle))
+        return validation_error(ctx, path, "render.mesh_primitive rotation_angle must be a number");
+    yyjson_val *rotation_property = obj_get(component, "rotation_property");
+    if (rotation_property != NULL && !is_non_empty_string(component, "rotation_property"))
+        return validation_error(ctx, path, "render.mesh_primitive rotation_property must be non-empty");
+    return true;
 }
 
 static bool validate_non_empty_string_field(validation_context *ctx, yyjson_val *json, const char *json_path,
@@ -4994,12 +5068,14 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                     return validation_error(ctx, path, "light component color must be a vec3");
             }
             else if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
-                     SDL_strcmp(type, "render.sprite") == 0 || SDL_strcmp(type, "render.model") == 0)
+                     SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.sprite") == 0 ||
+                     SDL_strcmp(type, "render.model") == 0)
             {
                 yyjson_val *lighting = obj_get(component, "lighting");
                 if (lighting != NULL && !yyjson_is_bool(lighting))
                     return validation_error(ctx, path, "render primitive lighting must be a boolean");
-                if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0)
+                if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
+                    SDL_strcmp(type, "render.mesh_primitive") == 0)
                 {
                     yyjson_val *texture_value = obj_get(component, "texture");
                     if (texture_value != NULL && !is_non_empty_string(component, "texture"))
@@ -5017,6 +5093,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                     yyjson_val *size_property = obj_get(component, "size_property");
                     if (size_property != NULL && !is_non_empty_string(component, "size_property"))
                         return validation_error(ctx, path, "render.cube size_property must be non-empty");
+                }
+                if (SDL_strcmp(type, "render.mesh_primitive") == 0)
+                {
+                    if (!validate_render_mesh_primitive_component(ctx, component, path, names))
+                        return false;
                 }
                 if (SDL_strcmp(type, "render.sphere") == 0)
                 {
@@ -5451,6 +5532,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
                                             "render.cube texture must be a non-empty image asset id");
                 const char *texture = json_string(component, "texture");
                 if (texture != NULL && !require_ref(ctx, &names->images, "image asset", texture, component_path))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "render.mesh_primitive") == 0)
+            {
+                if (!validate_render_mesh_primitive_component(ctx, component, component_path, names))
                     return false;
             }
             else if (SDL_strcmp(type, "render.sprite") == 0)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8905,6 +8905,221 @@ TEST(GameDataRuntime, ActivePooledActorsRenderAndEmitParticles)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, EmitsAuthoredMeshPrimitiveDescriptors)
+{
+    const std::filesystem::path dir = unique_test_dir("mesh_primitives");
+    write_text(dir / "mesh_primitives.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Mesh Primitives", "id": "test.mesh_primitives", "version": "0.1.0" },
+  "world": { "name": "world.mesh_primitives", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.mesh.cube",
+      "active": true,
+      "transform": { "position": [1.0, 0.0, 0.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cube", "size": [1.0, 2.0, 3.0], "draw_mode": "solid_wire", "wire_color": [255, 0, 0, 255] }
+      ]
+    },
+    {
+      "name": "entity.mesh.sphere",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.25, "segments": 12, "rings": 6 }
+      ]
+    },
+    {
+      "name": "entity.mesh.capsule",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.3, "height": 1.8 }
+      ]
+    },
+    {
+      "name": "entity.mesh.cylinder",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cylinder", "radius_top": 0.4, "radius_bottom": 0.6, "height": 1.5, "draw_mode": "wire" }
+      ]
+    },
+    {
+      "name": "entity.mesh.cone",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cone", "radius": 0.7, "height": 1.2, "radius_top": 0.0 }
+      ]
+    },
+    {
+      "name": "entity.mesh.torus",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.8, "minor_radius": 0.15, "segments": 32, "tube_segments": 10 }
+      ]
+    },
+    {
+      "name": "entity.mesh.pyramid",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "pyramid", "size": [1.0, 1.4, 1.0] }
+      ]
+    },
+    {
+      "name": "entity.mesh.wedge",
+      "active": true,
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "wedge", "size": [1.0, 0.5, 1.5], "lighting": false }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true
+})json");
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file((dir / "mesh_primitives.game.json").string().c_str(), session, &runtime,
+                                          error, sizeof(error)))
+        << error;
+
+    struct MeshCapture
+    {
+        int count = 0;
+        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE + 1] = {};
+    } capture;
+    auto capture_mesh = [](void *userdata, const sdl3d_game_data_render_primitive *primitive) -> bool {
+        auto *mesh_capture = static_cast<MeshCapture *>(userdata);
+        if (primitive->type != SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE)
+            return true;
+        mesh_capture->count++;
+        EXPECT_GT(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID);
+        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE);
+        if (primitive->mesh_primitive <= SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID ||
+            primitive->mesh_primitive > SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE)
+        {
+            return false;
+        }
+        mesh_capture->seen[primitive->mesh_primitive] = true;
+        EXPECT_TRUE(primitive->lighting_enabled || primitive->mesh_primitive == SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE);
+        if (std::string(primitive->entity_name) == "entity.mesh.cube")
+        {
+            EXPECT_EQ(primitive->draw_mode, SDL3D_GAME_DATA_RENDER_DRAW_SOLID_WIRE);
+            EXPECT_NEAR(primitive->size.y, 2.0f, 0.0001f);
+            EXPECT_EQ(primitive->wire_color.r, 255);
+        }
+        if (std::string(primitive->entity_name) == "entity.mesh.cylinder")
+        {
+            EXPECT_EQ(primitive->draw_mode, SDL3D_GAME_DATA_RENDER_DRAW_WIRE);
+            EXPECT_NEAR(primitive->radius_top, 0.4f, 0.0001f);
+            EXPECT_NEAR(primitive->radius_bottom, 0.6f, 0.0001f);
+            EXPECT_NEAR(primitive->height, 1.5f, 0.0001f);
+        }
+        if (std::string(primitive->entity_name) == "entity.mesh.cone")
+        {
+            EXPECT_NEAR(primitive->radius_top, 0.0f, 0.0001f);
+            EXPECT_NEAR(primitive->radius_bottom, 0.7f, 0.0001f);
+        }
+        if (std::string(primitive->entity_name) == "entity.mesh.torus")
+        {
+            EXPECT_NEAR(primitive->major_radius, 0.8f, 0.0001f);
+            EXPECT_NEAR(primitive->minor_radius, 0.15f, 0.0001f);
+            EXPECT_EQ(primitive->tube_segments, 10);
+        }
+        return true;
+    };
+
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_mesh, &capture));
+    EXPECT_EQ(capture.count, 8);
+    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE; ++kind)
+        EXPECT_TRUE(capture.seen[kind]) << kind;
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataValidation, RejectsInvalidMeshPrimitiveComponents)
+{
+    const std::filesystem::path dir = unique_test_dir("invalid_mesh_primitive");
+    write_text(dir / "bad_kind.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Mesh Primitive", "id": "test.bad_mesh_primitive", "version": "0.1.0" },
+  "world": { "name": "world.bad_mesh_primitive", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.bad",
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "octahedron" }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "bad_segments.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Mesh Primitive", "id": "test.bad_mesh_primitive", "version": "0.1.0" },
+  "world": { "name": "world.bad_mesh_primitive", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.bad",
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "torus", "segments": 2 }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "bad_draw_mode.game.json",
+               R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad Mesh Primitive", "id": "test.bad_mesh_primitive", "version": "0.1.0" },
+  "world": { "name": "world.bad_mesh_primitive", "kind": "fixed_screen" },
+  "entities": [
+    {
+      "name": "entity.bad",
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cube", "draw_mode": "xray" }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "renders_world": true
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(
+        sdl3d_game_data_validate_file((dir / "bad_kind.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("render.mesh_primitive primitive is unknown"), std::string::npos) << error;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_segments.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("render.mesh_primitive tessellation values must be integers >= 3"),
+              std::string::npos)
+        << error;
+    SDL_zeroa(error);
+    EXPECT_FALSE(sdl3d_game_data_validate_file((dir / "bad_draw_mode.game.json").string().c_str(), nullptr, error,
+                                               sizeof(error)));
+    EXPECT_NE(std::string(error).find("render.mesh_primitive draw_mode is unknown"), std::string::npos) << error;
+
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, ActorPoolsApplySceneExitPolicies)
 {
     const std::filesystem::path dir = unique_test_dir("actor_pool_scene_policy");


### PR DESCRIPTION
## Summary

- adds the `render.mesh_primitive` data/runtime descriptor for cube, sphere, capsule, cylinder, cone, torus, pyramid, and wedge procedural shapes
- adds public primitive-kind and draw-mode enums plus descriptor fields for dimensions, tessellation, wire color, and wire draw modes
- validates mesh primitive components for static entities and archetypes, including primitive names, draw modes, dimensions, tessellation, transform fields, and texture refs
- documents the new descriptor schema and current production-rendering boundary

## Tests

- `./build/debug/tests/sdl3d_game_data_test --gtest_filter='GameDataRuntime.EmitsAuthoredMeshPrimitiveDescriptors:GameDataValidation.RejectsInvalidMeshPrimitiveComponents'`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j4`

Refs #298
