### PR TITLE
Add brush FPS tuning diagnostics

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -588,6 +588,7 @@ the active scene's brush-world instances:
       "player_radius": 0.35,
       "step_height": 0.65,
       "ceiling_clearance": 0.1,
+      "walkable_normal_y": 0.7,
       "mouse_sensitivity": 0.002
     }
   ]
@@ -597,10 +598,28 @@ the active scene's brush-world instances:
 The actor transform is the player's eye position. The controller sweeps an AABB
 body through `world.brush_worlds` in active-scene world space, slides along
 brush planes, supports basic stair stepping, gravity, jumping, and mouse-look,
-and writes the same diagnostic properties as `controller.fps_sector`.
+and writes the same base diagnostic properties as `controller.fps_sector`.
 `brush_world` is validated as the intended collision world; runtime collision
 uses all active brush-world instances so multi-part brush scenes compose
 naturally. Missing `contents_mask` defaults to `["solid", "player_clip"]`.
+`walkable_normal_y` controls floor classification; the default `0.7` treats
+surfaces up to roughly 45 degrees as walkable.
+
+Brush FPS controllers also publish brush-specific diagnostics for tuning and
+debug UI:
+
+- `brush_collision_kind` (`none`, `wall`, `floor`, `ceiling`, or `solid`)
+- `brush_collision_normal`
+- `brush_collision_brush`
+- `brush_collision_material`
+- `brush_collision_contents`
+- `brush_collision_surface_flags`
+- `brush_floor_normal`
+- `brush_floor_brush`
+- `brush_step_up`
+
+Each diagnostic property name can be overridden with the corresponding
+`*_property` field, for example `brush_collision_kind_property`.
 
 ## Sector Levels
 
@@ -1383,15 +1402,18 @@ clears `reload_pending`. If `consume_reserve` is `false`, the clip fills
 without reducing reserve ammo, which is useful for energy weapons or prototypes.
 
 `weapon.hitscan` traces instantly from an actor. It can trace against sector
-geometry through `sector_level`, select the nearest active actor with
-`target_tag`, consume the same clip/ammo fields as projectiles, and run authored
-actions with a payload:
+geometry through `sector_level`, brush geometry through `trace_brush_worlds`
+and `brush_contents_mask`, select the nearest active actor with `target_tag`,
+consume the same clip/ammo fields as projectiles, and run authored actions with
+a payload:
 
 ```json
 {
   "type": "weapon.hitscan",
   "target": "entity.player",
   "sector_level": "sector.e1m1",
+  "trace_brush_worlds": true,
+  "brush_contents_mask": ["solid", "projectile_clip"],
   "direction_from_property": "camera_forward",
   "target_tag": "enemy",
   "range": 64.0,
@@ -1409,10 +1431,13 @@ actions with a payload:
 ```
 
 Hitscan payloads include `source_actor_name`, `actor_name` / `hit_actor_name`,
