### PR TITLE
Add brush world trace queries

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -546,6 +546,17 @@ override the authored defaults. Runtime and editor code should use
 Brush render meshes are available through `brush_world.render_model` and are
 drawn by the generic data-game frame path.
 
+Collision, weapon, sensor, and editor systems can query brush worlds through
+the generic trace helpers. `slayer3d_game_data_trace_brush_world()` traces in a
+named brush world's local space; `slayer3d_game_data_trace_active_brush_worlds()`
+traces in active-scene world space and honors each `world.brush_worlds`
+instance's placement. Traces support point/ray, swept sphere, and swept AABB
+shapes, filter against `contents` masks, ignore `nocollide` faces, and report
+the hit fraction, plane normal, brush, material, contents, and surface flags.
+`slayer3d_game_data_slide_brush_world()` and
+`slayer3d_game_data_slide_active_brush_worlds()` layer deterministic
+plane-sliding over those traces for controllers and projectile movement.
+
 ## Sector Levels
 
 `sector_levels` describe sector/portal worlds as data. This is the reusable

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -461,6 +461,65 @@ extern "C"
         bool debug_wireframe;
     } slayer3d_game_data_brush_world_instance;
 
+    /** @brief Collision shape used by a brush-world trace. */
+    typedef enum slayer3d_game_data_brush_trace_shape
+    {
+        /** @brief Infinitesimal point/ray trace. */
+        SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT = 0,
+        /** @brief Swept sphere trace with radius from `extents.x`. */
+        SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE = 1,
+        /** @brief Swept axis-aligned box trace using xyz half-extents. */
+        SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB = 2,
+    } slayer3d_game_data_brush_trace_shape;
+
+    /** @brief Input descriptor for tracing through authored brush worlds. */
+    typedef struct slayer3d_game_data_brush_trace_desc
+    {
+        /** @brief Trace start point in world coordinates. */
+        slayer3d_vec3 start;
+        /** @brief Trace end point in world coordinates. */
+        slayer3d_vec3 end;
+        /** @brief Shape to sweep along start-to-end. */
+        slayer3d_game_data_brush_trace_shape shape;
+        /** @brief Sphere radius in x, or AABB half-extents for xyz. */
+        slayer3d_vec3 extents;
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_CONTENT_* flags to collide with. */
+        unsigned int contents_mask;
+    } slayer3d_game_data_brush_trace_desc;
+
+    /** @brief Deterministic result from an authored brush-world trace. */
+    typedef struct slayer3d_game_data_brush_trace_result
+    {
+        /** @brief True when the trace touches a brush matching the contents mask. */
+        bool hit;
+        /** @brief True when the trace starts inside a matching brush. */
+        bool start_solid;
+        /** @brief True when the trace remains inside a matching brush. */
+        bool all_solid;
+        /** @brief First hit fraction in [0, 1] along start-to-end. */
+        float fraction;
+        /** @brief End position at @p fraction. */
+        slayer3d_vec3 end_position;
+        /** @brief Hit point on the swept shape origin path. */
+        slayer3d_vec3 point;
+        /** @brief Outward collision plane normal, or zero when starting solid. */
+        slayer3d_vec3 normal;
+        /** @brief Authored brush world name. */
+        const char *world_name;
+        /** @brief Authored brush name. */
+        const char *brush_name;
+        /** @brief Authored face material name for plane hits, or NULL. */
+        const char *material_name;
+        /** @brief Brush index in the authored world, or -1. */
+        int brush_index;
+        /** @brief Face index that produced the collision normal, or -1. */
+        int face_index;
+        /** @brief Contents bitmask on the hit brush. */
+        unsigned int contents;
+        /** @brief Surface flags on the hit face. */
+        unsigned int surface_flags;
+    } slayer3d_game_data_brush_trace_result;
+
     /**
      * @brief Callback for active authored sector level instances.
      *
@@ -1215,6 +1274,50 @@ extern "C"
      */
     bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtime, const char *name,
                                             slayer3d_game_data_brush_world *out_world);
