### PR TITLE
Refactor game data helper includes into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ target_sources(
         src/game.c
         src/game_data_brush.c
         src/game_data.c
+        src/game_data_action_lookup.c
+        src/game_data_controller_binding_helpers.c
+        src/game_data_input_device_helpers.c
+        src/game_data_json_helpers.c
         src/game_data_runtime_collections.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ target_sources(
         src/game.c
         src/game_data_brush.c
         src/game_data.c
+        src/game_data_runtime_collections.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c
         src/game_data_standard_options.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -300,8 +300,6 @@ static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, gr
 
 #include "game_data/game_data_scene_flow_runtime.inc"
 
-#include "game_data/game_data_runtime_collections.inc"
-
 #include "game_data/game_data_network_sessions.inc"
 
 #include "game_data/game_data_menu_ui.inc"

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -108,6 +108,7 @@ static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjso
 static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
+static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
 static bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
 static void sensor_actor_list_free(sensor_actor_list *list);
 static bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
@@ -199,7 +200,7 @@ static char *path_join(const char *base_dir, const char *path)
     return joined;
 }
 
-static slayer3d_actor_registry *runtime_registry(const slayer3d_game_data_runtime *runtime)
+slayer3d_actor_registry *runtime_registry(const slayer3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? slayer3d_game_session_get_registry(runtime->session) : NULL;
 }
@@ -259,7 +260,6 @@ static bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtim
                                         bool fallback_exclude_source);
 static void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
-static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
 static bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row);
 static char grid_map_cell(const grid_map_runtime *map, int col, int row);
 static bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position);
@@ -280,19 +280,13 @@ static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, gr
 
 #include "game_data/game_data_lua_api.inc"
 
-#include "game_data/game_data_json_helpers.inc"
-
 #include "game_data/game_data_grid_runtime.inc"
 
 #include "game_data/game_data_scene_lookup.inc"
 
 #include "game_data/game_data_replication_helpers.inc"
 
-#include "game_data/game_data_input_device_helpers.inc"
-
 #include "game_data/game_data_adapter_helpers.inc"
-
-#include "game_data/game_data_action_lookup.inc"
 
 #include "game_data/game_data_render_runtime.inc"
 
@@ -311,8 +305,6 @@ static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, gr
 #include "game_data/game_data_actions.inc"
 
 #include "game_data/game_data_scene_load_runtime.inc"
-
-#include "game_data/game_data_controller_binding_helpers.inc"
 
 #include "game_data/game_data_update_runtime.inc"
 

--- a/src/game_data/game_data_scene_lookup.inc
+++ b/src/game_data/game_data_scene_lookup.inc
@@ -206,7 +206,7 @@ static bool entity_json_has_tag(yyjson_val *entity, const char *tag)
     return false;
 }
 
-static bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count)
+bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count)
 {
     if (tag_count <= 0)
         return false;

--- a/src/game_data_action_lookup.c
+++ b/src/game_data_action_lookup.c
@@ -1,4 +1,11 @@
-/* Signal and action lookup helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_action_lookup.c
+ * @brief Signal, action, and actor lookup helpers for authored game data.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
 
 int slayer3d_game_data_find_signal(const slayer3d_game_data_runtime *runtime, const char *name)
 {
@@ -24,7 +31,7 @@ int slayer3d_game_data_find_action(const slayer3d_game_data_runtime *runtime, co
     return -1;
 }
 
-static const char *find_action_name(const slayer3d_game_data_runtime *runtime, int action_id)
+const char *find_action_name(const slayer3d_game_data_runtime *runtime, int action_id)
 {
     if (runtime == NULL || action_id < 0)
         return NULL;

--- a/src/game_data_controller_binding_helpers.c
+++ b/src/game_data_controller_binding_helpers.c
@@ -1,35 +1,42 @@
-/* Controller action binding helper functions. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_controller_binding_helpers.c
+ * @brief Controller action and signal binding helper functions.
+ */
 
-static int fps_controller_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+int fps_controller_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name)
 {
     yyjson_val *actions = obj_get(component, "actions");
     const char *action = json_string(actions, name, NULL);
     return slayer3d_game_data_find_action(runtime, action);
 }
 