-`origin`, `direction`, `hit_position`, `hit_distance`, `hit_actor`, and
-`hit_wall`. Use these fields for damage, particles, lights, sounds, decals, or
-debug UI. Actor hit tests use a target actor's `hit_radius` or `radius`
-property, falling back to the action's `hit_radius` value.
+`origin`, `direction`, `hit_position`, `hit_distance`, `hit_actor`, `hit_wall`,
+`hit_brush`, `hit_brush_world`, `hit_brush_name`, `hit_material`,
+`hit_normal`, `hit_contents`, and `hit_surface_flags`. Use these fields for
+damage, particles, lights, sounds, decals, or debug UI. Actor hit tests use a
+target actor's `hit_radius` or `radius` property, falling back to the action's
+`hit_radius` value. Brush hits block actor hits behind the wall because the
+actor query is limited to the nearest wall distance.
 
 ## Sector Level Fragments
 

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -16907,7 +16907,8 @@ static slayer3d_vec3 weapon_direction_from_action(const slayer3d_registered_acto
 static slayer3d_properties *weapon_hitscan_payload(const slayer3d_registered_actor *source,
                                                    const slayer3d_registered_actor *hit, slayer3d_vec3 origin,
                                                    slayer3d_vec3 direction, slayer3d_vec3 hit_position, float distance,
-                                                   bool wall_hit)
+                                                   bool wall_hit,
+                                                   const slayer3d_game_data_brush_trace_result *brush_hit)
 {
     slayer3d_properties *payload = slayer3d_properties_create();
     if (payload == NULL)
@@ -16922,6 +16923,21 @@ static slayer3d_properties *weapon_hitscan_payload(const slayer3d_registered_act
     slayer3d_properties_set_float(payload, "hit_distance", distance);
     slayer3d_properties_set_bool(payload, "hit_actor", hit != NULL);
     slayer3d_properties_set_bool(payload, "hit_wall", wall_hit);
+    slayer3d_properties_set_bool(payload, "hit_brush", brush_hit != NULL && brush_hit->hit);
+    slayer3d_properties_set_string(payload, "hit_brush_world",
+                                   brush_hit != NULL && brush_hit->world_name != NULL ? brush_hit->world_name : "");
+    slayer3d_properties_set_string(payload, "hit_brush_name",
+                                   brush_hit != NULL && brush_hit->brush_name != NULL ? brush_hit->brush_name : "");
+    slayer3d_properties_set_string(
+        payload, "hit_material", brush_hit != NULL && brush_hit->material_name != NULL ? brush_hit->material_name : "");
+    slayer3d_properties_set_vec3(payload, "hit_normal",
+                                 brush_hit != NULL ? brush_hit->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_int(payload, "hit_contents",
+                                brush_hit != NULL ? (int)SDL_min(brush_hit->contents, (unsigned int)SDL_MAX_SINT32)
+                                                  : 0);
+    slayer3d_properties_set_int(payload, "hit_surface_flags",
+                                brush_hit != NULL ? (int)SDL_min(brush_hit->surface_flags, (unsigned int)SDL_MAX_SINT32)
+                                                  : 0);
     return payload;
 }
 
@@ -16943,6 +16959,9 @@ static bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, y
                                                     origin.z + direction.z * range);
 
     const sector_level_runtime *level = find_sector_level_runtime(runtime, json_string(action, "sector_level", NULL));
+    slayer3d_game_data_brush_trace_result brush_result;
+    SDL_zero(brush_result);
+    bool has_brush_result = false;
     if (level != NULL)
     {
         const slayer3d_level_trace_result trace =
@@ -16950,6 +16969,29 @@ static bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, y
         wall_distance = SDL_clamp(trace.fraction, 0.0f, 1.0f) * range;
         wall_hit = trace.hit;
         hit_position = trace.end_point;
+    }
+    if (obj_get(action, "brush_contents_mask") != NULL || json_bool(action, "trace_brush_worlds", false))
+    {
+        slayer3d_game_data_brush_trace_desc brush_trace;
+        SDL_zero(brush_trace);
+        brush_trace.start = origin;
+        brush_trace.end = slayer3d_vec3_make(origin.x + direction.x * range, origin.y + direction.y * range,
+                                             origin.z + direction.z * range);
+        brush_trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+        brush_trace.contents_mask = brush_flags_from_json(
+            obj_get(action, "brush_contents_mask"), brush_content_flag_from_string,
+            SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP);
+        if (slayer3d_game_data_trace_active_brush_worlds(runtime, &brush_trace, &brush_result) && brush_result.hit)
+        {
+            const float brush_distance = SDL_clamp(brush_result.fraction, 0.0f, 1.0f) * range;
+            if (brush_distance < wall_distance)
+            {
+                wall_distance = brush_distance;
+                wall_hit = true;
+                hit_position = brush_result.end_position;
+                has_brush_result = true;
+            }
+        }
     }
 
     float actor_distance = wall_distance;
@@ -16964,9 +17006,9 @@ static bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, y
     }
 
     weapon_fire_commit(runtime, action, source);
-    slayer3d_properties *hit_payload =
-        weapon_hitscan_payload(source, hit_actor, origin, direction, hit_position,
-                               hit_actor != NULL ? actor_distance : wall_distance, wall_hit);
+    slayer3d_properties *hit_payload = weapon_hitscan_payload(
+        source, hit_actor, origin, direction, hit_position, hit_actor != NULL ? actor_distance : wall_distance,
+        wall_hit, has_brush_result && hit_actor == NULL ? &brush_result : NULL);
     const bool ok =
         execute_optional_action_array(runtime,
                                       hit_actor != NULL || wall_hit || json_bool(action, "run_actions_on_miss", false)
@@ -19563,6 +19605,99 @@ static unsigned int fps_brush_contents_mask(yyjson_val *component)
                                  SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
 }
 
