### PR TITLE
Add brush diagnostics UI overlay

### DIFF
--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -82,6 +82,40 @@
         "scale": 0.72
       },
       {
+        "name": "ui.brush_geometry.trace_diagnostics",
+        "font": "font.brush_geometry.hud",
+        "format": "TRACE %llu BRUSH %llu CAND %llu HIT %llu",
+        "bindings": [
+          { "type": "metric", "metric": "brush.trace_count" },
+          { "type": "metric", "metric": "brush.brush_count" },
+          { "type": "metric", "metric": "brush.collision_candidate_count" },
+          { "type": "metric", "metric": "brush.hit_count" }
+        ],
+        "x": 0.985,
+        "y": 0.063,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.brush_geometry.render_diagnostics",
+        "font": "font.brush_geometry.hud",
+        "format": "RENDER %llu/%llu CULL %llu TRI %llu",
+        "bindings": [
+          { "type": "metric", "metric": "brush.render_mesh_draws" },
+          { "type": "metric", "metric": "brush.render_mesh_submissions" },
+          { "type": "metric", "metric": "brush.render_mesh_culled" },
+          { "type": "metric", "metric": "brush.render_triangles_submitted" }
+        ],
+        "x": 0.985,
+        "y": 0.091,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
         "name": "ui.brush_geometry.trigger_state",
         "font": "font.brush_geometry.hud",
         "format": "TRIGGER %d",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1824,6 +1824,30 @@ keeps HUD text renderable before the first action writes a transient value:
 }
 ```
 
+UI text can also bind engine metrics. `fps`, `frame`, and `paused` are always
+available. Brush-world diagnostics are exposed with `brush.*` metric names so
+debug overlays can inspect collision and render cost without game-specific C:
+
+```json
+{
+  "format": "RENDER %llu/%llu CULL %llu TRI %llu",
+  "bindings": [
+    { "type": "metric", "metric": "brush.render_mesh_draws" },
+    { "type": "metric", "metric": "brush.render_mesh_submissions" },
+    { "type": "metric", "metric": "brush.render_mesh_culled" },
+    { "type": "metric", "metric": "brush.render_triangles_submitted" }
+  ]
+}
+```
+
+Supported brush metrics are `brush.trace_count`,
+`brush.world_instance_count`, `brush.world_bounds_reject_count`,
+`brush.brush_count`, `brush.contents_reject_count`,
+`brush.bounds_reject_count`, `brush.collision_candidate_count`,
+`brush.hit_count`, `brush.render_mesh_submissions`,
+`brush.render_mesh_culled`, `brush.render_mesh_draws`, and
+`brush.render_triangles_submitted`.
+
 `property.set` and `property.add` normally target a fixed actor:
 
 ```json

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -3433,8 +3433,8 @@ extern "C"
      * @brief Resolve UI text content from data-authored bindings.
      *
      * Literal `text` entries are copied directly. Entries with `bindings`
-     * resolve engine metrics and actor properties, then format them using the
-     * descriptor's `format` string.
+     * resolve engine metrics, brush diagnostics, scene state, and actor
+     * properties, then format them using the descriptor's `format` string.
      */
     bool slayer3d_game_data_format_ui_text(const slayer3d_game_data_runtime *runtime,
                                            const slayer3d_game_data_ui_text *text,

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -13949,6 +13949,50 @@ typedef struct ui_value
     };
 } ui_value;
 
