### PR TITLE
Add mesh primitives dojo, composites, and horizontal camera FOV

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ targets. The generic `sdl3d_runner` can launch games from:
 
 The demo games are compatibility proofs for engine capabilities. New demo work
 should strengthen reusable systems instead of adding one-off host code.
+The repository also includes data-only dojos for focused primitive and mechanic
+tuning, including FPS mechanics and procedural mesh primitive showcases.
 
 Default authored display and world conventions are intentionally simple:
 SDL3D games target a 1280x720 logical canvas that is letterboxed to preserve

--- a/demos/mesh_primitives_dojo/README.md
+++ b/demos/mesh_primitives_dojo/README.md
@@ -10,6 +10,5 @@ build/debug/sdl3d_runner \
 ```
 
 The room is a large sector-bounded square using untextured gray materials, a
-single directional sun light, an FPS camera/controller, and one authored entity
-for each primitive kind: cube, sphere, capsule, cylinder, cone, torus, pyramid,
-and wedge.
+single directional sun light, an FPS camera/controller, one authored entity for
+each primitive kind, and a few mock actors assembled with `render.composite`.

--- a/demos/mesh_primitives_dojo/README.md
+++ b/demos/mesh_primitives_dojo/README.md
@@ -1,0 +1,15 @@
+# Mesh Primitives Dojo
+
+Data-only graybox showcase for the procedural `render.mesh_primitive` component.
+It runs through the generic SDL3D runner and contains no demo-specific host code.
+
+```sh
+build/debug/sdl3d_runner \
+  --root demos/mesh_primitives_dojo/data \
+  --data asset://mesh_primitives_dojo.game.json
+```
+
+The room is a large sector-bounded square using untextured gray materials, a
+single directional sun light, an FPS camera/controller, and one authored entity
+for each primitive kind: cube, sphere, capsule, cylinder, cone, torus, pyramid,
+and wedge.

--- a/demos/mesh_primitives_dojo/data/fragments/actors/player.json
+++ b/demos/mesh_primitives_dojo/data/fragments/actors/player.json
@@ -1,0 +1,37 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["player", "fps_actor"],
+      "transform": { "position": [13.0, 1.6, 4.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 3.1415927 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.mesh_primitives.graybox_room",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 7.0,
+          "jump_velocity": 6.0,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.55,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ]
+}

--- a/demos/mesh_primitives_dojo/data/fragments/actors/player.json
+++ b/demos/mesh_primitives_dojo/data/fragments/actors/player.json
@@ -5,7 +5,7 @@
       "name": "entity.player",
       "active": true,
       "tags": ["player", "fps_actor"],
-      "transform": { "position": [13.0, 1.6, 4.0] },
+      "transform": { "position": [26.0, 1.6, 6.0] },
       "properties": {
         "yaw": { "type": "float", "value": 3.1415927 },
         "pitch": { "type": "float", "value": 0.0 },

--- a/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
+++ b/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
@@ -27,7 +27,7 @@
       "active": true,
       "transform": { "position": [13.0, 1.0, 14.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.95, "segments": 32, "rings": 16, "color": [80, 180, 255, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.95, "segments": 24, "rings": 12, "color": [80, 180, 255, 255], "lighting": true }
       ]
     },
     {
@@ -35,7 +35,7 @@
       "active": true,
       "transform": { "position": [20.0, 1.35, 14.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.55, "height": 2.5, "segments": 24, "rings": 10, "color": [110, 235, 130, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.55, "height": 2.5, "segments": 20, "rings": 8, "color": [110, 235, 130, 255], "lighting": true }
       ]
     },
     {
@@ -43,7 +43,7 @@
       "active": true,
       "transform": { "position": [27.0, 1.0, 14.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "cylinder", "radius_top": 0.75, "radius_bottom": 0.75, "height": 2.0, "segments": 32, "color": [255, 210, 70, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "cylinder", "radius_top": 0.75, "radius_bottom": 0.75, "height": 2.0, "segments": 24, "color": [255, 210, 70, 255], "lighting": true }
       ]
     },
     {
@@ -51,7 +51,7 @@
       "active": true,
       "transform": { "position": [34.0, 1.0, 14.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "cone", "radius": 0.9, "height": 2.0, "segments": 32, "color": [255, 125, 55, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "cone", "radius": 0.9, "height": 2.0, "segments": 24, "color": [255, 125, 55, 255], "lighting": true }
       ]
     },
     {
@@ -59,7 +59,7 @@
       "active": true,
       "transform": { "position": [41.0, 1.25, 14.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.8, "minor_radius": 0.22, "segments": 36, "tube_segments": 14, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "draw_mode": "solid_wire", "wire_color": [20, 20, 24, 220], "color": [185, 115, 255, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.8, "minor_radius": 0.22, "segments": 28, "tube_segments": 10, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [185, 115, 255, 255], "lighting": true }
       ]
     },
     {
@@ -91,7 +91,7 @@
       "active": true,
       "transform": { "position": [20.0, 1.4, 24.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "disc", "radius": 1.05, "segments": 40, "draw_mode": "solid_wire", "wire_color": [22, 26, 30, 220], "color": [255, 226, 105, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "disc", "radius": 1.05, "segments": 28, "color": [255, 226, 105, 255], "lighting": true }
       ]
     },
     {
@@ -99,7 +99,7 @@
       "active": true,
       "transform": { "position": [27.0, 1.0, 24.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 1.05, "segments": 32, "rings": 12, "color": [255, 190, 65, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 1.05, "segments": 24, "rings": 8, "color": [255, 190, 65, 255], "lighting": true }
       ]
     },
     {
@@ -107,7 +107,7 @@
       "active": true,
       "transform": { "position": [34.0, 1.0, 24.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.9, 1.7, 1.45], "bevel_radius": 0.32, "rings": 5, "draw_mode": "solid_wire", "wire_color": [22, 24, 28, 220], "color": [120, 190, 255, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.9, 1.7, 1.45], "bevel_radius": 0.28, "rings": 4, "color": [120, 190, 255, 255], "lighting": true }
       ]
     },
     {
@@ -115,7 +115,7 @@
       "active": true,
       "transform": { "position": [41.0, 1.2, 24.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "pipe", "major_radius": 0.95, "minor_radius": 0.18, "arc_angle": 3.1415927, "segments": 28, "tube_segments": 12, "draw_mode": "solid_wire", "wire_color": [18, 22, 28, 230], "color": [90, 230, 210, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "pipe", "major_radius": 0.95, "minor_radius": 0.18, "arc_angle": 3.1415927, "segments": 20, "tube_segments": 8, "color": [90, 230, 210, 255], "lighting": true }
       ]
     },
     {
@@ -131,7 +131,7 @@
       "active": true,
       "transform": { "position": [6.0, 1.55, 34.0] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "billboard_plane", "size": [2.2, 2.2, 0.05], "draw_mode": "solid_wire", "wire_color": [15, 18, 24, 230], "color": [180, 255, 125, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "billboard_plane", "size": [2.2, 2.2, 0.05], "color": [180, 255, 125, 255], "lighting": true }
       ]
     },
     {
@@ -145,7 +145,7 @@
           "wire_color": [18, 20, 24, 210],
           "parts": [
             { "primitive": "rounded_box", "offset": [0.0, 0.9, 0.0], "size": [1.2, 1.55, 0.85], "bevel_radius": 0.2, "rings": 4, "color": [100, 165, 235, 255] },
-            { "primitive": "sphere", "offset": [0.0, 1.85, 0.0], "radius": 0.42, "segments": 20, "rings": 10, "color": [230, 235, 245, 255] },
+            { "primitive": "sphere", "offset": [0.0, 1.85, 0.0], "radius": 0.42, "segments": 16, "rings": 8, "color": [230, 235, 245, 255] },
             { "primitive": "disc", "offset": [-0.16, 1.88, 0.39], "radius": 0.08, "segments": 16, "color": [45, 120, 255, 255], "emissive": true },
             { "primitive": "disc", "offset": [0.16, 1.88, 0.39], "radius": 0.08, "segments": 16, "color": [45, 120, 255, 255], "emissive": true },
             { "primitive": "capsule", "offset": [-0.86, 0.85, 0.0], "radius": 0.16, "height": 1.25, "segments": 14, "rings": 6, "color": [75, 95, 130, 255] },
@@ -164,7 +164,7 @@
           "lighting": true,
           "wire_color": [16, 18, 24, 220],
           "parts": [
-            { "primitive": "capsule", "offset": [0.0, 0.55, 0.0], "radius": 0.34, "height": 2.35, "segments": 22, "rings": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [205, 220, 240, 255] },
+            { "primitive": "capsule", "offset": [0.0, 0.55, 0.0], "radius": 0.34, "height": 2.35, "segments": 18, "rings": 6, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [205, 220, 240, 255] },
             { "primitive": "wedge", "offset": [-0.95, 0.4, 0.1], "size": [1.5, 0.25, 1.35], "rotation_axis": [0.0, 1.0, 0.0], "rotation_angle": 0.35, "color": [255, 115, 75, 255] },
             { "primitive": "wedge", "offset": [0.95, 0.4, 0.1], "size": [1.5, 0.25, 1.35], "rotation_axis": [0.0, 1.0, 0.0], "rotation_angle": -0.35, "color": [255, 115, 75, 255] },
             { "primitive": "cone", "offset": [0.0, 0.55, -1.32], "radius": 0.36, "height": 0.65, "segments": 20, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": -1.5707964, "color": [95, 210, 255, 255], "emissive": true }
@@ -181,8 +181,8 @@
           "type": "render.composite",
           "lighting": true,
           "parts": [
-            { "primitive": "tube_segment", "major_radius": 0.9, "minor_radius": 0.12, "arc_angle": 6.2831853, "segments": 40, "tube_segments": 10, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [95, 245, 255, 255], "emissive": true },
-            { "primitive": "disc", "radius": 0.78, "segments": 40, "color": [45, 75, 150, 130] }
+            { "primitive": "tube_segment", "major_radius": 0.9, "minor_radius": 0.12, "arc_angle": 6.2831853, "segments": 28, "tube_segments": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [95, 245, 255, 255], "emissive": true },
+            { "primitive": "disc", "radius": 0.78, "segments": 28, "color": [45, 75, 150, 130] }
           ]
         }
       ]

--- a/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
+++ b/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
@@ -4,7 +4,7 @@
     {
       "name": "entity.sun",
       "active": true,
-      "transform": { "position": [13.0, 6.0, 12.0] },
+      "transform": { "position": [26.0, 8.0, 24.0] },
       "components": [
         {
           "type": "light.directional",
@@ -17,7 +17,7 @@
     {
       "name": "entity.mesh.cube",
       "active": true,
-      "transform": { "position": [4.0, 1.0, 10.0] },
+      "transform": { "position": [6.0, 1.0, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "cube", "size": [1.6, 1.6, 1.6], "color": [230, 70, 70, 255], "lighting": true }
       ]
@@ -25,7 +25,7 @@
     {
       "name": "entity.mesh.sphere",
       "active": true,
-      "transform": { "position": [10.0, 1.0, 10.0] },
+      "transform": { "position": [13.0, 1.0, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.95, "segments": 32, "rings": 16, "color": [80, 180, 255, 255], "lighting": true }
       ]
@@ -33,7 +33,7 @@
     {
       "name": "entity.mesh.capsule",
       "active": true,
-      "transform": { "position": [16.0, 1.35, 10.0] },
+      "transform": { "position": [20.0, 1.35, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.55, "height": 2.5, "segments": 24, "rings": 10, "color": [110, 235, 130, 255], "lighting": true }
       ]
@@ -41,7 +41,7 @@
     {
       "name": "entity.mesh.cylinder",
       "active": true,
-      "transform": { "position": [22.0, 1.0, 10.0] },
+      "transform": { "position": [27.0, 1.0, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "cylinder", "radius_top": 0.75, "radius_bottom": 0.75, "height": 2.0, "segments": 32, "color": [255, 210, 70, 255], "lighting": true }
       ]
@@ -49,7 +49,7 @@
     {
       "name": "entity.mesh.cone",
       "active": true,
-      "transform": { "position": [4.0, 1.0, 16.5] },
+      "transform": { "position": [34.0, 1.0, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "cone", "radius": 0.9, "height": 2.0, "segments": 32, "color": [255, 125, 55, 255], "lighting": true }
       ]
@@ -57,7 +57,7 @@
     {
       "name": "entity.mesh.torus",
       "active": true,
-      "transform": { "position": [10.0, 1.25, 16.5] },
+      "transform": { "position": [41.0, 1.25, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.8, "minor_radius": 0.22, "segments": 36, "tube_segments": 14, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "draw_mode": "solid_wire", "wire_color": [20, 20, 24, 220], "color": [185, 115, 255, 255], "lighting": true }
       ]
@@ -65,7 +65,7 @@
     {
       "name": "entity.mesh.pyramid",
       "active": true,
-      "transform": { "position": [16.0, 1.0, 16.5] },
+      "transform": { "position": [48.0, 1.0, 14.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "pyramid", "size": [1.9, 2.0, 1.9], "color": [70, 235, 225, 255], "lighting": true }
       ]
@@ -73,9 +73,118 @@
     {
       "name": "entity.mesh.wedge",
       "active": true,
-      "transform": { "position": [22.0, 0.85, 16.5] },
+      "transform": { "position": [6.0, 0.85, 24.0] },
       "components": [
         { "type": "render.mesh_primitive", "primitive": "wedge", "size": [2.0, 1.7, 2.0], "draw_mode": "solid_wire", "wire_color": [20, 20, 24, 220], "color": [255, 95, 190, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.plane",
+      "active": true,
+      "transform": { "position": [13.0, 1.5, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "plane", "size": [2.4, 1.4, 0.05], "draw_mode": "solid_wire", "wire_color": [25, 25, 28, 220], "color": [245, 120, 120, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.disc",
+      "active": true,
+      "transform": { "position": [20.0, 1.4, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "disc", "radius": 1.05, "segments": 40, "draw_mode": "solid_wire", "wire_color": [22, 26, 30, 220], "color": [255, 226, 105, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.hemisphere",
+      "active": true,
+      "transform": { "position": [27.0, 1.0, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 1.05, "segments": 32, "rings": 12, "color": [255, 190, 65, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.rounded_box",
+      "active": true,
+      "transform": { "position": [34.0, 1.0, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.9, 1.7, 1.45], "bevel_radius": 0.32, "rings": 5, "draw_mode": "solid_wire", "wire_color": [22, 24, 28, 220], "color": [120, 190, 255, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.pipe",
+      "active": true,
+      "transform": { "position": [41.0, 1.2, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "pipe", "major_radius": 0.95, "minor_radius": 0.18, "arc_angle": 3.1415927, "segments": 28, "tube_segments": 12, "draw_mode": "solid_wire", "wire_color": [18, 22, 28, 230], "color": [90, 230, 210, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.arrow",
+      "active": true,
+      "transform": { "position": [48.0, 1.35, 24.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "arrow", "radius": 0.55, "height": 2.4, "segments": 24, "rotation_axis": [0.0, 0.0, 1.0], "rotation_angle": -1.5707964, "color": [255, 90, 215, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.billboard_plane",
+      "active": true,
+      "transform": { "position": [6.0, 1.55, 34.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "billboard_plane", "size": [2.2, 2.2, 0.05], "draw_mode": "solid_wire", "wire_color": [15, 18, 24, 230], "color": [180, 255, 125, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mock.robot",
+      "active": true,
+      "transform": { "position": [17.0, 0.9, 35.0] },
+      "components": [
+        {
+          "type": "render.composite",
+          "lighting": true,
+          "wire_color": [18, 20, 24, 210],
+          "parts": [
+            { "primitive": "rounded_box", "offset": [0.0, 0.9, 0.0], "size": [1.2, 1.55, 0.85], "bevel_radius": 0.2, "rings": 4, "color": [100, 165, 235, 255] },
+            { "primitive": "sphere", "offset": [0.0, 1.85, 0.0], "radius": 0.42, "segments": 20, "rings": 10, "color": [230, 235, 245, 255] },
+            { "primitive": "disc", "offset": [-0.16, 1.88, 0.39], "radius": 0.08, "segments": 16, "color": [45, 120, 255, 255], "emissive": true },
+            { "primitive": "disc", "offset": [0.16, 1.88, 0.39], "radius": 0.08, "segments": 16, "color": [45, 120, 255, 255], "emissive": true },
+            { "primitive": "capsule", "offset": [-0.86, 0.85, 0.0], "radius": 0.16, "height": 1.25, "segments": 14, "rings": 6, "color": [75, 95, 130, 255] },
+            { "primitive": "capsule", "offset": [0.86, 0.85, 0.0], "radius": 0.16, "height": 1.25, "segments": 14, "rings": 6, "color": [75, 95, 130, 255] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.mock.ship",
+      "active": true,
+      "transform": { "position": [28.0, 1.0, 35.0] },
+      "components": [
+        {
+          "type": "render.composite",
+          "lighting": true,
+          "wire_color": [16, 18, 24, 220],
+          "parts": [
+            { "primitive": "capsule", "offset": [0.0, 0.55, 0.0], "radius": 0.34, "height": 2.35, "segments": 22, "rings": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [205, 220, 240, 255] },
+            { "primitive": "wedge", "offset": [-0.95, 0.4, 0.1], "size": [1.5, 0.25, 1.35], "rotation_axis": [0.0, 1.0, 0.0], "rotation_angle": 0.35, "color": [255, 115, 75, 255] },
+            { "primitive": "wedge", "offset": [0.95, 0.4, 0.1], "size": [1.5, 0.25, 1.35], "rotation_axis": [0.0, 1.0, 0.0], "rotation_angle": -0.35, "color": [255, 115, 75, 255] },
+            { "primitive": "cone", "offset": [0.0, 0.55, -1.32], "radius": 0.36, "height": 0.65, "segments": 20, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": -1.5707964, "color": [95, 210, 255, 255], "emissive": true }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "entity.mock.portal",
+      "active": true,
+      "transform": { "position": [40.5, 1.6, 35.0] },
+      "components": [
+        {
+          "type": "render.composite",
+          "lighting": true,
+          "parts": [
+            { "primitive": "tube_segment", "major_radius": 0.9, "minor_radius": 0.12, "arc_angle": 6.2831853, "segments": 40, "tube_segments": 10, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [95, 245, 255, 255], "emissive": true },
+            { "primitive": "disc", "radius": 0.78, "segments": 40, "color": [45, 75, 150, 130] }
+          ]
+        }
       ]
     }
   ]

--- a/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
+++ b/demos/mesh_primitives_dojo/data/fragments/actors/primitives.json
@@ -1,0 +1,82 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.sun",
+      "active": true,
+      "transform": { "position": [13.0, 6.0, 12.0] },
+      "components": [
+        {
+          "type": "light.directional",
+          "direction": [-0.45, -1.0, -0.35],
+          "color": [1.0, 0.94, 0.82],
+          "intensity": 2.35
+        }
+      ]
+    },
+    {
+      "name": "entity.mesh.cube",
+      "active": true,
+      "transform": { "position": [4.0, 1.0, 10.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cube", "size": [1.6, 1.6, 1.6], "color": [230, 70, 70, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.sphere",
+      "active": true,
+      "transform": { "position": [10.0, 1.0, 10.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.95, "segments": 32, "rings": 16, "color": [80, 180, 255, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.capsule",
+      "active": true,
+      "transform": { "position": [16.0, 1.35, 10.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.55, "height": 2.5, "segments": 24, "rings": 10, "color": [110, 235, 130, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.cylinder",
+      "active": true,
+      "transform": { "position": [22.0, 1.0, 10.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cylinder", "radius_top": 0.75, "radius_bottom": 0.75, "height": 2.0, "segments": 32, "color": [255, 210, 70, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.cone",
+      "active": true,
+      "transform": { "position": [4.0, 1.0, 16.5] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "cone", "radius": 0.9, "height": 2.0, "segments": 32, "color": [255, 125, 55, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.torus",
+      "active": true,
+      "transform": { "position": [10.0, 1.25, 16.5] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.8, "minor_radius": 0.22, "segments": 36, "tube_segments": 14, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "draw_mode": "solid_wire", "wire_color": [20, 20, 24, 220], "color": [185, 115, 255, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.pyramid",
+      "active": true,
+      "transform": { "position": [16.0, 1.0, 16.5] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "pyramid", "size": [1.9, 2.0, 1.9], "color": [70, 235, 225, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mesh.wedge",
+      "active": true,
+      "transform": { "position": [22.0, 0.85, 16.5] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "wedge", "size": [2.0, 1.7, 2.0], "draw_mode": "solid_wire", "wire_color": [20, 20, 24, 220], "color": [255, 95, 190, 255], "lighting": true }
+      ]
+    }
+  ]
+}

--- a/demos/mesh_primitives_dojo/data/fragments/input/fps_controls.json
+++ b/demos/mesh_primitives_dojo/data/fragments/input/fps_controls.json
@@ -1,0 +1,19 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "input": {
+    "contexts": [
+      {
+        "name": "input.mesh_primitives_dojo",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
+          { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/mesh_primitives_dojo/data/fragments/world/graybox_room.json
+++ b/demos/mesh_primitives_dojo/data/fragments/world/graybox_room.json
@@ -11,7 +11,7 @@
       "sectors": [
         {
           "name": "showcase_room",
-          "points": [[0, 0], [26, 0], [26, 24], [0, 24]],
+          "points": [[0, 0], [52, 0], [52, 48], [0, 48]],
           "floor_y": 0.0,
           "ceil_y": 7.0,
           "floor_material": "floor.gray",

--- a/demos/mesh_primitives_dojo/data/fragments/world/graybox_room.json
+++ b/demos/mesh_primitives_dojo/data/fragments/world/graybox_room.json
@@ -1,0 +1,24 @@
+{
+  "schema": "sdl3d.fragment.v0",
+  "sector_level_fragments": [
+    {
+      "level": "sector.mesh_primitives.graybox_room",
+      "materials": [
+        { "name": "floor.gray", "albedo": [0.30, 0.31, 0.33, 1.0], "roughness": 0.9, "tex_scale": 6.0 },
+        { "name": "wall.gray", "albedo": [0.43, 0.45, 0.48, 1.0], "roughness": 0.82, "tex_scale": 6.0 },
+        { "name": "ceiling.gray", "albedo": [0.24, 0.25, 0.28, 1.0], "roughness": 0.92, "tex_scale": 6.0 }
+      ],
+      "sectors": [
+        {
+          "name": "showcase_room",
+          "points": [[0, 0], [26, 0], [26, 24], [0, 24]],
+          "floor_y": 0.0,
+          "ceil_y": 7.0,
+          "floor_material": "floor.gray",
+          "ceil_material": "ceiling.gray",
+          "wall_material": "wall.gray"
+        }
+      ]
+    }
+  ]
+}

--- a/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
+++ b/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
@@ -32,7 +32,10 @@
         "name": "camera.mesh_primitives.player",
         "type": "fps",
         "target_entity": "entity.player",
-        "fovy": 90.0,
+        "fov": 90.0,
+        "fov_axis": "horizontal",
+        "fov_key": "camera.fov",
+        "fov_axis_key": "camera.fov_axis",
         "active": true
       }
     ]

--- a/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
+++ b/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
@@ -1,0 +1,54 @@
+{
+  "schema": "sdl3d.game.v0",
+  "metadata": {
+    "name": "SDL3D Mesh Primitives Dojo",
+    "id": "demo.mesh_primitives_dojo",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/world/graybox_room.json", "sections": ["sector_level_fragments"] },
+    { "path": "fragments/actors/player.json", "sections": ["entities"] },
+    { "path": "fragments/actors/primitives.json", "sections": ["entities"] }
+  ],
+  "app": {
+    "title": "SDL3D Mesh Primitives Dojo",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "world": {
+    "name": "world.mesh_primitives_dojo",
+    "kind": "sector",
+    "units": "meters",
+    "meters_per_unit": 1.0,
+    "ambient_light": [0.18, 0.18, 0.19],
+    "cameras": [
+      {
+        "name": "camera.mesh_primitives.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fovy": 90.0,
+        "active": true
+      }
+    ]
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.mesh_primitives.hud", "builtin": "Inter", "size": 22 }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": false,
+    "clear_color": [0.045, 0.05, 0.06]
+  },
+  "scenes": {
+    "initial": "scene.mesh_primitives.showcase",
+    "files": ["scenes/showcase.scene.json"]
+  }
+}

--- a/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
+++ b/demos/mesh_primitives_dojo/data/mesh_primitives_dojo.game.json
@@ -50,6 +50,11 @@
     "bloom": false,
     "clear_color": [0.045, 0.05, 0.06]
   },
+  "presentation": {
+    "metrics": {
+      "fps_sample_seconds": 0.25
+    }
+  },
   "scenes": {
     "initial": "scene.mesh_primitives.showcase",
     "files": ["scenes/showcase.scene.json"]

--- a/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
+++ b/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
@@ -1,0 +1,71 @@
+{
+  "schema": "sdl3d.scene.v0",
+  "name": "scene.mesh_primitives.showcase",
+  "camera": "camera.mesh_primitives.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.sun",
+    "entity.mesh.cube",
+    "entity.mesh.sphere",
+    "entity.mesh.capsule",
+    "entity.mesh.cylinder",
+    "entity.mesh.cone",
+    "entity.mesh.torus",
+    "entity.mesh.pyramid",
+    "entity.mesh.wedge"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.mesh_primitives.graybox_room",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.mesh_primitives.title",
+        "text": "Mesh Primitives Dojo",
+        "font": "font.mesh_primitives.hud",
+        "position": [0.02, 0.03],
+        "anchor": "top_left",
+        "color": [235, 240, 250, 230],
+        "scale": 0.85
+      },
+      {
+        "name": "ui.mesh_primitives.help",
+        "text": "WASD move  Mouse look  Space jump  P pause  Esc quit",
+        "font": "font.mesh_primitives.hud",
+        "position": [0.02, 0.07],
+        "anchor": "top_left",
+        "color": [205, 215, 230, 210],
+        "scale": 0.65
+      },
+      {
+        "name": "ui.mesh_primitives.reticle",
+        "text": "+",
+        "font": "font.mesh_primitives.hud",
+        "position": [0.5, 0.5],
+        "anchor": "center",
+        "color": [255, 255, 255, 180],
+        "scale": 0.9
+      }
+    ]
+  }
+}

--- a/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
+++ b/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
@@ -68,6 +68,18 @@
         "scale": 0.65
       },
       {
+        "name": "ui.mesh_primitives.fps",
+        "font": "font.mesh_primitives.hud",
+        "format": "FPS %.0f",
+        "bindings": [
+          { "type": "metric", "metric": "fps" }
+        ],
+        "position": [0.985, 0.03],
+        "anchor": "top_right",
+        "color": [180, 235, 190, 230],
+        "scale": 0.72
+      },
+      {
         "name": "ui.mesh_primitives.reticle",
         "text": "+",
         "font": "font.mesh_primitives.hud",

--- a/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
+++ b/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
@@ -53,8 +53,9 @@
         "name": "ui.mesh_primitives.title",
         "text": "Mesh Primitives Dojo",
         "font": "font.mesh_primitives.hud",
-        "position": [0.02, 0.03],
-        "anchor": "top_left",
+        "x": 0.02,
+        "y": 0.03,
+        "normalized": true,
         "color": [235, 240, 250, 230],
         "scale": 0.85
       },
@@ -62,10 +63,41 @@
         "name": "ui.mesh_primitives.help",
         "text": "WASD move  Mouse look  Space jump  P pause  Esc quit",
         "font": "font.mesh_primitives.hud",
-        "position": [0.02, 0.07],
-        "anchor": "top_left",
+        "x": 0.02,
+        "y": 0.075,
+        "normalized": true,
         "color": [205, 215, 230, 210],
         "scale": 0.65
+      },
+      {
+        "name": "ui.mesh_primitives.labels.row1",
+        "text": "Front row: cube  sphere  capsule  cylinder  cone  torus  pyramid",
+        "font": "font.mesh_primitives.hud",
+        "x": 0.02,
+        "y": 0.125,
+        "normalized": true,
+        "color": [185, 200, 220, 200],
+        "scale": 0.52
+      },
+      {
+        "name": "ui.mesh_primitives.labels.row2",
+        "text": "Middle row: wedge  plane  disc  hemisphere  rounded box  pipe  arrow",
+        "font": "font.mesh_primitives.hud",
+        "x": 0.02,
+        "y": 0.165,
+        "normalized": true,
+        "color": [185, 200, 220, 200],
+        "scale": 0.52
+      },
+      {
+        "name": "ui.mesh_primitives.labels.row3",
+        "text": "Back row: billboard plane  composite robot  composite ship  composite portal",
+        "font": "font.mesh_primitives.hud",
+        "x": 0.02,
+        "y": 0.205,
+        "normalized": true,
+        "color": [185, 200, 220, 200],
+        "scale": 0.52
       },
       {
         "name": "ui.mesh_primitives.fps",
@@ -74,8 +106,10 @@
         "bindings": [
           { "type": "metric", "metric": "fps" }
         ],
-        "position": [0.985, 0.03],
-        "anchor": "top_right",
+        "x": 0.985,
+        "y": 0.03,
+        "normalized": true,
+        "align": "right",
         "color": [180, 235, 190, 230],
         "scale": 0.72
       },
@@ -83,8 +117,10 @@
         "name": "ui.mesh_primitives.reticle",
         "text": "+",
         "font": "font.mesh_primitives.hud",
-        "position": [0.5, 0.5],
-        "anchor": "center",
+        "x": 0.5,
+        "y": 0.5,
+        "normalized": true,
+        "align": "center",
         "color": [255, 255, 255, 180],
         "scale": 0.9
       }

--- a/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
+++ b/demos/mesh_primitives_dojo/data/scenes/showcase.scene.json
@@ -14,7 +14,17 @@
     "entity.mesh.cone",
     "entity.mesh.torus",
     "entity.mesh.pyramid",
-    "entity.mesh.wedge"
+    "entity.mesh.wedge",
+    "entity.mesh.plane",
+    "entity.mesh.disc",
+    "entity.mesh.hemisphere",
+    "entity.mesh.rounded_box",
+    "entity.mesh.pipe",
+    "entity.mesh.arrow",
+    "entity.mesh.billboard_plane",
+    "entity.mock.robot",
+    "entity.mock.ship",
+    "entity.mock.portal"
   ],
   "input": {
     "mouse_capture": "unpaused",

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -138,7 +138,7 @@ build/debug/sdl3d_runner \
 ```
 
 The starter proves the data-only shape for common FPS primitives: WASD/mouse