+static float fps_brush_walkable_normal_y(yyjson_val *component)
+{
+    return SDL_clamp(json_float(component, "walkable_normal_y", 0.7f), 0.0f, 1.0f);
+}
+
+typedef struct fps_brush_diagnostics
+{
+    const char *collision_kind;
+    slayer3d_vec3 collision_normal;
+    const char *collision_brush;
+    const char *collision_material;
+    unsigned int collision_contents;
+    unsigned int collision_surface_flags;
+    slayer3d_vec3 floor_normal;
+    const char *floor_brush;
+    bool stepped_up;
+} fps_brush_diagnostics;
+
+static void fps_brush_diagnostics_init(fps_brush_diagnostics *diagnostics)
+{
+    if (diagnostics == NULL)
+        return;
+    SDL_zero(*diagnostics);
+    diagnostics->collision_kind = "none";
+    diagnostics->collision_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    diagnostics->floor_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+}
+
+static const char *fps_brush_collision_kind(slayer3d_vec3 normal, float walkable_normal_y)
+{
+    if (normal.y >= walkable_normal_y)
+        return "floor";
+    if (normal.y <= -walkable_normal_y)
+        return "ceiling";
+    return "wall";
+}
+
+static void fps_brush_record_collision(fps_brush_diagnostics *diagnostics,
+                                       const slayer3d_game_data_brush_trace_result *result, float walkable_normal_y)
+{
+    if (diagnostics == NULL || result == NULL || !result->hit)
+        return;
+    diagnostics->collision_kind =
+        result->start_solid ? "solid" : fps_brush_collision_kind(result->normal, walkable_normal_y);
+    diagnostics->collision_normal = result->normal;
+    diagnostics->collision_brush = result->brush_name;
+    diagnostics->collision_material = result->material_name;
+    diagnostics->collision_contents = result->contents;
+    diagnostics->collision_surface_flags = result->surface_flags;
+}
+
+static void fps_brush_record_floor(fps_brush_diagnostics *diagnostics,
+                                   const slayer3d_game_data_brush_trace_result *result)
+{
+    if (diagnostics == NULL || result == NULL || !result->hit)
+        return;
+    diagnostics->floor_normal = result->normal;
+    diagnostics->floor_brush = result->brush_name;
+}
+
+static void fps_brush_publish_diagnostics(const fps_brush_diagnostics *diagnostics, yyjson_val *component,
+                                          slayer3d_registered_actor *actor)
+{
+    if (diagnostics == NULL || component == NULL || actor == NULL)
+        return;
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "brush_collision_kind_property", "brush_collision_kind"),
+                                   diagnostics->collision_kind != NULL ? diagnostics->collision_kind : "none");
+    slayer3d_properties_set_vec3(actor->props,
+                                 json_string(component, "brush_collision_normal_property", "brush_collision_normal"),
+                                 diagnostics->collision_normal);
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "brush_collision_brush_property", "brush_collision_brush"),
+                                   diagnostics->collision_brush != NULL ? diagnostics->collision_brush : "");
+    slayer3d_properties_set_string(
+        actor->props, json_string(component, "brush_collision_material_property", "brush_collision_material"),
+        diagnostics->collision_material != NULL ? diagnostics->collision_material : "");
+    slayer3d_properties_set_int(actor->props,
+                                json_string(component, "brush_collision_contents_property", "brush_collision_contents"),
+                                (int)SDL_min(diagnostics->collision_contents, (unsigned int)SDL_MAX_SINT32));
+    slayer3d_properties_set_int(
+        actor->props, json_string(component, "brush_collision_surface_flags_property", "brush_collision_surface_flags"),
+        (int)SDL_min(diagnostics->collision_surface_flags, (unsigned int)SDL_MAX_SINT32));
+    slayer3d_properties_set_vec3(actor->props,
+                                 json_string(component, "brush_floor_normal_property", "brush_floor_normal"),
+                                 diagnostics->floor_normal);
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "brush_floor_brush_property", "brush_floor_brush"),
+                                   diagnostics->floor_brush != NULL ? diagnostics->floor_brush : "");
+    slayer3d_properties_set_bool(actor->props, json_string(component, "brush_step_up_property", "brush_step_up"),
+                                 diagnostics->stepped_up);
+}
+
 static slayer3d_vec3 fps_brush_body_extents(const slayer3d_fps_mover *mover)
 {
     const float skin = 0.01f;
@@ -19615,7 +19750,8 @@ static bool fps_brush_slide_body(const slayer3d_game_data_runtime *runtime, cons
 }
 
 static bool fps_brush_snap_to_ground(const slayer3d_game_data_runtime *runtime, slayer3d_fps_mover *mover,
-                                     unsigned int contents_mask, slayer3d_vec3 *body_center)
+                                     unsigned int contents_mask, float walkable_normal_y,
+                                     fps_brush_diagnostics *diagnostics, slayer3d_vec3 *body_center)
 {
     if (runtime == NULL || mover == NULL || body_center == NULL)
         return false;
@@ -19625,17 +19761,19 @@ static bool fps_brush_snap_to_ground(const slayer3d_game_data_runtime *runtime, 
     slayer3d_game_data_brush_trace_result probe;
     if (!fps_brush_trace_body(runtime, mover, contents_mask, *body_center, probe_end, &probe))
         return false;
-    if (!probe.hit || probe.start_solid || probe.normal.y < 0.7f)
+    if (!probe.hit || probe.start_solid || probe.normal.y < walkable_normal_y)
         return false;
 
     *body_center = slayer3d_vec3_add(probe.end_position, slayer3d_vec3_scale(probe.normal, 0.01f));
     mover->vertical_velocity = 0.0f;
     mover->on_ground = true;
+    fps_brush_record_floor(diagnostics, &probe);
     return true;
 }
 
 static bool fps_brush_try_step_move(const slayer3d_game_data_runtime *runtime, slayer3d_fps_mover *mover,
-                                    unsigned int contents_mask, slayer3d_vec3 start, slayer3d_vec3 end,
+                                    unsigned int contents_mask, float walkable_normal_y,
+                                    fps_brush_diagnostics *diagnostics, slayer3d_vec3 start, slayer3d_vec3 end,
                                     slayer3d_vec3 *out_position)
 {
     if (runtime == NULL || mover == NULL || out_position == NULL || mover->config.step_height <= 0.0f)
@@ -19652,14 +19790,16 @@ static bool fps_brush_try_step_move(const slayer3d_game_data_runtime *runtime, s
     if (!fps_brush_slide_body(runtime, mover, contents_mask, raised_start, raised_end, &slide_trace) ||
         slide_trace.start_solid)
     {
+        fps_brush_record_collision(diagnostics, &slide_trace, walkable_normal_y);
         return false;
     }
+    fps_brush_record_collision(diagnostics, &slide_trace, walkable_normal_y);
 
     slayer3d_game_data_brush_trace_result down_trace;
     const slayer3d_vec3 down_end = slayer3d_vec3_make(
         slide_trace.end_position.x, slide_trace.end_position.y - step_height - 0.05f, slide_trace.end_position.z);
     if (!fps_brush_trace_body(runtime, mover, contents_mask, slide_trace.end_position, down_end, &down_trace) ||
-        !down_trace.hit || down_trace.start_solid || down_trace.normal.y < 0.7f)
+        !down_trace.hit || down_trace.start_solid || down_trace.normal.y < walkable_normal_y)
     {
         return false;
     }
@@ -19667,6 +19807,9 @@ static bool fps_brush_try_step_move(const slayer3d_game_data_runtime *runtime, s
     *out_position = slayer3d_vec3_add(down_trace.end_position, slayer3d_vec3_scale(down_trace.normal, 0.01f));
     mover->on_ground = true;
     mover->vertical_velocity = 0.0f;
+    if (diagnostics != NULL)
+        diagnostics->stepped_up = true;
+    fps_brush_record_floor(diagnostics, &down_trace);
     return true;
 }
 
@@ -19697,8 +19840,11 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
     mover->pitch = fps_brush_clampf(mover->pitch - mouse_dy * mouse_sensitivity, -1.4f, 1.4f);
 
     const unsigned int contents_mask = fps_brush_contents_mask(component);
+    const float walkable_normal_y = fps_brush_walkable_normal_y(component);
+    fps_brush_diagnostics diagnostics;
+    fps_brush_diagnostics_init(&diagnostics);
     slayer3d_vec3 body_center = fps_brush_eye_to_body_center(mover, mover->position);
-    (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, &body_center);
+    (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, walkable_normal_y, &diagnostics, &body_center);
 
     if (fps_controller_action_pressed(runtime, input, jump_action))
         slayer3d_fps_mover_jump(mover);
@@ -19731,13 +19877,20 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
             if (mover->on_ground && slide.hit)
             {
                 slayer3d_vec3 stepped;
-                if (fps_brush_try_step_move(runtime, mover, contents_mask, body_center, horizontal_end, &stepped))
+                if (fps_brush_try_step_move(runtime, mover, contents_mask, walkable_normal_y, &diagnostics, body_center,
+                                            horizontal_end, &stepped))
+                {
                     body_center = stepped;
+                }
                 else
+                {
+                    fps_brush_record_collision(&diagnostics, &slide, walkable_normal_y);
                     body_center = slayer3d_vec3_add(slide.end_position, slayer3d_vec3_scale(slide.normal, 0.01f));
+                }
             }
             else
             {
+                fps_brush_record_collision(&diagnostics, &slide, walkable_normal_y);
                 body_center = slide.hit
                                   ? slayer3d_vec3_add(slide.end_position, slayer3d_vec3_scale(slide.normal, 0.01f))
                                   : slide.end_position;
@@ -19755,10 +19908,15 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
         body_center = vertical.end_position;
         if (vertical.hit)
         {
-            if (mover->vertical_velocity < 0.0f && vertical.normal.y >= 0.7f)
+            if (mover->vertical_velocity < 0.0f && vertical.normal.y >= walkable_normal_y)
             {
                 body_center = slayer3d_vec3_add(body_center, slayer3d_vec3_scale(vertical.normal, 0.01f));
                 mover->on_ground = true;
+                fps_brush_record_floor(&diagnostics, &vertical);
+            }
+            else
+            {
+                fps_brush_record_collision(&diagnostics, &vertical, walkable_normal_y);
             }
             mover->vertical_velocity = 0.0f;
         }
@@ -19769,7 +19927,7 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
     }
 
     if (!mover->on_ground && mover->vertical_velocity <= 0.0f)
-        (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, &body_center);
+        (void)fps_brush_snap_to_ground(runtime, mover, contents_mask, walkable_normal_y, &diagnostics, &body_center);
 
     mover->position = fps_brush_body_center_to_eye(mover, body_center);
     mover->current_sector = -1;
@@ -19779,6 +19937,7 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
         mover->has_last_good = true;
     }
     fps_controller_publish_actor_state(controller, component, actor);
+    fps_brush_publish_diagnostics(&diagnostics, component, actor);
 }
 
 static void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -3068,9 +3068,35 @@ static bool validate_fps_brush_component(validation_context *ctx, yyjson_val *co
         return false;
     char contents_path[PATH_BUFFER_SIZE];
     format_path(contents_path, sizeof(contents_path), "%s.contents_mask", path);
-    return validate_brush_string_or_string_array(ctx, obj_get(component, "contents_mask"), contents_path,
-                                                 "brush content", brush_content_name_valid, false) &&
-           validate_fps_controller_common(ctx, component, path, names, "controller.fps_brush");
+    if (!validate_brush_string_or_string_array(ctx, obj_get(component, "contents_mask"), contents_path, "brush content",
+                                               brush_content_name_valid, false) ||
+        !validate_fps_controller_common(ctx, component, path, names, "controller.fps_brush"))
+    {
+        return false;
+    }
+    yyjson_val *walkable = obj_get(component, "walkable_normal_y");
+    if (walkable != NULL &&
+        (!yyjson_is_num(walkable) || yyjson_get_num(walkable) < 0.0 || yyjson_get_num(walkable) > 1.0))
+    {
+        return validation_error(ctx, path, "controller.fps_brush walkable_normal_y must be in [0, 1]");
+    }
+    const char *property_keys[] = {"brush_collision_kind_property",
+                                   "brush_collision_normal_property",
+                                   "brush_collision_brush_property",
+                                   "brush_collision_material_property",
+                                   "brush_collision_contents_property",
+                                   "brush_collision_surface_flags_property",
+                                   "brush_floor_normal_property",
+                                   "brush_floor_brush_property",
+                                   "brush_step_up_property"};
+    for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, property_keys[i]);
+        if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+            return validation_error(ctx, path,
+                                    "controller.fps_brush diagnostic property names must be non-empty strings");
+    }
+    return true;
 }
 
 static bool validate_combat_health_component(validation_context *ctx, yyjson_val *component, const char *path)
