### PR TITLE
Add sector-local colored lighting dojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ targets. The generic `slayer3d_runner` can launch games from:
 The demo games are compatibility proofs for engine capabilities. New demo work
 should strengthen reusable systems instead of adding one-off host code.
 The repository also includes data-only dojos for focused primitive and mechanic
-tuning, including FPS mechanics and procedural mesh primitive showcases.
+tuning, including FPS mechanics, procedural mesh primitives, and sector-local
+lighting showcases.
 
 Default authored display and world conventions are intentionally simple:
 Slayer 3D games target a 1280x720 logical canvas that is letterboxed to preserve

--- a/demos/lighting_dojo/README.md
+++ b/demos/lighting_dojo/README.md
@@ -1,0 +1,14 @@
+# Slayer 3D Lighting Dojo
+
+Data-only sector/FPS lighting showcase for sector-local brightness and tint.
+
+Run it with:
+
+```sh
+./build/debug/sdl3d_runner --root demos/lighting_dojo/data --data asset://lighting_dojo.game.json
+```
+
+The dojo contains connected rooms and hallways with neutral, dark, bright,
+warm, cold, red, green, and mixed lighting treatments. Use WASD and mouse look
+to inspect sector surfaces, lit mesh primitives, composite mock actors, and
+dynamic point lights.

--- a/demos/lighting_dojo/data/fragments/actors/player.json
+++ b/demos/lighting_dojo/data/fragments/actors/player.json
@@ -1,0 +1,37 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "tags": ["player", "fps_actor"],
+      "transform": { "position": [4.0, 1.6, 4.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": -1 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_sector",
+          "sector_level": "sector.lighting_dojo.showcase",
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 6.0,
+          "jump_velocity": 6.0,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.55,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ]
+}

--- a/demos/lighting_dojo/data/fragments/actors/showcase_props.json
+++ b/demos/lighting_dojo/data/fragments/actors/showcase_props.json
@@ -6,7 +6,7 @@
       "active": true,
       "transform": { "position": [4.0, 2.8, 4.0] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.95, 0.82], "intensity": 0.6, "range": 5.0 },
