### PR TITLE
Add brush trace broad-phase diagnostics

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -555,7 +555,10 @@ code should use
 `slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are
-drawn by the generic data-game frame path.
+drawn by the generic data-game frame path. During load, brush worlds also
+precompute local AABBs for each brush and for the whole world. When
+`acceleration` is enabled on a scene instance, active-scene trace queries use
+those bounds as a broad phase before exact plane clipping.
 
 Collision, weapon, sensor, and editor systems can query brush worlds through
 the generic trace helpers. `slayer3d_game_data_trace_brush_world()` traces in a
@@ -567,6 +570,9 @@ the hit fraction, plane normal, brush, material, contents, and surface flags.
 `slayer3d_game_data_slide_brush_world()` and
 `slayer3d_game_data_slide_active_brush_worlds()` layer deterministic
 plane-sliding over those traces for controllers and projectile movement.
+`slayer3d_game_data_get_brush_diagnostics()` exposes cumulative trace counters
+for debug UI, tests, and future editor instrumentation; reset them with
+`slayer3d_game_data_reset_brush_diagnostics()`.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -431,6 +431,10 @@ extern "C"
         const slayer3d_game_data_brush_face *faces;
         /** @brief Number of entries in @p faces. */
         int face_count;
+        /** @brief Precomputed local-space bounds for broad-phase trace rejection. */
+        slayer3d_bounding_box bounds;
+        /** @brief True when @p bounds is valid. */
+        bool has_bounds;
     } slayer3d_game_data_brush;
 
     /** @brief Runtime-owned native brush world. */
@@ -452,6 +456,10 @@ extern "C"
         int brush_count;
         /** @brief Runtime-compiled static render mesh for visible brush faces, or NULL when empty. */
         const slayer3d_model *render_model;
+        /** @brief Precomputed local-space bounds spanning all bounded brushes. */
+        slayer3d_bounding_box bounds;
+        /** @brief True when @p bounds is valid. */
+        bool has_bounds;
     } slayer3d_game_data_brush_world;
 
     /** @brief Active-scene instance of an authored brush world. */
@@ -529,6 +537,27 @@ extern "C"
         /** @brief Surface flags on the hit face. */
         unsigned int surface_flags;
     } slayer3d_game_data_brush_trace_result;
+
+    /** @brief Runtime counters for brush-world trace broad-phase and narrow-phase work. */
+    typedef struct slayer3d_game_data_brush_diagnostics
+    {
+        /** @brief Number of valid local brush-world trace evaluations. */
+        Uint64 trace_count;
+        /** @brief Active-scene brush world instances visited by trace requests. */
+        Uint64 world_instance_count;
+        /** @brief Active-scene brush world instances rejected by world bounds. */
+        Uint64 world_bounds_reject_count;
+        /** @brief Authored brushes considered by local trace loops. */
+        Uint64 brush_count;
+        /** @brief Brushes rejected because contents did not overlap the trace mask. */
+        Uint64 contents_reject_count;
+        /** @brief Brushes rejected by precomputed brush bounds. */
+        Uint64 bounds_reject_count;
+        /** @brief Brushes that reached exact plane-based trace tests. */
+        Uint64 collision_candidate_count;
+        /** @brief Local brush-world trace evaluations that produced a hit. */
+        Uint64 hit_count;
+    } slayer3d_game_data_brush_diagnostics;
 
     /**
      * @brief Callback for active authored sector level instances.
@@ -1328,6 +1357,18 @@ extern "C"
     bool slayer3d_game_data_slide_active_brush_worlds(const slayer3d_game_data_runtime *runtime,
                                                       const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
                                                       slayer3d_game_data_brush_trace_result *out_result);
+
+    /**
+     * @brief Copy accumulated brush-world trace diagnostics.
+     *
+     * Diagnostics are cumulative until reset and are intended for tests,
+     * debug UI, and future editor instrumentation.
+     */
+    bool slayer3d_game_data_get_brush_diagnostics(const slayer3d_game_data_runtime *runtime,
+                                                  slayer3d_game_data_brush_diagnostics *out_diagnostics);
+
+    /** @brief Reset accumulated brush-world trace diagnostics to zero. */
+    void slayer3d_game_data_reset_brush_diagnostics(slayer3d_game_data_runtime *runtime);
 
     /** @brief Runtime-owned node resolved from an authored sector navigation graph. */
     typedef struct slayer3d_game_data_sector_nav_node

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -22,6 +22,7 @@
 #include "script_internal.h"
 #include "slayer3d/actor_controller.h"
 #include "slayer3d/asset.h"
+#include "slayer3d/collision.h"
 #include "slayer3d/door.h"
 #include "slayer3d/fps_mover.h"
 #include "slayer3d/input.h"
@@ -590,6 +591,7 @@ typedef struct slayer3d_game_data_runtime
     int sector_level_count;
     brush_world_runtime *brush_worlds;
     int brush_world_count;
+    slayer3d_game_data_brush_diagnostics brush_diagnostics;
     sector_door_runtime *sector_doors;
     int sector_door_count;
     sector_platform_runtime *sector_platforms;
@@ -3787,6 +3789,13 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 face->surface_flags =
                     brush_flags_from_json(obj_get(face_json, "surface_flags"), brush_surface_flag_from_string, 0u);
             }
+        }
+
+        if (!slayer3d_game_data_brush_world_build_acceleration(world))
+        {
+            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' acceleration data",
+                       world->name != NULL ? world->name : "<unnamed>");
+            return false;
         }
 
         if (!slayer3d_game_data_brush_world_compile_render_model(world,
@@ -7849,7 +7858,8 @@ bool slayer3d_game_data_trace_brush_world(const slayer3d_game_data_runtime *runt
     const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
     if (world_runtime == NULL)
         return false;
-    return slayer3d_game_data_brush_world_trace_local(&world_runtime->desc, desc, out_result);
+    return slayer3d_game_data_brush_world_trace_local_with_diagnostics(
+        &world_runtime->desc, desc, true, out_result, &((slayer3d_game_data_runtime *)runtime)->brush_diagnostics);
 }
 
 typedef struct brush_scene_trace_context
@@ -7874,9 +7884,28 @@ static bool trace_brush_world_instance(void *userdata, const slayer3d_game_data_
     slayer3d_game_data_brush_trace_desc local_desc = *context->world_desc;
     local_desc.start = slayer3d_vec3_sub(local_desc.start, instance->position);
     local_desc.end = slayer3d_vec3_sub(local_desc.end, instance->position);
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(context->runtime, instance->world_name);
+    if (world_runtime == NULL)
+    {
+        context->ok = false;
+        return false;
+    }
+    slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
+    ++mutable_runtime->brush_diagnostics.world_instance_count;
+    if (instance->acceleration_enabled && world_runtime->desc.has_bounds)
+    {
+        const slayer3d_bounding_box trace_bounds = slayer3d_game_data_brush_trace_bounds(&local_desc);
+        if (!slayer3d_check_aabb_aabb(trace_bounds, world_runtime->desc.bounds))
+        {
+            ++mutable_runtime->brush_diagnostics.world_bounds_reject_count;
+            return true;
+        }
+    }
 
     slayer3d_game_data_brush_trace_result local_result;
-    if (!slayer3d_game_data_trace_brush_world(context->runtime, instance->world_name, &local_desc, &local_result))
+    if (!slayer3d_game_data_brush_world_trace_local_with_diagnostics(&world_runtime->desc, &local_desc,
+                                                                     instance->acceleration_enabled, &local_result,
+                                                                     &mutable_runtime->brush_diagnostics))
     {
         context->ok = false;
         return false;
@@ -7912,6 +7941,22 @@ bool slayer3d_game_data_trace_active_brush_worlds(const slayer3d_game_data_runti
 
     *out_result = context.closest;
     return true;
+}
+
+bool slayer3d_game_data_get_brush_diagnostics(const slayer3d_game_data_runtime *runtime,
+                                              slayer3d_game_data_brush_diagnostics *out_diagnostics)
+{
+    if (runtime == NULL || out_diagnostics == NULL)
+        return false;
+    *out_diagnostics = runtime->brush_diagnostics;
+    return true;
+}
+
+void slayer3d_game_data_reset_brush_diagnostics(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    SDL_zero(runtime->brush_diagnostics);
 }
 
 typedef struct brush_named_trace_context

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -7,7 +7,50 @@
 
 #include <SDL3/SDL_stdinc.h>
 
+#include "slayer3d/collision.h"
 #include "slayer3d/math.h"
+
+static void brush_bounds_add_point(slayer3d_bounding_box *bounds, bool *has_bounds, slayer3d_vec3 point)
+{
+    if (bounds == NULL || has_bounds == NULL)
+        return;
+    if (!*has_bounds)
+    {
+        bounds->min = point;
+        bounds->max = point;
+        *has_bounds = true;
+        return;
+    }
+    bounds->min.x = SDL_min(bounds->min.x, point.x);
+    bounds->min.y = SDL_min(bounds->min.y, point.y);
+    bounds->min.z = SDL_min(bounds->min.z, point.z);
+    bounds->max.x = SDL_max(bounds->max.x, point.x);
+    bounds->max.y = SDL_max(bounds->max.y, point.y);
+    bounds->max.z = SDL_max(bounds->max.z, point.z);
+}
+
+slayer3d_bounding_box slayer3d_game_data_brush_trace_bounds(const slayer3d_game_data_brush_trace_desc *desc)
+{
+    slayer3d_vec3 extents = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (desc != NULL)
+    {
+        if (desc->shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE)
+            extents = slayer3d_vec3_make(SDL_max(desc->extents.x, 0.0f), SDL_max(desc->extents.x, 0.0f),
+                                         SDL_max(desc->extents.x, 0.0f));
+        else if (desc->shape == SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB)
+            extents = slayer3d_vec3_make(SDL_max(desc->extents.x, 0.0f), SDL_max(desc->extents.y, 0.0f),
+                                         SDL_max(desc->extents.z, 0.0f));
+    }
+
+    const slayer3d_vec3 start = desc != NULL ? desc->start : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const slayer3d_vec3 end = desc != NULL ? desc->end : start;
+    return (slayer3d_bounding_box){
+        slayer3d_vec3_make(SDL_min(start.x, end.x) - extents.x, SDL_min(start.y, end.y) - extents.y,
+                           SDL_min(start.z, end.z) - extents.z),
+        slayer3d_vec3_make(SDL_max(start.x, end.x) + extents.x, SDL_max(start.y, end.y) + extents.y,
+                           SDL_max(start.z, end.z) + extents.z),
+    };
+}
 
 static bool brush_plane_normalized(const slayer3d_game_data_brush_face *face, slayer3d_vec3 *out_normal,
                                    float *out_distance)
@@ -210,6 +253,50 @@ static void brush_mesh_bounds_add(slayer3d_mesh *mesh, slayer3d_vec3 p)
     mesh->local_bounds.max.x = SDL_max(mesh->local_bounds.max.x, p.x);
     mesh->local_bounds.max.y = SDL_max(mesh->local_bounds.max.y, p.y);
     mesh->local_bounds.max.z = SDL_max(mesh->local_bounds.max.z, p.z);
+}
+
+bool slayer3d_game_data_brush_world_build_acceleration(slayer3d_game_data_brush_world *world)
+{
+    if (world == NULL)
+        return false;
+
+    int max_face_count = 0;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+        max_face_count = SDL_max(max_face_count, world->brushes[brush_index].face_count);
+    const int polygon_capacity = SDL_max(16, max_face_count * 2 + 8);
+    slayer3d_vec3 *polygon = (slayer3d_vec3 *)SDL_malloc((size_t)polygon_capacity * sizeof(*polygon));
+    if (polygon == NULL)
+        return world->brush_count <= 0;
+
+    bool world_has_bounds = false;
+    slayer3d_bounding_box world_bounds;
+    SDL_zero(world_bounds);
+    slayer3d_game_data_brush *brushes = (slayer3d_game_data_brush *)world->brushes;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        slayer3d_game_data_brush *brush = &brushes[brush_index];
+        bool brush_has_bounds = false;
+        slayer3d_bounding_box brush_bounds;
+        SDL_zero(brush_bounds);
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const int count = brush_build_face_polygon(brush, face_index, polygon, polygon_capacity, NULL, NULL, NULL);
+            for (int vertex_index = 0; vertex_index < count; ++vertex_index)
+                brush_bounds_add_point(&brush_bounds, &brush_has_bounds, polygon[vertex_index]);
+        }
+        brush->has_bounds = brush_has_bounds;
+        if (brush_has_bounds)
+        {
+            brush->bounds = brush_bounds;
+            brush_bounds_add_point(&world_bounds, &world_has_bounds, brush_bounds.min);
+            brush_bounds_add_point(&world_bounds, &world_has_bounds, brush_bounds.max);
+        }
+    }
+    world->has_bounds = world_has_bounds;
+    if (world_has_bounds)
+        world->bounds = world_bounds;
+    SDL_free(polygon);
+    return true;
 }
 
 static bool brush_model_copy_materials(const slayer3d_game_data_brush_world *world, slayer3d_model *model)
@@ -559,13 +646,42 @@ bool slayer3d_game_data_brush_world_trace_local(const slayer3d_game_data_brush_w
                                                 const slayer3d_game_data_brush_trace_desc *desc,
                                                 slayer3d_game_data_brush_trace_result *out_result)
 {
+    return slayer3d_game_data_brush_world_trace_local_with_diagnostics(world, desc, true, out_result, NULL);
+}
+
+bool slayer3d_game_data_brush_world_trace_local_with_diagnostics(const slayer3d_game_data_brush_world *world,
+                                                                 const slayer3d_game_data_brush_trace_desc *desc,
+                                                                 bool acceleration_enabled,
+                                                                 slayer3d_game_data_brush_trace_result *out_result,
+                                                                 slayer3d_game_data_brush_diagnostics *diagnostics)
+{
     slayer3d_game_data_brush_trace_result closest = slayer3d_game_data_brush_trace_default_result(desc);
     if (world == NULL || desc == NULL || out_result == NULL || !slayer3d_game_data_brush_trace_shape_valid(desc))
         return false;
+    if (diagnostics != NULL)
+        ++diagnostics->trace_count;
+
+    const slayer3d_bounding_box trace_bounds = slayer3d_game_data_brush_trace_bounds(desc);
 
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
     {
         const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        if (diagnostics != NULL)
+            ++diagnostics->brush_count;
+        if ((brush->contents & desc->contents_mask) == 0u)
+        {
+            if (diagnostics != NULL)
+                ++diagnostics->contents_reject_count;
+            continue;
+        }
+        if (acceleration_enabled && brush->has_bounds && !slayer3d_check_aabb_aabb(trace_bounds, brush->bounds))
+        {
+            if (diagnostics != NULL)
+                ++diagnostics->bounds_reject_count;
+            continue;
+        }
+        if (diagnostics != NULL)
+            ++diagnostics->collision_candidate_count;
         slayer3d_game_data_brush_trace_result candidate = slayer3d_game_data_brush_trace_default_result(desc);
         if (!brush_trace_one_brush(brush, desc, &candidate))
             continue;
@@ -590,6 +706,8 @@ bool slayer3d_game_data_brush_world_trace_local(const slayer3d_game_data_brush_w
     }
 
     *out_result = closest;
+    if (diagnostics != NULL && closest.hit)
+        ++diagnostics->hit_count;
     return true;
 }
 

--- a/src/game_data_brush_internal.h
+++ b/src/game_data_brush_internal.h
@@ -13,9 +13,19 @@ slayer3d_game_data_brush_trace_result slayer3d_game_data_brush_trace_default_res
 
 bool slayer3d_game_data_brush_trace_shape_valid(const slayer3d_game_data_brush_trace_desc *desc);
 
+slayer3d_bounding_box slayer3d_game_data_brush_trace_bounds(const slayer3d_game_data_brush_trace_desc *desc);
+
 bool slayer3d_game_data_brush_world_trace_local(const slayer3d_game_data_brush_world *world,
                                                 const slayer3d_game_data_brush_trace_desc *desc,
                                                 slayer3d_game_data_brush_trace_result *out_result);
+
+bool slayer3d_game_data_brush_world_trace_local_with_diagnostics(const slayer3d_game_data_brush_world *world,
+                                                                 const slayer3d_game_data_brush_trace_desc *desc,
+                                                                 bool acceleration_enabled,
+                                                                 slayer3d_game_data_brush_trace_result *out_result,
+                                                                 slayer3d_game_data_brush_diagnostics *diagnostics);
+
+bool slayer3d_game_data_brush_world_build_acceleration(slayer3d_game_data_brush_world *world);
 
 bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brush_world *world, slayer3d_model *model);
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -11099,6 +11099,14 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "brush_trace.game.json").string().c_str(), session, &runtime, error,
                                              sizeof(error)))
         << error;
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.trace", &world));
+    EXPECT_TRUE(world.has_bounds);
+    EXPECT_NEAR(world.bounds.min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(world.bounds.max.x, 9.0f, 0.001f);
+    ASSERT_EQ(world.brush_count, 3);
+    EXPECT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.max.y, 3.0f, 0.001f);
 
     slayer3d_game_data_brush_trace_desc trace{};
     slayer3d_game_data_brush_trace_result result{};
@@ -11112,6 +11120,15 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     EXPECT_NEAR(result.fraction, 0.5f, 0.001f);
     EXPECT_STREQ(result.brush_name, "brush.box");
     EXPECT_NEAR(result.normal.x, -1.0f, 0.0001f);
+    slayer3d_game_data_brush_diagnostics diagnostics{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.trace_count, 1u);
+    EXPECT_EQ(diagnostics.brush_count, 3u);
+    EXPECT_EQ(diagnostics.contents_reject_count, 1u);
+    EXPECT_EQ(diagnostics.bounds_reject_count, 1u);
+    EXPECT_EQ(diagnostics.collision_candidate_count, 1u);
+    EXPECT_EQ(diagnostics.hit_count, 1u);
+    slayer3d_game_data_reset_brush_diagnostics(runtime);
 
     trace.start = slayer3d_vec3_make(2.0f, 1.0f, 6.0f);
     trace.end = slayer3d_vec3_make(2.0f, 1.0f, 2.0f);
@@ -11197,6 +11214,20 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     EXPECT_STREQ(result.brush_name, "brush.box");
     EXPECT_NEAR(result.end_position.x, -0.25375f, 0.002f);
     EXPECT_GT(result.end_position.z, 5.9f);
+
+    slayer3d_game_data_reset_brush_diagnostics(runtime);
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.extents = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.start = slayer3d_vec3_make(-100.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(-90.0f, 1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, &result));
+    EXPECT_FALSE(result.hit);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.world_instance_count, 1u);
+    EXPECT_EQ(diagnostics.world_bounds_reject_count, 1u);
+    EXPECT_EQ(diagnostics.brush_count, 0u);
+    EXPECT_EQ(diagnostics.collision_candidate_count, 0u);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- precompute local AABBs for authored brushes and brush worlds at load time
- use brush/world bounds as a broad phase for brush trace queries when acceleration is enabled
- add cumulative brush trace diagnostics for tests, debug UI, and future editor instrumentation
- document brush acceleration and diagnostics APIs

## Verification
- clang-format -i include/slayer3d/game_data.h src/game_data.c src/game_data_brush.c src/game_data_brush_internal.h tests/test_game_data.cpp
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.TracesAuthoredBrushWorldsWithContentsAndSweptHulls:GameDataRuntime.RunsAuthoredFpsBrushController:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j8
- git diff --check

Part of #306.