-input, an FPS sector controller, a 90-degree FOV camera, a sector room,
+input, an FPS sector controller, an FPS camera, a sector room,
 navigation graph, reticle/FPS/resource HUD text, pause menu, projectile weapon,
 projectile pool, pickup archetype, resource-station archetype, and editor
 palette metadata. It uses colored geometry and built-in fonts so it remains

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -163,8 +163,8 @@ runner path while avoiding splash/title/campaign flow during development.
 
 `demos/mesh_primitives_dojo` is a graybox showcase for procedural 3D placeholder
 geometry. It uses a sector-bounded room, one directional sun light, an FPS
-camera, and one differently colored actor for each `render.mesh_primitive`
-shape:
+camera, one differently colored actor for each `render.mesh_primitive` shape,
+and composite mock actors assembled from primitive parts:
 
 ```sh
 build/debug/sdl3d_runner \

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -164,7 +164,8 @@ runner path while avoiding splash/title/campaign flow during development.
 `demos/mesh_primitives_dojo` is a graybox showcase for procedural 3D placeholder
 geometry. It uses a sector-bounded room, one directional sun light, an FPS
 camera, one differently colored actor for each `render.mesh_primitive` shape,
-and composite mock actors assembled from primitive parts:
+composite mock actors assembled from primitive parts, and spaced HUD labels plus
+an FPS counter for quick performance checks:
 
 ```sh
 build/debug/sdl3d_runner \

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -161,6 +161,17 @@ Focused dojo scenes should use authored scene-enter setup to place the player
 near the mechanic being tuned. That keeps the workflow equivalent to the final
 runner path while avoiding splash/title/campaign flow during development.
 
+`demos/mesh_primitives_dojo` is a graybox showcase for procedural 3D placeholder
+geometry. It uses a sector-bounded room, one directional sun light, an FPS
+camera, and one differently colored actor for each `render.mesh_primitive`
+shape:
+
+```sh
+build/debug/sdl3d_runner \
+  --root demos/mesh_primitives_dojo/data \
+  --data asset://mesh_primitives_dojo.game.json
+```
+
 ## Data-Only Parity Checklist
 
 Before treating a game as data-only, validate the runner-backed game path:

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1419,7 +1419,12 @@ Reusable components include:
   `segments`/`slices`, `rings`, and `tube_segments`. This is the stable
   data/runtime representation for procedural mesh primitives. The generic
   presentation path renders every primitive as shaded solid geometry by
-  default, with optional wire-only or solid-plus-wire modes.
+  default, with optional wire-only or solid-plus-wire modes. Solid procedural
+  primitives are generated through a presentation cache when hosts provide one,
+  so repeated static placeholder geometry can reuse stable CPU mesh data and
+  hardware backends can keep GPU buffers instead of rebuilding geometry every
+  frame. Wire overlays are useful for inspection, but they still add extra line
+  work and should be used selectively in large scenes.
 - `render.composite`: expands one actor into multiple procedural
   `render.mesh_primitive` parts. Use `parts` as a non-empty array of mesh
   primitive descriptors. Part `offset` values are local offsets from the owning

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -342,22 +342,46 @@ camera with their `camera` field, and logic actions can switch cameras with
 Camera types:
 
 - `orthographic`: fixed position/target/up with `size`.
-- `perspective`: fixed position/target/up with `fovy`. If omitted, the
-  vertical field of view defaults to 90 degrees.
+- `perspective`: fixed position/target/up with `fov` and optional `fov_axis`.
+  `fov_axis` may be `vertical` or `horizontal`; omitted cameras use vertical
+  FOV. The legacy `fovy` field is still accepted as a vertical-FOV alias when
+  `fov` is absent. If omitted, the vertical field of view defaults to 90
+  degrees.
 - `chase`: follows an actor named by `target_entity`. The forward vector comes
   from a Vec3 actor property such as `velocity` or an authored
   `camera_forward`, with `fallback_forward` used when that property is near
   zero. Use `chase_distance: 0` for actor-perspective cameras and larger
-  values for behind-the-actor chase cameras. If omitted, `fovy` defaults to 90
-  degrees.
+  values for behind-the-actor chase cameras. If omitted, FOV defaults to 90
+  degrees on the vertical axis.
 - `fps`: reads a first-person sector controller from `target_entity` and
   renders from that actor's eye position. If the controller has not updated
   yet, the camera falls back to the actor's `yaw`, `pitch`, and `view_smooth`
   properties. The controller also publishes a normalized view direction to
   `camera_forward` by default; override this with `forward_property` when a
   game wants a different property name for projectile or camera logic. If
-  omitted, `fovy` defaults to 90 degrees.
+  omitted, FOV defaults to 90 degrees on the vertical axis.
 - `adapter`: delegates camera ownership to a native or Lua adapter.
+
+Perspective, chase, and FPS cameras can be tuned at runtime with scene state:
+
+```json
+{
+  "name": "camera.player",
+  "type": "fps",
+  "target_entity": "entity.player",
+  "fov": 90.0,
+  "fov_axis": "horizontal",
+  "fov_key": "settings.camera.fov",
+  "fov_axis_key": "settings.camera.fov_axis"
+}
+```
+
+`fov_key` reads a numeric scene-state value. `fov_axis_key` reads a string scene
+state value and accepts `vertical` or `horizontal`. Invalid runtime values fall
+back to the authored camera values. Use horizontal FOV for FPS-style settings
+when designers want values like "90 degrees" to mean the player's visible
+left-to-right angle; at 16:9, a 90-degree horizontal FOV renders with a vertical
+FOV of roughly 58.7 degrees.
 
 ## Storage And Persistence
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1406,15 +1406,27 @@ Reusable components include:
   dimensions.
 - `render.mesh_primitive`: declares a procedural placeholder mesh descriptor.
   The canonical `primitive` values are `cube`, `sphere`, `capsule`,
-  `cylinder`, `cone`, `torus`, `pyramid`, and `wedge`. These descriptors use
-  the same transform, `color`, `texture`, `lighting`, and `emissive` fields as
-  other render primitives where applicable, and add `draw_mode`: `solid`
-  (default), `wire`, or `solid_wire`. Dimension fields include `size`,
-  `radius`, `height`, `radius_top`, `radius_bottom`, `major_radius`,
-  `minor_radius`, `segments`/`slices`, `rings`, and `tube_segments`. This is the
-  stable data/runtime representation for procedural mesh primitives. The
-  generic presentation path renders every primitive as shaded solid geometry by
+  `cylinder`, `cone`, `torus`, `pyramid`, `wedge`, `plane`, `quad`, `disc`,
+  `hemisphere`, `rounded_box`, `tube_segment`, `pipe`, `arrow`, and
+  `billboard_plane`. `quad` is an alias for `plane`; `pipe` is an alias for
+  `tube_segment`. `billboard_plane` is a flat 3D placeholder plane; use
+  `render.sprite` when you need an actual texture-backed camera-facing
+  billboard. These descriptors use the same transform, `color`, `texture`,
+  `lighting`, and `emissive` fields as other render primitives where
+  applicable, and add `draw_mode`: `solid` (default), `wire`, or `solid_wire`.
+  Dimension fields include `size`, `radius`, `height`, `radius_top`,
+  `radius_bottom`, `major_radius`, `minor_radius`, `bevel_radius`, `arc_angle`,
+  `segments`/`slices`, `rings`, and `tube_segments`. This is the stable
+  data/runtime representation for procedural mesh primitives. The generic
+  presentation path renders every primitive as shaded solid geometry by
   default, with optional wire-only or solid-plus-wire modes.
+- `render.composite`: expands one actor into multiple procedural
+  `render.mesh_primitive` parts. Use `parts` as a non-empty array of mesh
+  primitive descriptors. Part `offset` values are local offsets from the owning
+  actor, and part fields such as `color`, `lighting`, `draw_mode`, dimensions,
+  and rotation override the composite defaults. This is intended for quick
+  proof-of-concept actors such as robots, ships, decorations, pickups, markers,
+  and editor placeholders before bespoke model assets exist.
 - `render.model`: renders an authored `assets.models` entry with `model`,
   optional `scale`, axis-angle rotation, `color` tint, and optional skeletal
   animation playback via `animation_clip` and `animation_time_property`.

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -186,6 +186,12 @@ combat/resources, hazards, and navigation. New dojos should follow that pattern:
 one scene per editing question, with authored scene-enter setup that places the
 player near the mechanic under test.
 
+`demos/mesh_primitives_dojo` is the reference shape for visual primitive
+showcases. It keeps the project data-only, uses graybox sector bounds and
+simple lighting, and places authored actors far enough apart that each
+procedural mesh primitive can be inspected from the same FPS runtime path future
+games will use.
+
 Use optional `editor` metadata beside the authored object it describes. This
 keeps future editor palettes and prefab browsers grounded in the same JSON that
 runtime validation sees. Metadata should describe categories, previews, bounds,

--- a/include/sdl3d/camera.h
+++ b/include/sdl3d/camera.h
@@ -17,17 +17,25 @@ extern "C"
         SDL3D_CAMERA_ORTHOGRAPHIC = 1
     } sdl3d_camera_projection;
 
+    typedef enum sdl3d_camera_fov_axis
+    {
+        SDL3D_CAMERA_FOV_VERTICAL = 0,
+        SDL3D_CAMERA_FOV_HORIZONTAL = 1
+    } sdl3d_camera_fov_axis;
+
     typedef struct sdl3d_camera3d
     {
         sdl3d_vec3 position;
         sdl3d_vec3 target;
         sdl3d_vec3 up;
         /*
-         * For SDL3D_CAMERA_PERSPECTIVE: vertical field-of-view in degrees.
+         * For SDL3D_CAMERA_PERSPECTIVE: field-of-view in degrees. fov_axis
+         * selects whether this value is vertical or horizontal.
          * For SDL3D_CAMERA_ORTHOGRAPHIC: vertical view volume in world units.
          */
         float fovy;
         sdl3d_camera_projection projection;
+        sdl3d_camera_fov_axis fov_axis;
     } sdl3d_camera3d;
 
     /*

--- a/include/sdl3d/drawing3d.h
+++ b/include/sdl3d/drawing3d.h
@@ -134,6 +134,17 @@ extern "C"
     bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
                          sdl3d_color tint);
 
+    /**
+     * @brief Draw a mesh whose vertex/index arrays are stable for the caller's lifetime.
+     *
+     * This is equivalent to sdl3d_draw_mesh(), but tells hardware backends they may
+     * cache GPU buffers for the mesh instead of uploading vertex data every frame.
+     * Use this for cached procedural meshes, loaded static models, and other
+     * immutable geometry. Do not pass stack-owned or per-frame temporary arrays.
+     */
+    bool sdl3d_draw_static_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
+                                sdl3d_color tint);
+
     /*
      * Draw every mesh in a model with a uniform translation + scale. Material
      * albedo factors and albedo textures modulate the supplied tint. Texture

--- a/include/sdl3d/fps_mover.h
+++ b/include/sdl3d/fps_mover.h
@@ -113,7 +113,7 @@ extern "C"
      * Build a camera looking along the mover's facing. The camera position
      * includes the view-smooth offset so stair transitions appear smooth.
      */