@@ -7043,6 +7069,16 @@ static bool validate_weapon_hitscan_action(validation_context *ctx, yyjson_val *
     const char *sector_level = json_string(action, "sector_level");
     if (sector_level != NULL && !require_ref(ctx, &names->sector_levels, "sector level", sector_level, json_path))
         return false;
+    yyjson_val *trace_brush_worlds = obj_get(action, "trace_brush_worlds");
+    if (trace_brush_worlds != NULL && !yyjson_is_bool(trace_brush_worlds))
+        return validation_error(ctx, json_path, "weapon.hitscan trace_brush_worlds must be a boolean");
+    char contents_path[PATH_BUFFER_SIZE];
+    format_path(contents_path, sizeof(contents_path), "%s.brush_contents_mask", json_path);
+    if (!validate_brush_string_or_string_array(ctx, obj_get(action, "brush_contents_mask"), contents_path,
+                                               "brush content", brush_content_name_valid, false))
+    {
+        return false;
+    }
     if (!validate_non_empty_string_field(ctx, action, json_path, "weapon.hitscan", "target_tag") ||
         !validate_non_empty_string_field(ctx, action, json_path, "weapon.hitscan", "hit_tag"))
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8994,6 +8994,130 @@ TEST(GameDataRuntime, WeaponHitscanTracesSectorAndRunsImpactActions)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, WeaponHitscanTracesActiveBrushWorlds)
+{
+    const std::filesystem::path dir = unique_test_dir("weapon_hitscan_brush");
+    write_text(dir / "weapon_hitscan_brush.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Weapon Brush Hitscan", "id": "test.weapon_hitscan_brush", "version": "0.1.0" },
+  "world": { "name": "world.weapon_hitscan_brush", "kind": "brush" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.5, 2.0] },
+      "properties": {
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "energy": { "type": "int", "value": 1 },
+        "fire_timer": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "weapon.hitscan",
+            "target": "entity.player",
+            "trace_brush_worlds": true,
+            "brush_contents_mask": ["solid", "projectile_clip"],
+            "range": 20.0,
+            "ammo_resource": "energy",
+            "cooldown": 0.0,
+            "run_actions_on_miss": false,
+            "actions": [
+              {
+                "type": "property.set",
+                "target": "entity.player",
+                "key": "last_hit_brush",
+                "value_from_payload": "hit_brush_name"
+              },
+              {
+                "type": "property.set",
+                "target": "entity.player",
+                "key": "last_hit_material",
+                "value_from_payload": "hit_material"
+              },
+              {
+                "type": "property.set",
+                "target": "entity.player",
+                "key": "last_hit_distance",
+                "value_from_payload": "hit_distance"
+              },
+              {
+                "type": "property.set",
+                "target": "entity.player",
+                "key": "last_hit_brush_flag",
+                "value_from_payload": "hit_brush"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "brush_worlds": [
+    {
+      "name": "brush.hitscan",
+      "materials": [{ "name": "mat.wall", "albedo": [0.3, 0.3, 0.3, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.target_wall",
+          "contents": ["solid", "projectile_clip"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 2.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 2.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 1, 0], "distance": 3.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, 1], "distance": 0.2 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0.2 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "world": { "brush_worlds": [{ "world": "brush.hitscan" }] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "weapon_hitscan_brush.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int fire = slayer3d_game_data_find_signal(runtime, "signal.fire");
+    ASSERT_GE(fire, 0);
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+
+    slayer3d_signal_emit(bus, fire, nullptr);
+    EXPECT_EQ(slayer3d_properties_get_int(player->props, "energy", -1), 0);
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_hit_brush", ""), "brush.target_wall");
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_hit_material", ""), "mat.wall");
+    EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "last_hit_brush_flag", false));
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "last_hit_distance", 0.0f), 1.8f, 0.01f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidWeaponPrimitives)
 {
     const std::filesystem::path dir = unique_test_dir("invalid_weapon_primitives");
@@ -9062,6 +9186,39 @@ TEST(GameDataRuntime, RejectsInvalidWeaponPrimitives)
                                               error, sizeof(error)));
     EXPECT_NE(std::string(error).find("weapon.hitscan range and hit_radius must be non-negative"), std::string::npos)
         << error;
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+
+    write_text(dir / "invalid_hitscan_brush_mask.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Invalid Hitscan Brush Mask", "id": "test.invalid_hitscan_brush_mask", "version": "0.1.0" },
+  "world": { "name": "world.invalid_hitscan_brush_mask", "kind": "brush" },
+  "entities": [{ "name": "entity.player" }],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "weapon.hitscan",
+            "target": "entity.player",
+            "trace_brush_worlds": true,
+            "brush_contents_mask": ["solid", "missing_content"]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_load_file((dir / "invalid_hitscan_brush_mask.game.json").string().c_str(), session,
+                                              &runtime, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("brush content value is unknown"), std::string::npos) << error;
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);
@@ -10940,6 +11097,7 @@ TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
           "player_radius": 0.25,
           "step_height": 0.4,
           "ceiling_clearance": 0.1,
+          "walkable_normal_y": 0.65,
           "mouse_sensitivity": 0.0
         }
       ]
