### PR TITLE
Add native brush world schema

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -44,6 +44,7 @@ Every root game file is a JSON object.
 | `grid_pickup_layers` | no | Dense grid-indexed pickup layers rendered and collected without one actor per pickup. |
 | `sector_levels` | no | Authored sector/portal worlds for Doom/Quake-style indoor levels. |
 | `sector_level_fragments` | no | Composition-only material/sector/light fragments merged into named sector levels before validation. |
+| `brush_worlds` | no | Native convex-brush worlds for true 3D FPS-style spaces. |
 | `sector_navigation` | no | Authored sector navigation graphs for AI/path queries in sector worlds. |
 | `sector_doors` | no | Runtime sliding doors for sector/FPS worlds. |
 | `sector_platforms` | no | Runtime moving floor/ceiling sectors for lifts, elevators, and oscillating platforms. |
@@ -125,6 +126,7 @@ a JSON object with schema `slayer3d.fragment.v0`.
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/world/e1m1.materials.json", "sections": ["sector_level_fragments"] },
     { "path": "fragments/world/e1m1.sectors.json", "sections": ["sector_level_fragments"] },
+    { "path": "fragments/world/keep_01.brushes.json", "sections": ["brush_worlds"] },
     { "path": "fragments/world/e1m1.doors.json", "sections": ["assets", "sector_doors", "signals", "logic"] },
     { "path": "fragments/world/e1m1.platforms.json", "sections": ["sector_platforms"] },
     { "path": "fragments/input/profiles.json", "sections": ["input"] },
@@ -448,6 +450,98 @@ metrics share the same scale vocabulary.
 World kinds may include fixed-screen playfields, tile grids, room graphs,
 sector/portal maps, brush worlds, or general 3D scenes as engine support
 grows.
+
+## Brush Worlds
+
+`brush_worlds` describe native true-3D worlds built from authored convex
+brushes. This is the foundation for Quake-like spaces: vertical rooms,
+overhangs, ramps, clips, trigger volumes, and future brush collision/render
+acceleration. Sector worlds remain supported; choose brush worlds when a level
+needs real 3D geometry rather than a sector/portal floor plan.
+
+Slice 1 loads and validates brush data. Mesh compilation, collision traces,
+lighting integration, and FPS controller support are intentionally layered on
+top in later slices.
+
+```json
+{
+  "brush_worlds": [
+    {
+      "name": "brush.keep_01",
+      "units": "meters",
+      "meters_per_unit": 1.0,
+      "materials": [
+        {
+          "name": "stone_wall",
+          "texture": "asset://textures/stone_wall.png",
+          "albedo": [0.8, 0.8, 0.8, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 2.0
+        }
+      ],
+      "brushes": [
+        {
+          "name": "brush.start_room",
+          "tags": ["room", "solid"],
+          "contents": ["solid", "player_clip"],
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  8 }, "material": "stone_wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "stone_wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  4 }, "material": "stone_wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "stone_wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  8 }, "material": "stone_wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "stone_wall" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Validation requires:
+
+- unique brush world names
+- `units` omitted or `"meters"`, with positive `meters_per_unit`
+- non-empty `materials` with unique names
+- material `albedo` as vec3/vec4 values in `[0, 1]`
+- non-negative `metallic` and `roughness`
+- positive `tex_scale`
+- optional material `texture` as a non-empty existing asset path
+- non-empty `brushes` with unique names
+- optional unique non-empty brush `tags`
+- `contents` as one value or an array of unique values: `solid`,
+  `player_clip`, `projectile_clip`, `trigger`, `water`, `lava`, or `sky`
+- each brush to contain at least four `faces`
+- each face to declare `plane.normal` as a non-zero vec3 and
+  `plane.distance` as a number
+- each face `material` to reference a declared material by name or index
+- optional `surface_flags` as one value or an array of unique values:
+  `nocollide`, `slick`, `ladder`, `emissive`, or `portal_candidate`
+
+Scenes instantiate brush worlds through `world.brush_worlds`:
+
+```json
+{
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.keep_01",
+  "world": {
+    "brush_worlds": [
+      {
+        "world": "brush.keep_01",
+        "position": [0.0, 0.0, 0.0],
+        "acceleration": true,
+        "debug_wireframe": false
+      }
+    ]
+  }
+}
+```
+
+`acceleration_key` and `debug_wireframe_key` may name scene-state booleans that
+override the authored defaults. Runtime, editor, and future renderer/collision
+code should use `slayer3d_game_data_get_brush_world()` and
+`slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 
 ## Sector Levels
 

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -343,6 +343,121 @@ extern "C"
         bool sector_lighting_enabled;
     } slayer3d_game_data_sector_level_instance;
 
