### PR TITLE
Refactor grid and property effect runtime modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,10 @@ target_sources(
         src/game_data.c
         src/game_data_action_lookup.c
         src/game_data_controller_binding_helpers.c
+        src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c
         src/game_data_json_helpers.c
+        src/game_data_property_effect_runtime.c
         src/game_data_runtime_collections.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -105,7 +105,7 @@ static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtim
                                               SDL_GamepadButton button);
 static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                                 const slayer3d_game_data_ui_metrics *metrics);
-static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
+bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
 static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
@@ -260,27 +260,7 @@ static bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtim
                                         bool fallback_exclude_source);
 static void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
-static bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row);
-static char grid_map_cell(const grid_map_runtime *map, int col, int row);
-static bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position);
-static bool grid_map_world_to_cell(const grid_map_runtime *map, float x, float y, int *out_col, int *out_row);
-static bool grid_map_is_walkable(const grid_map_runtime *map, int col, int row);
-static bool grid_map_next_step(const grid_map_runtime *map, int start_col, int start_row, int goal_col, int goal_row,
-                               int *out_col, int *out_row);
-static bool grid_actor_index_register(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map,
-                                      const char *pool_name, slayer3d_registered_actor *actor, int col, int row);
-static void grid_actor_index_clear(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map,
-                                   const char *pool_name);
-static slayer3d_registered_actor *grid_actor_index_find(slayer3d_game_data_runtime *runtime, const char *map_name,
-                                                        const char *pool_name, int col, int row);
-static grid_pickup_layer_runtime *find_grid_pickup_layer(slayer3d_game_data_runtime *runtime, const char *name);
-static bool grid_pickup_layer_reset(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer);
-static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer, int col,
-                                         int row, grid_pickup_kind_runtime *out_kind);
-
 #include "game_data/game_data_lua_api.inc"
-
-#include "game_data/game_data_grid_runtime.inc"
 
 #include "game_data/game_data_scene_lookup.inc"
 

--- a/src/game_data/game_data_scene_lookup.inc
+++ b/src/game_data/game_data_scene_lookup.inc
@@ -129,7 +129,7 @@ static bool scene_has_entity(const scene_entry *scene, const char *entity_name)
     return false;
 }
 
-static bool active_scene_has_entity_internal(const slayer3d_game_data_runtime *runtime, const char *entity_name)
+bool active_scene_has_entity_internal(const slayer3d_game_data_runtime *runtime, const char *entity_name)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
     if (scene_has_entity(scene, entity_name))

--- a/src/game_data/game_data_sensor_runtime.inc
+++ b/src/game_data/game_data_sensor_runtime.inc
@@ -56,7 +56,7 @@ static void execute_sensor_payload_actions(slayer3d_game_data_runtime *runtime, 
     (void)execute_action_array(runtime, sensor->actions, payload);
 }
 
-static bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor)
+bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor)
 {
     if (runtime == NULL || actor == NULL)
         return false;

--- a/src/game_data/game_data_update_runtime.inc
+++ b/src/game_data/game_data_update_runtime.inc
@@ -5,8 +5,6 @@
 
 #include "game_data_motion_runtime.inc"
 
-#include "game_data_property_effect_runtime.inc"
-
 #include "game_data_sensor_runtime.inc"
 
 static void update_noise_events(slayer3d_game_data_runtime *runtime, float dt)

--- a/src/game_data_grid_runtime.c
+++ b/src/game_data_grid_runtime.c
@@ -1,6 +1,13 @@
-/* Grid-map and pickup-layer runtime helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_grid_runtime.c
+ * @brief Grid-map and pickup-layer runtime helpers for authored game data.
+ */
 
-static bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row)
 {
     if (map == NULL || col == NULL || row == NULL || map->width <= 0 || map->height <= 0)
         return false;
@@ -19,14 +26,14 @@ static bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *
     return true;
 }
 
