### PR TITLE
Add brush gameplay sensors

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -2123,6 +2123,26 @@ Use `actor_tag` instead of `actor` to apply a sector sensor to every active
 actor with a matching tag. `sector_index` may be used instead of `sector` when
 the authored sector order is deliberate and stable.
 
+`sensor.brush_contents` detects whether an actor's current point is inside an
+active brush matching an authored `contents_mask`. The default mask is
+`trigger`, making it suitable for trigger volumes in brush worlds. It supports
+`enter`, `stay` / `overlap`, and `exit`; payloads include `actor_name`,
+`brush_world`, `brush_name`, `contents`, `surface_flags`, `hit_position`, and
+`hit_normal`.
+
+```json
+{
+  "name": "sensor.secret.trigger",
+  "type": "sensor.brush_contents",
+  "actor": "entity.player",
+  "contents_mask": "trigger",
+  "edge": "enter",
+  "actions": [
+    { "type": "property.set", "target_from_payload": "actor_name", "key": "found_secret", "value": true }
+  ]
+}
+```
+
 `sensor.perception` detects whether an observer can see one or more targets
 inside a sector level. It combines range, field-of-view, sector line-of-sight,
 and the standard `target_filter` object, so faction-aware AI perception can be
@@ -2156,6 +2176,31 @@ threshold directly; `-1.0` means omnidirectional. `yaw_property` defaults to
 and `observer_actor_name` for the observer, `target_actor_name` and
 `other_actor_name` for the seen target, `sector_level`, `distance`,
 `perception_distance`, `range`, `origin`, and `target_position`.
+
+`sensor.brush_perception` is the brush-world equivalent. It uses active brush
+world traces for line-of-sight instead of a sector level, and `contents_mask`
+selects which brush contents block sight. The default blocker mask is
+`["solid", "player_clip"]`. Payloads include the standard perception fields
+plus brush trace fields such as `hit_brush`, `hit_brush_name`, `hit_material`,
+`hit_contents`, and `hit_surface_flags`.
+
+```json
+{
+  "name": "sensor.guard.brush_los",
+  "type": "sensor.brush_perception",
+  "observer": "entity.guard",
+  "target_tag": "actor",
+  "contents_mask": ["solid", "player_clip"],
+  "range": 20.0,
+  "fov_degrees": 120.0,
+  "target_filter": { "relationship": "hostile" },
+  "edge": "stay",
+  "actions": [
+    { "type": "property.set", "target": "entity.guard", "key": "alerted", "value": true },
+    { "type": "property.set", "target_from_payload": "target_actor_name", "key": "was_seen", "value": true }
+  ]
+}
+```
 
 `noise.emit` creates a short-lived runtime noise event. It does not play audio
 by itself; pair it with `audio.play_sfx` when the game should also make an

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -52,6 +52,8 @@ typedef enum game_data_sensor_type
     GAME_DATA_SENSOR_CONTACT_2D,
     GAME_DATA_SENSOR_HEARING,
     GAME_DATA_SENSOR_INPUT_PRESSED,
+    GAME_DATA_SENSOR_BRUSH_CONTENTS,
+    GAME_DATA_SENSOR_BRUSH_PERCEPTION,
     GAME_DATA_SENSOR_PERCEPTION,
     GAME_DATA_SENSOR_SECTOR,
     GAME_DATA_SENSOR_VOLUME,
