### PR TITLE
Add brush velocity motion component

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1609,6 +1609,13 @@ Reusable components include:
   through an authored `sector_level`, tracing against sector volumes and
   despawning on impact by default. Use this for data-authored projectiles in
   FPS/sector worlds.
+- `motion.brush_velocity_3d`: moves an actor by a `vec3` velocity property
+  through active brush-world instances, using swept point, sphere, or AABB
+  traces. It collides with `solid` and `projectile_clip` contents by default,
+  can publish impact diagnostics, can run `impact_actions` or emit `on_impact`
+  with brush/material payload data, and despawns on impact by default. Use this
+  for projectiles, thrown props, and simple kinematic movers in true-3D brush
+  worlds.
 - `motion.patrol`: moves an actor through an authored list of 3D waypoints.
   Use `speed`, `wait_time`, `arrival_radius`, `mode` (`loop` or `ping_pong`),
   and optional `yaw_property` to expose movement direction to rendering or Lua

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -19940,6 +19940,149 @@ static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyj
     fps_brush_publish_diagnostics(&diagnostics, component, actor);
 }
 
+static slayer3d_game_data_brush_trace_shape brush_velocity_shape_from_string(const char *shape)
+{
+    if (SDL_strcmp(shape != NULL ? shape : "", "sphere") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE;
+    if (SDL_strcmp(shape != NULL ? shape : "", "aabb") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB;
+    return SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+}
+
+static slayer3d_vec3 brush_velocity_extents(yyjson_val *component, const slayer3d_registered_actor *actor,
+                                            slayer3d_game_data_brush_trace_shape shape)
+{
+    if (shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE)
+    {
+        const float radius =
+            SDL_max(json_float(component, "radius", actor_numeric_property(actor, "radius", 0.0f)), 0.0f);
+        return slayer3d_vec3_make(radius, 0.0f, 0.0f);
+    }
+    if (shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB)
+    {
+        const char *extents_property = json_string(component, "extents_property", "extents");
+        return json_vec3_value(obj_get(component, "extents"), actor_vec_property(actor, extents_property));
+    }
+    return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+}
+
+static unsigned int brush_velocity_contents_mask(yyjson_val *component)
+{
+    return brush_flags_from_json(obj_get(component, "contents_mask"), brush_content_flag_from_string,
+                                 SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID |
+                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP);
+}
+
+static void brush_velocity_publish_impact_diagnostics(const slayer3d_game_data_brush_trace_result *result,
+                                                      yyjson_val *component, slayer3d_registered_actor *actor)
+{
+    if (result == NULL || component == NULL || actor == NULL)
+        return;
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "last_impact_brush_property", "last_impact_brush"),
+                                   result->brush_name != NULL ? result->brush_name : "");
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "last_impact_world_property", "last_impact_world"),
+                                   result->world_name != NULL ? result->world_name : "");
+    slayer3d_properties_set_string(actor->props,
+                                   json_string(component, "last_impact_material_property", "last_impact_material"),
+                                   result->material_name != NULL ? result->material_name : "");
+    slayer3d_properties_set_vec3(actor->props,
+                                 json_string(component, "last_impact_position_property", "last_impact_position"),
+                                 result->end_position);
+    slayer3d_properties_set_vec3(
+        actor->props, json_string(component, "last_impact_normal_property", "last_impact_normal"), result->normal);
+    slayer3d_properties_set_int(actor->props,
+                                json_string(component, "last_impact_contents_property", "last_impact_contents"),
+                                (int)SDL_min(result->contents, (unsigned int)SDL_MAX_SINT32));
+    slayer3d_properties_set_int(
+        actor->props, json_string(component, "last_impact_surface_flags_property", "last_impact_surface_flags"),
+        (int)SDL_min(result->surface_flags, (unsigned int)SDL_MAX_SINT32));
+}
+
+static slayer3d_properties *brush_velocity_impact_payload(const slayer3d_registered_actor *actor, slayer3d_vec3 start,
+                                                          slayer3d_vec3 end, slayer3d_vec3 velocity,
+                                                          const slayer3d_game_data_brush_trace_result *result)
+{
+    slayer3d_properties *payload = slayer3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    slayer3d_properties_set_string(payload, "actor_name", actor != NULL && actor->name != NULL ? actor->name : "");
+    slayer3d_properties_set_string(payload, "moving_actor_name",
+                                   actor != NULL && actor->name != NULL ? actor->name : "");
+    slayer3d_properties_set_vec3(payload, "trace_start", start);
+    slayer3d_properties_set_vec3(payload, "trace_end", end);
+    slayer3d_properties_set_vec3(payload, "velocity", velocity);
+    slayer3d_properties_set_bool(payload, "hit_brush", result != NULL && result->hit);
+    slayer3d_properties_set_string(payload, "hit_brush_world",
+                                   result != NULL && result->world_name != NULL ? result->world_name : "");
+    slayer3d_properties_set_string(payload, "hit_brush_name",
+                                   result != NULL && result->brush_name != NULL ? result->brush_name : "");
+    slayer3d_properties_set_string(payload, "hit_material",
+                                   result != NULL && result->material_name != NULL ? result->material_name : "");
+    slayer3d_properties_set_vec3(payload, "hit_position",
+                                 result != NULL ? result->end_position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(payload, "hit_normal",
+                                 result != NULL ? result->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_float(payload, "hit_fraction", result != NULL ? result->fraction : 1.0f);
+    slayer3d_properties_set_float(payload, "hit_distance",
+                                  result != NULL ? slayer3d_vec3_length(slayer3d_vec3_sub(result->end_position, start))
+                                                 : 0.0f);
+    slayer3d_properties_set_int(payload, "hit_contents",
+                                result != NULL ? (int)SDL_min(result->contents, (unsigned int)SDL_MAX_SINT32) : 0);
+    slayer3d_properties_set_int(payload, "hit_surface_flags",
+                                result != NULL ? (int)SDL_min(result->surface_flags, (unsigned int)SDL_MAX_SINT32) : 0);
+    return payload;
+}
+
+static bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                         slayer3d_registered_actor *actor, int actor_id, int pool_index,
+                                         int actor_index, float dt)
+{
+    const char *property = json_string(component, "property", "velocity");
+    const slayer3d_vec3 velocity = actor_vec_property(actor, property);
+    if (actor == NULL || slayer3d_vec3_length_squared(velocity) <= 0.000001f)
+        return true;
+
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.start = actor->position;
+    trace.end = slayer3d_vec3_make(actor->position.x + velocity.x * dt, actor->position.y + velocity.y * dt,
+                                   actor->position.z + velocity.z * dt);
+    trace.shape = brush_velocity_shape_from_string(json_string(component, "shape", "point"));
+    trace.extents = brush_velocity_extents(component, actor, trace.shape);
+    trace.contents_mask = brush_velocity_contents_mask(component);
+
+    slayer3d_game_data_brush_trace_result result;
+    const bool traced = json_bool(component, "slide", false)
+                            ? slayer3d_game_data_slide_active_brush_worlds(runtime, &trace, 4, &result)
+                            : slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, &result);
+    if (!traced)
+        return false;
+
+    actor_set_position(actor, result.end_position);
+    if (!result.hit)
+        return true;
+
+    brush_velocity_publish_impact_diagnostics(&result, component, actor);
+    slayer3d_properties *payload = brush_velocity_impact_payload(actor, trace.start, trace.end, velocity, &result);
+    const bool ok = execute_optional_action_array(runtime, obj_get(component, "impact_actions"), payload);
+    emit_optional_signal(runtime, component, "on_impact", payload);
+    slayer3d_properties_destroy(payload);
+    if (!ok)
+        return false;
+
+    if (json_bool(component, "despawn_on_hit", true))
+    {
+        if (actor_id > 0)
+            (void)actor_pool_request_despawn(runtime, &runtime->actor_pools[pool_index], actor, actor_index,
+                                             json_string(component, "reason", "brush impact"));
+        else
+            actor->active = false;
+    }
+    return true;
+}
+
 static void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt)
 {
     for (int i = 0; runtime != NULL && i < runtime->sector_door_count; ++i)
@@ -20362,6 +20505,13 @@ static void update_motion_components(slayer3d_game_data_runtime *runtime, yyjson
                             actor->active = false;
                         break;
                     }
+                }
+                else if (SDL_strcmp(type, "motion.brush_velocity_3d") == 0)
+                {
+                    if (!update_brush_velocity_motion(runtime, component, actor, actor_id, pool_index, i, dt))
+                        break;
+                    if (!runtime_actor_is_active(runtime, actor))
+                        break;
                 }
                 else if (SDL_strcmp(type, "motion.scroll_wrap") == 0)
                 {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5,6 +5,7 @@
 
 #include "game_data_validation.h"
 
+#include <float.h>
 #include <stdarg.h>
 
 #include <SDL3/SDL_iostream.h>
@@ -2849,6 +2850,7 @@ static bool is_supported_component_type(const char *type)
         "light.directional",
         "light.point",
         "light.spot",
+        "motion.brush_velocity_3d",
         "motion.grid_agent",
         "motion.oscillate",
         "motion.patrol",
@@ -3097,6 +3099,56 @@ static bool validate_fps_brush_component(validation_context *ctx, yyjson_val *co
                                     "controller.fps_brush diagnostic property names must be non-empty strings");
     }
     return true;
