### PR TITLE
Refactor script and adapter helpers into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,12 +148,14 @@ target_sources(
         src/game_data_brush.c
         src/game_data.c
         src/game_data_action_lookup.c
+        src/game_data_adapter_helpers.c
         src/game_data_controller_binding_helpers.c
         src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c
         src/game_data_json_helpers.c
         src/game_data_property_effect_runtime.c
         src/game_data_runtime_collections.c
+        src/game_data_scripts.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c
         src/game_data_standard_options.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -177,7 +177,7 @@ static const char *asset_path_without_scheme(const char *path)
     return path != NULL && SDL_strncmp(path, "asset://", 8) == 0 ? path + 8 : path;
 }
 
-static char *path_join(const char *base_dir, const char *path)
+char *path_join(const char *base_dir, const char *path)
 {
     if (path == NULL)
         return NULL;
@@ -221,7 +221,6 @@ static slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *r
 }
 
 static void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
-static void lua_push_actor_wrapper(lua_State *lua, const slayer3d_registered_actor *actor);
 static void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
 static actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
 static const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name);
@@ -266,8 +265,6 @@ static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 
 #include "game_data/game_data_replication_helpers.inc"
 
-#include "game_data/game_data_adapter_helpers.inc"
-
 #include "game_data/game_data_render_runtime.inc"
 
 #include "game_data/game_data_ui_animation_runtime.inc"
@@ -279,8 +276,6 @@ static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 #include "game_data/game_data_menu_ui.inc"
 
 #include "game_data/game_data_actors_input.inc"
-
-#include "game_data/game_data_scripts.inc"
 
 #include "game_data/game_data_actions.inc"
 

--- a/src/game_data/game_data_lua_api.inc
+++ b/src/game_data/game_data_lua_api.inc
@@ -1638,7 +1638,7 @@ static void install_lua_helpers(lua_State *lua)
     SDL_free(source);
 }
 