@@ -18874,6 +18876,10 @@ static bool load_sensors(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
             entry->type = GAME_DATA_SENSOR_HEARING;
         else if (SDL_strcmp(type, "sensor.input_pressed") == 0)
             entry->type = GAME_DATA_SENSOR_INPUT_PRESSED;
+        else if (SDL_strcmp(type, "sensor.brush_contents") == 0)
+            entry->type = GAME_DATA_SENSOR_BRUSH_CONTENTS;
+        else if (SDL_strcmp(type, "sensor.brush_perception") == 0)
+            entry->type = GAME_DATA_SENSOR_BRUSH_PERCEPTION;
         else if (SDL_strcmp(type, "sensor.perception") == 0)
             entry->type = GAME_DATA_SENSOR_PERCEPTION;
         else if (SDL_strcmp(type, "sensor.sector") == 0)
@@ -20814,6 +20820,23 @@ static void execute_sensor_actions(slayer3d_game_data_runtime *runtime, const se
     slayer3d_properties_destroy(payload);
 }
 
+static void emit_sensor_payload_signal(slayer3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                       const slayer3d_properties *payload)
+{
+    slayer3d_signal_bus *bus = runtime_bus(runtime);
+    if (bus == NULL || sensor == NULL || sensor->signal_id < 0)
+        return;
+    slayer3d_signal_emit(bus, sensor->signal_id, payload);
+}
+
+static void execute_sensor_payload_actions(slayer3d_game_data_runtime *runtime, const sensor_entry *sensor,
+                                           const slayer3d_properties *payload)
+{
+    if (runtime == NULL || sensor == NULL || !yyjson_is_arr(sensor->actions))
+        return;
+    (void)execute_action_array(runtime, sensor->actions, payload);
+}
+
 static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor)
 {
     if (runtime == NULL || actor == NULL)
@@ -21120,6 +21143,116 @@ static bool sensor_edge_is_exit(const sensor_entry *sensor)
     return sensor != NULL && sensor->edge != NULL && SDL_strcmp(sensor->edge, "exit") == 0;
 }
 