+static bool read_brush_diagnostic_metric(const slayer3d_game_data_runtime *runtime, const char *metric,
+                                         ui_value *out_value)
+{
+    if (runtime == NULL || metric == NULL || out_value == NULL || SDL_strncmp(metric, "brush.", 6) != 0)
+        return false;
+
+    slayer3d_game_data_brush_diagnostics diagnostics;
+    if (!slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics))
+        return false;
+
+    const char *name = metric + 6;
+    Uint64 value = 0u;
+    if (SDL_strcmp(name, "trace_count") == 0)
+        value = diagnostics.trace_count;
+    else if (SDL_strcmp(name, "world_instance_count") == 0)
+        value = diagnostics.world_instance_count;
+    else if (SDL_strcmp(name, "world_bounds_reject_count") == 0)
+        value = diagnostics.world_bounds_reject_count;
+    else if (SDL_strcmp(name, "brush_count") == 0)
+        value = diagnostics.brush_count;
+    else if (SDL_strcmp(name, "contents_reject_count") == 0)
+        value = diagnostics.contents_reject_count;
+    else if (SDL_strcmp(name, "bounds_reject_count") == 0)
+        value = diagnostics.bounds_reject_count;
+    else if (SDL_strcmp(name, "collision_candidate_count") == 0)
+        value = diagnostics.collision_candidate_count;
+    else if (SDL_strcmp(name, "hit_count") == 0)
+        value = diagnostics.hit_count;
+    else if (SDL_strcmp(name, "render_mesh_submissions") == 0)
+        value = diagnostics.render_mesh_submissions;
+    else if (SDL_strcmp(name, "render_mesh_culled") == 0)
+        value = diagnostics.render_mesh_culled;
+    else if (SDL_strcmp(name, "render_mesh_draws") == 0)
+        value = diagnostics.render_mesh_draws;
+    else if (SDL_strcmp(name, "render_triangles_submitted") == 0)
+        value = diagnostics.render_triangles_submitted;
+    else
+        return false;
+
+    out_value->type = UI_VALUE_UINT64;
+    out_value->as_uint64 = value;
+    return true;
+}
+
 static bool read_ui_binding_value(const slayer3d_game_data_runtime *runtime, yyjson_val *binding,
                                   const slayer3d_game_data_ui_metrics *metrics, ui_value *out_value)
 {
@@ -13979,6 +14023,8 @@ static bool read_ui_binding_value(const slayer3d_game_data_runtime *runtime, yyj
             out_value->as_bool = metrics != NULL && metrics->paused;
             return true;
         }
+        if (read_brush_diagnostic_metric(runtime, metric, out_value))
+            return true;
         return false;
     }
 
@@ -14080,6 +14126,27 @@ static bool format_bound_ui_text(const char *format, const ui_value *values, int
     if (value_count == 2 && values[0].type == UI_VALUE_FLOAT && values[1].type == UI_VALUE_UINT64)
     {
         SDL_snprintf(buffer, buffer_size, format, values[0].as_float, (unsigned long long)values[1].as_uint64);
+        return true;
+    }
+    if (value_count == 2 && values[0].type == UI_VALUE_UINT64 && values[1].type == UI_VALUE_UINT64)
+    {
+        SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64,
+                     (unsigned long long)values[1].as_uint64);
+        return true;
+    }
+    if (value_count == 3 && values[0].type == UI_VALUE_UINT64 && values[1].type == UI_VALUE_UINT64 &&
+        values[2].type == UI_VALUE_UINT64)
+    {
+        SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64,
+                     (unsigned long long)values[1].as_uint64, (unsigned long long)values[2].as_uint64);
+        return true;
+    }
+    if (value_count == 4 && values[0].type == UI_VALUE_UINT64 && values[1].type == UI_VALUE_UINT64 &&
+        values[2].type == UI_VALUE_UINT64 && values[3].type == UI_VALUE_UINT64)
+    {
+        SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64,
+                     (unsigned long long)values[1].as_uint64, (unsigned long long)values[2].as_uint64,
+                     (unsigned long long)values[3].as_uint64);
         return true;
     }
     return false;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -9055,6 +9055,37 @@ static bool validate_data_condition(validation_context *ctx, yyjson_val *conditi
     return validation_error(ctx, path, "unsupported condition type '%s'", type != NULL ? type : "<missing>");
 }
 