+}
+
+static bool brush_velocity_shape_valid(const char *shape)
+{
+    return shape == NULL || SDL_strcmp(shape, "point") == 0 || SDL_strcmp(shape, "sphere") == 0 ||
+           SDL_strcmp(shape, "aabb") == 0;
+}
+
+static bool validate_brush_velocity_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                              validation_names *names)
+{
+    const char *shape = json_string(component, "shape");
+    if (!brush_velocity_shape_valid(shape))
+        return validation_error(ctx, path, "motion.brush_velocity_3d shape must be point, sphere, or aabb");
+
+    const char *string_fields[] = {"property",
+                                   "extents_property",
+                                   "reason",
+                                   "last_impact_brush_property",
+                                   "last_impact_world_property",
+                                   "last_impact_material_property",
+                                   "last_impact_position_property",
+                                   "last_impact_normal_property",
+                                   "last_impact_contents_property",
+                                   "last_impact_surface_flags_property"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        if (!validate_non_empty_string_field(ctx, component, path, "motion.brush_velocity_3d", string_fields[i]))
+            return false;
+    }
+
+    yyjson_val *radius = obj_get(component, "radius");
+    if (radius != NULL && (!yyjson_is_num(radius) || yyjson_get_num(radius) < 0.0))
+        return validation_error(ctx, path, "motion.brush_velocity_3d radius must be non-negative");
+    yyjson_val *extents = obj_get(component, "extents");
+    if (extents != NULL && (!is_exact_vec_array(extents, 3) || !numeric_array_values_in_range(extents, 0.0, DBL_MAX)))
+        return validation_error(ctx, path, "motion.brush_velocity_3d extents must be a non-negative vec3");
+
+    yyjson_val *slide = obj_get(component, "slide");
+    yyjson_val *despawn_on_hit = obj_get(component, "despawn_on_hit");
+    if ((slide != NULL && !yyjson_is_bool(slide)) || (despawn_on_hit != NULL && !yyjson_is_bool(despawn_on_hit)))
+        return validation_error(ctx, path, "motion.brush_velocity_3d slide and despawn_on_hit must be booleans");
+
+    char contents_path[PATH_BUFFER_SIZE];
+    format_path(contents_path, sizeof(contents_path), "%s.contents_mask", path);
+    yyjson_val *impact_actions = obj_get(component, "impact_actions");
+    return validate_brush_string_or_string_array(ctx, obj_get(component, "contents_mask"), contents_path,
+                                                 "brush content", brush_content_name_valid, false) &&
+           validate_optional_signal_field(ctx, component, path, names, "on_impact") &&
+           (impact_actions == NULL || validate_action_array(ctx, impact_actions, path, names));
 }
 
 static bool validate_combat_health_component(validation_context *ctx, yyjson_val *component, const char *path)
