### PR TITLE
Add generic world model query interface

### DIFF
--- a/docs/game-data-model.md
+++ b/docs/game-data-model.md
@@ -94,6 +94,16 @@ World-specific systems should be optional modules. A sector renderer should not
 leak sector assumptions into a fixed-screen game; a tile-map system should not
 force grid assumptions into a 3D scene.
 
+Editor and tooling code should prefer the generic world-model query layer over
+parsing authored scene JSON directly. The game-data runtime can enumerate active
+world instances, return world-space bounds, perform generic trace and
+point-contents queries, and expose diagnostics with stable references back to
+the underlying sector level or brush world. Sector and brush implementations
+remain distinct internally, but tools can start from the shared
+`slayer3d_game_data_for_each_world_model_instance`,
+`slayer3d_game_data_trace_world_models`, and
+`slayer3d_game_data_query_world_model_point` APIs.
+
 ## Data Boundary
 
 Use JSON for:

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -611,6 +611,137 @@ extern "C"
         Uint64 render_triangles_submitted;
     } slayer3d_game_data_brush_diagnostics;
 
+    /** @brief Runtime world model implementation kind. */
+    typedef enum slayer3d_game_data_world_model_type
+    {
+        /** @brief Invalid or unavailable world model type. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID = 0,
+        /** @brief Sector/portal world model built from 2.5D sector geometry. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL = 1,
+        /** @brief Convex brush world model built from true 3D brush planes. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD = 2,
+    } slayer3d_game_data_world_model_type;
+
+    enum
+    {
+        /** @brief Include authored sector level instances in generic world-model queries. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS = 1u << 0,
+        /** @brief Include authored brush world instances in generic world-model queries. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS = 1u << 1,
+        /** @brief Include every supported authored world model in generic world-model queries. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_ALL =
+            SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS | SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS,
+    };
+
+    /** @brief Active-scene world model instance descriptor for editor/tooling code. */
+    typedef struct slayer3d_game_data_world_model_instance
+    {
+        /** @brief Runtime implementation kind. */
+        slayer3d_game_data_world_model_type type;
+        /** @brief Authored world model name, such as a sector level or brush world id. */
+        const char *name;
+        /** @brief Optional authored variant/debug label, such as a sector level variant. */
+        const char *variant_name;
+        /** @brief World-space translation applied to this model instance. */
+        slayer3d_vec3 position;
+        /** @brief World-space bounds for the instance when known. */
+        slayer3d_bounding_box bounds;
+        /** @brief True when @p bounds contains usable world-space bounds. */
+        bool has_bounds;
+        /** @brief Sector level for sector instances, otherwise NULL. */
+        const slayer3d_level *sector_level;
+        /** @brief Runtime sectors for sector instances, otherwise NULL. */
+        const slayer3d_sector *sectors;
+        /** @brief Number of entries in @p sectors. */
+        int sector_count;
+        /** @brief Brush world for brush instances, otherwise NULL. */
+        const slayer3d_game_data_brush_world *brush_world;
+    } slayer3d_game_data_world_model_instance;
+
+    /** @brief Generic trace descriptor for active world model queries. */
+    typedef struct slayer3d_game_data_world_trace_desc
+    {
+        /** @brief Trace start point in world coordinates. */
+        slayer3d_vec3 start;
+        /** @brief Trace end point in world coordinates. */
+        slayer3d_vec3 end;
+        /** @brief Shape to sweep. Sector levels currently support point traces; brush worlds support all values. */
+        slayer3d_game_data_brush_trace_shape shape;
+        /** @brief Sphere radius in x, or AABB half-extents for xyz. */
+        slayer3d_vec3 extents;
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_CONTENT_* flags for brush traces. */
+        unsigned int contents_mask;
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_* flags, or 0 for all models. */
+        unsigned int model_filter;
+    } slayer3d_game_data_world_trace_desc;
+
+    /** @brief Generic trace/pick result for active world model queries. */
+    typedef struct slayer3d_game_data_world_trace_result
+    {
+        /** @brief True when the trace intersected or exited a matching world model. */
+        bool hit;
+        /** @brief True when the trace starts inside a matching solid brush. */
+        bool start_solid;
+        /** @brief True when the trace remains inside a matching solid brush. */
+        bool all_solid;
+        /** @brief Implementation that produced the hit. */
+        slayer3d_game_data_world_model_type type;
+        /** @brief Authored world model name. */
+        const char *world_name;
+        /** @brief Authored sector/brush name when available. */
+        const char *element_name;
+        /** @brief Authored material name for brush face hits, or NULL. */
+        const char *material_name;
+        /** @brief Sector or brush index, or -1 when unavailable. */
+        int element_index;
+        /** @brief Brush face index, or -1 when unavailable. */
+        int face_index;
+        /** @brief First hit fraction in [0, 1] along start-to-end. */
+        float fraction;
+        /** @brief End position at @p fraction. */
+        slayer3d_vec3 end_position;
+        /** @brief Hit point on the swept shape origin path. */
+        slayer3d_vec3 point;
+        /** @brief Hit plane normal for brush traces, or zero for sector exit traces. */
+        slayer3d_vec3 normal;
+        /** @brief Brush contents bitmask, or 0 for sector traces. */
+        unsigned int contents;
+        /** @brief Brush surface flags, or 0 for sector traces. */
+        unsigned int surface_flags;
+    } slayer3d_game_data_world_trace_result;
+
+    /** @brief Generic point-contents result for active world model queries. */
+    typedef struct slayer3d_game_data_world_point_result
+    {
+        /** @brief True when the point lies inside a matching world model volume. */
+        bool inside;
+        /** @brief Implementation that contains the point. */
+        slayer3d_game_data_world_model_type type;
+        /** @brief Authored world model name. */
+        const char *world_name;
+        /** @brief Authored sector/brush name when available. */
+        const char *element_name;
+        /** @brief Sector or brush index, or -1 when unavailable. */
+        int element_index;
+        /** @brief Brush contents bitmask, or 0 for sector point queries. */
+        unsigned int contents;
+    } slayer3d_game_data_world_point_result;
+
+    /** @brief Generic world-model diagnostics for editor/debug UI. */
+    typedef struct slayer3d_game_data_world_model_diagnostics
+    {
+        /** @brief Active sector level instances enumerated by the last diagnostic query. */
+        Uint64 active_sector_level_instances;
+        /** @brief Active brush world instances enumerated by the last diagnostic query. */
+        Uint64 active_brush_world_instances;
+        /** @brief Cumulative generic world trace requests. */
+        Uint64 world_trace_count;
+        /** @brief Cumulative generic point-contents requests. */
+        Uint64 point_query_count;
+        /** @brief Existing brush-world trace/render diagnostics. */
+        slayer3d_game_data_brush_diagnostics brush;
+    } slayer3d_game_data_world_model_diagnostics;
+
     /**
      * @brief Callback for active authored sector level instances.
      *
@@ -626,6 +757,16 @@ extern "C"
      */
     typedef bool (*slayer3d_game_data_brush_world_instance_fn)(void *userdata,
                                                                const slayer3d_game_data_brush_world_instance *instance);
+
+    /**
+     * @brief Callback for active authored world model instances.
+     *
+     * Return false to stop iteration early. The descriptor and all nested
+     * pointers are valid only for the duration of the callback; strings and
+     * native world pointers are runtime-owned.
+     */
+    typedef bool (*slayer3d_game_data_world_model_instance_fn)(void *userdata,
+                                                               const slayer3d_game_data_world_model_instance *instance);
 
     /**
      * @brief Runtime metrics used when evaluating data-authored UI bindings.
@@ -1525,6 +1666,52 @@ extern "C"
     bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_runtime *runtime,
                                                           slayer3d_game_data_brush_world_instance_fn callback,
                                                           void *userdata);
+
+    /**
+     * @brief Iterate all active scene world model instances through a common descriptor.
+     *
+     * This is the editor/tooling-facing enumeration layer over sector and
+     * brush worlds. It allows tools to inspect placement, bounds, and stable
+     * world references without branching over the authored scene JSON shape.
+     */
+    bool slayer3d_game_data_for_each_world_model_instance(const slayer3d_game_data_runtime *runtime,
+                                                          slayer3d_game_data_world_model_instance_fn callback,
+                                                          void *userdata);
+
+    /**
+     * @brief Trace through active scene world model instances.
+     *
+     * Brush worlds use the existing brush trace implementation. Sector levels
+     * currently support point traces that detect exiting sector volume; shaped
+     * traces are ignored for sector models and still evaluated against brush
+     * models when included by @p desc.model_filter.
+     */
+    bool slayer3d_game_data_trace_world_models(const slayer3d_game_data_runtime *runtime,
+                                               const slayer3d_game_data_world_trace_desc *desc,
+                                               slayer3d_game_data_world_trace_result *out_result);
+
+    /**
+     * @brief Query which active world model volume contains a point.
+     *
+     * The first matching sector or brush volume in active-scene order is
+     * returned. Set @p model_filter to a bitmask of
+     * SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_* values, or 0 for all models.
+     * Set @p brush_contents_mask to a bitmask of
+     * SLAYER3D_GAME_DATA_BRUSH_CONTENT_* values for brush point queries, or 0
+     * for every brush contents type.
+     */
+    bool slayer3d_game_data_query_world_model_point(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 point,
+                                                    unsigned int model_filter, unsigned int brush_contents_mask,
+                                                    slayer3d_game_data_world_point_result *out_result);
+
+    /**
+     * @brief Copy generic world-model diagnostics for debug UI and editor tools.
+     *
+     * Instance counts reflect the currently active scene at call time. Trace
+     * and point-query counts are cumulative until the runtime is destroyed.
+     */
+    bool slayer3d_game_data_get_world_model_diagnostics(const slayer3d_game_data_runtime *runtime,
+                                                        slayer3d_game_data_world_model_diagnostics *out_diagnostics);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -592,6 +592,8 @@ typedef struct slayer3d_game_data_runtime
     brush_world_runtime *brush_worlds;
     int brush_world_count;
     slayer3d_game_data_brush_diagnostics brush_diagnostics;
+    Uint64 world_model_trace_count;
+    Uint64 world_model_point_query_count;
     sector_door_runtime *sector_doors;
     int sector_door_count;
     sector_platform_runtime *sector_platforms;

--- a/src/game_data/game_data_world_queries.inc
+++ b/src/game_data/game_data_world_queries.inc
@@ -793,6 +793,102 @@ bool slayer3d_game_data_slide_active_brush_worlds(const slayer3d_game_data_runti
 static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
                                                                                 const slayer3d_level **out_level,
                                                                                 const sector_level_runtime *level,
+                                                                                bool sector_lighting_enabled);
+
+static unsigned int world_model_filter_or_all(unsigned int model_filter)
+{
+    return model_filter != 0u ? model_filter : SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_ALL;
+}
+
+static unsigned int brush_contents_mask_or_all(unsigned int contents_mask)
+{
+    return contents_mask != 0u ? contents_mask
+                               : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP |
+                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER | SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER |
+                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY;
+}
+
+static slayer3d_bounding_box translated_bounds(slayer3d_bounding_box bounds, slayer3d_vec3 position)
+{
+    bounds.min = slayer3d_vec3_add(bounds.min, position);
+    bounds.max = slayer3d_vec3_add(bounds.max, position);
+    return bounds;
+}
+
+static bool model_bounds(const slayer3d_model *model, slayer3d_bounding_box *out_bounds)
+{
+    if (out_bounds != NULL)
+        SDL_zero(*out_bounds);
+    if (model == NULL || out_bounds == NULL)
+        return false;
+
+    bool has_bounds = false;
+    for (int i = 0; i < model->mesh_count; ++i)
+    {
+        const slayer3d_mesh *mesh = &model->meshes[i];
+        if (!mesh->has_local_bounds)
+            continue;
+        if (!has_bounds)
+        {
+            *out_bounds = mesh->local_bounds;
+            has_bounds = true;
+            continue;
+        }
+        out_bounds->min.x = SDL_min(out_bounds->min.x, mesh->local_bounds.min.x);
+        out_bounds->min.y = SDL_min(out_bounds->min.y, mesh->local_bounds.min.y);
+        out_bounds->min.z = SDL_min(out_bounds->min.z, mesh->local_bounds.min.z);
+        out_bounds->max.x = SDL_max(out_bounds->max.x, mesh->local_bounds.max.x);
+        out_bounds->max.y = SDL_max(out_bounds->max.y, mesh->local_bounds.max.y);
+        out_bounds->max.z = SDL_max(out_bounds->max.z, mesh->local_bounds.max.z);
+    }
+    return has_bounds;
+}
+
+static void init_world_trace_result(const slayer3d_game_data_world_trace_desc *desc,
+                                    slayer3d_game_data_world_trace_result *out_result)
+{
+    if (out_result == NULL)
+        return;
+    SDL_zero(*out_result);
+    out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+    out_result->element_index = -1;
+    out_result->face_index = -1;
+    out_result->fraction = 1.0f;
+    if (desc != NULL)
+    {
+        out_result->end_position = desc->end;
+        out_result->point = desc->end;
+    }
+}
+
+static void init_world_point_result(slayer3d_game_data_world_point_result *out_result)
+{
+    if (out_result == NULL)
+        return;
+    SDL_zero(*out_result);
+    out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+    out_result->element_index = -1;
+}
+
+static bool world_trace_shape_valid(slayer3d_game_data_brush_trace_shape shape, slayer3d_vec3 extents)
+{
+    switch (shape)
+    {
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT:
+        return true;
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_SPHERE:
+        return extents.x >= 0.0f;
+    case SLAYER3D_GAME_DATA_BRUSH_TRACE_AABB:
+        return extents.x >= 0.0f && extents.y >= 0.0f && extents.z >= 0.0f;
+    default:
+        return false;
+    }
+}
+
+static slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
+                                                                                const slayer3d_level **out_level,
+                                                                                const sector_level_runtime *level,
                                                                                 bool sector_lighting_enabled)
 {
     if (out_level != NULL)
@@ -905,5 +1001,322 @@ bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_r
         if (!callback(userdata, &instance))
             return true;
     }
