### PR TITLE
Render authored mesh primitives

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1388,10 +1388,9 @@ Reusable components include:
   (default), `wire`, or `solid_wire`. Dimension fields include `size`,
   `radius`, `height`, `radius_top`, `radius_bottom`, `major_radius`,
   `minor_radius`, `segments`/`slices`, `rings`, and `tube_segments`. This is the
-  stable data/runtime representation for procedural mesh primitives. Rendering
-  support for the full primitive set is provided by the procedural mesh
-  presentation path; until that path is enabled, existing `render.cube` and
-  `render.sphere` remain the production drawing components.
+  stable data/runtime representation for procedural mesh primitives. The
+  generic presentation path renders every primitive as shaded solid geometry by
+  default, with optional wire-only or solid-plus-wire modes.
 - `render.model`: renders an authored `assets.models` entry with `model`,
   optional `scale`, axis-angle rotation, `color` tint, and optional skeletal
   animation playback via `animation_clip` and `animation_time_property`.

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -320,8 +320,9 @@ extern "C"
      * @brief Draw authored render primitives for the active scene.
      *
      * This renders currently supported primitive components (`render.cube`,
-     * `render.sphere`, `render.sprite`, and `render.model`) using SDL3D's
-     * immediate drawing helpers. Call inside an active 3D pass.
+     * `render.sphere`, `render.mesh_primitive`, `render.sprite`, and
+     * `render.model`) using SDL3D's immediate drawing helpers. Call inside an
+     * active 3D pass.
      */
     bool sdl3d_game_data_draw_render_primitives(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer);
 

--- a/include/sdl3d/shapes.h
+++ b/include/sdl3d/shapes.h
@@ -122,6 +122,30 @@ extern "C"
     bool sdl3d_draw_capsule_wires(sdl3d_render_context *context, sdl3d_vec3 start, sdl3d_vec3 end, float radius,
                                   int slices, int rings, sdl3d_color color);
 