-    sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy);
+    sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fov);
 
 #ifdef __cplusplus
 }

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -433,6 +433,20 @@ extern "C"
         SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID = 7,
         /** @brief Wedge/ramp mesh primitive. */
         SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE = 8,
+        /** @brief Flat rectangular plane/quad mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_PLANE = 9,
+        /** @brief Flat circular disc mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_DISC = 10,
+        /** @brief Half-sphere dome mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_HEMISPHERE = 11,
+        /** @brief Rounded box mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX = 12,
+        /** @brief Curved pipe/tube segment mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT = 13,
+        /** @brief Arrow marker mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_ARROW = 14,
+        /** @brief Flat vertical billboard-style plane mesh primitive. */
+        SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE = 15,
     } sdl3d_game_data_mesh_primitive_kind;
 
     /** @brief Draw mode selected by authored procedural mesh primitives. */
@@ -491,6 +505,10 @@ extern "C"
         float major_radius;
         /** @brief Torus minor/tube radius for SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS. */
         float minor_radius;
+        /** @brief Rounded-box bevel radius for SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX. */
+        float bevel_radius;
+        /** @brief Arc angle in radians for SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT. */
+        float arc_angle;
         /** @brief Secondary tessellation count, such as torus tube segments. */
         int tube_segments;
         /** @brief Authored tint color. */
@@ -2252,8 +2270,9 @@ extern "C"
     /**
      * @brief Iterate active authored render primitive components.
      *
-     * Components currently supported by this iterator are `render.cube` and
-     * `render.sphere`. Iteration skips inactive actors.
+     * Components currently supported by this iterator include `render.cube`,
+     * `render.sphere`, `render.mesh_primitive`, `render.composite`,
+     * `render.sprite`, and `render.model`. Iteration skips inactive actors.
      */
     bool sdl3d_game_data_for_each_render_primitive(const sdl3d_game_data_runtime *runtime,
                                                    sdl3d_game_data_render_primitive_fn callback, void *userdata);

--- a/include/sdl3d/game_data.h
+++ b/include/sdl3d/game_data.h
@@ -2192,7 +2192,8 @@ extern "C"
      *
      * Adapter cameras are game-specific and return false here because their
      * final pose is computed by game code or script. Orthographic cameras use
-     * `size` as sdl3d_camera3d::fovy; perspective cameras use `fovy`.
+     * `size` as sdl3d_camera3d::fovy; perspective cameras use `fov` or the
+     * legacy `fovy` field with an optional `fov_axis`.
      */
     bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const char *name,
                                     sdl3d_camera3d *out_camera);

--- a/include/sdl3d/game_presentation.h
+++ b/include/sdl3d/game_presentation.h
@@ -158,6 +158,42 @@ extern "C"
         sdl3d_asset_resolver *assets;               /**< Resolver used for lazy loads; not owned. */
     } sdl3d_game_data_model_cache;
 
+    /** @brief One cached procedural mesh generated from an authored render.mesh_primitive descriptor. */
+    typedef struct sdl3d_game_data_mesh_primitive_cache_entry
+    {
+        sdl3d_game_data_mesh_primitive_kind primitive; /**< Cached primitive kind. */
+        sdl3d_vec3 size;                               /**< Cached authored size. */
+        float radius;                                  /**< Cached primary radius. */
+        float radius_top;                              /**< Cached top radius for cones/cylinders. */
+        float radius_bottom;                           /**< Cached bottom radius for cones/cylinders. */
+        float height;                                  /**< Cached height. */
+        float major_radius;                            /**< Cached torus/tube major radius. */
+        float minor_radius;                            /**< Cached torus/tube minor radius. */
+        float bevel_radius;                            /**< Cached rounded-box bevel radius. */
+        float arc_angle;                               /**< Cached tube arc angle. */
+        int slices;                                    /**< Cached longitudinal segment count. */
+        int rings;                                     /**< Cached ring/bevel segment count. */
+        int tube_segments;                             /**< Cached tube segment count. */
+        sdl3d_mesh mesh;                               /**< Owned immutable mesh arrays. */
+        bool loaded;                                   /**< True once @ref mesh owns geometry. */
+    } sdl3d_game_data_mesh_primitive_cache_entry;
+
+    /**
+     * @brief Runtime cache for static procedural meshes referenced by authored render data.
+     *
+     * The cache owns generated immutable vertex/index arrays. Hardware backends can
+     * then cache GPU buffers for these stable meshes instead of rebuilding and
+     * uploading procedural geometry every frame.
+     */
+    typedef struct sdl3d_game_data_mesh_primitive_cache
+    {
+        sdl3d_game_data_mesh_primitive_cache_entry *entries; /**< Cached generated meshes. */
+        int count;                                           /**< Number of cache entries. */
+        int capacity;                                        /**< Allocated cache slots. */
+        int hits;                                            /**< Lookup hits, useful for tests/profiling. */
+        int misses;                                          /**< Mesh builds, useful for tests/profiling. */
+    } sdl3d_game_data_mesh_primitive_cache;
+
     /**
      * @brief Result produced by the generic authored menu controller.
      *
@@ -274,6 +310,7 @@ extern "C"
         sdl3d_game_data_particle_cache *particle_cache; /**< Particle cache used by authored emitters. */
         sdl3d_game_data_sprite_cache *sprite_cache;     /**< Sprite cache used by authored render.sprite data. */
         sdl3d_game_data_model_cache *model_cache;       /**< Model cache used by authored render.model data. */
+        sdl3d_game_data_mesh_primitive_cache *mesh_primitive_cache; /**< Cache for authored procedural meshes. */
         const sdl3d_game_data_app_flow *app_flow;       /**< Optional app flow whose transitions are drawn. */
         const sdl3d_game_data_ui_metrics *metrics;      /**< Optional UI metrics. */
         const sdl3d_game_data_render_eval *render_eval; /**< Optional primitive effect evaluation inputs. */
@@ -360,6 +397,12 @@ extern "C"
      * @brief Free all models owned by a world model cache.
      */
     void sdl3d_game_data_model_cache_free(sdl3d_game_data_model_cache *cache);
+
+    /** @brief Initialize a procedural mesh primitive cache. */
+    void sdl3d_game_data_mesh_primitive_cache_init(sdl3d_game_data_mesh_primitive_cache *cache);
+
+    /** @brief Free all generated mesh primitive geometry owned by @p cache. */
+    void sdl3d_game_data_mesh_primitive_cache_free(sdl3d_game_data_mesh_primitive_cache *cache);
 
     /**
      * @brief Draw active-scene authored sector levels.

--- a/include/sdl3d/shapes.h
+++ b/include/sdl3d/shapes.h
@@ -61,6 +61,22 @@ extern "C"
     bool sdl3d_draw_plane(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color);
 
     /*
+     * Flat quad in the local XY plane, centered at `center`, with outward
+     * normal +Z. `size` gives the extent along local X and Y.
+     */
+    bool sdl3d_draw_quad(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color);
+    bool sdl3d_draw_quad_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color);
+
+    /*
+     * Flat disc in the local XY plane, centered at `center`, with outward
+     * normal +Z. `segments` must be >= 3.
+     */
+    bool sdl3d_draw_disc(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int segments,
+                         sdl3d_color color);
+    bool sdl3d_draw_disc_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int segments,
+                               sdl3d_color color);
+
+    /*
      * Grid in the local XZ plane centered at the origin. Draws
      * `slices + 1` lines per axis. `slices` must be >= 1 and `spacing`
      * must be positive.
@@ -101,6 +117,16 @@ extern "C"
                                  sdl3d_color color);
 
     /*
+     * Hemisphere dome aligned with +Y and centered around `center`. The
+     * curved surface is capped by a flat base. `rings` must be >= 2 and
+     * `slices` must be >= 3.
+     */
+    bool sdl3d_draw_hemisphere(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                               sdl3d_color color);
+    bool sdl3d_draw_hemisphere_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings,
+                                     int slices, sdl3d_color color);
+
+    /*
      * Cylinder (or truncated cone when top and bottom radii differ)
      * aligned with the local +Y axis, centered vertically at `center`.
      * `slices` must be >= 3. Both radii must be non-negative; a zero
@@ -131,6 +157,34 @@ extern "C"
                           int segments, int tube_segments, sdl3d_color color);
     bool sdl3d_draw_torus_wires(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius,
                                 float minor_radius, int segments, int tube_segments, sdl3d_color color);
+
+    /*
+     * Curved tube segment around the local +Y axis. `arc_angle` is in
+     * radians; values near 2*pi form a full torus-like pipe.
+     */
+    bool sdl3d_draw_tube_segment(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius,
+                                 float minor_radius, float arc_angle, int segments, int tube_segments,
+                                 sdl3d_color color);
+    bool sdl3d_draw_tube_segment_wires(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius,
+                                       float minor_radius, float arc_angle, int segments, int tube_segments,
+                                       sdl3d_color color);
+
+    /*
+     * Rounded box centered in local space. `radius` is clamped to half the
+     * smallest size axis. `segments` controls bevel tessellation.
+     */
+    bool sdl3d_draw_rounded_box(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, float radius,
+                                int segments, sdl3d_color color);
+    bool sdl3d_draw_rounded_box_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, float radius,
+                                      int segments, sdl3d_color color);
+
+    /*
+     * Arrow marker aligned along local +Y, centered in local space.
+     */
+    bool sdl3d_draw_arrow(sdl3d_render_context *context, sdl3d_vec3 center, float radius, float height, int segments,
+                          sdl3d_color color);
+    bool sdl3d_draw_arrow_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, float height,
+                                int segments, sdl3d_color color);
 
     /*
      * Square pyramid centered in local space. `size.x` and `size.z` define

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,6 +1,17 @@
 #include "sdl3d/camera.h"
 
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_stdinc.h>
+
+static float camera_vertical_fov_radians(const sdl3d_camera3d *camera, float aspect)
+{
+    const float fov_radians = sdl3d_degrees_to_radians(camera->fovy);
+    if (camera->fov_axis != SDL3D_CAMERA_FOV_HORIZONTAL)
+        return fov_radians;
+
+    const float half_tan = SDL_tanf(fov_radians * 0.5f) / aspect;
+    return 2.0f * SDL_atanf(half_tan);
+}
 
 bool sdl3d_camera3d_compute_matrices(const sdl3d_camera3d *camera, int backbuffer_width, int backbuffer_height,
                                      float near_plane, float far_plane, sdl3d_mat4 *out_view,
@@ -36,7 +47,7 @@ bool sdl3d_camera3d_compute_matrices(const sdl3d_camera3d *camera, int backbuffe
     switch (camera->projection)
     {
     case SDL3D_CAMERA_PERSPECTIVE: {
-        const float fovy_radians = sdl3d_degrees_to_radians(camera->fovy);
+        const float fovy_radians = camera_vertical_fov_radians(camera, aspect);
         return sdl3d_mat4_perspective(fovy_radians, aspect, near_plane, far_plane, out_projection);
     }
     case SDL3D_CAMERA_ORTHOGRAPHIC: {

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -20,6 +20,7 @@ struct sdl3d_data_game_runtime
     sdl3d_game_data_particle_cache particle_cache;
     sdl3d_game_data_sprite_cache sprite_cache;
     sdl3d_game_data_model_cache model_cache;
+    sdl3d_game_data_mesh_primitive_cache mesh_primitive_cache;
     sdl3d_game_data_app_flow app_flow;
     sdl3d_game_data_frame_state frame_state;
     sdl3d_game_data_input_profile_refresh_state input_profile_refresh;
@@ -958,6 +959,7 @@ bool sdl3d_data_game_runtime_create(const sdl3d_data_game_runtime_desc *desc, sd
     sdl3d_game_data_image_cache_init(&runtime->image_cache, runtime->assets);
     sdl3d_game_data_sprite_cache_init(&runtime->sprite_cache, runtime->assets);
     sdl3d_game_data_model_cache_init(&runtime->model_cache, runtime->assets);
+    sdl3d_game_data_mesh_primitive_cache_init(&runtime->mesh_primitive_cache);
     if (!sdl3d_game_data_app_flow_start(&runtime->app_flow, runtime->data))
     {
         set_error(error_buffer, error_buffer_size, SDL_GetError());
@@ -993,6 +995,7 @@ void sdl3d_data_game_runtime_destroy(sdl3d_data_game_runtime *runtime)
     disconnect_managed_network(runtime);
     disconnect_haptics_policies(runtime);
     sdl3d_game_data_particle_cache_free(&runtime->particle_cache);
+    sdl3d_game_data_mesh_primitive_cache_free(&runtime->mesh_primitive_cache);
     sdl3d_game_data_model_cache_free(&runtime->model_cache);
     sdl3d_game_data_sprite_cache_free(&runtime->sprite_cache);
     sdl3d_game_data_image_cache_free(&runtime->image_cache);
@@ -1379,6 +1382,7 @@ void sdl3d_data_game_runtime_render(sdl3d_data_game_runtime *runtime, sdl3d_game
     frame.particle_cache = &runtime->particle_cache;
     frame.sprite_cache = &runtime->sprite_cache;
     frame.model_cache = &runtime->model_cache;
+    frame.mesh_primitive_cache = &runtime->mesh_primitive_cache;
     frame.app_flow = &runtime->app_flow;
     frame.metrics = &runtime->frame_state.metrics;
     frame.render_eval = &runtime->frame_state.render_eval;

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1616,6 +1616,21 @@ bool sdl3d_draw_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, cons
                                     NULL, NULL);
 }
 
+bool sdl3d_draw_static_mesh(sdl3d_render_context *context, const sdl3d_mesh *mesh, const sdl3d_texture2d *texture,
+                            sdl3d_color tint)
+{
+    if (context != NULL && context->shading_mode != SDL3D_SHADING_UNLIT && mesh != NULL && mesh->normals != NULL)
+    {
+        sdl3d_lighting_params lp;
+        sdl3d_build_lighting_params(context, &lp);
+        lp.roughness = 1.0f;
+        return sdl3d_draw_mesh_internal(context, mesh, texture, NULL, sdl3d_color_to_modulate(tint), &lp, NULL, true,
+                                        NULL, NULL);
+    }
+    return sdl3d_draw_mesh_internal(context, mesh, texture, NULL, sdl3d_color_to_modulate(tint), NULL, NULL, true, NULL,
+                                    NULL);
+}
+
 /* ------------------------------------------------------------------ */
 /* Model node hierarchy helpers                                        */
 /* ------------------------------------------------------------------ */

--- a/src/fps_mover.c
+++ b/src/fps_mover.c
@@ -395,7 +395,7 @@ void sdl3d_fps_mover_teleport(sdl3d_fps_mover *mover, sdl3d_vec3 eye_position, b
     mover->has_last_good = true;
 }
 
-sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy)
+sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fov)
 {
     sdl3d_camera3d cam;
     SDL_zero(cam);
@@ -403,7 +403,7 @@ sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy)
     if (mover == NULL)
     {
         cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
-        cam.fovy = fovy;
+        cam.fovy = fov;
         cam.projection = SDL3D_CAMERA_PERSPECTIVE;
         return cam;
     }
@@ -416,7 +416,7 @@ sdl3d_camera3d sdl3d_fps_mover_camera(const sdl3d_fps_mover *mover, float fovy)
     cam.position = sdl3d_vec3_make(mover->position.x, eye_y, mover->position.z);
     cam.target = sdl3d_vec3_make(mover->position.x + fx, eye_y + fy, mover->position.z + fz);
     cam.up = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