-static void register_lua_api(slayer3d_game_data_runtime *runtime, slayer3d_script_engine *engine)
+void register_lua_api(slayer3d_game_data_runtime *runtime, slayer3d_script_engine *engine)
 {
     if (runtime == NULL || engine == NULL)
         return;

--- a/src/game_data_adapter_helpers.c
+++ b/src/game_data_adapter_helpers.c
@@ -1,6 +1,16 @@
-/* Timer, adapter, script, and Lua invocation helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_adapter_helpers.c
+ * @brief Timer, adapter, script, and Lua invocation helpers for authored game data.
+ */
 
-static int find_timer_index(const slayer3d_game_data_runtime *runtime, const char *name)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_stdinc.h>
+
+#include "lauxlib.h"
+
+int find_timer_index(const slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return -1;
@@ -12,7 +22,7 @@ static int find_timer_index(const slayer3d_game_data_runtime *runtime, const cha
     return -1;
 }
 
-static adapter_entry *find_adapter(slayer3d_game_data_runtime *runtime, const char *name)
+adapter_entry *find_adapter(slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;
@@ -24,7 +34,7 @@ static adapter_entry *find_adapter(slayer3d_game_data_runtime *runtime, const ch
     return NULL;
 }
 
-static script_entry *find_script(slayer3d_game_data_runtime *runtime, const char *id)
+script_entry *find_script(slayer3d_game_data_runtime *runtime, const char *id)
 {
     if (runtime == NULL || id == NULL)
         return NULL;
@@ -36,8 +46,8 @@ static script_entry *find_script(slayer3d_game_data_runtime *runtime, const char
     return NULL;
 }
 
-static bool append_adapter(slayer3d_game_data_runtime *runtime, const char *name,
-                           slayer3d_game_data_adapter_fn callback, void *userdata)
+bool append_adapter(slayer3d_game_data_runtime *runtime, const char *name, slayer3d_game_data_adapter_fn callback,
+                    void *userdata)
 {
     adapter_entry *entries =
         (adapter_entry *)SDL_realloc(runtime->adapters, (size_t)(runtime->adapter_count + 1) * sizeof(*entries));
@@ -56,8 +66,8 @@ static bool append_adapter(slayer3d_game_data_runtime *runtime, const char *name
     return true;
 }
 
-static bool set_adapter_lua_function(slayer3d_game_data_runtime *runtime, const char *name, const char *script_id,
-                                     const char *function_name, slayer3d_script_ref function_ref)
+bool set_adapter_lua_function(slayer3d_game_data_runtime *runtime, const char *name, const char *script_id,
+                              const char *function_name, slayer3d_script_ref function_ref)
 {
     if (runtime == NULL || name == NULL || name[0] == '\0' || script_id == NULL || script_id[0] == '\0' ||
         function_name == NULL || function_name[0] == '\0' || function_ref == SLAYER3D_SCRIPT_REF_INVALID)
@@ -154,7 +164,7 @@ static void lua_push_payload(lua_State *lua, const slayer3d_properties *payload)
     }
 }
 
-static void lua_push_actor_wrapper(lua_State *lua, const slayer3d_registered_actor *actor)
+void lua_push_actor_wrapper(lua_State *lua, const slayer3d_registered_actor *actor)
 {
     if (actor == NULL)
     {
@@ -243,8 +253,8 @@ static bool call_lua_adapter(slayer3d_game_data_runtime *runtime, const adapter_
     return ok;
 }
 
-static bool invoke_adapter(slayer3d_game_data_runtime *runtime, adapter_entry *adapter,
-                           slayer3d_registered_actor *target, const slayer3d_properties *payload)
+bool invoke_adapter(slayer3d_game_data_runtime *runtime, adapter_entry *adapter, slayer3d_registered_actor *target,
+                    const slayer3d_properties *payload)
 {
     if (adapter == NULL)
         return false;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -601,6 +601,7 @@ typedef struct slayer3d_game_data_runtime
 
 void set_error(char *buffer, int buffer_size, const char *message);
 void set_errorf(char *buffer, int buffer_size, const char *format, ...);
+char *path_join(const char *base_dir, const char *path);
 
 yyjson_val *obj_get(yyjson_val *object, const char *key);
 const char *json_string(yyjson_val *object, const char *key, const char *fallback);
@@ -693,5 +694,25 @@ bool fps_controller_action_pressed(const slayer3d_game_data_runtime *runtime, co
                                    int action_id);
 slayer3d_actor_patrol_mode parse_patrol_mode(const char *value);
 int patrol_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *component, const char *name);
+
+int find_timer_index(const slayer3d_game_data_runtime *runtime, const char *name);
+adapter_entry *find_adapter(slayer3d_game_data_runtime *runtime, const char *name);
+script_entry *find_script(slayer3d_game_data_runtime *runtime, const char *id);
+bool append_adapter(slayer3d_game_data_runtime *runtime, const char *name, slayer3d_game_data_adapter_fn callback,
+                    void *userdata);
+bool set_adapter_lua_function(slayer3d_game_data_runtime *runtime, const char *name, const char *script_id,
+                              const char *function_name, slayer3d_script_ref function_ref);
+bool invoke_adapter(slayer3d_game_data_runtime *runtime, adapter_entry *adapter, slayer3d_registered_actor *target,
+                    const slayer3d_properties *payload);
+void lua_push_actor_wrapper(lua_State *lua, const slayer3d_registered_actor *actor);
+
+void register_lua_api(slayer3d_game_data_runtime *runtime, slayer3d_script_engine *engine);
+bool load_timers(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);
+bool load_script_index_into_engine(slayer3d_game_data_runtime *runtime, slayer3d_asset_resolver *assets,
+                                   slayer3d_script_engine *engine, int index, slayer3d_script_ref *module_refs,
+                                   bool *loading, bool *loaded, char *error_buffer, int error_buffer_size);
+bool load_scripts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_lua_adapters(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                       int error_buffer_size);
 
 #endif

--- a/src/game_data_scripts.c
+++ b/src/game_data_scripts.c
@@ -1,8 +1,13 @@
-/* Lua script manifest and adapter loading helpers.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_scripts.c
+ * @brief Lua script manifest and adapter loading helpers for authored game data.
+ */
 
-static bool load_timers(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer,
-                        int error_buffer_size)
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+bool load_timers(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *timers = obj_get(logic, "timers");
     if (!yyjson_is_arr(timers))
@@ -115,9 +120,9 @@ static bool load_script_entry(slayer3d_game_data_runtime *runtime, script_entry 
     return true;
 }
 
-static bool load_script_index_into_engine(slayer3d_game_data_runtime *runtime, slayer3d_asset_resolver *assets,
-                                          slayer3d_script_engine *engine, int index, slayer3d_script_ref *module_refs,
-                                          bool *loading, bool *loaded, char *error_buffer, int error_buffer_size)
+bool load_script_index_into_engine(slayer3d_game_data_runtime *runtime, slayer3d_asset_resolver *assets,
+                                   slayer3d_script_engine *engine, int index, slayer3d_script_ref *module_refs,
+                                   bool *loading, bool *loaded, char *error_buffer, int error_buffer_size)
 {
     if (runtime == NULL || assets == NULL || engine == NULL || index < 0 || index >= runtime->script_count ||
         module_refs == NULL || loading == NULL || loaded == NULL)
@@ -201,8 +206,7 @@ static bool load_script_index_into_engine(slayer3d_game_data_runtime *runtime, s
     return true;
 }
 
-static bool load_scripts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                         int error_buffer_size)
+bool load_scripts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *scripts = obj_get(root, "scripts");
     if (!yyjson_is_arr(scripts) || yyjson_arr_size(scripts) == 0)
@@ -307,8 +311,7 @@ static bool load_scripts(slayer3d_game_data_runtime *runtime, yyjson_val *root, 
     return true;
 }
 
-static bool load_lua_adapters(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                              int error_buffer_size)
+bool load_lua_adapters(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *adapters = obj_get(root, "adapters");
     if (!yyjson_is_arr(adapters))


### PR DESCRIPTION
## Summary
- move Lua script manifest/loading helpers from textual include into src/game_data_scripts.c
- move timer, adapter lookup, Lua adapter invocation helpers into src/game_data_adapter_helpers.c
- register both modules in CMake and make the required internal helper surface explicit

## Testing
- cmake --build build/debug --target slayer3d_game_data_test --clean-first -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8

## Next slice
Continue the include cleanup with a scene/menu boundary pass or another low-coupling runtime helper batch. Scene lookup is a good candidate, but it should be handled deliberately because many systems depend on it.