-static char grid_map_cell(const grid_map_runtime *map, int col, int row)
+char grid_map_cell(const grid_map_runtime *map, int col, int row)
 {
     if (!grid_map_normalize_cell(map, &col, &row))
         return '\0';
     return map->cells[row * map->width + col];
 }
 
-static bool grid_map_is_walkable(const grid_map_runtime *map, int col, int row)
+bool grid_map_is_walkable(const grid_map_runtime *map, int col, int row)
 {
     const char cell = grid_map_cell(map, col, row);
     if (cell == '\0' || map == NULL || map->walkable == NULL)
@@ -39,7 +46,7 @@ static bool grid_map_is_walkable(const grid_map_runtime *map, int col, int row)
     return false;
 }
 
-static bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position)
+bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position)
 {
     if (map == NULL || out_position == NULL || !grid_map_normalize_cell(map, &col, &row))
         return false;
@@ -54,7 +61,7 @@ static int grid_round_to_int(float value)
     return value >= 0.0f ? (int)(value + 0.5f) : (int)(value - 0.5f);
 }
 
-static bool grid_map_world_to_cell(const grid_map_runtime *map, float x, float y, int *out_col, int *out_row)
+bool grid_map_world_to_cell(const grid_map_runtime *map, float x, float y, int *out_col, int *out_row)
 {
     if (map == NULL || out_col == NULL || out_row == NULL || map->cell_width <= 0.0f || map->cell_height <= 0.0f ||
         map->row_direction == 0.0f)
@@ -144,8 +151,7 @@ static grid_actor_index *get_or_create_grid_actor_index(slayer3d_game_data_runti
     return index;
 }
 
-static void grid_actor_index_clear(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map,
-                                   const char *pool_name)
+void grid_actor_index_clear(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map, const char *pool_name)
 {
     grid_actor_index *index = find_grid_actor_index(runtime, map != NULL ? map->name : NULL, pool_name);
     if (index == NULL || index->actors == NULL || index->width <= 0 || index->height <= 0)
@@ -153,8 +159,8 @@ static void grid_actor_index_clear(slayer3d_game_data_runtime *runtime, const gr
     SDL_memset(index->actors, 0, (size_t)index->width * (size_t)index->height * sizeof(*index->actors));
 }
 
-static bool grid_actor_index_register(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map,
-                                      const char *pool_name, slayer3d_registered_actor *actor, int col, int row)
+bool grid_actor_index_register(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map, const char *pool_name,
+                               slayer3d_registered_actor *actor, int col, int row)
 {
     if (actor == NULL || !grid_map_normalize_cell(map, &col, &row))
         return false;
@@ -165,8 +171,8 @@ static bool grid_actor_index_register(slayer3d_game_data_runtime *runtime, const
     return true;
 }
 
-static slayer3d_registered_actor *grid_actor_index_find(slayer3d_game_data_runtime *runtime, const char *map_name,
-                                                        const char *pool_name, int col, int row)
+slayer3d_registered_actor *grid_actor_index_find(slayer3d_game_data_runtime *runtime, const char *map_name,
+                                                 const char *pool_name, int col, int row)
 {
     const grid_map_runtime *map = find_grid_map(runtime, map_name);
     if (!grid_map_normalize_cell(map, &col, &row))
@@ -193,7 +199,7 @@ static slayer3d_registered_actor *grid_actor_index_find(slayer3d_game_data_runti
     return actor;
 }
 
-static grid_pickup_layer_runtime *find_grid_pickup_layer(slayer3d_game_data_runtime *runtime, const char *name)
+grid_pickup_layer_runtime *find_grid_pickup_layer(slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;
@@ -205,7 +211,7 @@ static grid_pickup_layer_runtime *find_grid_pickup_layer(slayer3d_game_data_runt
     return NULL;
 }
 
-static bool grid_pickup_layer_reset(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer)
+bool grid_pickup_layer_reset(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer)
 {
     (void)runtime;
     if (layer == NULL || layer->map == NULL || layer->cells == NULL)
@@ -231,8 +237,8 @@ static bool grid_pickup_layer_reset(slayer3d_game_data_runtime *runtime, grid_pi
     return true;
 }
 
-static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer, int col,
-                                         int row, grid_pickup_kind_runtime *out_kind)
+bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer, int col,
+                                  int row, grid_pickup_kind_runtime *out_kind)
 {
     (void)runtime;
     if (out_kind != NULL)
@@ -250,8 +256,8 @@ static bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, gr
     return true;
 }
 
-static bool grid_map_next_step(const grid_map_runtime *map, int start_col, int start_row, int goal_col, int goal_row,
-                               int *out_col, int *out_row)
+bool grid_map_next_step(const grid_map_runtime *map, int start_col, int start_row, int goal_col, int goal_row,
+                        int *out_col, int *out_row)
 {
     if (out_col != NULL)
         *out_col = start_col;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -625,8 +625,26 @@ slayer3d_actor_registry *runtime_registry(const slayer3d_game_data_runtime *runt
 yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
 const scene_entry *active_scene_entry_const(const slayer3d_game_data_runtime *runtime);
 const char *find_action_name(const slayer3d_game_data_runtime *runtime, int action_id);
+bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
+bool active_scene_has_entity_internal(const slayer3d_game_data_runtime *runtime, const char *entity_name);
 bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_count);
 const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
+bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row);
+char grid_map_cell(const grid_map_runtime *map, int col, int row);
+bool grid_map_is_walkable(const grid_map_runtime *map, int col, int row);
+bool grid_map_cell_to_world(const grid_map_runtime *map, int col, int row, slayer3d_vec3 *out_position);
+bool grid_map_world_to_cell(const grid_map_runtime *map, float x, float y, int *out_col, int *out_row);
+bool grid_map_next_step(const grid_map_runtime *map, int start_col, int start_row, int goal_col, int goal_row,
+                        int *out_col, int *out_row);
+void grid_actor_index_clear(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map, const char *pool_name);
+bool grid_actor_index_register(slayer3d_game_data_runtime *runtime, const grid_map_runtime *map, const char *pool_name,
+                               slayer3d_registered_actor *actor, int col, int row);
+slayer3d_registered_actor *grid_actor_index_find(slayer3d_game_data_runtime *runtime, const char *map_name,
+                                                 const char *pool_name, int col, int row);
+grid_pickup_layer_runtime *find_grid_pickup_layer(slayer3d_game_data_runtime *runtime, const char *name);
+bool grid_pickup_layer_reset(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer);
+bool grid_pickup_layer_collect_at(slayer3d_game_data_runtime *runtime, grid_pickup_layer_runtime *layer, int col,
+                                  int row, grid_pickup_kind_runtime *out_kind);
 const runtime_collection *find_runtime_collection_const(const slayer3d_game_data_runtime *runtime,
                                                         const char *collection_name);
 bool runtime_collection_field_to_string(const runtime_collection *collection, int row_index, const char *field_name,

--- a/src/game_data_property_effect_runtime.c
+++ b/src/game_data_property_effect_runtime.c
@@ -1,4 +1,11 @@
-/* Runtime property effect update helpers. Included by game_data_update_runtime.inc to preserve internal linkage. */
+/**
+ * @file game_data_property_effect_runtime.c
+ * @brief Runtime property effect update helpers for authored game data.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
 
 static float move_float_toward(float value, float target, float max_delta)
 {


### PR DESCRIPTION
## Summary
- move grid-map and grid-pickup runtime helpers from textual includes into src/game_data_grid_runtime.c
- move property-effect update helpers into src/game_data_property_effect_runtime.c
- register both modules in CMake and make the required internal runtime helper declarations explicit

## Testing
- cmake --build build/debug --target slayer3d_game_data_test --clean-first -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8

## Next slice
Continue the .inc cleanup with a dedicated scene/menu or script/adapter boundary pass. Those remaining files are more coupled, so they should move in narrower batches with explicit internal interfaces.