+static bool ui_metric_name_valid(const char *metric)
+{
+    if (metric == NULL || metric[0] == '\0')
+        return false;
+
+    static const char *const metrics[] = {
+        "fps",
+        "frame",
+        "paused",
+        "brush.trace_count",
+        "brush.world_instance_count",
+        "brush.world_bounds_reject_count",
+        "brush.brush_count",
+        "brush.contents_reject_count",
+        "brush.bounds_reject_count",
+        "brush.collision_candidate_count",
+        "brush.hit_count",
+        "brush.render_mesh_submissions",
+        "brush.render_mesh_culled",
+        "brush.render_mesh_draws",
+        "brush.render_triangles_submitted",
+    };
+
+    for (size_t i = 0; i < SDL_arraysize(metrics); ++i)
+    {
+        if (SDL_strcmp(metric, metrics[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
 static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *ui = obj_get(root, "ui");
@@ -9102,7 +9133,14 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
                 if (!is_non_empty_string(binding, "key"))
                     return validation_error(ctx, binding_path, "UI property binding requires a non-empty key");
             }
-            else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
+            else if (SDL_strcmp(type != NULL ? type : "", "metric") == 0)
+            {
+                const char *metric = json_string(binding, "metric");
+                if (!ui_metric_name_valid(metric))
+                    return validation_error(ctx, binding_path, "unsupported UI metric '%s'",
+                                            metric != NULL ? metric : "<missing>");
+            }
+            else
             {
                 if (SDL_strcmp(type != NULL ? type : "", "scene_state") != 0)
                     return validation_error(ctx, binding_path, "unsupported UI binding type '%s'",
@@ -10164,7 +10202,14 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
                 if (!is_non_empty_string(binding, "key"))
                     return validation_error(ctx, binding_path, "scene UI property binding requires a non-empty key");
             }
-            else if (SDL_strcmp(type != NULL ? type : "", "metric") != 0)
+            else if (SDL_strcmp(type != NULL ? type : "", "metric") == 0)
+            {
+                const char *metric = json_string(binding, "metric");
+                if (!ui_metric_name_valid(metric))
+                    return validation_error(ctx, binding_path, "unsupported scene UI metric '%s'",
+                                            metric != NULL ? metric : "<missing>");
+            }
+            else
             {
                 if (SDL_strcmp(type != NULL ? type : "", "scene_state") != 0)
                     return validation_error(ctx, binding_path, "unsupported scene UI binding type '%s'",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -7479,6 +7479,30 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_GT(slayer3d_properties_get_int(visible->props, "spotted", 0), 0);
     EXPECT_EQ(slayer3d_properties_get_int(occluded->props, "spotted", 0), 0);
 
+    slayer3d_render_stats before_stats{};
+    slayer3d_render_stats after_stats{};
+    after_stats.model_mesh_submissions = 7;
+    after_stats.model_mesh_culled = 2;
+    after_stats.model_mesh_draws = 5;
+    after_stats.model_triangles_submitted = 128;
+    slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
+    bool saw_render_diagnostics = false;
+    char render_diagnostics[128]{};
+    auto find_render_diagnostics = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+        if (std::string(text->name) != "ui.brush_geometry.render_diagnostics")
+            return true;
+        auto *args = static_cast<std::tuple<slayer3d_game_data_runtime *, bool *, char *> *>(userdata);
+        *std::get<1>(*args) = true;
+        slayer3d_game_data_ui_metrics metrics{};
+        EXPECT_TRUE(slayer3d_game_data_format_ui_text(std::get<0>(*args), text, &metrics, std::get<2>(*args), 128));
+        return false;
+    };
+    std::tuple<slayer3d_game_data_runtime *, bool *, char *> render_diagnostics_args{runtime, &saw_render_diagnostics,
+                                                                                     render_diagnostics};
+    ASSERT_TRUE(slayer3d_game_data_for_each_ui_text(runtime, find_render_diagnostics, &render_diagnostics_args));
+    EXPECT_TRUE(saw_render_diagnostics);
+    EXPECT_STREQ(render_diagnostics, "RENDER 5/7 CULL 2 TRI 128");
+
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
     const int forward = slayer3d_game_data_find_action(runtime, "action.move.forward");


### PR DESCRIPTION
## Summary
- expose brush trace/render diagnostics through validated UI metric bindings
- add a data-authored brush diagnostics overlay to the brush geometry dojo
- document supported brush diagnostic metric names and cover formatting in game-data tests

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test

## Manual test
- ./build/debug/sdl3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json