@@ -5493,6 +5545,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (property != NULL && !is_non_empty_string(component, "property"))
                     return validation_error(ctx, path, "%s property must be non-empty", type);
             }
+            else if (SDL_strcmp(type, "motion.brush_velocity_3d") == 0)
+            {
+                if (!validate_brush_velocity_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "lifecycle.ttl") == 0)
             {
                 yyjson_val *ttl = obj_get(component, "ttl");
@@ -5970,6 +6027,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
                 yyjson_val *property = obj_get(component, "property");
                 if (property != NULL && !is_non_empty_string(component, "property"))
                     return validation_error(ctx, component_path, "%s property must be non-empty", type);
+            }
+            else if (SDL_strcmp(type, "motion.brush_velocity_3d") == 0)
+            {
+                if (!validate_brush_velocity_component(ctx, component, component_path, names))
+                    return false;
             }
             else if (SDL_strcmp(type, "motion.sector_velocity_3d") == 0)
             {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12077,6 +12077,131 @@ TEST(GameDataRuntime, SectorVelocityMotionDespawnsPooledActorsOnImpact)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, BrushVelocityMotionDespawnsPooledActorsOnImpact)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_velocity_motion");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "updates_game": true,
+  "entities": ["entity.player"],
+  "world": { "brush_worlds": [{ "world": "brush.test" }] }
+})json");
+    write_text(dir / "brush_velocity.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Velocity Motion Test" },
+  "world": { "name": "world.test", "kind": "brush" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.5, 2.0] },
+      "properties": {
+        "camera_forward": { "type": "vec3", "value": [1.0, 0.0, 0.0] },
+        "fire_timer": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "properties": {
+        "velocity": { "type": "vec3", "value": [0.0, 0.0, 0.0] },
+        "radius": { "type": "float", "value": 0.25 }
+      },
+      "components": [
+        {
+          "type": "motion.brush_velocity_3d",
+          "property": "velocity",
+          "shape": "sphere",
+          "contents_mask": ["solid", "projectile_clip"],
+          "impact_actions": [
+            { "type": "property.set", "target": "entity.player", "key": "last_hit_brush", "value_from_payload": "hit_brush_name" },
+            { "type": "property.set", "target": "entity.player", "key": "last_hit_material", "value_from_payload": "hit_material" },
+            { "type": "property.set", "target": "entity.player", "key": "last_hit_distance", "value_from_payload": "hit_distance" }
+          ],
+          "reason": "hit brush"
+        }
+      ]
+    }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1, "scene": "scene.play" }
+  ],
+  "signals": ["signal.fire"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.fire",
+        "actions": [
+          {
+            "type": "projectile.fire",
+            "target": "entity.player",
+            "pool": "pool.shots",
+            "velocity_from_property": "camera_forward",
+            "speed": 20.0
+          }
+        ]
+      }
+    ]
+  },
+  "brush_worlds": [
+    {
+      "name": "brush.test",
+      "materials": [{ "name": "mat.wall", "albedo": [0.35, 0.35, 0.38, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.projectile_wall",
+          "contents": ["solid", "projectile_clip"],
+          "faces": [
+            { "plane": { "normal": [ 1, 0, 0], "distance": 4.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": -3.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0,  1, 0], "distance": 3.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0,  1], "distance": 4.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": -0.5 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "brush_velocity.game.json").string().c_str(), session, &runtime,
+                                             error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *shot = slayer3d_game_data_find_actor(runtime, "pool.shots.0");
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(shot, nullptr);
+    ASSERT_NE(player, nullptr);
+    ASSERT_FALSE(shot->active);
+    const int fire_signal = slayer3d_game_data_find_signal(runtime, "signal.fire");
+    ASSERT_GE(fire_signal, 0);
+    slayer3d_signal_emit(slayer3d_game_session_get_signal_bus(session), fire_signal, nullptr);
+    ASSERT_TRUE(shot->active);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.1f));
+    EXPECT_TRUE(shot->active);
+    EXPECT_NEAR(shot->position.x, 2.0f, 0.05f);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.2f));
+    EXPECT_FALSE(shot->active);
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_hit_brush", ""), "brush.projectile_wall");
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_hit_material", ""), "mat.wall");
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "last_hit_distance", 0.0f), 1.25f, 0.1f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, VolumeSensorsRunEnterAndExitActions)
 {
     const std::filesystem::path dir = unique_test_dir("volume_sensor_actions");
@@ -14348,6 +14473,26 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "unknown sector level",
+        },
+        {
+            "bad_brush_velocity_shape",
+            R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "actor_archetypes": [
+    {
+      "name": "archetype.shot",
+      "components": [
+        { "type": "motion.brush_velocity_3d", "shape": "capsule" }
+      ]
+    }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "shape must be point, sphere, or aabb",
         },
         {
             "bad_spawn_from",


### PR DESCRIPTION
## Summary
- adds data-authored `motion.brush_velocity_3d` for point, sphere, and AABB sweeps through active brush-world instances
- publishes brush/material impact diagnostics and payload fields for authored `impact_actions` / `on_impact`
- supports authored contents masks, slide mode, and pooled/static actor despawn-on-hit behavior
- documents the new component and adds runtime + validation coverage

## Validation
- `cmake --build build/debug --target slayer3d_game_data_test -j8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.BrushVelocityMotionDespawnsPooledActorsOnImpact:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions'`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j8`

## Next slice
Continue issue #306 slice 5 by adding brush-world gameplay sensors/content queries: point-contents checks, brush trigger enter/stay/exit, and line-of-sight/raycast sensor helpers that reuse the brush trace API.

Part of #306