### PR TITLE
Improve brush material lighting controls

### DIFF
--- a/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
+++ b/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
@@ -10,8 +10,8 @@
         { "name": "mat.wall", "albedo": [0.42, 0.44, 0.47, 1.0], "roughness": 0.86, "tex_scale": 4.0 },
         { "name": "mat.ceiling", "albedo": [0.33, 0.34, 0.38, 1.0], "roughness": 0.92, "tex_scale": 4.0 },
         { "name": "mat.ramp", "albedo": [0.64, 0.48, 0.32, 1.0], "roughness": 0.78, "tex_scale": 3.0 },
-        { "name": "mat.accent_blue", "albedo": [0.20, 0.40, 0.86, 1.0], "roughness": 0.72, "tex_scale": 3.0 },
-        { "name": "mat.accent_red", "albedo": [0.78, 0.22, 0.18, 1.0], "roughness": 0.76, "tex_scale": 3.0 },
+        { "name": "mat.accent_blue", "albedo": [0.20, 0.40, 0.86, 1.0], "emissive": [0.02, 0.05, 0.12], "roughness": 0.72, "tex_scale": 3.0 },
+        { "name": "mat.accent_red", "albedo": [0.78, 0.22, 0.18, 1.0], "emissive": [0.10, 0.02, 0.01], "roughness": 0.76, "tex_scale": 3.0 },
         { "name": "mat.trigger", "albedo": [0.08, 0.75, 0.95, 0.32], "roughness": 0.5, "tex_scale": 2.0 }
       ],
       "brushes": [
@@ -22,7 +22,7 @@
           "faces": [
             { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
             { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
-            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat.floor" },
+            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat.floor", "uv": { "scale": [0.5, 0.5], "offset": [0.0, 0.0] } },
             { "plane": { "normal": [0, -1, 0], "distance": 0.5 }, "material": "mat.floor" },
             { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.floor" },
             { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.floor" }
@@ -100,7 +100,7 @@
           "faces": [
             { "plane": { "normal": [1, 0, 0], "distance": 4.0 }, "material": "mat.ramp" },
             { "plane": { "normal": [-1, 0, 0], "distance": 4.0 }, "material": "mat.ramp" },
-            { "plane": { "normal": [-0.25, 1.0, 0.0], "distance": 2.5 }, "material": "mat.ramp" },
+            { "plane": { "normal": [-0.25, 1.0, 0.0], "distance": 2.5 }, "material": "mat.ramp", "uv": { "scale": [1.0, 1.0], "offset": [0.25, 0.0], "rotation_degrees": 15.0 } },
             { "plane": { "normal": [0, -1, 0], "distance": 0.0 }, "material": "mat.ramp" },
             { "plane": { "normal": [0, 0, 1], "distance": 2.25 }, "material": "mat.ramp" },
             { "plane": { "normal": [0, 0, -1], "distance": 2.25 }, "material": "mat.ramp" }

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -28,6 +28,7 @@
         "world": "brush.brush_geometry.showcase",
         "position": [0.0, 0.0, 0.0],
         "acceleration": true,
+        "lighting": true,
         "debug_wireframe": false
       }
     ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -475,6 +475,7 @@ in later slices.
           "name": "stone_wall",
           "texture": "asset://textures/stone_wall.png",
           "albedo": [0.8, 0.8, 0.8, 1.0],
+          "emissive": [0.0, 0.0, 0.0],
           "roughness": 0.9,
           "tex_scale": 2.0
         }
@@ -485,7 +486,11 @@ in later slices.
           "tags": ["room", "solid"],
           "contents": ["solid", "player_clip"],
           "faces": [
-            { "plane": { "normal": [ 1,  0,  0], "distance":  8 }, "material": "stone_wall" },
+            {
+              "plane": { "normal": [ 1,  0,  0], "distance":  8 },
+              "material": "stone_wall",
+              "uv": { "scale": [1.0, 1.0], "offset": [0.0, 0.0], "rotation_degrees": 0.0 }
+            },
             { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "stone_wall" },
             { "plane": { "normal": [ 0,  1,  0], "distance":  4 }, "material": "stone_wall" },
             { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "stone_wall" },
@@ -506,6 +511,7 @@ Validation requires:
 - non-empty `materials` with unique names
 - material `albedo` as vec3/vec4 values in `[0, 1]`
 - non-negative `metallic` and `roughness`
+- optional material `emissive` as a non-negative RGB vec3
 - positive `tex_scale`
 - optional material `texture` as a non-empty existing asset path
 - non-empty `brushes` with unique names
@@ -517,6 +523,9 @@ Validation requires:
 - each face to declare `plane.normal` as a non-zero vec3 and
   `plane.distance` as a number
 - each face `material` to reference a declared material by name or index
+- optional face `uv` object with positive vec2 `scale`, vec2 `offset`, and
+  numeric `rotation_degrees`; UV transforms are applied after the material's
+  world-unit `tex_scale`
 - optional `surface_flags` as one value or an array of unique values:
   `nocollide`, `slick`, `ladder`, `emissive`, or `portal_candidate`
 
@@ -532,6 +541,7 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
         "world": "brush.keep_01",
         "position": [0.0, 0.0, 0.0],
         "acceleration": true,
+        "lighting": true,
         "debug_wireframe": false
       }
     ]
@@ -539,8 +549,9 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
 }
 ```
 
-`acceleration_key` and `debug_wireframe_key` may name scene-state booleans that
-override the authored defaults. Runtime and editor code should use
+`acceleration_key`, `lighting_key`, and `debug_wireframe_key` may name
+scene-state booleans that override the authored defaults. Runtime and editor
+code should use
 `slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -389,6 +389,8 @@ extern "C"
         float metallic;
         /** @brief Authored roughness factor for future material systems. */
         float roughness;
+        /** @brief Additive emissive RGB material factor. */
+        slayer3d_vec3 emissive;
         /** @brief Positive texture scale hint. */
         float tex_scale;
     } slayer3d_game_data_brush_material;
@@ -404,6 +406,12 @@ extern "C"
         int material_index;
         /** @brief Resolved material name, or NULL when no material was authored. */
         const char *material_name;
+        /** @brief Per-face UV scale multiplier, default {1, 1}. */
+        float uv_scale[2];
+        /** @brief Per-face UV offset, applied after scale/rotation. */
+        float uv_offset[2];
+        /** @brief Per-face UV rotation in degrees. */
+        float uv_rotation_degrees;
         /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_SURFACE_* flags. */
         unsigned int surface_flags;
     } slayer3d_game_data_brush_face;
@@ -457,6 +465,8 @@ extern "C"
         slayer3d_vec3 position;
         /** @brief Whether renderers/collision systems should use future acceleration data. */
         bool acceleration_enabled;
+        /** @brief Whether brush surfaces participate in dynamic lighting for this instance. */
+        bool lighting_enabled;
         /** @brief Whether debug wireframe should be requested for this instance. */
         bool debug_wireframe;
     } slayer3d_game_data_brush_world_instance;

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -3720,6 +3720,7 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
             material->albedo = json_vec4(material_json, "albedo", slayer3d_vec4_make(1.0f, 1.0f, 1.0f, 1.0f));
             material->metallic = json_float(material_json, "metallic", 0.0f);
             material->roughness = json_float(material_json, "roughness", 1.0f);
