### PR TITLE
Add brush render diagnostics

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -571,8 +571,12 @@ the hit fraction, plane normal, brush, material, contents, and surface flags.
 `slayer3d_game_data_slide_active_brush_worlds()` layer deterministic
 plane-sliding over those traces for controllers and projectile movement.
 `slayer3d_game_data_get_brush_diagnostics()` exposes cumulative trace counters
-for debug UI, tests, and future editor instrumentation; reset them with
-`slayer3d_game_data_reset_brush_diagnostics()`.
+and brush render-counter deltas for debug UI, tests, and future editor
+instrumentation; reset them with
+`slayer3d_game_data_reset_brush_diagnostics()`. Brush render diagnostics are
+derived from the generic render-context stats exposed by
+`slayer3d_get_render_stats()`, because brush worlds compile to static model
+meshes that use the same frustum culling path as other models.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -29,6 +29,7 @@
 #include "slayer3d/network.h"
 #include "slayer3d/network_replication.h"
 #include "slayer3d/properties.h"
+#include "slayer3d/render_context.h"
 #include "slayer3d/sprite_asset.h"
 #include "slayer3d/storage.h"
 #include "slayer3d/transition.h"
@@ -557,6 +558,14 @@ extern "C"
         Uint64 collision_candidate_count;
         /** @brief Local brush-world trace evaluations that produced a hit. */
         Uint64 hit_count;
+        /** @brief Brush-world model meshes submitted to the renderer. */
+        Uint64 render_mesh_submissions;
+        /** @brief Brush-world model meshes rejected by renderer frustum culling. */
+        Uint64 render_mesh_culled;
+        /** @brief Brush-world model meshes accepted by the renderer. */
+        Uint64 render_mesh_draws;
+        /** @brief Approximate brush-world triangles submitted after renderer culling. */
+        Uint64 render_triangles_submitted;
     } slayer3d_game_data_brush_diagnostics;
 
     /**
@@ -1369,6 +1378,11 @@ extern "C"
 
     /** @brief Reset accumulated brush-world trace diagnostics to zero. */
     void slayer3d_game_data_reset_brush_diagnostics(slayer3d_game_data_runtime *runtime);
+
+    /** @brief Add render-context stat deltas to accumulated brush diagnostics. */
+    void slayer3d_game_data_accumulate_brush_render_diagnostics(slayer3d_game_data_runtime *runtime,
+                                                                const slayer3d_render_stats *before,
+                                                                const slayer3d_render_stats *after);
 
     /** @brief Runtime-owned node resolved from an authored sector navigation graph. */
     typedef struct slayer3d_game_data_sector_nav_node

--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -41,6 +41,19 @@ extern "C"
         SDL_RendererLogicalPresentation logical_presentation;
     } slayer3d_render_context_config;
 