+    return true;
+}
+
+typedef struct world_model_iteration_context
+{
+    slayer3d_game_data_world_model_instance_fn callback;
+    void *userdata;
+    bool stopped;
+} world_model_iteration_context;
+
+static bool emit_sector_world_model_instance(void *userdata,
+                                             const slayer3d_game_data_sector_level_instance *sector_instance)
+{
+    world_model_iteration_context *context = (world_model_iteration_context *)userdata;
+    if (context == NULL || context->callback == NULL || sector_instance == NULL)
+        return false;
+
+    slayer3d_game_data_world_model_instance instance;
+    SDL_zero(instance);
+    instance.type = SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL;
+    instance.name = sector_instance->level_name;
+    instance.variant_name = sector_instance->variant_name;
+    instance.position = sector_instance->position;
+    instance.sector_level = sector_instance->level;
+    instance.sectors = sector_instance->sectors;
+    instance.sector_count = sector_instance->sector_count;
+    slayer3d_bounding_box bounds;
+    if (model_bounds(sector_instance->level != NULL ? &sector_instance->level->model : NULL, &bounds))
+    {
+        instance.bounds = translated_bounds(bounds, sector_instance->position);
+        instance.has_bounds = true;
+    }
+
+    if (!context->callback(context->userdata, &instance))
+    {
+        context->stopped = true;
+        return false;
+    }
+    return true;
+}
+
+static bool emit_brush_world_model_instance(void *userdata,
+                                            const slayer3d_game_data_brush_world_instance *brush_instance)
+{
+    world_model_iteration_context *context = (world_model_iteration_context *)userdata;
+    if (context == NULL || context->callback == NULL || brush_instance == NULL)
+        return false;
+
+    slayer3d_game_data_world_model_instance instance;
+    SDL_zero(instance);
+    instance.type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+    instance.name = brush_instance->world_name;
+    instance.position = brush_instance->position;
+    instance.brush_world = brush_instance->world;
+    if (brush_instance->world != NULL && brush_instance->world->has_bounds)
+    {
+        instance.bounds = translated_bounds(brush_instance->world->bounds, brush_instance->position);
+        instance.has_bounds = true;
+    }
+
+    if (!context->callback(context->userdata, &instance))
+    {
+        context->stopped = true;
+        return false;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_for_each_world_model_instance(const slayer3d_game_data_runtime *runtime,
+                                                      slayer3d_game_data_world_model_instance_fn callback,
+                                                      void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    world_model_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    if (!slayer3d_game_data_for_each_sector_level_instance(runtime, emit_sector_world_model_instance, &context))
+        return false;
+    if (context.stopped)
+        return true;
+    return slayer3d_game_data_for_each_brush_world_instance(runtime, emit_brush_world_model_instance, &context);
+}
+
+typedef struct world_sector_trace_context
+{
+    const slayer3d_game_data_runtime *runtime;
+    const slayer3d_game_data_world_trace_desc *desc;
+    slayer3d_game_data_world_trace_result *result;
+    bool ok;
+} world_sector_trace_context;
+
+static bool trace_sector_world_instance(void *userdata, const slayer3d_game_data_sector_level_instance *instance)
+{
+    world_sector_trace_context *context = (world_sector_trace_context *)userdata;
+    if (context == NULL || context->desc == NULL || context->result == NULL || instance == NULL ||
+        instance->level == NULL || instance->sectors == NULL)
+    {
+        if (context != NULL)
+            context->ok = false;
+        return false;
+    }
+    if (context->desc->shape != SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT)
+        return true;
+
+    const slayer3d_vec3 local_start = slayer3d_vec3_sub(context->desc->start, instance->position);
+    const slayer3d_vec3 local_end = slayer3d_vec3_sub(context->desc->end, instance->position);
+    const slayer3d_vec3 direction = slayer3d_vec3_sub(local_end, local_start);
+    const float distance = slayer3d_vec3_length(direction);
+    if (distance <= 0.000001f)
+        return true;
+
+    const slayer3d_level_trace_result sector_hit =
+        slayer3d_level_trace_point(instance->level, instance->sectors, local_start, direction, distance);
+    if (!sector_hit.hit)
+        return true;
+    if (context->result->hit && sector_hit.fraction >= context->result->fraction)
+        return true;
+
+    context->result->hit = true;
+    context->result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL;
+    context->result->world_name = instance->level_name;
+    context->result->element_index = sector_hit.end_sector;
+    context->result->face_index = -1;
+    context->result->fraction = sector_hit.fraction;
+    context->result->end_position = slayer3d_vec3_add(sector_hit.end_point, instance->position);
+    context->result->point = context->result->end_position;
+    context->result->normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const sector_level_runtime *level_runtime = find_sector_level_runtime(context->runtime, instance->level_name);
+    if (level_runtime != NULL && sector_hit.end_sector >= 0 && sector_hit.end_sector < level_runtime->sector_count)
+        context->result->element_name = level_runtime->sector_names[sector_hit.end_sector];
+    return true;
+}
+
+bool slayer3d_game_data_trace_world_models(const slayer3d_game_data_runtime *runtime,
+                                           const slayer3d_game_data_world_trace_desc *desc,
+                                           slayer3d_game_data_world_trace_result *out_result)
+{
+    init_world_trace_result(desc, out_result);
+    if (runtime == NULL || desc == NULL || out_result == NULL || !world_trace_shape_valid(desc->shape, desc->extents))
+    {
+        return false;
+    }
+
+    slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)runtime;
+    ++mutable_runtime->world_model_trace_count;
+    const unsigned int filter = world_model_filter_or_all(desc->model_filter);
+
+    if ((filter & SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS) != 0u)
+    {
+        world_sector_trace_context context;
+        SDL_zero(context);
+        context.runtime = runtime;
+        context.desc = desc;
+        context.result = out_result;
+        context.ok = true;
+        if (!slayer3d_game_data_for_each_sector_level_instance(runtime, trace_sector_world_instance, &context) ||
+            !context.ok)
+        {
+            return false;
+        }
+    }
+
+    if ((filter & SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS) != 0u)
+    {
+        slayer3d_game_data_brush_trace_desc brush_desc;
+        SDL_zero(brush_desc);
+        brush_desc.start = desc->start;
+        brush_desc.end = desc->end;
+        brush_desc.shape = desc->shape;
+        brush_desc.extents = desc->extents;
+        brush_desc.contents_mask = brush_contents_mask_or_all(desc->contents_mask);
+        slayer3d_game_data_brush_trace_result brush_result;
+        if (!slayer3d_game_data_trace_active_brush_worlds(runtime, &brush_desc, &brush_result))
+            return false;
+        if (brush_result.hit && (!out_result->hit || brush_result.fraction < out_result->fraction ||
+                                 (brush_result.start_solid && !out_result->start_solid)))
+        {
+            out_result->hit = true;
+            out_result->start_solid = brush_result.start_solid;
+            out_result->all_solid = brush_result.all_solid;
+            out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+            out_result->world_name = brush_result.world_name;
+            out_result->element_name = brush_result.brush_name;
+            out_result->material_name = brush_result.material_name;
+            out_result->element_index = brush_result.brush_index;
+            out_result->face_index = brush_result.face_index;
+            out_result->fraction = brush_result.fraction;
+            out_result->end_position = brush_result.end_position;
+            out_result->point = brush_result.point;
+            out_result->normal = brush_result.normal;
+            out_result->contents = brush_result.contents;
+            out_result->surface_flags = brush_result.surface_flags;
+        }
+    }
+    return true;
+}
+
+bool slayer3d_game_data_query_world_model_point(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 point,
+                                                unsigned int model_filter, unsigned int brush_contents_mask,
+                                                slayer3d_game_data_world_point_result *out_result)
+{
+    init_world_point_result(out_result);
+    if (runtime == NULL || out_result == NULL)
+        return false;
+
+    slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)runtime;
+    ++mutable_runtime->world_model_point_query_count;
+    const unsigned int filter = world_model_filter_or_all(model_filter);
+    if ((filter & SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS) != 0u)
+    {
+        const scene_entry *scene = active_scene_entry_const(runtime);
+        yyjson_val *instances = obj_get(obj_get(scene != NULL ? scene->root : NULL, "world"), "sector_levels");
+        for (size_t i = 0; yyjson_is_arr(instances) && i < yyjson_arr_size(instances); ++i)
+        {
+            yyjson_val *entry = yyjson_arr_get(instances, i);
+            const char *level_name = json_string(entry, "level", NULL);
+            const sector_level_runtime *level_runtime = find_sector_level_runtime(runtime, level_name);
+            if (level_runtime == NULL)
+                return false;
+            const bool sector_lighting_enabled = scene_state_bool(
+                runtime, json_string(entry, "sector_lighting_key", NULL), json_bool(entry, "sector_lighting", true));
+            const slayer3d_level *level = NULL;
+            const char *variant_name = scene_state_string(runtime, json_string(entry, "variant_key", NULL),
+                                                          json_string(entry, "variant", "lightmapped"));
+            if (sector_level_variant_from_string(variant_name, &level, level_runtime, sector_lighting_enabled) == 0 ||
+                level == NULL)
+            {
+                return false;
+            }
+            const slayer3d_vec3 position = json_vec3(entry, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+            const slayer3d_vec3 local_point = slayer3d_vec3_sub(point, position);
+            const int sector_index = slayer3d_level_find_sector_at(level, level_runtime->sectors, local_point.x,
+                                                                   local_point.z, local_point.y);
+            if (sector_index >= 0 && sector_index < level_runtime->sector_count)
+            {
+                out_result->inside = true;
+                out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL;
+                out_result->world_name = level_runtime->name;
+                out_result->element_name = level_runtime->sector_names[sector_index];
+                out_result->element_index = sector_index;
+                return true;
+            }
+        }
+    }
+
+    if ((filter & SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS) != 0u)
+    {
+        slayer3d_game_data_brush_trace_desc trace;
+        SDL_zero(trace);
+        trace.start = point;
+        trace.end = point;
+        trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+        trace.contents_mask = brush_contents_mask_or_all(brush_contents_mask);
+        slayer3d_game_data_brush_trace_result result;
+        if (!slayer3d_game_data_trace_active_brush_worlds(runtime, &trace, &result))
+            return false;
+        if (result.hit && result.start_solid)
+        {
+            out_result->inside = true;
+            out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+            out_result->world_name = result.world_name;
+            out_result->element_name = result.brush_name;
+            out_result->element_index = result.brush_index;
+            out_result->contents = result.contents;
+            return true;
+        }
+    }
+
+    return true;
+}
+
+typedef struct world_model_diagnostics_count_context
+{
+    Uint64 sector_count;
+    Uint64 brush_count;
+} world_model_diagnostics_count_context;
+
+static bool count_sector_world_instance(void *userdata, const slayer3d_game_data_sector_level_instance *instance)
+{
+    (void)instance;
+    world_model_diagnostics_count_context *context = (world_model_diagnostics_count_context *)userdata;
+    if (context != NULL)
+        ++context->sector_count;
+    return true;
+}
+
+static bool count_brush_world_instance(void *userdata, const slayer3d_game_data_brush_world_instance *instance)
+{
+    (void)instance;
+    world_model_diagnostics_count_context *context = (world_model_diagnostics_count_context *)userdata;
+    if (context != NULL)
+        ++context->brush_count;
+    return true;
+}
+
+bool slayer3d_game_data_get_world_model_diagnostics(const slayer3d_game_data_runtime *runtime,
+                                                    slayer3d_game_data_world_model_diagnostics *out_diagnostics)
+{
+    if (runtime == NULL || out_diagnostics == NULL)
+        return false;
+
+    SDL_zero(*out_diagnostics);
+    world_model_diagnostics_count_context context;
+    SDL_zero(context);
+    if (!slayer3d_game_data_for_each_sector_level_instance(runtime, count_sector_world_instance, &context) ||
+        !slayer3d_game_data_for_each_brush_world_instance(runtime, count_brush_world_instance, &context))
+    {
+        return false;
+    }
+    out_diagnostics->active_sector_level_instances = context.sector_count;
+    out_diagnostics->active_brush_world_instances = context.brush_count;
+    out_diagnostics->world_trace_count = runtime->world_model_trace_count;
+    out_diagnostics->point_query_count = runtime->world_model_point_query_count;
+    out_diagnostics->brush = runtime->brush_diagnostics;
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -146,6 +146,17 @@ struct BrushWorldInstanceCapture
     bool debug_wireframe = false;
 };
 
+struct WorldModelInstanceCapture
+{
+    int count = 0;
+    int sectors = 0;
+    int brushes = 0;
+    bool saw_sector_bounds = false;
+    bool saw_brush_bounds = false;
+    slayer3d_bounding_box sector_bounds{};
+    slayer3d_bounding_box brush_bounds{};
+};
+
 struct SectorDoorRenderCapture
 {
     int door_primitives = 0;
@@ -1552,6 +1563,32 @@ bool capture_brush_world_instance(void *userdata, const slayer3d_game_data_brush
     capture->acceleration_enabled = instance->acceleration_enabled;
     capture->lighting_enabled = instance->lighting_enabled;
     capture->debug_wireframe = instance->debug_wireframe;
+    return true;
+}
+
+bool capture_world_model_instance(void *userdata, const slayer3d_game_data_world_model_instance *instance)
+{
+    auto *capture = static_cast<WorldModelInstanceCapture *>(userdata);
+    capture->count++;
+    if (instance->type == SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL)
+    {
+        capture->sectors++;
+        EXPECT_STREQ(instance->name, "sector.world_model");
+        EXPECT_STREQ(instance->variant_name, "lightmapped");
+        EXPECT_NE(instance->sector_level, nullptr);
+        EXPECT_NE(instance->sectors, nullptr);
+        EXPECT_EQ(instance->sector_count, 1);
+        capture->saw_sector_bounds = instance->has_bounds;
+        capture->sector_bounds = instance->bounds;
+    }
+    else if (instance->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
+    {
+        capture->brushes++;
+        EXPECT_STREQ(instance->name, "brush.world_model");
+        EXPECT_NE(instance->brush_world, nullptr);
+        capture->saw_brush_bounds = instance->has_bounds;
+        capture->brush_bounds = instance->bounds;
+    }
     return true;
 }
 
@@ -11345,6 +11382,147 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     EXPECT_EQ(diagnostics.render_mesh_culled, 1u);
     EXPECT_EQ(diagnostics.render_mesh_draws, 2u);
     EXPECT_EQ(diagnostics.render_triangles_submitted, 48u);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, WorldModelInterfaceEnumeratesQueriesAndTracesSectorAndBrushWorlds)
+{
+    const std::filesystem::path dir = unique_test_dir("world_model_interface");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "sector_levels": [
+      { "level": "sector.world_model", "variant": "lightmapped" }
+    ],
+    "brush_worlds": [
+      { "world": "brush.world_model", "position": [10.0, 0.0, 0.0] }
+    ]
+  }
+})json");
+    write_text(dir / "world_model.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "World Model Interface Test" },
+  "world": { "name": "world.model_interface", "kind": "mixed" },
+  "sector_levels": [
+    {
+      "name": "sector.world_model",
+      "materials": [
+        { "name": "floor", "albedo": [0.25, 0.25, 0.25, 1.0] },
+        { "name": "wall", "albedo": [0.55, 0.55, 0.55, 1.0] }
+      ],
+      "sectors": [
+        {
+          "name": "room",
+          "points": [[0, 0], [4, 0], [4, 4], [0, 4]],
+          "floor_y": 0.0,
+          "ceil_y": 3.0,
+          "floor_material": "floor",
+          "ceil_material": "floor",
+          "wall_material": "wall"
+        }
+      ]
+    }
+  ],
+  "brush_worlds": [
+    {
+      "name": "brush.world_model",
+      "materials": [{ "name": "mat.wall", "albedo": [0.8, 0.2, 0.2, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.cube",
+          "contents": ["solid", "player_clip"],
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "world_model.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+
+    WorldModelInstanceCapture capture{};
+    ASSERT_TRUE(slayer3d_game_data_for_each_world_model_instance(runtime, capture_world_model_instance, &capture));
+    EXPECT_EQ(capture.count, 2);
+    EXPECT_EQ(capture.sectors, 1);
+    EXPECT_EQ(capture.brushes, 1);
+    EXPECT_TRUE(capture.saw_sector_bounds);
+    EXPECT_TRUE(capture.saw_brush_bounds);
+    EXPECT_NEAR(capture.sector_bounds.min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(capture.sector_bounds.max.z, 4.0f, 0.001f);
+    EXPECT_NEAR(capture.brush_bounds.min.x, 10.0f, 0.001f);
+    EXPECT_NEAR(capture.brush_bounds.max.x, 12.0f, 0.001f);
+
+    slayer3d_game_data_world_point_result point{};
+    ASSERT_TRUE(
+        slayer3d_game_data_query_world_model_point(runtime, slayer3d_vec3_make(1.0f, 1.0f, 1.0f), 0, 0, &point));
+    EXPECT_TRUE(point.inside);
+    EXPECT_EQ(point.type, SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL);
+    EXPECT_STREQ(point.world_name, "sector.world_model");
+    EXPECT_STREQ(point.element_name, "room");
+    EXPECT_EQ(point.element_index, 0);
+
+    ASSERT_TRUE(slayer3d_game_data_query_world_model_point(runtime, slayer3d_vec3_make(11.0f, 1.0f, 1.0f),
+                                                           SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS,
+                                                           SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, &point));
+    EXPECT_TRUE(point.inside);
+    EXPECT_EQ(point.type, SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
+    EXPECT_STREQ(point.world_name, "brush.world_model");
+    EXPECT_STREQ(point.element_name, "brush.cube");
+    EXPECT_EQ(point.contents, SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+
+    slayer3d_game_data_world_trace_desc trace{};
+    slayer3d_game_data_world_trace_result result{};
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.start = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(6.0f, 1.0f, 1.0f);
+    trace.model_filter = SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS;
+    ASSERT_TRUE(slayer3d_game_data_trace_world_models(runtime, &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_EQ(result.type, SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL);
+    EXPECT_STREQ(result.world_name, "sector.world_model");
+    EXPECT_STREQ(result.element_name, "room");
+    EXPECT_LT(result.fraction, 1.0f);
+
+    trace.start = slayer3d_vec3_make(8.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(11.0f, 1.0f, 1.0f);
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.model_filter = SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS;
+    ASSERT_TRUE(slayer3d_game_data_trace_world_models(runtime, &trace, &result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_EQ(result.type, SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
+    EXPECT_STREQ(result.world_name, "brush.world_model");
+    EXPECT_STREQ(result.element_name, "brush.cube");
+    EXPECT_STREQ(result.material_name, "mat.wall");
+    EXPECT_NEAR(result.end_position.x, 10.0f, 0.001f);
+    EXPECT_NEAR(result.normal.x, -1.0f, 0.001f);
+
+    slayer3d_game_data_world_model_diagnostics diagnostics{};
+    ASSERT_TRUE(slayer3d_game_data_get_world_model_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.active_sector_level_instances, 1u);
+    EXPECT_EQ(diagnostics.active_brush_world_instances, 1u);
+    EXPECT_EQ(diagnostics.world_trace_count, 2u);
+    EXPECT_EQ(diagnostics.point_query_count, 2u);
+    EXPECT_GE(diagnostics.brush.trace_count, 2u);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add a generic active world-model interface over sector level and brush world scene instances
- expose common bounds, trace, point-contents, and diagnostics APIs for editor/tooling callers
- add a mixed sector+brush runtime test proving enumeration, point queries, traces, and diagnostics
- document the tooling guidance in the game-data model docs

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.WorldModelInterfaceEnumeratesQueriesAndTracesSectorAndBrushWorlds:GameDataRuntime.LoadsAuthoredSectorLevels:GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.TracesAuthoredBrushWorldsWithContentsAndSweptHulls'`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug -j 8`

Part of #323.

## Next Slice
- Brush runtime/source split: continue moving brush load/query/controller code behind focused modules now that tooling has a common world-model API to consume.