+            material->emissive = json_vec3(material_json, "emissive", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
             material->tex_scale = json_float(material_json, "tex_scale", 1.0f);
             if (material->name == NULL || (texture != NULL && material->texture == NULL))
             {
@@ -3779,6 +3780,10 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 face->material_index =
                     brush_material_index_from_ref(materials, world->material_count, obj_get(face_json, "material"));
                 face->material_name = face->material_index >= 0 ? materials[face->material_index].name : NULL;
+                yyjson_val *uv_json = obj_get(face_json, "uv");
+                (void)json_vec2_value(obj_get(uv_json, "scale"), 1.0f, 1.0f, &face->uv_scale[0], &face->uv_scale[1]);
+                (void)json_vec2_value(obj_get(uv_json, "offset"), 0.0f, 0.0f, &face->uv_offset[0], &face->uv_offset[1]);
+                face->uv_rotation_degrees = json_float(uv_json, "rotation_degrees", 0.0f);
                 face->surface_flags =
                     brush_flags_from_json(obj_get(face_json, "surface_flags"), brush_surface_flag_from_string, 0u);
             }
@@ -8061,6 +8066,8 @@ bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_r
         instance.position = json_vec3(entry, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
         instance.acceleration_enabled = scene_state_bool(runtime, json_string(entry, "acceleration_key", NULL),
                                                          json_bool(entry, "acceleration", true));
+        instance.lighting_enabled =
+            scene_state_bool(runtime, json_string(entry, "lighting_key", NULL), json_bool(entry, "lighting", true));
         instance.debug_wireframe = scene_state_bool(runtime, json_string(entry, "debug_wireframe_key", NULL),
                                                     json_bool(entry, "debug_wireframe", false));
         if (!callback(userdata, &instance))

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -231,6 +231,9 @@ static bool brush_model_copy_materials(const slayer3d_game_data_brush_world *wor
         dst->albedo[3] = src->albedo.w;
         dst->metallic = src->metallic;
         dst->roughness = src->roughness;
+        dst->emissive[0] = src->emissive.x;
+        dst->emissive[1] = src->emissive.y;
+        dst->emissive[2] = src->emissive.z;
         if (src->texture != NULL)
             dst->albedo_map = SDL_strdup(src->texture);
         if (dst->name == NULL || (src->texture != NULL && dst->albedo_map == NULL))
@@ -364,6 +367,11 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
             slayer3d_mesh *mesh = &model->meshes[mesh_for_material];
             const slayer3d_game_data_brush_material *material = &world->materials[face->material_index];
             const float tex_scale = SDL_max(material->tex_scale, 0.0001f);
+            const float uv_scale_x = face->uv_scale[0] != 0.0f ? face->uv_scale[0] : 1.0f;
+            const float uv_scale_y = face->uv_scale[1] != 0.0f ? face->uv_scale[1] : 1.0f;
+            const float uv_rotation = face->uv_rotation_degrees * SDL_PI_F / 180.0f;
+            const float uv_cos = SDL_cosf(uv_rotation);
+            const float uv_sin = SDL_sinf(uv_rotation);
             const slayer3d_color color = brush_material_color(material);
             const float rgba[4] = {
                 (float)color.r / 255.0f,
@@ -385,8 +393,10 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
                     mesh->normals[vertex * 3 + 0] = normal.x;
                     mesh->normals[vertex * 3 + 1] = normal.y;
                     mesh->normals[vertex * 3 + 2] = normal.z;
-                    mesh->uvs[vertex * 2 + 0] = slayer3d_vec3_dot(verts[corner], u) / tex_scale;
-                    mesh->uvs[vertex * 2 + 1] = slayer3d_vec3_dot(verts[corner], v) / tex_scale;
+                    const float base_u = slayer3d_vec3_dot(verts[corner], u) / tex_scale;
+                    const float base_v = slayer3d_vec3_dot(verts[corner], v) / tex_scale;
+                    mesh->uvs[vertex * 2 + 0] = (base_u * uv_cos - base_v * uv_sin) * uv_scale_x + face->uv_offset[0];
+                    mesh->uvs[vertex * 2 + 1] = (base_u * uv_sin + base_v * uv_cos) * uv_scale_y + face->uv_offset[1];
                     mesh->colors[vertex * 4 + 0] = rgba[0];
                     mesh->colors[vertex * 4 + 1] = rgba[1];
                     mesh->colors[vertex * 4 + 2] = rgba[2];

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2814,6 +2814,19 @@ static bool is_exact_vec3_or_vec4_array(yyjson_val *value)
     return is_exact_vec_array(value, 3) || is_exact_vec_array(value, 4);
 }
 
+static bool numeric_array_values_positive(yyjson_val *value)
+{
+    if (!yyjson_is_arr(value))
+        return false;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (!yyjson_is_num(entry) || yyjson_get_num(entry) <= 0.0)
+            return false;
+    }
+    return true;
+}
+
 static bool numeric_array_values_in_range(yyjson_val *value, double min_value, double max_value)
 {
     if (!yyjson_is_arr(value))
@@ -5162,11 +5175,18 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
             }
             yyjson_val *metallic = obj_get(material, "metallic");
             yyjson_val *roughness = obj_get(material, "roughness");
+            yyjson_val *emissive = obj_get(material, "emissive");
             yyjson_val *tex_scale = obj_get(material, "tex_scale");
             if ((metallic != NULL && (!yyjson_is_num(metallic) || yyjson_get_num(metallic) < 0.0)) ||
                 (roughness != NULL && (!yyjson_is_num(roughness) || yyjson_get_num(roughness) < 0.0)))
             {
                 ok = validation_error(ctx, material_path, "brush material metallic and roughness must be non-negative");
+                break;
+            }
+            if (emissive != NULL &&
+                (!is_exact_vec_array(emissive, 3) || !numeric_array_values_in_range(emissive, 0.0, DBL_MAX)))
+            {
+                ok = validation_error(ctx, material_path, "brush material emissive must be a non-negative vec3");
                 break;
             }
             if (tex_scale != NULL && (!yyjson_is_num(tex_scale) || yyjson_get_num(tex_scale) <= 0.0))
@@ -5255,6 +5275,7 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
                 format_path(flags_path, sizeof(flags_path), "%s.surface_flags", face_path);
                 yyjson_val *face = yyjson_arr_get(faces, face_index);
                 yyjson_val *plane = obj_get(face, "plane");
+                yyjson_val *uv = obj_get(face, "uv");
                 if (!yyjson_is_obj(face))
                 {
                     ok = validation_error(ctx, face_path, "brush face entries must be objects");
@@ -5277,6 +5298,32 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
                 {
                     ok = false;
                     break;
+                }
+                if (uv != NULL)
+                {
+                    if (!yyjson_is_obj(uv))
+                    {
+                        ok = validation_error(ctx, face_path, "brush face uv must be an object");
+                        break;
+                    }
+                    yyjson_val *scale = obj_get(uv, "scale");
+                    yyjson_val *offset = obj_get(uv, "offset");
+                    yyjson_val *rotation = obj_get(uv, "rotation_degrees");
+                    if (scale != NULL && (!is_exact_vec_array(scale, 2) || !numeric_array_values_positive(scale)))
+                    {
+                        ok = validation_error(ctx, face_path, "brush face uv scale must be a positive vec2");
+                        break;
+                    }
+                    if (offset != NULL && !is_exact_vec_array(offset, 2))
+                    {
+                        ok = validation_error(ctx, face_path, "brush face uv offset must be a vec2");
+                        break;
+                    }
+                    if (rotation != NULL && !yyjson_is_num(rotation))
+                    {
+                        ok = validation_error(ctx, face_path, "brush face uv rotation_degrees must be a number");
+                        break;
+                    }
                 }
             }
         }
@@ -9720,12 +9767,18 @@ static bool validate_scene_brush_worlds(validation_context *ctx, yyjson_val *sce
         yyjson_val *acceleration = obj_get(entry, "acceleration");
         if (acceleration != NULL && !yyjson_is_bool(acceleration))
             return validation_error(ctx, entry_path, "scene brush world acceleration must be a boolean");
+        yyjson_val *lighting = obj_get(entry, "lighting");
+        if (lighting != NULL && !yyjson_is_bool(lighting))
+            return validation_error(ctx, entry_path, "scene brush world lighting must be a boolean");
         yyjson_val *debug_wireframe = obj_get(entry, "debug_wireframe");
         if (debug_wireframe != NULL && !yyjson_is_bool(debug_wireframe))
             return validation_error(ctx, entry_path, "scene brush world debug_wireframe must be a boolean");
         yyjson_val *acceleration_key = obj_get(entry, "acceleration_key");
         if (acceleration_key != NULL && !is_non_empty_string(entry, "acceleration_key"))
             return validation_error(ctx, entry_path, "scene brush world acceleration_key must be non-empty");
+        yyjson_val *lighting_key = obj_get(entry, "lighting_key");
+        if (lighting_key != NULL && !is_non_empty_string(entry, "lighting_key"))
+            return validation_error(ctx, entry_path, "scene brush world lighting_key must be non-empty");
         yyjson_val *debug_wireframe_key = obj_get(entry, "debug_wireframe_key");
         if (debug_wireframe_key != NULL && !is_non_empty_string(entry, "debug_wireframe_key"))
             return validation_error(ctx, entry_path, "scene brush world debug_wireframe_key must be non-empty");

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2266,6 +2266,10 @@ static bool draw_brush_world_instance(void *userdata, const slayer3d_game_data_b
         ok = slayer3d_translate(context->renderer, instance->position.x, instance->position.y, instance->position.z);
     }
 
+    const bool restore_lighting = slayer3d_is_lighting_enabled(context->renderer);
+    if (!instance->lighting_enabled)
+        slayer3d_set_lighting_enabled(context->renderer, false);
+
     if (ok)
     {
         ok = slayer3d_draw_model_ex_with_assets(
@@ -2289,6 +2293,8 @@ static bool draw_brush_world_instance(void *userdata, const slayer3d_game_data_b
             ok = false;
         }
     }
+    if (!instance->lighting_enabled)
+        slayer3d_set_lighting_enabled(context->renderer, restore_lighting);
     if (pushed && !slayer3d_pop_matrix(context->renderer))
         ok = false;
     if (!ok)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -142,6 +142,7 @@ struct BrushWorldInstanceCapture
     const slayer3d_game_data_brush_world *world = nullptr;
     slayer3d_vec3 position{};
     bool acceleration_enabled = true;
+    bool lighting_enabled = true;
     bool debug_wireframe = false;
 };
 
@@ -1549,6 +1550,7 @@ bool capture_brush_world_instance(void *userdata, const slayer3d_game_data_brush
     capture->world = instance->world;
     capture->position = instance->position;
     capture->acceleration_enabled = instance->acceleration_enabled;
+    capture->lighting_enabled = instance->lighting_enabled;
     capture->debug_wireframe = instance->debug_wireframe;
     return true;
 }
@@ -7368,6 +7370,14 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_EQ(world.material_count, 7);
     EXPECT_GE(world.brush_count, 10);
     EXPECT_GE(world.render_model->mesh_count, 6);
+    auto find_material = [&world](const char *name) -> const slayer3d_game_data_brush_material * {
+        for (int i = 0; i < world.material_count; ++i)
+        {
+            if (world.materials[i].name != nullptr && SDL_strcmp(world.materials[i].name, name) == 0)
+                return &world.materials[i];
+        }
+        return nullptr;
+    };
     auto find_brush = [&world](const char *name) -> const slayer3d_game_data_brush * {
         for (int i = 0; i < world.brush_count; ++i)
         {
@@ -7390,6 +7400,20 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
         }
         return range;
     };
+    const slayer3d_game_data_brush_material *blue_material = find_material("mat.accent_blue");
+    ASSERT_NE(blue_material, nullptr);
+    EXPECT_GT(blue_material->emissive.z, 0.0f);
+    bool saw_model_emissive = false;
+    for (int i = 0; i < world.render_model->material_count; ++i)
+    {
+        const slayer3d_material &material = world.render_model->materials[i];
+        if (material.name != nullptr && SDL_strcmp(material.name, "mat.accent_blue") == 0)
+        {
+            saw_model_emissive = true;
+            EXPECT_GT(material.emissive[2], 0.0f);
+        }
+    }
+    EXPECT_TRUE(saw_model_emissive);
     const slayer3d_game_data_brush *pillar = find_brush("brush.pillar.center");
     const slayer3d_game_data_brush *overhang_west = find_brush("brush.bridge.overhang_west");
     const slayer3d_game_data_brush *overhang_east = find_brush("brush.bridge.overhang_east");
@@ -7401,6 +7425,20 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     const auto east_x = x_range(overhang_east);
     EXPECT_LT(west_x.second, pillar_x.first);
     EXPECT_GT(east_x.first, pillar_x.second);
+    const slayer3d_game_data_brush *floor = find_brush("brush.room.floor");
+    ASSERT_NE(floor, nullptr);
+    bool saw_floor_uv = false;
+    for (int i = 0; i < floor->face_count; ++i)
+    {
+        const slayer3d_game_data_brush_face &face = floor->faces[i];
+        if (SDL_fabsf(face.normal.y - 1.0f) <= 0.001f)
+        {
+            saw_floor_uv = true;
+            EXPECT_FLOAT_EQ(face.uv_scale[0], 0.5f);
+            EXPECT_FLOAT_EQ(face.uv_scale[1], 0.5f);
+        }
+    }
+    EXPECT_TRUE(saw_floor_uv);
     int rendered_vertices = 0;
     for (int i = 0; i < world.render_model->mesh_count; ++i)
     {
@@ -7421,6 +7459,7 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_EQ(capture.count, 1);
     EXPECT_EQ(capture.world_name, "brush.brush_geometry.showcase");
     EXPECT_TRUE(capture.acceleration_enabled);
+    EXPECT_TRUE(capture.lighting_enabled);
 
     ASSERT_EQ(slayer3d_game_data_world_light_count(runtime), 2);
     slayer3d_camera3d camera{};
@@ -10635,6 +10674,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
         "world": "brush.test",
         "position": [1.0, 2.0, 3.0],
         "acceleration": false,
+        "lighting": false,
         "debug_wireframe": true
       }
     ]
@@ -10661,6 +10701,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
         {
           "name": "mat.trim",
           "albedo": [0.85, 0.55, 0.20, 1.0],
+          "emissive": [0.4, 0.2, 0.05],
           "roughness": 0.7
         }
       ],