+static unsigned int sensor_brush_contents_mask(const sensor_entry *sensor, unsigned int fallback)
+{
+    return brush_flags_from_json(sensor != NULL ? obj_get(sensor->json, "contents_mask") : NULL,
+                                 brush_content_flag_from_string, fallback);
+}
+
+static bool trace_active_brush_point_contents(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 point,
+                                              unsigned int contents_mask,
+                                              slayer3d_game_data_brush_trace_result *out_result)
+{
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.start = point;
+    trace.end = point;
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = contents_mask;
+    return slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, out_result);
+}
+
+static void brush_trace_payload_fields(slayer3d_properties *payload,
+                                       const slayer3d_game_data_brush_trace_result *result)
+{
+    if (payload == NULL)
+        return;
+    const bool hit = result != NULL && result->hit;
+    slayer3d_properties_set_bool(payload, "hit_brush", hit);
+    slayer3d_properties_set_string(payload, "brush_world", hit && result->world_name != NULL ? result->world_name : "");
+    slayer3d_properties_set_string(payload, "hit_brush_world",
+                                   hit && result->world_name != NULL ? result->world_name : "");
+    slayer3d_properties_set_string(payload, "brush_name", hit && result->brush_name != NULL ? result->brush_name : "");
+    slayer3d_properties_set_string(payload, "hit_brush_name",
+                                   hit && result->brush_name != NULL ? result->brush_name : "");
+    slayer3d_properties_set_string(payload, "material",
+                                   hit && result->material_name != NULL ? result->material_name : "");
+    slayer3d_properties_set_string(payload, "hit_material",
+                                   hit && result->material_name != NULL ? result->material_name : "");
+    slayer3d_properties_set_vec3(payload, "hit_position",
+                                 hit ? result->end_position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(payload, "hit_normal", hit ? result->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_float(payload, "hit_fraction", hit ? result->fraction : 1.0f);
+    slayer3d_properties_set_int(payload, "contents",
+                                hit ? (int)SDL_min(result->contents, (unsigned int)SDL_MAX_SINT32) : 0);
+    slayer3d_properties_set_int(payload, "hit_contents",
+                                hit ? (int)SDL_min(result->contents, (unsigned int)SDL_MAX_SINT32) : 0);
+    slayer3d_properties_set_int(payload, "surface_flags",
+                                hit ? (int)SDL_min(result->surface_flags, (unsigned int)SDL_MAX_SINT32) : 0);
+    slayer3d_properties_set_int(payload, "hit_surface_flags",
+                                hit ? (int)SDL_min(result->surface_flags, (unsigned int)SDL_MAX_SINT32) : 0);
+}
+
+static slayer3d_properties *create_brush_contents_sensor_payload(const sensor_entry *sensor,
+                                                                 const slayer3d_registered_actor *actor,
+                                                                 const slayer3d_game_data_brush_trace_result *result)
+{
+    slayer3d_properties *payload = slayer3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+    slayer3d_properties_set_string(payload, "actor_name", actor != NULL && actor->name != NULL ? actor->name : "");
+    slayer3d_properties_set_string(payload, "sensor_name", sensor != NULL && sensor->name != NULL ? sensor->name : "");
+    slayer3d_properties_set_vec3(payload, "point",
+                                 actor != NULL ? actor->position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    brush_trace_payload_fields(payload, result);
+    return payload;
+}
+
+static void update_brush_contents_sensor_actor(slayer3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                               slayer3d_registered_actor *actor)
+{
+    if (!runtime_actor_is_active(runtime, actor))
+        return;
+
+    slayer3d_game_data_brush_trace_result result;
+    const unsigned int mask = sensor_brush_contents_mask(sensor, SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER);
+    const bool traced = trace_active_brush_point_contents(runtime, actor->position, mask, &result);
+    const bool active =
+        traced && result.hit && result.start_solid &&
+        actor_matches_target_filter(runtime, actor, NULL, sensor->json, NULL, sensor->entity_tag, false);
+    sensor_contact_pair_state *state = sensor_contact_pair_state_for(
+        sensor, actor != NULL ? actor->name : NULL, sensor->name != NULL ? sensor->name : "brush_contents");
+    if (state == NULL)
+        return;
+
+    const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                             : sensor_edge_is_stay(sensor) ? active
+                                                           : (active && !state->active);
+    if (should_emit)
+    {
+        slayer3d_properties *payload = create_brush_contents_sensor_payload(sensor, actor, active ? &result : NULL);
+        emit_sensor_payload_signal(runtime, sensor, payload);
+        execute_sensor_payload_actions(runtime, sensor, payload);
+        slayer3d_properties_destroy(payload);
+    }
+    state->active = active;
+    state->seen = true;
+}
+
+static void update_brush_contents_sensor(slayer3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    sensor_actor_list actors;
+    SDL_zero(actors);
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &actors))
+    {
+        for (int i = 0; i < actors.count; ++i)
+            update_brush_contents_sensor_actor(runtime, sensor, actors.items[i]);
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&actors);
+}
+
 static int sensor_target_sector_index(const sector_level_runtime *level, const sensor_entry *sensor)
 {
     if (level == NULL || sensor == NULL)
@@ -21350,6 +21483,49 @@ static bool perception_sensor_has_line_of_sight(const sensor_entry *sensor, cons
     return !trace.hit || SDL_clamp(trace.fraction, 0.0f, 1.0f) >= 0.995f;
 }
 
+static bool brush_perception_sensor_has_line_of_sight(const slayer3d_game_data_runtime *runtime,
+                                                      const sensor_entry *sensor,
+                                                      const slayer3d_registered_actor *observer,
+                                                      const slayer3d_registered_actor *target, float *out_distance,
+                                                      slayer3d_vec3 *out_origin, slayer3d_vec3 *out_target,
+                                                      slayer3d_game_data_brush_trace_result *out_trace)
+{
+    if (runtime == NULL || sensor == NULL || observer == NULL || target == NULL)
+        return false;
+    if (out_trace != NULL)
+        SDL_zero(*out_trace);
+
+    const slayer3d_vec3 origin = slayer3d_vec3_make(
+        observer->position.x, observer->position.y + sensor->observer_eye_height, observer->position.z);
+    const slayer3d_vec3 target_point =
+        slayer3d_vec3_make(target->position.x, target->position.y + sensor->target_eye_height, target->position.z);
+    const slayer3d_vec3 delta = slayer3d_vec3_sub(target_point, origin);
+    const float distance = slayer3d_vec3_length(delta);
+    if (distance <= 0.000001f || distance > sensor->range)
+        return false;
+
+    if (out_distance != NULL)
+        *out_distance = distance;
+    if (out_origin != NULL)
+        *out_origin = origin;
+    if (out_target != NULL)
+        *out_target = target_point;
+
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.start = origin;
+    trace.end = target_point;
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = sensor_brush_contents_mask(sensor, SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID |
+                                                                 SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+    slayer3d_game_data_brush_trace_result result;
+    if (!slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, &result))
+        return false;
+    if (out_trace != NULL)
+        *out_trace = result;
+    return !result.hit || SDL_clamp(result.fraction, 0.0f, 1.0f) >= 0.995f;
+}
+
 static slayer3d_properties *create_perception_sensor_payload(const sensor_entry *sensor,
                                                              const sector_level_runtime *level,
                                                              const slayer3d_registered_actor *observer,
@@ -21405,6 +21581,97 @@ static void execute_perception_sensor_actions(slayer3d_game_data_runtime *runtim
     if (payload != NULL)
         (void)execute_action_array(runtime, sensor->actions, payload);
     slayer3d_properties_destroy(payload);
+}
+
+static slayer3d_properties *create_brush_perception_sensor_payload(const sensor_entry *sensor,
+                                                                   const slayer3d_registered_actor *observer,
+                                                                   const slayer3d_registered_actor *target,
+                                                                   float distance, slayer3d_vec3 origin,
+                                                                   slayer3d_vec3 target_point, bool visible,
+                                                                   const slayer3d_game_data_brush_trace_result *trace)
+{
+    slayer3d_properties *payload = slayer3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    slayer3d_properties_set_string(payload, "actor_name",
+                                   observer != NULL && observer->name != NULL ? observer->name : "");
+    slayer3d_properties_set_string(payload, "observer_actor_name",
+                                   observer != NULL && observer->name != NULL ? observer->name : "");
+    slayer3d_properties_set_string(payload, "target_actor_name",
+                                   target != NULL && target->name != NULL ? target->name : "");
+    slayer3d_properties_set_string(payload, "other_actor_name",
+                                   target != NULL && target->name != NULL ? target->name : "");
+    slayer3d_properties_set_string(payload, "sensor_name", sensor != NULL && sensor->name != NULL ? sensor->name : "");
+    slayer3d_properties_set_bool(payload, "line_of_sight", visible);
+    slayer3d_properties_set_bool(payload, "brush_line_of_sight", visible);
+    slayer3d_properties_set_float(payload, "distance", distance);
+    slayer3d_properties_set_float(payload, "perception_distance", distance);
+    slayer3d_properties_set_float(payload, "range", sensor != NULL ? sensor->range : 0.0f);
+    slayer3d_properties_set_vec3(payload, "origin", origin);
+    slayer3d_properties_set_vec3(payload, "target_position", target_point);
+    brush_trace_payload_fields(payload, trace);
+    return payload;
+}
+
+static void update_brush_perception_sensor_pair(slayer3d_game_data_runtime *runtime, sensor_entry *sensor,
+                                                slayer3d_registered_actor *observer, slayer3d_registered_actor *target)
+{
+    if (!runtime_actor_is_active(runtime, observer) || !runtime_actor_is_active(runtime, target) || observer == target)
+        return;
+
+    sensor_contact_pair_state *state = sensor_contact_pair_state_for(sensor, observer->name, target->name);
+    if (state == NULL)
+        return;
+
+    float distance = 0.0f;
+    slayer3d_vec3 origin = observer->position;
+    slayer3d_vec3 target_point = target->position;
+    slayer3d_game_data_brush_trace_result trace;
+    SDL_zero(trace);
+    bool active = actor_matches_target_filter(runtime, target, observer, sensor->json, NULL, sensor->other_tag, true) &&
+                  perception_actor_in_field_of_view(sensor, observer, target) &&
+                  brush_perception_sensor_has_line_of_sight(runtime, sensor, observer, target, &distance, &origin,
+                                                            &target_point, &trace);
+
+    const bool should_emit = sensor_edge_is_exit(sensor)   ? (!active && state->active)
+                             : sensor_edge_is_stay(sensor) ? active
+                                                           : (active && !state->active);
+    if (should_emit)
+    {
+        slayer3d_properties *payload = create_brush_perception_sensor_payload(
+            sensor, observer, target, distance, origin, target_point, active, trace.hit ? &trace : NULL);
+        emit_sensor_payload_signal(runtime, sensor, payload);
+        execute_sensor_payload_actions(runtime, sensor, payload);
+        slayer3d_properties_destroy(payload);
+    }
+    state->active = active;
+    state->seen = true;
+}
+
+static void update_brush_perception_sensor(slayer3d_game_data_runtime *runtime, sensor_entry *sensor)
+{
+    sensor_actor_list observers;
+    sensor_actor_list targets;
+    SDL_zero(observers);
+    SDL_zero(targets);
+
+    sensor_contact_states_begin(sensor);
+    if (collect_sensor_endpoint_actors(runtime, sensor->entity, sensor->entity_tag, &observers) &&
+        collect_sensor_endpoint_actors(runtime, sensor->other, sensor->other_tag, &targets))
+    {
+        for (int observer_index = 0; observer_index < observers.count; ++observer_index)
+        {
+            for (int target_index = 0; target_index < targets.count; ++target_index)
+            {
+                update_brush_perception_sensor_pair(runtime, sensor, observers.items[observer_index],
+                                                    targets.items[target_index]);
+            }
+        }
+    }
+    sensor_contact_states_end(sensor);
+    sensor_actor_list_free(&observers);
+    sensor_actor_list_free(&targets);
 }
 
 static void update_perception_sensor_pair(slayer3d_game_data_runtime *runtime, sensor_entry *sensor,
@@ -21609,6 +21876,16 @@ static void update_sensors(slayer3d_game_data_runtime *runtime)
         if (sensor->type == GAME_DATA_SENSOR_VOLUME)
         {
             update_volume_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_BRUSH_CONTENTS)
+        {
+            update_brush_contents_sensor(runtime, sensor);
+            continue;
+        }
+        if (sensor->type == GAME_DATA_SENSOR_BRUSH_PERCEPTION)
+        {
+            update_brush_perception_sensor(runtime, sensor);
             continue;
         }
         if (sensor->type == GAME_DATA_SENSOR_PERCEPTION)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8243,6 +8243,142 @@ static bool validate_logic(validation_context *ctx, yyjson_val *root, validation
                 return false;
             continue;
         }
+        if (SDL_strcmp(type, "sensor.brush_contents") == 0)
+        {
+            const char *actor = json_string(sensor, "actor");
+            if (actor == NULL)
+                actor = json_string(sensor, "entity");
+            const char *actor_tag = json_string(sensor, "actor_tag");
+            if (actor_tag == NULL)
+                actor_tag = json_string(sensor, "a_tag");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((actor == NULL && actor_tag == NULL) || (actor != NULL && actor_tag != NULL))
+                return validation_error(ctx, path, "sensor.brush_contents requires exactly one of actor or actor_tag");
+            if (actor != NULL && !require_actor_ref(ctx, names, actor, path))
+                return false;
+            if (actor_tag != NULL && actor_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.brush_contents actor_tag must be non-empty");
+            char contents_path[PATH_BUFFER_SIZE];
+            format_path(contents_path, sizeof(contents_path), "%s.contents_mask", path);
+            if (!validate_brush_string_or_string_array(ctx, obj_get(sensor, "contents_mask"), contents_path,
+                                                       "brush content", brush_content_name_valid, false))
+                return false;
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path, "sensor.brush_contents edge must be enter, stay, overlap, or exit");
+            }
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.brush_contents"))
+                return false;
+            continue;
+        }
+        if (SDL_strcmp(type, "sensor.brush_perception") == 0)
+        {
+            const char *observer = json_string(sensor, "observer");
+            if (observer == NULL)
+                observer = json_string(sensor, "entity");
+            if (observer == NULL)
+                observer = json_string(sensor, "actor");
+            const char *observer_tag = json_string(sensor, "observer_tag");
+            if (observer_tag == NULL)
+                observer_tag = json_string(sensor, "actor_tag");
+            const char *target = json_string(sensor, "target");
+            if (target == NULL)
+                target = json_string(sensor, "b");
+            const char *target_tag = json_string(sensor, "target_tag");
+            if (target_tag == NULL)
+                target_tag = json_string(sensor, "b_tag");
+            yyjson_val *actions = obj_get(sensor, "actions");
+            const char *edge = json_string(sensor, "edge");
+            const char *signal = json_string(sensor, "on_enter");
+            if (edge != NULL && (SDL_strcmp(edge, "stay") == 0 || SDL_strcmp(edge, "overlap") == 0))
+            {
+                const char *on_stay = json_string(sensor, "on_stay");
+                signal = on_stay != NULL ? on_stay : signal;
+            }
+            else if (edge != NULL && SDL_strcmp(edge, "exit") == 0)
+            {
+                const char *on_exit = json_string(sensor, "on_exit");
+                signal = on_exit != NULL ? on_exit : signal;
+            }
+
+            if ((observer == NULL && observer_tag == NULL) || (observer != NULL && observer_tag != NULL))
+                return validation_error(ctx, path,
+                                        "sensor.brush_perception requires exactly one of observer or observer_tag");
+            if ((target == NULL && target_tag == NULL) || (target != NULL && target_tag != NULL))
+                return validation_error(ctx, path,
+                                        "sensor.brush_perception requires exactly one of target or target_tag");
+            if (observer != NULL && !require_actor_ref(ctx, names, observer, path))
+                return false;
+            if (target != NULL && !require_actor_ref(ctx, names, target, path))
+                return false;
+            if (observer_tag != NULL && observer_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.brush_perception observer_tag must be non-empty");
+            if (target_tag != NULL && target_tag[0] == '\0')
+                return validation_error(ctx, path, "sensor.brush_perception target_tag must be non-empty");
+            yyjson_val *range = obj_get(sensor, "range");
+            if (range != NULL && (!yyjson_is_num(range) || yyjson_get_num(range) <= 0.0))
+                return validation_error(ctx, path, "sensor.brush_perception range must be positive");
+            yyjson_val *min_dot = obj_get(sensor, "min_dot");
+            if (min_dot != NULL &&
+                (!yyjson_is_num(min_dot) || yyjson_get_num(min_dot) < -1.0 || yyjson_get_num(min_dot) > 1.0))
+            {
+                return validation_error(ctx, path, "sensor.brush_perception min_dot must be between -1 and 1");
+            }
+            yyjson_val *fov_degrees = obj_get(sensor, "fov_degrees");
+            if (fov_degrees != NULL && (!yyjson_is_num(fov_degrees) || yyjson_get_num(fov_degrees) <= 0.0 ||
+                                        yyjson_get_num(fov_degrees) > 360.0))
+            {
+                return validation_error(ctx, path, "sensor.brush_perception fov_degrees must be in the range (0, 360]");
+            }
+            yyjson_val *observer_eye_height = obj_get(sensor, "observer_eye_height");
+            yyjson_val *target_eye_height = obj_get(sensor, "target_eye_height");
+            yyjson_val *eye_height = obj_get(sensor, "eye_height");
+            if ((observer_eye_height != NULL && !yyjson_is_num(observer_eye_height)) ||
+                (target_eye_height != NULL && !yyjson_is_num(target_eye_height)) ||
+                (eye_height != NULL && !yyjson_is_num(eye_height)))
+            {
+                return validation_error(ctx, path, "sensor.brush_perception eye heights must be numeric");
+            }
+            yyjson_val *yaw_property = obj_get(sensor, "yaw_property");
+            if (yaw_property != NULL && (!yyjson_is_str(yaw_property) || yyjson_get_str(yaw_property)[0] == '\0'))
+                return validation_error(ctx, path, "sensor.brush_perception yaw_property must be a non-empty string");
+            char contents_path[PATH_BUFFER_SIZE];
+            format_path(contents_path, sizeof(contents_path), "%s.contents_mask", path);
+            if (!validate_brush_string_or_string_array(ctx, obj_get(sensor, "contents_mask"), contents_path,
+                                                       "brush content", brush_content_name_valid, false))
+                return false;
+            if (edge != NULL && SDL_strcmp(edge, "enter") != 0 && SDL_strcmp(edge, "stay") != 0 &&
+                SDL_strcmp(edge, "overlap") != 0 && SDL_strcmp(edge, "exit") != 0)
+            {
+                return validation_error(ctx, path,
+                                        "sensor.brush_perception edge must be enter, stay, overlap, or exit");
+            }
+            if (actions != NULL && !validate_action_array(ctx, actions, path, names))
+                return false;
+            if (actions == NULL && !require_ref(ctx, &names->signals, "signal", signal, path))
+                return false;
+            if (!validate_target_filter_fields(ctx, sensor, path, "sensor.brush_perception"))
+                return false;
+            continue;
+        }
         if (SDL_strcmp(type, "sensor.perception") == 0)
         {
             const char *observer = json_string(sensor, "observer");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13683,6 +13683,181 @@ TEST(GameDataRuntime, RunsAuthoredHearingSensorsForNoiseEventsAndTargetFilters)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RunsAuthoredBrushContentsAndPerceptionSensors)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_gameplay_sensors");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "entities": ["entity.player", "entity.visible", "entity.blocked"],
+  "world": { "brush_worlds": [{ "world": "brush.sensor" }] }
+})json");
+    write_text(dir / "brush_gameplay_sensors.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Gameplay Sensors Test" },
+  "world": { "name": "world.test", "kind": "brush" },
+  "entities": [
+    {
+      "name": "entity.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.0, 1.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "in_trigger": { "type": "bool", "value": false },
+        "left_trigger": { "type": "bool", "value": false },
+        "trigger_ticks": { "type": "int", "value": 0 },
+        "last_trigger": { "type": "string", "value": "" }
+      }
+    },
+    {
+      "name": "entity.visible",
+      "active": true,
+      "tags": ["npc"],
+      "transform": { "position": [2.0, 1.0, -3.0] },
+      "properties": {
+        "spotted": { "type": "int", "value": 0 },
+        "last_distance": { "type": "float", "value": 0.0 }
+      }
+    },
+    {
+      "name": "entity.blocked",
+      "active": true,
+      "tags": ["npc"],
+      "transform": { "position": [0.0, 1.0, -3.0] },
+      "properties": {
+        "spotted": { "type": "int", "value": 0 }
+      }
+    }
+  ],
+  "brush_worlds": [
+    {
+      "name": "brush.sensor",
+      "materials": [
+        { "name": "mat.trigger", "albedo": [0.1, 0.7, 0.9, 0.35] },
+        { "name": "mat.wall", "albedo": [0.3, 0.3, 0.35, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.trigger_zone",
+          "contents": "trigger",
+          "faces": [
+            { "plane": { "normal": [ 1, 0, 0], "distance": 2.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [-1, 0, 0], "distance": -1.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0,  1, 0], "distance": 2.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, 0,  1], "distance": 2.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0.0 }, "material": "mat.trigger" }
+          ]
+        },
+        {
+          "name": "brush.los_wall",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1, 0, 0], "distance": 0.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 0.5 }, "material": "mat.wall" },
+            { "plane": { "normal": [0,  1, 0], "distance": 2.2 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0,  1], "distance": -1.0 }, "material": "mat.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 2.0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.trigger.enter",
+        "type": "sensor.brush_contents",
+        "actor": "entity.player",
+        "contents_mask": "trigger",
+        "edge": "enter",
+        "actions": [
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "in_trigger", "value": true },
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "last_trigger", "value_from_payload": "brush_name" }
+        ]
+      },
+      {
+        "name": "sensor.trigger.stay",
+        "type": "sensor.brush_contents",
+        "actor": "entity.player",
+        "contents_mask": "trigger",
+        "edge": "stay",
+        "actions": [
+          { "type": "property.add", "target_from_payload": "actor_name", "key": "trigger_ticks", "value": 1 }
+        ]
+      },
+      {
+        "name": "sensor.trigger.exit",
+        "type": "sensor.brush_contents",
+        "actor": "entity.player",
+        "contents_mask": "trigger",
+        "edge": "exit",
+        "actions": [
+          { "type": "property.set", "target_from_payload": "actor_name", "key": "left_trigger", "value": true }
+        ]
+      },
+      {
+        "name": "sensor.brush_los",
+        "type": "sensor.brush_perception",
+        "observer": "entity.player",
+        "target_tag": "npc",
+        "contents_mask": "solid",
+        "range": 8.0,
+        "fov_degrees": 180.0,
+        "edge": "stay",
+        "actions": [
+          { "type": "property.add", "target_from_payload": "target_actor_name", "key": "spotted", "value": 1 },
+          { "type": "property.set", "target_from_payload": "target_actor_name", "key": "last_distance", "value_from_payload": "distance" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "brush_gameplay_sensors.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    slayer3d_registered_actor *visible = slayer3d_game_data_find_actor(runtime, "entity.visible");
+    slayer3d_registered_actor *blocked = slayer3d_game_data_find_actor(runtime, "entity.blocked");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(visible, nullptr);
+    ASSERT_NE(blocked, nullptr);
+
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_FALSE(slayer3d_properties_get_bool(player->props, "in_trigger", true));
+    EXPECT_EQ(slayer3d_properties_get_int(player->props, "trigger_ticks", -1), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(visible->props, "spotted", 0), 1);
+    EXPECT_GT(slayer3d_properties_get_float(visible->props, "last_distance", 0.0f), 3.0f);
+    EXPECT_EQ(slayer3d_properties_get_int(blocked->props, "spotted", 0), 0);
+
+    player->position = slayer3d_vec3_make(1.5f, 1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "in_trigger", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_trigger", ""), "brush.trigger_zone");
+    EXPECT_EQ(slayer3d_properties_get_int(player->props, "trigger_ticks", 0), 1);
+
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_EQ(slayer3d_properties_get_int(player->props, "trigger_ticks", 0), 2);
+
+    player->position = slayer3d_vec3_make(3.0f, 1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "left_trigger", false));
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
 {
     const std::filesystem::path dir = unique_test_dir("sector_doors_invalid");
@@ -13784,6 +13959,40 @@ TEST(GameDataRuntime, RejectsInvalidSectorDoorsAndActions)
               ]
             })json",
             "sensor.hearing range",
+        },
+        {
+            "invalid_brush_contents_sensor",
+            R"json([])json",
+            R"json({
+              "sensors": [
+                {
+                  "type": "sensor.brush_contents",
+                  "actor": "entity.player",
+                  "contents_mask": ["trigger", "missing_content"],
+                  "actions": [
+                    { "type": "property.set", "target_from_payload": "actor_name", "key": "alert", "value": true }
+                  ]
+                }
+              ]
+            })json",
+            "brush content value is unknown",
+        },
+        {
+            "invalid_brush_perception_sensor",
+            R"json([])json",
+            R"json({
+              "sensors": [
+                {
+                  "type": "sensor.brush_perception",
+                  "observer": "entity.player",
+                  "range": -1,
+                  "actions": [
+                    { "type": "property.set", "target_from_payload": "target_actor_name", "key": "alert", "value": true }
+                  ]
+                }
+              ]
+            })json",
+            "sensor.brush_perception requires exactly one of target or target_tag",
         },
         {
             "invalid_noise_action",


### PR DESCRIPTION
## Summary
- Add `sensor.brush_contents` for data-authored brush trigger/contents checks with enter, stay/overlap, and exit edges.
- Add `sensor.brush_perception` for brush-world line-of-sight checks using active brush traces and authored contents masks.
- Add brush trace payload fields for JSON actions/signals, including brush world/name, material, contents, surface flags, hit position, and hit normal.
- Add validation and documentation for both sensor types.
- Add focused runtime coverage proving brush trigger enter/stay/exit and brush LOS filtering through an occluding solid brush.

Part of #306.

## Verification
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RunsAuthoredBrushContentsAndPerceptionSensors:GameDataRuntime.RejectsInvalidSectorDoorsAndActions'`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j8`

## Next work slice
The next practical slice should add or extend a brush gameplay dojo that demonstrates these primitives in an interactive scene: trigger volumes, brush LOS/perception, brush projectiles, doors, teleporters, jump pads, and hazards working together through JSON/Lua-authored behavior.