+    /*
+     * Torus aligned around the local +Y axis. `major_radius` is the
+     * distance from the origin to the tube centerline, and `minor_radius`
+     * is the tube radius. Both segment counts must be >= 3.
+     */
+    bool sdl3d_draw_torus(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius, float minor_radius,
+                          int segments, int tube_segments, sdl3d_color color);
+    bool sdl3d_draw_torus_wires(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius,
+                                float minor_radius, int segments, int tube_segments, sdl3d_color color);
+
+    /*
+     * Square pyramid centered in local space. `size.x` and `size.z` define
+     * the base extents, and `size.y` defines the height.
+     */
+    bool sdl3d_draw_pyramid(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+    bool sdl3d_draw_pyramid_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+
+    /*
+     * Wedge/ramp triangular prism centered in local space. The low edge is
+     * at local -Z and the high edge is at local +Z.
+     */
+    bool sdl3d_draw_wedge(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+    bool sdl3d_draw_wedge_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -821,6 +821,121 @@ static bool append_sphere_draw_batch(primitive_draw_context *context, const sdl3
     return true;
 }
 
+static const sdl3d_texture2d *primitive_texture(primitive_draw_context *context,
+                                                const sdl3d_game_data_render_primitive *primitive)
+{
+    if (context == NULL || primitive == NULL || primitive->texture_image == NULL || context->image_cache == NULL)
+        return NULL;
+    sdl3d_game_data_image_cache_entry *entry =
+        find_or_load_image_entry(context->runtime, context->image_cache, primitive->texture_image);
+    return entry != NULL ? &entry->texture : NULL;
+}
+
+static bool draw_mesh_primitive_solid(primitive_draw_context *context,
+                                      const sdl3d_game_data_render_primitive *primitive)
+{
+    if (context == NULL || primitive == NULL)
+        return false;
+    const sdl3d_texture2d *texture = primitive_texture(context, primitive);
+    switch (primitive->mesh_primitive)
+    {
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE:
+        return sdl3d_draw_cube_textured(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                        sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 0.0f, texture, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_SPHERE:
+        return sdl3d_draw_sphere_textured(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                          primitive->rings, primitive->slices, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), 0.0f,
+                                          texture, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CAPSULE: {
+        const float cylinder_span = SDL_max(primitive->height - primitive->radius * 2.0f, 0.0f);
+        const sdl3d_vec3 start = sdl3d_vec3_make(0.0f, -cylinder_span * 0.5f, 0.0f);
+        const sdl3d_vec3 end = sdl3d_vec3_make(0.0f, cylinder_span * 0.5f, 0.0f);
+        return sdl3d_draw_capsule(context->renderer, start, end, primitive->radius, primitive->slices, primitive->rings,
+                                  primitive->color);
+    }
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CYLINDER:
+        return sdl3d_draw_cylinder(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius_top,
+                                   primitive->radius_bottom, primitive->height, primitive->slices, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE:
+        return sdl3d_draw_cylinder(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius_top,
+                                   primitive->radius_bottom, primitive->height, primitive->slices, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS:
+        return sdl3d_draw_torus(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->major_radius,
+                                primitive->minor_radius, primitive->slices, primitive->tube_segments, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID:
+        return sdl3d_draw_pyramid(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                  primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE:
+        return sdl3d_draw_wedge(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID:
+    default:
+        return false;
+    }
+}
+
+static bool draw_mesh_primitive_wires(primitive_draw_context *context,
+                                      const sdl3d_game_data_render_primitive *primitive)
+{
+    if (context == NULL || primitive == NULL)
+        return false;
+    switch (primitive->mesh_primitive)
+    {
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE:
+        return sdl3d_draw_cube_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                     primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_SPHERE:
+        return sdl3d_draw_sphere_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                       primitive->rings, primitive->slices, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CAPSULE: {
+        const float cylinder_span = SDL_max(primitive->height - primitive->radius * 2.0f, 0.0f);
+        const sdl3d_vec3 start = sdl3d_vec3_make(0.0f, -cylinder_span * 0.5f, 0.0f);
+        const sdl3d_vec3 end = sdl3d_vec3_make(0.0f, cylinder_span * 0.5f, 0.0f);
+        return sdl3d_draw_capsule_wires(context->renderer, start, end, primitive->radius, primitive->slices,
+                                        primitive->rings, primitive->wire_color);
+    }
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CYLINDER:
+        return sdl3d_draw_cylinder_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius_top,
+                                         primitive->radius_bottom, primitive->height, primitive->slices,
+                                         primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE:
+        return sdl3d_draw_cylinder_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius_top,
+                                         primitive->radius_bottom, primitive->height, primitive->slices,
+                                         primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS:
+        return sdl3d_draw_torus_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->major_radius,
+                                      primitive->minor_radius, primitive->slices, primitive->tube_segments,
+                                      primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID:
+        return sdl3d_draw_pyramid_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                        primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE:
+        return sdl3d_draw_wedge_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                      primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID:
+    default:
+        return false;
+    }
+}
+
+static bool draw_mesh_primitive(primitive_draw_context *context, const sdl3d_game_data_render_primitive *primitive)
+{
+    if (!sdl3d_push_matrix(context->renderer))
+        return false;
+    bool ok = sdl3d_translate(context->renderer, primitive->position.x, primitive->position.y, primitive->position.z);
+    const float axis_length_sq = primitive->rotation_axis.x * primitive->rotation_axis.x +
+                                 primitive->rotation_axis.y * primitive->rotation_axis.y +
+                                 primitive->rotation_axis.z * primitive->rotation_axis.z;
+    if (ok && axis_length_sq > 0.000001f && SDL_fabsf(primitive->rotation_angle) > 0.000001f)
+        ok = sdl3d_rotate(context->renderer, primitive->rotation_axis, primitive->rotation_angle);
+    if (ok && primitive->draw_mode != SDL3D_GAME_DATA_RENDER_DRAW_WIRE)
+        ok = draw_mesh_primitive_solid(context, primitive);
+    if (ok && primitive->draw_mode != SDL3D_GAME_DATA_RENDER_DRAW_SOLID)
+        ok = draw_mesh_primitive_wires(context, primitive);
+    const bool pop_ok = sdl3d_pop_matrix(context->renderer);
+    return ok && pop_ok;
+}
+
 static bool draw_primitive(void *userdata, const sdl3d_game_data_render_primitive *primitive)
 {
     primitive_draw_context *context = (primitive_draw_context *)userdata;
@@ -838,29 +953,22 @@ static bool draw_primitive(void *userdata, const sdl3d_game_data_render_primitiv
                        primitive->emissive_color.z);
     if (primitive->type == SDL3D_GAME_DATA_RENDER_CUBE)
     {
-        const sdl3d_texture2d *texture = NULL;
-        if (primitive->texture_image != NULL && context->image_cache != NULL)
-        {
-            sdl3d_game_data_image_cache_entry *entry =
-                find_or_load_image_entry(context->runtime, context->image_cache, primitive->texture_image);
-            texture = entry != NULL ? &entry->texture : NULL;
-        }
+        const sdl3d_texture2d *texture = primitive_texture(context, primitive);
         if (!sdl3d_draw_cube_textured(context->renderer, primitive->position, primitive->size, primitive->rotation_axis,
                                       primitive->rotation_angle, texture, primitive->color))
             return false;
     }
     else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE)
     {
-        const sdl3d_texture2d *texture = NULL;
-        if (primitive->texture_image != NULL && context->image_cache != NULL)
-        {
-            sdl3d_game_data_image_cache_entry *entry =
-                find_or_load_image_entry(context->runtime, context->image_cache, primitive->texture_image);
-            texture = entry != NULL ? &entry->texture : NULL;
-        }
+        const sdl3d_texture2d *texture = primitive_texture(context, primitive);
         if (!sdl3d_draw_sphere_textured(context->renderer, primitive->position, primitive->radius, primitive->rings,
                                         primitive->slices, primitive->rotation_axis, primitive->rotation_angle, texture,
                                         primitive->color))
+            return false;
+    }
+    else if (primitive->type == SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE)
+    {
+        if (!draw_mesh_primitive(context, primitive))
             return false;
     }
     else if (primitive->type == SDL3D_GAME_DATA_RENDER_SPHERE_BATCH)

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -940,3 +940,284 @@ bool sdl3d_draw_capsule_wires(sdl3d_render_context *context, sdl3d_vec3 start, s
     }
     return sdl3d_draw_capsule_solid(context, start, end, radius, slices, rings, color, true);
 }
+
+static void sdl3d_shape_store_vertex(float *positions, float *normals, int index, sdl3d_vec3 position,
+                                     sdl3d_vec3 normal)
+{
+    positions[index * 3 + 0] = position.x;
+    positions[index * 3 + 1] = position.y;
+    positions[index * 3 + 2] = position.z;
+    normals[index * 3 + 0] = normal.x;
+    normals[index * 3 + 1] = normal.y;
+    normals[index * 3 + 2] = normal.z;
+}
+
+static sdl3d_vec3 sdl3d_shape_face_normal(sdl3d_vec3 a, sdl3d_vec3 b, sdl3d_vec3 c)
+{
+    return sdl3d_vec3_normalize(sdl3d_vec3_cross(sdl3d_vec3_sub(b, a), sdl3d_vec3_sub(c, a)));
+}
+
+bool sdl3d_draw_torus(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius, float minor_radius,
+                      int segments, int tube_segments, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(major_radius, "major_radius", "sdl3d_draw_torus") ||
+        !sdl3d_shape_require_positive(minor_radius, "minor_radius", "sdl3d_draw_torus"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_torus requires segments >= 3.");
+    if (tube_segments < 3)
+        return SDL_SetError("sdl3d_draw_torus requires tube_segments >= 3.");
+
+    const int verts_per_ring = tube_segments + 1;
+    const int vert_count = (segments + 1) * verts_per_ring;
+    const int idx_count = segments * tube_segments * 6;
+    float *positions = (float *)SDL_malloc((size_t)vert_count * 3 * sizeof(float));
+    float *normals = (float *)SDL_malloc((size_t)vert_count * 3 * sizeof(float));
+    unsigned int *indices = (unsigned int *)SDL_malloc((size_t)idx_count * sizeof(unsigned int));
+    if (positions == NULL || normals == NULL || indices == NULL)
+    {
+        SDL_free(positions);
+        SDL_free(normals);
+        SDL_free(indices);
+        return SDL_OutOfMemory();
+    }
+
+    for (int i = 0; i <= segments; ++i)
+    {
+        const float u = 2.0f * SDL3D_SHAPES_PI * (float)i / (float)segments;
+        const float cu = SDL_cosf(u);
+        const float su = SDL_sinf(u);
+        for (int j = 0; j <= tube_segments; ++j)
+        {
+            const float v = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)tube_segments;
+            const float cv = SDL_cosf(v);
+            const float sv = SDL_sinf(v);
+            const int vi = i * verts_per_ring + j;
+            const float radial = major_radius + minor_radius * cv;
+            const sdl3d_vec3 normal = sdl3d_vec3_make(cv * cu, sv, cv * su);
+            const sdl3d_vec3 position =
+                sdl3d_vec3_make(center.x + radial * cu, center.y + minor_radius * sv, center.z + radial * su);
+            sdl3d_shape_store_vertex(positions, normals, vi, position, normal);
+        }
+    }
+
+    int ii = 0;
+    for (int i = 0; i < segments; ++i)
+    {
+        for (int j = 0; j < tube_segments; ++j)
+        {
+            const unsigned int v00 = (unsigned int)(i * verts_per_ring + j);
+            const unsigned int v01 = v00 + 1U;
+            const unsigned int v10 = (unsigned int)((i + 1) * verts_per_ring + j);
+            const unsigned int v11 = v10 + 1U;
+            indices[ii++] = v00;
+            indices[ii++] = v11;
+            indices[ii++] = v10;
+            indices[ii++] = v00;
+            indices[ii++] = v01;
+            indices[ii++] = v11;
+        }
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = vert_count;
+    mesh.index_count = idx_count;
+    const bool result = sdl3d_draw_mesh(context, &mesh, NULL, color);
+    SDL_free(positions);
+    SDL_free(normals);
+    SDL_free(indices);
+    return result;
+}
+
+bool sdl3d_draw_torus_wires(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius, float minor_radius,
+                            int segments, int tube_segments, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(major_radius, "major_radius", "sdl3d_draw_torus_wires") ||
+        !sdl3d_shape_require_positive(minor_radius, "minor_radius", "sdl3d_draw_torus_wires"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_torus_wires requires segments >= 3.");
+    if (tube_segments < 3)
+        return SDL_SetError("sdl3d_draw_torus_wires requires tube_segments >= 3.");
+
+    for (int i = 0; i < segments; ++i)
+    {
+        const float u0 = 2.0f * SDL3D_SHAPES_PI * (float)i / (float)segments;
+        const float u1 = 2.0f * SDL3D_SHAPES_PI * (float)(i + 1) / (float)segments;
+        const float cu0 = SDL_cosf(u0), su0 = SDL_sinf(u0);
+        const float cu1 = SDL_cosf(u1), su1 = SDL_sinf(u1);
+        for (int j = 0; j < tube_segments; ++j)
+        {
+            const float v0 = 2.0f * SDL3D_SHAPES_PI * (float)j / (float)tube_segments;
+            const float v1 = 2.0f * SDL3D_SHAPES_PI * (float)(j + 1) / (float)tube_segments;
+            const float cv0 = SDL_cosf(v0), sv0 = SDL_sinf(v0);
+            const float cv1 = SDL_cosf(v1), sv1 = SDL_sinf(v1);
+            const sdl3d_vec3 p00 =
+                sdl3d_vec3_make(center.x + (major_radius + minor_radius * cv0) * cu0, center.y + minor_radius * sv0,
+                                center.z + (major_radius + minor_radius * cv0) * su0);
+            const sdl3d_vec3 p01 =
+                sdl3d_vec3_make(center.x + (major_radius + minor_radius * cv1) * cu0, center.y + minor_radius * sv1,
+                                center.z + (major_radius + minor_radius * cv1) * su0);
+            const sdl3d_vec3 p10 =
+                sdl3d_vec3_make(center.x + (major_radius + minor_radius * cv0) * cu1, center.y + minor_radius * sv0,
+                                center.z + (major_radius + minor_radius * cv0) * su1);
+            if (!sdl3d_draw_line_3d(context, p00, p01, color) || !sdl3d_draw_line_3d(context, p00, p10, color))
+                return false;
+        }
+    }
+    return true;
+}
+
+bool sdl3d_draw_pyramid(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_pyramid") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_pyramid") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_pyramid"))
+    {
+        return false;
+    }
+
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float hz = size.z * 0.5f;
+    const sdl3d_vec3 apex = sdl3d_vec3_make(center.x, center.y + hy, center.z);
+    const sdl3d_vec3 bl = sdl3d_vec3_make(center.x - hx, center.y - hy, center.z - hz);
+    const sdl3d_vec3 br = sdl3d_vec3_make(center.x + hx, center.y - hy, center.z - hz);
+    const sdl3d_vec3 tr = sdl3d_vec3_make(center.x + hx, center.y - hy, center.z + hz);
+    const sdl3d_vec3 tl = sdl3d_vec3_make(center.x - hx, center.y - hy, center.z + hz);
+    const sdl3d_vec3 faces[6][3] = {
+        {bl, apex, br}, {br, apex, tr}, {tr, apex, tl}, {tl, apex, bl}, {bl, br, tr}, {bl, tr, tl},
+    };
+    float positions[18 * 3];
+    float normals[18 * 3];
+    unsigned int indices[18];
+    for (int f = 0; f < 6; ++f)
+    {
+        const sdl3d_vec3 normal = sdl3d_shape_face_normal(faces[f][0], faces[f][1], faces[f][2]);
+        for (int v = 0; v < 3; ++v)
+        {
+            const int vi = f * 3 + v;
+            sdl3d_shape_store_vertex(positions, normals, vi, faces[f][v], normal);
+            indices[vi] = (unsigned int)vi;
+        }
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = 18;
+    mesh.index_count = 18;
+    return sdl3d_draw_mesh(context, &mesh, NULL, color);
+}
+
+bool sdl3d_draw_pyramid_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_pyramid_wires") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_pyramid_wires") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_pyramid_wires"))
+    {
+        return false;
+    }
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float hz = size.z * 0.5f;
+    const sdl3d_vec3 p[5] = {
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x, center.y + hy, center.z),
+    };
+    static const int edges[8][2] = {{0, 1}, {1, 2}, {2, 3}, {3, 0}, {0, 4}, {1, 4}, {2, 4}, {3, 4}};
+    for (int i = 0; i < 8; ++i)
+    {
+        if (!sdl3d_draw_line_3d(context, p[edges[i][0]], p[edges[i][1]], color))
+            return false;
+    }
+    return true;
+}
+
+bool sdl3d_draw_wedge(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_wedge") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_wedge") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_wedge"))
+    {
+        return false;
+    }
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float hz = size.z * 0.5f;
+    const sdl3d_vec3 p[6] = {
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x - hx, center.y + hy, center.z + hz),
+        sdl3d_vec3_make(center.x + hx, center.y + hy, center.z + hz),
+    };
+    const sdl3d_vec3 triangles[8][3] = {
+        {p[0], p[3], p[1]}, {p[0], p[2], p[3]}, {p[2], p[5], p[3]}, {p[2], p[4], p[5]},
+        {p[0], p[4], p[2]}, {p[0], p[1], p[5]}, {p[0], p[5], p[4]}, {p[1], p[3], p[5]},
+    };
+    float positions[24 * 3];
+    float normals[24 * 3];
+    unsigned int indices[24];
+    for (int f = 0; f < 8; ++f)
+    {
+        const sdl3d_vec3 normal = sdl3d_shape_face_normal(triangles[f][0], triangles[f][1], triangles[f][2]);
+        for (int v = 0; v < 3; ++v)
+        {
+            const int vi = f * 3 + v;
+            sdl3d_shape_store_vertex(positions, normals, vi, triangles[f][v], normal);
+            indices[vi] = (unsigned int)vi;
+        }
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = 24;
+    mesh.index_count = 24;
+    return sdl3d_draw_mesh(context, &mesh, NULL, color);
+}
+
+bool sdl3d_draw_wedge_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_wedge_wires") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_wedge_wires") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_wedge_wires"))
+    {
+        return false;
+    }
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float hz = size.z * 0.5f;
+    const sdl3d_vec3 p[6] = {
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z - hz),
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z + hz),
+        sdl3d_vec3_make(center.x - hx, center.y + hy, center.z + hz),
+        sdl3d_vec3_make(center.x + hx, center.y + hy, center.z + hz),
+    };
+    static const int edges[9][2] = {{0, 1}, {0, 2}, {1, 3}, {2, 3}, {2, 4}, {3, 5}, {4, 5}, {0, 4}, {1, 5}};
+    for (int i = 0; i < 9; ++i)
+    {
+        if (!sdl3d_draw_line_3d(context, p[edges[i][0]], p[edges[i][1]], color))
+            return false;
+    }
+    return true;
+}

--- a/tests/test_shapes.cpp
+++ b/tests/test_shapes.cpp
@@ -596,6 +596,71 @@ TEST_F(SDL3DShapesFixture, CapsuleAcceptsArbitraryAxis)
     EXPECT_TRUE(PixelEquals(p, kRed));
 }
 