+    /** @brief Cumulative render submission counters for profiling/debug UI. */
+    typedef struct slayer3d_render_stats
+    {
+        /** @brief Model meshes submitted to the render path before visibility culling. */
+        Uint64 model_mesh_submissions;
+        /** @brief Model meshes rejected by render-context frustum culling. */
+        Uint64 model_mesh_culled;
+        /** @brief Model meshes accepted for drawing. */
+        Uint64 model_mesh_draws;
+        /** @brief Approximate triangles submitted by accepted model meshes. */
+        Uint64 model_triangles_submitted;
+    } slayer3d_render_stats;
+
     /**
      * @brief High-level window configuration.
      *
@@ -170,6 +183,8 @@ extern "C"
     slayer3d_backend slayer3d_get_render_context_backend(const slayer3d_render_context *context);
     int slayer3d_get_render_context_width(const slayer3d_render_context *context);
     int slayer3d_get_render_context_height(const slayer3d_render_context *context);
+    bool slayer3d_get_render_stats(const slayer3d_render_context *context, slayer3d_render_stats *out_stats);
+    void slayer3d_reset_render_stats(slayer3d_render_context *context);
     bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color);
     bool slayer3d_clear_render_context_rect(slayer3d_render_context *context, const SDL_Rect *rect,
                                             slayer3d_color color);

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1691,8 +1691,10 @@ static bool slayer3d_draw_model_mesh(slayer3d_render_context *context, const sla
     slayer3d_vec4 mesh_modulate = tint_modulate;
     bool ok = true;
 
+    ++context->stats.model_mesh_submissions;
     if (!slayer3d_mesh_is_visible(context, mesh))
     {
+        ++context->stats.model_mesh_culled;
         return true;
     }
 
@@ -1790,6 +1792,12 @@ static bool slayer3d_draw_model_mesh(slayer3d_render_context *context, const sla
 
         ok = slayer3d_draw_mesh_internal(context, mesh, texture, lightmap_texture, mesh_modulate, lp_ptr,
                                          joint_matrices, true, NULL, NULL);
+    }
+    if (ok)
+    {
+        ++context->stats.model_mesh_draws;
+        context->stats.model_triangles_submitted +=
+            (Uint64)((mesh->index_count > 0 ? mesh->index_count : mesh->vertex_count) / 3);
     }
     return ok;
 }

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -7959,6 +7959,28 @@ void slayer3d_game_data_reset_brush_diagnostics(slayer3d_game_data_runtime *runt
     SDL_zero(runtime->brush_diagnostics);
 }
 
+void slayer3d_game_data_accumulate_brush_render_diagnostics(slayer3d_game_data_runtime *runtime,
+                                                            const slayer3d_render_stats *before,
+                                                            const slayer3d_render_stats *after)
+{
+    if (runtime == NULL || before == NULL || after == NULL)
+        return;
+
+    runtime->brush_diagnostics.render_mesh_submissions +=
+        after->model_mesh_submissions >= before->model_mesh_submissions
+            ? after->model_mesh_submissions - before->model_mesh_submissions
+            : 0u;
+    runtime->brush_diagnostics.render_mesh_culled += after->model_mesh_culled >= before->model_mesh_culled
+                                                         ? after->model_mesh_culled - before->model_mesh_culled
+                                                         : 0u;
+    runtime->brush_diagnostics.render_mesh_draws +=
+        after->model_mesh_draws >= before->model_mesh_draws ? after->model_mesh_draws - before->model_mesh_draws : 0u;
+    runtime->brush_diagnostics.render_triangles_submitted +=
+        after->model_triangles_submitted >= before->model_triangles_submitted
+            ? after->model_triangles_submitted - before->model_triangles_submitted
+            : 0u;
+}
+
 typedef struct brush_named_trace_context
 {
     const slayer3d_game_data_runtime *runtime;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2314,6 +2314,9 @@ bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_r
     if (runtime == NULL || renderer == NULL)
         return false;
 
+    slayer3d_render_stats before_stats;
+    SDL_zero(before_stats);
+    const bool have_before_stats = slayer3d_get_render_stats(renderer, &before_stats);
     brush_world_draw_context context;
     SDL_zero(context);
     context.renderer = renderer;
@@ -2321,6 +2324,13 @@ bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_r
     context.ok = true;
     const bool iterated =
         slayer3d_game_data_for_each_brush_world_instance(runtime, draw_brush_world_instance, &context);
+    slayer3d_render_stats after_stats;
+    SDL_zero(after_stats);
+    if (have_before_stats && slayer3d_get_render_stats(renderer, &after_stats))
+    {
+        slayer3d_game_data_accumulate_brush_render_diagnostics((slayer3d_game_data_runtime *)runtime, &before_stats,
+                                                               &after_stats);
+    }
     return iterated && context.ok;
 }
 

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -412,6 +412,30 @@ int slayer3d_get_render_context_height(const slayer3d_render_context *context)
     return context->height;
 }
 
+bool slayer3d_get_render_stats(const slayer3d_render_context *context, slayer3d_render_stats *out_stats)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (out_stats == NULL)
+    {
+        return SDL_InvalidParamError("out_stats");
+    }
+
+    *out_stats = context->stats;
+    return true;
+}
+
+void slayer3d_reset_render_stats(slayer3d_render_context *context)
+{
+    if (context == NULL)
+    {
+        return;
+    }
+    SDL_zero(context->stats);
+}
+
 bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color)
 {
     if (context == NULL)

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -33,6 +33,7 @@ struct slayer3d_render_context
     slayer3d_backend_interface backend_iface;
     int width;
     int height;
+    slayer3d_render_stats stats;
 
     float near_plane;
     float far_plane;

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -216,6 +216,35 @@ slayer3d_texture2d MakeSolidTexture(slayer3d_color color)
     EXPECT_TRUE(slayer3d_create_texture_from_image(&image, &texture)) << SDL_GetError();
     return texture;
 }
+
+void FillTriangleMesh(slayer3d_mesh &mesh, float x_offset, float z)
+{
+    static float positions[2][9];
+    static unsigned int indices[2][3];
+    const int slot = x_offset > 100.0f ? 1 : 0;
+    positions[slot][0] = x_offset - 0.5f;
+    positions[slot][1] = -0.5f;
+    positions[slot][2] = z;
+    positions[slot][3] = x_offset + 0.5f;
+    positions[slot][4] = -0.5f;
+    positions[slot][5] = z;
+    positions[slot][6] = x_offset;
+    positions[slot][7] = 0.5f;
+    positions[slot][8] = z;
+    indices[slot][0] = 0;
+    indices[slot][1] = 1;
+    indices[slot][2] = 2;
+
+    SDL_zero(mesh);
+    mesh.positions = positions[slot];
+    mesh.vertex_count = 3;
+    mesh.indices = indices[slot];
+    mesh.index_count = 3;
+    mesh.material_index = -1;
+    mesh.has_local_bounds = true;
+    mesh.local_bounds.min = slayer3d_vec3_make(x_offset - 0.5f, -0.5f, z);
+    mesh.local_bounds.max = slayer3d_vec3_make(x_offset + 0.5f, 0.5f, z);
+}
 } // namespace
 
 /* --- Lifecycle ----------------------------------------------------------- */
