### PR TITLE
Add brush FPS controller

### DIFF
--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -6,6 +6,8 @@
     "version": "0.1.0"
   },
   "imports": [
+    { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
+    { "path": "fragments/actors/player.json", "sections": ["entities"] },
     { "path": "fragments/world/showcase.brushes.json", "sections": ["brush_worlds"] },
     { "path": "fragments/actors/lights.json", "sections": ["entities"] }
   ],
@@ -41,11 +43,9 @@
     "ambient_light": [0.16, 0.17, 0.18],
     "cameras": [
       {
-        "name": "camera.brush_geometry.overview",
-        "type": "perspective",
-        "position": [15.0, 8.0, 17.0],
-        "target": [0.0, 2.2, 0.0],
-        "up": [0.0, 1.0, 0.0],
+        "name": "camera.brush_geometry.player",
+        "type": "fps",
+        "target_entity": "entity.brush_geometry.player",
         "fov": 90.0,
         "fov_axis": "horizontal",
         "active": true

--- a/demos/brush_geometry_dojo/data/fragments/actors/player.json
+++ b/demos/brush_geometry_dojo/data/fragments/actors/player.json
@@ -1,0 +1,39 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.brush_geometry.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.6, 11.5] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "on_ground": { "type": "bool", "value": false },
+        "vertical_velocity": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_brush",
+          "brush_world": "brush.brush_geometry.showcase",
+          "contents_mask": ["solid", "player_clip"],
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 7.0,
+          "jump_velocity": 5.8,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.65,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ]
+}