+TEST_F(SDL3DShapesFixture, TorusPyramidAndWedgeRender)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_set_backface_culling_enabled(c.ctx, true));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_torus(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.55f, 0.18f, 24, 8, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+    EXPECT_GT(CountColor(c.ctx, kRed), 100);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_pyramid(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.2f, 1.2f, 1.2f), kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+    EXPECT_GT(CountColor(c.ctx, kGreen), 100);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_wedge(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.2f, 1.0f, 1.2f), kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+    EXPECT_GT(CountColor(c.ctx, kBlue), 100);
+}
+
+TEST_F(SDL3DShapesFixture, NewPrimitiveWiresDrawWithoutFilling)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_torus_wires(c.ctx, sdl3d_vec3_make(-0.8f, 0, 0), 0.35f, 0.12f, 16, 6, kGreen));
+    ASSERT_TRUE(
+        sdl3d_draw_pyramid_wires(c.ctx, sdl3d_vec3_make(0.6f, 0, 0), sdl3d_vec3_make(0.7f, 0.8f, 0.7f), kGreen));
+    ASSERT_TRUE(sdl3d_draw_wedge_wires(c.ctx, sdl3d_vec3_make(0, -0.9f, 0), sdl3d_vec3_make(0.7f, 0.6f, 0.7f), kGreen));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+
+    const int total = sdl3d_get_render_context_width(c.ctx) * sdl3d_get_render_context_height(c.ctx);
+    const int green = CountColor(c.ctx, kGreen);
+    EXPECT_GT(green, 20);
+    EXPECT_LT(green, total / 2);
+}
+
+TEST_F(SDL3DShapesFixture, RejectsBadNewPrimitiveArguments)
+{
+    WindowRenderer wr(64, 64);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    EXPECT_FALSE(sdl3d_draw_torus(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.0f, 0.1f, 8, 6, kRed));
+    EXPECT_FALSE(sdl3d_draw_torus(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 0.1f, 2, 6, kRed));
+    EXPECT_FALSE(sdl3d_draw_torus_wires(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 0.1f, 8, 2, kRed));
+    EXPECT_FALSE(sdl3d_draw_pyramid(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(-1.0f, 1.0f, 1.0f), kRed));
+    EXPECT_FALSE(sdl3d_draw_wedge(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, -1.0f, 1.0f), kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+}
+
 /* --- Matrix-stack composition ------------------------------------------- */
 
 TEST_F(SDL3DShapesFixture, CubeHonorsModelMatrixStack)


### PR DESCRIPTION
## Summary

- adds immediate-mode torus, pyramid, and wedge solid/wire shape primitives
- wires `render.mesh_primitive` through the generic presentation path for all eight primitive kinds
- supports `solid`, `wire`, and `solid_wire` draw modes with dynamic lighting for solid geometry
- updates docs and presentation API comments now that mesh primitives render through the generic path

## Tests

- `./build/debug/tests/sdl3d_shapes_test --gtest_filter='SDL3DShapesFixture.TorusPyramidAndWedgeRender:SDL3DShapesFixture.NewPrimitiveWiresDrawWithoutFilling:SDL3DShapesFixture.RejectsBadNewPrimitiveArguments'`
- `./build/debug/tests/sdl3d_shapes_test`
- `./build/debug/tests/sdl3d_game_data_test`
- `cmake --build build/debug -j4`

Refs #298