+        { "type": "light.point", "color": [1.0, 0.95, 0.82], "intensity": 0.6, "range": 5.0, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.18, "segments": 16, "rings": 8, "color": [255, 235, 175, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -15,7 +15,7 @@
       "active": true,
       "transform": { "position": [4.0, 2.2, 13.0] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.42, 0.12], "intensity": 1.8, "range": 6.5 },
+        { "type": "light.point", "color": [1.0, 0.42, 0.12], "intensity": 1.8, "range": 6.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [255, 120, 45, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -24,7 +24,7 @@
       "active": true,
       "transform": { "position": [14.0, 2.2, 13.0] },
       "components": [
-        { "type": "light.point", "color": [0.25, 0.48, 1.0], "intensity": 1.7, "range": 6.5 },
+        { "type": "light.point", "color": [0.25, 0.48, 1.0], "intensity": 1.7, "range": 6.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [70, 135, 255, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -33,7 +33,7 @@
       "active": true,
       "transform": { "position": [43.0, 2.1, 11.0] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.18, 0.12], "intensity": 1.5, "range": 5.5 },
+        { "type": "light.point", "color": [1.0, 0.18, 0.12], "intensity": 1.5, "range": 5.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [255, 65, 40, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -42,7 +42,7 @@
       "active": true,
       "transform": { "position": [47.0, 2.1, 15.0] },
       "components": [
-        { "type": "light.point", "color": [0.15, 0.7, 1.0], "intensity": 1.5, "range": 5.5 },
+        { "type": "light.point", "color": [0.15, 0.7, 1.0], "intensity": 1.5, "range": 5.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [45, 190, 255, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -51,7 +51,7 @@
       "active": true,
       "transform": { "position": [4.0, 1.0, 5.7] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.3, 1.5, 1.0], "bevel_radius": 0.18, "rings": 4, "color": [210, 220, 235, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.3, 1.5, 1.0], "bevel_radius": 0.18, "rings": 4, "color": [210, 220, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
       ]
     },
     {
@@ -59,7 +59,7 @@
       "active": true,
       "transform": { "position": [14.0, 1.0, 5.7] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.75, "segments": 24, "rings": 10, "color": [210, 220, 235, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.75, "segments": 24, "rings": 10, "color": [210, 220, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
       ]
     },
     {
@@ -67,7 +67,7 @@
       "active": true,
       "transform": { "position": [24.0, 1.0, 5.7] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.42, "height": 1.8, "segments": 20, "rings": 8, "color": [210, 220, 235, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.42, "height": 1.8, "segments": 20, "rings": 8, "color": [210, 220, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
       ]
     },
     {
@@ -75,7 +75,7 @@
       "active": true,
       "transform": { "position": [24.0, 0.95, 13.2] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.65, "minor_radius": 0.16, "segments": 28, "tube_segments": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [220, 225, 235, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.65, "minor_radius": 0.16, "segments": 28, "tube_segments": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [220, 225, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
       ]
     },
     {
@@ -83,7 +83,7 @@
       "active": true,
       "transform": { "position": [34.0, 0.9, 13.2] },
       "components": [
-        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 0.9, "segments": 24, "rings": 8, "color": [220, 225, 235, 255], "lighting": true }
+        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 0.9, "segments": 24, "rings": 8, "color": [220, 225, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
       ]
     },
     {
@@ -94,6 +94,7 @@
         {
           "type": "render.composite",
           "lighting": true,
+          "lighting_key": "lighting.dojo.actor_primitives",
           "wire_color": [16, 18, 22, 220],
           "parts": [
             { "primitive": "rounded_box", "offset": [0.0, 0.85, 0.0], "size": [1.1, 1.45, 0.8], "bevel_radius": 0.18, "rings": 4, "color": [160, 180, 235, 255] },

--- a/demos/lighting_dojo/data/fragments/actors/showcase_props.json
+++ b/demos/lighting_dojo/data/fragments/actors/showcase_props.json
@@ -1,0 +1,110 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.light.neutral",
+      "active": true,
+      "transform": { "position": [4.0, 2.8, 4.0] },
+      "components": [
+        { "type": "light.point", "color": [1.0, 0.95, 0.82], "intensity": 0.6, "range": 5.0 },
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.18, "segments": 16, "rings": 8, "color": [255, 235, 175, 255], "lighting": false, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.light.warm",
+      "active": true,
+      "transform": { "position": [4.0, 2.2, 13.0] },
+      "components": [
+        { "type": "light.point", "color": [1.0, 0.42, 0.12], "intensity": 1.8, "range": 6.5 },
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [255, 120, 45, 255], "lighting": false, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.light.blue",
+      "active": true,
+      "transform": { "position": [14.0, 2.2, 13.0] },
+      "components": [
+        { "type": "light.point", "color": [0.25, 0.48, 1.0], "intensity": 1.7, "range": 6.5 },
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [70, 135, 255, 255], "lighting": false, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.light.lab.left",
+      "active": true,
+      "transform": { "position": [43.0, 2.1, 11.0] },
+      "components": [
+        { "type": "light.point", "color": [1.0, 0.18, 0.12], "intensity": 1.5, "range": 5.5 },
+        { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [255, 65, 40, 255], "lighting": false, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.light.lab.right",
+      "active": true,
+      "transform": { "position": [47.0, 2.1, 15.0] },
+      "components": [
+        { "type": "light.point", "color": [0.15, 0.7, 1.0], "intensity": 1.5, "range": 5.5 },
+        { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [45, 190, 255, 255], "lighting": false, "emissive": true }
+      ]
+    },
+    {
+      "name": "entity.sample.neutral",
+      "active": true,
+      "transform": { "position": [4.0, 1.0, 5.7] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.3, 1.5, 1.0], "bevel_radius": 0.18, "rings": 4, "color": [210, 220, 235, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.sample.dark",
+      "active": true,
+      "transform": { "position": [14.0, 1.0, 5.7] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.75, "segments": 24, "rings": 10, "color": [210, 220, 235, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.sample.bright",
+      "active": true,
+      "transform": { "position": [24.0, 1.0, 5.7] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "capsule", "radius": 0.42, "height": 1.8, "segments": 20, "rings": 8, "color": [210, 220, 235, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.sample.red",
+      "active": true,
+      "transform": { "position": [24.0, 0.95, 13.2] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "torus", "major_radius": 0.65, "minor_radius": 0.16, "segments": 28, "tube_segments": 8, "rotation_axis": [1.0, 0.0, 0.0], "rotation_angle": 1.5707964, "color": [220, 225, 235, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.sample.green",
+      "active": true,
+      "transform": { "position": [34.0, 0.9, 13.2] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "hemisphere", "radius": 0.9, "segments": 24, "rings": 8, "color": [220, 225, 235, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.mock.lab_robot",
+      "active": true,
+      "transform": { "position": [45.0, 0.8, 13.0] },
+      "components": [
+        {
+          "type": "render.composite",
+          "lighting": true,
+          "wire_color": [16, 18, 22, 220],
+          "parts": [
+            { "primitive": "rounded_box", "offset": [0.0, 0.85, 0.0], "size": [1.1, 1.45, 0.8], "bevel_radius": 0.18, "rings": 4, "color": [160, 180, 235, 255] },
+            { "primitive": "sphere", "offset": [0.0, 1.78, 0.0], "radius": 0.38, "segments": 18, "rings": 8, "color": [225, 230, 240, 255] },
+            { "primitive": "disc", "offset": [-0.15, 1.80, 0.35], "radius": 0.08, "segments": 16, "color": [255, 55, 55, 255], "lighting": false, "emissive": true },
+            { "primitive": "disc", "offset": [0.15, 1.80, 0.35], "radius": 0.08, "segments": 16, "color": [70, 190, 255, 255], "lighting": false, "emissive": true },
+            { "primitive": "capsule", "offset": [-0.78, 0.75, 0.0], "radius": 0.15, "height": 1.1, "segments": 14, "rings": 6, "color": [85, 100, 130, 255] },
+            { "primitive": "capsule", "offset": [0.78, 0.75, 0.0], "radius": 0.15, "height": 1.1, "segments": 14, "rings": 6, "color": [85, 100, 130, 255] }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demos/lighting_dojo/data/fragments/actors/showcase_props.json
+++ b/demos/lighting_dojo/data/fragments/actors/showcase_props.json
@@ -4,9 +4,9 @@
     {
       "name": "entity.light.neutral",
       "active": true,
-      "transform": { "position": [4.0, 2.8, 4.0] },
+      "transform": { "position": [4.0, 2.5, 5.6] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.95, 0.82], "intensity": 0.6, "range": 5.0, "enabled_key": "lighting.dojo.dynamic_lights" },
+        { "type": "light.point", "color": [1.0, 0.95, 0.82], "intensity": 1.5, "range": 5.8, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.18, "segments": 16, "rings": 8, "color": [255, 235, 175, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -15,7 +15,7 @@
       "active": true,
       "transform": { "position": [4.0, 2.2, 13.0] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.42, 0.12], "intensity": 1.8, "range": 6.5, "enabled_key": "lighting.dojo.dynamic_lights" },
+        { "type": "light.point", "color": [1.0, 0.42, 0.12], "intensity": 2.6, "range": 7.2, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [255, 120, 45, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -24,7 +24,7 @@
       "active": true,
       "transform": { "position": [14.0, 2.2, 13.0] },
       "components": [
-        { "type": "light.point", "color": [0.25, 0.48, 1.0], "intensity": 1.7, "range": 6.5, "enabled_key": "lighting.dojo.dynamic_lights" },
+        { "type": "light.point", "color": [0.25, 0.48, 1.0], "intensity": 2.5, "range": 7.2, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.20, "segments": 16, "rings": 8, "color": [70, 135, 255, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -33,7 +33,7 @@
       "active": true,
       "transform": { "position": [43.0, 2.1, 11.0] },
       "components": [
-        { "type": "light.point", "color": [1.0, 0.18, 0.12], "intensity": 1.5, "range": 5.5, "enabled_key": "lighting.dojo.dynamic_lights" },
+        { "type": "light.point", "color": [1.0, 0.18, 0.12], "intensity": 2.8, "range": 7.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [255, 65, 40, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -42,7 +42,7 @@
       "active": true,
       "transform": { "position": [47.0, 2.1, 15.0] },
       "components": [
-        { "type": "light.point", "color": [0.15, 0.7, 1.0], "intensity": 1.5, "range": 5.5, "enabled_key": "lighting.dojo.dynamic_lights" },
+        { "type": "light.point", "color": [0.15, 0.7, 1.0], "intensity": 2.8, "range": 7.5, "enabled_key": "lighting.dojo.dynamic_lights" },
         { "type": "render.mesh_primitive", "primitive": "disc", "radius": 0.18, "segments": 20, "color": [45, 190, 255, 255], "lighting": false, "emissive": true }
       ]
     },
@@ -87,9 +87,33 @@
       ]
     },
     {
+      "name": "entity.sample.warm_probe",
+      "active": true,
+      "transform": { "position": [4.0, 1.0, 13.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.15, 1.3, 0.9], "bevel_radius": 0.15, "rings": 4, "color": [210, 220, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
+      ]
+    },
+    {
+      "name": "entity.sample.blue_probe",
+      "active": true,
+      "transform": { "position": [14.0, 1.0, 13.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "rounded_box", "size": [1.15, 1.3, 0.9], "bevel_radius": 0.15, "rings": 4, "color": [210, 220, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
+      ]
+    },
+    {
+      "name": "entity.sample.lab_probe",
+      "active": true,
+      "transform": { "position": [45.0, 0.9, 13.0] },
+      "components": [
+        { "type": "render.mesh_primitive", "primitive": "sphere", "radius": 0.65, "segments": 24, "rings": 10, "color": [220, 225, 235, 255], "lighting": true, "lighting_key": "lighting.dojo.actor_primitives" }
+      ]
+    },
+    {
       "name": "entity.mock.lab_robot",
       "active": true,
-      "transform": { "position": [45.0, 0.8, 13.0] },
+      "transform": { "position": [45.0, 0.8, 15.4] },
       "components": [
         {
           "type": "render.composite",

--- a/demos/lighting_dojo/data/fragments/input/fps_controls.json
+++ b/demos/lighting_dojo/data/fragments/input/fps_controls.json
@@ -1,0 +1,19 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "input": {
+    "contexts": [
+      {
+        "name": "input.lighting_dojo",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
+          { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/lighting_dojo/data/fragments/input/fps_controls.json
+++ b/demos/lighting_dojo/data/fragments/input/fps_controls.json
@@ -11,6 +11,10 @@
           { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
           { "name": "action.pause", "bindings": [{ "device": "keyboard", "key": "P" }] },
+          { "name": "action.lighting.sector.toggle", "bindings": [{ "device": "keyboard", "key": "1" }] },
+          { "name": "action.lighting.dynamic.toggle", "bindings": [{ "device": "keyboard", "key": "2" }] },
+          { "name": "action.lighting.actor.toggle", "bindings": [{ "device": "keyboard", "key": "3" }] },
+          { "name": "action.lighting.bloom.toggle", "bindings": [{ "device": "keyboard", "key": "4" }] },
           { "name": "action.exit", "bindings": [{ "device": "keyboard", "key": "ESCAPE" }] }
         ]
       }

--- a/demos/lighting_dojo/data/fragments/logic/lighting_toggles.json
+++ b/demos/lighting_dojo/data/fragments/logic/lighting_toggles.json
@@ -1,0 +1,59 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "signals": [
+    "signal.lighting.sector.toggle",
+    "signal.lighting.dynamic.toggle",
+    "signal.lighting.actor.toggle",
+    "signal.lighting.bloom.toggle"
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.lighting.sector.toggle",
+        "on_pressed": "signal.lighting.sector.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.lighting.dynamic.toggle",
+        "on_pressed": "signal.lighting.dynamic.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.lighting.actor.toggle",
+        "on_pressed": "signal.lighting.actor.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.lighting.bloom.toggle",
+        "on_pressed": "signal.lighting.bloom.toggle"
+      }
+    ],
+    "bindings": [
+      {
+        "signal": "signal.lighting.sector.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "lighting.dojo.sector_lighting", "default": true }
+        ]
+      },
+      {
+        "signal": "signal.lighting.dynamic.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "lighting.dojo.dynamic_lights", "default": true }
+        ]
+      },
+      {
+        "signal": "signal.lighting.actor.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "lighting.dojo.actor_primitives", "default": true }
+        ]
+      },
+      {
+        "signal": "signal.lighting.bloom.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "lighting.dojo.bloom", "default": true }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
+++ b/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
@@ -4,10 +4,10 @@
     {
       "level": "sector.lighting_dojo.showcase",
       "materials": [
-        { "name": "floor.concrete", "albedo": [0.36, 0.36, 0.38, 1.0], "roughness": 0.9, "tex_scale": 5.0 },
-        { "name": "wall.panel", "albedo": [0.52, 0.54, 0.58, 1.0], "roughness": 0.8, "tex_scale": 4.0 },
-        { "name": "ceiling.dark", "albedo": [0.20, 0.21, 0.24, 1.0], "roughness": 0.95, "tex_scale": 4.0 },
-        { "name": "floor.warning", "albedo": [0.45, 0.38, 0.18, 1.0], "roughness": 0.88, "tex_scale": 3.0 }
+        { "name": "floor.concrete", "albedo": [0.16, 0.16, 0.18, 1.0], "roughness": 0.9, "tex_scale": 5.0 },
+        { "name": "wall.panel", "albedo": [0.62, 0.64, 0.68, 1.0], "roughness": 0.8, "tex_scale": 4.0 },
+        { "name": "ceiling.dark", "albedo": [0.72, 0.12, 0.10, 1.0], "roughness": 0.95, "tex_scale": 4.0 },
+        { "name": "floor.warning", "albedo": [0.20, 0.20, 0.22, 1.0], "roughness": 0.88, "tex_scale": 3.0 }
       ],
       "sectors": [
         {

--- a/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
+++ b/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
@@ -1,0 +1,152 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "sector_level_fragments": [
+    {
+      "level": "sector.lighting_dojo.showcase",
+      "materials": [
+        { "name": "floor.concrete", "albedo": [0.36, 0.36, 0.38, 1.0], "roughness": 0.9, "tex_scale": 5.0 },
+        { "name": "wall.panel", "albedo": [0.52, 0.54, 0.58, 1.0], "roughness": 0.8, "tex_scale": 4.0 },
+        { "name": "ceiling.dark", "albedo": [0.20, 0.21, 0.24, 1.0], "roughness": 0.95, "tex_scale": 4.0 },
+        { "name": "floor.warning", "albedo": [0.45, 0.38, 0.18, 1.0], "roughness": 0.88, "tex_scale": 3.0 }
+      ],
+      "sectors": [
+        {
+          "name": "neutral_room",
+          "points": [[0, 0], [8, 0], [8, 8], [0, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 192, "color": [1.0, 1.0, 1.0, 0.0] }
+        },
+        {
+          "name": "dark_room",
+          "points": [[10, 0], [18, 0], [18, 8], [10, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 48, "color": [0.45, 0.50, 0.65, 0.3] }
+        },
+        {
+          "name": "fullbright_room",
+          "points": [[20, 0], [28, 0], [28, 8], [20, 8]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 255, "color": [1.0, 1.0, 1.0, 0.0] }
+        },
+        {
+          "name": "warm_hall",
+          "points": [[0, 10], [8, 10], [8, 16], [0, 16]],
+          "floor_y": 0.0,
+          "ceil_y": 3.4,
+          "floor_material": "floor.warning",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 176, "color": [1.0, 0.46, 0.14, 0.85] }
+        },
+        {
+          "name": "blue_hall",
+          "points": [[10, 10], [18, 10], [18, 16], [10, 16]],
+          "floor_y": 0.0,
+          "ceil_y": 3.4,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 142, "color": [0.20, 0.42, 1.0, 1.0] }
+        },
+        {
+          "name": "red_alarm_room",
+          "points": [[20, 10], [28, 10], [28, 16], [20, 16]],
+          "floor_y": 0.0,
+          "ceil_y": 3.4,
+          "floor_material": "floor.warning",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 160, "color": [1.0, 0.08, 0.05, 1.0] }
+        },
+        {
+          "name": "green_toxic_room",
+          "points": [[30, 10], [38, 10], [38, 16], [30, 16]],
+          "floor_y": -0.15,
+          "ceil_y": 3.4,
+          "floor_material": "floor.warning",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 150, "color": [0.18, 1.0, 0.35, 1.0] }
+        },
+        {
+          "name": "mixed_light_lab",
+          "points": [[40, 8], [50, 8], [50, 18], [40, 18]],
+          "floor_y": 0.0,
+          "ceil_y": 5.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 126, "color": [0.72, 0.64, 1.0, 0.45] }
+        },
+        {
+          "name": "connector_a",
+          "points": [[8, 3], [10, 3], [10, 5], [8, 5]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 128, "color": [1.0, 1.0, 1.0, 0.0] }
+        },
+        {
+          "name": "connector_b",
+          "points": [[18, 3], [20, 3], [20, 5], [18, 5]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 144, "color": [0.7, 0.85, 1.0, 0.35] }
+        },
+        {
+          "name": "connector_c",
+          "points": [[26, 8], [28, 8], [28, 10], [26, 10]],
+          "floor_y": 0.0,
+          "ceil_y": 3.6,
+          "floor_material": "floor.warning",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 150, "color": [1.0, 0.2, 0.1, 0.85] }
+        },
+        {
+          "name": "connector_d",
+          "points": [[28, 13], [30, 13], [30, 15], [28, 15]],
+          "floor_y": -0.15,
+          "ceil_y": 3.4,
+          "floor_material": "floor.warning",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 146, "color": [0.45, 1.0, 0.35, 0.8] }
+        },
+        {
+          "name": "connector_e",
+          "points": [[38, 12], [40, 12], [40, 14], [38, 14]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "floor.concrete",
+          "ceil_material": "ceiling.dark",
+          "wall_material": "wall.panel",
+          "lighting": { "level": 130, "color": [0.65, 0.8, 1.0, 0.5] }
+        }
+      ],
+      "lights": [
+        { "position": [4.0, 2.8, 4.0], "color": [1.0, 0.95, 0.85], "intensity": 0.8, "range": 6.0 },
+        { "position": [4.0, 2.4, 13.0], "color": [1.0, 0.55, 0.18], "intensity": 1.4, "range": 7.0 },
+        { "position": [14.0, 2.4, 13.0], "color": [0.25, 0.55, 1.0], "intensity": 1.2, "range": 7.0 },
+        { "position": [45.0, 3.2, 13.0], "color": [1.0, 0.95, 0.55], "intensity": 1.8, "range": 8.0 }
+      ]
+    }
+  ]
+}

--- a/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
+++ b/demos/lighting_dojo/data/fragments/world/sector_lighting_showcase.json
@@ -18,7 +18,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 192, "color": [1.0, 1.0, 1.0, 0.0] }
+          "lighting": { "level": 178, "color": [1.0, 1.0, 1.0, 0.0] }
         },
         {
           "name": "dark_room",
@@ -28,7 +28,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 48, "color": [0.45, 0.50, 0.65, 0.3] }
+          "lighting": { "level": 112, "color": [0.65, 0.72, 0.95, 0.18] }
         },
         {
           "name": "fullbright_room",
@@ -38,7 +38,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 255, "color": [1.0, 1.0, 1.0, 0.0] }
+          "lighting": { "level": 214, "color": [1.0, 1.0, 1.0, 0.0] }
         },
         {
           "name": "warm_hall",
@@ -48,7 +48,7 @@
           "floor_material": "floor.warning",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 176, "color": [1.0, 0.46, 0.14, 0.85] }
+          "lighting": { "level": 166, "color": [1.0, 0.58, 0.24, 0.48] }
         },
         {
           "name": "blue_hall",
@@ -58,7 +58,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 142, "color": [0.20, 0.42, 1.0, 1.0] }
+          "lighting": { "level": 154, "color": [0.34, 0.58, 1.0, 0.55] }
         },
         {
           "name": "red_alarm_room",
@@ -68,7 +68,7 @@
           "floor_material": "floor.warning",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 160, "color": [1.0, 0.08, 0.05, 1.0] }
+          "lighting": { "level": 158, "color": [1.0, 0.22, 0.15, 0.55] }
         },
         {
           "name": "green_toxic_room",
@@ -78,7 +78,7 @@
           "floor_material": "floor.warning",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 150, "color": [0.18, 1.0, 0.35, 1.0] }
+          "lighting": { "level": 150, "color": [0.30, 1.0, 0.42, 0.55] }
         },
         {
           "name": "mixed_light_lab",
@@ -88,7 +88,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 126, "color": [0.72, 0.64, 1.0, 0.45] }
+          "lighting": { "level": 146, "color": [0.76, 0.70, 1.0, 0.32] }
         },
         {
           "name": "connector_a",
@@ -98,7 +98,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 128, "color": [1.0, 1.0, 1.0, 0.0] }
+          "lighting": { "level": 145, "color": [0.88, 0.92, 1.0, 0.10] }
         },
         {
           "name": "connector_b",
@@ -108,7 +108,7 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 144, "color": [0.7, 0.85, 1.0, 0.35] }
+          "lighting": { "level": 162, "color": [0.76, 0.88, 1.0, 0.22] }
         },
         {
           "name": "connector_c",
@@ -118,7 +118,7 @@
           "floor_material": "floor.warning",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 150, "color": [1.0, 0.2, 0.1, 0.85] }
+          "lighting": { "level": 158, "color": [1.0, 0.34, 0.20, 0.42] }
         },
         {
           "name": "connector_d",
@@ -128,7 +128,7 @@
           "floor_material": "floor.warning",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 146, "color": [0.45, 1.0, 0.35, 0.8] }
+          "lighting": { "level": 152, "color": [0.44, 1.0, 0.42, 0.40] }
         },
         {
           "name": "connector_e",
@@ -138,14 +138,14 @@
           "floor_material": "floor.concrete",
           "ceil_material": "ceiling.dark",
           "wall_material": "wall.panel",
-          "lighting": { "level": 130, "color": [0.65, 0.8, 1.0, 0.5] }
+          "lighting": { "level": 145, "color": [0.74, 0.86, 1.0, 0.30] }
         }
       ],
       "lights": [
-        { "position": [4.0, 2.8, 4.0], "color": [1.0, 0.95, 0.85], "intensity": 0.8, "range": 6.0 },
-        { "position": [4.0, 2.4, 13.0], "color": [1.0, 0.55, 0.18], "intensity": 1.4, "range": 7.0 },
-        { "position": [14.0, 2.4, 13.0], "color": [0.25, 0.55, 1.0], "intensity": 1.2, "range": 7.0 },
-        { "position": [45.0, 3.2, 13.0], "color": [1.0, 0.95, 0.55], "intensity": 1.8, "range": 8.0 }
+        { "position": [4.0, 2.8, 4.0], "color": [1.0, 0.95, 0.85], "intensity": 0.65, "range": 5.5 },
+        { "position": [4.0, 2.4, 13.0], "color": [1.0, 0.55, 0.18], "intensity": 0.85, "range": 6.0 },
+        { "position": [14.0, 2.4, 13.0], "color": [0.25, 0.55, 1.0], "intensity": 0.8, "range": 6.0 },
+        { "position": [45.0, 3.2, 13.0], "color": [1.0, 0.95, 0.55], "intensity": 1.0, "range": 7.0 }
       ]
     }
   ]

--- a/demos/lighting_dojo/data/lighting_dojo.game.json
+++ b/demos/lighting_dojo/data/lighting_dojo.game.json
@@ -1,0 +1,63 @@
+{
+  "schema": "slayer3d.game.v0",
+  "metadata": {
+    "name": "Slayer 3D Lighting Dojo",
+    "id": "demo.lighting_dojo",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/world/sector_lighting_showcase.json", "sections": ["sector_level_fragments"] },
+    { "path": "fragments/actors/player.json", "sections": ["entities"] },
+    { "path": "fragments/actors/showcase_props.json", "sections": ["entities"] }
+  ],
+  "app": {
+    "title": "Slayer 3D Lighting Dojo",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
+    "pause": { "action": "action.pause" },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "world": {
+    "name": "world.lighting_dojo",
+    "kind": "sector",
+    "units": "meters",
+    "meters_per_unit": 1.0,
+    "ambient_light": [0.08, 0.08, 0.09],
+    "cameras": [
+      {
+        "name": "camera.lighting_dojo.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fov": 90.0,
+        "fov_axis": "horizontal",
+        "fov_key": "camera.fov",
+        "fov_axis_key": "camera.fov_axis",
+        "active": true
+      }
+    ]
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.lighting_dojo.hud", "builtin": "Inter", "size": 22 }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": true,
+    "clear_color": [0.015, 0.018, 0.024],
+    "tonemap": "aces"
+  },
+  "presentation": {
+    "metrics": {
+      "fps_sample_seconds": 0.25
+    }
+  },
+  "scenes": {
+    "initial": "scene.lighting_dojo.showcase",
+    "files": ["scenes/showcase.scene.json"]
+  }
+}

--- a/demos/lighting_dojo/data/lighting_dojo.game.json
+++ b/demos/lighting_dojo/data/lighting_dojo.game.json
@@ -7,6 +7,7 @@
   },
   "imports": [
     { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/logic/lighting_toggles.json", "sections": ["signals", "logic"] },
     { "path": "fragments/world/sector_lighting_showcase.json", "sections": ["sector_level_fragments"] },
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/actors/showcase_props.json", "sections": ["entities"] }
@@ -48,6 +49,7 @@
   "render": {
     "lighting": true,
     "bloom": true,
+    "bloom_key": "lighting.dojo.bloom",
     "clear_color": [0.015, 0.018, 0.024],
     "tonemap": "aces"
   },

--- a/demos/lighting_dojo/data/scenes/showcase.scene.json
+++ b/demos/lighting_dojo/data/scenes/showcase.scene.json
@@ -26,6 +26,10 @@
       "action.move.left",
       "action.move.right",
       "action.jump",
+      "action.lighting.sector.toggle",
+      "action.lighting.dynamic.toggle",
+      "action.lighting.actor.toggle",
+      "action.lighting.bloom.toggle",
       "action.pause"
     ]
   },
@@ -35,6 +39,7 @@
         "level": "sector.lighting_dojo.showcase",
         "variant": "lightmapped",
         "position": [0.0, 0.0, 0.0],
+        "sector_lighting_key": "lighting.dojo.sector_lighting",
         "portal_culling": true
       }
     ]
@@ -53,7 +58,7 @@
       },
       {
         "name": "ui.lighting_dojo.help",
-        "text": "WASD move  Mouse look  Space jump  P pause  Esc quit",
+        "text": "WASD move  Mouse look  Space jump  1 sector  2 point lights  3 actor lighting  4 bloom",
         "font": "font.lighting_dojo.hud",
         "x": 0.02,
         "y": 0.075,
@@ -70,6 +75,50 @@
         "normalized": true,
         "color": [185, 200, 220, 200],
         "scale": 0.52
+      },
+      {
+        "name": "ui.lighting_dojo.toggle_sector",
+        "font": "font.lighting_dojo.hud",
+        "format": "1 Sector %d",
+        "bindings": [{ "type": "scene_state", "key": "lighting.dojo.sector_lighting", "default": true }],
+        "x": 0.02,
+        "y": 0.155,
+        "normalized": true,
+        "color": [210, 225, 240, 210],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.lighting_dojo.toggle_dynamic",
+        "font": "font.lighting_dojo.hud",
+        "format": "2 Point %d",
+        "bindings": [{ "type": "scene_state", "key": "lighting.dojo.dynamic_lights", "default": true }],
+        "x": 0.125,
+        "y": 0.155,
+        "normalized": true,
+        "color": [210, 225, 240, 210],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.lighting_dojo.toggle_actor",
+        "font": "font.lighting_dojo.hud",
+        "format": "3 Actors %d",
+        "bindings": [{ "type": "scene_state", "key": "lighting.dojo.actor_primitives", "default": true }],
+        "x": 0.23,
+        "y": 0.155,
+        "normalized": true,
+        "color": [210, 225, 240, 210],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.lighting_dojo.toggle_bloom",
+        "font": "font.lighting_dojo.hud",
+        "format": "4 Bloom %d",
+        "bindings": [{ "type": "scene_state", "key": "lighting.dojo.bloom", "default": true }],
+        "x": 0.335,
+        "y": 0.155,
+        "normalized": true,
+        "color": [210, 225, 240, 210],
+        "scale": 0.48
       },
       {
         "name": "ui.lighting_dojo.fps",

--- a/demos/lighting_dojo/data/scenes/showcase.scene.json
+++ b/demos/lighting_dojo/data/scenes/showcase.scene.json
@@ -16,6 +16,9 @@
     "entity.sample.bright",
     "entity.sample.red",
     "entity.sample.green",
+    "entity.sample.warm_probe",
+    "entity.sample.blue_probe",
+    "entity.sample.lab_probe",
     "entity.mock.lab_robot"
   ],
   "input": {

--- a/demos/lighting_dojo/data/scenes/showcase.scene.json
+++ b/demos/lighting_dojo/data/scenes/showcase.scene.json
@@ -1,0 +1,101 @@
+{
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.lighting_dojo.showcase",
+  "camera": "camera.lighting_dojo.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.player",
+    "entity.light.neutral",
+    "entity.light.warm",
+    "entity.light.blue",
+    "entity.light.lab.left",
+    "entity.light.lab.right",
+    "entity.sample.neutral",
+    "entity.sample.dark",
+    "entity.sample.bright",
+    "entity.sample.red",
+    "entity.sample.green",
+    "entity.mock.lab_robot"
+  ],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.pause"
+    ]
+  },
+  "world": {
+    "sector_levels": [
+      {
+        "level": "sector.lighting_dojo.showcase",
+        "variant": "lightmapped",
+        "position": [0.0, 0.0, 0.0],
+        "portal_culling": true
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.lighting_dojo.title",
+        "text": "Lighting Dojo",
+        "font": "font.lighting_dojo.hud",
+        "x": 0.02,
+        "y": 0.03,
+        "normalized": true,
+        "color": [235, 240, 250, 230],
+        "scale": 0.82
+      },
+      {
+        "name": "ui.lighting_dojo.help",
+        "text": "WASD move  Mouse look  Space jump  P pause  Esc quit",
+        "font": "font.lighting_dojo.hud",
+        "x": 0.02,
+        "y": 0.075,
+        "normalized": true,
+        "color": [205, 215, 230, 210],
+        "scale": 0.62
+      },
+      {
+        "name": "ui.lighting_dojo.legend",
+        "text": "Rooms: neutral, dark, fullbright, warm, blue, red, toxic green, mixed dynamic lights",
+        "font": "font.lighting_dojo.hud",
+        "x": 0.02,
+        "y": 0.115,
+        "normalized": true,
+        "color": [185, 200, 220, 200],
+        "scale": 0.52
+      },
+      {
+        "name": "ui.lighting_dojo.fps",
+        "font": "font.lighting_dojo.hud",
+        "format": "FPS %.0f",
+        "bindings": [
+          { "type": "metric", "metric": "fps" }
+        ],
+        "x": 0.985,
+        "y": 0.03,
+        "normalized": true,
+        "align": "right",
+        "color": [180, 235, 190, 230],
+        "scale": 0.72
+      },
+      {
+        "name": "ui.lighting_dojo.reticle",
+        "text": "+",
+        "font": "font.lighting_dojo.hud",
+        "x": 0.5,
+        "y": 0.5,
+        "normalized": true,
+        "align": "center",
+        "color": [255, 255, 255, 180],
+        "scale": 0.9
+      }
+    ]
+  }
+}

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -173,6 +173,16 @@ build/debug/slayer3d_runner \
   --data asset://mesh_primitives_dojo.game.json
 ```
 
+`demos/lighting_dojo` is a data-only sector lighting showcase. It demonstrates
+Doom/Build-style sector brightness, RGB tint influence, lit mesh primitives,
+composite mock actors, and dynamic point lights in connected rooms:
+
+```sh
+build/debug/slayer3d_runner \
+  --root demos/lighting_dojo/data \
+  --data asset://lighting_dojo.game.json
+```
+
 ## Data-Only Parity Checklist
 
 Before treating a game as data-only, validate the runner-backed game path:

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -88,6 +88,7 @@ The root `render` object configures frame-level presentation defaults:
     "lighting": true,
     "lighting_key": "render_lighting_enabled",
     "bloom": true,
+    "bloom_key": "render_bloom_enabled",
     "ssao": true,
     "profile": "modern",
     "profile_key": "render_profile"
@@ -612,6 +613,8 @@ Scenes render sector levels by declaring instances under `world.sector_levels`:
         "variant": "lightmapped",
         "variant_key": "render_sector_variant",
         "position": [0.0, 0.0, 0.0],
+        "sector_lighting": true,
+        "sector_lighting_key": "render_sector_lighting",
         "portal_culling": true,
         "portal_culling_key": "render_portal_culling"
       }
@@ -628,11 +631,15 @@ world primitives. Use `asset://` image paths for pack-file and embedded builds.
 `level` references a top-level sector level. `variant` defaults to
 `lightmapped` and may be `lightmapped`, `vertex_baked`, or `unlit`.
 `position` defaults to the origin and translates the level as a whole.
-`portal_culling` defaults to `true`; when enabled, generic presentation
-computes visibility from the active camera before drawing the level.
-`variant_key` and `portal_culling_key` are optional scene-state keys. When
-present, they override `variant` and `portal_culling` at runtime. This supports
-data-authored debug/profile controls without custom host-side input code.
+`sector_lighting` defaults to `true`; when disabled, the instance uses matching
+runtime variants built without sector-local lighting and actor primitives in the
+instance no longer receive sector-local color modulation. `portal_culling`
+defaults to `true`; when enabled, generic presentation computes visibility from
+the active camera before drawing the level. `variant_key`,
+`sector_lighting_key`, and `portal_culling_key` are optional scene-state keys.
+When present, they override `variant`, `sector_lighting`, and `portal_culling`
+at runtime. This supports data-authored debug/profile controls without custom
+host-side input code.
 
 Renderer, controller, and editor phases should consume runtime descriptors
 instead of parsing JSON directly. `world.kind` remains a high-level statement
@@ -1450,7 +1457,10 @@ Reusable components include:
 - `motion.oscillate` and `motion.spin`: simple authored movement effects.
 - `light.point`, `light.spot`, and `light.directional`: actor-attached light
   components. They work on static actors and active pooled actors. Component
-  lights inherit the actor transform and may use an `offset`.
+  lights inherit the actor transform and may use an `offset`. `enabled` defaults
+  to `true`; `enabled_key` reads a scene-state boolean at draw time so debug
+  menus and data-authored profile controls can disable a light group without
+  removing actors.
 - `particles.emitter`: actor-attached particle emitter. On pooled actors, the
   emitter is active only while the actor is active.
 - `render.cube`: renders a cube using authored `size`, or a vec3 actor property
@@ -1466,8 +1476,11 @@ Reusable components include:
   `tube_segment`. `billboard_plane` is a flat 3D placeholder plane; use
   `render.sprite` when you need an actual texture-backed camera-facing
   billboard. These descriptors use the same transform, `color`, `texture`,
-  `lighting`, and `emissive` fields as other render primitives where
-  applicable, and add `draw_mode`: `solid` (default), `wire`, or `solid_wire`.
+  `lighting`, `lighting_key`, and `emissive` fields as other render primitives
+  where applicable, and add `draw_mode`: `solid` (default), `wire`, or
+  `solid_wire`. `lighting_key` reads a scene-state boolean and is useful for
+  isolating whether actor primitives, sector-local lighting, or dynamic lights
+  are driving a scene.
   Dimension fields include `size`, `radius`, `height`, `radius_top`,
   `radius_bottom`, `major_radius`, `minor_radius`, `bevel_radius`, `arc_angle`,
   `segments`/`slices`, `rings`, and `tube_segments`. This is the stable

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -483,7 +483,24 @@ sector metadata, and baked lights are authored in JSON and loaded into runtime
           "ceil_y": 4.0,
           "floor_material": "rock_floor",
           "ceil_material": "wall_metal",
-          "wall_material": "wall_metal"
+          "wall_material": "wall_metal",
+          "lighting": {
+            "level": 176,
+            "color": [1.0, 0.72, 0.45, 0.65]
+          }
+        },
+        {
+          "name": "blue_hallway",
+          "points": [[10, 2], [18, 2], [18, 6], [10, 6]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "rock_floor",
+          "ceil_material": "wall_metal",
+          "wall_material": "wall_metal",
+          "lighting": {
+            "level": 96,
+            "color": [0.25, 0.45, 1.0, 1.0]
+          }
         },
         {
           "name": "hazard_basin",
@@ -526,14 +543,51 @@ Validation requires:
 - valid material references
 - optional `floor_normal`, `ceil_normal`, and `push_velocity` as vec3 arrays
 - non-negative `ambient_sound_id` and `damage_per_second`
+- optional `lighting` as an object with `level` integer in `[0, 255]` and
+  optional `color` vec3/vec4 values in `[0, 1]`
 - optional lights with `position` vec3, optional `color` vec3, non-negative
   `intensity`, and positive `range`
 
+Sector `lighting` is a Doom/Build-style local brightness and tint term. Missing
+`lighting` preserves the legacy sector look. When present, `level` defaults to
+`255` and `color` defaults to white. `color[3]`, when supplied, is tint
+influence rather than transparency: `0` applies brightness only, `1` fully
+applies the RGB tint, and values between them blend between white and the
+authored RGB. Sector-local lighting is baked cheaply into sector floor, ceiling,
+wall, step, and portal surfaces. Lit actor render components inside the active
+scene's sector levels also receive the same sector-local modulation for sprites,
+3D models, and mesh primitives. Components with `"lighting": false` are left
+unchanged. Batched pickup layers and particles currently keep their authored
+colors; use per-actor primitives when per-sector tint correctness matters for
+those effects. Sector-local lighting composes with authored baked/static lights
+and dynamic scene lights; it does not affect UI.
+
 At load time Slayer 3D builds three runtime variants per sector level:
 
-- `lightmapped`: baked lights plus lightmap atlas data
-- `vertex_baked`: baked vertex lighting without a lightmap atlas
-- `unlit`: raw material color/texture without baked lights
+- `lightmapped`: sector-local lighting plus baked static lights in a lightmap
+  atlas
+- `vertex_baked`: sector-local lighting plus baked static lights in vertex
+  colors, without a lightmap atlas
+- `unlit`: material color/texture modulated by sector-local lighting, without
+  baked static lights
+
+Tools and data logic can update a sector at runtime with `sector_lighting.set`:
+
+```json
+{
+  "type": "sector_lighting.set",
+  "sector_level": "sector.level_1",
+  "sector": "red_hallway",
+  "level": 128,
+  "color": [1.0, 0.1, 0.05, 1.0]
+}
+```
+
+Use either `sector` or `sector_index`. Runtime updates rebuild the affected
+level's render variants atomically, so they are suitable for editor preview and
+occasional scripted changes. Avoid changing many large sectors every frame;
+prefer authored sector values plus dynamic lights for high-frequency lighting
+effects.
 
 Scenes render sector levels by declaring instances under `world.sector_levels`:
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -192,6 +192,11 @@ simple lighting, and places authored actors far enough apart that each
 procedural mesh primitive can be inspected from the same FPS runtime path future
 games will use.
 
+`demos/lighting_dojo` is the reference shape for sector-local lighting
+showcases. It uses connected sector rooms and hallways with varied brightness
+and tint values, plus lit primitives and dynamic lights, so lighting behavior
+can be inspected from the same generic runner path as gameplay.
+
 Use optional `editor` metadata beside the authored object it describes. This
 keeps future editor palettes and prefab browsers grounded in the same JSON that
 runtime validation sees. Metadata should describe categories, previews, bounds,

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1125,6 +1125,30 @@ extern "C"
                                                  slayer3d_game_data_sector_nav_node *out_node);
 
     /**
+     * @brief Read authored or runtime-edited sector-local lighting.
+     *
+     * @p sector may be either a sector name or a decimal sector index. Returns
+     * false when the level/sector cannot be resolved, when the sector has no
+     * authored lighting, or when the output pointers are invalid. @p out_color
+     * receives RGB tint plus alpha/influence in [0, 1].
+     */
+    bool slayer3d_game_data_get_sector_lighting(const slayer3d_game_data_runtime *runtime, const char *sector_level,
+                                                const char *sector, float *out_level, float out_color[4],
+                                                char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Set sector-local lighting and rebuild the level's render variants.
+     *
+     * @p sector may be either a sector name or a decimal sector index. @p level
+     * is clamped to [0, 255]. @p color is clamped per channel to [0, 1] and
+     * uses color[3] as tint influence, not transparency. The update is atomic:
+     * if rebuilding fails, the previous runtime level data remains active.
+     */
+    bool slayer3d_game_data_set_sector_lighting(slayer3d_game_data_runtime *runtime, const char *sector_level,
+                                                const char *sector, float level, const float color[4],
+                                                char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Iterate sector levels declared by the active scene.
      *
      * The active scene owns placement and variant selection through

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -339,6 +339,8 @@ extern "C"
         slayer3d_vec3 position;
         /** @brief Whether renderers should compute portal visibility for this instance. */
         bool portal_culling;
+        /** @brief Whether authored sector-local lighting is applied to this instance. */
+        bool sector_lighting_enabled;
     } slayer3d_game_data_sector_level_instance;
 
     /**

--- a/include/slayer3d/level.h
+++ b/include/slayer3d/level.h
@@ -63,6 +63,9 @@ extern "C"
         int ambient_sound_id;    /**< Ambient zone id. Zero means no ambient zone. */
         float push_velocity[3];  /**< World-space sector velocity in units per second. */
         float damage_per_second; /**< Sector floor damage rate in game health units per second. */
+        bool has_lighting;       /**< True when authored sector-local lighting should override default brightness. */
+        float lighting_level;    /**< Doom-style brightness value in [0, 255]. */
+        float lighting_color[4]; /**< RGB tint plus alpha/influence in [0, 1]. */
     } slayer3d_sector;
 
     /**

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -376,6 +376,9 @@ typedef struct sector_level_runtime
     slayer3d_level lightmapped;
     slayer3d_level vertex_baked;
     slayer3d_level unlit;
+    slayer3d_level lightmapped_without_sector_lighting;
+    slayer3d_level vertex_baked_without_sector_lighting;
+    slayer3d_level unlit_without_sector_lighting;
 } sector_level_runtime;
 
 typedef struct sector_door_runtime
@@ -3349,31 +3352,76 @@ static bool load_sector_level_lights(sector_level_runtime *level, yyjson_val *li
     return true;
 }
 
-static bool build_sector_level_variants(sector_level_runtime *level, char *error_buffer, int error_buffer_size)
+static slayer3d_sector *copy_sectors_without_sector_lighting(const sector_level_runtime *level)
 {
-    if (!slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
-                              level->lights, level->light_count, &level->lightmapped))
+    if (level == NULL || level->sector_count <= 0)
+        return NULL;
+
+    slayer3d_sector *sectors = (slayer3d_sector *)SDL_malloc(sizeof(*sectors) * (size_t)level->sector_count);
+    if (sectors == NULL)
+        return NULL;
+    SDL_memcpy(sectors, level->sectors, sizeof(*sectors) * (size_t)level->sector_count);
+    for (int i = 0; i < level->sector_count; ++i)
     {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' lightmapped build failed: %s", level->name,
-                   SDL_GetError());
+        sectors[i].has_lighting = false;
+        sectors[i].lighting_level = 255.0f;
+        sectors[i].lighting_color[0] = 1.0f;
+        sectors[i].lighting_color[1] = 1.0f;
+        sectors[i].lighting_color[2] = 1.0f;
+        sectors[i].lighting_color[3] = 0.0f;
+    }
+    return sectors;
+}
+
+static bool build_sector_level_variant_set(sector_level_runtime *level, const slayer3d_sector *sectors,
+                                           slayer3d_level *lightmapped, slayer3d_level *vertex_baked,
+                                           slayer3d_level *unlit, const char *label, char *error_buffer,
+                                           int error_buffer_size)
+{
+    if (!slayer3d_build_level(sectors, level->sector_count, level->materials, level->material_count, level->lights,
+                              level->light_count, lightmapped))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' %s lightmapped build failed: %s", level->name,
+                   label, SDL_GetError());
         return false;
     }
-    if (!slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
-                              level->lights, level->light_count, &level->vertex_baked))
+    if (!slayer3d_build_level(sectors, level->sector_count, level->materials, level->material_count, level->lights,
+                              level->light_count, vertex_baked))
     {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' vertex-baked build failed: %s", level->name,
-                   SDL_GetError());
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' %s vertex-baked build failed: %s", level->name,
+                   label, SDL_GetError());
         return false;
     }
-    strip_sector_level_lightmap(&level->vertex_baked);
-    if (!slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, NULL, 0,
-                              &level->unlit))
+    strip_sector_level_lightmap(vertex_baked);
+    if (!slayer3d_build_level(sectors, level->sector_count, level->materials, level->material_count, NULL, 0, unlit))
     {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' unlit build failed: %s", level->name,
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' %s unlit build failed: %s", level->name, label,
                    SDL_GetError());
         return false;
     }
     return true;
+}
+
+static bool build_sector_level_variants(sector_level_runtime *level, char *error_buffer, int error_buffer_size)
+{
+    if (!build_sector_level_variant_set(level, level->sectors, &level->lightmapped, &level->vertex_baked, &level->unlit,
+                                        "sector-lit", error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+
+    slayer3d_sector *unlit_sectors = copy_sectors_without_sector_lighting(level);
+    if (unlit_sectors == NULL && level->sector_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector lighting toggle variants");
+        return false;
+    }
+    const bool ok = build_sector_level_variant_set(
+        level, unlit_sectors != NULL ? unlit_sectors : level->sectors, &level->lightmapped_without_sector_lighting,
+        &level->vertex_baked_without_sector_lighting, &level->unlit_without_sector_lighting, "sector-neutral",
+        error_buffer, error_buffer_size);
+    SDL_free(unlit_sectors);
+    return ok;
 }
 
 static bool set_sector_level_geometry(sector_level_runtime *level, int sector_index,
@@ -3414,6 +3462,44 @@ static bool set_sector_level_geometry(sector_level_runtime *level, int sector_in
                    SDL_GetError());
         return false;
     }
+
+    slayer3d_sector *unlit_sectors = copy_sectors_without_sector_lighting(level);
+    if (unlit_sectors == NULL && level->sector_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate sector lighting toggle geometry update");
+        return false;
+    }
+    slayer3d_sector *neutral_sectors = unlit_sectors != NULL ? unlit_sectors : level->sectors;
+    bool ok = true;
+    if (!slayer3d_level_set_sector_geometry(&level->lightmapped_without_sector_lighting, neutral_sectors,
+                                            level->sector_count, sector_index, geometry, level->materials,
+                                            level->material_count, level->lights, level->light_count))
+    {
+        set_errorf(error_buffer, error_buffer_size,
+                   "sector level '%s' sector-neutral lightmapped geometry update failed: %s", level->name,
+                   SDL_GetError());
+        ok = false;
+    }
+    if (ok && !slayer3d_level_set_sector_geometry(&level->vertex_baked_without_sector_lighting, neutral_sectors,
+                                                  level->sector_count, sector_index, geometry, level->materials,
+                                                  level->material_count, level->lights, level->light_count))
+    {
+        set_errorf(error_buffer, error_buffer_size,
+                   "sector level '%s' sector-neutral vertex-baked geometry update failed: %s", level->name,
+                   SDL_GetError());
+        ok = false;
+    }
+    if (ok &&
+        !slayer3d_level_set_sector_geometry(&level->unlit_without_sector_lighting, neutral_sectors, level->sector_count,
+                                            sector_index, geometry, level->materials, level->material_count, NULL, 0))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' sector-neutral unlit geometry update failed: %s",
+                   level->name, SDL_GetError());
+        ok = false;
+    }
+    SDL_free(unlit_sectors);
+    if (!ok)
+        return false;
     return true;
 }
 
@@ -5800,7 +5886,13 @@ bool slayer3d_game_data_get_world_units(const slayer3d_game_data_runtime *runtim
 int slayer3d_game_data_world_light_count(const slayer3d_game_data_runtime *runtime)
 {
     yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
-    int count = yyjson_is_arr(lights) ? (int)yyjson_arr_size(lights) : 0;
+    int count = 0;
+    for (size_t i = 0; yyjson_is_arr(lights) && i < yyjson_arr_size(lights); ++i)
+    {
+        yyjson_val *light = yyjson_arr_get(lights, i);
+        if (scene_state_bool(runtime, json_string(light, "enabled_key", NULL), json_bool(light, "enabled", true)))
+            count++;
+    }
     yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
     for (size_t i = 0; runtime != NULL && yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
@@ -5812,9 +5904,14 @@ int slayer3d_game_data_world_light_count(const slayer3d_game_data_runtime *runti
         yyjson_val *components = obj_get(entity, "components");
         for (size_t c = 0; yyjson_is_arr(components) && c < yyjson_arr_size(components); ++c)
         {
-            const char *type = json_string(yyjson_arr_get(components, c), "type", "");
-            if (SDL_strncmp(type, "light.", 6) == 0)
+            yyjson_val *component = yyjson_arr_get(components, c);
+            const char *type = json_string(component, "type", "");
+            if (SDL_strncmp(type, "light.", 6) == 0 &&
+                scene_state_bool(runtime, json_string(component, "enabled_key", NULL),
+                                 json_bool(component, "enabled", true)))
+            {
                 count++;
+            }
         }
     }
     for (int pool_index = 0; runtime != NULL && pool_index < runtime->actor_pool_count; ++pool_index)
@@ -5826,9 +5923,14 @@ int slayer3d_game_data_world_light_count(const slayer3d_game_data_runtime *runti
         int light_components = 0;
         for (size_t c = 0; yyjson_is_arr(components) && c < yyjson_arr_size(components); ++c)
         {
-            const char *type = json_string(yyjson_arr_get(components, c), "type", "");
-            if (SDL_strncmp(type, "light.", 6) == 0)
+            yyjson_val *component = yyjson_arr_get(components, c);
+            const char *type = json_string(component, "type", "");
+            if (SDL_strncmp(type, "light.", 6) == 0 &&
+                scene_state_bool(runtime, json_string(component, "enabled_key", NULL),
+                                 json_bool(component, "enabled", true)))
+            {
                 light_components++;
+            }
         }
         if (light_components <= 0)
             continue;
@@ -5927,16 +6029,29 @@ static bool read_light_json(const slayer3d_game_data_runtime *runtime, yyjson_va
     return true;
 }
 
-bool slayer3d_game_data_get_world_light(const slayer3d_game_data_runtime *runtime, int index, slayer3d_light *out_light)
+static bool slayer3d_game_data_get_world_light_internal(const slayer3d_game_data_runtime *runtime, int index,
+                                                        slayer3d_light *out_light, yyjson_val **out_light_json)
 {
     yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
-    const int world_count = yyjson_is_arr(lights) ? (int)yyjson_arr_size(lights) : 0;
+    if (out_light_json != NULL)
+        *out_light_json = NULL;
     if (runtime == NULL || index < 0 || out_light == NULL)
         return false;
-    if (index < world_count)
-        return read_light_json(runtime, yyjson_arr_get(lights, (size_t)index), NULL, out_light);
 
-    int remaining = index - world_count;
+    int remaining = index;
+    for (size_t i = 0; yyjson_is_arr(lights) && i < yyjson_arr_size(lights); ++i)
+    {
+        yyjson_val *light = yyjson_arr_get(lights, i);
+        if (!scene_state_bool(runtime, json_string(light, "enabled_key", NULL), json_bool(light, "enabled", true)))
+            continue;
+        if (remaining-- == 0)
+        {
+            if (out_light_json != NULL)
+                *out_light_json = light;
+            return read_light_json(runtime, light, NULL, out_light);
+        }
+    }
+
     yyjson_val *entities = obj_get(runtime_root(runtime), "entities");
     for (size_t i = 0; yyjson_is_arr(entities) && i < yyjson_arr_size(entities); ++i)
     {
@@ -5952,8 +6067,17 @@ bool slayer3d_game_data_get_world_light(const slayer3d_game_data_runtime *runtim
             const char *type = json_string(component, "type", "");
             if (SDL_strncmp(type, "light.", 6) != 0)
                 continue;
+            if (!scene_state_bool(runtime, json_string(component, "enabled_key", NULL),
+                                  json_bool(component, "enabled", true)))
+            {
+                continue;
+            }
             if (remaining-- == 0)
+            {
+                if (out_light_json != NULL)
+                    *out_light_json = component;
                 return read_light_json(runtime, component, actor, out_light);
+            }
         }
     }
     for (int pool_index = 0; pool_index < runtime->actor_pool_count; ++pool_index)
@@ -5973,12 +6097,26 @@ bool slayer3d_game_data_get_world_light(const slayer3d_game_data_runtime *runtim
                 const char *type = json_string(component, "type", "");
                 if (SDL_strncmp(type, "light.", 6) != 0)
                     continue;
+                if (!scene_state_bool(runtime, json_string(component, "enabled_key", NULL),
+                                      json_bool(component, "enabled", true)))
+                {
+                    continue;
+                }
                 if (remaining-- == 0)
+                {
+                    if (out_light_json != NULL)
+                        *out_light_json = component;
                     return read_light_json(runtime, component, actor, out_light);
+                }
             }
         }
     }
     return false;
+}
+
+bool slayer3d_game_data_get_world_light(const slayer3d_game_data_runtime *runtime, int index, slayer3d_light *out_light)
+{
+    return slayer3d_game_data_get_world_light_internal(runtime, index, out_light, NULL);
 }
 
 static float game_data_clampf(float value, float lo, float hi);
@@ -6088,11 +6226,10 @@ static void apply_light_effects(const slayer3d_game_data_runtime *runtime, yyjso
 bool slayer3d_game_data_get_world_light_evaluated(const slayer3d_game_data_runtime *runtime, int index,
                                                   const slayer3d_game_data_render_eval *eval, slayer3d_light *out_light)
 {
-    if (!slayer3d_game_data_get_world_light(runtime, index, out_light))
+    yyjson_val *light_json = NULL;
+    if (!slayer3d_game_data_get_world_light_internal(runtime, index, out_light, &light_json))
         return false;
 
-    yyjson_val *lights = obj_get(obj_get(runtime_root(runtime), "world"), "lights");
-    yyjson_val *light_json = yyjson_is_arr(lights) ? yyjson_arr_get(lights, (size_t)index) : NULL;
     apply_light_effects(runtime, light_json, eval, out_light);
     return true;
 }
@@ -6242,6 +6379,13 @@ static slayer3d_game_data_mesh_primitive_kind mesh_primitive_kind_from_string(co
     return SLAYER3D_GAME_DATA_MESH_PRIMITIVE_INVALID;
 }
 
+static bool render_component_lighting_enabled(const slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                              bool fallback)
+{
+    return scene_state_bool(runtime, json_string(component, "lighting_key", NULL),
+                            json_bool(component, "lighting", fallback));
+}
+
 static slayer3d_game_data_render_draw_mode render_draw_mode_from_string(const char *name)
 {
     if (name == NULL || SDL_strcmp(name, "solid") == 0)
@@ -6293,6 +6437,11 @@ static const slayer3d_sector *active_scene_sector_for_position(const slayer3d_ga
     for (size_t i = 0; i < yyjson_arr_size(instances); ++i)
     {
         yyjson_val *entry = yyjson_arr_get(instances, i);
+        if (!scene_state_bool(runtime, json_string(entry, "sector_lighting_key", NULL),
+                              json_bool(entry, "sector_lighting", true)))
+        {
+            continue;
+        }
         const sector_level_runtime *level = find_sector_level_runtime(runtime, json_string(entry, "level", NULL));
         if (level == NULL)
             continue;
@@ -6343,7 +6492,7 @@ static bool emit_actor_render_primitives(const slayer3d_game_data_runtime *runti
             primitive.rotation_angle += slayer3d_properties_get_float(actor->props, rotation_property, 0.0f);
         primitive.color = json_color(component, "color", (slayer3d_color){255, 255, 255, 255});
         primitive.texture_image = json_string(component, "texture", NULL);
-        primitive.lighting_enabled = json_bool(component, "lighting", true);
+        primitive.lighting_enabled = render_component_lighting_enabled(runtime, component, true);
         primitive.emissive = json_bool(component, "emissive", false);
         primitive.emissive_color =
             primitive.emissive ? slayer3d_vec3_make(0.2f, 0.2f, 0.2f) : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
@@ -6401,7 +6550,8 @@ static bool emit_actor_render_primitives(const slayer3d_game_data_runtime *runti
                         slayer3d_properties_get_float(actor->props, part_rotation_property, 0.0f);
                 part_primitive.color = json_color(part, "color", part_primitive.color);
                 part_primitive.texture_image = json_string(part, "texture", part_primitive.texture_image);
-                part_primitive.lighting_enabled = json_bool(part, "lighting", part_primitive.lighting_enabled);
+                part_primitive.lighting_enabled =
+                    render_component_lighting_enabled(runtime, part, part_primitive.lighting_enabled);
                 part_primitive.emissive = json_bool(part, "emissive", part_primitive.emissive);
                 part_primitive.emissive_color =
                     part_primitive.emissive ? slayer3d_vec3_make(0.2f, 0.2f, 0.2f) : part_primitive.emissive_color;
@@ -6549,7 +6699,7 @@ static bool emit_sector_door_render_primitives(const slayer3d_game_data_runtime 
                                                 SDL_max(bounds.max.z - bounds.min.z, 0.001f));
             primitive.color = json_color(render, "color", (slayer3d_color){170, 185, 205, 255});
             primitive.texture_image = json_string(render, "texture", NULL);
-            primitive.lighting_enabled = json_bool(render, "lighting", true);
+            primitive.lighting_enabled = render_component_lighting_enabled(runtime, render, true);
             primitive.emissive = json_bool(render, "emissive", false);
             primitive.emissive_color =
                 primitive.emissive ? json_vec3(render, "emissive_color", slayer3d_vec3_make(0.12f, 0.15f, 0.18f))
@@ -6955,49 +7105,64 @@ static bool rebuild_sector_level_variants_atomic(sector_level_runtime *level, ch
     slayer3d_level lightmapped;
     slayer3d_level vertex_baked;
     slayer3d_level unlit;
+    slayer3d_level lightmapped_without_sector_lighting;
+    slayer3d_level vertex_baked_without_sector_lighting;
+    slayer3d_level unlit_without_sector_lighting;
     SDL_zero(lightmapped);
     SDL_zero(vertex_baked);
     SDL_zero(unlit);
+    SDL_zero(lightmapped_without_sector_lighting);
+    SDL_zero(vertex_baked_without_sector_lighting);
+    SDL_zero(unlit_without_sector_lighting);
 
     bool ok = true;
-    if (!slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
-                              level->lights, level->light_count, &lightmapped))
+    if (!build_sector_level_variant_set(level, level->sectors, &lightmapped, &vertex_baked, &unlit, "sector-lit",
+                                        error_buffer, error_buffer_size))
     {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' lightmapped rebuild failed: %s", level->name,
-                   SDL_GetError());
         ok = false;
     }
-    if (ok && !slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
-                                    level->lights, level->light_count, &vertex_baked))
-    {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' vertex-baked rebuild failed: %s", level->name,
-                   SDL_GetError());
-        ok = false;
-    }
+    slayer3d_sector *unlit_sectors = NULL;
     if (ok)
-        strip_sector_level_lightmap(&vertex_baked);
-    if (ok && !slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, NULL,
-                                    0, &unlit))
     {
-        set_errorf(error_buffer, error_buffer_size, "sector level '%s' unlit rebuild failed: %s", level->name,
-                   SDL_GetError());
+        unlit_sectors = copy_sectors_without_sector_lighting(level);
+        if (unlit_sectors == NULL && level->sector_count > 0)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate sector lighting toggle rebuild variants");
+            ok = false;
+        }
+    }
+    if (ok && !build_sector_level_variant_set(level, unlit_sectors != NULL ? unlit_sectors : level->sectors,
+                                              &lightmapped_without_sector_lighting,
+                                              &vertex_baked_without_sector_lighting, &unlit_without_sector_lighting,
+                                              "sector-neutral", error_buffer, error_buffer_size))
+    {
         ok = false;
     }
+    SDL_free(unlit_sectors);
 
     if (!ok)
     {
         slayer3d_free_level(&lightmapped);
         slayer3d_free_level(&vertex_baked);
         slayer3d_free_level(&unlit);
+        slayer3d_free_level(&lightmapped_without_sector_lighting);
+        slayer3d_free_level(&vertex_baked_without_sector_lighting);
+        slayer3d_free_level(&unlit_without_sector_lighting);
         return false;
     }
 
     slayer3d_free_level(&level->lightmapped);
     slayer3d_free_level(&level->vertex_baked);
     slayer3d_free_level(&level->unlit);
+    slayer3d_free_level(&level->lightmapped_without_sector_lighting);
+    slayer3d_free_level(&level->vertex_baked_without_sector_lighting);
+    slayer3d_free_level(&level->unlit_without_sector_lighting);
     level->lightmapped = lightmapped;
     level->vertex_baked = vertex_baked;
     level->unlit = unlit;
+    level->lightmapped_without_sector_lighting = lightmapped_without_sector_lighting;
+    level->vertex_baked_without_sector_lighting = vertex_baked_without_sector_lighting;
+    level->unlit_without_sector_lighting = unlit_without_sector_lighting;
     return true;
 }
 
@@ -7394,7 +7559,8 @@ bool slayer3d_game_data_get_sector_level(const slayer3d_game_data_runtime *runti
 
 static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
                                                                                 const slayer3d_level **out_level,
-                                                                                const sector_level_runtime *level)
+                                                                                const sector_level_runtime *level,
+                                                                                bool sector_lighting_enabled)
 {
     if (out_level != NULL)
         *out_level = NULL;
@@ -7405,19 +7571,19 @@ static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(
     if (SDL_strcmp(name, "lightmapped") == 0)
     {
         if (out_level != NULL)
-            *out_level = &level->lightmapped;
+            *out_level = sector_lighting_enabled ? &level->lightmapped : &level->lightmapped_without_sector_lighting;
         return SLAYER3D_GAME_DATA_SECTOR_LEVEL_LIGHTMAPPED;
     }
     if (SDL_strcmp(name, "vertex_baked") == 0)
     {
         if (out_level != NULL)
-            *out_level = &level->vertex_baked;
+            *out_level = sector_lighting_enabled ? &level->vertex_baked : &level->vertex_baked_without_sector_lighting;
         return SLAYER3D_GAME_DATA_SECTOR_LEVEL_VERTEX_BAKED;
     }
     if (SDL_strcmp(name, "unlit") == 0)
     {
         if (out_level != NULL)
-            *out_level = &level->unlit;
+            *out_level = sector_lighting_enabled ? &level->unlit : &level->unlit_without_sector_lighting;
         return SLAYER3D_GAME_DATA_SECTOR_LEVEL_UNLIT;
     }
     return 0;
@@ -7444,9 +7610,11 @@ bool slayer3d_game_data_for_each_sector_level_instance(const slayer3d_game_data_
         const char *variant_name = scene_state_string(runtime, json_string(entry, "variant_key", NULL),
                                                       json_string(entry, "variant", "lightmapped"));
         const sector_level_runtime *level_runtime = find_sector_level_runtime(runtime, level_name);
+        const bool sector_lighting_enabled = scene_state_bool(runtime, json_string(entry, "sector_lighting_key", NULL),
+                                                              json_bool(entry, "sector_lighting", true));
         const slayer3d_level *level = NULL;
         const slayer3d_game_data_sector_level_variant variant =
-            sector_level_variant_from_string(variant_name, &level, level_runtime);
+            sector_level_variant_from_string(variant_name, &level, level_runtime, sector_lighting_enabled);
         if (level_runtime == NULL || level == NULL || variant == 0)
             return false;
 
@@ -7461,6 +7629,7 @@ bool slayer3d_game_data_for_each_sector_level_instance(const slayer3d_game_data_
         instance.position = json_vec3(entry, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
         instance.portal_culling = scene_state_bool(runtime, json_string(entry, "portal_culling_key", NULL),
                                                    json_bool(entry, "portal_culling", true));
+        instance.sector_lighting_enabled = sector_lighting_enabled;
         if (!callback(userdata, &instance))
             return true;
     }
@@ -22571,6 +22740,9 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
         slayer3d_free_level(&runtime->sector_levels[i].lightmapped);
         slayer3d_free_level(&runtime->sector_levels[i].vertex_baked);
         slayer3d_free_level(&runtime->sector_levels[i].unlit);
+        slayer3d_free_level(&runtime->sector_levels[i].lightmapped_without_sector_lighting);
+        slayer3d_free_level(&runtime->sector_levels[i].vertex_baked_without_sector_lighting);
+        slayer3d_free_level(&runtime->sector_levels[i].unlit_without_sector_lighting);
     }
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -669,7 +669,10 @@ static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjso
                                 const slayer3d_game_data_ui_metrics *metrics);
 static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
 static sector_level_runtime *find_sector_level_runtime_mutable(slayer3d_game_data_runtime *runtime, const char *name);
+static const sector_level_runtime *find_sector_level_runtime(const slayer3d_game_data_runtime *runtime,
+                                                             const char *name);
 static int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name);
+static void modulate_color_by_sector_lighting(slayer3d_color *color, const slayer3d_sector *sector);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
 
@@ -3298,6 +3301,23 @@ static bool load_sector_level_sectors(sector_level_runtime *level, yyjson_val *m
         sector->ambient_sound_id = json_int(sector_json, "ambient_sound_id", 0);
         json_float_array(obj_get(sector_json, "push_velocity"), sector->push_velocity, 3, NULL);
         sector->damage_per_second = json_float(sector_json, "damage_per_second", 0.0f);
+        yyjson_val *lighting = obj_get(sector_json, "lighting");
+        if (yyjson_is_obj(lighting))
+        {
+            static const float default_lighting_color[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+            yyjson_val *color = obj_get(lighting, "color");
+            sector->has_lighting = true;
+            sector->lighting_level = json_float(lighting, "level", 255.0f);
+            if (yyjson_is_arr(color) && yyjson_arr_size(color) == 3U &&
+                json_float_array(color, sector->lighting_color, 3, default_lighting_color))
+            {
+                sector->lighting_color[3] = 1.0f;
+            }
+            else
+            {
+                json_float_array(color, sector->lighting_color, 4, default_lighting_color);
+            }
+        }
     }
     return true;
 }
@@ -6262,6 +6282,40 @@ static void populate_mesh_primitive_descriptor(const slayer3d_registered_actor *
         primitive->radius_top = json_float(component, "radius_top", 0.0f);
 }
 
+static const slayer3d_sector *active_scene_sector_for_position(const slayer3d_game_data_runtime *runtime,
+                                                               slayer3d_vec3 position)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *instances = obj_get(obj_get(scene != NULL ? scene->root : NULL, "world"), "sector_levels");
+    if (!yyjson_is_arr(instances))
+        return NULL;
+
+    for (size_t i = 0; i < yyjson_arr_size(instances); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(instances, i);
+        const sector_level_runtime *level = find_sector_level_runtime(runtime, json_string(entry, "level", NULL));
+        if (level == NULL)
+            continue;
+        const slayer3d_vec3 origin = json_vec3(entry, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        const slayer3d_vec3 local =
+            slayer3d_vec3_make(position.x - origin.x, position.y - origin.y, position.z - origin.z);
+        const int sector_index =
+            slayer3d_level_find_sector_at(&level->lightmapped, level->sectors, local.x, local.z, local.y);
+        if (sector_index >= 0 && sector_index < level->sector_count && level->sectors[sector_index].has_lighting)
+            return &level->sectors[sector_index];
+    }
+    return NULL;
+}
+
+static void apply_sector_lighting_to_render_primitive(const slayer3d_game_data_runtime *runtime,
+                                                      slayer3d_game_data_render_primitive *primitive)
+{
+    if (runtime == NULL || primitive == NULL || !primitive->lighting_enabled || primitive->instances != NULL)
+        return;
+    modulate_color_by_sector_lighting(&primitive->color,
+                                      active_scene_sector_for_position(runtime, primitive->position));
+}
+
 static bool emit_actor_render_primitives(const slayer3d_game_data_runtime *runtime,
                                          const slayer3d_game_data_render_eval *eval,
                                          const slayer3d_registered_actor *actor, yyjson_val *components,
@@ -6358,6 +6412,7 @@ static bool emit_actor_render_primitives(const slayer3d_game_data_runtime *runti
                     apply_render_effects(runtime, component, eval, &part_primitive);
                     apply_render_effects(runtime, part, eval, &part_primitive);
                 }
+                apply_sector_lighting_to_render_primitive(runtime, &part_primitive);
                 if (!callback(userdata, &part_primitive))
                     return false;
             }
@@ -6394,6 +6449,7 @@ static bool emit_actor_render_primitives(const slayer3d_game_data_runtime *runti
 
         if (eval != NULL)
             apply_render_effects(runtime, component, eval, &primitive);
+        apply_sector_lighting_to_render_primitive(runtime, &primitive);
         if (!callback(userdata, &primitive))
             return false;
     }
@@ -6500,6 +6556,7 @@ static bool emit_sector_door_render_primitives(const slayer3d_game_data_runtime 
                                    : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
             if (eval != NULL)
                 apply_render_effects(runtime, render, eval, &primitive);
+            apply_sector_lighting_to_render_primitive(runtime, &primitive);
             if (!callback(userdata, &primitive))
                 return false;
         }
@@ -6825,6 +6882,206 @@ static int sector_level_find_sector_name(const sector_level_runtime *level, cons
             return i;
     }
     return -1;
+}
+
+static int sector_level_resolve_sector_index(const sector_level_runtime *level, const char *sector)
+{
+    if (level == NULL || sector == NULL || sector[0] == '\0')
+        return -1;
+    const int named_index = sector_level_find_sector_name(level, sector);
+    if (named_index >= 0)
+        return named_index;
+
+    char *end = NULL;
+    const long parsed = SDL_strtol(sector, &end, 10);
+    if (end != NULL && *end == '\0' && parsed >= 0 && parsed < level->sector_count)
+        return (int)parsed;
+    return -1;
+}
+
+static float clamp01(float value)
+{
+    if (value <= 0.0f)
+        return 0.0f;
+    if (value >= 1.0f)
+        return 1.0f;
+    return value;
+}
+
+static void sector_lighting_rgb(const slayer3d_sector *sector, float out_rgb[3])
+{
+    if (out_rgb == NULL)
+        return;
+    out_rgb[0] = 1.0f;
+    out_rgb[1] = 1.0f;
+    out_rgb[2] = 1.0f;
+    if (sector == NULL || !sector->has_lighting)
+        return;
+
+    const float level = SDL_clamp(sector->lighting_level, 0.0f, 255.0f) / 255.0f;
+    const float influence = clamp01(sector->lighting_color[3]);
+    for (int i = 0; i < 3; ++i)
+    {
+        const float tint = 1.0f + (clamp01(sector->lighting_color[i]) - 1.0f) * influence;
+        out_rgb[i] = level * tint;
+    }
+}
+
+static Uint8 color_channel_from_float(float value)
+{
+    value = SDL_clamp(value, 0.0f, 255.0f);
+    return (Uint8)(value + 0.5f);
+}
+
+static void modulate_color_by_sector_lighting(slayer3d_color *color, const slayer3d_sector *sector)
+{
+    if (color == NULL || sector == NULL || !sector->has_lighting)
+        return;
+    float lighting[3];
+    sector_lighting_rgb(sector, lighting);
+    color->r = color_channel_from_float((float)color->r * lighting[0]);
+    color->g = color_channel_from_float((float)color->g * lighting[1]);
+    color->b = color_channel_from_float((float)color->b * lighting[2]);
+}
+
+static bool rebuild_sector_level_variants_atomic(sector_level_runtime *level, char *error_buffer, int error_buffer_size)
+{
+    if (level == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "sector level is invalid");
+        return false;
+    }
+
+    slayer3d_level lightmapped;
+    slayer3d_level vertex_baked;
+    slayer3d_level unlit;
+    SDL_zero(lightmapped);
+    SDL_zero(vertex_baked);
+    SDL_zero(unlit);
+
+    bool ok = true;
+    if (!slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
+                              level->lights, level->light_count, &lightmapped))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' lightmapped rebuild failed: %s", level->name,
+                   SDL_GetError());
+        ok = false;
+    }
+    if (ok && !slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count,
+                                    level->lights, level->light_count, &vertex_baked))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' vertex-baked rebuild failed: %s", level->name,
+                   SDL_GetError());
+        ok = false;
+    }
+    if (ok)
+        strip_sector_level_lightmap(&vertex_baked);
+    if (ok && !slayer3d_build_level(level->sectors, level->sector_count, level->materials, level->material_count, NULL,
+                                    0, &unlit))
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' unlit rebuild failed: %s", level->name,
+                   SDL_GetError());
+        ok = false;
+    }
+
+    if (!ok)
+    {
+        slayer3d_free_level(&lightmapped);
+        slayer3d_free_level(&vertex_baked);
+        slayer3d_free_level(&unlit);
+        return false;
+    }
+
+    slayer3d_free_level(&level->lightmapped);
+    slayer3d_free_level(&level->vertex_baked);
+    slayer3d_free_level(&level->unlit);
+    level->lightmapped = lightmapped;
+    level->vertex_baked = vertex_baked;
+    level->unlit = unlit;
+    return true;
+}
+
+bool slayer3d_game_data_get_sector_lighting(const slayer3d_game_data_runtime *runtime, const char *sector_level,
+                                            const char *sector, float *out_level, float out_color[4],
+                                            char *error_buffer, int error_buffer_size)
+{
+    if (out_level != NULL)
+        *out_level = 0.0f;
+    if (out_color != NULL)
+        SDL_memset(out_color, 0, sizeof(float) * 4U);
+    const sector_level_runtime *level = find_sector_level_runtime(runtime, sector_level);
+    const int sector_index = sector_level_resolve_sector_index(level, sector);
+    if (level == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' not found",
+                   sector_level != NULL ? sector_level : "<null>");
+        return false;
+    }
+    if (sector_index < 0)
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector '%s' not found", sector != NULL ? sector : "<null>");
+        return false;
+    }
+
+    const slayer3d_sector *resolved = &level->sectors[sector_index];
+    if (!resolved->has_lighting)
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector '%s' has no authored lighting", sector);
+        return false;
+    }
+    if (out_level == NULL || out_color == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "sector lighting output pointers are required");
+        return false;
+    }
+    *out_level = resolved->lighting_level;
+    SDL_memcpy(out_color, resolved->lighting_color, sizeof(resolved->lighting_color));
+    return true;
+}
+
+bool slayer3d_game_data_set_sector_lighting(slayer3d_game_data_runtime *runtime, const char *sector_level,
+                                            const char *sector, float level, const float color[4], char *error_buffer,
+                                            int error_buffer_size)
+{
+    sector_level_runtime *resolved_level = find_sector_level_runtime_mutable(runtime, sector_level);
+    const int sector_index = sector_level_resolve_sector_index(resolved_level, sector);
+    if (resolved_level == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector level '%s' not found",
+                   sector_level != NULL ? sector_level : "<null>");
+        return false;
+    }
+    if (sector_index < 0)
+    {
+        set_errorf(error_buffer, error_buffer_size, "sector '%s' not found", sector != NULL ? sector : "<null>");
+        return false;
+    }
+    if (color == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "sector lighting color is required");
+        return false;
+    }
+
+    slayer3d_sector *target = &resolved_level->sectors[sector_index];
+    const bool old_has_lighting = target->has_lighting;
+    const float old_level = target->lighting_level;
+    float old_color[4];
+    SDL_memcpy(old_color, target->lighting_color, sizeof(old_color));
+
+    target->has_lighting = true;
+    target->lighting_level = SDL_clamp(level, 0.0f, 255.0f);
+    for (int i = 0; i < 4; ++i)
+        target->lighting_color[i] = clamp01(color[i]);
+
+    if (!rebuild_sector_level_variants_atomic(resolved_level, error_buffer, error_buffer_size))
+    {
+        target->has_lighting = old_has_lighting;
+        target->lighting_level = old_level;
+        SDL_memcpy(target->lighting_color, old_color, sizeof(target->lighting_color));
+        (void)rebuild_sector_level_variants_atomic(resolved_level, NULL, 0);
+        return false;
+    }
+    return true;
 }
 
 static yyjson_val *find_sector_navigation_graph(const slayer3d_game_data_runtime *runtime, const char *graph_name)
@@ -16948,6 +17205,36 @@ static bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *
         return execute_sector_door_state_action(runtime, action, payload, "toggle");
     if (SDL_strcmp(type, "sector_door.interact") == 0)
         return execute_sector_door_interact_action(runtime, action);
+    if (SDL_strcmp(type, "sector_lighting.set") == 0)
+    {
+        float color[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+        yyjson_val *color_json = obj_get(action, "color");
+        if (yyjson_is_arr(color_json) && yyjson_arr_size(color_json) == 3U)
+        {
+            (void)json_float_array(color_json, color, 3, color);
+            color[3] = 1.0f;
+        }
+        else
+        {
+            (void)json_float_array(color_json, color, 4, color);
+        }
+        char error[256] = {0};
+        char sector_index_text[32];
+        const char *sector = json_string(action, "sector", NULL);
+        yyjson_val *sector_index_value = obj_get(action, "sector_index");
+        if (sector == NULL && yyjson_is_int(sector_index_value))
+        {
+            SDL_snprintf(sector_index_text, sizeof(sector_index_text), "%d", (int)yyjson_get_int(sector_index_value));
+            sector = sector_index_text;
+        }
+        const bool ok = slayer3d_game_data_set_sector_lighting(runtime, json_string(action, "sector_level", NULL),
+                                                               sector, json_float(action, "level", 255.0f), color,
+                                                               error, (int)sizeof(error));
+        if (!ok)
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "sector_lighting.set failed: %s",
+                        error[0] != '\0' ? error : "unknown error");
+        return ok;
+    }
 
     if (SDL_strcmp(type, "transform.set_position") == 0)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2916,6 +2916,12 @@ static bool validate_render_mesh_primitive_component(validation_context *ctx, yy
     yyjson_val *wire_color = obj_get(component, "wire_color");
     if (wire_color != NULL && !is_vec_array(wire_color, 3))
         return validation_error(ctx, path, "render.mesh_primitive wire_color must be a vec3 or vec4");
+    yyjson_val *lighting = obj_get(component, "lighting");
+    if (lighting != NULL && !yyjson_is_bool(lighting))
+        return validation_error(ctx, path, "render.mesh_primitive lighting must be a boolean");
+    yyjson_val *lighting_key = obj_get(component, "lighting_key");
+    if (lighting_key != NULL && !is_non_empty_string(component, "lighting_key"))
+        return validation_error(ctx, path, "render.mesh_primitive lighting_key must be non-empty");
     yyjson_val *size = obj_get(component, "size");
     if (size != NULL && !is_vec_array(size, 3))
         return validation_error(ctx, path, "render.mesh_primitive size must be a vec3");
@@ -5160,6 +5166,12 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 yyjson_val *color = obj_get(component, "color");
                 if (color != NULL && !is_vec_array(color, 3))
                     return validation_error(ctx, path, "light component color must be a vec3");
+                yyjson_val *enabled = obj_get(component, "enabled");
+                if (enabled != NULL && !yyjson_is_bool(enabled))
+                    return validation_error(ctx, path, "light component enabled must be a boolean");
+                yyjson_val *enabled_key = obj_get(component, "enabled_key");
+                if (enabled_key != NULL && !is_non_empty_string(component, "enabled_key"))
+                    return validation_error(ctx, path, "light component enabled_key must be non-empty");
             }
             else if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
                      SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.composite") == 0 ||
@@ -5168,6 +5180,9 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 yyjson_val *lighting = obj_get(component, "lighting");
                 if (lighting != NULL && !yyjson_is_bool(lighting))
                     return validation_error(ctx, path, "render primitive lighting must be a boolean");
+                yyjson_val *lighting_key = obj_get(component, "lighting_key");
+                if (lighting_key != NULL && !is_non_empty_string(component, "lighting_key"))
+                    return validation_error(ctx, path, "render primitive lighting_key must be non-empty");
                 if (SDL_strcmp(type, "render.cube") == 0 || SDL_strcmp(type, "render.sphere") == 0 ||
                     SDL_strcmp(type, "render.mesh_primitive") == 0 || SDL_strcmp(type, "render.composite") == 0)
                 {
@@ -5617,8 +5632,26 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
                                             "lifecycle.ttl property names and reason must be non-empty strings");
                 }
             }
+            else if (SDL_strncmp(type, "light.", 6) == 0)
+            {
+                yyjson_val *color = obj_get(component, "color");
+                if (color != NULL && !is_vec_array(color, 3))
+                    return validation_error(ctx, component_path, "light component color must be a vec3");
+                yyjson_val *enabled = obj_get(component, "enabled");
+                if (enabled != NULL && !yyjson_is_bool(enabled))
+                    return validation_error(ctx, component_path, "light component enabled must be a boolean");
+                yyjson_val *enabled_key = obj_get(component, "enabled_key");
+                if (enabled_key != NULL && !is_non_empty_string(component, "enabled_key"))
+                    return validation_error(ctx, component_path, "light component enabled_key must be non-empty");
+            }
             else if (SDL_strcmp(type, "render.cube") == 0)
             {
+                yyjson_val *lighting = obj_get(component, "lighting");
+                if (lighting != NULL && !yyjson_is_bool(lighting))
+                    return validation_error(ctx, component_path, "render primitive lighting must be a boolean");
+                yyjson_val *lighting_key = obj_get(component, "lighting_key");
+                if (lighting_key != NULL && !is_non_empty_string(component, "lighting_key"))
+                    return validation_error(ctx, component_path, "render primitive lighting_key must be non-empty");
                 yyjson_val *size = obj_get(component, "size");
                 if (size != NULL && !is_vec_array(size, 3))
                     return validation_error(ctx, component_path, "render.cube size must be a vec3");
@@ -8577,6 +8610,12 @@ static bool validate_lights(validation_context *ctx, yyjson_val *root, validatio
         char path[PATH_BUFFER_SIZE];
         format_path(path, sizeof(path), "$.world.lights[%zu]", i);
         yyjson_val *light = yyjson_arr_get(lights, i);
+        yyjson_val *enabled = obj_get(light, "enabled");
+        if (enabled != NULL && !yyjson_is_bool(enabled))
+            return validation_error(ctx, path, "light enabled must be a boolean");
+        yyjson_val *enabled_key = obj_get(light, "enabled_key");
+        if (enabled_key != NULL && !is_non_empty_string(light, "enabled_key"))
+            return validation_error(ctx, path, "light enabled_key must be non-empty");
         const char *target_entity = json_string(light, "target_entity");
         if (target_entity != NULL && !require_ref(ctx, &names->entities, "entity", target_entity, path))
             return false;
@@ -9058,6 +9097,12 @@ static bool validate_scene_sector_levels(validation_context *ctx, yyjson_val *sc
         yyjson_val *portal_culling_key = obj_get(entry, "portal_culling_key");
         if (portal_culling_key != NULL && !is_non_empty_string(entry, "portal_culling_key"))
             return validation_error(ctx, entry_path, "scene sector level portal_culling_key must be non-empty");
+        yyjson_val *sector_lighting = obj_get(entry, "sector_lighting");
+        if (sector_lighting != NULL && !yyjson_is_bool(sector_lighting))
+            return validation_error(ctx, entry_path, "scene sector level sector_lighting must be a boolean");
+        yyjson_val *sector_lighting_key = obj_get(entry, "sector_lighting_key");
+        if (sector_lighting_key != NULL && !is_non_empty_string(entry, "sector_lighting_key"))
+            return validation_error(ctx, entry_path, "scene sector level sector_lighting_key must be non-empty");
     }
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2806,6 +2806,24 @@ static bool is_exact_vec_array(yyjson_val *value, size_t count)
     return yyjson_is_arr(value) && yyjson_arr_size(value) == count && is_vec_array(value, count);
 }
 
+static bool is_exact_vec3_or_vec4_array(yyjson_val *value)
+{
+    return is_exact_vec_array(value, 3) || is_exact_vec_array(value, 4);
+}
+
+static bool numeric_array_values_in_range(yyjson_val *value, double min_value, double max_value)
+{
+    if (!yyjson_is_arr(value))
+        return false;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (!yyjson_is_num(entry) || yyjson_get_num(entry) < min_value || yyjson_get_num(entry) > max_value)
+            return false;
+    }
+    return true;
+}
+
 static bool is_wave_axis_value(yyjson_val *value)
 {
     if (value == NULL || yyjson_is_num(value))
@@ -4776,6 +4794,30 @@ static bool validate_sector_levels(validation_context *ctx, yyjson_val *root)
             {
                 ok = validation_error(ctx, sector_path, "sector damage_per_second must be non-negative");
                 break;
+            }
+            yyjson_val *lighting = obj_get(sector, "lighting");
+            if (lighting != NULL)
+            {
+                if (!yyjson_is_obj(lighting))
+                {
+                    ok = validation_error(ctx, sector_path, "sector lighting must be an object");
+                    break;
+                }
+                yyjson_val *lighting_level = obj_get(lighting, "level");
+                if (lighting_level != NULL && (!yyjson_is_int(lighting_level) || yyjson_get_int(lighting_level) < 0 ||
+                                               yyjson_get_int(lighting_level) > 255))
+                {
+                    ok = validation_error(ctx, sector_path, "sector lighting level must be an integer in [0, 255]");
+                    break;
+                }
+                yyjson_val *color = obj_get(lighting, "color");
+                if (color != NULL &&
+                    (!is_exact_vec3_or_vec4_array(color) || !numeric_array_values_in_range(color, 0.0, 1.0)))
+                {
+                    ok = validation_error(ctx, sector_path,
+                                          "sector lighting color must be a vec3 or vec4 with values in [0, 1]");
+                    break;
+                }
             }
         }
 
@@ -7049,6 +7091,31 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (actions != NULL)
             return validate_action_array(ctx, actions, json_path, names);
         return require_ref(ctx, &names->signals, "signal", signal, json_path);
+    }
+    if (SDL_strcmp(type, "sector_lighting.set") == 0)
+    {
+        const char *sector_level = json_string(action, "sector_level");
+        const char *sector = json_string(action, "sector");
+        yyjson_val *sector_index = obj_get(action, "sector_index");
+        if (!require_ref(ctx, &names->sector_levels, "sector level", sector_level, json_path))
+            return false;
+        if ((sector == NULL && sector_index == NULL) || (sector != NULL && sector_index != NULL))
+            return validation_error(ctx, json_path,
+                                    "sector_lighting.set requires exactly one of sector or sector_index");
+        if (sector != NULL && sector[0] == '\0')
+            return validation_error(ctx, json_path, "sector_lighting.set sector must be non-empty");
+        if (sector_index != NULL && (!yyjson_is_int(sector_index) || yyjson_get_int(sector_index) < 0))
+            return validation_error(ctx, json_path, "sector_lighting.set sector_index must be non-negative");
+        yyjson_val *level = obj_get(action, "level");
+        if (level != NULL && (!yyjson_is_num(level) || yyjson_get_num(level) < 0.0 || yyjson_get_num(level) > 255.0))
+            return validation_error(ctx, json_path, "sector_lighting.set level must be in [0, 255]");
+        yyjson_val *color = obj_get(action, "color");
+        if (color != NULL && (!is_exact_vec3_or_vec4_array(color) || !numeric_array_values_in_range(color, 0.0, 1.0)))
+        {
+            return validation_error(ctx, json_path,
+                                    "sector_lighting.set color must be a vec3 or vec4 with values in [0, 1]");
+        }
+        return true;
     }
     if (SDL_strcmp(type, "projectile.fire") == 0)
     {

--- a/src/level.c
+++ b/src/level.c
@@ -198,6 +198,7 @@ typedef enum
 typedef struct
 {
     int acc_index;
+    int sector_index;
     int first_vertex;
     int vertex_count;
     lm_surface_type type;
@@ -385,8 +386,9 @@ static float max4(float a, float b, float c, float d)
     return value > d ? value : d;
 }
 
-static bool lm_record_wall_surface(lm_surface_list *list, int acc_index, const macc *acc, int first_vertex, float x0,
-                                   float z0, float x1, float z1, float bot0, float top0, float bot1, float top1)
+static bool lm_record_wall_surface(lm_surface_list *list, int acc_index, int sector_index, const macc *acc,
+                                   int first_vertex, float x0, float z0, float x1, float z1, float bot0, float top0,
+                                   float bot1, float top1)
 {
     float dx = x1 - x0;
     float dz = z1 - z0;
@@ -402,6 +404,7 @@ static bool lm_record_wall_surface(lm_surface_list *list, int acc_index, const m
 
     SDL_zero(surface);
     surface.acc_index = acc_index;
+    surface.sector_index = sector_index;
     surface.first_vertex = first_vertex;
     surface.vertex_count = acc->vc - first_vertex;
     surface.type = LM_SURFACE_WALL;
@@ -427,8 +430,8 @@ static bool lm_record_wall_surface(lm_surface_list *list, int acc_index, const m
     return lm_surface_list_append(list, &surface);
 }
 
-static bool lm_record_floor_ceil_surface(lm_surface_list *list, int acc_index, const macc *acc, int first_vertex,
-                                         const slayer3d_sector *sector, bool floor_surface)
+static bool lm_record_floor_ceil_surface(lm_surface_list *list, int acc_index, int sector_index, const macc *acc,
+                                         int first_vertex, const slayer3d_sector *sector, bool floor_surface)
 {
     lm_surface surface;
     slayer3d_vec3 normal = floor_surface ? slayer3d_sector_floor_normal(sector) : slayer3d_sector_ceil_normal(sector);
@@ -442,6 +445,7 @@ static bool lm_record_floor_ceil_surface(lm_surface_list *list, int acc_index, c
 
     SDL_zero(surface);
     surface.acc_index = acc_index;
+    surface.sector_index = sector_index;
     surface.first_vertex = first_vertex;
     surface.vertex_count = acc->vc - first_vertex;
     surface.type = floor_surface ? LM_SURFACE_FLOOR : LM_SURFACE_CEILING;
@@ -579,6 +583,70 @@ static Uint8 lm_channel_clamp(float value)
     return (Uint8)(value + 0.5f);
 }
 
+static float clamp01(float value)
+{
+    if (value <= 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value >= 1.0f)
+    {
+        return 1.0f;
+    }
+    return value;
+}
+
+static void sector_lighting_rgb(const slayer3d_sector *sector, float out_rgb[3])
+{
+    if (out_rgb == NULL)
+    {
+        return;
+    }
+    out_rgb[0] = 1.0f;
+    out_rgb[1] = 1.0f;
+    out_rgb[2] = 1.0f;
+    if (sector == NULL || !sector->has_lighting)
+    {
+        return;
+    }
+
+    const float level = SDL_clamp(sector->lighting_level, 0.0f, 255.0f) / 255.0f;
+    const float influence = clamp01(sector->lighting_color[3]);
+    for (int i = 0; i < 3; ++i)
+    {
+        const float tint = 1.0f + (clamp01(sector->lighting_color[i]) - 1.0f) * influence;
+        out_rgb[i] = level * tint;
+    }
+}
+
+static void sector_modulate_rgba(const slayer3d_sector *sector, const float *rgba, float out_rgba[4])
+{
+    float lighting[3];
+    if (out_rgba == NULL)
+    {
+        return;
+    }
+    if (rgba == NULL)
+    {
+        out_rgba[0] = 1.0f;
+        out_rgba[1] = 1.0f;
+        out_rgba[2] = 1.0f;
+        out_rgba[3] = 1.0f;
+    }
+    else
+    {
+        SDL_memcpy(out_rgba, rgba, sizeof(float) * 4U);
+    }
+    if (sector == NULL || !sector->has_lighting)
+    {
+        return;
+    }
+    sector_lighting_rgb(sector, lighting);
+    out_rgba[0] *= lighting[0];
+    out_rgba[1] *= lighting[1];
+    out_rgba[2] *= lighting[2];
+}
+
 static bool lm_build_texture(slayer3d_level *out)
 {
     slayer3d_image image;
@@ -621,8 +689,8 @@ static bool lm_build_texture(slayer3d_level *out)
     return true;
 }
 
-static bool lm_bake_lightmap(const lm_surface_list *list, const slayer3d_level_light *lights, int light_count,
-                             slayer3d_level *out)
+static bool lm_bake_lightmap(const lm_surface_list *list, const slayer3d_sector *sectors,
+                             const slayer3d_level_light *lights, int light_count, slayer3d_level *out)
 {
     const int atlas_w = out->lightmap_width;
     const int atlas_h = out->lightmap_height;
@@ -653,13 +721,24 @@ static bool lm_bake_lightmap(const lm_surface_list *list, const slayer3d_level_l
         {
             for (int x = 0; x < surface->atlas_w; ++x)
             {
+                float sector_light[3] = {0.2f, 0.2f, 0.2f};
+                const slayer3d_sector *sector =
+                    sectors != NULL && surface->sector_index >= 0 ? &sectors[surface->sector_index] : NULL;
                 float s = surface->atlas_w > 1 ? (float)x / (float)(surface->atlas_w - 1) : 0.0f;
                 float t = surface->atlas_h > 1 ? (float)y / (float)(surface->atlas_h - 1) : 0.0f;
                 float wx, wy, wz;
-                float lr = 51.0f;
-                float lg = 51.0f;
-                float lb = 51.0f;
+                float lr;
+                float lg;
+                float lb;
                 int atlas_index;
+
+                if (sector != NULL && sector->has_lighting)
+                {
+                    sector_lighting_rgb(sector, sector_light);
+                }
+                lr = sector_light[0] * 255.0f;
+                lg = sector_light[1] * 255.0f;
+                lb = sector_light[2] * 255.0f;
 
                 if (surface->type == LM_SURFACE_WALL)
                 {
@@ -786,13 +865,16 @@ static bool add_floor_ceil(macc *a, const slayer3d_sector *s, bool floor_surface
     return true;
 }
 
-static bool add_wall_and_lightmap(macc *wall_acc, lm_surface_list *surf_list, int wall_acc_index, float x0, float z0,
-                                  float x1, float z1, float bot0, float top0, float bot1, float top1,
-                                  const slayer3d_level_material *material)
+static bool add_wall_and_lightmap(macc *wall_acc, lm_surface_list *surf_list, int wall_acc_index, int sector_index,
+                                  const slayer3d_sector *sector, float x0, float z0, float x1, float z1, float bot0,
+                                  float top0, float bot1, float top1, const slayer3d_level_material *material)
 {
+    float rgba[4];
     int vb = wall_acc->vc;
-    return add_wall(wall_acc, x0, z0, x1, z1, bot0, top0, bot1, top1, material->albedo, material->tex_scale) &&
-           lm_record_wall_surface(surf_list, wall_acc_index, wall_acc, vb, x0, z0, x1, z1, bot0, top0, bot1, top1);
+    sector_modulate_rgba(sector, material->albedo, rgba);
+    return add_wall(wall_acc, x0, z0, x1, z1, bot0, top0, bot1, top1, rgba, material->tex_scale) &&
+           lm_record_wall_surface(surf_list, wall_acc_index, sector_index, wall_acc, vb, x0, z0, x1, z1, bot0, top0,
+                                  bot1, top1);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1035,9 +1117,11 @@ static bool mark_dirty_sector_neighbors(const edge_info *edges, int edge_count, 
 }
 
 static bool add_wall_runtime(macc *wall_acc, float x0, float z0, float x1, float z1, float bot0, float top0, float bot1,
-                             float top1, const slayer3d_level_material *material)
+                             float top1, const slayer3d_sector *sector, const slayer3d_level_material *material)
 {
-    return add_wall(wall_acc, x0, z0, x1, z1, bot0, top0, bot1, top1, material->albedo, material->tex_scale);
+    float rgba[4];
+    sector_modulate_rgba(sector, material->albedo, rgba);
+    return add_wall(wall_acc, x0, z0, x1, z1, bot0, top0, bot1, top1, rgba, material->tex_scale);
 }
 
 static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_count, const edge_info *edges,
@@ -1070,7 +1154,9 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
         if (fi >= 0)
         {
             macc *floor_acc = &accs[s * material_count + fi];
-            if (!add_floor_ceil(floor_acc, sec, true, materials[fi].albedo, materials[fi].tex_scale))
+            float rgba[4];
+            sector_modulate_rgba(sec, materials[fi].albedo, rgba);
+            if (!add_floor_ceil(floor_acc, sec, true, rgba, materials[fi].tex_scale))
             {
                 return false;
             }
@@ -1078,7 +1164,9 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
         if (ci >= 0)
         {
             macc *ceil_acc = &accs[s * material_count + ci];
-            if (!add_floor_ceil(ceil_acc, sec, false, materials[ci].albedo, materials[ci].tex_scale))
+            float rgba[4];
+            sector_modulate_rgba(sec, materials[ci].albedo, rgba);
+            if (!add_floor_ceil(ceil_acc, sec, false, rgba, materials[ci].tex_scale))
             {
                 return false;
             }
@@ -1141,7 +1229,7 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
             {
                 if (!add_wall_runtime(wall_acc, ax, az, bx, bz, slayer3d_sector_floor_at(sec, ax, az),
                                       slayer3d_sector_ceil_at(sec, ax, az), slayer3d_sector_floor_at(sec, bx, bz),
-                                      slayer3d_sector_ceil_at(sec, bx, bz), &materials[wi]))
+                                      slayer3d_sector_ceil_at(sec, bx, bz), sec, &materials[wi]))
                 {
                     return false;
                 }
@@ -1181,7 +1269,7 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
                         if (!add_wall_runtime(wall_acc, wx0, wz0, wx1, wz1, slayer3d_sector_floor_at(sec, wx0, wz0),
                                               slayer3d_sector_ceil_at(sec, wx0, wz0),
                                               slayer3d_sector_floor_at(sec, wx1, wz1),
-                                              slayer3d_sector_ceil_at(sec, wx1, wz1), &materials[wi]))
+                                              slayer3d_sector_ceil_at(sec, wx1, wz1), sec, &materials[wi]))
                         {
                             return false;
                         }
@@ -1203,7 +1291,7 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
                     if (sec_floor0 < other_floor0 - 0.001f || sec_floor1 < other_floor1 - 0.001f)
                     {
                         if (!add_wall_runtime(wall_acc, ox0, oz0, ox1, oz1, sec_floor0, other_floor0, sec_floor1,
-                                              other_floor1, &materials[wi]))
+                                              other_floor1, sec, &materials[wi]))
                         {
                             return false;
                         }
@@ -1211,7 +1299,7 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
                     if (sec_ceil0 > other_ceil0 + 0.001f || sec_ceil1 > other_ceil1 + 0.001f)
                     {
                         if (!add_wall_runtime(wall_acc, ox0, oz0, ox1, oz1, other_ceil0, sec_ceil0, other_ceil1,
-                                              sec_ceil1, &materials[wi]))
+                                              sec_ceil1, sec, &materials[wi]))
                         {
                             return false;
                         }
@@ -1223,7 +1311,7 @@ static bool build_dirty_sector_accs(const slayer3d_sector *sectors, int sector_c
                     float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
                     if (!add_wall_runtime(wall_acc, wx0, wz0, bx, bz, slayer3d_sector_floor_at(sec, wx0, wz0),
                                           slayer3d_sector_ceil_at(sec, wx0, wz0), slayer3d_sector_floor_at(sec, bx, bz),
-                                          slayer3d_sector_ceil_at(sec, bx, bz), &materials[wi]))
+                                          slayer3d_sector_ceil_at(sec, bx, bz), sec, &materials[wi]))
                     {
                         return false;
                     }
@@ -1389,8 +1477,10 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
             int floor_acc_index = s * material_count + fi;
             macc *floor_acc = &accs[floor_acc_index];
             int vb = floor_acc->vc;
-            if (!add_floor_ceil(floor_acc, sec, true, materials[fi].albedo, materials[fi].tex_scale) ||
-                !lm_record_floor_ceil_surface(&surf_list, floor_acc_index, floor_acc, vb, sec, true))
+            float rgba[4];
+            sector_modulate_rgba(sec, materials[fi].albedo, rgba);
+            if (!add_floor_ceil(floor_acc, sec, true, rgba, materials[fi].tex_scale) ||
+                !lm_record_floor_ceil_surface(&surf_list, floor_acc_index, s, floor_acc, vb, sec, true))
             {
                 goto fail;
             }
@@ -1400,8 +1490,10 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
             int ceil_acc_index = s * material_count + ci;
             macc *ceil_acc = &accs[ceil_acc_index];
             int vb = ceil_acc->vc;
-            if (!add_floor_ceil(ceil_acc, sec, false, materials[ci].albedo, materials[ci].tex_scale) ||
-                !lm_record_floor_ceil_surface(&surf_list, ceil_acc_index, ceil_acc, vb, sec, false))
+            float rgba[4];
+            sector_modulate_rgba(sec, materials[ci].albedo, rgba);
+            if (!add_floor_ceil(ceil_acc, sec, false, rgba, materials[ci].tex_scale) ||
+                !lm_record_floor_ceil_surface(&surf_list, ceil_acc_index, s, ceil_acc, vb, sec, false))
             {
                 goto fail;
             }
@@ -1487,7 +1579,7 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
 
             if (novl == 0)
             {
-                if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, ax, az, bx, bz,
+                if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, s, sec, ax, az, bx, bz,
                                            slayer3d_sector_floor_at(sec, ax, az), slayer3d_sector_ceil_at(sec, ax, az),
                                            slayer3d_sector_floor_at(sec, bx, bz), slayer3d_sector_ceil_at(sec, bx, bz),
                                            &materials[wi]))
@@ -1513,7 +1605,7 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
                     {
                         float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
                         float wx1 = ax + (bx - ax) * overlaps[oi].t0, wz1 = az + (bz - az) * overlaps[oi].t0;
-                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, wx0, wz0, wx1, wz1,
+                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, s, sec, wx0, wz0, wx1, wz1,
                                                    slayer3d_sector_floor_at(sec, wx0, wz0),
                                                    slayer3d_sector_ceil_at(sec, wx0, wz0),
                                                    slayer3d_sector_floor_at(sec, wx1, wz1),
@@ -1535,15 +1627,15 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
                     float other_ceil1 = slayer3d_sector_ceil_at(other, ox1, oz1);
                     if (sec_floor0 < other_floor0 - 0.001f || sec_floor1 < other_floor1 - 0.001f)
                     {
-                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, ox0, oz0, ox1, oz1, sec_floor0,
-                                                   other_floor0, sec_floor1, other_floor1, &materials[wi]))
+                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, s, sec, ox0, oz0, ox1, oz1,
+                                                   sec_floor0, other_floor0, sec_floor1, other_floor1, &materials[wi]))
                         {
                             goto fail;
                         }
                     }
                     if (sec_ceil0 > other_ceil0 + 0.001f || sec_ceil1 > other_ceil1 + 0.001f)
                     {
-                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, ox0, oz0, ox1, oz1,
+                        if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, s, sec, ox0, oz0, ox1, oz1,
                                                    other_ceil0, sec_ceil0, other_ceil1, sec_ceil1, &materials[wi]))
                         {
                             goto fail;
@@ -1554,7 +1646,7 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
                 if (cursor < 1.0f - 0.001f)
                 {
                     float wx0 = ax + (bx - ax) * cursor, wz0 = az + (bz - az) * cursor;
-                    if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, wx0, wz0, bx, bz,
+                    if (!add_wall_and_lightmap(wall_acc, &surf_list, wall_acc_index, s, sec, wx0, wz0, bx, bz,
                                                slayer3d_sector_floor_at(sec, wx0, wz0),
                                                slayer3d_sector_ceil_at(sec, wx0, wz0),
                                                slayer3d_sector_floor_at(sec, bx, bz),
@@ -1631,7 +1723,7 @@ bool slayer3d_build_level(const slayer3d_sector *sectors, int sector_count, cons
                 lm_assign_surface_uvs(&accs[surface->acc_index], surface, atlas_w, atlas_h);
             }
 
-            if (!lm_bake_lightmap(&surf_list, lights, light_count, out) || !lm_build_texture(out))
+            if (!lm_bake_lightmap(&surf_list, sectors, lights, light_count, out) || !lm_build_texture(out))
             {
                 goto fail;
             }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -382,6 +382,11 @@ std::filesystem::path mesh_primitives_dojo_data_path()
     return demo_data_path("mesh_primitives_dojo", "mesh_primitives_dojo.game.json");
 }
 
+std::filesystem::path lighting_dojo_data_path()
+{
+    return demo_data_path("lighting_dojo", "lighting_dojo.game.json");
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -7179,6 +7184,86 @@ TEST(GameDataRuntime, MeshPrimitivesDojoLoadsGrayboxShowcase)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
+{
+    const std::filesystem::path dojo_path = lighting_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(slayer3d_game_data_load_app_config_file(dojo_path.string().c_str(), &config, title, sizeof(title),
+                                                        app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "Slayer 3D Lighting Dojo");
+    EXPECT_EQ(config.logical_width, SLAYER3D_GAME_DEFAULT_LOGICAL_WIDTH);
+    EXPECT_EQ(config.logical_height, SLAYER3D_GAME_DEFAULT_LOGICAL_HEIGHT);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    ASSERT_TRUE(slayer3d_game_data_set_active_scene(runtime, "scene.lighting_dojo.showcase"));
+    EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.player"), nullptr);
+    EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.mock.lab_robot"), nullptr);
+
+    slayer3d_game_data_sector_level level{};
+    ASSERT_TRUE(slayer3d_game_data_get_sector_level(runtime, "sector.lighting_dojo.showcase", &level));
+    ASSERT_GE(level.sector_count, 12);
+    bool saw_dark = false;
+    bool saw_green = false;
+    for (int i = 0; i < level.sector_count; ++i)
+    {
+        const std::string name = level.sector_names[i] != nullptr ? level.sector_names[i] : "";
+        if (name == "dark_room")
+        {
+            saw_dark = true;
+            EXPECT_TRUE(level.sectors[i].has_lighting);
+            EXPECT_LT(level.sectors[i].lighting_level, 64.0f);
+        }
+        if (name == "green_toxic_room")
+        {
+            saw_green = true;
+            EXPECT_TRUE(level.sectors[i].has_lighting);
+            EXPECT_GT(level.sectors[i].lighting_color[1], level.sectors[i].lighting_color[0]);
+        }
+    }
+    EXPECT_TRUE(saw_dark);
+    EXPECT_TRUE(saw_green);
+
+    ASSERT_GE(slayer3d_game_data_world_light_count(runtime), 5);
+
+    struct LightingDojoCapture
+    {
+        bool saw_green_sample = false;
+        bool saw_lab_robot = false;
+        slayer3d_color green_sample{};
+    } capture;
+    auto capture_lighting_dojo = [](void *userdata, const slayer3d_game_data_render_primitive *primitive) -> bool {
+        auto *data = static_cast<LightingDojoCapture *>(userdata);
+        const std::string name = primitive->entity_name != nullptr ? primitive->entity_name : "";
+        if (name == "entity.sample.green")
+        {
+            data->saw_green_sample = true;
+            data->green_sample = primitive->color;
+        }
+        if (name == "entity.mock.lab_robot" && primitive->type == SLAYER3D_GAME_DATA_RENDER_MESH_PRIMITIVE)
+            data->saw_lab_robot = true;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_render_primitive(runtime, capture_lighting_dojo, &capture));
+    EXPECT_TRUE(capture.saw_green_sample);
+    EXPECT_TRUE(capture.saw_lab_robot);
+    EXPECT_GT(capture.green_sample.g, capture.green_sample.r);
+    EXPECT_GT(capture.green_sample.g, capture.green_sample.b);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, UsesDefaultWorldUnitsAndPerspectiveFovy)
 {
     const std::filesystem::path dir = unique_test_dir("world_camera_defaults");
@@ -10114,7 +10199,8 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
           "ceil_material": "wall",
           "wall_material": "wall",
           "ambient_sound_id": 2,
-          "damage_per_second": 1.5
+          "damage_per_second": 1.5,
+          "lighting": { "level": 176, "color": [1.0, 0.2, 0.1, 0.75] }
         },
         {
           "name": "hall",
@@ -10155,6 +10241,11 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
     EXPECT_STREQ(level.sector_names[1], "hall");
     EXPECT_EQ(level.sectors[0].ambient_sound_id, 2);
     EXPECT_FLOAT_EQ(slayer3d_sector_damage_per_second(&level.sectors[0]), 1.5f);
+    EXPECT_TRUE(level.sectors[0].has_lighting);
+    EXPECT_FLOAT_EQ(level.sectors[0].lighting_level, 176.0f);
+    EXPECT_FLOAT_EQ(level.sectors[0].lighting_color[1], 0.2f);
+    EXPECT_FLOAT_EQ(level.sectors[0].lighting_color[3], 0.75f);
+    EXPECT_FALSE(level.sectors[1].has_lighting);
     expect_vec3_near(slayer3d_sector_push_velocity(&level.sectors[1]), slayer3d_vec3_make(1.0f, 0.0f, 0.0f));
     ASSERT_EQ(level.light_count, 1);
     EXPECT_FLOAT_EQ(level.lights[0].intensity, 2.0f);
@@ -10175,6 +10266,129 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
     slayer3d_game_data_sector_level missing{};
     EXPECT_FALSE(slayer3d_game_data_get_sector_level(runtime, "sector.missing", &missing));
     EXPECT_EQ(missing.name, nullptr);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, SectorLightingModulatesLitActorsAndCanUpdateAtRuntime)
+{
+    const std::filesystem::path dir = unique_test_dir("sector_lighting_runtime");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.lit", "entity.unlit"],
+  "world": {
+    "sector_levels": [
+      { "level": "sector.lighting", "variant": "lightmapped" }
+    ]
+  }
+})json");
+    write_text(dir / "sector_lighting_runtime.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Sector Lighting Runtime Test" },
+  "world": { "name": "world.sector_lighting", "kind": "sector" },
+  "sector_levels": [
+    {
+      "name": "sector.lighting",
+      "materials": [{ "name": "mat", "albedo": [1.0, 1.0, 1.0, 1.0] }],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [5, 0], [5, 5], [0, 5]],
+          "floor_y": 0.0,
+          "ceil_y": 4.0,
+          "floor_material": "mat",
+          "ceil_material": "mat",
+          "wall_material": "mat",
+          "lighting": { "level": 128, "color": [1.0, 0.0, 0.0, 1.0] }
+        }
+      ]
+    }
+  ],
+  "entities": [
+    {
+      "name": "entity.lit",
+      "active": true,
+      "transform": { "position": [2.0, 1.0, 2.0] },
+      "components": [
+        { "type": "render.cube", "size": [1.0, 1.0, 1.0], "color": [200, 100, 50, 255], "lighting": true }
+      ]
+    },
+    {
+      "name": "entity.unlit",
+      "active": true,
+      "transform": { "position": [3.0, 1.0, 2.0] },
+      "components": [
+        { "type": "render.sphere", "radius": 0.5, "color": [200, 100, 50, 255], "lighting": false }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "sector_lighting_runtime.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+
+    struct SectorActorCapture
+    {
+        slayer3d_color lit{};
+        slayer3d_color unlit{};
+        bool saw_lit = false;
+        bool saw_unlit = false;
+    } capture;
+    auto capture_actor = [](void *userdata, const slayer3d_game_data_render_primitive *primitive) -> bool {
+        auto *data = static_cast<SectorActorCapture *>(userdata);
+        const std::string name = primitive->entity_name != nullptr ? primitive->entity_name : "";
+        if (name == "entity.lit")
+        {
+            data->lit = primitive->color;
+            data->saw_lit = true;
+        }
+        if (name == "entity.unlit")
+        {
+            data->unlit = primitive->color;
+            data->saw_unlit = true;
+        }
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_render_primitive(runtime, capture_actor, &capture));
+    ASSERT_TRUE(capture.saw_lit);
+    ASSERT_TRUE(capture.saw_unlit);
+    EXPECT_EQ(capture.lit.r, 100);
+    EXPECT_EQ(capture.lit.g, 0);
+    EXPECT_EQ(capture.lit.b, 0);
+    EXPECT_EQ(capture.unlit.r, 200);
+    EXPECT_EQ(capture.unlit.g, 100);
+    EXPECT_EQ(capture.unlit.b, 50);
+
+    float level = 0.0f;
+    float color[4]{};
+    ASSERT_TRUE(
+        slayer3d_game_data_get_sector_lighting(runtime, "sector.lighting", "room", &level, color, error, sizeof(error)))
+        << error;
+    EXPECT_FLOAT_EQ(level, 128.0f);
+    EXPECT_FLOAT_EQ(color[0], 1.0f);
+    EXPECT_FLOAT_EQ(color[3], 1.0f);
+
+    const float green[4] = {0.0f, 1.0f, 0.0f, 1.0f};
+    ASSERT_TRUE(
+        slayer3d_game_data_set_sector_lighting(runtime, "sector.lighting", "room", 255.0f, green, error, sizeof(error)))
+        << error;
+    capture = {};
+    ASSERT_TRUE(slayer3d_game_data_for_each_render_primitive(runtime, capture_actor, &capture));
+    ASSERT_TRUE(capture.saw_lit);
+    EXPECT_EQ(capture.lit.r, 0);
+    EXPECT_EQ(capture.lit.g, 100);
+    EXPECT_EQ(capture.lit.b, 0);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -12415,6 +12629,27 @@ TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
             })json",
             "noise.emit radius",
         },
+        {
+            "invalid_sector_lighting_action",
+            R"json([])json",
+            R"json({
+              "bindings": [
+                {
+                  "signal": "signal.run",
+                  "actions": [
+                    {
+                      "type": "sector_lighting.set",
+                      "sector_level": "sector.test",
+                      "sector": "room",
+                      "level": 300,
+                      "color": [1.0, 1.0, 1.0, 1.0]
+                    }
+                  ]
+                }
+              ]
+            })json",
+            "sector_lighting.set level",
+        },
     };
 
     for (const Case &test_case : cases)
@@ -12708,6 +12943,36 @@ TEST(GameDataRuntime, RejectsInvalidAuthoredSectorLevels)
               }]
             })json",
             "ceil_y",
+        },
+        {
+            "bad_lighting_level",
+            R"json({
+              "name": "sector.bad",
+              "materials": [{ "name": "floor" }],
+              "sectors": [{
+                "points": [[0,0], [2,0], [2,2], [0,2]],
+                "floor_y": 0,
+                "ceil_y": 3,
+                "wall_material": "floor",
+                "lighting": { "level": 300, "color": [1.0, 1.0, 1.0, 1.0] }
+              }]
+            })json",
+            "lighting level",
+        },
+        {
+            "bad_lighting_color",
+            R"json({
+              "name": "sector.bad",
+              "materials": [{ "name": "floor" }],
+              "sectors": [{
+                "points": [[0,0], [2,0], [2,2], [0,2]],
+                "floor_y": 0,
+                "ceil_y": 3,
+                "wall_material": "floor",
+                "lighting": { "level": 128, "color": [1.0, -0.1, 1.0, 1.0] }
+              }]
+            })json",
+            "lighting color",
         },
     };
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -131,6 +131,7 @@ struct SectorLevelInstanceCapture
     const slayer3d_level *level = nullptr;
     slayer3d_vec3 position{};
     bool portal_culling = true;
+    bool sector_lighting_enabled = true;
 };
 
 struct SectorDoorRenderCapture
@@ -1520,6 +1521,7 @@ bool capture_sector_level_instance(void *userdata, const slayer3d_game_data_sect
     capture->level = instance->level;
     capture->position = instance->position;
     capture->portal_culling = instance->portal_culling;
+    capture->sector_lighting_enabled = instance->sector_lighting_enabled;
     return true;
 }
 
@@ -7236,10 +7238,22 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
 
     ASSERT_GE(slayer3d_game_data_world_light_count(runtime), 5);
 
+    SectorLevelInstanceCapture sector_capture{};
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &sector_capture));
+    ASSERT_EQ(sector_capture.count, 1);
+    EXPECT_TRUE(sector_capture.sector_lighting_enabled);
+    const slayer3d_level *sector_lit_level = sector_capture.level;
+
+    slayer3d_game_data_render_settings render_settings{};
+    ASSERT_TRUE(slayer3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_TRUE(render_settings.bloom_enabled);
+
     struct LightingDojoCapture
     {
         bool saw_green_sample = false;
         bool saw_lab_robot = false;
+        bool green_sample_lighting_enabled = false;
         slayer3d_color green_sample{};
     } capture;
     auto capture_lighting_dojo = [](void *userdata, const slayer3d_game_data_render_primitive *primitive) -> bool {
@@ -7249,6 +7263,7 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
         {
             data->saw_green_sample = true;
             data->green_sample = primitive->color;
+            data->green_sample_lighting_enabled = primitive->lighting_enabled;
         }
         if (name == "entity.mock.lab_robot" && primitive->type == SLAYER3D_GAME_DATA_RENDER_MESH_PRIMITIVE)
             data->saw_lab_robot = true;
@@ -7257,8 +7272,37 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
     ASSERT_TRUE(slayer3d_game_data_for_each_render_primitive(runtime, capture_lighting_dojo, &capture));
     EXPECT_TRUE(capture.saw_green_sample);
     EXPECT_TRUE(capture.saw_lab_robot);
+    EXPECT_TRUE(capture.green_sample_lighting_enabled);
     EXPECT_GT(capture.green_sample.g, capture.green_sample.r);
     EXPECT_GT(capture.green_sample.g, capture.green_sample.b);
+
+    auto emit_signal = [session, runtime](const char *name) {
+        const int signal = slayer3d_game_data_find_signal(runtime, name);
+        ASSERT_GE(signal, 0) << name;
+        slayer3d_signal_emit(slayer3d_game_session_get_signal_bus(session), signal, nullptr);
+    };
+
+    emit_signal("signal.lighting.dynamic.toggle");
+    EXPECT_EQ(slayer3d_game_data_world_light_count(runtime), 0);
+
+    emit_signal("signal.lighting.bloom.toggle");
+    ASSERT_TRUE(slayer3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_FALSE(render_settings.bloom_enabled);
+
+    emit_signal("signal.lighting.actor.toggle");
+    LightingDojoCapture actor_toggle_capture{};
+    ASSERT_TRUE(slayer3d_game_data_for_each_render_primitive(runtime, capture_lighting_dojo, &actor_toggle_capture));
+    EXPECT_TRUE(actor_toggle_capture.saw_green_sample);
+    EXPECT_FALSE(actor_toggle_capture.green_sample_lighting_enabled);
+    EXPECT_GT(actor_toggle_capture.green_sample.b, actor_toggle_capture.green_sample.g);
+
+    emit_signal("signal.lighting.sector.toggle");
+    sector_capture = {};
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_sector_level_instance(runtime, capture_sector_level_instance, &sector_capture));
+    ASSERT_EQ(sector_capture.count, 1);
+    EXPECT_FALSE(sector_capture.sector_lighting_enabled);
+    EXPECT_NE(sector_capture.level, sector_lit_level);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7210,6 +7210,9 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
 
     ASSERT_TRUE(slayer3d_game_data_set_active_scene(runtime, "scene.lighting_dojo.showcase"));
     EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.player"), nullptr);
+    EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.sample.warm_probe"), nullptr);
+    EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.sample.blue_probe"), nullptr);
+    EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.sample.lab_probe"), nullptr);
     EXPECT_NE(slayer3d_game_data_find_actor(runtime, "entity.mock.lab_robot"), nullptr);
 
     slayer3d_game_data_sector_level level{};
@@ -7224,7 +7227,8 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
         {
             saw_dark = true;
             EXPECT_TRUE(level.sectors[i].has_lighting);
-            EXPECT_LT(level.sectors[i].lighting_level, 64.0f);
+            EXPECT_GT(level.sectors[i].lighting_level, 90.0f);
+            EXPECT_LT(level.sectors[i].lighting_level, 140.0f);
         }
         if (name == "green_toxic_room")
         {

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -139,6 +139,68 @@ TEST(SLAYER3DSectorMetadata, DamageRateIsClampedAndScalesByDelta)
     EXPECT_FLOAT_EQ(slayer3d_sector_damage_for_delta(nullptr, 1.0f), 0.0f);
 }
 
+TEST(SLAYER3DLevelBuilder, SectorLightingTintsGeneratedSurfaceColors)
+{
+    slayer3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                           MakeLevelMaterial("wall.png")};
+    slayer3d_sector sector = MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f);
+    slayer3d_level level{};
+
+    sector.has_lighting = true;
+    sector.lighting_level = 128.0f;
+    sector.lighting_color[0] = 1.0f;
+    sector.lighting_color[1] = 0.0f;
+    sector.lighting_color[2] = 0.0f;
+    sector.lighting_color[3] = 1.0f;
+
+    ASSERT_TRUE(slayer3d_build_level(&sector, 1, materials, 3, nullptr, 0, &level)) << SDL_GetError();
+    const slayer3d_mesh *floor = FindSectorMaterialMesh(level, 0, sector.floor_material);
+    ASSERT_NE(floor, nullptr);
+    ASSERT_NE(floor->colors, nullptr);
+    ASSERT_GE(floor->vertex_count, 1);
+    EXPECT_NEAR(floor->colors[0], 128.0f / 255.0f, 0.001f);
+    EXPECT_NEAR(floor->colors[1], 0.0f, 0.001f);
+    EXPECT_NEAR(floor->colors[2], 0.0f, 0.001f);
+    EXPECT_NEAR(floor->colors[3], 1.0f, 0.001f);
+
+    slayer3d_free_level(&level);
+}
+
+TEST(SLAYER3DLevelBuilder, SectorLightingChangesLightmapBase)
+{
+    slayer3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),
+                                           MakeLevelMaterial("wall.png")};
+    slayer3d_sector sector = MakeSquareSector(0.0f, 0.0f, 4.0f, 4.0f);
+    slayer3d_level_light light{};
+    slayer3d_level level{};
+
+    sector.has_lighting = true;
+    sector.lighting_level = 64.0f;
+    sector.lighting_color[0] = 0.0f;
+    sector.lighting_color[1] = 0.0f;
+    sector.lighting_color[2] = 1.0f;
+    sector.lighting_color[3] = 1.0f;
+
+    light.position[0] = 1000.0f;
+    light.position[1] = 1000.0f;
+    light.position[2] = 1000.0f;
+    light.color[0] = 1.0f;
+    light.color[1] = 1.0f;
+    light.color[2] = 1.0f;
+    light.intensity = 1.0f;
+    light.range = 1.0f;
+
+    ASSERT_TRUE(slayer3d_build_level(&sector, 1, materials, 3, &light, 1, &level)) << SDL_GetError();
+    ASSERT_NE(level.lightmap_pixels, nullptr);
+    ASSERT_GT(level.lightmap_width, 0);
+    ASSERT_GT(level.lightmap_height, 0);
+    EXPECT_EQ(level.lightmap_pixels[0], 0);
+    EXPECT_EQ(level.lightmap_pixels[1], 0);
+    EXPECT_EQ(level.lightmap_pixels[2], 64);
+
+    slayer3d_free_level(&level);
+}
+
 TEST(SLAYER3DLevelBuilder, BuildsIndependentSectorMaterialChunks)
 {
     const slayer3d_level_material materials[] = {MakeLevelMaterial("floor.png"), MakeLevelMaterial("ceil.png"),


### PR DESCRIPTION
## Summary

- add authored sector-local lighting metadata (`level` plus RGBA tint influence) with validation and docs
- apply sector-local lighting to sector surfaces/lightmaps and lit actor render primitives in active sector scenes
- add runtime/editor-facing sector lighting get/set APIs plus `sector_lighting.set` data action
- add a data-only `lighting_dojo` showing neutral, dark, bright, colored, mixed, and dynamic-light areas

## Tests

- `cmake --build build/sector-lighting --parallel 8`
- `ctest --test-dir build/sector-lighting --output-on-failure`
- `./build/sector-lighting/tests/slayer3d_level_test`
- `./build/sector-lighting/tests/slayer3d_game_data_test`
- `ctest --test-dir build/sector-lighting --output-on-failure -R "(GameDataRuntime\\.RejectsInvalidSectorDoorsAndActions|GameDataRuntime\\.SectorLightingModulatesLitActorsAndCanUpdateAtRuntime|GameDataRuntime\\.LightingDojoLoadsSectorLocalLightingShowcase|SLAYER3DLevelBuilder\\.SectorLighting)"`

Closes #302.