+    enum
+    {
+        /** @brief Brush blocks actor and projectile movement unless masked out by caller. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID = 1u << 0,
+        /** @brief Brush blocks player movement but may be ignored by other traces. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP = 1u << 1,
+        /** @brief Brush blocks projectile traces but may be ignored by actors. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP = 1u << 2,
+        /** @brief Brush is a gameplay trigger volume rather than blocking geometry. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER = 1u << 3,
+        /** @brief Brush represents water contents. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER = 1u << 4,
+        /** @brief Brush represents lava or damaging liquid contents. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA = 1u << 5,
+        /** @brief Brush surface should be treated as sky by renderers. */
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY = 1u << 6,
+    };
+
+    enum
+    {
+        /** @brief Face does not emit collision geometry. */
+        SLAYER3D_GAME_DATA_BRUSH_SURFACE_NO_COLLIDE = 1u << 0,
+        /** @brief Face has low-friction movement semantics. */
+        SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK = 1u << 1,
+        /** @brief Face can be climbed by compatible controllers. */
+        SLAYER3D_GAME_DATA_BRUSH_SURFACE_LADDER = 1u << 2,
+        /** @brief Face should contribute emissive material response. */
+        SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE = 1u << 3,
+        /** @brief Face is a candidate for future portal/visibility tooling. */
+        SLAYER3D_GAME_DATA_BRUSH_SURFACE_PORTAL_CANDIDATE = 1u << 4,
+    };
+
+    /** @brief Runtime-owned material referenced by authored brush faces. */
+    typedef struct slayer3d_game_data_brush_material
+    {
+        /** @brief Stable authored material name. */
+        const char *name;
+        /** @brief Optional asset:// texture image path. */
+        const char *texture;
+        /** @brief Linear RGBA material factor, default white. */
+        slayer3d_vec4 albedo;
+        /** @brief Authored metallic factor for future material systems. */
+        float metallic;
+        /** @brief Authored roughness factor for future material systems. */
+        float roughness;
+        /** @brief Positive texture scale hint. */
+        float tex_scale;
+    } slayer3d_game_data_brush_material;
+
+    /** @brief One plane-bounded face on an authored convex brush. */
+    typedef struct slayer3d_game_data_brush_face
+    {
+        /** @brief Plane normal. Validation requires a non-zero vector. */
+        slayer3d_vec3 normal;
+        /** @brief Plane distance in normal-dot-position form. */
+        float distance;
+        /** @brief Index into the brush world's material array. */
+        int material_index;
+        /** @brief Resolved material name, or NULL when no material was authored. */
+        const char *material_name;
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_SURFACE_* flags. */
+        unsigned int surface_flags;
+    } slayer3d_game_data_brush_face;
+
+    /** @brief Authored convex brush loaded into runtime-owned data. */
+    typedef struct slayer3d_game_data_brush
+    {
+        /** @brief Stable authored brush name. */
+        const char *name;
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_CONTENT_* flags. */
+        unsigned int contents;
+        /** @brief Optional authored tags for editor/runtime queries. */
+        const char *const *tags;
+        /** @brief Number of entries in @p tags. */
+        int tag_count;
+        /** @brief Convex brush faces. */
+        const slayer3d_game_data_brush_face *faces;
+        /** @brief Number of entries in @p faces. */
+        int face_count;
+    } slayer3d_game_data_brush;
+
+    /** @brief Runtime-owned native brush world. */
+    typedef struct slayer3d_game_data_brush_world
+    {
+        /** @brief Stable authored brush world name. */
+        const char *name;
+        /** @brief Authored unit label, normally `meters`. */
+        const char *units;
+        /** @brief Conversion factor from authored units to meters. */
+        float meters_per_unit;
+        /** @brief Runtime material palette for brush faces. */
+        const slayer3d_game_data_brush_material *materials;
+        /** @brief Number of entries in @p materials. */
+        int material_count;
+        /** @brief Authored convex brushes. */
+        const slayer3d_game_data_brush *brushes;
+        /** @brief Number of entries in @p brushes. */
+        int brush_count;
+    } slayer3d_game_data_brush_world;
+
+    /** @brief Active-scene instance of an authored brush world. */
+    typedef struct slayer3d_game_data_brush_world_instance
+    {
+        /** @brief Authored brush world name. */
+        const char *world_name;
+        /** @brief Runtime-owned brush world descriptor. */
+        const slayer3d_game_data_brush_world *world;
+        /** @brief World-space translation applied before rendering/collision queries. */
+        slayer3d_vec3 position;
+        /** @brief Whether renderers/collision systems should use future acceleration data. */
+        bool acceleration_enabled;
+        /** @brief Whether debug wireframe should be requested for this instance. */
+        bool debug_wireframe;
+    } slayer3d_game_data_brush_world_instance;
+
     /**
      * @brief Callback for active authored sector level instances.
      *
@@ -350,6 +465,14 @@ extern "C"
      */
     typedef bool (*slayer3d_game_data_sector_level_instance_fn)(
         void *userdata, const slayer3d_game_data_sector_level_instance *instance);
+
+    /**
+     * @brief Callback for active authored brush world instances.
+     *
+     * Return false to stop iteration early.
+     */
+    typedef bool (*slayer3d_game_data_brush_world_instance_fn)(void *userdata,
+                                                               const slayer3d_game_data_brush_world_instance *instance);
 
     /**
      * @brief Runtime metrics used when evaluating data-authored UI bindings.
@@ -1075,6 +1198,21 @@ extern "C"
     bool slayer3d_game_data_get_sector_level(const slayer3d_game_data_runtime *runtime, const char *name,
                                              slayer3d_game_data_sector_level *out_level);
 
+    /**
+     * @brief Look up a JSON-authored brush world by name.
+     *
+     * This exposes loaded native brush-world data to renderer, collision,
+     * controller, sensor, and editor systems without making callers parse JSON.
+     * The returned pointers are runtime-owned.
+     *
+     * @param runtime Loaded game data runtime.
+     * @param name Authored brush world name.
+     * @param out_world Receives runtime-owned brush world pointers.
+     * @return true when @p name resolves to an authored brush world.
+     */
+    bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtime, const char *name,
+                                            slayer3d_game_data_brush_world *out_world);
+
     /** @brief Runtime-owned node resolved from an authored sector navigation graph. */
     typedef struct slayer3d_game_data_sector_nav_node
     {
@@ -1161,6 +1299,18 @@ extern "C"
     bool slayer3d_game_data_for_each_sector_level_instance(const slayer3d_game_data_runtime *runtime,
                                                            slayer3d_game_data_sector_level_instance_fn callback,
                                                            void *userdata);
+
+    /**
+     * @brief Iterate brush worlds declared by the active scene.
+     *
+     * The active scene owns placement and debug policy through
+     * `world.brush_worlds`. This helper is renderer-agnostic so tests,
+     * editors, and future brush render/collision systems can inspect the same
+     * resolved instances.
+     */
+    bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_runtime *runtime,
+                                                          slayer3d_game_data_brush_world_instance_fn callback,
+                                                          void *userdata);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -381,6 +381,11 @@ typedef struct sector_level_runtime
     slayer3d_level unlit_without_sector_lighting;
 } sector_level_runtime;
 