@@ -276,6 +305,47 @@ TEST_F(SLAYER3DDrawingFixture, DrawOutsideModeRejected)
     SDL_ClearError();
     EXPECT_FALSE(slayer3d_draw_point_3d(ctx, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), kRed));
     EXPECT_NE(*SDL_GetError(), '\0');
+
+    slayer3d_destroy_render_context(ctx);
+}
+
+TEST_F(SLAYER3DDrawingFixture, RenderStatsTrackModelMeshCulling)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    slayer3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(slayer3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx)) << SDL_GetError();
+
+    slayer3d_mesh meshes[2]{};
+    FillTriangleMesh(meshes[0], 0.0f, 0.0f);
+    FillTriangleMesh(meshes[1], 1000.0f, 0.0f);
+    slayer3d_model model{};
+    model.meshes = meshes;
+    model.mesh_count = 2;
+
+    slayer3d_render_stats stats{};
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.model_mesh_submissions, 0u);
+
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, MakeCamera())) << SDL_GetError();
+    ASSERT_TRUE(slayer3d_draw_model_ex(ctx, &model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                       slayer3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, slayer3d_vec3_make(1.0f, 1.0f, 1.0f),
+                                       kRed))
+        << SDL_GetError();
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx)) << SDL_GetError();
+
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.model_mesh_submissions, 2u);
+    EXPECT_EQ(stats.model_mesh_culled, 1u);
+    EXPECT_EQ(stats.model_mesh_draws, 1u);
+    EXPECT_EQ(stats.model_triangles_submitted, 1u);
+
+    slayer3d_reset_render_stats(ctx);
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.model_mesh_submissions, 0u);
+    EXPECT_EQ(stats.model_mesh_culled, 0u);
+    EXPECT_EQ(stats.model_mesh_draws, 0u);
+    EXPECT_EQ(stats.model_triangles_submitted, 0u);
 
     slayer3d_destroy_render_context(ctx);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -11229,6 +11229,23 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     EXPECT_EQ(diagnostics.brush_count, 0u);
     EXPECT_EQ(diagnostics.collision_candidate_count, 0u);
 
+    slayer3d_render_stats before_stats{};
+    slayer3d_render_stats after_stats{};
+    before_stats.model_mesh_submissions = 4;
+    before_stats.model_mesh_culled = 1;
+    before_stats.model_mesh_draws = 3;
+    before_stats.model_triangles_submitted = 48;
+    after_stats.model_mesh_submissions = 7;
+    after_stats.model_mesh_culled = 2;
+    after_stats.model_mesh_draws = 5;
+    after_stats.model_triangles_submitted = 96;
+    slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.render_mesh_submissions, 3u);
+    EXPECT_EQ(diagnostics.render_mesh_culled, 1u);
+    EXPECT_EQ(diagnostics.render_mesh_draws, 2u);
+    EXPECT_EQ(diagnostics.render_triangles_submitted, 48u);
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary
- add public render-context model mesh stats for submissions, frustum culls, draws, and submitted triangles
- accumulate brush-world render stat deltas into brush diagnostics
- document brush render diagnostics as part of the brush-world acceleration/debug workflow
- add tests for renderer mesh culling counters and brush diagnostic accumulation

## Verification
- clang-format -i include/slayer3d/render_context.h include/slayer3d/game_data.h src/render_context_internal.h src/render_context.c src/drawing3d.c src/game_data.c src/game_presentation.c tests/test_drawing3d.cpp tests/test_game_data.cpp
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_drawing3d_test slayer3d_runner -j8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.TracesAuthoredBrushWorldsWithContentsAndSweptHulls:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- ./build/debug/tests/slayer3d_drawing3d_test --gtest_filter='SLAYER3DDrawingFixture.RenderStatsTrackModelMeshCulling'
- ./build/debug/tests/slayer3d_game_data_test
- ./build/debug/tests/slayer3d_drawing3d_test
- cmake --build build/debug -j8
- git diff --check

Part of #306.