-    cam.fovy = fovy;
+    cam.fovy = fov;
     cam.projection = SDL3D_CAMERA_PERSPECTIVE;
     return cam;
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -6182,6 +6182,20 @@ static sdl3d_game_data_mesh_primitive_kind mesh_primitive_kind_from_string(const
         return SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID;
     if (SDL_strcmp(name, "wedge") == 0)
         return SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE;
+    if (SDL_strcmp(name, "plane") == 0 || SDL_strcmp(name, "quad") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_PLANE;
+    if (SDL_strcmp(name, "disc") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_DISC;
+    if (SDL_strcmp(name, "hemisphere") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_HEMISPHERE;
+    if (SDL_strcmp(name, "rounded_box") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX;
+    if (SDL_strcmp(name, "tube_segment") == 0 || SDL_strcmp(name, "pipe") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT;
+    if (SDL_strcmp(name, "arrow") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_ARROW;
+    if (SDL_strcmp(name, "billboard_plane") == 0)
+        return SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE;
     return SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID;
 }
 
@@ -6194,6 +6208,35 @@ static sdl3d_game_data_render_draw_mode render_draw_mode_from_string(const char 
     if (SDL_strcmp(name, "solid_wire") == 0)
         return SDL3D_GAME_DATA_RENDER_DRAW_SOLID_WIRE;
     return SDL3D_GAME_DATA_RENDER_DRAW_SOLID;
+}
+
+static void populate_mesh_primitive_descriptor(const sdl3d_registered_actor *actor, yyjson_val *component,
+                                               sdl3d_game_data_render_primitive *primitive)
+{
+    if (component == NULL || primitive == NULL)
+        return;
+    primitive->type = SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE;
+    primitive->mesh_primitive = mesh_primitive_kind_from_string(json_string(component, "primitive", NULL));
+    primitive->draw_mode = render_draw_mode_from_string(json_string(component, "draw_mode", NULL));
+    primitive->size = json_vec3(component, "size", primitive->size);
+    const char *size_property = json_string(component, "size_property", NULL);
+    if (actor != NULL && size_property != NULL)
+        primitive->size = sdl3d_properties_get_vec3(actor->props, size_property, primitive->size);
+    primitive->radius = json_float(component, "radius", primitive->radius);
+    primitive->height =
+        json_float(component, "height", primitive->height > 0.0f ? primitive->height : primitive->size.y);
+    primitive->radius_top = json_float(component, "radius_top", primitive->radius);
+    primitive->radius_bottom = json_float(component, "radius_bottom", primitive->radius);
+    primitive->major_radius = json_float(component, "major_radius", primitive->major_radius);
+    primitive->minor_radius = json_float(component, "minor_radius", primitive->minor_radius);
+    primitive->bevel_radius =
+        json_float(component, "bevel_radius", json_float(component, "radius", primitive->bevel_radius));
+    primitive->arc_angle = json_float(component, "arc_angle", primitive->arc_angle);
+    primitive->slices = SDL_max(json_int(component, "slices", json_int(component, "segments", primitive->slices)), 3);
+    primitive->rings = SDL_max(json_int(component, "rings", primitive->rings), 3);
+    primitive->tube_segments = SDL_max(json_int(component, "tube_segments", primitive->tube_segments), 3);
+    if (primitive->mesh_primitive == SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE)
+        primitive->radius_top = json_float(component, "radius_top", 0.0f);
 }
 
 static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
@@ -6228,6 +6271,18 @@ static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
         primitive.emissive_color =
             primitive.emissive ? sdl3d_vec3_make(0.2f, 0.2f, 0.2f) : sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
         primitive.wire_color = json_color(component, "wire_color", (sdl3d_color){0, 0, 0, 255});
+        primitive.size = sdl3d_vec3_make(1.0f, 1.0f, 1.0f);
+        primitive.radius = 0.5f;
+        primitive.height = primitive.size.y;
+        primitive.radius_top = primitive.radius;
+        primitive.radius_bottom = primitive.radius;
+        primitive.major_radius = 0.5f;
+        primitive.minor_radius = 0.15f;
+        primitive.bevel_radius = 0.15f;
+        primitive.arc_angle = 3.1415927f;
+        primitive.slices = 24;
+        primitive.rings = 8;
+        primitive.tube_segments = primitive.rings;
 
         if (SDL_strcmp(type, "render.cube") == 0)
         {
@@ -6246,24 +6301,44 @@ static bool emit_actor_render_primitives(const sdl3d_game_data_runtime *runtime,
         }
         else if (SDL_strcmp(type, "render.mesh_primitive") == 0)
         {
-            primitive.type = SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE;
-            primitive.mesh_primitive = mesh_primitive_kind_from_string(json_string(component, "primitive", NULL));
-            primitive.draw_mode = render_draw_mode_from_string(json_string(component, "draw_mode", NULL));
-            primitive.size = json_vec3(component, "size", sdl3d_vec3_make(1.0f, 1.0f, 1.0f));
-            const char *size_property = json_string(component, "size_property", NULL);
-            if (size_property != NULL)
-                primitive.size = sdl3d_properties_get_vec3(actor->props, size_property, primitive.size);
-            primitive.radius = json_float(component, "radius", 0.5f);
-            primitive.height = json_float(component, "height", primitive.size.y);
-            primitive.radius_top = json_float(component, "radius_top", primitive.radius);
-            primitive.radius_bottom = json_float(component, "radius_bottom", primitive.radius);
-            primitive.major_radius = json_float(component, "major_radius", 0.5f);
-            primitive.minor_radius = json_float(component, "minor_radius", 0.15f);
-            primitive.slices = SDL_max(json_int(component, "slices", json_int(component, "segments", 24)), 3);
-            primitive.rings = SDL_max(json_int(component, "rings", 8), 3);
-            primitive.tube_segments = SDL_max(json_int(component, "tube_segments", primitive.rings), 3);
-            if (primitive.mesh_primitive == SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE)
-                primitive.radius_top = json_float(component, "radius_top", 0.0f);
+            populate_mesh_primitive_descriptor(actor, component, &primitive);
+        }
+        else if (SDL_strcmp(type, "render.composite") == 0)
+        {
+            yyjson_val *parts = obj_get(component, "parts");
+            if (!yyjson_is_arr(parts))
+                continue;
+            for (size_t p = 0; p < yyjson_arr_size(parts); ++p)
+            {
+                yyjson_val *part = yyjson_arr_get(parts, p);
+                sdl3d_game_data_render_primitive part_primitive = primitive;
+                const sdl3d_vec3 part_offset = json_vec3(part, "offset", sdl3d_vec3_make(0.0f, 0.0f, 0.0f));
+                part_primitive.position.x += part_offset.x;
+                part_primitive.position.y += part_offset.y;
+                part_primitive.position.z += part_offset.z;
+                part_primitive.rotation_axis = json_vec3(part, "rotation_axis", part_primitive.rotation_axis);
+                part_primitive.rotation_angle = json_float(part, "rotation_angle", part_primitive.rotation_angle);
+                const char *part_rotation_property = json_string(part, "rotation_property", NULL);
+                if (part_rotation_property != NULL)
+                    part_primitive.rotation_angle +=
+                        sdl3d_properties_get_float(actor->props, part_rotation_property, 0.0f);
+                part_primitive.color = json_color(part, "color", part_primitive.color);
+                part_primitive.texture_image = json_string(part, "texture", part_primitive.texture_image);
+                part_primitive.lighting_enabled = json_bool(part, "lighting", part_primitive.lighting_enabled);
+                part_primitive.emissive = json_bool(part, "emissive", part_primitive.emissive);
+                part_primitive.emissive_color =
+                    part_primitive.emissive ? sdl3d_vec3_make(0.2f, 0.2f, 0.2f) : part_primitive.emissive_color;
+                part_primitive.wire_color = json_color(part, "wire_color", part_primitive.wire_color);
+                populate_mesh_primitive_descriptor(actor, part, &part_primitive);
+                if (eval != NULL)
+                {
+                    apply_render_effects(runtime, component, eval, &part_primitive);
+                    apply_render_effects(runtime, part, eval, &part_primitive);
+                }
+                if (!callback(userdata, &part_primitive))
+                    return false;
+            }
+            continue;
         }
         else if (SDL_strcmp(type, "render.sprite") == 0)
         {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -4140,6 +4140,53 @@ static bool scene_state_bool(const sdl3d_game_data_runtime *runtime, const char 
     return fallback;
 }
 
+static float scene_state_float(const sdl3d_game_data_runtime *runtime, const char *key, float fallback)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || key == NULL || key[0] == '\0')
+        return fallback;
+    const sdl3d_value *value = sdl3d_properties_get_value(runtime->scene_state, key);
+    if (value == NULL)
+        return fallback;
+    if (value->type == SDL3D_VALUE_FLOAT)
+        return value->as_float;
+    if (value->type == SDL3D_VALUE_INT)
+        return (float)value->as_int;
+    return fallback;
+}
+
+static bool camera_fov_degrees_valid(float value)
+{
+    return value > 0.0f && value < 180.0f;
+}
+
+static sdl3d_camera_fov_axis parse_camera_fov_axis(const char *value, sdl3d_camera_fov_axis fallback)
+{
+    if (value == NULL)
+        return fallback;
+    if (SDL_strcasecmp(value, "vertical") == 0)
+        return SDL3D_CAMERA_FOV_VERTICAL;
+    if (SDL_strcasecmp(value, "horizontal") == 0)
+        return SDL3D_CAMERA_FOV_HORIZONTAL;
+    return fallback;
+}
+
+static float camera_fov_degrees(const sdl3d_game_data_runtime *runtime, yyjson_val *camera_json, float fallback)
+{
+    const float authored = json_float(camera_json, "fov", json_float(camera_json, "fovy", fallback));
+    const float valid_authored = camera_fov_degrees_valid(authored) ? authored : fallback;
+    const float runtime_value = scene_state_float(runtime, json_string(camera_json, "fov_key", NULL), valid_authored);
+    return camera_fov_degrees_valid(runtime_value) ? runtime_value : valid_authored;
+}
+
+static sdl3d_camera_fov_axis camera_fov_axis(const sdl3d_game_data_runtime *runtime, yyjson_val *camera_json)
+{
+    const sdl3d_camera_fov_axis authored =
+        parse_camera_fov_axis(json_string(camera_json, "fov_axis", NULL), SDL3D_CAMERA_FOV_VERTICAL);
+    return parse_camera_fov_axis(scene_state_string(runtime, json_string(camera_json, "fov_axis_key", NULL),
+                                                    json_string(camera_json, "fov_axis", NULL)),
+                                 authored);
+}
+
 static sdl3d_transition_type parse_transition_type(const char *value, sdl3d_transition_type fallback)
 {
     if (value == NULL)
@@ -5588,11 +5635,13 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
         if (target == NULL)
             return false;
 
-        const float fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        const float fov = camera_fov_degrees(runtime, camera_json, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        const sdl3d_camera_fov_axis fov_axis = camera_fov_axis(runtime, camera_json);
         const fps_controller_runtime *controller = find_fps_controller_const(runtime, target->name);
         if (controller != NULL && controller->initialized)
         {
-            *out_camera = sdl3d_fps_mover_camera(&controller->mover, fovy);
+            *out_camera = sdl3d_fps_mover_camera(&controller->mover, fov);
+            out_camera->fov_axis = fov_axis;
             return true;
         }
 
@@ -5605,7 +5654,8 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
             target->props, json_string(camera_json, "pitch_property", "pitch"), json_float(camera_json, "pitch", 0.0f));
         fallback_mover.view_smooth = sdl3d_properties_get_float(
             target->props, json_string(camera_json, "view_smooth_property", "view_smooth"), 0.0f);
-        *out_camera = sdl3d_fps_mover_camera(&fallback_mover, fovy);
+        *out_camera = sdl3d_fps_mover_camera(&fallback_mover, fov);
+        out_camera->fov_axis = fov_axis;
         return true;
     }
 
@@ -5651,7 +5701,8 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
         out_camera->target = sdl3d_vec3_make(anchor.x + velocity.x * lookahead, anchor.y + velocity.y * lookahead,
                                              anchor.z + target_z_offset);
         out_camera->up = json_vec3(camera_json, "up", sdl3d_vec3_make(0.0f, 0.0f, 1.0f));
-        out_camera->fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        out_camera->fovy = camera_fov_degrees(runtime, camera_json, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        out_camera->fov_axis = camera_fov_axis(runtime, camera_json);
         out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
         return true;
     }
@@ -5667,7 +5718,8 @@ bool sdl3d_game_data_get_camera(const sdl3d_game_data_runtime *runtime, const ch
     else
     {
         out_camera->projection = SDL3D_CAMERA_PERSPECTIVE;
-        out_camera->fovy = json_float(camera_json, "fovy", SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        out_camera->fovy = camera_fov_degrees(runtime, camera_json, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+        out_camera->fov_axis = camera_fov_axis(runtime, camera_json);
     }
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2817,16 +2817,37 @@ static bool is_wave_axis_value(yyjson_val *value)
 static bool is_supported_component_type(const char *type)
 {
     const char *known[] = {
-        "adapter.controller",  "collision.aabb",     "collision.circle",
-        "combat.health",       "control.axis_1d",    "controller.fps_sector",
-        "lifecycle.ttl",       "light.directional",  "light.point",
-        "light.spot",          "motion.grid_agent",  "motion.oscillate",
-        "motion.patrol",       "motion.scroll_wrap", "motion.sector_velocity_3d",
-        "motion.spin",         "motion.velocity_2d", "motion.velocity_3d",
-        "interactable",        "particles.emitter",  "pickup.respawn",
-        "property.decay",      "render.cube",        "render.mesh_primitive",
-        "render.model",        "render.sphere",      "render.sprite",
-        "status_effect.timer", "weapon.projectile",  "weapon.state",
+        "adapter.controller",
+        "collision.aabb",
+        "collision.circle",
+        "combat.health",
+        "control.axis_1d",
+        "controller.fps_sector",
+        "lifecycle.ttl",
+        "light.directional",
+        "light.point",
+        "light.spot",
+        "motion.grid_agent",
+        "motion.oscillate",
+        "motion.patrol",
+        "motion.scroll_wrap",
+        "motion.sector_velocity_3d",
+        "motion.spin",
+        "motion.velocity_2d",
+        "motion.velocity_3d",
+        "interactable",
+        "particles.emitter",
+        "pickup.respawn",
+        "property.decay",
+        "render.composite",
+        "render.cube",
+        "render.mesh_primitive",
+        "render.model",
+        "render.sphere",
+        "render.sprite",
+        "status_effect.timer",
+        "weapon.projectile",
+        "weapon.state",
     };
 
     if (type == NULL)
@@ -2841,7 +2862,9 @@ static bool is_supported_component_type(const char *type)
 
 static bool render_mesh_primitive_kind_valid(const char *primitive)
 {
-    const char *known[] = {"cube", "sphere", "capsule", "cylinder", "cone", "torus", "pyramid", "wedge"};
+    const char *known[] = {"cube",        "sphere",       "capsule", "cylinder", "cone",           "torus",
+                           "pyramid",     "wedge",        "plane",   "quad",     "disc",           "hemisphere",
+                           "rounded_box", "tube_segment", "pipe",    "arrow",    "billboard_plane"};
     for (size_t i = 0; primitive != NULL && i < SDL_arraysize(known); ++i)
     {
         if (SDL_strcmp(primitive, known[i]) == 0)
@@ -2910,6 +2933,34 @@ static bool validate_render_mesh_primitive_component(validation_context *ctx, yy
     yyjson_val *rotation_property = obj_get(component, "rotation_property");
     if (rotation_property != NULL && !is_non_empty_string(component, "rotation_property"))
         return validation_error(ctx, path, "render.mesh_primitive rotation_property must be non-empty");
+    yyjson_val *bevel_radius = obj_get(component, "bevel_radius");
+    if (bevel_radius != NULL && (!yyjson_is_num(bevel_radius) || yyjson_get_num(bevel_radius) < 0.0))
+        return validation_error(ctx, path, "render.mesh_primitive bevel_radius must be a non-negative number");
+    yyjson_val *arc_angle = obj_get(component, "arc_angle");
+    if (arc_angle != NULL && (!yyjson_is_num(arc_angle) || yyjson_get_num(arc_angle) <= 0.0))
+        return validation_error(ctx, path, "render.mesh_primitive arc_angle must be a positive number");
+    return true;
+}
+
+static bool validate_render_composite_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                                const validation_names *names)
+{
+    yyjson_val *parts = obj_get(component, "parts");
+    if (!yyjson_is_arr(parts) || yyjson_arr_size(parts) == 0)
+        return validation_error(ctx, path, "render.composite parts must be a non-empty array");
+    for (size_t i = 0; i < yyjson_arr_size(parts); ++i)
+    {
+        yyjson_val *part = yyjson_arr_get(parts, i);
+        if (!yyjson_is_obj(part))
+            return validation_error(ctx, path, "render.composite parts must be objects");
+        const char *type = json_string(part, "type");
+        if (type == NULL)
+            type = "render.mesh_primitive";
+        if (SDL_strcmp(type, "render.mesh_primitive") != 0)
+            return validation_error(ctx, path, "render.composite parts must be render.mesh_primitive descriptors");
+        if (!validate_render_mesh_primitive_component(ctx, part, path, names))
+            return false;
+    }
     return true;
 }
 
@@ -5068,14 +5119,14 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                     return validation_error(ctx, path, "light component color must be a vec3");
             }
             else if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
-                     SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.sprite") == 0 ||
-                     SDL_strcmp(type, "render.model") == 0)
+                     SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.composite") == 0 ||
+                     SDL_strcmp(type, "render.sprite") == 0 || SDL_strcmp(type, "render.model") == 0)
             {
                 yyjson_val *lighting = obj_get(component, "lighting");
                 if (lighting != NULL && !yyjson_is_bool(lighting))
                     return validation_error(ctx, path, "render primitive lighting must be a boolean");
                 if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
-                    SDL_strcmp(type, "render.mesh_primitive") == 0)
+                    SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.composite") == 0)
                 {
                     yyjson_val *texture_value = obj_get(component, "texture");
                     if (texture_value != NULL && !is_non_empty_string(component, "texture"))
@@ -5097,6 +5148,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (SDL_strcmp(type, "render.mesh_primitive") == 0)
                 {
                     if (!validate_render_mesh_primitive_component(ctx, component, path, names))
+                        return false;
+                }
+                if (SDL_strcmp(type, "render.composite") == 0)
+                {
+                    if (!validate_render_composite_component(ctx, component, path, names))
                         return false;
                 }
                 if (SDL_strcmp(type, "render.sphere") == 0)
@@ -5537,6 +5593,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             else if (SDL_strcmp(type, "render.mesh_primitive") == 0)
             {
                 if (!validate_render_mesh_primitive_component(ctx, component, component_path, names))
+                    return false;
+            }
+            else if (SDL_strcmp(type, "render.composite") == 0)
+            {
+                if (!validate_render_composite_component(ctx, component, component_path, names))
                     return false;
             }
             else if (SDL_strcmp(type, "render.sprite") == 0)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8143,9 +8143,24 @@ static bool validate_cameras(validation_context *ctx, yyjson_val *root, validati
         format_path(path, sizeof(path), "$.world.cameras[%zu]", i);
         yyjson_val *camera = yyjson_arr_get(cameras, i);
         const char *type = json_string(camera, "type");
+        yyjson_val *fov = obj_get(camera, "fov");
         yyjson_val *fovy = obj_get(camera, "fovy");
+        if (fov != NULL && fovy != NULL)
+            return validation_error(ctx, path, "camera must not define both fov and fovy");
+        if (fov != NULL && (!yyjson_is_num(fov) || yyjson_get_num(fov) <= 0.0 || yyjson_get_num(fov) >= 180.0))
+            return validation_error(ctx, path, "camera fov must be in the range (0, 180)");
         if (fovy != NULL && (!yyjson_is_num(fovy) || yyjson_get_num(fovy) <= 0.0 || yyjson_get_num(fovy) >= 180.0))
             return validation_error(ctx, path, "camera fovy must be in the range (0, 180)");
+        yyjson_val *fov_axis = obj_get(camera, "fov_axis");
+        if (fov_axis != NULL && (!yyjson_is_str(fov_axis) || (SDL_strcmp(yyjson_get_str(fov_axis), "vertical") != 0 &&
+                                                              SDL_strcmp(yyjson_get_str(fov_axis), "horizontal") != 0)))
+            return validation_error(ctx, path, "camera fov_axis must be 'vertical' or 'horizontal'");
+        yyjson_val *fov_key = obj_get(camera, "fov_key");
+        if (fov_key != NULL && (!yyjson_is_str(fov_key) || yyjson_get_str(fov_key)[0] == '\0'))
+            return validation_error(ctx, path, "camera fov_key must be a non-empty string");
+        yyjson_val *fov_axis_key = obj_get(camera, "fov_axis_key");
+        if (fov_axis_key != NULL && (!yyjson_is_str(fov_axis_key) || yyjson_get_str(fov_axis_key)[0] == '\0'))
+            return validation_error(ctx, path, "camera fov_axis_key must be a non-empty string");
         yyjson_val *size = obj_get(camera, "size");
         if (size != NULL && (!yyjson_is_num(size) || yyjson_get_num(size) <= 0.0))
             return validation_error(ctx, path, "camera size must be positive");

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -868,6 +868,28 @@ static bool draw_mesh_primitive_solid(primitive_draw_context *context,
     case SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE:
         return sdl3d_draw_wedge(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
                                 primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PLANE:
+        return sdl3d_draw_quad(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
+                               (sdl3d_vec2){primitive->size.x, primitive->size.y}, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_DISC:
+        return sdl3d_draw_disc(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                               primitive->slices, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_HEMISPHERE:
+        return sdl3d_draw_hemisphere(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                     primitive->rings, primitive->slices, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX:
+        return sdl3d_draw_rounded_box(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                      primitive->bevel_radius, primitive->rings, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT:
+        return sdl3d_draw_tube_segment(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->major_radius,
+                                       primitive->minor_radius, primitive->arc_angle, primitive->slices,
+                                       primitive->tube_segments, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ARROW:
+        return sdl3d_draw_arrow(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                primitive->height, primitive->slices, primitive->color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE:
+        return sdl3d_draw_quad(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
+                               (sdl3d_vec2){primitive->size.x, primitive->size.y}, primitive->color);
     case SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID:
     default:
         return false;
@@ -912,6 +934,28 @@ static bool draw_mesh_primitive_wires(primitive_draw_context *context,
     case SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE:
         return sdl3d_draw_wedge_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
                                       primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PLANE:
+        return sdl3d_draw_quad_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                     (sdl3d_vec2){primitive->size.x, primitive->size.y}, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_DISC:
+        return sdl3d_draw_disc_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                     primitive->slices, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_HEMISPHERE:
+        return sdl3d_draw_hemisphere_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                           primitive->rings, primitive->slices, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX:
+        return sdl3d_draw_rounded_box_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->size,
+                                            primitive->bevel_radius, primitive->rings, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT:
+        return sdl3d_draw_tube_segment_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                             primitive->major_radius, primitive->minor_radius, primitive->arc_angle,
+                                             primitive->slices, primitive->tube_segments, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ARROW:
+        return sdl3d_draw_arrow_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), primitive->radius,
+                                      primitive->height, primitive->slices, primitive->wire_color);
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE:
+        return sdl3d_draw_quad_wires(context->renderer, sdl3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                     (sdl3d_vec2){primitive->size.x, primitive->size.y}, primitive->wire_color);
     case SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID:
     default:
         return false;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -21,6 +21,7 @@ typedef struct primitive_draw_context
     sdl3d_game_data_image_cache *image_cache;
     sdl3d_game_data_sprite_cache *sprite_cache;
     sdl3d_game_data_model_cache *model_cache;
+    sdl3d_game_data_mesh_primitive_cache *mesh_primitive_cache;
     const sdl3d_camera3d *camera;
     const sdl3d_game_data_render_eval *eval;
     sdl3d_game_data_render_primitive sphere_batch;
@@ -29,6 +30,8 @@ typedef struct primitive_draw_context
     int sphere_batch_capacity;
     bool sphere_batch_active;
 } primitive_draw_context;
+
+static const float SDL3D_GAME_PRESENTATION_PI = 3.14159265358979323846f;
 
 typedef struct sector_level_draw_context
 {
@@ -387,6 +390,26 @@ static bool ensure_model_cache_capacity(sdl3d_game_data_model_cache *cache, int 
 
     sdl3d_game_data_model_cache_entry *entries =
         (sdl3d_game_data_model_cache_entry *)SDL_realloc(cache->entries, (size_t)next_capacity * sizeof(*entries));
+    if (entries == NULL)
+        return false;
+
+    SDL_memset(entries + cache->capacity, 0, (size_t)(next_capacity - cache->capacity) * sizeof(*entries));
+    cache->entries = entries;
+    cache->capacity = next_capacity;
+    return true;
+}
+
+static bool ensure_mesh_primitive_cache_capacity(sdl3d_game_data_mesh_primitive_cache *cache, int required)
+{
+    if (cache == NULL || required <= cache->capacity)
+        return cache != NULL;
+
+    int next_capacity = cache->capacity < 16 ? 16 : cache->capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    sdl3d_game_data_mesh_primitive_cache_entry *entries = (sdl3d_game_data_mesh_primitive_cache_entry *)SDL_realloc(
+        cache->entries, (size_t)next_capacity * sizeof(*entries));
     if (entries == NULL)
         return false;
 
@@ -831,12 +854,649 @@ static const sdl3d_texture2d *primitive_texture(primitive_draw_context *context,
     return entry != NULL ? &entry->texture : NULL;
 }
 
+static void mesh_primitive_free_mesh(sdl3d_mesh *mesh)
+{
+    if (mesh == NULL)
+        return;
+    SDL_free(mesh->positions);
+    SDL_free(mesh->normals);
+    SDL_free(mesh->uvs);
+    SDL_free(mesh->indices);
+    SDL_zero(*mesh);
+}
+
+static bool mesh_primitive_alloc_mesh(sdl3d_mesh *mesh, int vertex_count, int index_count, bool with_uvs)
+{
+    if (mesh == NULL || vertex_count <= 0 || index_count <= 0)
+        return false;
+    SDL_zero(*mesh);
+    mesh->positions = (float *)SDL_calloc((size_t)vertex_count * 3U, sizeof(float));
+    mesh->normals = (float *)SDL_calloc((size_t)vertex_count * 3U, sizeof(float));
+    mesh->uvs = with_uvs ? (float *)SDL_calloc((size_t)vertex_count * 2U, sizeof(float)) : NULL;
+    mesh->indices = (unsigned int *)SDL_calloc((size_t)index_count, sizeof(unsigned int));
+    if (mesh->positions == NULL || mesh->normals == NULL || (with_uvs && mesh->uvs == NULL) || mesh->indices == NULL)
+    {
+        mesh_primitive_free_mesh(mesh);
+        return SDL_OutOfMemory();
+    }
+    mesh->vertex_count = vertex_count;
+    mesh->index_count = index_count;
+    mesh->material_index = -1;
+    return true;
+}
+
+static void mesh_primitive_set_vertex(sdl3d_mesh *mesh, int index, sdl3d_vec3 position, sdl3d_vec3 normal, float u,
+                                      float v)
+{
+    mesh->positions[index * 3 + 0] = position.x;
+    mesh->positions[index * 3 + 1] = position.y;
+    mesh->positions[index * 3 + 2] = position.z;
+    mesh->normals[index * 3 + 0] = normal.x;
+    mesh->normals[index * 3 + 1] = normal.y;
+    mesh->normals[index * 3 + 2] = normal.z;
+    if (mesh->uvs != NULL)
+    {
+        mesh->uvs[index * 2 + 0] = u;
+        mesh->uvs[index * 2 + 1] = v;
+    }
+}
+
+static sdl3d_vec3 mesh_primitive_face_normal(sdl3d_vec3 a, sdl3d_vec3 b, sdl3d_vec3 c)
+{
+    return sdl3d_vec3_normalize(sdl3d_vec3_cross(sdl3d_vec3_sub(b, a), sdl3d_vec3_sub(c, a)));
+}
+
+static bool mesh_primitive_cache_entry_matches(const sdl3d_game_data_mesh_primitive_cache_entry *entry,
+                                               const sdl3d_game_data_render_primitive *primitive)
+{
+    if (entry == NULL || primitive == NULL || !entry->loaded)
+        return false;
+    return entry->primitive == primitive->mesh_primitive && entry->size.x == primitive->size.x &&
+           entry->size.y == primitive->size.y && entry->size.z == primitive->size.z &&
+           entry->radius == primitive->radius && entry->radius_top == primitive->radius_top &&
+           entry->radius_bottom == primitive->radius_bottom && entry->height == primitive->height &&
+           entry->major_radius == primitive->major_radius && entry->minor_radius == primitive->minor_radius &&
+           entry->bevel_radius == primitive->bevel_radius && entry->arc_angle == primitive->arc_angle &&
+           entry->slices == primitive->slices && entry->rings == primitive->rings &&
+           entry->tube_segments == primitive->tube_segments;
+}
+
+static void mesh_primitive_cache_entry_set_key(sdl3d_game_data_mesh_primitive_cache_entry *entry,
+                                               const sdl3d_game_data_render_primitive *primitive)
+{
+    entry->primitive = primitive->mesh_primitive;
+    entry->size = primitive->size;
+    entry->radius = primitive->radius;
+    entry->radius_top = primitive->radius_top;
+    entry->radius_bottom = primitive->radius_bottom;
+    entry->height = primitive->height;
+    entry->major_radius = primitive->major_radius;
+    entry->minor_radius = primitive->minor_radius;
+    entry->bevel_radius = primitive->bevel_radius;
+    entry->arc_angle = primitive->arc_angle;
+    entry->slices = primitive->slices;
+    entry->rings = primitive->rings;
+    entry->tube_segments = primitive->tube_segments;
+}
+
+static bool build_cube_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    if (!mesh_primitive_alloc_mesh(mesh, 24, 36, true))
+        return false;
+    const float hx = primitive->size.x * 0.5f;
+    const float hy = primitive->size.y * 0.5f;
+    const float hz = primitive->size.z * 0.5f;
+    const sdl3d_vec3 c[8] = {{-hx, -hy, -hz}, {hx, -hy, -hz}, {-hx, hy, -hz}, {hx, hy, -hz},
+                             {-hx, -hy, hz},  {hx, -hy, hz},  {-hx, hy, hz},  {hx, hy, hz}};
+    static const int faces[6][4] = {
+        {4, 5, 7, 6}, {1, 0, 2, 3}, {5, 1, 3, 7}, {0, 4, 6, 2}, {6, 7, 3, 2}, {0, 1, 5, 4},
+    };
+    static const sdl3d_vec3 normals[6] = {{0, 0, 1}, {0, 0, -1}, {1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}};
+    static const float uvs[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
+    for (int f = 0; f < 6; ++f)
+    {
+        const int base = f * 4;
+        for (int v = 0; v < 4; ++v)
+            mesh_primitive_set_vertex(mesh, base + v, c[faces[f][v]], normals[f], uvs[v][0], uvs[v][1]);
+        const unsigned int b = (unsigned int)base;
+        const int ii = f * 6;
+        mesh->indices[ii + 0] = b;
+        mesh->indices[ii + 1] = b + 1U;
+        mesh->indices[ii + 2] = b + 2U;
+        mesh->indices[ii + 3] = b;
+        mesh->indices[ii + 4] = b + 2U;
+        mesh->indices[ii + 5] = b + 3U;
+    }
+    return true;
+}
+
+static bool build_quad_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    if (!mesh_primitive_alloc_mesh(mesh, 4, 6, true))
+        return false;
+    const float hx = primitive->size.x * 0.5f;
+    const float hy = primitive->size.y * 0.5f;
+    const sdl3d_vec3 n = {0.0f, 0.0f, 1.0f};
+    mesh_primitive_set_vertex(mesh, 0, sdl3d_vec3_make(-hx, -hy, 0.0f), n, 0.0f, 1.0f);
+    mesh_primitive_set_vertex(mesh, 1, sdl3d_vec3_make(hx, -hy, 0.0f), n, 1.0f, 1.0f);
+    mesh_primitive_set_vertex(mesh, 2, sdl3d_vec3_make(hx, hy, 0.0f), n, 1.0f, 0.0f);
+    mesh_primitive_set_vertex(mesh, 3, sdl3d_vec3_make(-hx, hy, 0.0f), n, 0.0f, 0.0f);
+    const unsigned int indices[6] = {0, 1, 2, 0, 2, 3};
+    SDL_memcpy(mesh->indices, indices, sizeof(indices));
+    return true;
+}
+
+static bool build_disc_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int segments = primitive->slices;
+    if (!mesh_primitive_alloc_mesh(mesh, segments + 1, segments * 3, true))
+        return false;
+    const sdl3d_vec3 n = {0.0f, 0.0f, 1.0f};
+    mesh_primitive_set_vertex(mesh, 0, sdl3d_vec3_make(0.0f, 0.0f, 0.0f), n, 0.5f, 0.5f);
+    for (int i = 0; i < segments; ++i)
+    {
+        const float a = (float)i / (float)segments * SDL3D_GAME_PRESENTATION_PI * 2.0f;
+        const float x = SDL_cosf(a) * primitive->radius;
+        const float y = SDL_sinf(a) * primitive->radius;
+        mesh_primitive_set_vertex(mesh, i + 1, sdl3d_vec3_make(x, y, 0.0f), n,
+                                  0.5f + x / SDL_max(primitive->radius * 2.0f, 0.0001f),
+                                  0.5f + y / SDL_max(primitive->radius * 2.0f, 0.0001f));
+    }
+    int ii = 0;
+    for (int i = 0; i < segments; ++i)
+    {
+        mesh->indices[ii++] = 0U;
+        mesh->indices[ii++] = (unsigned int)(i + 1);
+        mesh->indices[ii++] = (unsigned int)((i + 1) % segments + 1);
+    }
+    return true;
+}
+
+static bool build_sphere_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int rings = primitive->rings;
+    const int slices = primitive->slices;
+    if (!mesh_primitive_alloc_mesh(mesh, (rings + 1) * (slices + 1), rings * slices * 6, true))
+        return false;
+    for (int r = 0; r <= rings; ++r)
+    {
+        const float theta = SDL3D_GAME_PRESENTATION_PI * (float)r / (float)rings;
+        for (int s = 0; s <= slices; ++s)
+        {
+            const float phi = SDL3D_GAME_PRESENTATION_PI * 2.0f * (float)s / (float)slices;
+            const sdl3d_vec3 normal =
+                sdl3d_vec3_make(SDL_sinf(theta) * SDL_cosf(phi), SDL_cosf(theta), SDL_sinf(theta) * SDL_sinf(phi));
+            const sdl3d_vec3 position = sdl3d_vec3_scale(normal, primitive->radius);
+            mesh_primitive_set_vertex(mesh, r * (slices + 1) + s, position, normal, (float)s / (float)slices,
+                                      1.0f - (float)r / (float)rings);
+        }
+    }
+    int ii = 0;
+    for (int r = 0; r < rings; ++r)
+    {
+        for (int s = 0; s < slices; ++s)
+        {
+            const unsigned int a = (unsigned int)(r * (slices + 1) + s);
+            const unsigned int b = a + 1U;
+            const unsigned int c = (unsigned int)((r + 1) * (slices + 1) + s);
+            const unsigned int d = c + 1U;
+            mesh->indices[ii++] = a;
+            mesh->indices[ii++] = b;
+            mesh->indices[ii++] = d;
+            mesh->indices[ii++] = a;
+            mesh->indices[ii++] = d;
+            mesh->indices[ii++] = c;
+        }
+    }
+    return true;
+}
+
+static bool build_cylinder_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int slices = primitive->slices;
+    const int side_verts = 2 * (slices + 1);
+    const int cap_verts = (slices + 2) * 2;
+    if (!mesh_primitive_alloc_mesh(mesh, side_verts + cap_verts, slices * 12, false))
+        return false;
+    const float hh = primitive->height * 0.5f;
+    for (int s = 0; s <= slices; ++s)
+    {
+        const float phi = SDL3D_GAME_PRESENTATION_PI * 2.0f * (float)s / (float)slices;
+        const float c = SDL_cosf(phi);
+        const float z = SDL_sinf(phi);
+        const sdl3d_vec3 normal = sdl3d_vec3_make(c, 0.0f, z);
+        mesh_primitive_set_vertex(mesh, s, sdl3d_vec3_make(primitive->radius_top * c, hh, primitive->radius_top * z),
+                                  normal, 0.0f, 0.0f);
+        mesh_primitive_set_vertex(mesh, slices + 1 + s,
+                                  sdl3d_vec3_make(primitive->radius_bottom * c, -hh, primitive->radius_bottom * z),
+                                  normal, 0.0f, 0.0f);
+    }
+    int ii = 0;
+    for (int s = 0; s < slices; ++s)
+    {
+        const unsigned int t0 = (unsigned int)s;
+        const unsigned int t1 = (unsigned int)(s + 1);
+        const unsigned int b0 = (unsigned int)(slices + 1 + s);
+        const unsigned int b1 = (unsigned int)(slices + 1 + s + 1);
+        mesh->indices[ii++] = b0;
+        mesh->indices[ii++] = t0;
+        mesh->indices[ii++] = t1;
+        mesh->indices[ii++] = b0;
+        mesh->indices[ii++] = t1;
+        mesh->indices[ii++] = b1;
+    }
+    int cap = side_verts;
+    mesh_primitive_set_vertex(mesh, cap, sdl3d_vec3_make(0.0f, hh, 0.0f), sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0, 0);
+    for (int s = 0; s <= slices; ++s)
+    {
+        const float phi = SDL3D_GAME_PRESENTATION_PI * 2.0f * (float)s / (float)slices;
+        mesh_primitive_set_vertex(
+            mesh, cap + 1 + s,
+            sdl3d_vec3_make(primitive->radius_top * SDL_cosf(phi), hh, primitive->radius_top * SDL_sinf(phi)),
+            sdl3d_vec3_make(0.0f, 1.0f, 0.0f), 0, 0);
+    }
+    for (int s = 0; s < slices; ++s)
+    {
+        mesh->indices[ii++] = (unsigned int)cap;
+        mesh->indices[ii++] = (unsigned int)(cap + 1 + s + 1);
+        mesh->indices[ii++] = (unsigned int)(cap + 1 + s);
+    }
+    cap += slices + 2;
+    mesh_primitive_set_vertex(mesh, cap, sdl3d_vec3_make(0.0f, -hh, 0.0f), sdl3d_vec3_make(0.0f, -1.0f, 0.0f), 0, 0);
+    for (int s = 0; s <= slices; ++s)
+    {
+        const float phi = SDL3D_GAME_PRESENTATION_PI * 2.0f * (float)s / (float)slices;
+        mesh_primitive_set_vertex(
+            mesh, cap + 1 + s,
+            sdl3d_vec3_make(primitive->radius_bottom * SDL_cosf(phi), -hh, primitive->radius_bottom * SDL_sinf(phi)),
+            sdl3d_vec3_make(0.0f, -1.0f, 0.0f), 0, 0);
+    }
+    for (int s = 0; s < slices; ++s)
+    {
+        mesh->indices[ii++] = (unsigned int)cap;
+        mesh->indices[ii++] = (unsigned int)(cap + 1 + s);
+        mesh->indices[ii++] = (unsigned int)(cap + 1 + s + 1);
+    }
+    return true;
+}
+
+static bool build_capsule_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int slices = primitive->slices;
+    const int rings = primitive->rings;
+    const int total_rings = 2 * rings + 2;
+    const int verts_per_ring = slices + 1;
+    if (!mesh_primitive_alloc_mesh(mesh, total_rings * verts_per_ring, (total_rings - 1) * slices * 6, false))
+        return false;
+
+    const float cylinder_span = SDL_max(primitive->height - primitive->radius * 2.0f, 0.0f);
+    const float start_y = -cylinder_span * 0.5f;
+    const float end_y = cylinder_span * 0.5f;
+    for (int k = 0; k < total_rings; ++k)
+    {
+        float ring_radius = 0.0f;
+        float center_y = 0.0f;
+        float normal_y = 0.0f;
+        if (k <= rings)
+        {
+            const float t = (float)k / (float)rings;
+            const float theta = SDL3D_GAME_PRESENTATION_PI * 0.5f * t;
+            ring_radius = primitive->radius * SDL_sinf(theta);
+            center_y = end_y + primitive->radius * SDL_cosf(theta);
+            normal_y = SDL_cosf(theta);
+        }
+        else
+        {
+            const int lower_k = k - (rings + 1);
+            const float t = (float)lower_k / (float)rings;
+            const float theta = SDL3D_GAME_PRESENTATION_PI * 0.5f * t;
+            ring_radius = primitive->radius * SDL_cosf(theta);
+            center_y = start_y - primitive->radius * SDL_sinf(theta);
+            normal_y = -SDL_sinf(theta);
+        }
+        for (int s = 0; s <= slices; ++s)
+        {
+            const float phi = SDL3D_GAME_PRESENTATION_PI * 2.0f * (float)s / (float)slices;
+            const float x = ring_radius * SDL_cosf(phi);
+            const float z = ring_radius * SDL_sinf(phi);
+            const sdl3d_vec3 normal = sdl3d_vec3_normalize(sdl3d_vec3_make(
+                SDL_cosf(phi) * ring_radius, normal_y * primitive->radius, SDL_sinf(phi) * ring_radius));
+            mesh_primitive_set_vertex(mesh, k * verts_per_ring + s, sdl3d_vec3_make(x, center_y, z), normal, 0, 0);
+        }
+    }
+
+    int ii = 0;
+    for (int k = 0; k + 1 < total_rings; ++k)
+    {
+        for (int s = 0; s < slices; ++s)
+        {
+            const unsigned int a = (unsigned int)(k * verts_per_ring + s);
+            const unsigned int b = a + 1U;
+            const unsigned int c = (unsigned int)((k + 1) * verts_per_ring + s);
+            const unsigned int d = c + 1U;
+            mesh->indices[ii++] = a;
+            mesh->indices[ii++] = c;
+            mesh->indices[ii++] = d;
+            mesh->indices[ii++] = a;
+            mesh->indices[ii++] = d;
+            mesh->indices[ii++] = b;
+        }
+    }
+    return true;
+}
+
+static bool build_torus_like_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh, bool full_torus)
+{
+    const int segments = primitive->slices;
+    const int tube_segments = primitive->tube_segments;
+    const int arc_vertices = segments + 1;
+    const int tube_vertices = tube_segments + 1;
+    if (!mesh_primitive_alloc_mesh(mesh, arc_vertices * tube_vertices, segments * tube_segments * 6, false))
+        return false;
+    const float arc_angle = full_torus ? SDL3D_GAME_PRESENTATION_PI * 2.0f : primitive->arc_angle;
+    const float start_angle = full_torus ? 0.0f : -arc_angle * 0.5f;
+    for (int a = 0; a <= segments; ++a)
+    {
+        const float u = start_angle + (float)a / (float)segments * arc_angle;
+        const sdl3d_vec3 radial = sdl3d_vec3_make(SDL_cosf(u), 0.0f, SDL_sinf(u));
+        const sdl3d_vec3 center = sdl3d_vec3_scale(radial, primitive->major_radius);
+        for (int t = 0; t <= tube_segments; ++t)
+        {
+            const float v = (float)t / (float)tube_segments * SDL3D_GAME_PRESENTATION_PI * 2.0f;
+            const sdl3d_vec3 normal =
+                sdl3d_vec3_normalize(sdl3d_vec3_make(radial.x * SDL_cosf(v), SDL_sinf(v), radial.z * SDL_cosf(v)));
+            mesh_primitive_set_vertex(mesh, a * tube_vertices + t,
+                                      sdl3d_vec3_add(center, sdl3d_vec3_scale(normal, primitive->minor_radius)), normal,
+                                      0, 0);
+        }
+    }
+    int ii = 0;
+    for (int a = 0; a < segments; ++a)
+    {
+        for (int t = 0; t < tube_segments; ++t)
+        {
+            const unsigned int p00 = (unsigned int)(a * tube_vertices + t);
+            const unsigned int p01 = p00 + 1U;
+            const unsigned int p10 = (unsigned int)((a + 1) * tube_vertices + t);
+            const unsigned int p11 = p10 + 1U;
+            mesh->indices[ii++] = p00;
+            mesh->indices[ii++] = p10;
+            mesh->indices[ii++] = p01;
+            mesh->indices[ii++] = p01;
+            mesh->indices[ii++] = p10;
+            mesh->indices[ii++] = p11;
+        }
+    }
+    return true;
+}
+
+static bool build_pyramid_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    if (!mesh_primitive_alloc_mesh(mesh, 18, 18, false))
+        return false;
+    const float hx = primitive->size.x * 0.5f;
+    const float hy = primitive->size.y * 0.5f;
+    const float hz = primitive->size.z * 0.5f;
+    const sdl3d_vec3 apex = sdl3d_vec3_make(0.0f, hy, 0.0f);
+    const sdl3d_vec3 bl = sdl3d_vec3_make(-hx, -hy, -hz);
+    const sdl3d_vec3 br = sdl3d_vec3_make(hx, -hy, -hz);
+    const sdl3d_vec3 tr = sdl3d_vec3_make(hx, -hy, hz);
+    const sdl3d_vec3 tl = sdl3d_vec3_make(-hx, -hy, hz);
+    const sdl3d_vec3 faces[6][3] = {{bl, apex, br}, {br, apex, tr}, {tr, apex, tl},
+                                    {tl, apex, bl}, {bl, br, tr},   {bl, tr, tl}};
+    for (int f = 0; f < 6; ++f)
+    {
+        const sdl3d_vec3 normal = mesh_primitive_face_normal(faces[f][0], faces[f][1], faces[f][2]);
+        for (int v = 0; v < 3; ++v)
+        {
+            const int vi = f * 3 + v;
+            mesh_primitive_set_vertex(mesh, vi, faces[f][v], normal, 0, 0);
+            mesh->indices[vi] = (unsigned int)vi;
+        }
+    }
+    return true;
+}
+
+static bool build_wedge_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    if (!mesh_primitive_alloc_mesh(mesh, 24, 24, false))
+        return false;
+    const float hx = primitive->size.x * 0.5f;
+    const float hy = primitive->size.y * 0.5f;
+    const float hz = primitive->size.z * 0.5f;
+    const sdl3d_vec3 p[6] = {sdl3d_vec3_make(-hx, -hy, -hz), sdl3d_vec3_make(hx, -hy, -hz),
+                             sdl3d_vec3_make(-hx, -hy, hz),  sdl3d_vec3_make(hx, -hy, hz),
+                             sdl3d_vec3_make(-hx, hy, hz),   sdl3d_vec3_make(hx, hy, hz)};
+    const sdl3d_vec3 triangles[8][3] = {
+        {p[0], p[3], p[1]}, {p[0], p[2], p[3]}, {p[2], p[5], p[3]}, {p[2], p[4], p[5]},
+        {p[0], p[4], p[2]}, {p[0], p[1], p[5]}, {p[0], p[5], p[4]}, {p[1], p[3], p[5]},
+    };
+    for (int f = 0; f < 8; ++f)
+    {
+        const sdl3d_vec3 normal = mesh_primitive_face_normal(triangles[f][0], triangles[f][1], triangles[f][2]);
+        for (int v = 0; v < 3; ++v)
+        {
+            const int vi = f * 3 + v;
+            mesh_primitive_set_vertex(mesh, vi, triangles[f][v], normal, 0, 0);
+            mesh->indices[vi] = (unsigned int)vi;
+        }
+    }
+    return true;
+}
+
+static bool build_hemisphere_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int rings = primitive->rings;
+    const int slices = primitive->slices;
+    const int curved_vertices = (rings + 1) * (slices + 1);
+    const int cap_center = curved_vertices;
+    if (!mesh_primitive_alloc_mesh(mesh, curved_vertices + 1, rings * slices * 6 + slices * 3, false))
+        return false;
+    const float y_offset = primitive->radius * 0.5f;
+    for (int r = 0; r <= rings; ++r)
+    {
+        const float theta = (float)r / (float)rings * SDL3D_GAME_PRESENTATION_PI * 0.5f;
+        const float rr = SDL_sinf(theta) * primitive->radius;
+        const float y = SDL_cosf(theta) * primitive->radius - y_offset;
+        for (int s = 0; s <= slices; ++s)
+        {
+            const float phi = (float)s / (float)slices * SDL3D_GAME_PRESENTATION_PI * 2.0f;
+            const sdl3d_vec3 position = sdl3d_vec3_make(SDL_cosf(phi) * rr, y, SDL_sinf(phi) * rr);
+            const sdl3d_vec3 normal = sdl3d_vec3_normalize(sdl3d_vec3_make(position.x, y + y_offset, position.z));
+            mesh_primitive_set_vertex(mesh, r * (slices + 1) + s, position, normal, 0, 0);
+        }
+    }
+    int ii = 0;
+    for (int r = 0; r < rings; ++r)
+    {
+        for (int s = 0; s < slices; ++s)
+        {
+            const unsigned int a = (unsigned int)(r * (slices + 1) + s);
+            const unsigned int b = a + 1U;
+            const unsigned int c = (unsigned int)((r + 1) * (slices + 1) + s);
+            const unsigned int d = c + 1U;
+            mesh->indices[ii++] = a;
+            mesh->indices[ii++] = c;
+            mesh->indices[ii++] = b;
+            mesh->indices[ii++] = b;
+            mesh->indices[ii++] = c;
+            mesh->indices[ii++] = d;
+        }
+    }
+    mesh_primitive_set_vertex(mesh, cap_center, sdl3d_vec3_make(0.0f, -y_offset, 0.0f),
+                              sdl3d_vec3_make(0.0f, -1.0f, 0.0f), 0, 0);
+    const int base_row = rings * (slices + 1);
+    for (int s = 0; s < slices; ++s)
+    {
+        mesh->indices[ii++] = (unsigned int)cap_center;
+        mesh->indices[ii++] = (unsigned int)(base_row + s + 1);
+        mesh->indices[ii++] = (unsigned int)(base_row + s);
+    }
+    return true;
+}
+
+static bool build_rounded_box_mesh(const sdl3d_game_data_render_primitive *primitive, sdl3d_mesh *mesh)
+{
+    const int grid = SDL_max(primitive->rings + 2, 3);
+    const int face_vertices = grid * grid;
+    if (!mesh_primitive_alloc_mesh(mesh, face_vertices * 6, (grid - 1) * (grid - 1) * 36, false))
+        return false;
+    const sdl3d_vec3 half = sdl3d_vec3_scale(primitive->size, 0.5f);
+    const float radius = SDL_min(primitive->bevel_radius,
+                                 SDL_min(primitive->size.x, SDL_min(primitive->size.y, primitive->size.z)) * 0.5f);
+    const sdl3d_vec3 inner =
+        sdl3d_vec3_make(SDL_max(half.x - radius, 0.0f), SDL_max(half.y - radius, 0.0f), SDL_max(half.z - radius, 0.0f));
+    int vi = 0;
+    for (int face = 0; face < 6; ++face)
+    {
+        const int axis = face / 2;
+        const float sign = (face % 2) == 0 ? -1.0f : 1.0f;
+        for (int y = 0; y < grid; ++y)
+        {
+            const float v = -1.0f + 2.0f * (float)y / (float)(grid - 1);
+            for (int x = 0; x < grid; ++x)
+            {
+                const float u = -1.0f + 2.0f * (float)x / (float)(grid - 1);
+                sdl3d_vec3 local;
+                if (axis == 0)
+                    local = sdl3d_vec3_make(sign * half.x, u * half.y, v * half.z);
+                else if (axis == 1)
+                    local = sdl3d_vec3_make(u * half.x, sign * half.y, v * half.z);
+                else
+                    local = sdl3d_vec3_make(u * half.x, v * half.y, sign * half.z);
+                const sdl3d_vec3 clamped =
+                    sdl3d_vec3_make(SDL_clamp(local.x, -inner.x, inner.x), SDL_clamp(local.y, -inner.y, inner.y),
+                                    SDL_clamp(local.z, -inner.z, inner.z));
+                const sdl3d_vec3 delta = sdl3d_vec3_sub(local, clamped);
+                sdl3d_vec3 face_normal = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+                if (axis == 0)
+                    face_normal.x = sign;
+                else if (axis == 1)
+                    face_normal.y = sign;
+                else
+                    face_normal.z = sign;
+                const sdl3d_vec3 normal =
+                    sdl3d_vec3_length_squared(delta) > 0.000001f ? sdl3d_vec3_normalize(delta) : face_normal;
+                mesh_primitive_set_vertex(mesh, vi++, sdl3d_vec3_add(clamped, sdl3d_vec3_scale(normal, radius)), normal,
+                                          0, 0);
+            }
+        }
+    }
+    int ii = 0;
+    for (int face = 0; face < 6; ++face)
+    {
+        const int base = face * face_vertices;
+        for (int y = 0; y < grid - 1; ++y)
+        {
+            for (int x = 0; x < grid - 1; ++x)
+            {
+                const unsigned int a = (unsigned int)(base + y * grid + x);
+                const unsigned int b = a + 1U;
+                const unsigned int c = (unsigned int)(base + (y + 1) * grid + x);
+                const unsigned int d = c + 1U;
+                mesh->indices[ii++] = a;
+                mesh->indices[ii++] = c;
+                mesh->indices[ii++] = b;
+                mesh->indices[ii++] = b;
+                mesh->indices[ii++] = c;
+                mesh->indices[ii++] = d;
+            }
+        }
+    }
+    return true;
+}
+
+static bool build_mesh_primitive_cache_entry(sdl3d_game_data_mesh_primitive_cache_entry *entry,
+                                             const sdl3d_game_data_render_primitive *primitive)
+{
+    bool ok = false;
+    mesh_primitive_cache_entry_set_key(entry, primitive);
+    switch (primitive->mesh_primitive)
+    {
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE:
+        ok = build_cube_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_SPHERE:
+        ok = build_sphere_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CAPSULE:
+        ok = build_capsule_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CYLINDER:
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_CONE:
+        ok = build_cylinder_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TORUS:
+        ok = build_torus_like_mesh(primitive, &entry->mesh, true);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_TUBE_SEGMENT:
+        ok = build_torus_like_mesh(primitive, &entry->mesh, false);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PYRAMID:
+        ok = build_pyramid_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE:
+        ok = build_wedge_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_PLANE:
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE:
+        ok = build_quad_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_DISC:
+        ok = build_disc_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_HEMISPHERE:
+        ok = build_hemisphere_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ROUNDED_BOX:
+        ok = build_rounded_box_mesh(primitive, &entry->mesh);
+        break;
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_ARROW:
+    case SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID:
+    default:
+        ok = false;
+        break;
+    }
+    entry->loaded = ok;
+    if (!ok)
+        mesh_primitive_free_mesh(&entry->mesh);
+    return ok;
+}
+
+static const sdl3d_mesh *find_or_build_mesh_primitive(sdl3d_game_data_mesh_primitive_cache *cache,
+                                                      const sdl3d_game_data_render_primitive *primitive)
+{
+    if (cache == NULL || primitive == NULL)
+        return NULL;
+    for (int i = 0; i < cache->count; ++i)
+    {
+        if (mesh_primitive_cache_entry_matches(&cache->entries[i], primitive))
+        {
+            ++cache->hits;
+            return &cache->entries[i].mesh;
+        }
+    }
+    if (!ensure_mesh_primitive_cache_capacity(cache, cache->count + 1))
+        return NULL;
+    sdl3d_game_data_mesh_primitive_cache_entry *entry = &cache->entries[cache->count];
+    SDL_zero(*entry);
+    if (!build_mesh_primitive_cache_entry(entry, primitive))
+        return NULL;
+    ++cache->count;
+    ++cache->misses;
+    return &entry->mesh;
+}
+
 static bool draw_mesh_primitive_solid(primitive_draw_context *context,
                                       const sdl3d_game_data_render_primitive *primitive)
 {
     if (context == NULL || primitive == NULL)
         return false;
     const sdl3d_texture2d *texture = primitive_texture(context, primitive);
+    const sdl3d_mesh *cached_mesh = find_or_build_mesh_primitive(context->mesh_primitive_cache, primitive);
+    if (cached_mesh != NULL)
+        return sdl3d_draw_static_mesh(context->renderer, cached_mesh, cached_mesh->uvs != NULL ? texture : NULL,
+                                      primitive->color);
     switch (primitive->mesh_primitive)
     {
     case SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE:
@@ -1434,10 +2094,28 @@ void sdl3d_game_data_model_cache_free(sdl3d_game_data_model_cache *cache)
     SDL_zero(*cache);
 }
 
+void sdl3d_game_data_mesh_primitive_cache_init(sdl3d_game_data_mesh_primitive_cache *cache)
+{
+    if (cache == NULL)
+        return;
+    SDL_zero(*cache);
+}
+
+void sdl3d_game_data_mesh_primitive_cache_free(sdl3d_game_data_mesh_primitive_cache *cache)
+{
+    if (cache == NULL)
+        return;
+    for (int i = 0; i < cache->count; ++i)
+        mesh_primitive_free_mesh(&cache->entries[i].mesh);
+    SDL_free(cache->entries);
+    SDL_zero(*cache);
+}
+
 static bool draw_render_primitives_evaluated_with_cache(
     const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer, const sdl3d_game_data_render_eval *eval,
     sdl3d_game_data_image_cache *image_cache, sdl3d_game_data_sprite_cache *sprite_cache,
-    sdl3d_game_data_model_cache *model_cache, const sdl3d_camera3d *camera)
+    sdl3d_game_data_model_cache *model_cache, sdl3d_game_data_mesh_primitive_cache *mesh_primitive_cache,
+    const sdl3d_camera3d *camera)
 {
     if (runtime == NULL || renderer == NULL)
         return false;
@@ -1449,6 +2127,7 @@ static bool draw_render_primitives_evaluated_with_cache(
     context.image_cache = image_cache;
     context.sprite_cache = sprite_cache;
     context.model_cache = model_cache;
+    context.mesh_primitive_cache = mesh_primitive_cache;
     context.camera = camera;
     context.eval = eval;
     bool ok = sdl3d_game_data_for_each_render_primitive_evaluated(runtime, eval, draw_primitive, &context);
@@ -1573,14 +2252,14 @@ static bool draw_active_scene_skybox(const sdl3d_game_data_runtime *runtime, sdl
 
 bool sdl3d_game_data_draw_render_primitives(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer)
 {
-    return draw_render_primitives_evaluated_with_cache(runtime, renderer, NULL, NULL, NULL, NULL, NULL);
+    return draw_render_primitives_evaluated_with_cache(runtime, renderer, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 bool sdl3d_game_data_draw_render_primitives_evaluated(const sdl3d_game_data_runtime *runtime,
                                                       sdl3d_render_context *renderer,
                                                       const sdl3d_game_data_render_eval *eval)
 {
-    return draw_render_primitives_evaluated_with_cache(runtime, renderer, eval, NULL, NULL, NULL, NULL);
+    return draw_render_primitives_evaluated_with_cache(runtime, renderer, eval, NULL, NULL, NULL, NULL, NULL);
 }
 
 bool sdl3d_game_data_draw_ui_text(const sdl3d_game_data_runtime *runtime, sdl3d_render_context *renderer,
@@ -2625,9 +3304,9 @@ bool sdl3d_game_data_draw_frame(const sdl3d_game_data_frame_desc *frame)
                  ok;
             if (frame->particle_cache != NULL)
                 ok = sdl3d_game_data_draw_particles(frame->runtime, frame->renderer, frame->particle_cache) && ok;
-            ok = draw_render_primitives_evaluated_with_cache(frame->runtime, frame->renderer, frame->render_eval,
-                                                             frame->image_cache, frame->sprite_cache,
-                                                             frame->model_cache, &camera) &&
+            ok = draw_render_primitives_evaluated_with_cache(
+                     frame->runtime, frame->renderer, frame->render_eval, frame->image_cache, frame->sprite_cache,
+                     frame->model_cache, frame->mesh_primitive_cache, &camera) &&
                  ok;
             ok = run_frame_hook(frame, frame->after_world_3d) && ok;
             sdl3d_end_mode_3d(frame->renderer);

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -359,6 +359,137 @@ bool sdl3d_draw_plane(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_ve
     return result;
 }
 
+bool sdl3d_draw_quad(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_quad") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_quad"))
+    {
+        return false;
+    }
+
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const float positions[12] = {
+        center.x - hx, center.y - hy, center.z, center.x + hx, center.y - hy, center.z,
+        center.x + hx, center.y + hy, center.z, center.x - hx, center.y + hy, center.z,
+    };
+    const float normals[12] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    };
+    const unsigned int indices[6] = {0, 1, 2, 0, 2, 3};
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = (float *)positions;
+    mesh.normals = (float *)normals;
+    mesh.indices = (unsigned int *)indices;
+    mesh.vertex_count = 4;
+    mesh.index_count = 6;
+    return sdl3d_draw_mesh(context, &mesh, NULL, color);
+}
+
+bool sdl3d_draw_quad_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec2 size, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_quad_wires") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_quad_wires"))
+    {
+        return false;
+    }
+
+    const float hx = size.x * 0.5f;
+    const float hy = size.y * 0.5f;
+    const sdl3d_vec3 p[4] = {
+        sdl3d_vec3_make(center.x - hx, center.y - hy, center.z),
+        sdl3d_vec3_make(center.x + hx, center.y - hy, center.z),
+        sdl3d_vec3_make(center.x + hx, center.y + hy, center.z),
+        sdl3d_vec3_make(center.x - hx, center.y + hy, center.z),
+    };
+    static const int edges[4][2] = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+    for (int i = 0; i < 4; ++i)
+    {
+        if (!sdl3d_draw_line_3d(context, p[edges[i][0]], p[edges[i][1]], color))
+            return false;
+    }
+    return true;
+}
+
+bool sdl3d_draw_disc(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int segments, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_disc"))
+        return false;
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_disc requires segments >= 3.");
+
+    const int vert_count = segments + 1;
+    const int idx_count = segments * 3;
+    float *positions = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    float *normals = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    unsigned int *indices = (unsigned int *)SDL_malloc((size_t)idx_count * sizeof(unsigned int));
+    if (positions == NULL || normals == NULL || indices == NULL)
+    {
+        SDL_free(positions);
+        SDL_free(normals);
+        SDL_free(indices);
+        return SDL_OutOfMemory();
+    }
+
+    positions[0] = center.x;
+    positions[1] = center.y;
+    positions[2] = center.z;
+    normals[0] = 0.0f;
+    normals[1] = 0.0f;
+    normals[2] = 1.0f;
+    for (int i = 0; i < segments; ++i)
+    {
+        const float a = (float)i / (float)segments * SDL3D_SHAPES_PI * 2.0f;
+        const int vi = i + 1;
+        positions[vi * 3 + 0] = center.x + SDL_cosf(a) * radius;
+        positions[vi * 3 + 1] = center.y + SDL_sinf(a) * radius;
+        positions[vi * 3 + 2] = center.z;
+        normals[vi * 3 + 0] = 0.0f;
+        normals[vi * 3 + 1] = 0.0f;
+        normals[vi * 3 + 2] = 1.0f;
+    }
+    for (int i = 0; i < segments; ++i)
+    {
+        indices[i * 3 + 0] = 0U;
+        indices[i * 3 + 1] = (unsigned int)(i + 1);
+        indices[i * 3 + 2] = (unsigned int)((i + 1) % segments + 1);
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = vert_count;
+    mesh.index_count = idx_count;
+    const bool result = sdl3d_draw_mesh(context, &mesh, NULL, color);
+    SDL_free(positions);
+    SDL_free(normals);
+    SDL_free(indices);
+    return result;
+}
+
+bool sdl3d_draw_disc_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int segments,
+                           sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_disc_wires"))
+        return false;
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_disc_wires requires segments >= 3.");
+    sdl3d_vec3 previous = sdl3d_vec3_make(center.x + radius, center.y, center.z);
+    for (int i = 1; i <= segments; ++i)
+    {
+        const float a = (float)i / (float)segments * SDL3D_SHAPES_PI * 2.0f;
+        const sdl3d_vec3 next =
+            sdl3d_vec3_make(center.x + SDL_cosf(a) * radius, center.y + SDL_sinf(a) * radius, center.z);
+        if (!sdl3d_draw_line_3d(context, previous, next, color))
+            return false;
+        previous = next;
+    }
+    return true;
+}
+
 bool sdl3d_draw_grid(sdl3d_render_context *context, int slices, float spacing, sdl3d_color color)
 {
     if (slices < 1)
@@ -594,6 +725,139 @@ bool sdl3d_draw_sphere_wires(sdl3d_render_context *context, sdl3d_vec3 center, f
             }
             previous = next;
         }
+    }
+    return true;
+}
+
+bool sdl3d_draw_hemisphere(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                           sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_hemisphere"))
+        return false;
+    if (rings < 2)
+        return SDL_SetError("sdl3d_draw_hemisphere requires rings >= 2.");
+    if (slices < 3)
+        return SDL_SetError("sdl3d_draw_hemisphere requires slices >= 3.");
+
+    const int curved_vertices = (rings + 1) * (slices + 1);
+    const int cap_center = curved_vertices;
+    const int vert_count = curved_vertices + 1;
+    const int idx_count = rings * slices * 6 + slices * 3;
+    float *positions = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    float *normals = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    unsigned int *indices = (unsigned int *)SDL_malloc((size_t)idx_count * sizeof(unsigned int));
+    if (positions == NULL || normals == NULL || indices == NULL)
+    {
+        SDL_free(positions);
+        SDL_free(normals);
+        SDL_free(indices);
+        return SDL_OutOfMemory();
+    }
+
+    const float y_offset = radius * 0.5f;
+    for (int r = 0; r <= rings; ++r)
+    {
+        const float t = (float)r / (float)rings;
+        const float theta = t * SDL3D_SHAPES_PI * 0.5f;
+        const float ring_radius = SDL_sinf(theta) * radius;
+        const float y = SDL_cosf(theta) * radius - y_offset;
+        for (int s = 0; s <= slices; ++s)
+        {
+            const float phi = (float)s / (float)slices * SDL3D_SHAPES_PI * 2.0f;
+            const float x = SDL_cosf(phi) * ring_radius;
+            const float z = SDL_sinf(phi) * ring_radius;
+            const int vi = r * (slices + 1) + s;
+            positions[vi * 3 + 0] = center.x + x;
+            positions[vi * 3 + 1] = center.y + y;
+            positions[vi * 3 + 2] = center.z + z;
+            const sdl3d_vec3 normal = sdl3d_vec3_normalize(sdl3d_vec3_make(x, y + y_offset, z));
+            normals[vi * 3 + 0] = normal.x;
+            normals[vi * 3 + 1] = normal.y;
+            normals[vi * 3 + 2] = normal.z;
+        }
+    }
+
+    int ii = 0;
+    for (int r = 0; r < rings; ++r)
+    {
+        for (int s = 0; s < slices; ++s)
+        {
+            const unsigned int a = (unsigned int)(r * (slices + 1) + s);
+            const unsigned int b = a + 1U;
+            const unsigned int c = (unsigned int)((r + 1) * (slices + 1) + s);
+            const unsigned int d = c + 1U;
+            indices[ii++] = a;
+            indices[ii++] = c;
+            indices[ii++] = b;
+            indices[ii++] = b;
+            indices[ii++] = c;
+            indices[ii++] = d;
+        }
+    }
+
+    positions[cap_center * 3 + 0] = center.x;
+    positions[cap_center * 3 + 1] = center.y - y_offset;
+    positions[cap_center * 3 + 2] = center.z;
+    normals[cap_center * 3 + 0] = 0.0f;
+    normals[cap_center * 3 + 1] = -1.0f;
+    normals[cap_center * 3 + 2] = 0.0f;
+    const int base_row = rings * (slices + 1);
+    for (int s = 0; s < slices; ++s)
+    {
+        indices[ii++] = (unsigned int)cap_center;
+        indices[ii++] = (unsigned int)(base_row + s + 1);
+        indices[ii++] = (unsigned int)(base_row + s);
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = vert_count;
+    mesh.index_count = idx_count;
+    const bool result = sdl3d_draw_mesh(context, &mesh, NULL, color);
+    SDL_free(positions);
+    SDL_free(normals);
+    SDL_free(indices);
+    return result;
+}
+
+bool sdl3d_draw_hemisphere_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, int rings, int slices,
+                                 sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_hemisphere_wires"))
+        return false;
+    if (rings < 2)
+        return SDL_SetError("sdl3d_draw_hemisphere_wires requires rings >= 2.");
+    if (slices < 3)
+        return SDL_SetError("sdl3d_draw_hemisphere_wires requires slices >= 3.");
+
+    const float y_offset = radius * 0.5f;
+    for (int r = 1; r <= rings; ++r)
+    {
+        const float theta = (float)r / (float)rings * SDL3D_SHAPES_PI * 0.5f;
+        const float ring_radius = SDL_sinf(theta) * radius;
+        const float y = center.y + SDL_cosf(theta) * radius - y_offset;
+        sdl3d_vec3 previous = sdl3d_vec3_make(center.x + ring_radius, y, center.z);
+        for (int s = 1; s <= slices; ++s)
+        {
+            const float phi = (float)s / (float)slices * SDL3D_SHAPES_PI * 2.0f;
+            const sdl3d_vec3 next =
+                sdl3d_vec3_make(center.x + SDL_cosf(phi) * ring_radius, y, center.z + SDL_sinf(phi) * ring_radius);
+            if (!sdl3d_draw_line_3d(context, previous, next, color))
+                return false;
+            previous = next;
+        }
+    }
+    for (int s = 0; s < slices; ++s)
+    {
+        const float phi = (float)s / (float)slices * SDL3D_SHAPES_PI * 2.0f;
+        const sdl3d_vec3 pole = sdl3d_vec3_make(center.x, center.y + radius - y_offset, center.z);
+        const sdl3d_vec3 edge =
+            sdl3d_vec3_make(center.x + SDL_cosf(phi) * radius, center.y - y_offset, center.z + SDL_sinf(phi) * radius);
+        if (!sdl3d_draw_line_3d(context, pole, edge, color))
+            return false;
     }
     return true;
 }
@@ -1074,6 +1338,322 @@ bool sdl3d_draw_torus_wires(sdl3d_render_context *context, sdl3d_vec3 center, fl
         }
     }
     return true;
+}
+
+bool sdl3d_draw_tube_segment(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius, float minor_radius,
+                             float arc_angle, int segments, int tube_segments, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(major_radius, "major_radius", "sdl3d_draw_tube_segment") ||
+        !sdl3d_shape_require_positive(minor_radius, "minor_radius", "sdl3d_draw_tube_segment") ||
+        !sdl3d_shape_require_positive(arc_angle, "arc_angle", "sdl3d_draw_tube_segment"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_tube_segment requires segments >= 3.");
+    if (tube_segments < 3)
+        return SDL_SetError("sdl3d_draw_tube_segment requires tube_segments >= 3.");
+
+    const int arc_vertices = segments + 1;
+    const int tube_vertices = tube_segments + 1;
+    const int vert_count = arc_vertices * tube_vertices;
+    const int idx_count = segments * tube_segments * 6;
+    float *positions = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    float *normals = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    unsigned int *indices = (unsigned int *)SDL_malloc((size_t)idx_count * sizeof(unsigned int));
+    if (positions == NULL || normals == NULL || indices == NULL)
+    {
+        SDL_free(positions);
+        SDL_free(normals);
+        SDL_free(indices);
+        return SDL_OutOfMemory();
+    }
+
+    const float start_angle = -arc_angle * 0.5f;
+    for (int a = 0; a <= segments; ++a)
+    {
+        const float u = start_angle + (float)a / (float)segments * arc_angle;
+        const sdl3d_vec3 radial = sdl3d_vec3_make(SDL_cosf(u), 0.0f, SDL_sinf(u));
+        const sdl3d_vec3 ring_center =
+            sdl3d_vec3_make(center.x + radial.x * major_radius, center.y, center.z + radial.z * major_radius);
+        for (int t = 0; t <= tube_segments; ++t)
+        {
+            const float v = (float)t / (float)tube_segments * SDL3D_SHAPES_PI * 2.0f;
+            const sdl3d_vec3 normal =
+                sdl3d_vec3_normalize(sdl3d_vec3_make(radial.x * SDL_cosf(v), SDL_sinf(v), radial.z * SDL_cosf(v)));
+            const int vi = a * tube_vertices + t;
+            positions[vi * 3 + 0] = ring_center.x + normal.x * minor_radius;
+            positions[vi * 3 + 1] = ring_center.y + normal.y * minor_radius;
+            positions[vi * 3 + 2] = ring_center.z + normal.z * minor_radius;
+            normals[vi * 3 + 0] = normal.x;
+            normals[vi * 3 + 1] = normal.y;
+            normals[vi * 3 + 2] = normal.z;
+        }
+    }
+
+    int ii = 0;
+    for (int a = 0; a < segments; ++a)
+    {
+        for (int t = 0; t < tube_segments; ++t)
+        {
+            const unsigned int p00 = (unsigned int)(a * tube_vertices + t);
+            const unsigned int p01 = p00 + 1U;
+            const unsigned int p10 = (unsigned int)((a + 1) * tube_vertices + t);
+            const unsigned int p11 = p10 + 1U;
+            indices[ii++] = p00;
+            indices[ii++] = p10;
+            indices[ii++] = p01;
+            indices[ii++] = p01;
+            indices[ii++] = p10;
+            indices[ii++] = p11;
+        }
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = vert_count;
+    mesh.index_count = idx_count;
+    const bool result = sdl3d_draw_mesh(context, &mesh, NULL, color);
+    SDL_free(positions);
+    SDL_free(normals);
+    SDL_free(indices);
+    return result;
+}
+
+bool sdl3d_draw_tube_segment_wires(sdl3d_render_context *context, sdl3d_vec3 center, float major_radius,
+                                   float minor_radius, float arc_angle, int segments, int tube_segments,
+                                   sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(major_radius, "major_radius", "sdl3d_draw_tube_segment_wires") ||
+        !sdl3d_shape_require_positive(minor_radius, "minor_radius", "sdl3d_draw_tube_segment_wires") ||
+        !sdl3d_shape_require_positive(arc_angle, "arc_angle", "sdl3d_draw_tube_segment_wires"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_tube_segment_wires requires segments >= 3.");
+    if (tube_segments < 3)
+        return SDL_SetError("sdl3d_draw_tube_segment_wires requires tube_segments >= 3.");
+
+    const float start_angle = -arc_angle * 0.5f;
+    for (int a = 0; a <= segments; ++a)
+    {
+        const float u = start_angle + (float)a / (float)segments * arc_angle;
+        const sdl3d_vec3 radial = sdl3d_vec3_make(SDL_cosf(u), 0.0f, SDL_sinf(u));
+        const sdl3d_vec3 ring_center =
+            sdl3d_vec3_make(center.x + radial.x * major_radius, center.y, center.z + radial.z * major_radius);
+        sdl3d_vec3 previous = sdl3d_vec3_make(ring_center.x + radial.x * minor_radius, ring_center.y,
+                                              ring_center.z + radial.z * minor_radius);
+        for (int t = 1; t <= tube_segments; ++t)
+        {
+            const float v = (float)t / (float)tube_segments * SDL3D_SHAPES_PI * 2.0f;
+            const sdl3d_vec3 normal =
+                sdl3d_vec3_normalize(sdl3d_vec3_make(radial.x * SDL_cosf(v), SDL_sinf(v), radial.z * SDL_cosf(v)));
+            const sdl3d_vec3 next =
+                sdl3d_vec3_make(ring_center.x + normal.x * minor_radius, ring_center.y + normal.y * minor_radius,
+                                ring_center.z + normal.z * minor_radius);
+            if (!sdl3d_draw_line_3d(context, previous, next, color))
+                return false;
+            previous = next;
+        }
+    }
+
+    for (int t = 0; t < tube_segments; ++t)
+    {
+        const float v = (float)t / (float)tube_segments * SDL3D_SHAPES_PI * 2.0f;
+        sdl3d_vec3 previous = sdl3d_vec3_make(0.0f, 0.0f, 0.0f);
+        bool has_previous = false;
+        for (int a = 0; a <= segments; ++a)
+        {
+            const float u = start_angle + (float)a / (float)segments * arc_angle;
+            const sdl3d_vec3 radial = sdl3d_vec3_make(SDL_cosf(u), 0.0f, SDL_sinf(u));
+            const sdl3d_vec3 ring_center =
+                sdl3d_vec3_make(center.x + radial.x * major_radius, center.y, center.z + radial.z * major_radius);
+            const sdl3d_vec3 normal =
+                sdl3d_vec3_normalize(sdl3d_vec3_make(radial.x * SDL_cosf(v), SDL_sinf(v), radial.z * SDL_cosf(v)));
+            const sdl3d_vec3 next =
+                sdl3d_vec3_make(ring_center.x + normal.x * minor_radius, ring_center.y + normal.y * minor_radius,
+                                ring_center.z + normal.z * minor_radius);
+            if (has_previous && !sdl3d_draw_line_3d(context, previous, next, color))
+                return false;
+            previous = next;
+            has_previous = true;
+        }
+    }
+    return true;
+}
+
+static sdl3d_vec3 sdl3d_shape_clamp_vec3(sdl3d_vec3 value, sdl3d_vec3 min_value, sdl3d_vec3 max_value)
+{
+    return sdl3d_vec3_make(SDL_clamp(value.x, min_value.x, max_value.x), SDL_clamp(value.y, min_value.y, max_value.y),
+                           SDL_clamp(value.z, min_value.z, max_value.z));
+}
+
+static void sdl3d_shape_rounded_box_project(sdl3d_vec3 local, sdl3d_vec3 inner, float radius, sdl3d_vec3 *out_position,
+                                            sdl3d_vec3 *out_normal)
+{
+    const sdl3d_vec3 clamped = sdl3d_shape_clamp_vec3(local, sdl3d_vec3_make(-inner.x, -inner.y, -inner.z), inner);
+    sdl3d_vec3 normal = sdl3d_vec3_sub(local, clamped);
+    const float len_sq = normal.x * normal.x + normal.y * normal.y + normal.z * normal.z;
+    if (len_sq <= 0.000001f)
+        normal = sdl3d_vec3_make(0.0f, 1.0f, 0.0f);
+    else
+        normal = sdl3d_vec3_normalize(normal);
+    *out_position = sdl3d_vec3_add(clamped, sdl3d_vec3_scale(normal, radius));
+    *out_normal = normal;
+}
+
+bool sdl3d_draw_rounded_box(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, float radius,
+                            int segments, sdl3d_color color)
+{
+    if (!sdl3d_shape_require_nonnegative(size.x, "size.x", "sdl3d_draw_rounded_box") ||
+        !sdl3d_shape_require_nonnegative(size.y, "size.y", "sdl3d_draw_rounded_box") ||
+        !sdl3d_shape_require_nonnegative(size.z, "size.z", "sdl3d_draw_rounded_box") ||
+        !sdl3d_shape_require_nonnegative(radius, "radius", "sdl3d_draw_rounded_box"))
+    {
+        return false;
+    }
+    if (segments < 1)
+        return SDL_SetError("sdl3d_draw_rounded_box requires segments >= 1.");
+    const float max_radius = SDL_min(size.x, SDL_min(size.y, size.z)) * 0.5f;
+    radius = SDL_min(radius, max_radius);
+    if (radius <= 0.000001f)
+        return sdl3d_draw_cube(context, center, size, color);
+
+    const int grid = SDL_max(segments + 2, 3);
+    const int face_vertices = grid * grid;
+    const int vert_count = face_vertices * 6;
+    const int idx_count = (grid - 1) * (grid - 1) * 6 * 6;
+    float *positions = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    float *normals = (float *)SDL_malloc((size_t)vert_count * 3U * sizeof(float));
+    unsigned int *indices = (unsigned int *)SDL_malloc((size_t)idx_count * sizeof(unsigned int));
+    if (positions == NULL || normals == NULL || indices == NULL)
+    {
+        SDL_free(positions);
+        SDL_free(normals);
+        SDL_free(indices);
+        return SDL_OutOfMemory();
+    }
+
+    const sdl3d_vec3 half = sdl3d_vec3_scale(size, 0.5f);
+    const sdl3d_vec3 inner =
+        sdl3d_vec3_make(SDL_max(half.x - radius, 0.0f), SDL_max(half.y - radius, 0.0f), SDL_max(half.z - radius, 0.0f));
+    int vi = 0;
+    for (int face = 0; face < 6; ++face)
+    {
+        const int axis = face / 2;
+        const float sign = (face % 2) == 0 ? -1.0f : 1.0f;
+        for (int y = 0; y < grid; ++y)
+        {
+            const float v = -1.0f + 2.0f * (float)y / (float)(grid - 1);
+            for (int x = 0; x < grid; ++x)
+            {
+                const float u = -1.0f + 2.0f * (float)x / (float)(grid - 1);
+                sdl3d_vec3 local;
+                if (axis == 0)
+                    local = sdl3d_vec3_make(sign * half.x, u * half.y, v * half.z);
+                else if (axis == 1)
+                    local = sdl3d_vec3_make(u * half.x, sign * half.y, v * half.z);
+                else
+                    local = sdl3d_vec3_make(u * half.x, v * half.y, sign * half.z);
+                sdl3d_vec3 projected;
+                sdl3d_vec3 normal;
+                sdl3d_shape_rounded_box_project(local, inner, radius, &projected, &normal);
+                positions[vi * 3 + 0] = center.x + projected.x;
+                positions[vi * 3 + 1] = center.y + projected.y;
+                positions[vi * 3 + 2] = center.z + projected.z;
+                normals[vi * 3 + 0] = normal.x;
+                normals[vi * 3 + 1] = normal.y;
+                normals[vi * 3 + 2] = normal.z;
+                ++vi;
+            }
+        }
+    }
+
+    int ii = 0;
+    for (int face = 0; face < 6; ++face)
+    {
+        const int base = face * face_vertices;
+        for (int y = 0; y < grid - 1; ++y)
+        {
+            for (int x = 0; x < grid - 1; ++x)
+            {
+                const unsigned int a = (unsigned int)(base + y * grid + x);
+                const unsigned int b = a + 1U;
+                const unsigned int c = (unsigned int)(base + (y + 1) * grid + x);
+                const unsigned int d = c + 1U;
+                indices[ii++] = a;
+                indices[ii++] = c;
+                indices[ii++] = b;
+                indices[ii++] = b;
+                indices[ii++] = c;
+                indices[ii++] = d;
+            }
+        }
+    }
+
+    sdl3d_mesh mesh;
+    SDL_zerop(&mesh);
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.indices = indices;
+    mesh.vertex_count = vert_count;
+    mesh.index_count = idx_count;
+    const bool result = sdl3d_draw_mesh(context, &mesh, NULL, color);
+    SDL_free(positions);
+    SDL_free(normals);
+    SDL_free(indices);
+    return result;
+}
+
+bool sdl3d_draw_rounded_box_wires(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, float radius,
+                                  int segments, sdl3d_color color)
+{
+    (void)radius;
+    (void)segments;
+    return sdl3d_draw_cube_wires(context, center, size, color);
+}
+
+bool sdl3d_draw_arrow(sdl3d_render_context *context, sdl3d_vec3 center, float radius, float height, int segments,
+                      sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(radius, "radius", "sdl3d_draw_arrow") ||
+        !sdl3d_shape_require_positive(height, "height", "sdl3d_draw_arrow"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_arrow requires segments >= 3.");
+    const float shaft_height = height * 0.65f;
+    const float head_height = height - shaft_height;
+    const float shaft_radius = radius * 0.35f;
+    const sdl3d_vec3 shaft_center = sdl3d_vec3_make(center.x, center.y - height * 0.5f + shaft_height * 0.5f, center.z);
+    const sdl3d_vec3 head_center = sdl3d_vec3_make(center.x, center.y + height * 0.5f - head_height * 0.5f, center.z);
+    return sdl3d_draw_cylinder(context, shaft_center, shaft_radius, shaft_radius, shaft_height, segments, color) &&
+           sdl3d_draw_cylinder(context, head_center, 0.0f, radius, head_height, segments, color);
+}
+
+bool sdl3d_draw_arrow_wires(sdl3d_render_context *context, sdl3d_vec3 center, float radius, float height, int segments,
+                            sdl3d_color color)
+{
+    if (!sdl3d_shape_require_positive(radius, "radius", "sdl3d_draw_arrow_wires") ||
+        !sdl3d_shape_require_positive(height, "height", "sdl3d_draw_arrow_wires"))
+    {
+        return false;
+    }
+    if (segments < 3)
+        return SDL_SetError("sdl3d_draw_arrow_wires requires segments >= 3.");
+    const float shaft_height = height * 0.65f;
+    const float head_height = height - shaft_height;
+    const float shaft_radius = radius * 0.35f;
+    const sdl3d_vec3 shaft_center = sdl3d_vec3_make(center.x, center.y - height * 0.5f + shaft_height * 0.5f, center.z);
+    const sdl3d_vec3 head_center = sdl3d_vec3_make(center.x, center.y + height * 0.5f - head_height * 0.5f, center.z);
+    return sdl3d_draw_cylinder_wires(context, shaft_center, shaft_radius, shaft_radius, shaft_height, segments,
+                                     color) &&
+           sdl3d_draw_cylinder_wires(context, head_center, 0.0f, radius, head_height, segments, color);
 }
 
 bool sdl3d_draw_pyramid(sdl3d_render_context *context, sdl3d_vec3 center, sdl3d_vec3 size, sdl3d_color color)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7063,7 +7063,7 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
     struct MeshDojoCapture
     {
         int count = 0;
-        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE + 1] = {};
+        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE + 1] = {};
         bool saw_solid_wire = false;
     } capture;
     auto capture_mesh = [](void *userdata, const sdl3d_game_data_render_primitive *primitive) -> bool {
@@ -7073,9 +7073,9 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
         mesh_capture->count++;
         EXPECT_TRUE(primitive->lighting_enabled) << primitive->entity_name;
         EXPECT_GT(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID);
-        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE);
+        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE);
         if (primitive->mesh_primitive > SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID &&
-            primitive->mesh_primitive <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE)
+            primitive->mesh_primitive <= SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE)
         {
             mesh_capture->seen[primitive->mesh_primitive] = true;
         }
@@ -7084,9 +7084,9 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
         return true;
     };
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_mesh, &capture));
-    EXPECT_EQ(capture.count, 8);
+    EXPECT_GE(capture.count, 15);
     EXPECT_TRUE(capture.saw_solid_wire);
-    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE; ++kind)
+    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE; ++kind)
         EXPECT_TRUE(capture.seen[kind]) << kind;
 
     sdl3d_game_data_destroy(runtime);