--- a/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
+++ b/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
@@ -1,0 +1,17 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "input": {
+    "contexts": [
+      {
+        "name": "input.brush_geometry.fps",
+        "actions": [
+          { "name": "action.move.forward", "bindings": [{ "device": "keyboard", "key": "W" }] },
+          { "name": "action.move.back", "bindings": [{ "device": "keyboard", "key": "S" }] },
+          { "name": "action.move.left", "bindings": [{ "device": "keyboard", "key": "A" }] },
+          { "name": "action.move.right", "bindings": [{ "device": "keyboard", "key": "D" }] },
+          { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -1,15 +1,24 @@
 {
   "schema": "slayer3d.scene.v0",
   "name": "scene.brush_geometry.showcase",
-  "camera": "camera.brush_geometry.overview",
+  "camera": "camera.brush_geometry.player",
   "updates_game": true,
   "renders_world": true,
   "entities": [
+    "entity.brush_geometry.player",
     "entity.brush_geometry.sun",
     "entity.brush_geometry.blue_fill"
   ],
   "input": {
-    "actions": ["action.exit"]
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.exit"
+    ]
   },
   "world": {
     "brush_worlds": [
@@ -35,13 +44,25 @@
       },
       {
         "name": "ui.brush_geometry.help",
-        "text": "Static brush mesh showcase: room slabs, ramp wedge, overhang, pillar  Esc quit",
+        "text": "WASD move  Mouse look  Space jump  Esc quit",
         "font": "font.brush_geometry.hud",
         "x": 0.02,
         "y": 0.075,
         "normalized": true,
         "color": [205, 215, 230, 210],
         "scale": 0.62
+      },
+      {
+        "name": "ui.brush_geometry.reticle",
+        "text": "+",
+        "font": "font.brush_geometry.hud",
+        "x": 0.5,
+        "y": 0.5,
+        "normalized": true,
+        "align": "center",
+        "valign": "middle",
+        "color": [235, 240, 250, 185],
+        "scale": 0.92
       },
       {
         "name": "ui.brush_geometry.fps",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -557,6 +557,51 @@ the hit fraction, plane normal, brush, material, contents, and surface flags.
 `slayer3d_game_data_slide_active_brush_worlds()` layer deterministic
 plane-sliding over those traces for controllers and projectile movement.
 
+Use `controller.fps_brush` on an actor to drive first-person movement through
+the active scene's brush-world instances:
+
+```json
+{
+  "name": "entity.player",
+  "active": true,
+  "transform": { "position": [0.0, 1.6, 8.0] },
+  "properties": {
+    "yaw": { "type": "float", "value": 0.0 },
+    "pitch": { "type": "float", "value": 0.0 }
+  },
+  "components": [
+    {
+      "type": "controller.fps_brush",
+      "brush_world": "brush.keep_01",
+      "contents_mask": ["solid", "player_clip"],
+      "actions": {
+        "forward": "action.move.forward",
+        "back": "action.move.back",
+        "left": "action.move.left",
+        "right": "action.move.right",
+        "jump": "action.jump"
+      },
+      "move_speed": 7.0,
+      "jump_velocity": 5.8,
+      "gravity": 14.0,
+      "player_height": 1.6,
+      "player_radius": 0.35,
+      "step_height": 0.65,
+      "ceiling_clearance": 0.1,
+      "mouse_sensitivity": 0.002
+    }
+  ]
+}
+```
+
+The actor transform is the player's eye position. The controller sweeps an AABB
+body through `world.brush_worlds` in active-scene world space, slides along
+brush planes, supports basic stair stepping, gravity, jumping, and mouse-look,
+and writes the same diagnostic properties as `controller.fps_sector`.
+`brush_world` is validated as the intended collision world; runtime collision
+uses all active brush-world instances so multi-part brush scenes compose
+naturally. Missing `contents_mask` defaults to `["solid", "player_clip"]`.
+
 ## Sector Levels
 
 `sector_levels` describe sector/portal worlds as data. This is the reusable
@@ -1015,23 +1060,24 @@ defaults are `yaw`, `pitch`, `view_smooth`, `vertical_velocity`, `on_ground`,
 and `current_sector`. Use an `fps` camera targeting the same actor for the
 player view.
 
-FPS sector controllers also expose reusable actions for trigger volumes and
-scripted events:
+FPS controllers also expose reusable actions for trigger volumes and scripted
+events:
 
 ```json
 {
-  "type": "controller.fps_sector.launch",
+  "type": "controller.fps.launch",
   "target": "entity.player",
   "vertical_velocity": 15.0
 }
 ```
 
-`controller.fps_sector.launch` applies an upward impulse to the controller and
-requires a positive `vertical_velocity`.
+`controller.fps.launch` applies an upward impulse to either an
+`controller.fps_sector` or `controller.fps_brush` actor and requires a positive
+`vertical_velocity`.
 
 ```json
 {
-  "type": "controller.fps_sector.teleport",
+  "type": "controller.fps.teleport",
   "target": "entity.player",
   "position": [72.0, 4.1, 63.0],
   "yaw": -1.5707964,
@@ -1039,10 +1085,12 @@ requires a positive `vertical_velocity`.
 }
 ```
 
-`controller.fps_sector.teleport` moves the controller and actor to the given
+`controller.fps.teleport` moves the controller and actor to the given
 eye-position. `yaw` and `pitch` are optional; omitted angles preserve the
 current orientation. Both actions also support `target_from_payload` instead of
-`target` when a sensor payload supplies the actor name.
+`target` when a sensor payload supplies the actor name. The older
+`controller.fps_sector.launch` and `controller.fps_sector.teleport` names remain
+accepted for existing authored content.
 
 ## Scenes
 
@@ -1548,6 +1596,9 @@ Reusable components include:
 - `controller.fps_sector`: first-person movement through a sector level using
   authored input actions, sector collision, jumping, gravity, stair stepping,
   and mouse-look.
+- `controller.fps_brush`: first-person movement through active brush-world
+  instances using authored input actions, AABB brush collision, jumping,
+  gravity, stair stepping, and mouse-look.
 - `combat.health`: declares that an actor participates in generic combat
   health/armor actions. The actual runtime state remains ordinary actor
   properties so UI, Lua, replication, saves, and data actions can read the same

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -18436,9 +18436,9 @@ static bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *
 
     if (SDL_strcmp(type, "projectile.fire") == 0)
         return execute_projectile_fire_action(runtime, action, payload);
-    if (SDL_strcmp(type, "controller.fps_sector.launch") == 0)
+    if (SDL_strcmp(type, "controller.fps.launch") == 0 || SDL_strcmp(type, "controller.fps_sector.launch") == 0)
         return execute_fps_controller_launch_action(runtime, action, payload);
-    if (SDL_strcmp(type, "controller.fps_sector.teleport") == 0)
+    if (SDL_strcmp(type, "controller.fps.teleport") == 0 || SDL_strcmp(type, "controller.fps_sector.teleport") == 0)
         return execute_fps_controller_teleport_action(runtime, action, payload);
     if (SDL_strcmp(type, "grid.spawn_from_glyphs") == 0)
         return execute_grid_spawn_from_glyphs_action(runtime, action);
@@ -19370,6 +19370,8 @@ static fps_controller_runtime *fps_controller_for_actor_action(slayer3d_game_dat
     slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, target);
     yyjson_val *entity = find_entity_json(runtime, target);
     yyjson_val *component = find_component_json(entity, "controller.fps_sector");
+    if (component == NULL)
+        component = find_component_json(entity, "controller.fps_brush");
     fps_controller_runtime *controller =
         actor != NULL && component != NULL ? find_or_add_fps_controller(runtime, target, component) : NULL;
     if (controller == NULL || !initialize_fps_controller_runtime(runtime, controller, component, actor))
@@ -19543,6 +19545,239 @@ static void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yy
     slayer3d_fps_mover_update(&controller->mover, &sector_level->lightmapped, sector_level->sectors, wish, mouse_dx,
                               mouse_dy, json_float(component, "mouse_sensitivity", 0.002f), dt);
     resolve_fps_controller_sector_doors(runtime, controller);
+    fps_controller_publish_actor_state(controller, component, actor);
+}
+
+static float fps_brush_clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
+static unsigned int fps_brush_contents_mask(yyjson_val *component)
+{
+    return brush_flags_from_json(obj_get(component, "contents_mask"), brush_content_flag_from_string,
+                                 SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+}
+
+static slayer3d_vec3 fps_brush_body_extents(const slayer3d_fps_mover *mover)
+{
+    const float skin = 0.01f;
+    const float radius = SDL_max((mover != NULL ? mover->config.player_radius : 0.0f) - skin, 0.0f);
+    const float height =
+        SDL_max(mover != NULL ? mover->config.player_height + mover->config.ceiling_clearance : 0.0f, radius * 2.0f);
+    return slayer3d_vec3_make(radius, SDL_max(height * 0.5f - skin, 0.0f), radius);
+}
+
+static slayer3d_vec3 fps_brush_eye_to_body_center(const slayer3d_fps_mover *mover, slayer3d_vec3 eye_position)
+{
+    const float height = mover != NULL ? mover->config.player_height : 0.0f;
+    const float clearance = mover != NULL ? mover->config.ceiling_clearance : 0.0f;
+    return slayer3d_vec3_make(eye_position.x, eye_position.y - height * 0.5f + clearance * 0.5f, eye_position.z);
+}
+
+static slayer3d_vec3 fps_brush_body_center_to_eye(const slayer3d_fps_mover *mover, slayer3d_vec3 body_center)
+{
+    const float height = mover != NULL ? mover->config.player_height : 0.0f;
+    const float clearance = mover != NULL ? mover->config.ceiling_clearance : 0.0f;
+    return slayer3d_vec3_make(body_center.x, body_center.y + height * 0.5f - clearance * 0.5f, body_center.z);
+}
+
+static bool fps_brush_trace_body(const slayer3d_game_data_runtime *runtime, const slayer3d_fps_mover *mover,
+                                 unsigned int contents_mask, slayer3d_vec3 start, slayer3d_vec3 end,
+                                 slayer3d_game_data_brush_trace_result *out_result)
+{
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.start = start;
+    trace.end = end;
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB;
+    trace.extents = fps_brush_body_extents(mover);
+    trace.contents_mask = contents_mask;
+    return slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, out_result);
+}
+
+static bool fps_brush_slide_body(const slayer3d_game_data_runtime *runtime, const slayer3d_fps_mover *mover,
+                                 unsigned int contents_mask, slayer3d_vec3 start, slayer3d_vec3 end,
+                                 slayer3d_game_data_brush_trace_result *out_result)
+{
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.start = start;
+    trace.end = end;
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB;
+    trace.extents = fps_brush_body_extents(mover);
+    trace.contents_mask = contents_mask;
+    return slayer3d_game_data_slide_active_brush_worlds(runtime, &trace, 4, out_result);
+}
+
+static bool fps_brush_snap_to_ground(const slayer3d_game_data_runtime *runtime, slayer3d_fps_mover *mover,
+                                     unsigned int contents_mask, slayer3d_vec3 *body_center)
+{
+    if (runtime == NULL || mover == NULL || body_center == NULL)
+        return false;
+
+    const float probe_distance = SDL_max(mover->config.step_height, 0.05f) + 0.05f;
+    const slayer3d_vec3 probe_end = slayer3d_vec3_make(body_center->x, body_center->y - probe_distance, body_center->z);
+    slayer3d_game_data_brush_trace_result probe;
+    if (!fps_brush_trace_body(runtime, mover, contents_mask, *body_center, probe_end, &probe))
+        return false;
+    if (!probe.hit || probe.start_solid || probe.normal.y < 0.7f)
+        return false;
+
+    *body_center = slayer3d_vec3_add(probe.end_position, slayer3d_vec3_scale(probe.normal, 0.01f));
+    mover->vertical_velocity = 0.0f;
+    mover->on_ground = true;
+    return true;
+}
+
+static bool fps_brush_try_step_move(const slayer3d_game_data_runtime *runtime, slayer3d_fps_mover *mover,
+                                    unsigned int contents_mask, slayer3d_vec3 start, slayer3d_vec3 end,
+                                    slayer3d_vec3 *out_position)
+{
+    if (runtime == NULL || mover == NULL || out_position == NULL || mover->config.step_height <= 0.0f)
+        return false;
+
+    const float step_height = mover->config.step_height;
+    const slayer3d_vec3 raised_start = slayer3d_vec3_make(start.x, start.y + step_height, start.z);
+    const slayer3d_vec3 raised_end = slayer3d_vec3_make(end.x, end.y + step_height, end.z);
+    slayer3d_game_data_brush_trace_result up_trace;
+    if (!fps_brush_trace_body(runtime, mover, contents_mask, start, raised_start, &up_trace) || up_trace.hit)
+        return false;
+
+    slayer3d_game_data_brush_trace_result slide_trace;
+    if (!fps_brush_slide_body(runtime, mover, contents_mask, raised_start, raised_end, &slide_trace) ||
+        slide_trace.start_solid)
+    {
+        return false;
+    }
+
+    slayer3d_game_data_brush_trace_result down_trace;
+    const slayer3d_vec3 down_end = slayer3d_vec3_make(
+        slide_trace.end_position.x, slide_trace.end_position.y - step_height - 0.05f, slide_trace.end_position.z);
+    if (!fps_brush_trace_body(runtime, mover, contents_mask, slide_trace.end_position, down_end, &down_trace) ||
+        !down_trace.hit || down_trace.start_solid || down_trace.normal.y < 0.7f)
+    {
+        return false;
+    }
+
+    *out_position = slayer3d_vec3_add(down_trace.end_position, slayer3d_vec3_scale(down_trace.normal, 0.01f));
+    mover->on_ground = true;
+    mover->vertical_velocity = 0.0f;
+    return true;
+}
+
+static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                        slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
+{
+    if (runtime == NULL || component == NULL || actor == NULL)
+        return;
+    if (find_brush_world_runtime(runtime, json_string(component, "brush_world", NULL)) == NULL)
+        return;
+
+    fps_controller_runtime *controller = find_or_add_fps_controller(runtime, actor->name, component);
+    if (controller == NULL || !initialize_fps_controller_runtime(runtime, controller, component, actor))
+        return;
+
+    const int forward_action = fps_controller_action_id(runtime, component, "forward");
+    const int back_action = fps_controller_action_id(runtime, component, "back");
+    const int left_action = fps_controller_action_id(runtime, component, "left");
+    const int right_action = fps_controller_action_id(runtime, component, "right");
+    const int jump_action = fps_controller_action_id(runtime, component, "jump");
+
+    slayer3d_fps_mover *mover = &controller->mover;
+    const bool mouse_look = json_bool(component, "mouse_look", true);
+    const float mouse_dx = mouse_look && input != NULL ? slayer3d_input_get_mouse_dx(input) : 0.0f;
+    const float mouse_dy = mouse_look && input != NULL ? slayer3d_input_get_mouse_dy(input) : 0.0f;
+    const float mouse_sensitivity = json_float(component, "mouse_sensitivity", 0.002f);
+    mover->yaw += mouse_dx * mouse_sensitivity;
+    mover->pitch = fps_brush_clampf(mover->pitch - mouse_dy * mouse_sensitivity, -1.4f, 1.4f);
+
+    const unsigned int contents_mask = fps_brush_contents_mask(component);
+    slayer3d_vec3 body_center = fps_brush_eye_to_body_center(mover, mover->position);
+    (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, &body_center);
+
+    if (fps_controller_action_pressed(runtime, input, jump_action))
+        slayer3d_fps_mover_jump(mover);
+
+    float forward = fps_controller_action_value(runtime, input, forward_action) -
+                    fps_controller_action_value(runtime, input, back_action);
+    float side = fps_controller_action_value(runtime, input, right_action) -
+                 fps_controller_action_value(runtime, input, left_action);
+    const float wish_len_sq = forward * forward + side * side;
+    if (wish_len_sq > 1.0f)
+    {
+        const float inv_len = 1.0f / SDL_sqrtf(wish_len_sq);
+        forward *= inv_len;
+        side *= inv_len;
+    }
+
+    const float fwd_x = SDL_sinf(mover->yaw);
+    const float fwd_z = -SDL_cosf(mover->yaw);
+    const float right_x = SDL_cosf(mover->yaw);
+    const float right_z = SDL_sinf(mover->yaw);
+    const slayer3d_vec3 horizontal_delta =
+        slayer3d_vec3_make((fwd_x * forward + right_x * side) * mover->config.move_speed * SDL_max(dt, 0.0f), 0.0f,
+                           (fwd_z * forward + right_z * side) * mover->config.move_speed * SDL_max(dt, 0.0f));
+    if (slayer3d_vec3_length_squared(horizontal_delta) > 0.0000001f)
+    {
+        const slayer3d_vec3 horizontal_end = slayer3d_vec3_add(body_center, horizontal_delta);
+        slayer3d_game_data_brush_trace_result slide;
+        if (fps_brush_slide_body(runtime, mover, contents_mask, body_center, horizontal_end, &slide))
+        {
+            if (mover->on_ground && slide.hit)
+            {
+                slayer3d_vec3 stepped;
+                if (fps_brush_try_step_move(runtime, mover, contents_mask, body_center, horizontal_end, &stepped))
+                    body_center = stepped;
+                else
+                    body_center = slayer3d_vec3_add(slide.end_position, slayer3d_vec3_scale(slide.normal, 0.01f));
+            }
+            else
+            {
+                body_center = slide.hit
+                                  ? slayer3d_vec3_add(slide.end_position, slayer3d_vec3_scale(slide.normal, 0.01f))
+                                  : slide.end_position;
+            }
+        }
+    }
+
+    mover->vertical_velocity -= mover->config.gravity * SDL_max(dt, 0.0f);
+    const slayer3d_vec3 vertical_end =
+        slayer3d_vec3_make(body_center.x, body_center.y + mover->vertical_velocity * SDL_max(dt, 0.0f), body_center.z);
+    slayer3d_game_data_brush_trace_result vertical;
+    mover->on_ground = false;
+    if (fps_brush_trace_body(runtime, mover, contents_mask, body_center, vertical_end, &vertical))
+    {
+        body_center = vertical.end_position;
+        if (vertical.hit)
+        {
+            if (mover->vertical_velocity < 0.0f && vertical.normal.y >= 0.7f)
+            {
+                body_center = slayer3d_vec3_add(body_center, slayer3d_vec3_scale(vertical.normal, 0.01f));
+                mover->on_ground = true;
+            }
+            mover->vertical_velocity = 0.0f;
+        }
+    }
+    else
+    {
+        body_center = vertical_end;
+    }
+
+    if (!mover->on_ground && mover->vertical_velocity <= 0.0f)
+        (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, &body_center);
+
+    mover->position = fps_brush_body_center_to_eye(mover, body_center);
+    mover->current_sector = -1;
+    if (mover->on_ground)
+    {
+        mover->last_good_position = mover->position;
+        mover->has_last_good = true;
+    }
     fps_controller_publish_actor_state(controller, component, actor);
 }
 
@@ -19857,6 +20092,10 @@ static void update_control_components(slayer3d_game_data_runtime *runtime, yyjso
             else if (SDL_strcmp(type, "controller.fps_sector") == 0)
             {
                 update_fps_sector_controller(runtime, component, actor, input, dt);
+            }
+            else if (SDL_strcmp(type, "controller.fps_brush") == 0)
+            {
+                update_fps_brush_controller(runtime, component, actor, input, dt);
             }
             else if (SDL_strcmp(type, "weapon.projectile") == 0 && input != NULL)
             {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2843,6 +2843,7 @@ static bool is_supported_component_type(const char *type)
         "collision.circle",
         "combat.health",
         "control.axis_1d",
+        "controller.fps_brush",
         "controller.fps_sector",
         "lifecycle.ttl",
         "light.directional",
@@ -2995,17 +2996,17 @@ static bool validate_non_empty_string_field(validation_context *ctx, yyjson_val 
                                             const char *type, const char *field);
 static bool validate_optional_signal_field(validation_context *ctx, yyjson_val *json, const char *json_path,
                                            validation_names *names, const char *field);
+static bool brush_content_name_valid(const char *name);
+static bool validate_brush_string_or_string_array(validation_context *ctx, yyjson_val *value, const char *path,
+                                                  const char *label, bool (*name_valid)(const char *name),
+                                                  bool allow_empty);
 
-static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *component, const char *path,
-                                          validation_names *names)
+static bool validate_fps_controller_common(validation_context *ctx, yyjson_val *component, const char *path,
+                                           validation_names *names, const char *type_name)
 {
-    const char *level = json_string(component, "sector_level");
-    if (!require_ref(ctx, &names->sector_levels, "sector level", level, path))
-        return false;
-
     yyjson_val *actions = obj_get(component, "actions");
     if (!yyjson_is_obj(actions))
-        return validation_error(ctx, path, "controller.fps_sector requires an actions object");
+        return validation_error(ctx, path, "%s requires an actions object", type_name);
     const char *action_keys[] = {"forward", "back", "left", "right"};
     for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
     {
@@ -3028,7 +3029,7 @@ static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *c
     {
         yyjson_val *value = obj_get(component, property_keys[i]);
         if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
-            return validation_error(ctx, path, "controller.fps_sector property names must be non-empty strings");
+            return validation_error(ctx, path, "%s property names must be non-empty strings", type_name);
     }
 
     const char *non_negative[] = {"move_speed",    "jump_velocity", "gravity",           "player_height",
@@ -3037,18 +3038,39 @@ static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *c
     {
         yyjson_val *value = obj_get(component, non_negative[i]);
         if (value != NULL && (!yyjson_is_num(value) || yyjson_get_num(value) < 0.0))
-            return validation_error(ctx, path, "controller.fps_sector numeric tuning values must be non-negative");
+            return validation_error(ctx, path, "%s numeric tuning values must be non-negative", type_name);
     }
     yyjson_val *mouse_look = obj_get(component, "mouse_look");
     if (mouse_look != NULL && !yyjson_is_bool(mouse_look))
-        return validation_error(ctx, path, "controller.fps_sector mouse_look must be a boolean");
+        return validation_error(ctx, path, "%s mouse_look must be a boolean", type_name);
     yyjson_val *spawn_yaw = obj_get(component, "spawn_yaw");
     yyjson_val *spawn_pitch = obj_get(component, "spawn_pitch");
     if ((spawn_yaw != NULL && !yyjson_is_num(spawn_yaw)) || (spawn_pitch != NULL && !yyjson_is_num(spawn_pitch)))
     {
-        return validation_error(ctx, path, "controller.fps_sector spawn yaw and pitch values must be numbers");
+        return validation_error(ctx, path, "%s spawn yaw and pitch values must be numbers", type_name);
     }
     return true;
+}
+
+static bool validate_fps_sector_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                          validation_names *names)
+{
+    const char *level = json_string(component, "sector_level");
+    return require_ref(ctx, &names->sector_levels, "sector level", level, path) &&
+           validate_fps_controller_common(ctx, component, path, names, "controller.fps_sector");
+}
+
+static bool validate_fps_brush_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                         validation_names *names)
+{
+    const char *world = json_string(component, "brush_world");
+    if (!require_ref(ctx, &names->brush_worlds, "brush world", world, path))
+        return false;
+    char contents_path[PATH_BUFFER_SIZE];
+    format_path(contents_path, sizeof(contents_path), "%s.contents_mask", path);
+    return validate_brush_string_or_string_array(ctx, obj_get(component, "contents_mask"), contents_path,
+                                                 "brush content", brush_content_name_valid, false) &&
+           validate_fps_controller_common(ctx, component, path, names, "controller.fps_brush");
 }
 
 static bool validate_combat_health_component(validation_context *ctx, yyjson_val *component, const char *path)
@@ -5319,6 +5341,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_fps_sector_component(ctx, component, path, names))
                     return false;
             }
+            else if (SDL_strcmp(type, "controller.fps_brush") == 0)
+            {
+                if (!validate_fps_brush_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "combat.health") == 0)
             {
                 if (!validate_combat_health_component(ctx, component, path))
@@ -5864,10 +5891,10 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             {
                 return false;
             }
-            if (SDL_strcmp(type, "controller.fps_sector") == 0)
+            if (SDL_strcmp(type, "controller.fps_sector") == 0 || SDL_strcmp(type, "controller.fps_brush") == 0)
             {
                 return validation_error(ctx, component_path,
-                                        "controller.fps_sector is only supported on static entities");
+                                        "first-person controllers are only supported on static entities");
             }
             else if (SDL_strcmp(type, "combat.health") == 0)
             {
@@ -7473,7 +7500,8 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     {
         return validate_projectile_fire_shape(ctx, action, json_path, names, true);
     }
-    if (SDL_strcmp(type, "controller.fps_sector.launch") == 0 ||
+    if (SDL_strcmp(type, "controller.fps.launch") == 0 || SDL_strcmp(type, "controller.fps.teleport") == 0 ||
+        SDL_strcmp(type, "controller.fps_sector.launch") == 0 ||
         SDL_strcmp(type, "controller.fps_sector.teleport") == 0)
     {
         yyjson_val *target_value = obj_get(action, "target");
@@ -7489,21 +7517,20 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (target_from_payload_value != NULL &&
             (!yyjson_is_str(target_from_payload_value) || yyjson_get_str(target_from_payload_value)[0] == '\0'))
             return validation_error(ctx, json_path, "%s target_from_payload must be a non-empty string", type);
-        if (SDL_strcmp(type, "controller.fps_sector.launch") == 0)
+        if (SDL_strcmp(type, "controller.fps.launch") == 0 || SDL_strcmp(type, "controller.fps_sector.launch") == 0)
         {
             yyjson_val *vertical_velocity = obj_get(action, "vertical_velocity");
             if (!yyjson_is_num(vertical_velocity) || yyjson_get_num(vertical_velocity) <= 0.0)
-                return validation_error(ctx, json_path,
-                                        "controller.fps_sector.launch requires positive vertical_velocity");
+                return validation_error(ctx, json_path, "%s requires positive vertical_velocity", type);
             return true;
         }
 
         if (!is_vec_array(obj_get(action, "position"), 3))
-            return validation_error(ctx, json_path, "controller.fps_sector.teleport requires a vec3 position");
+            return validation_error(ctx, json_path, "%s requires a vec3 position", type);
         yyjson_val *yaw = obj_get(action, "yaw");
         yyjson_val *pitch = obj_get(action, "pitch");
         if ((yaw != NULL && !yyjson_is_num(yaw)) || (pitch != NULL && !yyjson_is_num(pitch)))
-            return validation_error(ctx, json_path, "controller.fps_sector.teleport yaw and pitch must be numeric");
+            return validation_error(ctx, json_path, "%s yaw and pitch must be numeric", type);
         return true;
     }
     if (SDL_strcmp(type, "grid.spawn_from_glyphs") == 0 || SDL_strcmp(type, "grid.spawn_runs_from_glyphs") == 0)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7390,8 +7390,11 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
 
     ASSERT_EQ(slayer3d_game_data_world_light_count(runtime), 2);
     slayer3d_camera3d camera{};
-    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.brush_geometry.overview", &camera));
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.brush_geometry.player", &camera));
     EXPECT_EQ(camera.fov_axis, SLAYER3D_CAMERA_FOV_HORIZONTAL);
+    EXPECT_EQ(camera.projection, SLAYER3D_CAMERA_PERSPECTIVE);
+    EXPECT_NEAR(camera.position.y, 1.6f, 0.05f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -10851,6 +10854,180 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
+{
+    const std::filesystem::path dir = unique_test_dir("fps_brush_controller");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.player",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "input": {
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump"
+    ]
+  },
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.test_room", "position": [0.0, 0.0, 0.0] }
+    ]
+  }
+})json");
+    write_text(dir / "fps_brush.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "FPS Brush Controller Test" },
+  "world": {
+    "name": "world.test",
+    "kind": "brush",
+    "cameras": [
+      {
+        "name": "camera.player",
+        "type": "fps",
+        "target_entity": "entity.player",
+        "fov": 90.0,
+        "fov_axis": "horizontal",
+        "active": true
+      }
+    ]
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.play",
+        "actions": [
+          { "name": "action.move.forward" },
+          { "name": "action.move.back" },
+          { "name": "action.move.left" },
+          { "name": "action.move.right" },
+          { "name": "action.jump" }
+        ]
+      }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.6, 1.5] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "current_sector": { "type": "int", "value": 7 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_brush",
+          "brush_world": "brush.test_room",
+          "contents_mask": ["solid", "player_clip"],
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 4.0,
+          "jump_velocity": 4.0,
+          "gravity": 9.0,
+          "player_height": 1.6,
+          "player_radius": 0.25,
+          "step_height": 0.4,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.0
+        }
+      ]
+    }
+  ],
+  "brush_worlds": [
+    {
+      "name": "brush.test_room",
+      "materials": [
+        { "name": "mat.floor", "albedo": [0.5, 0.5, 0.5, 1.0] },
+        { "name": "mat.wall", "albedo": [0.25, 0.25, 0.3, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.floor",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 4.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 4.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.5 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 0, 1], "distance": 4.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 0, -1], "distance": 4.0 }, "material": "mat.floor" }
+          ]
+        },
+        {
+          "name": "brush.north_wall",
+          "contents": ["solid", "player_clip"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 4.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 4.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 3.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": -3.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 4.0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "fps_brush.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    const float initial_z = player->position.z;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int forward = slayer3d_game_data_find_action(runtime, "action.move.forward");
+    ASSERT_GE(forward, 0);
+    slayer3d_input_set_action_override(input, forward, 1.0f);
+    for (int i = 0; i < 20; ++i)
+    {
+        ASSERT_NE(slayer3d_input_update(input, (Uint64)(1000 + i)), nullptr);
+        ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.1f));
+    }
+
+    EXPECT_LT(player->position.z, initial_z);
+    EXPECT_GT(player->position.z, -3.35f);
+    EXPECT_NEAR(player->position.y, 1.6f, 0.03f);
+    EXPECT_EQ(slayer3d_properties_get_int(player->props, "current_sector", 99), -1);
+    EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "on_ground", false));
+    expect_vec3_near(
+        slayer3d_properties_get_vec3(player->props, "camera_forward", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)),
+        slayer3d_vec3_make(0.0f, 0.0f, -1.0f));
+
+    slayer3d_camera3d camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.player", &camera));
+    EXPECT_EQ(camera.projection, SLAYER3D_CAMERA_PERSPECTIVE);
+    EXPECT_NEAR(camera.position.x, player->position.x, 0.001f);
+    EXPECT_NEAR(camera.position.y, player->position.y, 0.001f);
+    EXPECT_NEAR(camera.position.z, player->position.z, 0.001f);
+    EXPECT_LT(camera.target.z, camera.position.z);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, SectorLightingModulatesLitActorsAndCanUpdateAtRuntime)
 {
     const std::filesystem::path dir = unique_test_dir("sector_lighting_runtime");
@@ -12294,6 +12471,115 @@ TEST(GameDataRuntime, RejectsInvalidFpsSectorController)
         "ceil_y": 3,
         "wall_material": "floor"
       }]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+        write_text(game_path, game_json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(slayer3d_game_data_validate_file(game_path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, RejectsInvalidFpsBrushController)
+{
+    const std::filesystem::path dir = unique_test_dir("fps_brush_controller_invalid");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.player"],
+  "world": { "brush_worlds": [{ "world": "brush.test" }] }
+})json");
+
+    struct Case
+    {
+        const char *name;
+        const char *component_json;
+        const char *expected_error;
+    };
+    const Case cases[] = {
+        {
+            "unknown_world",
+            R"json({
+              "type": "controller.fps_brush",
+              "brush_world": "brush.missing",
+              "actions": {
+                "forward": "action.move.forward",
+                "back": "action.move.back",
+                "left": "action.move.left",
+                "right": "action.move.right"
+              }
+            })json",
+            "unknown brush world",
+        },
+        {
+            "bad_contents_mask",
+            R"json({
+              "type": "controller.fps_brush",
+              "brush_world": "brush.test",
+              "contents_mask": ["solid", "bad_content"],
+              "actions": {
+                "forward": "action.move.forward",
+                "back": "action.move.back",
+                "left": "action.move.left",
+                "right": "action.move.right"
+              }
+            })json",
+            "brush content value is unknown",
+        },
+    };
+
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path game_path = dir / (std::string(test_case.name) + ".game.json");
+        const std::string game_json = std::string(R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Invalid FPS Brush Controller" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.play",
+        "actions": [
+          { "name": "action.move.forward" },
+          { "name": "action.move.back" },
+          { "name": "action.move.left" },
+          { "name": "action.move.right" }
+        ]
+      }
+    ]
+  },
+  "entities": [
+    {
+      "name": "entity.player",
+      "components": [
+)json") + test_case.component_json +
+                                      R"json(
+      ]
+    }
+  ],
+  "brush_worlds": [
+    {
+      "name": "brush.test",
+      "materials": [{ "name": "mat" }],
+      "brushes": [
+        {
+          "name": "brush.floor",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1.0 }, "material": "mat" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1.0 }, "material": "mat" },
+            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.25 }, "material": "mat" }
+          ]
+        }
+      ]
     }
   ],
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }


### PR DESCRIPTION
## Summary
- adds a data-authored `controller.fps_brush` component that drives FPS movement through active brush worlds using swept AABB traces, sliding, gravity, jumping, and basic step-up movement
- adds generic `controller.fps.launch` / `controller.fps.teleport` aliases that work with sector and brush FPS controllers while keeping existing sector action names valid
- updates the brush geometry dojo into a walkable FPS scene with authored player controls and documents the brush controller schema

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j4`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j4`

## Manual test
- `./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json`

## Next slice
- Add brush-world surface response metadata and controller diagnostics: slope limits, explicit floor/wall classification, step debugging, and authored collision masks for player/projectile/hitscan so the brush movement model is easier to tune and inspect in the dojo.