+
+    /**
+     * @brief Trace a point, sphere, or AABB through one named brush world.
+     *
+     * Coordinates are local to the named brush world. Use
+     * slayer3d_game_data_trace_active_brush_worlds() for active-scene
+     * world-space queries that honor `world.brush_worlds` placement.
+     *
+     * The function tests only brushes whose `contents` overlap
+     * `desc.contents_mask`. It returns true for a valid query regardless of
+     * whether a hit occurred; inspect `out_result.hit`.
+     */
+    bool slayer3d_game_data_trace_brush_world(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                              const slayer3d_game_data_brush_trace_desc *desc,
+                                              slayer3d_game_data_brush_trace_result *out_result);
+
+    /**
+     * @brief Trace a point, sphere, or AABB through brush worlds in the active scene.
+     *
+     * Input and output positions are world-space. The closest hit across all
+     * active-scene brush world instances is returned.
+     */
+    bool slayer3d_game_data_trace_active_brush_worlds(const slayer3d_game_data_runtime *runtime,
+                                                      const slayer3d_game_data_brush_trace_desc *desc,
+                                                      slayer3d_game_data_brush_trace_result *out_result);
+
+    /**
+     * @brief Move through one named brush world while sliding along hit planes.
+     *
+     * This is a thin deterministic helper over brush traces. It repeatedly
+     * traces the requested movement, projects the remaining motion along the
+     * blocking plane, and returns the final non-penetrating end position in
+     * `out_result.end_position`. The first blocking hit metadata is preserved.
+     */
+    bool slayer3d_game_data_slide_brush_world(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                              const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
+                                              slayer3d_game_data_brush_trace_result *out_result);
+
+    /**
+     * @brief Active-scene world-space variant of slayer3d_game_data_slide_brush_world().
+     */
+    bool slayer3d_game_data_slide_active_brush_worlds(const slayer3d_game_data_runtime *runtime,
+                                                      const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
+                                                      slayer3d_game_data_brush_trace_result *out_result);
 
     /** @brief Runtime-owned node resolved from an authored sector navigation graph. */
     typedef struct slayer3d_game_data_sector_nav_node

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -4058,6 +4058,190 @@ static bool brush_world_compile_render_model(brush_world_runtime *runtime)
     return true;
 }
 