-static float fps_controller_action_value(const slayer3d_game_data_runtime *runtime, const slayer3d_input_manager *input,
-                                         int action_id)
+float fps_controller_action_value(const slayer3d_game_data_runtime *runtime, const slayer3d_input_manager *input,
+                                  int action_id)
 {
     if (input == NULL || action_id < 0 || !slayer3d_game_data_active_scene_allows_action(runtime, action_id))
         return 0.0f;
     return slayer3d_input_get_value(input, action_id);
 }
 
-static bool fps_controller_action_pressed(const slayer3d_game_data_runtime *runtime,
-                                          const slayer3d_input_manager *input, int action_id)
+bool fps_controller_action_pressed(const slayer3d_game_data_runtime *runtime, const slayer3d_input_manager *input,
+                                   int action_id)
 {
     return input != NULL && action_id >= 0 && slayer3d_game_data_active_scene_allows_action(runtime, action_id) &&
            slayer3d_input_is_pressed(input, action_id);
 }
 
-static slayer3d_actor_patrol_mode parse_patrol_mode(const char *value)
+slayer3d_actor_patrol_mode parse_patrol_mode(const char *value)
 {
     if (value != NULL && SDL_strcmp(value, "ping_pong") == 0)
         return SLAYER3D_ACTOR_PATROL_PING_PONG;
     return SLAYER3D_ACTOR_PATROL_LOOP;
 }
 
