### PR TITLE
Compile and render brush world meshes

### DIFF
--- a/demos/brush_geometry_dojo/README.md
+++ b/demos/brush_geometry_dojo/README.md
@@ -1,0 +1,8 @@
+# Brush Geometry Dojo
+
+Data-only showcase for native convex brush rendering.
+
+```sh
+./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json
+```
+

--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -1,0 +1,72 @@
+{
+  "schema": "slayer3d.game.v0",
+  "metadata": {
+    "name": "Slayer 3D Brush Geometry Dojo",
+    "id": "demo.brush_geometry_dojo",
+    "version": "0.1.0"
+  },
+  "imports": [
+    { "path": "fragments/world/showcase.brushes.json", "sections": ["brush_worlds"] },
+    { "path": "fragments/actors/lights.json", "sections": ["entities"] }
+  ],
+  "app": {
+    "title": "Slayer 3D Brush Geometry Dojo",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.brush_geometry_dojo",
+        "actions": [
+          {
+            "name": "action.exit",
+            "bindings": [
+              { "device": "keyboard", "key": "ESCAPE" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "world": {
+    "name": "world.brush_geometry_dojo",
+    "kind": "brush",
+    "units": "meters",
+    "meters_per_unit": 1.0,
+    "ambient_light": [0.16, 0.17, 0.18],
+    "cameras": [
+      {
+        "name": "camera.brush_geometry.overview",
+        "type": "perspective",
+        "position": [15.0, 8.0, 17.0],
+        "target": [0.0, 2.2, 0.0],
+        "up": [0.0, 1.0, 0.0],
+        "fov": 90.0,
+        "fov_axis": "horizontal",
+        "active": true
+      }
+    ]
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.brush_geometry.hud", "builtin": "Inter", "size": 22 }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": false,
+    "clear_color": [0.035, 0.04, 0.05]
+  },
+  "presentation": {
+    "metrics": { "fps_sample_seconds": 0.25 }
+  },
+  "scenes": {
+    "initial": "scene.brush_geometry.showcase",
+    "files": ["scenes/showcase.scene.json"]
+  }
+}

--- a/demos/brush_geometry_dojo/data/fragments/actors/lights.json
+++ b/demos/brush_geometry_dojo/data/fragments/actors/lights.json
@@ -1,0 +1,31 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.brush_geometry.sun",
+      "active": true,
+      "transform": { "position": [0.0, 10.0, 0.0] },
+      "components": [
+        {
+          "type": "light.directional",
+          "direction": [-0.35, -1.0, -0.42],
+          "color": [1.0, 0.94, 0.84],
+          "intensity": 2.15
+        }
+      ]
+    },
+    {
+      "name": "entity.brush_geometry.blue_fill",
+      "active": true,
+      "transform": { "position": [-7.5, 3.0, -5.0] },
+      "components": [
+        {
+          "type": "light.point",
+          "color": [0.25, 0.45, 1.0],
+          "intensity": 1.15,
+          "range": 11.0
+        }
+      ]
+    }
+  ]
+}

--- a/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
+++ b/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
@@ -1,0 +1,137 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.brush_geometry.showcase",
+      "units": "meters",
+      "meters_per_unit": 1.0,
+      "materials": [
+        { "name": "mat.floor", "albedo": [0.24, 0.25, 0.27, 1.0], "roughness": 0.9, "tex_scale": 4.0 },
+        { "name": "mat.wall", "albedo": [0.42, 0.44, 0.47, 1.0], "roughness": 0.86, "tex_scale": 4.0 },
+        { "name": "mat.ceiling", "albedo": [0.33, 0.34, 0.38, 1.0], "roughness": 0.92, "tex_scale": 4.0 },
+        { "name": "mat.ramp", "albedo": [0.64, 0.48, 0.32, 1.0], "roughness": 0.78, "tex_scale": 3.0 },
+        { "name": "mat.accent_blue", "albedo": [0.20, 0.40, 0.86, 1.0], "roughness": 0.72, "tex_scale": 3.0 },
+        { "name": "mat.accent_red", "albedo": [0.78, 0.22, 0.18, 1.0], "roughness": 0.76, "tex_scale": 3.0 }
+      ],
+      "brushes": [
+        {
+          "name": "brush.room.floor",
+          "contents": "solid",
+          "tags": ["room", "floor"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.5 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.floor" }
+          ]
+        },
+        {
+          "name": "brush.room.ceiling",
+          "contents": "solid",
+          "tags": ["room", "ceiling"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.ceiling" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.ceiling" },
+            { "plane": { "normal": [0, 1, 0], "distance": 7.4 }, "material": "mat.ceiling" },
+            { "plane": { "normal": [0, -1, 0], "distance": -7.0 }, "material": "mat.ceiling" },
+            { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.ceiling" },
+            { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.ceiling" }
+          ]
+        },
+        {
+          "name": "brush.room.wall_west",
+          "contents": "solid",
+          "tags": ["room", "wall"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": -17.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 7.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.room.wall_east",
+          "contents": "solid",
+          "tags": ["room", "wall"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": -17.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 7.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.room.wall_south",
+          "contents": "solid",
+          "tags": ["room", "wall"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 7.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": -17.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.room.wall_north",
+          "contents": "solid",
+          "tags": ["room", "wall"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 7.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": -17.5 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.ramp.wedge",
+          "contents": "solid",
+          "tags": ["showcase", "ramp"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 4.0 }, "material": "mat.ramp" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 4.0 }, "material": "mat.ramp" },
+            { "plane": { "normal": [-0.25, 1.0, 0.0], "distance": 2.5 }, "material": "mat.ramp" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.ramp" },
+            { "plane": { "normal": [0, 0, 1], "distance": 2.25 }, "material": "mat.ramp" },
+            { "plane": { "normal": [0, 0, -1], "distance": 2.25 }, "material": "mat.ramp" }
+          ]
+        },
+        {
+          "name": "brush.bridge.overhang",
+          "contents": "solid",
+          "tags": ["showcase", "overhang"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 10.0 }, "material": "mat.accent_blue" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 10.0 }, "material": "mat.accent_blue" },
+            { "plane": { "normal": [0, 1, 0], "distance": 4.25 }, "material": "mat.accent_blue" },
+            { "plane": { "normal": [0, -1, 0], "distance": -3.55 }, "material": "mat.accent_blue" },
+            { "plane": { "normal": [0, 0, 1], "distance": 1.0 }, "material": "mat.accent_blue" },
+            { "plane": { "normal": [0, 0, -1], "distance": 1.0 }, "material": "mat.accent_blue" }
+          ]
+        },
+        {
+          "name": "brush.pillar.center",
+          "contents": "solid",
+          "tags": ["showcase", "pillar"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1.0 }, "material": "mat.accent_red" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1.0 }, "material": "mat.accent_red" },
+            { "plane": { "normal": [0, 1, 0], "distance": 5.0 }, "material": "mat.accent_red" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.accent_red" },
+            { "plane": { "normal": [0, 0, 1], "distance": 1.0 }, "material": "mat.accent_red" },
+            { "plane": { "normal": [0, 0, -1], "distance": 1.0 }, "material": "mat.accent_red" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -1,0 +1,62 @@
+{
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.brush_geometry.showcase",
+  "camera": "camera.brush_geometry.overview",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": [
+    "entity.brush_geometry.sun",
+    "entity.brush_geometry.blue_fill"
+  ],
+  "input": {
+    "actions": ["action.exit"]
+  },
+  "world": {
+    "brush_worlds": [
+      {
+        "world": "brush.brush_geometry.showcase",
+        "position": [0.0, 0.0, 0.0],
+        "acceleration": true,
+        "debug_wireframe": false
+      }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.brush_geometry.title",
+        "text": "Brush Geometry Dojo",
+        "font": "font.brush_geometry.hud",
+        "x": 0.02,
+        "y": 0.03,
+        "normalized": true,
+        "color": [235, 240, 250, 230],
+        "scale": 0.85
+      },
+      {
+        "name": "ui.brush_geometry.help",
+        "text": "Static brush mesh showcase: room slabs, ramp wedge, overhang, pillar  Esc quit",
+        "font": "font.brush_geometry.hud",
+        "x": 0.02,
+        "y": 0.075,
+        "normalized": true,
+        "color": [205, 215, 230, 210],
+        "scale": 0.62
+      },
+      {
+        "name": "ui.brush_geometry.fps",
+        "font": "font.brush_geometry.hud",
+        "format": "FPS %.0f",
+        "bindings": [
+          { "type": "metric", "metric": "fps" }
+        ],
+        "x": 0.985,
+        "y": 0.03,
+        "normalized": true,
+        "align": "right",
+        "color": [180, 235, 190, 230],
+        "scale": 0.72
+      }
+    ]
+  }
+}

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -183,6 +183,16 @@ build/debug/slayer3d_runner \
   --data asset://lighting_dojo.game.json
 ```
 
+`demos/brush_geometry_dojo` is a data-only brush-world rendering showcase. It
+demonstrates true 3D convex brush slabs, ramps, overhangs, per-face materials,
+and dynamic lighting through the same generic runner frame path:
+
+```sh
+build/debug/slayer3d_runner \
+  --root demos/brush_geometry_dojo/data \
+  --data asset://brush_geometry_dojo.game.json
+```
+
 ## Data-Only Parity Checklist
 
 Before treating a game as data-only, validate the runner-backed game path:

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -459,9 +459,9 @@ overhangs, ramps, clips, trigger volumes, and future brush collision/render
 acceleration. Sector worlds remain supported; choose brush worlds when a level
 needs real 3D geometry rather than a sector/portal floor plan.
 
-Slice 1 loads and validates brush data. Mesh compilation, collision traces,
-lighting integration, and FPS controller support are intentionally layered on
-top in later slices.
+Brush worlds load, validate, and compile visible brush faces into immutable
+static meshes. Collision traces and FPS controller support are layered on top
+in later slices.
 
 ```json
 {
@@ -510,8 +510,9 @@ Validation requires:
 - optional material `texture` as a non-empty existing asset path
 - non-empty `brushes` with unique names
 - optional unique non-empty brush `tags`
-- `contents` as one value or an array of unique values: `solid`,
-  `player_clip`, `projectile_clip`, `trigger`, `water`, `lava`, or `sky`
+- optional `contents` as one value or an array of unique values: `solid`,
+  `player_clip`, `projectile_clip`, `trigger`, `water`, `lava`, or `sky`;
+  omitted contents default to `solid`
 - each brush to contain at least four `faces`
 - each face to declare `plane.normal` as a non-zero vec3 and
   `plane.distance` as a number
@@ -539,9 +540,11 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
 ```
 
 `acceleration_key` and `debug_wireframe_key` may name scene-state booleans that
-override the authored defaults. Runtime, editor, and future renderer/collision
-code should use `slayer3d_game_data_get_brush_world()` and
+override the authored defaults. Runtime and editor code should use
+`slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
+Brush render meshes are available through `brush_world.render_model` and are
+drawn by the generic data-game frame path.
 
 ## Sector Levels
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -197,6 +197,12 @@ showcases. It uses connected sector rooms and hallways with varied brightness
 and tint values, plus lit primitives and dynamic lights, so lighting behavior
 can be inspected from the same generic runner path as gameplay.
 
+`demos/brush_geometry_dojo` is the reference shape for brush-world rendering
+showcases. It keeps authored brush data separate from scene wiring, uses
+convex slabs for walls/floors/ceilings plus showcase ramp and overhang brushes,
+and verifies the generic runner renders brush meshes through the same lit 3D
+path as actors and procedural primitives.
+
 Use optional `editor` metadata beside the authored object it describes. This
 keeps future editor palettes and prefab browsers grounded in the same JSON that
 runtime validation sees. Metadata should describe categories, previews, bounds,

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -25,6 +25,7 @@
 #include "slayer3d/game.h"
 #include "slayer3d/level.h"
 #include "slayer3d/lighting.h"
+#include "slayer3d/model.h"
 #include "slayer3d/network.h"
 #include "slayer3d/network_replication.h"
 #include "slayer3d/properties.h"
@@ -441,6 +442,8 @@ extern "C"
         const slayer3d_game_data_brush *brushes;
         /** @brief Number of entries in @p brushes. */
         int brush_count;
+        /** @brief Runtime-compiled static render mesh for visible brush faces, or NULL when empty. */
+        const slayer3d_model *render_model;
     } slayer3d_game_data_brush_world;
 
     /** @brief Active-scene instance of an authored brush world. */

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -429,6 +429,25 @@ extern "C"
                                                            const slayer3d_camera3d *camera);
 
     /**
+     * @brief Draw active-scene authored brush worlds.
+     *
+     * Scene files declare brush world instances under `world.brush_worlds`.
+     * Call inside an active 3D pass. Brush worlds are compiled to immutable
+     * static meshes at game-data load time and are affected by the current
+     * renderer lighting state.
+     */
+    bool slayer3d_game_data_draw_brush_worlds(const slayer3d_game_data_runtime *runtime,
+                                              slayer3d_render_context *renderer);
+
+    /**
+     * @brief Draw active-scene brush worlds and resolve `asset://` material
+     * textures through an asset resolver.
+     */
+    bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_runtime *runtime,
+                                                          slayer3d_render_context *renderer,
+                                                          const slayer3d_asset_resolver *assets);
+
+    /**
      * @brief Draw authored UI text for the active scene.
      *
      * Built-in font assets are loaded on demand through @p font_cache. Text is

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -384,6 +384,7 @@ typedef struct sector_level_runtime
 typedef struct brush_world_runtime
 {
     slayer3d_game_data_brush_world desc;
+    slayer3d_model render_model;
 } brush_world_runtime;
 
 typedef struct sector_door_runtime
@@ -3653,6 +3654,410 @@ static int brush_material_index_from_ref(const slayer3d_game_data_brush_material
     return -1;
 }
 
+static slayer3d_vec3 brush_vec3_add(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return slayer3d_vec3_make(a.x + b.x, a.y + b.y, a.z + b.z);
+}
+
+static slayer3d_vec3 brush_vec3_sub(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return slayer3d_vec3_make(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+static bool brush_plane_normalized(const slayer3d_game_data_brush_face *face, slayer3d_vec3 *out_normal,
+                                   float *out_distance)
+{
+    if (face == NULL || out_normal == NULL || out_distance == NULL)
+        return false;
+    const float len = slayer3d_vec3_length(face->normal);
+    if (len <= 0.000001f)
+        return false;
+    *out_normal = slayer3d_vec3_scale(face->normal, 1.0f / len);
+    *out_distance = face->distance / len;
+    return true;
+}
+
+static bool brush_face_basis(slayer3d_vec3 normal, slayer3d_vec3 *out_u, slayer3d_vec3 *out_v)
+{
+    if (out_u == NULL || out_v == NULL)
+        return false;
+    const slayer3d_vec3 reference =
+        SDL_fabsf(normal.y) < 0.99f ? slayer3d_vec3_make(0.0f, 1.0f, 0.0f) : slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    slayer3d_vec3 u = slayer3d_vec3_cross(reference, normal);
+    if (slayer3d_vec3_length_squared(u) <= 0.000001f)
+        u = slayer3d_vec3_cross(slayer3d_vec3_make(0.0f, 0.0f, 1.0f), normal);
+    if (slayer3d_vec3_length_squared(u) <= 0.000001f)
+        return false;
+    u = slayer3d_vec3_normalize(u);
+    const slayer3d_vec3 v = slayer3d_vec3_normalize(slayer3d_vec3_cross(normal, u));
+    *out_u = u;
+    *out_v = v;
+    return true;
+}
+
+static int brush_clip_polygon_to_plane(const slayer3d_vec3 *input, int input_count, slayer3d_vec3 *output,
+                                       int output_capacity, slayer3d_vec3 normal, float distance)
+{
+    const float epsilon = 0.0005f;
+    int output_count = 0;
+    if (input == NULL || output == NULL || input_count <= 0 || output_capacity <= 0)
+        return 0;
+
+    slayer3d_vec3 prev = input[input_count - 1];
+    float prev_d = slayer3d_vec3_dot(normal, prev) - distance;
+    bool prev_inside = prev_d <= epsilon;
+    for (int i = 0; i < input_count; ++i)
+    {
+        const slayer3d_vec3 cur = input[i];
+        const float cur_d = slayer3d_vec3_dot(normal, cur) - distance;
+        const bool cur_inside = cur_d <= epsilon;
+        if (cur_inside != prev_inside)
+        {
+            const float denom = prev_d - cur_d;
+            if (SDL_fabsf(denom) > 0.000001f && output_count < output_capacity)
+            {
+                const float t = prev_d / denom;
+                output[output_count++] =
+                    brush_vec3_add(prev, slayer3d_vec3_scale(brush_vec3_sub(cur, prev), SDL_clamp(t, 0.0f, 1.0f)));
+            }
+        }
+        if (cur_inside && output_count < output_capacity)
+            output[output_count++] = cur;
+        prev = cur;
+        prev_d = cur_d;
+        prev_inside = cur_inside;
+    }
+    return output_count;
+}
+
+static int brush_compact_polygon(slayer3d_vec3 *points, int count)
+{
+    if (points == NULL || count <= 0)
+        return 0;
+
+    int write = 0;
+    for (int i = 0; i < count; ++i)
+    {
+        if (write > 0 && slayer3d_vec3_length_squared(brush_vec3_sub(points[i], points[write - 1])) <= 0.000001f)
+            continue;
+        points[write++] = points[i];
+    }
+    if (write > 1 && slayer3d_vec3_length_squared(brush_vec3_sub(points[0], points[write - 1])) <= 0.000001f)
+        --write;
+    return write;
+}
+
+static int brush_build_face_polygon(const slayer3d_game_data_brush *brush, int face_index, slayer3d_vec3 *polygon,
+                                    int polygon_capacity, slayer3d_vec3 *out_normal, slayer3d_vec3 *out_u,
+                                    slayer3d_vec3 *out_v)
+{
+    slayer3d_vec3 normal;
+    slayer3d_vec3 u;
+    slayer3d_vec3 v;
+    float distance = 0.0f;
+    if (brush == NULL || polygon == NULL || polygon_capacity < 4 || face_index < 0 || face_index >= brush->face_count ||
+        !brush_plane_normalized(&brush->faces[face_index], &normal, &distance) || !brush_face_basis(normal, &u, &v))
+    {
+        return 0;
+    }
+
+    const float extent = SDL_max(SDL_fabsf(distance) + 4096.0f, 4096.0f);
+    const slayer3d_vec3 center = slayer3d_vec3_scale(normal, distance);
+    polygon[0] = brush_vec3_sub(brush_vec3_sub(center, slayer3d_vec3_scale(u, extent)), slayer3d_vec3_scale(v, extent));
+    polygon[1] = brush_vec3_sub(brush_vec3_add(center, slayer3d_vec3_scale(u, extent)), slayer3d_vec3_scale(v, extent));
+    polygon[2] = brush_vec3_add(brush_vec3_add(center, slayer3d_vec3_scale(u, extent)), slayer3d_vec3_scale(v, extent));
+    polygon[3] = brush_vec3_add(brush_vec3_sub(center, slayer3d_vec3_scale(u, extent)), slayer3d_vec3_scale(v, extent));
+
+    int count = 4;
+    slayer3d_vec3 *scratch = (slayer3d_vec3 *)SDL_malloc((size_t)polygon_capacity * sizeof(*scratch));
+    if (scratch == NULL)
+        return 0;
+    for (int clip_index = 0; clip_index < brush->face_count && count >= 3; ++clip_index)
+    {
+        if (clip_index == face_index)
+            continue;
+        slayer3d_vec3 clip_normal;
+        float clip_distance = 0.0f;
+        if (!brush_plane_normalized(&brush->faces[clip_index], &clip_normal, &clip_distance))
+        {
+            count = 0;
+            break;
+        }
+        count = brush_clip_polygon_to_plane(polygon, count, scratch, polygon_capacity, clip_normal, clip_distance);
+        if (count > 0)
+            SDL_memcpy(polygon, scratch, (size_t)count * sizeof(*polygon));
+        count = brush_compact_polygon(polygon, count);
+    }
+    SDL_free(scratch);
+
+    if (count >= 3)
+    {
+        const slayer3d_vec3 winding_normal =
+            slayer3d_vec3_cross(brush_vec3_sub(polygon[1], polygon[0]), brush_vec3_sub(polygon[2], polygon[0]));
+        if (slayer3d_vec3_dot(winding_normal, normal) < 0.0f)
+        {
+            for (int a = 0, b = count - 1; a < b; ++a, --b)
+            {
+                const slayer3d_vec3 tmp = polygon[a];
+                polygon[a] = polygon[b];
+                polygon[b] = tmp;
+            }
+        }
+    }
+    if (out_normal != NULL)
+        *out_normal = normal;
+    if (out_u != NULL)
+        *out_u = u;
+    if (out_v != NULL)
+        *out_v = v;
+    return count;
+}
+
+static bool brush_is_renderable(const slayer3d_game_data_brush *brush)
+{
+    if (brush == NULL)
+        return false;
+    const unsigned int visible_contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID |
+                                          SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER |
+                                          SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY;
+    return (brush->contents & visible_contents) != 0u;
+}
+
+static Uint8 brush_color_channel(float value)
+{
+    if (value <= 0.0f)
+        return 0;
+    if (value >= 1.0f)
+        return 255;
+    return (Uint8)(value * 255.0f + 0.5f);
+}
+
+static slayer3d_color brush_material_color(const slayer3d_game_data_brush_material *material)
+{
+    if (material == NULL)
+        return (slayer3d_color){255, 255, 255, 255};
+    return (slayer3d_color){
+        brush_color_channel(material->albedo.x),
+        brush_color_channel(material->albedo.y),
+        brush_color_channel(material->albedo.z),
+        brush_color_channel(material->albedo.w),
+    };
+}
+
+static void brush_mesh_bounds_add(slayer3d_mesh *mesh, slayer3d_vec3 p)
+{
+    if (mesh == NULL)
+        return;
+    if (!mesh->has_local_bounds)
+    {
+        mesh->local_bounds.min = p;
+        mesh->local_bounds.max = p;
+        mesh->has_local_bounds = true;
+        return;
+    }
+    mesh->local_bounds.min.x = SDL_min(mesh->local_bounds.min.x, p.x);
+    mesh->local_bounds.min.y = SDL_min(mesh->local_bounds.min.y, p.y);
+    mesh->local_bounds.min.z = SDL_min(mesh->local_bounds.min.z, p.z);
+    mesh->local_bounds.max.x = SDL_max(mesh->local_bounds.max.x, p.x);
+    mesh->local_bounds.max.y = SDL_max(mesh->local_bounds.max.y, p.y);
+    mesh->local_bounds.max.z = SDL_max(mesh->local_bounds.max.z, p.z);
+}
+
+static bool brush_model_copy_materials(const slayer3d_game_data_brush_world *world, slayer3d_model *model)
+{
+    if (world == NULL || model == NULL || world->material_count <= 0)
+        return false;
+    model->materials = (slayer3d_material *)SDL_calloc((size_t)world->material_count, sizeof(*model->materials));
+    if (model->materials == NULL)
+        return false;
+    model->material_count = world->material_count;
+    for (int i = 0; i < world->material_count; ++i)
+    {
+        const slayer3d_game_data_brush_material *src = &world->materials[i];
+        slayer3d_material *dst = &model->materials[i];
+        dst->name = SDL_strdup(src->name != NULL ? src->name : "");
+        dst->albedo[0] = src->albedo.x;
+        dst->albedo[1] = src->albedo.y;
+        dst->albedo[2] = src->albedo.z;
+        dst->albedo[3] = src->albedo.w;
+        dst->metallic = src->metallic;
+        dst->roughness = src->roughness;
+        if (src->texture != NULL)
+            dst->albedo_map = SDL_strdup(src->texture);
+        if (dst->name == NULL || (src->texture != NULL && dst->albedo_map == NULL))
+            return false;
+    }
+    return true;
+}
+
+static bool brush_world_compile_render_model(brush_world_runtime *runtime)
+{
+    if (runtime == NULL)
+        return false;
+    slayer3d_game_data_brush_world *world = &runtime->desc;
+    slayer3d_model *model = &runtime->render_model;
+    SDL_zero(*model);
+    if (!brush_model_copy_materials(world, model))
+        return false;
+
+    int *triangle_counts = (int *)SDL_calloc((size_t)world->material_count, sizeof(*triangle_counts));
+    if (triangle_counts == NULL)
+        return false;
+
+    int max_face_count = 0;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+        max_face_count = SDL_max(max_face_count, world->brushes[brush_index].face_count);
+    const int polygon_capacity = SDL_max(16, max_face_count * 2 + 8);
+    slayer3d_vec3 *polygon = (slayer3d_vec3 *)SDL_malloc((size_t)polygon_capacity * sizeof(*polygon));
+    if (polygon == NULL)
+    {
+        SDL_free(triangle_counts);
+        return false;
+    }
+
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        if (!brush_is_renderable(brush))
+            continue;
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const int material_index = brush->faces[face_index].material_index;
+            if (material_index < 0 || material_index >= world->material_count)
+                continue;
+            const int count = brush_build_face_polygon(brush, face_index, polygon, polygon_capacity, NULL, NULL, NULL);
+            if (count >= 3)
+                triangle_counts[material_index] += count - 2;
+        }
+    }
+
+    int mesh_count = 0;
+    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    {
+        if (triangle_counts[material_index] > 0)
+            ++mesh_count;
+    }
+    if (mesh_count <= 0)
+    {
+        SDL_free(polygon);
+        SDL_free(triangle_counts);
+        world->render_model = NULL;
+        return true;
+    }
+
+    model->meshes = (slayer3d_mesh *)SDL_calloc((size_t)mesh_count, sizeof(*model->meshes));
+    if (model->meshes == NULL)
+    {
+        SDL_free(polygon);
+        SDL_free(triangle_counts);
+        return false;
+    }
+    model->mesh_count = mesh_count;
+
+    int mesh_index = 0;
+    int *material_to_mesh = (int *)SDL_malloc((size_t)world->material_count * sizeof(*material_to_mesh));
+    int *vertex_offsets = (int *)SDL_calloc((size_t)world->material_count, sizeof(*vertex_offsets));
+    if (material_to_mesh == NULL || vertex_offsets == NULL)
+    {
+        SDL_free(material_to_mesh);
+        SDL_free(vertex_offsets);
+        SDL_free(polygon);
+        SDL_free(triangle_counts);
+        return false;
+    }
+    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    {
+        material_to_mesh[material_index] = -1;
+        const int triangles = triangle_counts[material_index];
+        if (triangles <= 0)
+            continue;
+        slayer3d_mesh *mesh = &model->meshes[mesh_index];
+        const int vertex_count = triangles * 3;
+        mesh->name =
+            SDL_strdup(world->materials[material_index].name != NULL ? world->materials[material_index].name : "");
+        mesh->positions = (float *)SDL_calloc((size_t)vertex_count * 3u, sizeof(float));
+        mesh->normals = (float *)SDL_calloc((size_t)vertex_count * 3u, sizeof(float));
+        mesh->uvs = (float *)SDL_calloc((size_t)vertex_count * 2u, sizeof(float));
+        mesh->colors = (float *)SDL_calloc((size_t)vertex_count * 4u, sizeof(float));
+        mesh->indices = (unsigned int *)SDL_calloc((size_t)vertex_count, sizeof(unsigned int));
+        mesh->vertex_count = vertex_count;
+        mesh->index_count = vertex_count;
+        mesh->material_index = material_index;
+        if (mesh->name == NULL || mesh->positions == NULL || mesh->normals == NULL || mesh->uvs == NULL ||
+            mesh->colors == NULL || mesh->indices == NULL)
+        {
+            SDL_free(material_to_mesh);
+            SDL_free(vertex_offsets);
+            SDL_free(polygon);
+            SDL_free(triangle_counts);
+            return false;
+        }
+        for (int i = 0; i < vertex_count; ++i)
+            mesh->indices[i] = (unsigned int)i;
+        material_to_mesh[material_index] = mesh_index++;
+    }
+
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        if (!brush_is_renderable(brush))
+            continue;
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+            const int mesh_for_material = face->material_index >= 0 && face->material_index < world->material_count
+                                              ? material_to_mesh[face->material_index]
+                                              : -1;
+            slayer3d_vec3 normal;
+            slayer3d_vec3 u;
+            slayer3d_vec3 v;
+            const int count = brush_build_face_polygon(brush, face_index, polygon, polygon_capacity, &normal, &u, &v);
+            if (count < 3 || mesh_for_material < 0)
+                continue;
+            slayer3d_mesh *mesh = &model->meshes[mesh_for_material];
+            const slayer3d_game_data_brush_material *material = &world->materials[face->material_index];
+            const float tex_scale = SDL_max(material->tex_scale, 0.0001f);
+            const slayer3d_color color = brush_material_color(material);
+            const float rgba[4] = {
+                (float)color.r / 255.0f,
+                (float)color.g / 255.0f,
+                (float)color.b / 255.0f,
+                (float)color.a / 255.0f,
+            };
+            for (int tri = 1; tri + 1 < count; ++tri)
+            {
+                const slayer3d_vec3 verts[3] = {polygon[0], polygon[tri], polygon[tri + 1]};
+                for (int corner = 0; corner < 3; ++corner)
+                {
+                    const int vertex = vertex_offsets[face->material_index]++;
+                    if (vertex >= mesh->vertex_count)
+                        continue;
+                    mesh->positions[vertex * 3 + 0] = verts[corner].x;
+                    mesh->positions[vertex * 3 + 1] = verts[corner].y;
+                    mesh->positions[vertex * 3 + 2] = verts[corner].z;
+                    mesh->normals[vertex * 3 + 0] = normal.x;
+                    mesh->normals[vertex * 3 + 1] = normal.y;
+                    mesh->normals[vertex * 3 + 2] = normal.z;
+                    mesh->uvs[vertex * 2 + 0] = slayer3d_vec3_dot(verts[corner], u) / tex_scale;
+                    mesh->uvs[vertex * 2 + 1] = slayer3d_vec3_dot(verts[corner], v) / tex_scale;
+                    mesh->colors[vertex * 4 + 0] = rgba[0];
+                    mesh->colors[vertex * 4 + 1] = rgba[1];
+                    mesh->colors[vertex * 4 + 2] = rgba[2];
+                    mesh->colors[vertex * 4 + 3] = rgba[3];
+                    brush_mesh_bounds_add(mesh, verts[corner]);
+                }
+            }
+        }
+    }
+
+    world->render_model = model;
+    SDL_free(material_to_mesh);
+    SDL_free(vertex_offsets);
+    SDL_free(polygon);
+    SDL_free(triangle_counts);
+    return true;
+}
+
 static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                               int error_buffer_size)
 {
@@ -3778,6 +4183,13 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 face->surface_flags =
                     brush_flags_from_json(obj_get(face_json, "surface_flags"), brush_surface_flag_from_string, 0u);
             }
+        }
+
+        if (!brush_world_compile_render_model(&runtime->brush_worlds[world_index]))
+        {
+            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' render mesh",
+                       world->name != NULL ? world->name : "<unnamed>");
+            return false;
         }
     }
     return true;
@@ -23048,6 +23460,7 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     for (int i = 0; i < runtime->brush_world_count; ++i)
     {
         slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
+        slayer3d_free_model(&runtime->brush_worlds[i].render_model);
         SDL_free((void *)world->name);
         SDL_free((void *)world->units);
         for (int material_index = 0; material_index < world->material_count; ++material_index)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -43,6 +43,13 @@ typedef struct sector_level_draw_context
     bool ok;
 } sector_level_draw_context;
 
+typedef struct brush_world_draw_context
+{
+    slayer3d_render_context *renderer;
+    const slayer3d_asset_resolver *assets;
+    bool ok;
+} brush_world_draw_context;
+
 typedef struct ui_draw_context
 {
     const slayer3d_game_data_runtime *runtime;
@@ -2238,6 +2245,79 @@ bool slayer3d_game_data_draw_sector_levels_with_assets(const slayer3d_game_data_
     return iterated && context.ok;
 }
 
+static bool draw_brush_world_instance(void *userdata, const slayer3d_game_data_brush_world_instance *instance)
+{
+    brush_world_draw_context *context = (brush_world_draw_context *)userdata;
+    if (context == NULL || context->renderer == NULL || instance == NULL || instance->world == NULL)
+        return false;
+    if (instance->world->render_model == NULL || instance->world->render_model->mesh_count <= 0)
+        return true;
+
+    bool pushed = false;
+    bool ok = true;
+    if (instance->position.x != 0.0f || instance->position.y != 0.0f || instance->position.z != 0.0f)
+    {
+        if (!slayer3d_push_matrix(context->renderer))
+        {
+            context->ok = false;
+            return false;
+        }
+        pushed = true;
+        ok = slayer3d_translate(context->renderer, instance->position.x, instance->position.y, instance->position.z);
+    }
+
+    if (ok)
+    {
+        ok = slayer3d_draw_model_ex_with_assets(
+            context->renderer, context->assets, instance->world->render_model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+            slayer3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, slayer3d_vec3_make(1.0f, 1.0f, 1.0f),
+            (slayer3d_color){255, 255, 255, 255});
+    }
+    if (ok && instance->debug_wireframe && !slayer3d_is_wireframe_enabled(context->renderer))
+    {
+        if (slayer3d_set_wireframe_enabled(context->renderer, true))
+        {
+            ok = slayer3d_draw_model_ex_with_assets(
+                context->renderer, context->assets, instance->world->render_model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                slayer3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, slayer3d_vec3_make(1.0f, 1.0f, 1.0f),
+                (slayer3d_color){30, 35, 40, 220});
+            if (!slayer3d_set_wireframe_enabled(context->renderer, false))
+                ok = false;
+        }
+        else
+        {
+            ok = false;
+        }
+    }
+    if (pushed && !slayer3d_pop_matrix(context->renderer))
+        ok = false;
+    if (!ok)
+        context->ok = false;
+    return context->ok;
+}
+
+bool slayer3d_game_data_draw_brush_worlds(const slayer3d_game_data_runtime *runtime, slayer3d_render_context *renderer)
+{
+    return slayer3d_game_data_draw_brush_worlds_with_assets(runtime, renderer, NULL);
+}
+
+bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_runtime *runtime,
+                                                      slayer3d_render_context *renderer,
+                                                      const slayer3d_asset_resolver *assets)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    brush_world_draw_context context;
+    SDL_zero(context);
+    context.renderer = renderer;
+    context.assets = assets;
+    context.ok = true;
+    const bool iterated =
+        slayer3d_game_data_for_each_brush_world_instance(runtime, draw_brush_world_instance, &context);
+    return iterated && context.ok;
+}
+
 static bool draw_active_scene_skybox(const slayer3d_game_data_runtime *runtime, slayer3d_render_context *renderer,
                                      slayer3d_game_data_image_cache *image_cache)
 {
@@ -3325,6 +3405,9 @@ bool slayer3d_game_data_draw_frame(const slayer3d_game_data_frame_desc *frame)
             ok = slayer3d_game_data_draw_sector_levels_with_assets(
                      frame->runtime, frame->renderer, frame->image_cache != NULL ? frame->image_cache->assets : NULL,
                      &camera) &&
+                 ok;
+            ok = slayer3d_game_data_draw_brush_worlds_with_assets(
+                     frame->runtime, frame->renderer, frame->image_cache != NULL ? frame->image_cache->assets : NULL) &&
                  ok;
             if (frame->particle_cache != NULL)
                 ok = slayer3d_game_data_draw_particles(frame->runtime, frame->renderer, frame->particle_cache) && ok;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -398,6 +398,11 @@ std::filesystem::path lighting_dojo_data_path()
     return demo_data_path("lighting_dojo", "lighting_dojo.game.json");
 }
 
+std::filesystem::path brush_geometry_dojo_data_path()
+{
+    return demo_data_path("brush_geometry_dojo", "brush_geometry_dojo.game.json");
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -7334,6 +7339,64 @@ TEST(GameDataRuntime, LightingDojoLoadsSectorLocalLightingShowcase)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
+{
+    const std::filesystem::path dojo_path = brush_geometry_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_config config{};
+    char title[128]{};
+    char app_error[512]{};
+    ASSERT_TRUE(slayer3d_game_data_load_app_config_file(dojo_path.string().c_str(), &config, title, sizeof(title),
+                                                        app_error, sizeof(app_error)))
+        << app_error;
+    EXPECT_STREQ(config.title, "Slayer 3D Brush Geometry Dojo");
+    EXPECT_EQ(config.backend, SLAYER3D_BACKEND_OPENGL);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    ASSERT_TRUE(slayer3d_game_data_set_active_scene(runtime, "scene.brush_geometry.showcase"));
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.brush_geometry.showcase", &world));
+    ASSERT_NE(world.render_model, nullptr);
+    EXPECT_EQ(world.material_count, 6);
+    EXPECT_GE(world.brush_count, 9);
+    EXPECT_GE(world.render_model->mesh_count, 6);
+    int rendered_vertices = 0;
+    for (int i = 0; i < world.render_model->mesh_count; ++i)
+    {
+        const slayer3d_mesh *mesh = &world.render_model->meshes[i];
+        EXPECT_GE(mesh->material_index, 0);
+        EXPECT_LT(mesh->material_index, world.render_model->material_count);
+        EXPECT_NE(mesh->positions, nullptr);
+        EXPECT_NE(mesh->normals, nullptr);
+        EXPECT_NE(mesh->uvs, nullptr);
+        EXPECT_EQ(mesh->vertex_count, mesh->index_count);
+        EXPECT_TRUE(mesh->has_local_bounds);
+        rendered_vertices += mesh->vertex_count;
+    }
+    EXPECT_GT(rendered_vertices, 150);
+
+    BrushWorldInstanceCapture capture{};
+    ASSERT_TRUE(slayer3d_game_data_for_each_brush_world_instance(runtime, capture_brush_world_instance, &capture));
+    EXPECT_EQ(capture.count, 1);
+    EXPECT_EQ(capture.world_name, "brush.brush_geometry.showcase");
+    EXPECT_TRUE(capture.acceleration_enabled);
+
+    ASSERT_EQ(slayer3d_game_data_world_light_count(runtime), 2);
+    slayer3d_camera3d camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.brush_geometry.overview", &camera));
+    EXPECT_EQ(camera.fov_axis, SLAYER3D_CAMERA_FOV_HORIZONTAL);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, UsesDefaultWorldUnitsAndPerspectiveFovy)
 {
     const std::filesystem::path dir = unique_test_dir("world_camera_defaults");
@@ -10377,6 +10440,11 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
           "metallic": 0.0,
           "roughness": 0.8,
           "tex_scale": 2.0
+        },
+        {
+          "name": "mat.trim",
+          "albedo": [0.85, 0.55, 0.20, 1.0],
+          "roughness": 0.7
         }
       ],
       "brushes": [
@@ -10389,7 +10457,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
             { "plane": { "normal": [-1.0,  0.0,  0.0], "distance":  0.0 }, "material": 0 },
             { "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 }, "material": "mat.wall", "surface_flags": ["slick"] },
             { "plane": { "normal": [ 0.0, -1.0,  0.0], "distance":  0.0 }, "material": "mat.wall" },
-            { "plane": { "normal": [ 0.0,  0.0,  1.0], "distance":  4.0 }, "material": "mat.wall", "surface_flags": "emissive" },
+            { "plane": { "normal": [ 0.0,  0.0,  1.0], "distance":  4.0 }, "material": "mat.trim", "surface_flags": "emissive" },
             { "plane": { "normal": [ 0.0,  0.0, -1.0], "distance":  0.0 }, "material": "mat.wall" }
           ]
         }
@@ -10413,11 +10481,12 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(world.name, "brush.test");
     EXPECT_STREQ(world.units, "meters");
     EXPECT_FLOAT_EQ(world.meters_per_unit, 1.0f);
-    ASSERT_EQ(world.material_count, 1);
+    ASSERT_EQ(world.material_count, 2);
     EXPECT_STREQ(world.materials[0].name, "mat.wall");
     EXPECT_FLOAT_EQ(world.materials[0].albedo.z, 0.45f);
     EXPECT_FLOAT_EQ(world.materials[0].roughness, 0.8f);
     EXPECT_FLOAT_EQ(world.materials[0].tex_scale, 2.0f);
+    EXPECT_STREQ(world.materials[1].name, "mat.trim");
     ASSERT_EQ(world.brush_count, 1);
     EXPECT_STREQ(world.brushes[0].name, "brush.room");
     EXPECT_EQ(world.brushes[0].contents,
@@ -10430,7 +10499,20 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_EQ(world.brushes[0].faces[1].material_index, 0);
     EXPECT_STREQ(world.brushes[0].faces[1].material_name, "mat.wall");
     EXPECT_EQ(world.brushes[0].faces[2].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK);
+    EXPECT_EQ(world.brushes[0].faces[4].material_index, 1);
     EXPECT_EQ(world.brushes[0].faces[4].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE);
+    ASSERT_NE(world.render_model, nullptr);
+    ASSERT_EQ(world.render_model->material_count, 2);
+    ASSERT_EQ(world.render_model->mesh_count, 2);
+    EXPECT_EQ(world.render_model->meshes[0].material_index, 0);
+    EXPECT_EQ(world.render_model->meshes[0].vertex_count, 30);
+    EXPECT_EQ(world.render_model->meshes[0].index_count, 30);
+    EXPECT_EQ(world.render_model->meshes[1].material_index, 1);
+    EXPECT_EQ(world.render_model->meshes[1].vertex_count, 6);
+    EXPECT_EQ(world.render_model->meshes[1].index_count, 6);
+    EXPECT_NE(world.render_model->meshes[0].normals, nullptr);
+    EXPECT_NE(world.render_model->meshes[0].uvs, nullptr);
+    EXPECT_TRUE(world.render_model->meshes[0].has_local_bounds);
 
     slayer3d_game_data_brush_world missing{};
     EXPECT_FALSE(slayer3d_game_data_get_brush_world(runtime, "brush.missing", &missing));


### PR DESCRIPTION
## Summary
- Compiles authored convex brush worlds into immutable static render meshes grouped by material.
- Draws active-scene brush worlds through the generic data-game frame path with dynamic lighting, material color/texture readiness, and optional debug wireframe overlay.
- Adds a data-only brush geometry dojo plus tests that validate compiled brush mesh output and dojo load behavior.
- Documents that omitted brush contents default to solid and updates project guidance for the new brush dojo.

## Verification
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- cmake --build build/debug --target slayer3d_runner -j4
- ./build/debug/tests/slayer3d_game_data_test
- ./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json

Refs #306