@@ -9107,6 +9107,24 @@ TEST(GameDataRuntime, EmitsAuthoredMeshPrimitiveDescriptors)
       "components": [
         { "type": "render.mesh_primitive", "primitive": "wedge", "size": [1.0, 0.5, 1.5], "lighting": false }
       ]
+    },
+    {
+      "name": "entity.mesh.composite",
+      "active": true,
+      "components": [
+        {
+          "type": "render.composite",
+          "parts": [
+            { "primitive": "plane", "size": [1.2, 0.8, 0.05] },
+            { "primitive": "disc", "radius": 0.4, "segments": 16 },
+            { "primitive": "hemisphere", "radius": 0.45, "segments": 16, "rings": 8 },
+            { "primitive": "rounded_box", "size": [0.9, 0.7, 0.5], "bevel_radius": 0.1, "rings": 4 },
+            { "primitive": "pipe", "major_radius": 0.55, "minor_radius": 0.08, "arc_angle": 1.5707964, "segments": 12, "tube_segments": 8 },
+            { "primitive": "arrow", "radius": 0.2, "height": 1.0, "segments": 12 },
+            { "primitive": "billboard_plane", "size": [0.8, 0.8, 0.05] }
+          ]
+        }
+      ]
     }
   ],
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
@@ -9130,7 +9148,7 @@ TEST(GameDataRuntime, EmitsAuthoredMeshPrimitiveDescriptors)
     struct MeshCapture
     {
         int count = 0;
-        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE + 1] = {};
+        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE + 1] = {};
     } capture;
     auto capture_mesh = [](void *userdata, const sdl3d_game_data_render_primitive *primitive) -> bool {
         auto *mesh_capture = static_cast<MeshCapture *>(userdata);
@@ -9138,9 +9156,9 @@ TEST(GameDataRuntime, EmitsAuthoredMeshPrimitiveDescriptors)
             return true;
         mesh_capture->count++;
         EXPECT_GT(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID);
-        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE);
+        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE);
         if (primitive->mesh_primitive <= SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID ||
-            primitive->mesh_primitive > SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE)
+            primitive->mesh_primitive > SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE)
         {
             return false;
         }