+static slayer3d_game_data_brush_trace_result brush_trace_default_result(const slayer3d_game_data_brush_trace_desc *desc)
+{
+    slayer3d_game_data_brush_trace_result result;
+    SDL_zero(result);
+    result.fraction = 1.0f;
+    result.end_position = desc != NULL ? desc->end : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    result.point = result.end_position;
+    result.brush_index = -1;
+    result.face_index = -1;
+    return result;
+}
+
+static slayer3d_vec3 brush_trace_vec3_lerp(slayer3d_vec3 a, slayer3d_vec3 b, float t)
+{
+    return slayer3d_vec3_make(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t);
+}
+
+static float brush_trace_plane_support(const slayer3d_game_data_brush_trace_desc *desc, slayer3d_vec3 normal)
+{
+    if (desc == NULL)
+        return 0.0f;
+    if (desc->shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE)
+        return SDL_max(desc->extents.x, 0.0f);
+    if (desc->shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB)
+    {
+        return SDL_fabsf(normal.x) * SDL_max(desc->extents.x, 0.0f) +
+               SDL_fabsf(normal.y) * SDL_max(desc->extents.y, 0.0f) +
+               SDL_fabsf(normal.z) * SDL_max(desc->extents.z, 0.0f);
+    }
+    return 0.0f;
+}
+
+static bool brush_trace_shape_valid(const slayer3d_game_data_brush_trace_desc *desc)
+{
+    if (desc == NULL || desc->contents_mask == 0u)
+        return false;
+    switch (desc->shape)
+    {
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT:
+        return true;
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE:
+        return desc->extents.x >= 0.0f;
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB:
+        return desc->extents.x >= 0.0f && desc->extents.y >= 0.0f && desc->extents.z >= 0.0f;
+    default:
+        return false;
+    }
+}
+
+static bool brush_trace_one_brush(const slayer3d_game_data_brush *brush,
+                                  const slayer3d_game_data_brush_trace_desc *desc,
+                                  slayer3d_game_data_brush_trace_result *out_result)
+{
+    const float epsilon = 0.0005f;
+    bool starts_outside = false;
+    bool ends_outside = false;
+    float enter_fraction = -1.0f;
+    float leave_fraction = 1.0f;
+    int enter_face = -1;
+    slayer3d_vec3 enter_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+
+    if (brush == NULL || desc == NULL || out_result == NULL || (brush->contents & desc->contents_mask) == 0u)
+        return false;
+
+    for (int face_index = 0; face_index < brush->face_count; ++face_index)
+    {
+        const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+        if ((face->surface_flags & SLAYER3D_GAME_DATA_BRUSH_SURFACE_NO_COLLIDE) != 0u)
+            continue;
+
+        slayer3d_vec3 normal;
+        float distance = 0.0f;
+        if (!brush_plane_normalized(face, &normal, &distance))
+            continue;
+
+        const float expanded_distance = distance + brush_trace_plane_support(desc, normal);
+        const float start_distance = slayer3d_vec3_dot(normal, desc->start) - expanded_distance;
+        const float end_distance = slayer3d_vec3_dot(normal, desc->end) - expanded_distance;
+
+        if (start_distance > epsilon)
+            starts_outside = true;
+        if (end_distance > epsilon)
+            ends_outside = true;
+
+        if (start_distance > epsilon && end_distance > epsilon)
+            return false;
+        if (start_distance <= epsilon && end_distance <= epsilon)
+            continue;
+
+        if (start_distance > end_distance)
+        {
+            const float denom = start_distance - end_distance;
+            if (denom > 0.000001f)
+            {
+                float fraction = (start_distance - epsilon) / denom;
+                fraction = SDL_clamp(fraction, 0.0f, 1.0f);
+                if (fraction > enter_fraction)
+                {
+                    enter_fraction = fraction;
+                    enter_face = face_index;
+                    enter_normal = normal;
+                }
+            }
+        }
+        else
+        {
+            const float denom = start_distance - end_distance;
+            if (SDL_fabsf(denom) > 0.000001f)
+            {
+                float fraction = (start_distance + epsilon) / denom;
+                fraction = SDL_clamp(fraction, 0.0f, 1.0f);
+                if (fraction < leave_fraction)
+                    leave_fraction = fraction;
+            }
+        }
+    }
+
+    if (!starts_outside)
+    {
+        out_result->hit = true;
+        out_result->start_solid = true;
+        out_result->all_solid = !ends_outside;
+        out_result->fraction = 0.0f;
+        out_result->end_position = desc->start;
+        out_result->point = desc->start;
+        out_result->normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        out_result->face_index = -1;
+        return true;
+    }
+
+    if (enter_face >= 0 && enter_fraction >= 0.0f && enter_fraction <= leave_fraction && enter_fraction <= 1.0f)
+    {
+        out_result->hit = true;
+        out_result->fraction = enter_fraction;
+        out_result->end_position = brush_trace_vec3_lerp(desc->start, desc->end, enter_fraction);
+        out_result->point = out_result->end_position;
+        out_result->normal = enter_normal;
+        out_result->face_index = enter_face;
+        return true;
+    }
+
+    return false;
+}
+
+static bool brush_world_trace_local(const brush_world_runtime *world_runtime,
+                                    const slayer3d_game_data_brush_trace_desc *desc,
+                                    slayer3d_game_data_brush_trace_result *out_result)
+{
+    slayer3d_game_data_brush_trace_result closest = brush_trace_default_result(desc);
+    if (world_runtime == NULL || desc == NULL || out_result == NULL || !brush_trace_shape_valid(desc))
+        return false;
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        slayer3d_game_data_brush_trace_result candidate = brush_trace_default_result(desc);
+        if (!brush_trace_one_brush(brush, desc, &candidate))
+            continue;
+        if (!closest.hit || candidate.fraction < closest.fraction || (candidate.start_solid && !closest.start_solid))
+        {
+            closest = candidate;
+            closest.world_name = world->name;
+            closest.brush_name = brush->name;
+            closest.brush_index = brush_index;
+            closest.contents = brush->contents;
+            if (closest.face_index >= 0 && closest.face_index < brush->face_count)
+            {
+                closest.material_name = brush->faces[closest.face_index].material_name;
+                closest.surface_flags = brush->faces[closest.face_index].surface_flags;
+            }
+            else
+            {
+                closest.material_name = NULL;
+                closest.surface_flags = 0u;
+            }
+        }
+    }
+
+    if (out_result != NULL)
+        *out_result = closest;
+    return true;
+}
+
 static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                               int error_buffer_size)
 {
@@ -8230,6 +8414,191 @@ bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtim
 
     *out_world = world->desc;
     return true;
+}
+
+bool slayer3d_game_data_trace_brush_world(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                          const slayer3d_game_data_brush_trace_desc *desc,
+                                          slayer3d_game_data_brush_trace_result *out_result)
+{
+    if (out_result != NULL)
+        *out_result = brush_trace_default_result(desc);
+    if (runtime == NULL || world_name == NULL || desc == NULL || out_result == NULL)
+        return false;
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+        return false;
+    return brush_world_trace_local(world_runtime, desc, out_result);
+}
+
+typedef struct brush_scene_trace_context
+{
+    const slayer3d_game_data_runtime *runtime;
+    const slayer3d_game_data_brush_trace_desc *world_desc;
+    slayer3d_game_data_brush_trace_result closest;
+    bool ok;
+} brush_scene_trace_context;
+
+static bool trace_brush_world_instance(void *userdata, const slayer3d_game_data_brush_world_instance *instance)
+{
+    brush_scene_trace_context *context = (brush_scene_trace_context *)userdata;
+    if (context == NULL || context->runtime == NULL || context->world_desc == NULL || instance == NULL ||
+        instance->world_name == NULL)
+    {
+        if (context != NULL)
+            context->ok = false;
+        return false;
+    }
+
+    slayer3d_game_data_brush_trace_desc local_desc = *context->world_desc;
+    local_desc.start = brush_vec3_sub(local_desc.start, instance->position);
+    local_desc.end = brush_vec3_sub(local_desc.end, instance->position);
+
+    slayer3d_game_data_brush_trace_result local_result;
+    if (!slayer3d_game_data_trace_brush_world(context->runtime, instance->world_name, &local_desc, &local_result))
+    {
+        context->ok = false;
+        return false;
+    }
+
+    if (local_result.hit && (!context->closest.hit || local_result.fraction < context->closest.fraction ||
+                             (local_result.start_solid && !context->closest.start_solid)))
+    {
+        local_result.end_position = brush_vec3_add(local_result.end_position, instance->position);
+        local_result.point = brush_vec3_add(local_result.point, instance->position);
+        context->closest = local_result;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_trace_active_brush_worlds(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_brush_trace_desc *desc,
+                                                  slayer3d_game_data_brush_trace_result *out_result)
+{
+    if (out_result != NULL)
+        *out_result = brush_trace_default_result(desc);
+    if (runtime == NULL || desc == NULL || out_result == NULL || !brush_trace_shape_valid(desc))
+        return false;
+
+    brush_scene_trace_context context;
+    SDL_zero(context);
+    context.runtime = runtime;
+    context.world_desc = desc;
+    context.closest = brush_trace_default_result(desc);
+    context.ok = true;
+    if (!slayer3d_game_data_for_each_brush_world_instance(runtime, trace_brush_world_instance, &context) || !context.ok)
+        return false;
+
+    *out_result = context.closest;
+    return true;
+}
+
+typedef bool (*brush_slide_trace_fn)(void *userdata, const slayer3d_game_data_brush_trace_desc *desc,
+                                     slayer3d_game_data_brush_trace_result *out_result);
+
+static bool brush_slide_with_trace(brush_slide_trace_fn trace_fn, void *trace_userdata,
+                                   const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
+                                   slayer3d_game_data_brush_trace_result *out_result)
+{
+    if (out_result != NULL)
+        *out_result = brush_trace_default_result(desc);
+    if (trace_fn == NULL || desc == NULL || out_result == NULL || !brush_trace_shape_valid(desc))
+        return false;
+
+    slayer3d_game_data_brush_trace_desc step = *desc;
+    slayer3d_game_data_brush_trace_result first_hit = brush_trace_default_result(desc);
+    slayer3d_vec3 position = desc->start;
+    slayer3d_vec3 remaining = brush_vec3_sub(desc->end, desc->start);
+    const int bump_count = SDL_clamp(max_bumps, 1, 8);
+
+    for (int bump = 0; bump < bump_count; ++bump)
+    {
+        step.start = position;
+        step.end = brush_vec3_add(position, remaining);
+
+        slayer3d_game_data_brush_trace_result trace;
+        if (!trace_fn(trace_userdata, &step, &trace))
+            return false;
+        if (!trace.hit)
+        {
+            position = step.end;
+            break;
+        }
+        if (!first_hit.hit)
+            first_hit = trace;
+        if (trace.start_solid)
+        {
+            first_hit = trace;
+            position = trace.end_position;
+            break;
+        }
+
+        position = trace.end_position;
+        remaining = brush_vec3_sub(step.end, position);
+        const float into_plane = slayer3d_vec3_dot(remaining, trace.normal);
+        if (into_plane < 0.0f)
+            remaining = brush_vec3_sub(remaining, slayer3d_vec3_scale(trace.normal, into_plane));
+        if (slayer3d_vec3_length_squared(remaining) <= 0.000001f)
+            break;
+        position = brush_vec3_add(position, slayer3d_vec3_scale(trace.normal, 0.0005f));
+    }
+
+    if (first_hit.hit)
+    {
+        *out_result = first_hit;
+        out_result->end_position = position;
+        out_result->point = position;
+    }
+    else
+    {
+        *out_result = brush_trace_default_result(desc);
+        out_result->end_position = position;
+        out_result->point = position;
+    }
+    return true;
+}
+
+typedef struct brush_named_trace_context
+{
+    const slayer3d_game_data_runtime *runtime;
+    const char *world_name;
+} brush_named_trace_context;
+
+static bool brush_slide_trace_named(void *userdata, const slayer3d_game_data_brush_trace_desc *desc,
+                                    slayer3d_game_data_brush_trace_result *out_result)
+{
+    const brush_named_trace_context *context = (const brush_named_trace_context *)userdata;
+    if (context == NULL)
+        return false;
+    return slayer3d_game_data_trace_brush_world(context->runtime, context->world_name, desc, out_result);
+}
+
+static bool brush_slide_trace_active(void *userdata, const slayer3d_game_data_brush_trace_desc *desc,
+                                     slayer3d_game_data_brush_trace_result *out_result)
+{
+    const slayer3d_game_data_runtime *runtime = (const slayer3d_game_data_runtime *)userdata;
+    return slayer3d_game_data_trace_active_brush_worlds(runtime, desc, out_result);
+}
+
+bool slayer3d_game_data_slide_brush_world(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                          const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
+                                          slayer3d_game_data_brush_trace_result *out_result)
+{
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0')
+        return false;
+    brush_named_trace_context context;
+    context.runtime = runtime;
+    context.world_name = world_name;
+    return brush_slide_with_trace(brush_slide_trace_named, &context, desc, max_bumps, out_result);
+}
+
+bool slayer3d_game_data_slide_active_brush_worlds(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
+                                                  slayer3d_game_data_brush_trace_result *out_result)
+{
+    if (runtime == NULL)
+        return false;
+    return brush_slide_with_trace(brush_slide_trace_active, (void *)runtime, desc, max_bumps, out_result);
 }
 
 static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -10681,6 +10681,176 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
     }
 }
 
+TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_world_traces");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.trace", "position": [10.0, 0.0, 0.0] }
+    ]
+  }
+})json");
+    write_text(dir / "brush_trace.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Trace Test" },
+  "world": { "name": "world.brush_trace", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.trace",
+      "materials": [
+        { "name": "mat.wall", "albedo": [0.5, 0.5, 0.55, 1.0] },
+        { "name": "mat.ramp", "albedo": [0.8, 0.5, 0.25, 1.0] },
+        { "name": "mat.trigger", "albedo": [0.25, 0.8, 0.9, 0.35] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "contents": ["solid", "player_clip"],
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  4 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  3 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  4 }, "material": "mat.wall", "surface_flags": "slick" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.ramp",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1, 0, 0], "distance":  9 }, "material": "mat.ramp" },
+            { "plane": { "normal": [-1, 0, 0], "distance": -6 }, "material": "mat.ramp" },
+            { "plane": { "normal": [ 0, 0, 1], "distance":  3 }, "material": "mat.ramp" },
+            { "plane": { "normal": [ 0, 0,-1], "distance":  0 }, "material": "mat.ramp" },
+            { "plane": { "normal": [ 0,-1, 0], "distance":  0 }, "material": "mat.ramp" },
+            { "plane": { "normal": [-0.5, 1, 0], "distance": -2.5 }, "material": "mat.ramp" }
+          ]
+        },
+        {
+          "name": "brush.trigger",
+          "contents": "trigger",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  8 }, "material": "mat.trigger" },
+            { "plane": { "normal": [-1,  0,  0], "distance": -6 }, "material": "mat.trigger" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2 }, "material": "mat.trigger" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [ 0,  0,  1], "distance": -5 }, "material": "mat.trigger" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  7 }, "material": "mat.trigger" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "brush_trace.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+
+    slayer3d_game_data_brush_trace_desc trace{};
+    slayer3d_game_data_brush_trace_result result{};
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.start = slayer3d_vec3_make(-2.0f, 1.0f, 2.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_FALSE(result.start_solid);
+    EXPECT_NEAR(result.fraction, 0.5f, 0.001f);
+    EXPECT_STREQ(result.brush_name, "brush.box");
+    EXPECT_NEAR(result.normal.x, -1.0f, 0.0001f);
+
+    trace.start = slayer3d_vec3_make(2.0f, 1.0f, 6.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.material_name, "mat.wall");
+    EXPECT_EQ(result.surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK);
+    EXPECT_NEAR(result.normal.z, 1.0f, 0.0001f);
+
+    trace.start = slayer3d_vec3_make(-2.0f, 4.0f, 2.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 4.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_FALSE(result.hit);
+    EXPECT_FLOAT_EQ(result.fraction, 1.0f);
+
+    trace.start = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_TRUE(result.start_solid);
+    EXPECT_FLOAT_EQ(result.fraction, 0.0f);
+
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE;
+    trace.extents = slayer3d_vec3_make(0.5f, 0.0f, 0.0f);
+    trace.start = slayer3d_vec3_make(-2.0f, 1.0f, 2.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_NEAR(result.fraction, 0.375f, 0.001f);
+
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB;
+    trace.extents = slayer3d_vec3_make(0.25f, 0.5f, 0.25f);
+    trace.start = slayer3d_vec3_make(-2.0f, 1.0f, 2.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_NEAR(result.fraction, 0.4375f, 0.001f);
+
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.extents = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER;
+    trace.start = slayer3d_vec3_make(7.0f, 1.0f, -8.0f);
+    trace.end = slayer3d_vec3_make(7.0f, 1.0f, -6.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.brush_name, "brush.trigger");
+    EXPECT_EQ(result.contents, SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER);
+
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_FALSE(result.hit);
+
+    trace.start = slayer3d_vec3_make(7.0f, 5.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(7.0f, -1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.trace", &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.brush_name, "brush.ramp");
+    EXPECT_GT(result.normal.y, 0.8f);
+    EXPECT_LT(result.normal.x, -0.4f);
+
+    trace.start = slayer3d_vec3_make(8.0f, 1.0f, 2.0f);
+    trace.end = slayer3d_vec3_make(12.0f, 1.0f, 2.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.world_name, "brush.trace");
+    EXPECT_STREQ(result.brush_name, "brush.box");
+    EXPECT_NEAR(result.end_position.x, 10.0f, 0.001f);
+
+    trace.start = slayer3d_vec3_make(-2.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 3.0f);
+    ASSERT_TRUE(slayer3d_game_data_slide_brush_world(runtime, "brush.trace", &trace, 4, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.brush_name, "brush.box");
+    EXPECT_NEAR(result.end_position.x, -0.0005f, 0.001f);
+    EXPECT_GT(result.end_position.z, 2.9f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, SectorLightingModulatesLitActorsAndCanUpdateAtRuntime)
 {
     const std::filesystem::path dir = unique_test_dir("sector_lighting_runtime");


### PR DESCRIPTION
## Summary
- Adds public brush-world trace descriptors/results for point, swept sphere, and swept AABB queries.
- Implements named-world and active-scene brush traces with contents masks, scene instance transforms, no-collide face handling, hit metadata, and deterministic start-solid reporting.
- Adds plane-sliding helpers over brush traces for future FPS controller/projectile movement.
- Documents the trace/slide APIs and adds focused tests for hit/miss, start-solid, sphere/AABB hull expansion, contents filtering, surface flags, ramp normals, active-scene transforms, and sliding.

## Verification
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.TracesAuthoredBrushWorldsWithContentsAndSweptHulls:GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug --target slayer3d_runner -j4
- ./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json

Refs #306