@@ -10672,7 +10713,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
           "faces": [
             { "plane": { "normal": [ 1.0,  0.0,  0.0], "distance":  4.0 }, "material": "mat.wall" },
             { "plane": { "normal": [-1.0,  0.0,  0.0], "distance":  0.0 }, "material": 0 },
-            { "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 }, "material": "mat.wall", "surface_flags": ["slick"] },
+            { "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 }, "material": "mat.wall", "surface_flags": ["slick"], "uv": { "scale": [2.0, 0.5], "offset": [0.25, -0.5], "rotation_degrees": 90.0 } },
             { "plane": { "normal": [ 0.0, -1.0,  0.0], "distance":  0.0 }, "material": "mat.wall" },
             { "plane": { "normal": [ 0.0,  0.0,  1.0], "distance":  4.0 }, "material": "mat.trim", "surface_flags": "emissive" },
             { "plane": { "normal": [ 0.0,  0.0, -1.0], "distance":  0.0 }, "material": "mat.wall" }
@@ -10704,6 +10745,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_FLOAT_EQ(world.materials[0].roughness, 0.8f);
     EXPECT_FLOAT_EQ(world.materials[0].tex_scale, 2.0f);
     EXPECT_STREQ(world.materials[1].name, "mat.trim");
+    EXPECT_FLOAT_EQ(world.materials[1].emissive.x, 0.4f);
     ASSERT_EQ(world.brush_count, 1);
     EXPECT_STREQ(world.brushes[0].name, "brush.room");
     EXPECT_EQ(world.brushes[0].contents,
@@ -10716,10 +10758,16 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_EQ(world.brushes[0].faces[1].material_index, 0);
     EXPECT_STREQ(world.brushes[0].faces[1].material_name, "mat.wall");
     EXPECT_EQ(world.brushes[0].faces[2].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_scale[0], 2.0f);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_scale[1], 0.5f);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_offset[0], 0.25f);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_offset[1], -0.5f);
+    EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_rotation_degrees, 90.0f);
     EXPECT_EQ(world.brushes[0].faces[4].material_index, 1);
     EXPECT_EQ(world.brushes[0].faces[4].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE);
     ASSERT_NE(world.render_model, nullptr);
     ASSERT_EQ(world.render_model->material_count, 2);