@@ -11011,6 +11169,12 @@ TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
     EXPECT_NEAR(player->position.y, 1.6f, 0.03f);
     EXPECT_EQ(slayer3d_properties_get_int(player->props, "current_sector", 99), -1);
     EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "on_ground", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "brush_collision_kind", ""), "wall");
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "brush_collision_brush", ""), "brush.north_wall");
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "brush_floor_brush", ""), "brush.floor");
+    expect_vec3_near(
+        slayer3d_properties_get_vec3(player->props, "brush_floor_normal", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)),
+        slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
     expect_vec3_near(
         slayer3d_properties_get_vec3(player->props, "camera_forward", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)),
         slayer3d_vec3_make(0.0f, 0.0f, -1.0f));
@@ -12533,6 +12697,21 @@ TEST(GameDataRuntime, RejectsInvalidFpsBrushController)
               }
             })json",
             "brush content value is unknown",
+        },
+        {
+            "bad_walkable_normal",
+            R"json({
+              "type": "controller.fps_brush",
+              "brush_world": "brush.test",
+              "walkable_normal_y": 1.5,
+              "actions": {
+                "forward": "action.move.forward",
+                "back": "action.move.back",
+                "left": "action.move.left",
+                "right": "action.move.right"
+              }
+            })json",
+            "walkable_normal_y must be in [0, 1]",
         },
     };
 


### PR DESCRIPTION
## Summary
- adds `walkable_normal_y` tuning and brush-specific diagnostics to `controller.fps_brush` so floor/wall/ceiling classification is inspectable from actor properties
- adds active brush-world wall blocking for `weapon.hitscan` with authored `brush_contents_mask` and hit payload fields for brush/material/normal metadata
- validates the new authored fields and documents the controller and hitscan mask behavior

## Tests
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RunsAuthoredFpsBrushController:GameDataRuntime.WeaponHitscanTracesActiveBrushWorlds:GameDataRuntime.RejectsInvalidFpsBrushController:GameDataRuntime.RejectsInvalidWeaponPrimitives'`
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j4`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j4`

## Manual test
- `./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json`

## Next slice
- Add swept brush projectile/kinematic movement (`motion.brush_velocity_3d`) using sphere/AABB traces, impact payloads, despawn policies, and authored contents masks so projectiles and moving props interact with brush worlds the same way hitscan and FPS controllers do.