@@ -9174,8 +9192,8 @@ TEST(GameDataRuntime, EmitsAuthoredMeshPrimitiveDescriptors)
     };
 
     ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_mesh, &capture));
-    EXPECT_EQ(capture.count, 8);
-    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE; ++kind)
+    EXPECT_EQ(capture.count, 15);
+    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE; ++kind)
         EXPECT_TRUE(capture.seen[kind]) << kind;
 
     sdl3d_game_data_destroy(runtime);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7089,6 +7089,22 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
     for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_BILLBOARD_PLANE; ++kind)
         EXPECT_TRUE(capture.seen[kind]) << kind;
 
+    struct UiCapture
+    {
+        bool saw_fps = false;
+    } ui_capture;
+    auto capture_ui = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
+        auto *capture = static_cast<UiCapture *>(userdata);
+        if (std::string(text->name) == "ui.mesh_primitives.fps")
+        {
+            capture->saw_fps = true;
+            EXPECT_NE(text->format, nullptr);
+        }
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui, &ui_capture));
+    EXPECT_TRUE(ui_capture.saw_fps);
+
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7050,7 +7050,8 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
     sdl3d_camera3d camera{};
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.mesh_primitives.player", &camera));
     EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
-    EXPECT_FLOAT_EQ(camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+    EXPECT_FLOAT_EQ(camera.fovy, 90.0f);
+    EXPECT_EQ(camera.fov_axis, SDL3D_CAMERA_FOV_HORIZONTAL);
 
     ASSERT_EQ(sdl3d_game_data_world_light_count(runtime), 1);
     sdl3d_light sun{};
@@ -7108,6 +7109,16 @@ TEST(GameDataRuntime, UsesDefaultWorldUnitsAndPerspectiveFovy)
         "type": "perspective",
         "position": [0.0, 0.0, 2.0],
         "target": [0.0, 0.0, 0.0]
+      },
+      {
+        "name": "camera.runtime_fov",
+        "type": "perspective",
+        "position": [0.0, 0.0, 2.0],
+        "target": [0.0, 0.0, 0.0],
+        "fov": 75.0,
+        "fov_axis": "vertical",
+        "fov_key": "camera.fov",
+        "fov_axis_key": "camera.fov_axis"
       }
     ]
   }
