### PR TITLE
Expose brush editor metadata

### DIFF
--- a/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
+++ b/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
@@ -5,9 +5,39 @@
       "name": "brush.brush_geometry.showcase",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "editor": {
+        "stable_id": "brush_world.showcase.v1",
+        "display_name": "Brush Geometry Showcase",
+        "category": "dojos/brush",
+        "group": "showcase",
+        "tags": ["brush", "dojo", "true_3d"],
+        "snap": { "grid": [0.5, 0.25, 0.5], "rotation_degrees": 15.0, "align_to_floor": true }
+      },
       "materials": [
-        { "name": "mat.floor", "albedo": [0.24, 0.25, 0.27, 1.0], "roughness": 0.9, "tex_scale": 4.0 },
-        { "name": "mat.wall", "albedo": [0.42, 0.44, 0.47, 1.0], "roughness": 0.86, "tex_scale": 4.0 },
+        {
+          "name": "mat.floor",
+          "albedo": [0.24, 0.25, 0.27, 1.0],
+          "roughness": 0.9,
+          "tex_scale": 4.0,
+          "editor": {
+            "stable_id": "brush_material.showcase.floor.v1",
+            "display_name": "Neutral Floor",
+            "category": "materials/brush",
+            "tags": ["floor", "neutral"]
+          }
+        },
+        {
+          "name": "mat.wall",
+          "albedo": [0.42, 0.44, 0.47, 1.0],
+          "roughness": 0.86,
+          "tex_scale": 4.0,
+          "editor": {
+            "stable_id": "brush_material.showcase.wall.v1",
+            "display_name": "Neutral Wall",
+            "category": "materials/brush",
+            "tags": ["wall", "neutral"]
+          }
+        },
         { "name": "mat.ceiling", "albedo": [0.33, 0.34, 0.38, 1.0], "roughness": 0.92, "tex_scale": 4.0 },
         { "name": "mat.ramp", "albedo": [0.64, 0.48, 0.32, 1.0], "roughness": 0.78, "tex_scale": 3.0 },
         { "name": "mat.accent_blue", "albedo": [0.20, 0.40, 0.86, 1.0], "emissive": [0.02, 0.05, 0.12], "roughness": 0.72, "tex_scale": 3.0 },
@@ -19,10 +49,28 @@
           "name": "brush.room.floor",
           "contents": "solid",
           "tags": ["room", "floor"],
+          "editor": {
+            "stable_id": "brush.showcase.room.floor.v1",
+            "display_name": "Room Floor",
+            "category": "brushes/architecture",
+            "group": "room_shell",
+            "tags": ["floor", "shell"],
+            "snap": { "grid": 0.5, "align_to_floor": true }
+          },
           "faces": [
             { "plane": { "normal": [1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
             { "plane": { "normal": [-1, 0, 0], "distance": 18.0 }, "material": "mat.floor" },
-            { "plane": { "normal": [0, 1, 0], "distance": 0.0 }, "material": "mat.floor", "uv": { "scale": [0.5, 0.5], "offset": [0.0, 0.0] } },
+            {
+              "plane": { "normal": [0, 1, 0], "distance": 0.0 },
+              "material": "mat.floor",
+              "uv": { "scale": [0.5, 0.5], "offset": [0.0, 0.0] },
+              "editor": {
+                "stable_id": "brush_face.showcase.room.floor.top.v1",
+                "display_name": "Walkable Floor Surface",
+                "category": "faces/walkable",
+                "group": "room_shell"
+              }
+            },
             { "plane": { "normal": [0, -1, 0], "distance": 0.5 }, "material": "mat.floor" },
             { "plane": { "normal": [0, 0, 1], "distance": 18.0 }, "material": "mat.floor" },
             { "plane": { "normal": [0, 0, -1], "distance": 18.0 }, "material": "mat.floor" }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -470,6 +470,12 @@ in later slices.
       "name": "brush.keep_01",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "editor": {
+        "stable_id": "brush_world.keep_01.v1",
+        "display_name": "Keep 01",
+        "category": "levels/brush",
+        "snap": { "grid": [0.5, 0.25, 0.5], "rotation_degrees": 15.0 }
+      },
       "materials": [
         {
           "name": "stone_wall",
@@ -477,7 +483,12 @@ in later slices.
           "albedo": [0.8, 0.8, 0.8, 1.0],
           "emissive": [0.0, 0.0, 0.0],
           "roughness": 0.9,
-          "tex_scale": 2.0
+          "tex_scale": 2.0,
+          "editor": {
+            "stable_id": "material.keep_01.stone_wall.v1",
+            "display_name": "Stone Wall",
+            "category": "materials/walls"
+          }
         }
       ],
       "brushes": [
@@ -485,11 +496,20 @@ in later slices.
           "name": "brush.start_room",
           "tags": ["room", "solid"],
           "contents": ["solid", "player_clip"],
+          "editor": {
+            "stable_id": "brush.keep_01.start_room.v1",
+            "display_name": "Start Room",
+            "group": "start_area"
+          },
           "faces": [
             {
               "plane": { "normal": [ 1,  0,  0], "distance":  8 },
               "material": "stone_wall",
-              "uv": { "scale": [1.0, 1.0], "offset": [0.0, 0.0], "rotation_degrees": 0.0 }
+              "uv": { "scale": [1.0, 1.0], "offset": [0.0, 0.0], "rotation_degrees": 0.0 },
+              "editor": {
+                "stable_id": "face.keep_01.start_room.east.v1",
+                "display_name": "East Wall"
+              }
             },
             { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "stone_wall" },
             { "plane": { "normal": [ 0,  1,  0], "distance":  4 }, "material": "stone_wall" },
@@ -508,6 +528,8 @@ Validation requires:
 
 - unique brush world names
 - `units` omitted or `"meters"`, with positive `meters_per_unit`
+- optional `editor` metadata on brush worlds, materials, brushes, and faces;
+  `editor.stable_id` values must be unique inside each brush world
 - non-empty `materials` with unique names
 - material `albedo` as vec3/vec4 values in `[0, 1]`
 - non-negative `metallic` and `roughness`
@@ -577,6 +599,13 @@ instrumentation; reset them with
 derived from the generic render-context stats exposed by
 `slayer3d_get_render_stats()`, because brush worlds compile to static model
 meshes that use the same frustum culling path as other models.
+
+Editor metadata attached to brush worlds, materials, brushes, and faces is
+loaded into the runtime descriptors returned by
+`slayer3d_game_data_get_brush_world()`. Tooling can use this metadata for
+stable selection ids, hierarchy grouping, palette filtering, snap hints,
+prefab/archetype references, and face inspectors while still previewing the
+same runtime brush mesh that the game renders.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:
@@ -1259,9 +1288,12 @@ Runtime spawning uses preallocated pools:
 Pools support deterministic spawn/despawn, scene-exit policy, lifecycle safety,
 metrics, and Lua helpers.
 
-`entities`, `actor_archetypes`, `actor_instances`, and `actor_pools` may carry
-an optional `editor` object. The runtime ignores this metadata during gameplay;
-it exists for editors, dojos, palette browsers, prefab previews, and validation.
+`entities`, `actor_archetypes`, `actor_instances`, `actor_pools`, and brush
+world objects may carry an optional `editor` object. The runtime ignores this
+metadata during gameplay; it exists for editors, dojos, palette browsers,
+prefab previews, and validation. Brush editor metadata is also exposed through
+the loaded brush-world descriptors so tools can inspect worlds without
+reparsing JSON.
 
 ```json
 {
@@ -1286,6 +1318,8 @@ Supported editor fields:
 
 - `display_name`, `description`, `category`, `icon`, and `preview_asset`:
   non-empty strings when present
+- `stable_id`, `group`, `prefab`, and `archetype`: non-empty strings when
+  present; brush-world stable ids are validated as unique inside each world
 - `tags`: array of non-empty strings
 - `preview`: object with optional `primitive`, `asset`, and `color`; primitive
   may be `none`, `cube`, `sphere`, `capsule`, `sprite`, `model`, `light`,

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -316,6 +316,41 @@ extern "C"
         SLAYER3D_GAME_DATA_SECTOR_LEVEL_UNLIT = 3,
     } slayer3d_game_data_sector_level_variant;
 
+    /** @brief Optional editor/tooling metadata attached to authored objects. */
+    typedef struct slayer3d_game_data_editor_metadata
+    {
+        /** @brief Optional stable tooling id that survives display-name changes. */
+        const char *stable_id;
+        /** @brief Human-readable name for palettes and inspectors. */
+        const char *display_name;
+        /** @brief Human-readable description for tooling. */
+        const char *description;
+        /** @brief Tooling category path, such as `brushes/architecture`. */
+        const char *category;
+        /** @brief Optional grouping label for hierarchy views. */
+        const char *group;
+        /** @brief Optional prefab/template reference. */
+        const char *prefab;
+        /** @brief Optional actor archetype reference for placement tools. */
+        const char *archetype;
+        /** @brief Optional icon asset or symbolic icon id. */
+        const char *icon;
+        /** @brief Optional preview asset id/path. */
+        const char *preview_asset;
+        /** @brief Optional authored tags for filtering. */
+        const char *const *tags;
+        /** @brief Number of entries in @p tags. */
+        int tag_count;
+        /** @brief True when an explicit snap grid was authored. */
+        bool has_snap_grid;
+        /** @brief Tooling snap grid in authored units. */
+        slayer3d_vec3 snap_grid;
+        /** @brief Positive snap rotation in degrees, or 0 when omitted. */
+        float snap_rotation_degrees;
+        /** @brief Whether placement tools should align the object to floors. */
+        bool snap_align_to_floor;
+    } slayer3d_game_data_editor_metadata;
+
     /**
      * @brief Active-scene instance of an authored sector level.
      *
@@ -394,6 +429,8 @@ extern "C"
         slayer3d_vec3 emissive;
         /** @brief Positive texture scale hint. */
         float tex_scale;
+        /** @brief Optional editor/tooling metadata. */
+        slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush_material;
 
     /** @brief One plane-bounded face on an authored convex brush. */
@@ -415,6 +452,8 @@ extern "C"
         float uv_rotation_degrees;
         /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_SURFACE_* flags. */
         unsigned int surface_flags;
+        /** @brief Optional editor/tooling metadata. */
+        slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush_face;
 
     /** @brief Authored convex brush loaded into runtime-owned data. */
@@ -436,6 +475,8 @@ extern "C"
         slayer3d_bounding_box bounds;
         /** @brief True when @p bounds is valid. */
         bool has_bounds;
+        /** @brief Optional editor/tooling metadata. */
+        slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush;
 
     /** @brief Runtime-owned native brush world. */
@@ -461,6 +502,8 @@ extern "C"
         slayer3d_bounding_box bounds;
         /** @brief True when @p bounds is valid. */
         bool has_bounds;
+        /** @brief Optional editor/tooling metadata. */
+        slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush_world;
 
     /** @brief Active-scene instance of an authored brush world. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -691,6 +691,9 @@ static int sector_level_find_sector_name(const sector_level_runtime *level, cons
 static void modulate_color_by_sector_lighting(slayer3d_color *color, const slayer3d_sector *sector);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
+static bool load_editor_metadata(yyjson_val *editor, slayer3d_game_data_editor_metadata *out_metadata,
+                                 char *error_buffer, int error_buffer_size);
+static void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata);
 
 static float game_data_random01(slayer3d_game_data_runtime *runtime)
 {
@@ -3697,6 +3700,8 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
             set_error(error_buffer, error_buffer_size, "failed to allocate brush world strings");
             return false;
         }
+        if (!load_editor_metadata(obj_get(world_json, "editor"), &world->editor, error_buffer, error_buffer_size))
+            return false;
 
         slayer3d_game_data_brush_material *materials =
             (slayer3d_game_data_brush_material *)SDL_calloc((size_t)world->material_count, sizeof(*materials));
@@ -3729,6 +3734,9 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 set_error(error_buffer, error_buffer_size, "failed to allocate brush material strings");
                 return false;
             }
+            if (!load_editor_metadata(obj_get(material_json, "editor"), &material->editor, error_buffer,
+                                      error_buffer_size))
+                return false;
         }
 
         for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
@@ -3747,6 +3755,8 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 set_error(error_buffer, error_buffer_size, "failed to allocate brush name");
                 return false;
             }
+            if (!load_editor_metadata(obj_get(brush_json, "editor"), &brush->editor, error_buffer, error_buffer_size))
+                return false;
 
             const char **tags =
                 brush->tag_count > 0 ? (const char **)SDL_calloc((size_t)brush->tag_count, sizeof(*tags)) : NULL;
@@ -3788,6 +3798,8 @@ static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *r
                 face->uv_rotation_degrees = json_float(uv_json, "rotation_degrees", 0.0f);
                 face->surface_flags =
                     brush_flags_from_json(obj_get(face_json, "surface_flags"), brush_surface_flag_from_string, 0u);
+                if (!load_editor_metadata(obj_get(face_json, "editor"), &face->editor, error_buffer, error_buffer_size))
+                    return false;
             }
         }
 
@@ -3817,6 +3829,114 @@ static slayer3d_bounding_box json_bounds(yyjson_val *value, slayer3d_bounding_bo
         json_vec3(value, "min", fallback.min),
         json_vec3(value, "max", fallback.max),
     };
+}
+
+static bool load_editor_metadata(yyjson_val *editor, slayer3d_game_data_editor_metadata *out_metadata,
+                                 char *error_buffer, int error_buffer_size)
+{
+    if (out_metadata == NULL)
+        return false;
+    SDL_zero(*out_metadata);
+    if (!yyjson_is_obj(editor))
+        return true;
+
+    const char *stable_id = json_string(editor, "stable_id", NULL);
+    const char *display_name = json_string(editor, "display_name", NULL);
+    const char *description = json_string(editor, "description", NULL);
+    const char *category = json_string(editor, "category", NULL);
+    const char *group = json_string(editor, "group", NULL);
+    const char *prefab = json_string(editor, "prefab", NULL);
+    const char *archetype = json_string(editor, "archetype", NULL);
+    const char *icon = json_string(editor, "icon", NULL);
+    const char *preview_asset = json_string(editor, "preview_asset", NULL);
+    yyjson_val *snap = obj_get(editor, "snap");
+    yyjson_val *tags = obj_get(editor, "tags");
+
+#define DUP_EDITOR_STRING(field, source)                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((source) != NULL)                                                                                          \
+        {                                                                                                              \
+            (field) = SDL_strdup(source);                                                                              \
+            if ((field) == NULL)                                                                                       \
+            {                                                                                                          \
+                set_error(error_buffer, error_buffer_size, "failed to allocate editor metadata string");               \
+                goto fail;                                                                                             \
+            }                                                                                                          \
+        }                                                                                                              \
+    } while (0)
+
+    DUP_EDITOR_STRING(out_metadata->stable_id, stable_id);
+    DUP_EDITOR_STRING(out_metadata->display_name, display_name);
+    DUP_EDITOR_STRING(out_metadata->description, description);
+    DUP_EDITOR_STRING(out_metadata->category, category);
+    DUP_EDITOR_STRING(out_metadata->group, group);
+    DUP_EDITOR_STRING(out_metadata->prefab, prefab);
+    DUP_EDITOR_STRING(out_metadata->archetype, archetype);
+    DUP_EDITOR_STRING(out_metadata->icon, icon);
+    DUP_EDITOR_STRING(out_metadata->preview_asset, preview_asset);
+#undef DUP_EDITOR_STRING
+
+    out_metadata->tag_count = yyjson_is_arr(tags) ? (int)yyjson_arr_size(tags) : 0;
+    if (out_metadata->tag_count > 0)
+    {
+        const char **tag_storage = (const char **)SDL_calloc((size_t)out_metadata->tag_count, sizeof(*tag_storage));
+        if (tag_storage == NULL)
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate editor metadata tags");
+            goto fail;
+        }
+        out_metadata->tags = tag_storage;
+        for (int i = 0; i < out_metadata->tag_count; ++i)
+        {
+            tag_storage[i] = SDL_strdup(yyjson_get_str(yyjson_arr_get(tags, (size_t)i)));
+            if (tag_storage[i] == NULL)
+            {
+                set_error(error_buffer, error_buffer_size, "failed to allocate editor metadata tag");
+                goto fail;
+            }
+        }
+    }
+
+    yyjson_val *grid = obj_get(snap, "grid");
+    out_metadata->snap_grid = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    if (yyjson_is_num(grid))
+    {
+        const float value = (float)yyjson_get_num(grid);
+        out_metadata->snap_grid = slayer3d_vec3_make(value, value, value);
+        out_metadata->has_snap_grid = true;
+    }
+    else if (yyjson_is_arr(grid) && yyjson_arr_size(grid) >= 3)
+    {
+        out_metadata->snap_grid = json_vec3_value(grid, out_metadata->snap_grid);
+        out_metadata->has_snap_grid = true;
+    }
+    out_metadata->snap_rotation_degrees = json_float(snap, "rotation_degrees", 0.0f);
+    out_metadata->snap_align_to_floor = json_bool(snap, "align_to_floor", false);
+    return true;
+
+fail:
+    free_editor_metadata(out_metadata);
+    return false;
+}
+
+static void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata)
+{
+    if (metadata == NULL)
+        return;
+    SDL_free((void *)metadata->stable_id);
+    SDL_free((void *)metadata->display_name);
+    SDL_free((void *)metadata->description);
+    SDL_free((void *)metadata->category);
+    SDL_free((void *)metadata->group);
+    SDL_free((void *)metadata->prefab);
+    SDL_free((void *)metadata->archetype);
+    SDL_free((void *)metadata->icon);
+    SDL_free((void *)metadata->preview_asset);
+    for (int i = 0; i < metadata->tag_count; ++i)
+        SDL_free((void *)metadata->tags[i]);
+    SDL_free((void *)metadata->tags);
+    SDL_zero(*metadata);
 }
 
 static bool load_sector_doors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
@@ -24148,20 +24268,30 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     {
         slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
         slayer3d_free_model(&runtime->brush_worlds[i].render_model);
+        free_editor_metadata(&world->editor);
         SDL_free((void *)world->name);
         SDL_free((void *)world->units);
         for (int material_index = 0; material_index < world->material_count; ++material_index)
         {
-            SDL_free((void *)world->materials[material_index].name);
-            SDL_free((void *)world->materials[material_index].texture);
+            slayer3d_game_data_brush_material *material =
+                (slayer3d_game_data_brush_material *)&world->materials[material_index];
+            free_editor_metadata(&material->editor);
+            SDL_free((void *)material->name);
+            SDL_free((void *)material->texture);
         }
         for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
         {
-            const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+            slayer3d_game_data_brush *brush = (slayer3d_game_data_brush *)&world->brushes[brush_index];
             SDL_free((void *)brush->name);
+            free_editor_metadata(&brush->editor);
             for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
                 SDL_free((void *)brush->tags[tag_index]);
             SDL_free((void *)brush->tags);
+            for (int face_index = 0; face_index < brush->face_count; ++face_index)
+            {
+                slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[face_index];
+                free_editor_metadata(&face->editor);
+            }
             SDL_free((void *)brush->faces);
         }
         SDL_free((void *)world->materials);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -129,6 +129,10 @@ static void format_path(char *buffer, size_t buffer_size, const char *format, ..
 static bool validation_error(validation_context *ctx, const char *json_path, const char *format, ...);
 static bool validate_target_filter_fields(validation_context *ctx, yyjson_val *json, const char *json_path,
                                           const char *type);
+static bool validate_editor_metadata(validation_context *ctx, yyjson_val *metadata, const char *json_path,
+                                     validation_names *names, bool allow_templates);
+static bool require_unique_editor_stable_id(validation_context *ctx, name_table *stable_ids, yyjson_val *json,
+                                            const char *json_path);
 static bool validate_imports_with_stack(validation_context *ctx, yyjson_val *root, import_validation_stack *stack);
 static bool validate_imports(validation_context *ctx, yyjson_val *root);
 static bool compose_document_into(validation_context *ctx, yyjson_val *root, yyjson_val *sections,
@@ -5099,7 +5103,7 @@ static bool validate_sector_levels(validation_context *ctx, yyjson_val *root)
     return true;
 }
 
-static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
+static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *worlds = obj_get(root, "brush_worlds");
     if (worlds == NULL)
@@ -5116,8 +5120,10 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
         yyjson_val *brushes = obj_get(world, "brushes");
         name_table material_names;
         name_table brush_names;
+        name_table editor_stable_ids;
         SDL_zero(material_names);
         SDL_zero(brush_names);
+        SDL_zero(editor_stable_ids);
         bool ok = true;
 
         if (!yyjson_is_obj(world))
@@ -5137,6 +5143,16 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
         {
             ok = validation_error(ctx, world_path, "brush world meters_per_unit must be positive");
             goto done;
+        }
+        {
+            char editor_path[PATH_BUFFER_SIZE];
+            format_path(editor_path, sizeof(editor_path), "%s.editor", world_path);
+            if (!validate_editor_metadata(ctx, obj_get(world, "editor"), editor_path, names, false) ||
+                !require_unique_editor_stable_id(ctx, &editor_stable_ids, world, world_path))
+            {
+                ok = false;
+                goto done;
+            }
         }
         if (!yyjson_is_arr(materials) || yyjson_arr_size(materials) <= 0)
         {
@@ -5164,6 +5180,16 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
             {
                 ok = false;
                 break;
+            }
+            {
+                char editor_path[PATH_BUFFER_SIZE];
+                format_path(editor_path, sizeof(editor_path), "%s.editor", material_path);
+                if (!validate_editor_metadata(ctx, obj_get(material, "editor"), editor_path, names, false) ||
+                    !require_unique_editor_stable_id(ctx, &editor_stable_ids, material, material_path))
+                {
+                    ok = false;
+                    break;
+                }
             }
             yyjson_val *albedo = obj_get(material, "albedo");
             if (albedo != NULL &&
@@ -5222,6 +5248,16 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
             {
                 ok = false;
                 break;
+            }
+            {
+                char editor_path[PATH_BUFFER_SIZE];
+                format_path(editor_path, sizeof(editor_path), "%s.editor", brush_path);
+                if (!validate_editor_metadata(ctx, obj_get(brush, "editor"), editor_path, names, false) ||
+                    !require_unique_editor_stable_id(ctx, &editor_stable_ids, brush, brush_path))
+                {
+                    ok = false;
+                    break;
+                }
             }
 
             yyjson_val *tags = obj_get(brush, "tags");
@@ -5293,6 +5329,16 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
                     ok = validation_error(ctx, face_path, "brush face material must reference a declared material");
                     break;
                 }
+                {
+                    char editor_path[PATH_BUFFER_SIZE];
+                    format_path(editor_path, sizeof(editor_path), "%s.editor", face_path);
+                    if (!validate_editor_metadata(ctx, obj_get(face, "editor"), editor_path, names, false) ||
+                        !require_unique_editor_stable_id(ctx, &editor_stable_ids, face, face_path))
+                    {
+                        ok = false;
+                        break;
+                    }
+                }
                 if (!validate_brush_string_or_string_array(ctx, obj_get(face, "surface_flags"), flags_path,
                                                            "brush surface flag", brush_surface_flag_name_valid, true))
                 {
@@ -5331,6 +5377,7 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root)
     done:
         name_table_destroy(&material_names);
         name_table_destroy(&brush_names);
+        name_table_destroy(&editor_stable_ids);
         if (!ok)
             return false;
     }
@@ -6446,8 +6493,12 @@ static bool validate_editor_metadata(validation_context *ctx, yyjson_val *metada
         return validation_error(ctx, json_path, "editor metadata must be an object");
 
     if (!editor_string_field_valid(ctx, metadata, "display_name", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "stable_id", json_path) ||
         !editor_string_field_valid(ctx, metadata, "description", json_path) ||
         !editor_string_field_valid(ctx, metadata, "category", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "group", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "prefab", json_path) ||
+        !editor_string_field_valid(ctx, metadata, "archetype", json_path) ||
         !editor_string_field_valid(ctx, metadata, "icon", json_path) ||
         !editor_string_field_valid(ctx, metadata, "preview_asset", json_path) ||
         !editor_tags_valid(ctx, obj_get(metadata, "tags"), json_path) ||
@@ -6534,6 +6585,18 @@ static bool validate_editor_metadata_tree(validation_context *ctx, yyjson_val *r
             return false;
     }
     return true;
+}
+
+static bool require_unique_editor_stable_id(validation_context *ctx, name_table *stable_ids, yyjson_val *json,
+                                            const char *json_path)
+{
+    yyjson_val *editor = obj_get(json, "editor");
+    const char *stable_id = json_string(editor, "stable_id");
+    if (stable_id == NULL)
+        return true;
+    char path[PATH_BUFFER_SIZE];
+    format_path(path, sizeof(path), "%s.editor", json_path);
+    return require_unique_name(ctx, stable_ids, "editor stable id", stable_id, path);
 }
 
 static bool is_tween_easing(const char *easing)
@@ -10371,7 +10434,7 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_world_metadata(ctx, root) && validate_input_bindings(ctx, root) &&
            validate_input_assignment_sets(ctx, root) && validate_input_profiles(ctx, root, names) &&
            validate_grid_maps(ctx, root) && validate_grid_pickup_layers(ctx, root, names) &&
-           validate_sector_levels(ctx, root) && validate_brush_worlds(ctx, root) &&
+           validate_sector_levels(ctx, root) && validate_brush_worlds(ctx, root, names) &&
            validate_sector_navigation(ctx, root, names) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -10714,13 +10714,27 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
       "name": "brush.test",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "editor": {
+        "stable_id": "brush_world.test.v1",
+        "display_name": "Brush Test World",
+        "category": "tests/brush",
+        "group": "runtime",
+        "tags": ["brush", "runtime"],
+        "snap": { "grid": [0.5, 0.25, 0.5], "rotation_degrees": 15.0, "align_to_floor": true }
+      },
       "materials": [
         {
           "name": "mat.wall",
           "albedo": [0.25, 0.35, 0.45, 1.0],
           "metallic": 0.0,
           "roughness": 0.8,
-          "tex_scale": 2.0
+          "tex_scale": 2.0,
+          "editor": {
+            "stable_id": "brush_material.test.wall.v1",
+            "display_name": "Test Wall",
+            "category": "materials/test",
+            "tags": ["wall"]
+          }
         },
         {
           "name": "mat.trim",
@@ -10734,10 +10748,26 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
           "name": "brush.room",
           "tags": ["solid", "room"],
           "contents": ["solid", "player_clip"],
+          "editor": {
+            "stable_id": "brush.test.room.v1",
+            "display_name": "Runtime Test Room",
+            "group": "room",
+            "prefab": "prefab.test.room"
+          },
           "faces": [
             { "plane": { "normal": [ 1.0,  0.0,  0.0], "distance":  4.0 }, "material": "mat.wall" },
             { "plane": { "normal": [-1.0,  0.0,  0.0], "distance":  0.0 }, "material": 0 },
-            { "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 }, "material": "mat.wall", "surface_flags": ["slick"], "uv": { "scale": [2.0, 0.5], "offset": [0.25, -0.5], "rotation_degrees": 90.0 } },
+            {
+              "plane": { "normal": [ 0.0,  1.0,  0.0], "distance":  3.0 },
+              "material": "mat.wall",
+              "surface_flags": ["slick"],
+              "uv": { "scale": [2.0, 0.5], "offset": [0.25, -0.5], "rotation_degrees": 90.0 },
+              "editor": {
+                "stable_id": "brush_face.test.room.ceiling.v1",
+                "display_name": "Room Ceiling Face",
+                "group": "room_faces"
+              }
+            },
             { "plane": { "normal": [ 0.0, -1.0,  0.0], "distance":  0.0 }, "material": "mat.wall" },
             { "plane": { "normal": [ 0.0,  0.0,  1.0], "distance":  4.0 }, "material": "mat.trim", "surface_flags": "emissive" },
             { "plane": { "normal": [ 0.0,  0.0, -1.0], "distance":  0.0 }, "material": "mat.wall" }
@@ -10763,15 +10793,32 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(world.name, "brush.test");
     EXPECT_STREQ(world.units, "meters");
     EXPECT_FLOAT_EQ(world.meters_per_unit, 1.0f);
+    EXPECT_STREQ(world.editor.stable_id, "brush_world.test.v1");
+    EXPECT_STREQ(world.editor.display_name, "Brush Test World");
+    EXPECT_STREQ(world.editor.category, "tests/brush");
+    EXPECT_STREQ(world.editor.group, "runtime");
+    ASSERT_EQ(world.editor.tag_count, 2);
+    EXPECT_STREQ(world.editor.tags[1], "runtime");
+    EXPECT_TRUE(world.editor.has_snap_grid);
+    expect_vec3_near(world.editor.snap_grid, slayer3d_vec3_make(0.5f, 0.25f, 0.5f));
+    EXPECT_FLOAT_EQ(world.editor.snap_rotation_degrees, 15.0f);
+    EXPECT_TRUE(world.editor.snap_align_to_floor);
     ASSERT_EQ(world.material_count, 2);
     EXPECT_STREQ(world.materials[0].name, "mat.wall");
     EXPECT_FLOAT_EQ(world.materials[0].albedo.z, 0.45f);
     EXPECT_FLOAT_EQ(world.materials[0].roughness, 0.8f);
     EXPECT_FLOAT_EQ(world.materials[0].tex_scale, 2.0f);
+    EXPECT_STREQ(world.materials[0].editor.stable_id, "brush_material.test.wall.v1");
+    EXPECT_STREQ(world.materials[0].editor.display_name, "Test Wall");
+    ASSERT_EQ(world.materials[0].editor.tag_count, 1);
+    EXPECT_STREQ(world.materials[0].editor.tags[0], "wall");
     EXPECT_STREQ(world.materials[1].name, "mat.trim");
     EXPECT_FLOAT_EQ(world.materials[1].emissive.x, 0.4f);
     ASSERT_EQ(world.brush_count, 1);
     EXPECT_STREQ(world.brushes[0].name, "brush.room");
+    EXPECT_STREQ(world.brushes[0].editor.stable_id, "brush.test.room.v1");
+    EXPECT_STREQ(world.brushes[0].editor.display_name, "Runtime Test Room");
+    EXPECT_STREQ(world.brushes[0].editor.prefab, "prefab.test.room");
     EXPECT_EQ(world.brushes[0].contents,
               SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
     ASSERT_EQ(world.brushes[0].tag_count, 2);
@@ -10787,6 +10834,8 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_offset[0], 0.25f);
     EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_offset[1], -0.5f);
     EXPECT_FLOAT_EQ(world.brushes[0].faces[2].uv_rotation_degrees, 90.0f);
+    EXPECT_STREQ(world.brushes[0].faces[2].editor.stable_id, "brush_face.test.room.ceiling.v1");
+    EXPECT_STREQ(world.brushes[0].faces[2].editor.display_name, "Room Ceiling Face");
     EXPECT_EQ(world.brushes[0].faces[4].material_index, 1);
     EXPECT_EQ(world.brushes[0].faces[4].surface_flags, SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE);
     ASSERT_NE(world.render_model, nullptr);
@@ -11009,6 +11058,33 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
   "world": { "brush_worlds": [{ "world": "brush.good", "lighting": "yes" }] }
 })json",
             "scene brush world lighting must be a boolean",
+        },
+        {
+            "duplicate_editor_stable_id",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "editor": { "stable_id": "stable.duplicate" },
+      "materials": [
+        { "name": "mat.good", "editor": { "stable_id": "stable.duplicate" } }
+      ],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "duplicate editor stable id",
         },
     };
 


### PR DESCRIPTION
## Summary
- add runtime editor metadata descriptors for brush worlds, brush materials, brushes, and faces
- validate brush editor metadata and reject duplicate stable ids inside each brush world
- annotate the brush geometry dojo with stable tooling metadata and document the brush/editor metadata contract

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.RejectsInvalidBrushWorlds:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'
- ./build/debug/tests/slayer3d_game_data_test

Closes #306. Opened #323 for the follow-on editor/runtime foundation work.