### PR TITLE
Refactor game data world loaders into module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ target_sources(
         src/game.c
         src/game_data_brush.c
         src/game_data.c
+        src/game_data_world_loaders.c
         src/game_data_world_queries.c
         src/game_data_standard_options.c
         src/game_presentation.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -108,9 +108,6 @@ static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjso
 static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
-static bool load_editor_metadata(yyjson_val *editor, slayer3d_game_data_editor_metadata *out_metadata,
-                                 char *error_buffer, int error_buffer_size);
-static void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata);
 static bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
 static void sensor_actor_list_free(sensor_actor_list *list);
 static bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
@@ -263,7 +260,6 @@ static bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtim
 static void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
-static const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
 static bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row);
 static char grid_map_cell(const grid_map_runtime *map, int col, int row);
 static bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position);
@@ -287,8 +283,6 @@ static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, gr
 #include "game_data/game_data_json_helpers.inc"
 
 #include "game_data/game_data_grid_runtime.inc"
-
-#include "game_data/game_data_world_loaders.inc"
 
 #include "game_data/game_data_scene_lookup.inc"
 

--- a/src/game_data/game_data_grid_runtime.inc
+++ b/src/game_data/game_data_grid_runtime.inc
@@ -70,7 +70,7 @@ static bool grid_map_world_to_cell(const grid_map_runtime *map, float x, float y
     return true;
 }
 
-static const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name)
+const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;

--- a/src/game_data/game_data_json_helpers.inc
+++ b/src/game_data/game_data_json_helpers.inc
@@ -46,6 +46,57 @@ int json_int(yyjson_val *object, const char *key, int fallback)
     return yyjson_is_int(value) ? (int)yyjson_get_int(value) : fallback;
 }
 
+bool json_float_array(yyjson_val *value, float *out_values, int count, const float *fallback)
+{
+    if (out_values == NULL || count <= 0)
+        return false;
+
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < (size_t)count)
+    {
+        if (fallback != NULL)
+            SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
+        return fallback != NULL;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, (size_t)i);
+        if (!yyjson_is_num(entry))
+        {
+            if (fallback != NULL)
+                SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
+            return fallback != NULL;
+        }
+        out_values[i] = (float)yyjson_get_num(entry);
+    }
+    return true;
+}
+
+slayer3d_color json_color_value(yyjson_val *value, slayer3d_color fallback)
+{
+    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 3)
+        return fallback;
+
+    yyjson_val *r = yyjson_arr_get(value, 0);
+    yyjson_val *g = yyjson_arr_get(value, 1);
+    yyjson_val *b = yyjson_arr_get(value, 2);
+    yyjson_val *a = yyjson_arr_get(value, 3);
+    if (!yyjson_is_num(r) || !yyjson_is_num(g) || !yyjson_is_num(b))
+        return fallback;
+
+    return (slayer3d_color){
+        (Uint8)SDL_clamp((int)yyjson_get_num(r), 0, 255),
+        (Uint8)SDL_clamp((int)yyjson_get_num(g), 0, 255),
+        (Uint8)SDL_clamp((int)yyjson_get_num(b), 0, 255),
+        yyjson_is_num(a) ? (Uint8)SDL_clamp((int)yyjson_get_num(a), 0, 255) : fallback.a,
+    };
+}
+
+slayer3d_color json_color(yyjson_val *object, const char *key, slayer3d_color fallback)
+{
+    return json_color_value(obj_get(object, key), fallback);
+}
+
 static int json_int_or_string(yyjson_val *object, const char *key, int fallback)
 {
     yyjson_val *value = obj_get(object, key);
@@ -56,7 +107,7 @@ static int json_int_or_string(yyjson_val *object, const char *key, int fallback)
     return fallback;
 }
 
-static slayer3d_vec3 json_vec3_value(yyjson_val *value, slayer3d_vec3 fallback)
+slayer3d_vec3 json_vec3_value(yyjson_val *value, slayer3d_vec3 fallback)
 {
     if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 2)
         return fallback;
@@ -92,12 +143,12 @@ static slayer3d_vec4 json_vec4_value(yyjson_val *value, slayer3d_vec4 fallback)
                               yyjson_is_num(w) ? (float)yyjson_get_num(w) : fallback.w);
 }
 
-static slayer3d_vec4 json_vec4(yyjson_val *object, const char *key, slayer3d_vec4 fallback)
+slayer3d_vec4 json_vec4(yyjson_val *object, const char *key, slayer3d_vec4 fallback)
 {
     return json_vec4_value(obj_get(object, key), fallback);
 }
 