@@ -7130,6 +7141,19 @@ TEST(GameDataRuntime, UsesDefaultWorldUnitsAndPerspectiveFovy)
     ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.default", &camera));
     EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
     EXPECT_FLOAT_EQ(camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+    EXPECT_EQ(camera.fov_axis, SDL3D_CAMERA_FOV_VERTICAL);
+
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.runtime_fov", &camera));
+    EXPECT_FLOAT_EQ(camera.fovy, 75.0f);
+    EXPECT_EQ(camera.fov_axis, SDL3D_CAMERA_FOV_VERTICAL);
+
+    sdl3d_properties *scene_state = sdl3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    sdl3d_properties_set_float(scene_state, "camera.fov", 90.0f);
+    sdl3d_properties_set_string(scene_state, "camera.fov_axis", "horizontal");
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.runtime_fov", &camera));
+    EXPECT_FLOAT_EQ(camera.fovy, 90.0f);
+    EXPECT_EQ(camera.fov_axis, SDL3D_CAMERA_FOV_HORIZONTAL);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);
@@ -7179,6 +7203,36 @@ TEST(GameDataRuntime, RejectsInvalidWorldDisplayAndCameraConventions)
   }
 })json",
             "camera fovy must be in the range",
+        },
+        {
+            "bad_fov_axis",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Bad FOV Axis" },
+  "world": {
+    "name": "world.bad",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.bad", "type": "perspective", "fov": 90.0, "fov_axis": "diagonal" }
+    ]
+  }
+})json",
+            "camera fov_axis must be",
+        },
+        {
+            "ambiguous_fov",
+            R"json({
+  "schema": "sdl3d.game.v0",
+  "metadata": { "name": "Ambiguous FOV" },
+  "world": {
+    "name": "world.bad",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.bad", "type": "perspective", "fov": 90.0, "fovy": 60.0 }
+    ]
+  }
+})json",
+            "must not define both fov and fovy",
         },
     };
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7092,6 +7092,7 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
     struct UiCapture
     {
         bool saw_fps = false;
+        int label_count = 0;
     } ui_capture;
     auto capture_ui = [](void *userdata, const sdl3d_game_data_ui_text *text) -> bool {
         auto *capture = static_cast<UiCapture *>(userdata);
@@ -7099,11 +7100,21 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
         {
             capture->saw_fps = true;
             EXPECT_NE(text->format, nullptr);
+            EXPECT_TRUE(text->normalized);
+            EXPECT_FLOAT_EQ(text->x, 0.985f);
+            EXPECT_FLOAT_EQ(text->y, 0.03f);
+        }
+        if (std::string(text->name).find("ui.mesh_primitives.labels.") == 0)
+        {
+            ++capture->label_count;
+            EXPECT_TRUE(text->normalized);
+            EXPECT_GT(text->y, 0.1f);
         }
         return true;
     };
     ASSERT_TRUE(sdl3d_game_data_for_each_ui_text(runtime, capture_ui, &ui_capture));
     EXPECT_TRUE(ui_capture.saw_fps);