-static int patrol_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name)
+int patrol_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name)
 {
     yyjson_val *signals = obj_get(component, "signals");
     return slayer3d_game_data_find_signal(runtime, json_string(signals, name, NULL));

--- a/src/game_data_input_device_helpers.c
+++ b/src/game_data_input_device_helpers.c
@@ -1,6 +1,15 @@
-/* Input device name conversion helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_input_device_helpers.c
+ * @brief Authored input device name conversion helpers.
+ */
 
-static SDL_Scancode scancode_from_json(const char *name)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_keycode.h>
+#include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_stdinc.h>
+
+SDL_Scancode scancode_from_json(const char *name)
 {
     if (name == NULL)
         return SDL_SCANCODE_UNKNOWN;
@@ -23,7 +32,7 @@ static SDL_Scancode scancode_from_json(const char *name)
     return SDL_GetScancodeFromName(name);
 }
 
-static const char *scancode_display_name(SDL_Scancode scancode)
+const char *scancode_display_name(SDL_Scancode scancode)
 {
     if (scancode == SDL_SCANCODE_UNKNOWN)
         return "-";
@@ -31,7 +40,7 @@ static const char *scancode_display_name(SDL_Scancode scancode)
     return name != NULL && name[0] != '\0' ? name : "-";
 }
 
-static Uint8 mouse_button_from_json(const char *name)
+Uint8 mouse_button_from_json(const char *name)
 {
     if (name == NULL)
         return 0;
@@ -48,7 +57,7 @@ static Uint8 mouse_button_from_json(const char *name)
     return 0;
 }
 
-static const char *mouse_button_display_name(Uint8 button)
+const char *mouse_button_display_name(Uint8 button)
 {
     switch (button)
     {
@@ -67,7 +76,7 @@ static const char *mouse_button_display_name(Uint8 button)
     }
 }
 
-static slayer3d_mouse_axis mouse_axis_from_json(const char *name, bool *valid)
+slayer3d_mouse_axis mouse_axis_from_json(const char *name, bool *valid)
 {
     if (valid != NULL)
         *valid = true;
@@ -90,7 +99,7 @@ static slayer3d_mouse_axis mouse_axis_from_json(const char *name, bool *valid)
     return SLAYER3D_MOUSE_AXIS_X;
 }
 
-static const char *gamepad_button_display_name(SDL_GamepadButton button)
+const char *gamepad_button_display_name(SDL_GamepadButton button)
 {
     if (button == SDL_GAMEPAD_BUTTON_INVALID)
         return "-";
@@ -98,7 +107,7 @@ static const char *gamepad_button_display_name(SDL_GamepadButton button)
     return name != NULL && name[0] != '\0' ? name : "-";
 }
 
-static SDL_GamepadAxis gamepad_axis_from_json(const char *name)
+SDL_GamepadAxis gamepad_axis_from_json(const char *name)
 {
     if (name == NULL)
         return SDL_GAMEPAD_AXIS_INVALID;
@@ -117,7 +126,7 @@ static SDL_GamepadAxis gamepad_axis_from_json(const char *name)
     return SDL_GAMEPAD_AXIS_INVALID;
 }
 
-static SDL_GamepadButton gamepad_button_from_json(const char *name)
+SDL_GamepadButton gamepad_button_from_json(const char *name)
 {
     if (name == NULL)
         return SDL_GAMEPAD_BUTTON_INVALID;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -620,6 +620,10 @@ bool scene_state_bool(const slayer3d_game_data_runtime *runtime, const char *key
 yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
 const scene_entry *active_scene_entry_const(const slayer3d_game_data_runtime *runtime);
 const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
+const runtime_collection *find_runtime_collection_const(const slayer3d_game_data_runtime *runtime,
+                                                        const char *collection_name);
+bool runtime_collection_field_to_string(const runtime_collection *collection, int row_index, const char *field_name,
+                                        char *buffer, size_t buffer_size);
 sector_level_runtime *find_sector_level_runtime_mutable(slayer3d_game_data_runtime *runtime, const char *name);
 const sector_level_runtime *find_sector_level_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
 int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -607,18 +607,25 @@ const char *json_string(yyjson_val *object, const char *key, const char *fallbac
 bool json_bool(yyjson_val *object, const char *key, bool fallback);
 float json_float(yyjson_val *object, const char *key, float fallback);
 int json_int(yyjson_val *object, const char *key, int fallback);
+const char *first_non_empty_string(const char *first, const char *second, const char *fallback);
+char first_json_string_char(yyjson_val *object, const char *key, char fallback);
+int json_int_or_string(yyjson_val *object, const char *key, int fallback);
 bool json_float_array(yyjson_val *value, float *out_values, int count, const float *fallback);
 slayer3d_color json_color_value(yyjson_val *value, slayer3d_color fallback);
 slayer3d_color json_color(yyjson_val *object, const char *key, slayer3d_color fallback);
 bool json_vec2_value(yyjson_val *value, float fallback_x, float fallback_y, float *out_x, float *out_y);
 slayer3d_vec3 json_vec3_value(yyjson_val *value, slayer3d_vec3 fallback);
 slayer3d_vec3 json_vec3(yyjson_val *object, const char *key, slayer3d_vec3 fallback);
+slayer3d_vec4 json_vec4_value(yyjson_val *value, slayer3d_vec4 fallback);
 slayer3d_vec4 json_vec4(yyjson_val *object, const char *key, slayer3d_vec4 fallback);
 const char *scene_state_string(const slayer3d_game_data_runtime *runtime, const char *key, const char *fallback);
 bool scene_state_bool(const slayer3d_game_data_runtime *runtime, const char *key, bool fallback);
 
+slayer3d_actor_registry *runtime_registry(const slayer3d_game_data_runtime *runtime);
 yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
 const scene_entry *active_scene_entry_const(const slayer3d_game_data_runtime *runtime);
+const char *find_action_name(const slayer3d_game_data_runtime *runtime, int action_id);
+bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
 const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
 const runtime_collection *find_runtime_collection_const(const slayer3d_game_data_runtime *runtime,
                                                         const char *collection_name);
@@ -651,5 +658,22 @@ bool build_sector_level_variant_set(sector_level_runtime *level, const slayer3d_
 bool set_sector_level_geometry(sector_level_runtime *level, int sector_index, const slayer3d_sector_geometry *geometry,
                                char *error_buffer, int error_buffer_size);
 void modulate_color_by_sector_lighting(slayer3d_color *color, const slayer3d_sector *sector);
+
+SDL_Scancode scancode_from_json(const char *name);
+const char *scancode_display_name(SDL_Scancode scancode);
+Uint8 mouse_button_from_json(const char *name);
+const char *mouse_button_display_name(Uint8 button);
+slayer3d_mouse_axis mouse_axis_from_json(const char *name, bool *valid);
+const char *gamepad_button_display_name(SDL_GamepadButton button);
+SDL_GamepadAxis gamepad_axis_from_json(const char *name);
+SDL_GamepadButton gamepad_button_from_json(const char *name);
+
+int fps_controller_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name);
+float fps_controller_action_value(const slayer3d_game_data_runtime *runtime, const slayer3d_input_manager *input,
+                                  int action_id);
+bool fps_controller_action_pressed(const slayer3d_game_data_runtime *runtime, const slayer3d_input_manager *input,
+                                   int action_id);
+slayer3d_actor_patrol_mode parse_patrol_mode(const char *value);
+int patrol_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name);
 
 #endif

--- a/src/game_data_json_helpers.c
+++ b/src/game_data_json_helpers.c
@@ -1,4 +1,11 @@
-/* JSON helper functions shared by game-data runtime subsystems. */
+/**
+ * @file game_data_json_helpers.c
+ * @brief JSON helper functions shared by game-data runtime subsystems.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
 
 yyjson_val *obj_get(yyjson_val *object, const char *key)
 {
@@ -11,7 +18,7 @@ const char *json_string(yyjson_val *object, const char *key, const char *fallbac
     return yyjson_is_str(value) ? yyjson_get_str(value) : fallback;
 }
 
-static const char *first_non_empty_string(const char *first, const char *second, const char *fallback)
+const char *first_non_empty_string(const char *first, const char *second, const char *fallback)
 {
     if (first != NULL && first[0] != '\0')
         return first;
@@ -20,13 +27,11 @@ static const char *first_non_empty_string(const char *first, const char *second,
     return fallback;
 }
 
-static char first_json_string_char(yyjson_val *object, const char *key, char fallback)
+char first_json_string_char(yyjson_val *object, const char *key, char fallback)
 {
     const char *value = json_string(object, key, NULL);
     return value != NULL && value[0] != '\0' ? value[0] : fallback;
 }
-
-static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
 
 bool json_bool(yyjson_val *object, const char *key, bool fallback)
 {
@@ -97,7 +102,7 @@ slayer3d_color json_color(yyjson_val *object, const char *key, slayer3d_color fa
     return json_color_value(obj_get(object, key), fallback);
 }
 
-static int json_int_or_string(yyjson_val *object, const char *key, int fallback)
+int json_int_or_string(yyjson_val *object, const char *key, int fallback)
 {
     yyjson_val *value = obj_get(object, key);
     if (yyjson_is_int(value))
@@ -127,7 +132,7 @@ slayer3d_vec3 json_vec3(yyjson_val *object, const char *key, slayer3d_vec3 fallb
     return json_vec3_value(obj_get(object, key), fallback);
 }
 
-static slayer3d_vec4 json_vec4_value(yyjson_val *value, slayer3d_vec4 fallback)
+slayer3d_vec4 json_vec4_value(yyjson_val *value, slayer3d_vec4 fallback)
 {
     if (!yyjson_is_arr(value) || yyjson_arr_size(value) < 3)
         return fallback;

--- a/src/game_data_runtime_collections.c
+++ b/src/game_data_runtime_collections.c
@@ -1,4 +1,11 @@
-/* Runtime collection storage helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_runtime_collections.c
+ * @brief Runtime collection storage helpers for authored dynamic-list UI and session data.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
 
 static runtime_collection *find_runtime_collection(slayer3d_game_data_runtime *runtime, const char *collection_name)
 {
@@ -12,8 +19,8 @@ static runtime_collection *find_runtime_collection(slayer3d_game_data_runtime *r
     return NULL;
 }
 
-static const runtime_collection *find_runtime_collection_const(const slayer3d_game_data_runtime *runtime,
-                                                               const char *collection_name)
+const runtime_collection *find_runtime_collection_const(const slayer3d_game_data_runtime *runtime,
+                                                        const char *collection_name)
 {
     if (runtime == NULL || collection_name == NULL || collection_name[0] == '\0')
         return NULL;
@@ -87,8 +94,8 @@ static slayer3d_properties *runtime_collection_ensure_row(runtime_collection *co
     return collection->rows[row_index];
 }
 
-static bool runtime_collection_field_to_string(const runtime_collection *collection, int row_index,
-                                               const char *field_name, char *buffer, size_t buffer_size)
+bool runtime_collection_field_to_string(const runtime_collection *collection, int row_index, const char *field_name,
+                                        char *buffer, size_t buffer_size)
 {
     if (collection == NULL || row_index < 0 || row_index >= collection->row_count || field_name == NULL ||
         field_name[0] == '\0' || buffer == NULL || buffer_size == 0U || collection->rows[row_index] == NULL)


### PR DESCRIPTION
## Summary
- promote runtime collections, action lookup, input device conversion, controller binding helpers, and JSON helper parsing out of textual includes into normal C modules
- register the new modules in CMake
- make the small internal helper surface explicit in game_data_internal.h while preserving public behavior

## Testing
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8

## Notes
- This keeps the PR scoped to low-coupling helper extraction. Larger runtime, menu, render, and network includes should move in later batches once their internal boundaries are clearer.