-static bool json_vec2_value(yyjson_val *value, float fallback_x, float fallback_y, float *out_x, float *out_y)
+bool json_vec2_value(yyjson_val *value, float fallback_x, float fallback_y, float *out_x, float *out_y)
 {
     if (out_x == NULL || out_y == NULL)
         return false;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -607,21 +607,45 @@ const char *json_string(yyjson_val *object, const char *key, const char *fallbac
 bool json_bool(yyjson_val *object, const char *key, bool fallback);
 float json_float(yyjson_val *object, const char *key, float fallback);
 int json_int(yyjson_val *object, const char *key, int fallback);
+bool json_float_array(yyjson_val *value, float *out_values, int count, const float *fallback);
+slayer3d_color json_color_value(yyjson_val *value, slayer3d_color fallback);
+slayer3d_color json_color(yyjson_val *object, const char *key, slayer3d_color fallback);
+bool json_vec2_value(yyjson_val *value, float fallback_x, float fallback_y, float *out_x, float *out_y);
+slayer3d_vec3 json_vec3_value(yyjson_val *value, slayer3d_vec3 fallback);
 slayer3d_vec3 json_vec3(yyjson_val *object, const char *key, slayer3d_vec3 fallback);
+slayer3d_vec4 json_vec4(yyjson_val *object, const char *key, slayer3d_vec4 fallback);
 const char *scene_state_string(const slayer3d_game_data_runtime *runtime, const char *key, const char *fallback);
 bool scene_state_bool(const slayer3d_game_data_runtime *runtime, const char *key, bool fallback);
 
 yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
 const scene_entry *active_scene_entry_const(const slayer3d_game_data_runtime *runtime);
+const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
 sector_level_runtime *find_sector_level_runtime_mutable(slayer3d_game_data_runtime *runtime, const char *name);
 const sector_level_runtime *find_sector_level_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
 int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name);
 const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
+bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_grid_pickup_layers(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                             int error_buffer_size);
+bool load_sector_levels(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                        int error_buffer_size);
+bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                       int error_buffer_size);
+bool load_sector_doors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                       int error_buffer_size);
+bool load_sector_platforms(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                           int error_buffer_size);
+void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata);
+unsigned int brush_content_flag_from_string(const char *name);
+unsigned int brush_flags_from_json(yyjson_val *value, unsigned int (*flag_from_string)(const char *name),
+                                   unsigned int fallback);
 slayer3d_sector *copy_sectors_without_sector_lighting(const sector_level_runtime *level);
 bool build_sector_level_variant_set(sector_level_runtime *level, const slayer3d_sector *sectors,
                                     slayer3d_level *out_lightmapped, slayer3d_level *out_vertex_baked,
                                     slayer3d_level *out_unlit, const char *stage, char *error_buffer,
                                     int error_buffer_size);
+bool set_sector_level_geometry(sector_level_runtime *level, int sector_index, const slayer3d_sector_geometry *geometry,
+                               char *error_buffer, int error_buffer_size);
 void modulate_color_by_sector_lighting(slayer3d_color *color, const slayer3d_sector *sector);
 
 #endif

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -1,8 +1,20 @@
-/* Grid, sector, brush, door, and platform loaders.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_world_loaders.c
+ * @brief Grid, sector, brush, door, and platform loaders for authored game data.
+ */
 
-static bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                           int error_buffer_size)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "slayer3d/door.h"
+#include "slayer3d/level.h"
+#include "slayer3d/math.h"
+
+static bool load_editor_metadata(yyjson_val *editor, slayer3d_game_data_editor_metadata *out_metadata,
+                                 char *error_buffer, int error_buffer_size);
+
+bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *maps = obj_get(root, "grid_maps");
     if (maps == NULL)
@@ -82,33 +94,8 @@ static bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root
     return true;
 }
 
-static slayer3d_color json_color_value(yyjson_val *value, slayer3d_color fallback)
-{
-    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 3)
-        return fallback;
-
-    yyjson_val *r = yyjson_arr_get(value, 0);
-    yyjson_val *g = yyjson_arr_get(value, 1);
-    yyjson_val *b = yyjson_arr_get(value, 2);
-    yyjson_val *a = yyjson_arr_get(value, 3);
-    if (!yyjson_is_num(r) || !yyjson_is_num(g) || !yyjson_is_num(b))
-        return fallback;
-
-    return (slayer3d_color){
-        (Uint8)SDL_clamp((int)yyjson_get_num(r), 0, 255),
-        (Uint8)SDL_clamp((int)yyjson_get_num(g), 0, 255),
-        (Uint8)SDL_clamp((int)yyjson_get_num(b), 0, 255),
-        yyjson_is_num(a) ? (Uint8)SDL_clamp((int)yyjson_get_num(a), 0, 255) : fallback.a,
-    };
-}
-
-static slayer3d_color json_color(yyjson_val *object, const char *key, slayer3d_color fallback)
-{
-    return json_color_value(obj_get(object, key), fallback);
-}
-
-static bool load_grid_pickup_layers(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                                    int error_buffer_size)
+bool load_grid_pickup_layers(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                             int error_buffer_size)
 {
     yyjson_val *layers = obj_get(root, "grid_pickup_layers");
     if (layers == NULL)
@@ -191,32 +178,6 @@ static void strip_sector_level_lightmap(slayer3d_level *level)
         SDL_free(level->model.meshes[i].lightmap_uvs);
         level->model.meshes[i].lightmap_uvs = NULL;
     }