+    EXPECT_EQ(ui_capture.label_count, 3);
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -375,6 +375,11 @@ std::filesystem::path fps_mechanics_dojo_data_path()
     return demo_data_path("fps_mechanics_dojo", "fps_mechanics_dojo.game.json");
 }
 
+std::filesystem::path mesh_primitives_dojo_data_path()
+{
+    return demo_data_path("mesh_primitives_dojo", "mesh_primitives_dojo.game.json");
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -7004,6 +7009,84 @@ TEST(GameDataRuntime, EditorMetadataValidatesAndFpsMechanicsDojoLoads)
 
     EXPECT_TRUE(sdl3d_game_data_sector_nav_path_available(runtime, "nav.dojo.arena", sdl3d_vec3_make(4.0f, 1.0f, 4.0f),
                                                           sdl3d_vec3_make(24.0f, 1.0f, 6.0f)));
+
+    sdl3d_game_data_destroy(runtime);
+    sdl3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
+{
+    const std::filesystem::path dojo_path = mesh_primitives_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    sdl3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(sdl3d_game_data_load_app_config_file(dojo_path.string().c_str(), &config, title, sizeof(title),
+                                                     app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "SDL3D Mesh Primitives Dojo");
+    EXPECT_EQ(config.logical_width, SDL3D_GAME_DEFAULT_LOGICAL_WIDTH);
+    EXPECT_EQ(config.logical_height, SDL3D_GAME_DEFAULT_LOGICAL_HEIGHT);
+    EXPECT_EQ(config.backend, SDL3D_BACKEND_OPENGL);
+
+    sdl3d_game_session *session = nullptr;
+    ASSERT_TRUE(sdl3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    sdl3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(sdl3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    ASSERT_TRUE(sdl3d_game_data_set_active_scene(runtime, "scene.mesh_primitives.showcase"));
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.player"), nullptr);
+    EXPECT_NE(sdl3d_game_data_find_actor(runtime, "entity.sun"), nullptr);
+
+    const char *units = nullptr;
+    float meters_per_unit = 0.0f;
+    ASSERT_TRUE(sdl3d_game_data_get_world_units(runtime, &units, &meters_per_unit));
+    EXPECT_STREQ(units, SDL3D_GAME_DATA_DEFAULT_WORLD_UNITS);
+    EXPECT_FLOAT_EQ(meters_per_unit, SDL3D_GAME_DATA_DEFAULT_METERS_PER_UNIT);
+
+    sdl3d_camera3d camera{};
+    ASSERT_TRUE(sdl3d_game_data_get_camera(runtime, "camera.mesh_primitives.player", &camera));
+    EXPECT_EQ(camera.projection, SDL3D_CAMERA_PERSPECTIVE);
+    EXPECT_FLOAT_EQ(camera.fovy, SDL3D_GAME_DATA_DEFAULT_CAMERA_FOVY_DEGREES);
+
+    ASSERT_EQ(sdl3d_game_data_world_light_count(runtime), 1);
+    sdl3d_light sun{};
+    ASSERT_TRUE(sdl3d_game_data_get_world_light(runtime, 0, &sun));
+    EXPECT_EQ(sun.type, SDL3D_LIGHT_DIRECTIONAL);
+    EXPECT_NEAR(sun.direction.y, -1.0f, 0.0001f);
+    EXPECT_NEAR(sun.color[0], 1.0f, 0.0001f);
+
+    struct MeshDojoCapture
+    {
+        int count = 0;
+        bool seen[SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE + 1] = {};
+        bool saw_solid_wire = false;
+    } capture;
+    auto capture_mesh = [](void *userdata, const sdl3d_game_data_render_primitive *primitive) -> bool {
+        auto *mesh_capture = static_cast<MeshDojoCapture *>(userdata);
+        if (primitive->type != SDL3D_GAME_DATA_RENDER_MESH_PRIMITIVE)
+            return true;
+        mesh_capture->count++;
+        EXPECT_TRUE(primitive->lighting_enabled) << primitive->entity_name;
+        EXPECT_GT(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID);
+        EXPECT_LE(primitive->mesh_primitive, SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE);
+        if (primitive->mesh_primitive > SDL3D_GAME_DATA_MESH_PRIMITIVE_INVALID &&
+            primitive->mesh_primitive <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE)
+        {
+            mesh_capture->seen[primitive->mesh_primitive] = true;
+        }
+        if (primitive->draw_mode == SDL3D_GAME_DATA_RENDER_DRAW_SOLID_WIRE)
+            mesh_capture->saw_solid_wire = true;
+        return true;
+    };
+    ASSERT_TRUE(sdl3d_game_data_for_each_render_primitive(runtime, capture_mesh, &capture));
+    EXPECT_EQ(capture.count, 8);
+    EXPECT_TRUE(capture.saw_solid_wire);
+    for (int kind = SDL3D_GAME_DATA_MESH_PRIMITIVE_CUBE; kind <= SDL3D_GAME_DATA_MESH_PRIMITIVE_WEDGE; ++kind)
+        EXPECT_TRUE(capture.seen[kind]) << kind;
 
     sdl3d_game_data_destroy(runtime);
     sdl3d_game_session_destroy(session);

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -297,6 +297,20 @@ TEST(SDL3DCamera, PerspectiveMatrixDerivation)
     EXPECT_LT(ndc_z, 1.0f);
 }
 
+TEST(SDL3DCamera, HorizontalFovDerivesVerticalProjectionFromAspect)
+{
+    sdl3d_camera3d camera = {
+        {0.0f, 0.0f, 5.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, 90.0f, SDL3D_CAMERA_PERSPECTIVE};
+    camera.fov_axis = SDL3D_CAMERA_FOV_HORIZONTAL;
+
+    sdl3d_mat4 view;
+    sdl3d_mat4 projection;
+    ASSERT_TRUE(sdl3d_camera3d_compute_matrices(&camera, 1600, 900, 1.0f, 100.0f, &view, &projection));
+
+    EXPECT_PRED_FORMAT3(Near, projection.m[0], 1.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, projection.m[5], 16.0f / 9.0f, 1e-5f);
+}
+
 TEST(SDL3DCamera, OrthographicProducesUnitNDC)
 {
     const sdl3d_camera3d camera = {

--- a/tests/test_shapes.cpp
+++ b/tests/test_shapes.cpp
@@ -624,6 +624,35 @@ TEST_F(SDL3DShapesFixture, TorusPyramidAndWedgeRender)
     EXPECT_GT(CountColor(c.ctx, kBlue), 100);
 }
 
+TEST_F(SDL3DShapesFixture, AdditionalPlaceholderPrimitivesRender)
+{
+    WindowRenderer wr(128, 128);
+    ASSERT_TRUE(wr.ok());
+    ContextOwner c;
+    ASSERT_TRUE(sdl3d_create_render_context(wr.window(), wr.renderer(), nullptr, &c.ctx));
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(sdl3d_draw_quad(c.ctx, sdl3d_vec3_make(-0.7f, 0.7f, 0.0f), {0.7f, 0.5f}, kRed));
+    ASSERT_TRUE(sdl3d_draw_disc(c.ctx, sdl3d_vec3_make(0.7f, 0.7f, 0.0f), 0.32f, 18, kGreen));
+    ASSERT_TRUE(sdl3d_draw_hemisphere(c.ctx, sdl3d_vec3_make(-0.7f, -0.35f, 0.0f), 0.42f, 6, 18, kBlue));
+    ASSERT_TRUE(sdl3d_draw_rounded_box(c.ctx, sdl3d_vec3_make(0.65f, -0.35f, 0.0f),
+                                       sdl3d_vec3_make(0.55f, 0.55f, 0.55f), 0.14f, 3, kRed));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+    EXPECT_GT(CountColor(c.ctx, kRed), 40);
+    EXPECT_GT(CountColor(c.ctx, kGreen), 20);
+    EXPECT_GT(CountColor(c.ctx, kBlue), 20);
+
+    ASSERT_TRUE(sdl3d_clear_render_context(c.ctx, kBlack));
+    ASSERT_TRUE(sdl3d_begin_mode_3d(c.ctx, MakeCamera()));
+    ASSERT_TRUE(
+        sdl3d_draw_tube_segment(c.ctx, sdl3d_vec3_make(-0.55f, 0.0f, 0.0f), 0.45f, 0.1f, 3.1415927f, 16, 8, kGreen));
+    ASSERT_TRUE(sdl3d_draw_arrow(c.ctx, sdl3d_vec3_make(0.65f, 0.0f, 0.0f), 0.28f, 1.1f, 16, kBlue));
+    ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
+    EXPECT_GT(CountColor(c.ctx, kGreen), 20);
+    EXPECT_GT(CountColor(c.ctx, kBlue), 20);
+}
+
 TEST_F(SDL3DShapesFixture, NewPrimitiveWiresDrawWithoutFilling)
 {
     WindowRenderer wr(128, 128);
@@ -658,6 +687,12 @@ TEST_F(SDL3DShapesFixture, RejectsBadNewPrimitiveArguments)
     EXPECT_FALSE(sdl3d_draw_torus_wires(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 0.1f, 8, 2, kRed));
     EXPECT_FALSE(sdl3d_draw_pyramid(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(-1.0f, 1.0f, 1.0f), kRed));
     EXPECT_FALSE(sdl3d_draw_wedge(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, -1.0f, 1.0f), kRed));
+    EXPECT_FALSE(sdl3d_draw_disc(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 2, kRed));
+    EXPECT_FALSE(sdl3d_draw_hemisphere(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 1, 8, kRed));
+    EXPECT_FALSE(sdl3d_draw_tube_segment(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.5f, 0.1f, 0.0f, 8, 6, kRed));
+    EXPECT_FALSE(
+        sdl3d_draw_rounded_box(c.ctx, sdl3d_vec3_make(0, 0, 0), sdl3d_vec3_make(1.0f, 1.0f, 1.0f), 0.1f, 0, kRed));
+    EXPECT_FALSE(sdl3d_draw_arrow(c.ctx, sdl3d_vec3_make(0, 0, 0), 0.0f, 1.0f, 8, kRed));
     ASSERT_TRUE(sdl3d_end_mode_3d(c.ctx));
 }
 


### PR DESCRIPTION
## Summary

- adds a data-only `mesh_primitives_dojo` launched through `sdl3d_runner`
- builds a larger 52x48m graybox sector room with FPS movement, bounded walls, one directional sun light, and shaded mesh primitives
- adds procedural placeholder mesh kinds for `plane`/`quad`, `disc`, `hemisphere`, `rounded_box`, `tube_segment`/`pipe`, `arrow`, and `billboard_plane`
- adds `render.composite` so mock actors can be assembled from multiple primitive parts without custom C or model assets
- expands the dojo with all primitive kinds plus composite robot, ship, and portal mock actors
- adds horizontal camera FOV support with authored `fov`/`fov_axis` and runtime `fov_key`/`fov_axis_key` scene-state overrides
- switches the mesh primitives dojo camera to 90-degree horizontal FOV to reduce wide-angle perspective distortion
- fixes the mesh primitives dojo HUD labels by using the authored UI `x`/`y`/`normalized` fields and spacing labels into readable rows
- adds an authored FPS ticker to the mesh primitives dojo HUD
- trims the heaviest dojo content by reducing high tessellation counts and removing most solid+wire overlays while keeping wireframe coverage visible
- adds `sdl3d_draw_static_mesh()` and a presentation-level procedural mesh primitive cache so runner-hosted data games reuse generated CPU meshes and let hardware backends cache GPU buffers
- documents mesh primitives, composite primitives, procedural mesh caching, the dojo, and camera FOV controls

## Performance Notes

- Before procedural mesh caching, the mesh primitives dojo profile after content trimming was roughly `tick=0.06-0.08 ms`, `render=1.09-1.18 ms`, with most time in `present`/vsync.
- After routing authored solid mesh primitives through stable cached meshes, local debug profiling shows `render` around `0.58-0.62 ms` and `tick` around `0.07-0.12 ms`; frame time is still dominated by `present`/vsync.
- Wire overlays remain intentionally separate line work and should still be used selectively in large scenes.

## Tests

- `cmake --build build/debug -j4 --target sdl3d_game_data_test sdl3d_shapes_test sdl3d_runner`
- `./build/debug/tests/sdl3d_shapes_test --gtest_filter=SDL3DShapesFixture.AdditionalPlaceholderPrimitivesRender:SDL3DShapesFixture.NewPrimitiveWiresDrawWithoutFilling:SDL3DShapesFixture.RejectsBadNewPrimitiveArguments`
- `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.MeshPrimitivesDojoLoadsGrayboxShowcase:GameDataRuntime.EmitsAuthoredMeshPrimitiveDescriptors:GameDataValidation.RejectsInvalidMeshPrimitiveComponents`
- `./build/debug/tests/sdl3d_game_data_test`
- `./build/debug/tests/sdl3d_shapes_test`
- prior FOV checks on this PR: `./build/debug/tests/sdl3d_math_test`
- latest smoke check: `cmake --build build/debug -j4 --target sdl3d_game_data_test sdl3d_shapes_test sdl3d_runner`
- latest smoke check: `./build/debug/tests/sdl3d_game_data_test --gtest_filter=GameDataRuntime.MeshPrimitivesDojoLoadsGrayboxShowcase`
- latest smoke check: `./build/debug/tests/sdl3d_shapes_test --gtest_filter=SDL3DShapesFixture.AdditionalPlaceholderPrimitivesRender:SDL3DShapesFixture.NewPrimitiveWiresDrawWithoutFilling:SDL3DShapesFixture.RejectsBadNewPrimitiveArguments`
- latest profile smoke: `SDL3D_PROFILE_FRAMES=1 ./build/debug/sdl3d_runner --root demos/mesh_primitives_dojo/data --data asset://mesh_primitives_dojo.game.json`

Refs #298