+    EXPECT_FLOAT_EQ(world.render_model->materials[1].emissive[0], 0.4f);
     ASSERT_EQ(world.render_model->mesh_count, 2);
     EXPECT_EQ(world.render_model->meshes[0].material_index, 0);
     EXPECT_EQ(world.render_model->meshes[0].vertex_count, 30);
@@ -10743,6 +10791,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(capture.world->name, "brush.test");
     expect_vec3_near(capture.position, slayer3d_vec3_make(1.0f, 2.0f, 3.0f));
     EXPECT_FALSE(capture.acceleration_enabled);
+    EXPECT_FALSE(capture.lighting_enabled);
     EXPECT_TRUE(capture.debug_wireframe);
 
     slayer3d_game_data_destroy(runtime);
@@ -10834,6 +10883,54 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
             "brush content value is unknown",
         },
         {
+            "bad_emissive",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.bad", "emissive": [0.1, -0.2, 0.3] }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.bad" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.bad" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.bad" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.bad" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush material emissive must be a non-negative vec3",
+        },
+        {
+            "bad_uv_scale",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good", "uv": { "scale": [1, 0] } },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush face uv scale must be a positive vec2",
+        },
+        {
             "bad_scene_ref",
             R"json({
   "brush_worlds": [
@@ -10860,6 +10957,34 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
   "world": { "brush_worlds": [{ "world": "brush.missing" }] }
 })json",
             "unknown brush world reference",
+        },
+        {
+            "bad_lighting_flag",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.good",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": { "brush_worlds": [{ "world": "brush.good", "lighting": "yes" }] }
+})json",
+            "scene brush world lighting must be a boolean",
         },
     };
 


### PR DESCRIPTION
## Summary
- add brush material emissive data and copy it into compiled render materials
- add per-face UV scale/offset/rotation for brush surfaces
- add scene-level brush world lighting toggles with scene-state key support
- update brush geometry dojo data, docs, and validation tests

## Verification
- clang-format -i include/slayer3d/game_data.h src/game_data.c src/game_data_brush.c src/game_data_validation.c src/game_presentation.c tests/test_game_data.cpp
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.RejectsInvalidBrushWorlds:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j8
- git diff --check

Part of #306.