+typedef struct brush_world_runtime
+{
+    slayer3d_game_data_brush_world desc;
+} brush_world_runtime;
+
 typedef struct sector_door_runtime
 {
     yyjson_val *json;
@@ -579,6 +584,8 @@ typedef struct slayer3d_game_data_runtime
     int grid_pickup_layer_count;
     sector_level_runtime *sector_levels;
     int sector_level_count;
+    brush_world_runtime *brush_worlds;
+    int brush_world_count;
     sector_door_runtime *sector_doors;
     int sector_door_count;
     sector_platform_runtime *sector_platforms;
@@ -791,6 +798,7 @@ static void copy_property_value(slayer3d_properties *target, const char *key, co
 static yyjson_val *obj_get(yyjson_val *object, const char *key);
 static const char *json_string(yyjson_val *object, const char *key, const char *fallback);
 static yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
+static const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
 static actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
 static const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name);
 static actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
@@ -2640,6 +2648,27 @@ static slayer3d_vec3 json_vec3(yyjson_val *object, const char *key, slayer3d_vec
     return json_vec3_value(obj_get(object, key), fallback);
 }
 
+static slayer3d_vec4 json_vec4_value(yyjson_val *value, slayer3d_vec4 fallback)
+{
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 3)
+        return fallback;
+
+    yyjson_val *x = yyjson_arr_get(value, 0);
+    yyjson_val *y = yyjson_arr_get(value, 1);
+    yyjson_val *z = yyjson_arr_get(value, 2);
+    yyjson_val *w = yyjson_arr_get(value, 3);
+    if (!yyjson_is_num(x) || !yyjson_is_num(y) || !yyjson_is_num(z))
+        return fallback;
+
+    return slayer3d_vec4_make((float)yyjson_get_num(x), (float)yyjson_get_num(y), (float)yyjson_get_num(z),
+                              yyjson_is_num(w) ? (float)yyjson_get_num(w) : fallback.w);
+}
+
+static slayer3d_vec4 json_vec4(yyjson_val *object, const char *key, slayer3d_vec4 fallback)
+{
+    return json_vec4_value(obj_get(object, key), fallback);
+}
+
 static bool json_vec2_value(yyjson_val *value, float fallback_x, float fallback_y, float *out_x, float *out_y)
 {
     if (out_x == NULL || out_y == NULL)
@@ -3544,6 +3573,211 @@ static bool load_sector_levels(slayer3d_game_data_runtime *runtime, yyjson_val *
             !build_sector_level_variants(level, error_buffer, error_buffer_size))
         {
             return false;
+        }
+    }
+    return true;
+}
+
+static unsigned int brush_content_flag_from_string(const char *name)
+{
+    if (SDL_strcmp(name != NULL ? name : "", "solid") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    if (SDL_strcmp(name != NULL ? name : "", "player_clip") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP;
+    if (SDL_strcmp(name != NULL ? name : "", "projectile_clip") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP;
+    if (SDL_strcmp(name != NULL ? name : "", "trigger") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER;
+    if (SDL_strcmp(name != NULL ? name : "", "water") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER;
+    if (SDL_strcmp(name != NULL ? name : "", "lava") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA;
+    if (SDL_strcmp(name != NULL ? name : "", "sky") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY;
+    return 0u;
+}
+
+static unsigned int brush_surface_flag_from_string(const char *name)
+{
+    if (SDL_strcmp(name != NULL ? name : "", "nocollide") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_SURFACE_NO_COLLIDE;
+    if (SDL_strcmp(name != NULL ? name : "", "slick") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK;
+    if (SDL_strcmp(name != NULL ? name : "", "ladder") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_SURFACE_LADDER;
+    if (SDL_strcmp(name != NULL ? name : "", "emissive") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE;
+    if (SDL_strcmp(name != NULL ? name : "", "portal_candidate") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_SURFACE_PORTAL_CANDIDATE;
+    return 0u;
+}
+
+static unsigned int brush_flags_from_json(yyjson_val *value, unsigned int (*flag_from_string)(const char *name),
+                                          unsigned int fallback)
+{
+    if (yyjson_is_str(value))
+    {
+        const unsigned int flag = flag_from_string(yyjson_get_str(value));
+        return flag != 0u ? flag : fallback;
+    }
+    if (!yyjson_is_arr(value))
+        return fallback;
+
+    unsigned int flags = 0u;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (yyjson_is_str(entry))
+            flags |= flag_from_string(yyjson_get_str(entry));
+    }
+    return flags != 0u ? flags : fallback;
+}
+
+static int brush_material_index_from_ref(const slayer3d_game_data_brush_material *materials, int material_count,
+                                         yyjson_val *ref)
+{
+    if (yyjson_is_int(ref))
+    {
+        const int index = (int)yyjson_get_int(ref);
+        return index >= 0 && index < material_count ? index : -1;
+    }
+    if (yyjson_is_str(ref))
+    {
+        const char *name = yyjson_get_str(ref);
+        for (int i = 0; i < material_count; ++i)
+        {
+            if (materials[i].name != NULL && SDL_strcmp(materials[i].name, name) == 0)
+                return i;
+        }
+    }
+    return -1;
+}
+
+static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                              int error_buffer_size)
+{
+    yyjson_val *worlds = obj_get(root, "brush_worlds");
+    if (worlds == NULL)
+        return true;
+    if (!yyjson_is_arr(worlds))
+    {
+        set_error(error_buffer, error_buffer_size, "brush_worlds must be an array");
+        return false;
+    }
+
+    runtime->brush_world_count = (int)yyjson_arr_size(worlds);
+    runtime->brush_worlds =
+        (brush_world_runtime *)SDL_calloc((size_t)runtime->brush_world_count, sizeof(*runtime->brush_worlds));
+    if (runtime->brush_worlds == NULL && runtime->brush_world_count > 0)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush worlds");
+        return false;
+    }
+
+    for (int world_index = 0; world_index < runtime->brush_world_count; ++world_index)
+    {
+        yyjson_val *world_json = yyjson_arr_get(worlds, (size_t)world_index);
+        yyjson_val *materials_json = obj_get(world_json, "materials");
+        yyjson_val *brushes_json = obj_get(world_json, "brushes");
+        slayer3d_game_data_brush_world *world = &runtime->brush_worlds[world_index].desc;
+
+        world->name = SDL_strdup(json_string(world_json, "name", ""));
+        world->units = SDL_strdup(json_string(world_json, "units", "meters"));
+        world->meters_per_unit = json_float(world_json, "meters_per_unit", 1.0f);
+        world->material_count = (int)yyjson_arr_size(materials_json);
+        world->brush_count = (int)yyjson_arr_size(brushes_json);
+        if (world->name == NULL || world->units == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate brush world strings");
+            return false;
+        }
+
+        slayer3d_game_data_brush_material *materials =
+            (slayer3d_game_data_brush_material *)SDL_calloc((size_t)world->material_count, sizeof(*materials));
+        slayer3d_game_data_brush *brushes =
+            (slayer3d_game_data_brush *)SDL_calloc((size_t)world->brush_count, sizeof(*brushes));
+        if ((materials == NULL && world->material_count > 0) || (brushes == NULL && world->brush_count > 0))
+        {
+            SDL_free(materials);
+            SDL_free(brushes);
+            set_error(error_buffer, error_buffer_size, "failed to allocate brush world data");
+            return false;
+        }
+        world->materials = materials;
+        world->brushes = brushes;
+
+        for (int material_index = 0; material_index < world->material_count; ++material_index)
+        {
+            yyjson_val *material_json = yyjson_arr_get(materials_json, (size_t)material_index);
+            slayer3d_game_data_brush_material *material = &materials[material_index];
+            material->name = SDL_strdup(json_string(material_json, "name", ""));
+            const char *texture = json_string(material_json, "texture", NULL);
+            material->texture = texture != NULL ? SDL_strdup(texture) : NULL;
+            material->albedo = json_vec4(material_json, "albedo", slayer3d_vec4_make(1.0f, 1.0f, 1.0f, 1.0f));
+            material->metallic = json_float(material_json, "metallic", 0.0f);
+            material->roughness = json_float(material_json, "roughness", 1.0f);
+            material->tex_scale = json_float(material_json, "tex_scale", 1.0f);
+            if (material->name == NULL || (texture != NULL && material->texture == NULL))
+            {
+                set_error(error_buffer, error_buffer_size, "failed to allocate brush material strings");
+                return false;
+            }
+        }
+
+        for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+        {
+            yyjson_val *brush_json = yyjson_arr_get(brushes_json, (size_t)brush_index);
+            yyjson_val *tags_json = obj_get(brush_json, "tags");
+            yyjson_val *faces_json = obj_get(brush_json, "faces");
+            slayer3d_game_data_brush *brush = &brushes[brush_index];
+            brush->name = SDL_strdup(json_string(brush_json, "name", ""));
+            brush->contents = brush_flags_from_json(obj_get(brush_json, "contents"), brush_content_flag_from_string,
+                                                    SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
+            brush->tag_count = yyjson_is_arr(tags_json) ? (int)yyjson_arr_size(tags_json) : 0;
+            brush->face_count = (int)yyjson_arr_size(faces_json);
+            if (brush->name == NULL)
+            {
+                set_error(error_buffer, error_buffer_size, "failed to allocate brush name");
+                return false;
+            }
+
+            const char **tags =
+                brush->tag_count > 0 ? (const char **)SDL_calloc((size_t)brush->tag_count, sizeof(*tags)) : NULL;
+            slayer3d_game_data_brush_face *faces =
+                (slayer3d_game_data_brush_face *)SDL_calloc((size_t)brush->face_count, sizeof(*faces));
+            if ((tags == NULL && brush->tag_count > 0) || (faces == NULL && brush->face_count > 0))
+            {
+                SDL_free(tags);
+                SDL_free(faces);
+                set_error(error_buffer, error_buffer_size, "failed to allocate brush entries");
+                return false;
+            }
+            brush->tags = tags;
+            brush->faces = faces;
+
+            for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
+            {
+                tags[tag_index] = SDL_strdup(yyjson_get_str(yyjson_arr_get(tags_json, (size_t)tag_index)));
+                if (tags[tag_index] == NULL)
+                {
+                    set_error(error_buffer, error_buffer_size, "failed to allocate brush tag");
+                    return false;
+                }
+            }
+
+            for (int face_index = 0; face_index < brush->face_count; ++face_index)
+            {
+                yyjson_val *face_json = yyjson_arr_get(faces_json, (size_t)face_index);
+                yyjson_val *plane_json = obj_get(face_json, "plane");
+                slayer3d_game_data_brush_face *face = &faces[face_index];
+                face->normal = json_vec3(plane_json, "normal", slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
+                face->distance = json_float(plane_json, "distance", 0.0f);
+                face->material_index =
+                    brush_material_index_from_ref(materials, world->material_count, obj_get(face_json, "material"));
+                face->material_name = face->material_index >= 0 ? materials[face->material_index].name : NULL;
+                face->surface_flags =
+                    brush_flags_from_json(obj_get(face_json, "surface_flags"), brush_surface_flag_from_string, 0u);
+            }
         }
     }
     return true;
@@ -7557,6 +7791,35 @@ bool slayer3d_game_data_get_sector_level(const slayer3d_game_data_runtime *runti
     return true;
 }
 
+static const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->brush_world_count; ++i)
+    {
+        const brush_world_runtime *world = &runtime->brush_worlds[i];
+        if (world->desc.name != NULL && SDL_strcmp(world->desc.name, name) == 0)
+            return world;
+    }
+    return NULL;
+}
+
+bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtime, const char *name,
+                                        slayer3d_game_data_brush_world *out_world)
+{
+    if (out_world != NULL)
+        SDL_zero(*out_world);
+    if (runtime == NULL || name == NULL || out_world == NULL)
+        return false;
+
+    const brush_world_runtime *world = find_brush_world_runtime(runtime, name);
+    if (world == NULL)
+        return false;
+
+    *out_world = world->desc;
+    return true;
+}
+
 static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
                                                                                 const slayer3d_level **out_level,
                                                                                 const sector_level_runtime *level,
@@ -7630,6 +7893,43 @@ bool slayer3d_game_data_for_each_sector_level_instance(const slayer3d_game_data_
         instance.portal_culling = scene_state_bool(runtime, json_string(entry, "portal_culling_key", NULL),
                                                    json_bool(entry, "portal_culling", true));
         instance.sector_lighting_enabled = sector_lighting_enabled;
+        if (!callback(userdata, &instance))
+            return true;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_runtime *runtime,
+                                                      slayer3d_game_data_brush_world_instance_fn callback,
+                                                      void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *instances = obj_get(obj_get(scene != NULL ? scene->root : NULL, "world"), "brush_worlds");
+    if (instances == NULL)
+        return true;
+    if (!yyjson_is_arr(instances))
+        return false;
+
+    for (size_t i = 0; i < yyjson_arr_size(instances); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(instances, i);
+        const char *world_name = json_string(entry, "world", NULL);
+        const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+        if (world_runtime == NULL)
+            return false;
+
+        slayer3d_game_data_brush_world_instance instance;
+        SDL_zero(instance);
+        instance.world_name = world_runtime->desc.name;
+        instance.world = &world_runtime->desc;
+        instance.position = json_vec3(entry, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        instance.acceleration_enabled = scene_state_bool(runtime, json_string(entry, "acceleration_key", NULL),
+                                                         json_bool(entry, "acceleration", true));
+        instance.debug_wireframe = scene_state_bool(runtime, json_string(entry, "debug_wireframe_key", NULL),
+                                                    json_bool(entry, "debug_wireframe", false));
         if (!callback(userdata, &instance))
             return true;
     }
@@ -20582,6 +20882,7 @@ bool slayer3d_game_data_load_asset_with_options(slayer3d_asset_resolver *assets,
               load_grid_maps(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_pickup_layers(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_levels(runtime, root, error_buffer, error_buffer_size) &&
+              load_brush_worlds(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_doors(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_platforms(runtime, root, error_buffer, error_buffer_size) &&
               load_actor_pools(runtime, root, error_buffer, error_buffer_size) &&
@@ -22744,6 +23045,28 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
         slayer3d_free_level(&runtime->sector_levels[i].vertex_baked_without_sector_lighting);
         slayer3d_free_level(&runtime->sector_levels[i].unlit_without_sector_lighting);
     }
+    for (int i = 0; i < runtime->brush_world_count; ++i)
+    {
+        slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
+        SDL_free((void *)world->name);
+        SDL_free((void *)world->units);
+        for (int material_index = 0; material_index < world->material_count; ++material_index)
+        {
+            SDL_free((void *)world->materials[material_index].name);
+            SDL_free((void *)world->materials[material_index].texture);
+        }
+        for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+        {
+            const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+            SDL_free((void *)brush->name);
+            for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
+                SDL_free((void *)brush->tags[tag_index]);
+            SDL_free((void *)brush->tags);
+            SDL_free((void *)brush->faces);
+        }
+        SDL_free((void *)world->materials);
+        SDL_free((void *)world->brushes);
+    }
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {
         SDL_free(runtime->actor_pools[i].name);
@@ -22805,6 +23128,7 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_actor_indices);
     SDL_free(runtime->grid_pickup_layers);
     SDL_free(runtime->sector_levels);
+    SDL_free(runtime->brush_worlds);
     SDL_free(runtime->sector_doors);
     SDL_free(runtime->sector_platforms);
     SDL_free(runtime->fps_controllers);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -77,6 +77,7 @@ typedef struct validation_names
     name_table grid_maps;
     name_table grid_pickup_layers;
     name_table sector_levels;
+    name_table brush_worlds;
     name_table sector_navigation;
     name_table sector_doors;
     name_table sector_platforms;
@@ -1902,6 +1903,7 @@ static bool import_section_name_allowed(const char *name)
                                           "grid_pickup_layers",
                                           "sector_levels",
                                           "sector_level_fragments",
+                                          "brush_worlds",
                                           "sector_navigation",
                                           "sector_doors",
                                           "sector_platforms",
@@ -3422,6 +3424,27 @@ static bool collect_sector_levels(validation_context *ctx, yyjson_val *root, val
     return true;
 }
 
+static bool collect_brush_worlds(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *worlds = obj_get(root, "brush_worlds");
+    if (worlds == NULL)
+        return true;
+    if (!yyjson_is_arr(worlds))
+        return validation_error(ctx, "$.brush_worlds", "brush_worlds must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(worlds); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.brush_worlds[%zu]", i);
+        yyjson_val *world = yyjson_arr_get(worlds, i);
+        if (!yyjson_is_obj(world))
+            return validation_error(ctx, path, "brush world entries must be objects");
+        if (!require_unique_name(ctx, &names->brush_worlds, "brush world", json_string(world, "name"), path))
+            return false;
+    }
+    return true;
+}
+
 static bool collect_sector_navigation(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *graphs = obj_get(root, "sector_navigation");
@@ -4100,16 +4123,17 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
 {
     return collect_signals(ctx, root, names) && collect_entities(ctx, root, names) &&
            collect_grid_maps(ctx, root, names) && collect_grid_pickup_layers(ctx, root, names) &&
-           collect_sector_levels(ctx, root, names) && collect_sector_navigation(ctx, root, names) &&
-           collect_sector_doors(ctx, root, names) && collect_sector_platforms(ctx, root, names) &&
-           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
-           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
-           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
-           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
-           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
-           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
-           collect_models(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
-           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
+           collect_sector_levels(ctx, root, names) && collect_brush_worlds(ctx, root, names) &&
+           collect_sector_navigation(ctx, root, names) && collect_sector_doors(ctx, root, names) &&
+           collect_sector_platforms(ctx, root, names) && collect_actor_archetypes(ctx, root, names) &&
+           collect_actor_pools(ctx, root, names) && collect_scripts(ctx, root, names) &&
+           collect_adapters(ctx, root, names) && collect_input_actions(ctx, root, names) &&
+           collect_input_assignment_sets(ctx, root, names) && collect_input_profiles(ctx, root, names) &&
+           collect_network_input_channels(ctx, root, names) && collect_cameras(ctx, root, names) &&
+           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
+           collect_images(ctx, root, names) && collect_models(ctx, root, names) &&
+           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
+           collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -4638,6 +4662,97 @@ static bool sector_level_material_ref_valid(yyjson_val *materials, const name_ta
     return false;
 }
 
+static bool brush_content_name_valid(const char *name)
+{
+    static const char *const names[] = {"solid", "player_clip", "projectile_clip", "trigger", "water", "lava", "sky"};
+    for (size_t i = 0; name != NULL && i < SDL_arraysize(names); ++i)
+    {
+        if (SDL_strcmp(name, names[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool brush_surface_flag_name_valid(const char *name)
+{
+    static const char *const names[] = {"nocollide", "slick", "ladder", "emissive", "portal_candidate"};
+    for (size_t i = 0; name != NULL && i < SDL_arraysize(names); ++i)
+    {
+        if (SDL_strcmp(name, names[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool validate_brush_string_or_string_array(validation_context *ctx, yyjson_val *value, const char *path,
+                                                  const char *label, bool (*name_valid)(const char *name),
+                                                  bool allow_empty)
+{
+    if (value == NULL)
+        return true;
+    if (yyjson_is_str(value))
+    {
+        const char *name = yyjson_get_str(value);
+        if (name == NULL || name[0] == '\0' || (name_valid != NULL && !name_valid(name)))
+            return validation_error(ctx, path, "%s value is unknown", label);
+        return true;
+    }
+    if (!yyjson_is_arr(value))
+        return validation_error(ctx, path, "%s must be a string or string array", label);
+    if (!allow_empty && yyjson_arr_size(value) <= 0)
+        return validation_error(ctx, path, "%s array must be non-empty", label);
+
+    name_table names;
+    SDL_zero(names);
+    bool ok = true;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        char entry_path[PATH_BUFFER_SIZE];
+        format_path(entry_path, sizeof(entry_path), "%s[%zu]", path, i);
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (!yyjson_is_str(entry) || yyjson_get_str(entry) == NULL || yyjson_get_str(entry)[0] == '\0')
+        {
+            ok = validation_error(ctx, entry_path, "%s entries must be non-empty strings", label);
+            break;
+        }
+        const char *name = yyjson_get_str(entry);
+        if (name_valid != NULL && !name_valid(name))
+        {
+            ok = validation_error(ctx, entry_path, "%s value is unknown", label);
+            break;
+        }
+        if (!require_unique_name(ctx, &names, label, name, entry_path))
+        {
+            ok = false;
+            break;
+        }
+    }
+    name_table_destroy(&names);
+    return ok;
+}
+
+static bool brush_material_ref_valid(yyjson_val *materials, const name_table *material_names, yyjson_val *ref)
+{
+    if (yyjson_is_int(ref))
+    {
+        const int index = (int)yyjson_get_int(ref);
+        return index >= 0 && index < (int)yyjson_arr_size(materials);
+    }
+    if (yyjson_is_str(ref))
+        return name_table_contains(material_names, yyjson_get_str(ref));
+    return false;
+}
+
+static bool vec3_nonzero(yyjson_val *value)
+{
+    if (!is_exact_vec_array(value, 3))
+        return false;
+    const double x = yyjson_get_num(yyjson_arr_get(value, 0));
+    const double y = yyjson_get_num(yyjson_arr_get(value, 1));
+    const double z = yyjson_get_num(yyjson_arr_get(value, 2));
+    return x * x + y * y + z * z > 0.000001;
+}
+
 static bool validate_sector_levels(validation_context *ctx, yyjson_val *root)
 {
     yyjson_val *levels = obj_get(root, "sector_levels");
@@ -4865,6 +4980,210 @@ static bool validate_sector_levels(validation_context *ctx, yyjson_val *root)
     done:
         name_table_destroy(&material_names);
         name_table_destroy(&sector_names);
+        if (!ok)
+            return false;
+    }
+    return true;
+}
+
+static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
+{
+    yyjson_val *worlds = obj_get(root, "brush_worlds");
+    if (worlds == NULL)
+        return true;
+    if (!yyjson_is_arr(worlds))
+        return validation_error(ctx, "$.brush_worlds", "brush_worlds must be an array");
+
+    for (size_t world_index = 0; world_index < yyjson_arr_size(worlds); ++world_index)
+    {
+        char world_path[PATH_BUFFER_SIZE];
+        format_path(world_path, sizeof(world_path), "$.brush_worlds[%zu]", world_index);
+        yyjson_val *world = yyjson_arr_get(worlds, world_index);
+        yyjson_val *materials = obj_get(world, "materials");
+        yyjson_val *brushes = obj_get(world, "brushes");
+        name_table material_names;
+        name_table brush_names;
+        SDL_zero(material_names);
+        SDL_zero(brush_names);
+        bool ok = true;
+
+        if (!yyjson_is_obj(world))
+        {
+            ok = validation_error(ctx, world_path, "brush world entries must be objects");
+            goto done;
+        }
+
+        const char *units = json_string(world, "units");
+        if (units != NULL && SDL_strcmp(units, "meters") != 0)
+        {
+            ok = validation_error(ctx, world_path, "brush world units must be meters");
+            goto done;
+        }
+        yyjson_val *meters_per_unit = obj_get(world, "meters_per_unit");
+        if (meters_per_unit != NULL && (!yyjson_is_num(meters_per_unit) || yyjson_get_num(meters_per_unit) <= 0.0))
+        {
+            ok = validation_error(ctx, world_path, "brush world meters_per_unit must be positive");
+            goto done;
+        }
+        if (!yyjson_is_arr(materials) || yyjson_arr_size(materials) <= 0)
+        {
+            ok = validation_error(ctx, world_path, "brush world materials must be a non-empty array");
+            goto done;
+        }
+        if (!yyjson_is_arr(brushes) || yyjson_arr_size(brushes) <= 0)
+        {
+            ok = validation_error(ctx, world_path, "brush world brushes must be a non-empty array");
+            goto done;
+        }
+
+        for (size_t material_index = 0; ok && material_index < yyjson_arr_size(materials); ++material_index)
+        {
+            char material_path[PATH_BUFFER_SIZE];
+            format_path(material_path, sizeof(material_path), "%s.materials[%zu]", world_path, material_index);
+            yyjson_val *material = yyjson_arr_get(materials, material_index);
+            if (!yyjson_is_obj(material))
+            {
+                ok = validation_error(ctx, material_path, "brush material entries must be objects");
+                break;
+            }
+            if (!require_unique_name(ctx, &material_names, "brush material", json_string(material, "name"),
+                                     material_path))
+            {
+                ok = false;
+                break;
+            }
+            yyjson_val *albedo = obj_get(material, "albedo");
+            if (albedo != NULL &&
+                (!is_exact_vec3_or_vec4_array(albedo) || !numeric_array_values_in_range(albedo, 0.0, 1.0)))
+            {
+                ok = validation_error(ctx, material_path,
+                                      "brush material albedo must be a vec3 or vec4 with values in [0, 1]");
+                break;
+            }
+            yyjson_val *metallic = obj_get(material, "metallic");
+            yyjson_val *roughness = obj_get(material, "roughness");
+            yyjson_val *tex_scale = obj_get(material, "tex_scale");
+            if ((metallic != NULL && (!yyjson_is_num(metallic) || yyjson_get_num(metallic) < 0.0)) ||
+                (roughness != NULL && (!yyjson_is_num(roughness) || yyjson_get_num(roughness) < 0.0)))
+            {
+                ok = validation_error(ctx, material_path, "brush material metallic and roughness must be non-negative");
+                break;
+            }
+            if (tex_scale != NULL && (!yyjson_is_num(tex_scale) || yyjson_get_num(tex_scale) <= 0.0))
+            {
+                ok = validation_error(ctx, material_path, "brush material tex_scale must be positive");
+                break;
+            }
+            const char *texture = json_string(material, "texture");
+            if (texture != NULL && texture[0] == '\0')
+            {
+                ok = validation_error(ctx, material_path, "brush material texture must be non-empty when present");
+                break;
+            }
+            if (texture != NULL && !asset_path_exists(ctx, texture, material_path, "brush material texture"))
+            {
+                ok = false;
+                break;
+            }
+        }
+
+        for (size_t brush_index = 0; ok && brush_index < yyjson_arr_size(brushes); ++brush_index)
+        {
+            char brush_path[PATH_BUFFER_SIZE];
+            format_path(brush_path, sizeof(brush_path), "%s.brushes[%zu]", world_path, brush_index);
+            yyjson_val *brush = yyjson_arr_get(brushes, brush_index);
+            yyjson_val *faces = obj_get(brush, "faces");
+            if (!yyjson_is_obj(brush))
+            {
+                ok = validation_error(ctx, brush_path, "brush entries must be objects");
+                break;
+            }
+            if (!require_unique_name(ctx, &brush_names, "brush", json_string(brush, "name"), brush_path))
+            {
+                ok = false;
+                break;
+            }
+
+            yyjson_val *tags = obj_get(brush, "tags");
+            if (tags != NULL)
+            {
+                if (!yyjson_is_arr(tags))
+                {
+                    ok = validation_error(ctx, brush_path, "brush tags must be an array");
+                    break;
+                }
+                name_table tag_names;
+                SDL_zero(tag_names);
+                for (size_t tag_index = 0; ok && tag_index < yyjson_arr_size(tags); ++tag_index)
+                {
+                    char tag_path[PATH_BUFFER_SIZE];
+                    format_path(tag_path, sizeof(tag_path), "%s.tags[%zu]", brush_path, tag_index);
+                    yyjson_val *tag = yyjson_arr_get(tags, tag_index);
+                    if (!yyjson_is_str(tag) || yyjson_get_str(tag) == NULL || yyjson_get_str(tag)[0] == '\0')
+                    {
+                        ok = validation_error(ctx, tag_path, "brush tags must be non-empty strings");
+                        break;
+                    }
+                    if (!require_unique_name(ctx, &tag_names, "brush tag", yyjson_get_str(tag), tag_path))
+                        ok = false;
+                }
+                name_table_destroy(&tag_names);
+                if (!ok)
+                    break;
+            }
+
+            char contents_path[PATH_BUFFER_SIZE];
+            format_path(contents_path, sizeof(contents_path), "%s.contents", brush_path);
+            if (!validate_brush_string_or_string_array(ctx, obj_get(brush, "contents"), contents_path, "brush content",
+                                                       brush_content_name_valid, false))
+            {
+                ok = false;
+                break;
+            }
+            if (!yyjson_is_arr(faces) || yyjson_arr_size(faces) < 4)
+            {
+                ok = validation_error(ctx, brush_path, "brush faces must contain at least 4 entries");
+                break;
+            }
+            for (size_t face_index = 0; ok && face_index < yyjson_arr_size(faces); ++face_index)
+            {
+                char face_path[PATH_BUFFER_SIZE];
+                char plane_path[PATH_BUFFER_SIZE];
+                char flags_path[PATH_BUFFER_SIZE];
+                format_path(face_path, sizeof(face_path), "%s.faces[%zu]", brush_path, face_index);
+                format_path(plane_path, sizeof(plane_path), "%s.plane", face_path);
+                format_path(flags_path, sizeof(flags_path), "%s.surface_flags", face_path);
+                yyjson_val *face = yyjson_arr_get(faces, face_index);
+                yyjson_val *plane = obj_get(face, "plane");
+                if (!yyjson_is_obj(face))
+                {
+                    ok = validation_error(ctx, face_path, "brush face entries must be objects");
+                    break;
+                }
+                if (!yyjson_is_obj(plane) || !vec3_nonzero(obj_get(plane, "normal")) ||
+                    !yyjson_is_num(obj_get(plane, "distance")))
+                {
+                    ok = validation_error(ctx, plane_path,
+                                          "brush face plane requires non-zero normal vec3 and numeric distance");
+                    break;
+                }
+                if (!brush_material_ref_valid(materials, &material_names, obj_get(face, "material")))
+                {
+                    ok = validation_error(ctx, face_path, "brush face material must reference a declared material");
+                    break;
+                }
+                if (!validate_brush_string_or_string_array(ctx, obj_get(face, "surface_flags"), flags_path,
+                                                           "brush surface flag", brush_surface_flag_name_valid, true))
+                {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+
+    done:
+        name_table_destroy(&material_names);
+        name_table_destroy(&brush_names);
         if (!ok)
             return false;
     }
@@ -9107,6 +9426,52 @@ static bool validate_scene_sector_levels(validation_context *ctx, yyjson_val *sc
     return true;
 }
 
+static bool validate_scene_brush_worlds(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
+                                        validation_names *names)
+{
+    yyjson_val *world = obj_get(scene_root, "world");
+    if (world == NULL)
+        return true;
+    if (!yyjson_is_obj(world))
+        return validation_error(ctx, json_path, "scene world must be an object");
+
+    yyjson_val *brush_worlds = obj_get(world, "brush_worlds");
+    if (brush_worlds == NULL)
+        return true;
+    char worlds_path[PATH_BUFFER_SIZE];
+    format_path(worlds_path, sizeof(worlds_path), "%s.world.brush_worlds", json_path);
+    if (!yyjson_is_arr(brush_worlds))
+        return validation_error(ctx, worlds_path, "scene world.brush_worlds must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(brush_worlds); ++i)
+    {
+        char entry_path[PATH_BUFFER_SIZE];
+        format_path(entry_path, sizeof(entry_path), "%s[%zu]", worlds_path, i);
+        yyjson_val *entry = yyjson_arr_get(brush_worlds, i);
+        if (!yyjson_is_obj(entry))
+            return validation_error(ctx, entry_path, "scene brush world entries must be objects");
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(entry, "world"), entry_path))
+            return false;
+
+        yyjson_val *position = obj_get(entry, "position");
+        if (position != NULL && !is_exact_vec_array(position, 3))
+            return validation_error(ctx, entry_path, "scene brush world position must be a vec3 array");
+        yyjson_val *acceleration = obj_get(entry, "acceleration");
+        if (acceleration != NULL && !yyjson_is_bool(acceleration))
+            return validation_error(ctx, entry_path, "scene brush world acceleration must be a boolean");
+        yyjson_val *debug_wireframe = obj_get(entry, "debug_wireframe");
+        if (debug_wireframe != NULL && !yyjson_is_bool(debug_wireframe))
+            return validation_error(ctx, entry_path, "scene brush world debug_wireframe must be a boolean");
+        yyjson_val *acceleration_key = obj_get(entry, "acceleration_key");
+        if (acceleration_key != NULL && !is_non_empty_string(entry, "acceleration_key"))
+            return validation_error(ctx, entry_path, "scene brush world acceleration_key must be non-empty");
+        yyjson_val *debug_wireframe_key = obj_get(entry, "debug_wireframe_key");
+        if (debug_wireframe_key != NULL && !is_non_empty_string(entry, "debug_wireframe_key"))
+            return validation_error(ctx, entry_path, "scene brush world debug_wireframe_key must be non-empty");
+    }
+    return true;
+}
+
 static bool validate_scene_skybox(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
                                   validation_names *names)
 {
@@ -9166,6 +9531,8 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         return false;
 
     if (!validate_scene_sector_levels(ctx, root, json_path, names))
+        return false;
+    if (!validate_scene_brush_worlds(ctx, root, json_path, names))
         return false;
     if (!validate_scene_skybox(ctx, root, json_path, names))
         return false;
@@ -9645,8 +10012,8 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_world_metadata(ctx, root) && validate_input_bindings(ctx, root) &&
            validate_input_assignment_sets(ctx, root) && validate_input_profiles(ctx, root, names) &&
            validate_grid_maps(ctx, root) && validate_grid_pickup_layers(ctx, root, names) &&
-           validate_sector_levels(ctx, root) && validate_sector_navigation(ctx, root, names) &&
-           validate_components(ctx, root, names) &&
+           validate_sector_levels(ctx, root) && validate_brush_worlds(ctx, root) &&
+           validate_sector_navigation(ctx, root, names) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
@@ -9674,6 +10041,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->grid_maps);
     name_table_destroy(&names->grid_pickup_layers);
     name_table_destroy(&names->sector_levels);
+    name_table_destroy(&names->brush_worlds);
     name_table_destroy(&names->sector_navigation);
     name_table_destroy(&names->sector_doors);
     name_table_destroy(&names->sector_platforms);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -134,6 +134,16 @@ struct SectorLevelInstanceCapture
     bool sector_lighting_enabled = true;
 };
 
+struct BrushWorldInstanceCapture
+{
+    int count = 0;
+    std::string world_name;
+    const slayer3d_game_data_brush_world *world = nullptr;
+    slayer3d_vec3 position{};
+    bool acceleration_enabled = true;
+    bool debug_wireframe = false;
+};
+
 struct SectorDoorRenderCapture
 {
     int door_primitives = 0;
@@ -1522,6 +1532,18 @@ bool capture_sector_level_instance(void *userdata, const slayer3d_game_data_sect
     capture->position = instance->position;
     capture->portal_culling = instance->portal_culling;
     capture->sector_lighting_enabled = instance->sector_lighting_enabled;
+    return true;
+}
+
+bool capture_brush_world_instance(void *userdata, const slayer3d_game_data_brush_world_instance *instance)
+{
+    auto *capture = static_cast<BrushWorldInstanceCapture *>(userdata);
+    capture->count++;
+    capture->world_name = instance->world_name != nullptr ? instance->world_name : "";
+    capture->world = instance->world;
+    capture->position = instance->position;
+    capture->acceleration_enabled = instance->acceleration_enabled;
+    capture->debug_wireframe = instance->debug_wireframe;
     return true;
 }
 
@@ -10318,6 +10340,263 @@ TEST(GameDataRuntime, LoadsAuthoredSectorLevels)
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_worlds");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "brush_worlds": [
+      {
+        "world": "brush.test",
+        "position": [1.0, 2.0, 3.0],
+        "acceleration": false,
+        "debug_wireframe": true
+      }
+    ]
+  }
+})json");
+    write_text(dir / "brush_world.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush World Test" },
+  "world": { "name": "world.brush_test", "kind": "brush", "units": "meters", "meters_per_unit": 1.0 },
+  "brush_worlds": [
+    {
+      "name": "brush.test",
+      "units": "meters",
+      "meters_per_unit": 1.0,
+      "materials": [
+        {
+          "name": "mat.wall",
+          "albedo": [0.25, 0.35, 0.45, 1.0],
+          "metallic": 0.0,
+          "roughness": 0.8,
+          "tex_scale": 2.0
+        }
+      ],
+      "brushes": [
+        {
+          "name": "brush.room",
+          "tags": ["solid", "room"],
+          "contents": ["solid", "player_clip"],
+          "faces": [
+            { "plane": { "normal": [ 1.0,  0.0,  0.0], "distance":  4.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1.0,  0.0,  0.0], "distance":  0.0 }, "material": 0 },
+            { "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 }, "material": "mat.wall", "surface_flags": ["slick"] },
+            { "plane": { "normal": [ 0.0, -1.0,  0.0], "distance":  0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0.0,  0.0,  1.0], "distance":  4.0 }, "material": "mat.wall", "surface_flags": "emissive" },
+            { "plane": { "normal": [ 0.0,  0.0, -1.0], "distance":  0.0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "brush_world.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.test", &world));
+    EXPECT_STREQ(world.name, "brush.test");
+    EXPECT_STREQ(world.units, "meters");
+    EXPECT_FLOAT_EQ(world.meters_per_unit, 1.0f);
+    ASSERT_EQ(world.material_count, 1);
+    EXPECT_STREQ(world.materials[0].name, "mat.wall");
+    EXPECT_FLOAT_EQ(world.materials[0].albedo.z, 0.45f);
+    EXPECT_FLOAT_EQ(world.materials[0].roughness, 0.8f);
+    EXPECT_FLOAT_EQ(world.materials[0].tex_scale, 2.0f);
+    ASSERT_EQ(world.brush_count, 1);
+    EXPECT_STREQ(world.brushes[0].name, "brush.room");
+    EXPECT_EQ(world.brushes[0].contents,
+              SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+    ASSERT_EQ(world.brushes[0].tag_count, 2);
+    EXPECT_STREQ(world.brushes[0].tags[1], "room");
+    ASSERT_EQ(world.brushes[0].face_count, 6);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[0].normal.x, 1.0f);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[0].distance, 4.0f);
+    EXPECT_EQ(world.brushes[0].faces[1].material_index, 0);
+    EXPECT_STREQ(world.brushes[0].faces[1].material_name, "mat.wall");
+    EXPECT_EQ(world.brushes[0].faces[2].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK);
+    EXPECT_EQ(world.brushes[0].faces[4].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE);
+
+    slayer3d_game_data_brush_world missing{};
+    EXPECT_FALSE(slayer3d_game_data_get_brush_world(runtime, "brush.missing", &missing));
+    EXPECT_EQ(missing.name, nullptr);
+
+    BrushWorldInstanceCapture capture{};
+    ASSERT_TRUE(slayer3d_game_data_for_each_brush_world_instance(runtime, capture_brush_world_instance, &capture));
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.world_name, "brush.test");
+    ASSERT_NE(capture.world, nullptr);
+    EXPECT_STREQ(capture.world->name, "brush.test");
+    expect_vec3_near(capture.position, slayer3d_vec3_make(1.0f, 2.0f, 3.0f));
+    EXPECT_FALSE(capture.acceleration_enabled);
+    EXPECT_TRUE(capture.debug_wireframe);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
+{
+    struct Case
+    {
+        const char *name;
+        const char *brush_world_json;
+        const char *scene_json;
+        const char *error;
+    };
+    const Case cases[] = {
+        {
+            "bad_material_ref",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.missing" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush face material must reference a declared material",
+        },
+        {
+            "zero_normal",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [0, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush face plane requires non-zero normal vec3",
+        },
+        {
+            "bad_content",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "contents": ["opaque"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush content value is unknown",
+        },
+        {
+            "bad_scene_ref",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.good",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": { "brush_worlds": [{ "world": "brush.missing" }] }
+})json",
+            "unknown brush world reference",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path dir = unique_test_dir(test_case.name);
+        write_text(dir / "scenes" / "play.scene.json", test_case.scene_json != nullptr ? test_case.scene_json : R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play"
+})json");
+        std::string brush_world_section = test_case.brush_world_json;
+        const size_t section_start = brush_world_section.find("\"brush_worlds\"");
+        const size_t section_end = brush_world_section.rfind('}');
+        ASSERT_NE(section_start, std::string::npos) << test_case.name;
+        ASSERT_NE(section_end, std::string::npos) << test_case.name;
+        brush_world_section = brush_world_section.substr(section_start, section_end - section_start);
+        const std::string game_json = std::string(R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Invalid Brush World" },
+  "world": { "name": "world.invalid", "kind": "brush" },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] },
+)json") + brush_world_section + "\n}";
+        write_text(dir / "bad_brush.game.json", game_json.c_str());
+
+        slayer3d_game_session *session = nullptr;
+        ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+        char error[512]{};
+        slayer3d_game_data_runtime *runtime = nullptr;
+        EXPECT_FALSE(slayer3d_game_data_load_file((dir / "bad_brush.game.json").string().c_str(), session, &runtime,
+                                                  error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.error), std::string::npos) << test_case.name << ": " << error;
+        slayer3d_game_data_destroy(runtime);
+        slayer3d_game_session_destroy(session);
+        remove_test_dir(dir);
+    }
 }
 
 TEST(GameDataRuntime, SectorLightingModulatesLitActorsAndCanUpdateAtRuntime)


### PR DESCRIPTION
## Summary
- Adds native JSON-authored `brush_worlds` with validation for materials, convex brush faces, contents, surface flags, tags, and units.
- Loads brush worlds into runtime-owned descriptors and exposes renderer/editor-facing lookup and active-scene iteration APIs.
- Documents brush world authoring and adds focused load/rejection tests for the new schema.

## Verification
- `cmake --build build/debug --target slayer3d_game_data_test -j4`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j4`
- `ctest --test-dir build/debug --output-on-failure -j4`

Refs #306