### PR TITLE
Improve brush FPS gameplay dojo

### DIFF
--- a/demos/brush_geometry_dojo/README.md
+++ b/demos/brush_geometry_dojo/README.md
@@ -1,8 +1,13 @@
 # Brush Geometry Dojo
 
-Data-only showcase for native convex brush rendering.
+Data-only showcase for native convex brush rendering, FPS brush movement,
+trigger contents checks, and brush-world line-of-sight sensors.
+
+Move with WASD, look with the mouse, and jump with Space. Walk through the cyan
+trigger volume near the player start to verify `sensor.brush_contents`. The HUD
+also reports brush line-of-sight sensor results for a visible target and an
+occluded target behind the central pillar.
 
 ```sh
 ./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json
 ```
-

--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -8,8 +8,10 @@
   "imports": [
     { "path": "fragments/input/fps_controls.json", "sections": ["input"] },
     { "path": "fragments/actors/player.json", "sections": ["entities"] },
+    { "path": "fragments/actors/gameplay_targets.json", "sections": ["entities"] },
     { "path": "fragments/world/showcase.brushes.json", "sections": ["brush_worlds"] },
-    { "path": "fragments/actors/lights.json", "sections": ["entities"] }
+    { "path": "fragments/actors/lights.json", "sections": ["entities"] },
+    { "path": "fragments/logic/brush_gameplay_sensors.json", "sections": ["logic"] }
   ],
   "app": {
     "title": "Slayer 3D Brush Geometry Dojo",
@@ -60,6 +62,7 @@
   "render": {
     "lighting": true,
     "bloom": false,
+    "ssao": false,
     "clear_color": [0.035, 0.04, 0.05]
   },
   "presentation": {

--- a/demos/brush_geometry_dojo/data/fragments/actors/gameplay_targets.json
+++ b/demos/brush_geometry_dojo/data/fragments/actors/gameplay_targets.json
@@ -1,0 +1,41 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "entities": [
+    {
+      "name": "entity.brush_geometry.visible_target",
+      "active": true,
+      "tags": ["brush_target"],
+      "transform": { "position": [-4.8, 1.0, 8.4] },
+      "properties": {
+        "spotted": { "type": "int", "value": 0 }
+      },
+      "components": [
+        {
+          "type": "render.rounded_box",
+          "size": [0.75, 1.5, 0.75],
+          "radius": 0.12,
+          "color": [90, 210, 255, 255],
+          "lighting": true
+        }
+      ]
+    },
+    {
+      "name": "entity.brush_geometry.occluded_target",
+      "active": true,
+      "tags": ["brush_target"],
+      "transform": { "position": [0.0, 1.0, -4.0] },
+      "properties": {
+        "spotted": { "type": "int", "value": 0 }
+      },
+      "components": [
+        {
+          "type": "render.rounded_box",
+          "size": [0.75, 1.5, 0.75],
+          "radius": 0.12,
+          "color": [255, 120, 85, 255],
+          "lighting": true
+        }
+      ]
+    }
+  ]
+}

--- a/demos/brush_geometry_dojo/data/fragments/actors/player.json
+++ b/demos/brush_geometry_dojo/data/fragments/actors/player.json
@@ -10,7 +10,9 @@
         "pitch": { "type": "float", "value": 0.0 },
         "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
         "on_ground": { "type": "bool", "value": false },
-        "vertical_velocity": { "type": "float", "value": 0.0 }
+        "vertical_velocity": { "type": "float", "value": 0.0 },
+        "brush_trigger_active": { "type": "bool", "value": false },
+        "last_trigger_brush": { "type": "string", "value": "none" }
       },
       "components": [
         {

--- a/demos/brush_geometry_dojo/data/fragments/logic/brush_gameplay_sensors.json
+++ b/demos/brush_geometry_dojo/data/fragments/logic/brush_gameplay_sensors.json
@@ -1,0 +1,61 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "logic": {
+    "sensors": [
+      {
+        "name": "sensor.brush_geometry.trigger_enter",
+        "type": "sensor.brush_contents",
+        "actor": "entity.brush_geometry.player",
+        "contents_mask": "trigger",
+        "edge": "enter",
+        "actions": [
+          {
+            "type": "property.set",
+            "target_from_payload": "actor_name",
+            "key": "brush_trigger_active",
+            "value": true
+          },
+          {
+            "type": "property.set",
+            "target_from_payload": "actor_name",
+            "key": "last_trigger_brush",
+            "value_from_payload": "brush_name"
+          }
+        ]
+      },
+      {
+        "name": "sensor.brush_geometry.trigger_exit",
+        "type": "sensor.brush_contents",
+        "actor": "entity.brush_geometry.player",
+        "contents_mask": "trigger",
+        "edge": "exit",
+        "actions": [
+          {
+            "type": "property.set",
+            "target_from_payload": "actor_name",
+            "key": "brush_trigger_active",
+            "value": false
+          }
+        ]
+      },
+      {
+        "name": "sensor.brush_geometry.line_of_sight",
+        "type": "sensor.brush_perception",
+        "observer": "entity.brush_geometry.player",
+        "target_tag": "brush_target",
+        "contents_mask": ["solid", "player_clip"],
+        "range": 18.0,
+        "fov_degrees": 150.0,
+        "edge": "stay",
+        "actions": [
+          {
+            "type": "property.add",
+            "target_from_payload": "target_actor_name",
+            "key": "spotted",
+            "value": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
+++ b/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
@@ -11,7 +11,8 @@
         { "name": "mat.ceiling", "albedo": [0.33, 0.34, 0.38, 1.0], "roughness": 0.92, "tex_scale": 4.0 },
         { "name": "mat.ramp", "albedo": [0.64, 0.48, 0.32, 1.0], "roughness": 0.78, "tex_scale": 3.0 },
         { "name": "mat.accent_blue", "albedo": [0.20, 0.40, 0.86, 1.0], "roughness": 0.72, "tex_scale": 3.0 },
-        { "name": "mat.accent_red", "albedo": [0.78, 0.22, 0.18, 1.0], "roughness": 0.76, "tex_scale": 3.0 }
+        { "name": "mat.accent_red", "albedo": [0.78, 0.22, 0.18, 1.0], "roughness": 0.76, "tex_scale": 3.0 },
+        { "name": "mat.trigger", "albedo": [0.08, 0.75, 0.95, 0.32], "roughness": 0.5, "tex_scale": 2.0 }
       ],
       "brushes": [
         {
@@ -129,6 +130,19 @@
             { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.accent_red" },
             { "plane": { "normal": [0, 0, 1], "distance": 1.0 }, "material": "mat.accent_red" },
             { "plane": { "normal": [0, 0, -1], "distance": 1.0 }, "material": "mat.accent_red" }
+          ]
+        },
+        {
+          "name": "brush.trigger.los_demo",
+          "contents": "trigger",
+          "tags": ["gameplay", "trigger"],
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 3.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 3.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, 1, 0], "distance": 2.2 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, 0, 1], "distance": 9.0 }, "material": "mat.trigger" },
+            { "plane": { "normal": [0, 0, -1], "distance": -7.0 }, "material": "mat.trigger" }
           ]
         }
       ]

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -6,6 +6,8 @@
   "renders_world": true,
   "entities": [
     "entity.brush_geometry.player",
+    "entity.brush_geometry.visible_target",
+    "entity.brush_geometry.occluded_target",
     "entity.brush_geometry.sun",
     "entity.brush_geometry.blue_fill"
   ],
@@ -77,6 +79,33 @@
         "align": "right",
         "color": [180, 235, 190, 230],
         "scale": 0.72
+      },
+      {
+        "name": "ui.brush_geometry.trigger_state",
+        "font": "font.brush_geometry.hud",
+        "format": "TRIGGER %d",
+        "bindings": [
+          { "type": "property", "entity": "entity.brush_geometry.player", "key": "brush_trigger_active" }
+        ],
+        "x": 0.02,
+        "y": 0.925,
+        "normalized": true,
+        "color": [105, 225, 255, 230],
+        "scale": 0.62
+      },
+      {
+        "name": "ui.brush_geometry.perception_state",
+        "font": "font.brush_geometry.hud",
+        "format": "LOS visible %d blocked %d",
+        "bindings": [
+          { "type": "property", "entity": "entity.brush_geometry.visible_target", "key": "spotted" },
+          { "type": "property", "entity": "entity.brush_geometry.occluded_target", "key": "spotted" }
+        ],
+        "x": 0.02,
+        "y": 0.955,
+        "normalized": true,
+        "color": [210, 220, 235, 220],
+        "scale": 0.62
       }
     ]
   }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -8498,51 +8498,127 @@ bool slayer3d_game_data_trace_active_brush_worlds(const slayer3d_game_data_runti
 typedef bool (*brush_slide_trace_fn)(void *userdata, const slayer3d_game_data_brush_trace_desc *desc,
                                      slayer3d_game_data_brush_trace_result *out_result);
 
+static slayer3d_vec3 brush_clip_velocity(slayer3d_vec3 velocity, slayer3d_vec3 normal)
+{
+    const float overclip = 1.001f;
+    float backoff = slayer3d_vec3_dot(velocity, normal);
+    backoff = backoff < 0.0f ? backoff * overclip : backoff / overclip;
+    return brush_vec3_sub(velocity, slayer3d_vec3_scale(normal, backoff));
+}
+
 static bool brush_slide_with_trace(brush_slide_trace_fn trace_fn, void *trace_userdata,
                                    const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
                                    slayer3d_game_data_brush_trace_result *out_result)
 {
+    enum
+    {
+        MAX_CLIP_PLANES = 5
+    };
     if (out_result != NULL)
         *out_result = brush_trace_default_result(desc);
     if (trace_fn == NULL || desc == NULL || out_result == NULL || !brush_trace_shape_valid(desc))
         return false;
 
-    slayer3d_game_data_brush_trace_desc step = *desc;
-    slayer3d_game_data_brush_trace_result first_hit = brush_trace_default_result(desc);
     slayer3d_vec3 position = desc->start;
-    slayer3d_vec3 remaining = brush_vec3_sub(desc->end, desc->start);
+    slayer3d_vec3 velocity = brush_vec3_sub(desc->end, desc->start);
+    slayer3d_vec3 planes[MAX_CLIP_PLANES];
+    int plane_count = 0;
+    float time_left = 1.0f;
+    slayer3d_game_data_brush_trace_result first_hit = brush_trace_default_result(desc);
     const int bump_count = SDL_clamp(max_bumps, 1, 8);
+
+    if (slayer3d_vec3_length_squared(velocity) > 0.000001f)
+        planes[plane_count++] = slayer3d_vec3_normalize(velocity);
 
     for (int bump = 0; bump < bump_count; ++bump)
     {
+        slayer3d_game_data_brush_trace_desc step = *desc;
         step.start = position;
-        step.end = brush_vec3_add(position, remaining);
+        step.end = brush_vec3_add(position, slayer3d_vec3_scale(velocity, time_left));
 
         slayer3d_game_data_brush_trace_result trace;
         if (!trace_fn(trace_userdata, &step, &trace))
             return false;
+
+        if (trace.fraction > 0.0f)
+            position = trace.end_position;
         if (!trace.hit)
-        {
-            position = step.end;
             break;
-        }
         if (!first_hit.hit)
             first_hit = trace;
         if (trace.start_solid)
         {
-            first_hit = trace;
             position = trace.end_position;
             break;
         }
+        position = brush_vec3_add(position, slayer3d_vec3_scale(trace.normal, 0.001f));
 
-        position = trace.end_position;
-        remaining = brush_vec3_sub(step.end, position);
-        const float into_plane = slayer3d_vec3_dot(remaining, trace.normal);
-        if (into_plane < 0.0f)
-            remaining = brush_vec3_sub(remaining, slayer3d_vec3_scale(trace.normal, into_plane));
-        if (slayer3d_vec3_length_squared(remaining) <= 0.000001f)
+        time_left -= time_left * SDL_clamp(trace.fraction, 0.0f, 1.0f);
+        if (time_left <= 0.000001f)
             break;
-        position = brush_vec3_add(position, slayer3d_vec3_scale(trace.normal, 0.0005f));
+
+        bool duplicate_plane = false;
+        for (int i = 0; i < plane_count; ++i)
+        {
+            if (slayer3d_vec3_dot(trace.normal, planes[i]) > 0.99f)
+            {
+                velocity = brush_vec3_add(velocity, trace.normal);
+                duplicate_plane = true;
+                break;
+            }
+        }
+        if (duplicate_plane)
+            continue;
+
+        if (plane_count >= MAX_CLIP_PLANES)
+        {
+            velocity = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+            break;
+        }
+        planes[plane_count++] = trace.normal;
+
+        slayer3d_vec3 clipped_velocity = velocity;
+        for (int i = 0; i < plane_count; ++i)
+        {
+            if (slayer3d_vec3_dot(clipped_velocity, planes[i]) >= 0.1f)
+                continue;
+
+            clipped_velocity = brush_clip_velocity(velocity, planes[i]);
+
+            for (int j = 0; j < plane_count; ++j)
+            {
+                if (j == i || slayer3d_vec3_dot(clipped_velocity, planes[j]) >= 0.1f)
+                    continue;
+
+                clipped_velocity = brush_clip_velocity(clipped_velocity, planes[j]);
+                if (slayer3d_vec3_dot(clipped_velocity, planes[i]) >= 0.0f)
+                    continue;
+
+                slayer3d_vec3 crease = slayer3d_vec3_cross(planes[i], planes[j]);
+                if (slayer3d_vec3_length_squared(crease) <= 0.000001f)
+                {
+                    clipped_velocity = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+                    break;
+                }
+                crease = slayer3d_vec3_normalize(crease);
+                clipped_velocity = slayer3d_vec3_scale(crease, slayer3d_vec3_dot(crease, velocity));
+
+                for (int k = 0; k < plane_count; ++k)
+                {
+                    if (k != i && k != j && slayer3d_vec3_dot(clipped_velocity, planes[k]) < 0.1f)
+                    {
+                        clipped_velocity = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+                        break;
+                    }
+                }
+                break;
+            }
+            break;
+        }
+
+        velocity = clipped_velocity;
+        if (slayer3d_vec3_length_squared(velocity) <= 0.000001f)
+            break;
     }
 
     if (first_hit.hit)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7364,8 +7364,8 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.brush_geometry.showcase", &world));
     ASSERT_NE(world.render_model, nullptr);
-    EXPECT_EQ(world.material_count, 6);
-    EXPECT_GE(world.brush_count, 9);
+    EXPECT_EQ(world.material_count, 7);
+    EXPECT_GE(world.brush_count, 10);
     EXPECT_GE(world.render_model->mesh_count, 6);
     int rendered_vertices = 0;
     for (int i = 0; i < world.render_model->mesh_count; ++i)
@@ -7395,6 +7395,29 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_EQ(camera.fov_axis, SLAYER3D_CAMERA_FOV_HORIZONTAL);
     EXPECT_EQ(camera.projection, SLAYER3D_CAMERA_PERSPECTIVE);
     EXPECT_NEAR(camera.position.y, 1.6f, 0.05f);
+
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.brush_geometry.player");
+    slayer3d_registered_actor *visible = slayer3d_game_data_find_actor(runtime, "entity.brush_geometry.visible_target");
+    slayer3d_registered_actor *occluded =
+        slayer3d_game_data_find_actor(runtime, "entity.brush_geometry.occluded_target");
+    ASSERT_NE(player, nullptr);
+    ASSERT_NE(visible, nullptr);
+    ASSERT_NE(occluded, nullptr);
+    EXPECT_GT(slayer3d_properties_get_int(visible->props, "spotted", 0), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(occluded->props, "spotted", 0), 0);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    const int forward = slayer3d_game_data_find_action(runtime, "action.move.forward");
+    ASSERT_GE(forward, 0);
+    slayer3d_input_set_action_override(input, forward, 1.0f);
+    for (int i = 0; i < 6; ++i)
+    {
+        ASSERT_NE(slayer3d_input_update(input, (Uint64)(3000 + i)), nullptr);
+        ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.1f));
+    }
+    EXPECT_TRUE(slayer3d_properties_get_bool(player->props, "brush_trigger_active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(player->props, "last_trigger_brush", ""), "brush.trigger.los_demo");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -11003,8 +11026,18 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     ASSERT_TRUE(slayer3d_game_data_slide_brush_world(runtime, "brush.trace", &trace, 4, &result));
     EXPECT_TRUE(result.hit);
     EXPECT_STREQ(result.brush_name, "brush.box");
-    EXPECT_NEAR(result.end_position.x, -0.0005f, 0.001f);
+    EXPECT_NEAR(result.end_position.x, -0.0035f, 0.001f);
     EXPECT_GT(result.end_position.z, 2.9f);
+
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB;
+    trace.extents = slayer3d_vec3_make(0.25f, 0.5f, 0.25f);
+    trace.start = slayer3d_vec3_make(-2.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(2.0f, 1.0f, 6.0f);
+    ASSERT_TRUE(slayer3d_game_data_slide_brush_world(runtime, "brush.trace", &trace, 6, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_STREQ(result.brush_name, "brush.box");
+    EXPECT_NEAR(result.end_position.x, -0.25375f, 0.002f);
+    EXPECT_GT(result.end_position.z, 5.9f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -11178,6 +11211,18 @@ TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
     expect_vec3_near(
         slayer3d_properties_get_vec3(player->props, "camera_forward", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)),
         slayer3d_vec3_make(0.0f, 0.0f, -1.0f));
+
+    slayer3d_input_set_action_override(input, forward, 0.0f);
+    const int jump = slayer3d_game_data_find_action(runtime, "action.jump");
+    ASSERT_GE(jump, 0);
+    const float grounded_y = player->position.y;
+    slayer3d_input_set_action_override(input, jump, 1.0f);
+    ASSERT_NE(slayer3d_input_update(input, 2000), nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_GT(player->position.y, grounded_y);
+    EXPECT_GT(slayer3d_properties_get_float(player->props, "vertical_velocity", 0.0f), 0.0f);
+    EXPECT_FALSE(slayer3d_properties_get_bool(player->props, "on_ground", true));
+    slayer3d_input_set_action_override(input, jump, 0.0f);
 
     slayer3d_camera3d camera{};
     ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.player", &camera));


### PR DESCRIPTION
## Summary
- Replace brush slide movement with Quake-style multi-plane clipping so swept hulls can continue sliding through wall/corner contacts instead of sticking on the last plane.
- Add test coverage proving brush AABB corner sliding and Space-triggered `controller.fps_brush` jumping.
- Extend the brush geometry dojo with data-authored gameplay examples: trigger contents sensors, brush line-of-sight sensors, visible/occluded targets, and HUD readouts.
- Disable SSAO in the brush dojo to avoid the close-wall screen-space banding artifact while inspecting wall collision and brush geometry.
- Update the brush dojo README with the new test workflow.

Part of #306.

## Verification
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.TracesAuthoredBrushWorldsWithContentsAndSweptHulls:GameDataRuntime.RunsAuthoredFpsBrushController:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j8`

## Manual test
- `./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json`

## Next work slice
The next slice should continue the brush gameplay dojo by adding brush-world projectile/impact examples and reusable brush-aware doors/teleporters/jump-pad/hazard showcase rooms, then move into the lighting/material quality pass once gameplay primitives are demonstrated together.