-}
-
-static bool json_float_array(yyjson_val *value, float *out_values, int count, const float *fallback)
-{
-    if (out_values == NULL || count <= 0)
-        return false;
-
-    if (!yyjson_is_arr(value) || yyjson_arr_size(value) < (size_t)count)
-    {
-        if (fallback != NULL)
-            SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
-        return fallback != NULL;
-    }
-
-    for (int i = 0; i < count; ++i)
-    {
-        yyjson_val *entry = yyjson_arr_get(value, (size_t)i);
-        if (!yyjson_is_num(entry))
-        {
-            if (fallback != NULL)
-                SDL_memcpy(out_values, fallback, (size_t)count * sizeof(*out_values));
-            return fallback != NULL;
-        }
-        out_values[i] = (float)yyjson_get_num(entry);
-    }
-    return true;
 }
 
 static int sector_material_index(yyjson_val *materials, yyjson_val *ref, bool allow_none)
@@ -437,9 +398,8 @@ static bool build_sector_level_variants(sector_level_runtime *level, char *error
     return ok;
 }
 
-static bool set_sector_level_geometry(sector_level_runtime *level, int sector_index,
-                                      const slayer3d_sector_geometry *geometry, char *error_buffer,
-                                      int error_buffer_size)
+bool set_sector_level_geometry(sector_level_runtime *level, int sector_index, const slayer3d_sector_geometry *geometry,
+                               char *error_buffer, int error_buffer_size)
 {
     if (level == NULL || geometry == NULL || sector_index < 0 || sector_index >= level->sector_count)
     {
@@ -516,8 +476,8 @@ static bool set_sector_level_geometry(sector_level_runtime *level, int sector_in
     return true;
 }
 
-static bool load_sector_levels(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                               int error_buffer_size)
+bool load_sector_levels(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                        int error_buffer_size)
 {
     yyjson_val *levels = obj_get(root, "sector_levels");
     if (levels == NULL)
@@ -562,7 +522,7 @@ static bool load_sector_levels(slayer3d_game_data_runtime *runtime, yyjson_val *
     return true;
 }
 
-static unsigned int brush_content_flag_from_string(const char *name)
+unsigned int brush_content_flag_from_string(const char *name)
 {
     if (SDL_strcmp(name != NULL ? name : "", "solid") == 0)
         return SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
@@ -596,8 +556,8 @@ static unsigned int brush_surface_flag_from_string(const char *name)
     return 0u;
 }
 
-static unsigned int brush_flags_from_json(yyjson_val *value, unsigned int (*flag_from_string)(const char *name),
-                                          unsigned int fallback)
+unsigned int brush_flags_from_json(yyjson_val *value, unsigned int (*flag_from_string)(const char *name),
+                                   unsigned int fallback)
 {
     if (yyjson_is_str(value))
     {
@@ -637,8 +597,7 @@ static int brush_material_index_from_ref(const slayer3d_game_data_brush_material
     return -1;
 }
 
-static bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                              int error_buffer_size)
+bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *worlds = obj_get(root, "brush_worlds");
     if (worlds == NULL)
@@ -895,7 +854,7 @@ fail:
     return false;
 }
 
-static void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata)
+void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata)
 {
     if (metadata == NULL)
         return;
@@ -914,8 +873,7 @@ static void free_editor_metadata(slayer3d_game_data_editor_metadata *metadata)
     SDL_zero(*metadata);
 }
 
-static bool load_sector_doors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                              int error_buffer_size)
+bool load_sector_doors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *doors = obj_get(root, "sector_doors");
     if (doors == NULL)
@@ -973,8 +931,8 @@ static bool load_sector_doors(slayer3d_game_data_runtime *runtime, yyjson_val *r
     return true;
 }
 
-static bool load_sector_platforms(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                                  int error_buffer_size)
+bool load_sector_platforms(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                           int error_buffer_size)
 {
     yyjson_val *platforms = obj_get(root, "sector_platforms");
     if (platforms == NULL)


### PR DESCRIPTION
## Summary
- promote the grid/sector/brush/door/platform loader include into src/game_data_world_loaders.c
- register the new loader module in CMake instead of textually including it from game_data.c
- make the private helper dependencies explicit in game_data_internal.h, including shared JSON parsing helpers, brush content parsing, and sector geometry updates

## Testing
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8

## Next slice
Continue the game_data.c cleanup by promoting another self-contained runtime include, with a good candidate being scene lookup or runtime collections before tackling larger coupled modules like render, menu, or network runtime.