### PR TITLE
Refactor game data update runtime into module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ target_sources(
         src/game_data_runtime_collections.c
         src/game_data_scene_lookup.c
         src/game_data_scripts.c
+        src/game_data_update_runtime.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c
         src/game_data_standard_options.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -103,19 +103,19 @@ static bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, con
 static bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime, const char *action, Uint8 button);
 static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtime, const char *action,
                                               SDL_GamepadButton button);
-static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
-                                const slayer3d_game_data_ui_metrics *metrics);
+bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
+                         const slayer3d_game_data_ui_metrics *metrics);
 bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
 static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
 static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
 static void storage_config_from_root(yyjson_val *root, slayer3d_storage_config *out_config);
-static bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
-static void sensor_actor_list_free(sensor_actor_list *list);
-static bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
-                                           sensor_actor_list *out_list);
+bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
+void sensor_actor_list_free(sensor_actor_list *list);
+bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
+                                    sensor_actor_list *out_list);
 
-static float game_data_random01(slayer3d_game_data_runtime *runtime)
+float game_data_random01(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
         return 0.0f;
@@ -211,55 +211,53 @@ slayer3d_signal_bus *runtime_bus(const slayer3d_game_data_runtime *runtime)
     return runtime != NULL ? slayer3d_game_session_get_signal_bus(runtime->session) : NULL;
 }
 
-static slayer3d_timer_pool *runtime_timers(const slayer3d_game_data_runtime *runtime)
+slayer3d_timer_pool *runtime_timers(const slayer3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? slayer3d_game_session_get_timer_pool(runtime->session) : NULL;
 }
 
-static slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *runtime)
+slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *runtime)
 {
     return runtime != NULL ? slayer3d_game_session_get_input(runtime->session) : NULL;
 }
 
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
-static actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
+actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
 static const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name);
 static actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
                                                      int *out_index);
 const actor_pool_runtime *find_actor_pool_for_actor_const(const slayer3d_game_data_runtime *runtime,
                                                           const char *actor_name, int *out_index);
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
-static slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                                      int *out_index);
+slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                               int *out_index);
 static actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index);
-static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
-                                           actor_lifecycle_state state);
-static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor,
-                                       int index);
+void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
+                                    actor_lifecycle_state state);
+bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
 static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor,
                                           int index);
 static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
 static int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
-static void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
-static void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
-static void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
-static bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
+void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
+void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
+void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
+bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
 static bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
                                        bool active);
-static bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                       slayer3d_registered_actor *actor, int index, const char *reason);
+bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                slayer3d_registered_actor *actor, int index, const char *reason);
 static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
                                                  const char *to_scene);
 static slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                                       const slayer3d_properties *payload);
-static bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime,
-                                        const slayer3d_registered_actor *target,
-                                        const slayer3d_registered_actor *source, yyjson_val *json,
-                                        const slayer3d_properties *payload, const char *fallback_tag,
-                                        bool fallback_exclude_source);
-static void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
-static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
+bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
+                                 const slayer3d_registered_actor *source, yyjson_val *json,
+                                 const slayer3d_properties *payload, const char *fallback_tag,
+                                 bool fallback_exclude_source);
+void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
+void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 #include "game_data/game_data_lua_api.inc"
 
 #include "game_data/game_data_replication_helpers.inc"
@@ -279,8 +277,6 @@ static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 #include "game_data/game_data_actions.inc"
 
 #include "game_data/game_data_scene_load_runtime.inc"
-
-#include "game_data/game_data_update_runtime.inc"
 
 #include "game_data/game_data_load_runtime.inc"
 

--- a/src/game_data/game_data_actions.inc
+++ b/src/game_data/game_data_actions.inc
@@ -15,8 +15,7 @@
 
 #include "game_data_sector_noise_actions.inc"
 
-static bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                               const slayer3d_properties *payload)
+bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
     slayer3d_signal_bus *bus = runtime_bus(runtime);
@@ -485,8 +484,7 @@ static bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *
     return false;
 }
 
-static bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                 const slayer3d_properties *payload)
+bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload)
 {
     if (!yyjson_is_arr(actions))
         return false;
@@ -503,8 +501,8 @@ static bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val
     return ok;
 }
 
-static bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                          const slayer3d_properties *payload)
+bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
+                                   const slayer3d_properties *payload)
 {
     if (actions == NULL)
         return true;

--- a/src/game_data/game_data_actor_pool_actions.inc
+++ b/src/game_data/game_data_actor_pool_actions.inc
@@ -144,7 +144,7 @@ static bool reset_actor_properties_to_authored_defaults(slayer3d_game_data_runti
     return true;
 }
 
-static actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name)
+actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;
@@ -220,8 +220,8 @@ const actor_pool_runtime *find_actor_pool_for_actor_const(const slayer3d_game_da
     return NULL;
 }
 
-static slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                                      int *out_index)
+slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                               int *out_index)
 {
     if (out_index != NULL)
         *out_index = -1;
@@ -287,8 +287,8 @@ static slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime
     return slayer3d_game_data_find_actor(runtime, pool->actor_names[index]);
 }
 
-static bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                       slayer3d_registered_actor *actor, int index, const char *reason)
+bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                slayer3d_registered_actor *actor, int index, const char *reason)
 {
     if (runtime == NULL || pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
         return false;
@@ -311,7 +311,7 @@ static bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, acto
     return true;
 }
 
-static void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *properties)
+void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *properties)
 {
     if (actor == NULL || !yyjson_is_obj(properties))
         return;

--- a/src/game_data/game_data_actors_input.inc
+++ b/src/game_data/game_data_actors_input.inc
@@ -276,8 +276,8 @@ bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name)
     return false;
 }
 
-static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
-                                           actor_lifecycle_state state)
+void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
+                                    actor_lifecycle_state state)
 {
     if (pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
         return;
@@ -286,8 +286,7 @@ static void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_re
     slayer3d_properties_set_string(actor->props, "pool_lifecycle", actor_lifecycle_state_name(state));
 }
 
-static bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor,
-                                       int index)
+bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index)
 {
     return actor != NULL && actor->active &&
            (pool == NULL || pool->lifecycle_states == NULL ||
@@ -342,13 +341,13 @@ static void actor_pool_update_peak_active_count(slayer3d_game_data_runtime *runt
         pool->peak_active_count = active_count;
 }
 
-static void actor_pool_note_spawn_attempt(actor_pool_runtime *pool)
+void actor_pool_note_spawn_attempt(actor_pool_runtime *pool)
 {
     if (pool != NULL)
         pool->spawn_attempt_count++;
 }
 
-static void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool)
+void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool)
 {
     if (pool == NULL)
         return;
@@ -357,7 +356,7 @@ static void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, a
     actor_pool_update_peak_active_count(runtime, pool);
 }
 
-static void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason)
+void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason)
 {
     if (pool == NULL)
         return;
@@ -365,7 +364,7 @@ static void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *
     actor_pool_copy_reason(pool->last_spawn_failure_reason, sizeof(pool->last_spawn_failure_reason), reason);
 }
 
-static void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime)
+void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime)
 {
     if (runtime != NULL)
         runtime->actor_lifecycle_defer_depth++;
@@ -394,7 +393,7 @@ static void actor_lifecycle_flush(slayer3d_game_data_runtime *runtime)
     }
 }
 
-static void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime)
+void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL || runtime->actor_lifecycle_defer_depth <= 0)
         return;
@@ -421,7 +420,7 @@ static bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, acto
     return true;
 }
 
-static bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active)
+bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active)
 {
     if (pool == NULL || actor == NULL || index < 0 || index >= pool->capacity)
         return false;

--- a/src/game_data/game_data_combat_weapon_actions.inc
+++ b/src/game_data/game_data_combat_weapon_actions.inc
@@ -157,9 +157,9 @@ static void weapon_fire_commit(slayer3d_game_data_runtime *runtime, yyjson_val *
     weapon_emit_signal(runtime, action, "on_fire", actor, WEAPON_FIRE_READY);
 }
 
-static bool execute_projectile_fire_action_for_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                     const slayer3d_properties *payload,
-                                                     slayer3d_registered_actor *source_actor)
+bool execute_projectile_fire_action_for_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                              const slayer3d_properties *payload,
+                                              slayer3d_registered_actor *source_actor)
 {
     const char *target_name = json_string(action, "target", NULL);
     slayer3d_registered_actor *target =
@@ -273,7 +273,7 @@ static void set_actor_numeric_property(slayer3d_registered_actor *actor, const c
         slayer3d_properties_set_float(actor->props, key, value);
 }
 
-static float actor_numeric_property(const slayer3d_registered_actor *actor, const char *key, float fallback)
+float actor_numeric_property(const slayer3d_registered_actor *actor, const char *key, float fallback)
 {
     float value = fallback;
     return actor != NULL && actor->props != NULL &&
@@ -324,9 +324,8 @@ static void emit_combat_signal(slayer3d_game_data_runtime *runtime, yyjson_val *
         slayer3d_signal_emit(runtime_bus(runtime), signal_id, payload);
 }
 
-static bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                         const slayer3d_properties *payload, slayer3d_registered_actor *actor,
-                                         float amount);
+bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload, slayer3d_registered_actor *actor, float amount);
 
 static bool execute_combat_damage_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                          const slayer3d_properties *payload)
@@ -340,9 +339,8 @@ static bool execute_combat_damage_action(slayer3d_game_data_runtime *runtime, yy
     return apply_combat_damage_to_actor(runtime, action, payload, actor, amount);
 }
 
-static bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                         const slayer3d_properties *payload, slayer3d_registered_actor *actor,
-                                         float amount)
+bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload, slayer3d_registered_actor *actor, float amount)
 {
     if (actor == NULL)
         return false;
@@ -541,8 +539,8 @@ static slayer3d_properties *resource_event_payload(slayer3d_registered_actor *ta
     return event_payload;
 }
 
-static void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,
-                                 const slayer3d_properties *payload)
+void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,
+                          const slayer3d_properties *payload)
 {
     const int signal_id = action_signal_id(runtime, json, signal_key);
     if (signal_id >= 0 && runtime_bus(runtime) != NULL)
@@ -1029,7 +1027,7 @@ static bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, y
     return ok;
 }
 
-static void weapon_complete_reload(slayer3d_registered_actor *actor, yyjson_val *json)
+void weapon_complete_reload(slayer3d_registered_actor *actor, yyjson_val *json)
 {
     if (actor == NULL || json == NULL)
         return;

--- a/src/game_data/game_data_conditions_presentation.inc
+++ b/src/game_data/game_data_conditions_presentation.inc
@@ -1,19 +1,18 @@
 /* Conditions, UI binding, presentation clock, and animation helpers. Included by game_data_actions.inc to preserve
  * internal linkage. */
 
-static int action_signal_id(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *key)
+int action_signal_id(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *key)
 {
     return slayer3d_game_data_find_signal(runtime, json_string(action, key, NULL));
 }
 
-static bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                 const slayer3d_properties *payload);
-static bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                          const slayer3d_properties *payload);
-static int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
-                                         const slayer3d_registered_actor *actor);
-static float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
-static bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
+bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload);
+bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
+                                   const slayer3d_properties *payload);
+int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
+                                  const slayer3d_registered_actor *actor);
+float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
+bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
 
 static bool compare_value(const slayer3d_value *left, const char *op, yyjson_val *right)
 {
@@ -55,7 +54,7 @@ static bool compare_value(const slayer3d_value *left, const char *op, yyjson_val
     return false;
 }
 
-static bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value)
+bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value)
 {
     if (json == NULL || out_value == NULL)
         return false;
@@ -88,7 +87,7 @@ static bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value)
     return false;
 }
 
-static bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value)
+bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value)
 {
     if (props == NULL || key == NULL || key[0] == '\0' || value == NULL)
         return false;
@@ -206,8 +205,8 @@ static bool value_equals_json_bool(const slayer3d_value *left, bool right)
     return left != NULL && left->type == SLAYER3D_VALUE_BOOL && left->as_bool == right;
 }
 
-static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
-                                const slayer3d_game_data_ui_metrics *metrics)
+bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
+                         const slayer3d_game_data_ui_metrics *metrics)
 {
     if (condition == NULL)
         return true;

--- a/src/game_data/game_data_controller_runtime.inc
+++ b/src/game_data/game_data_controller_runtime.inc
@@ -135,8 +135,8 @@ static fps_controller_runtime *fps_controller_for_actor_action(slayer3d_game_dat
     return controller;
 }
 
-static bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                 const slayer3d_properties *payload)
+bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                          const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = NULL;
     yyjson_val *component = NULL;
@@ -150,8 +150,8 @@ static bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *run
     return true;
 }
 
-static bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                   const slayer3d_properties *payload)
+bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = NULL;
     yyjson_val *component = NULL;
@@ -199,7 +199,7 @@ static slayer3d_vec3 sector_door_closed_center(const slayer3d_door *door)
                               (bounds.min.z + bounds.max.z) * 0.5f);
 }
 
-static float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point)
+float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point)
 {
     if (door == NULL || door->panel_count <= 0)
         return 0.0f;
@@ -209,7 +209,7 @@ static float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3
     return dx * dx + dz * dz;
 }
 
-static bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot)
+bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot)
 {
     if (door == NULL)
         return false;

--- a/src/game_data/game_data_interaction_effect_actions.inc
+++ b/src/game_data/game_data_interaction_effect_actions.inc
@@ -169,11 +169,10 @@ static slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime
     return source;
 }
 
-static bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime,
-                                        const slayer3d_registered_actor *target,
-                                        const slayer3d_registered_actor *source, yyjson_val *json,
-                                        const slayer3d_properties *payload, const char *fallback_tag,
-                                        bool fallback_exclude_source)
+bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
+                                 const slayer3d_registered_actor *source, yyjson_val *json,
+                                 const slayer3d_properties *payload, const char *fallback_tag,
+                                 bool fallback_exclude_source)
 {
     if (target == NULL || !target->active)
         return false;
@@ -474,7 +473,7 @@ static slayer3d_registered_actor *effect_source_actor(slayer3d_game_data_runtime
     return source;
 }
 
-static bool collect_effect_targets(slayer3d_game_data_runtime *runtime, const char *tag, sensor_actor_list *out_list)
+bool collect_effect_targets(slayer3d_game_data_runtime *runtime, const char *tag, sensor_actor_list *out_list)
 {
     if (runtime == NULL || out_list == NULL)
         return false;

--- a/src/game_data/game_data_scene_flow_runtime.inc
+++ b/src/game_data/game_data_scene_flow_runtime.inc
@@ -93,14 +93,12 @@ static yyjson_val *active_timeline_events(const slayer3d_game_data_runtime *runt
     return yyjson_is_arr(events) ? events : NULL;
 }
 
-static bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                               const slayer3d_properties *payload);
-static bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                 const slayer3d_properties *payload);
-static bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                 const slayer3d_properties *payload);
-static bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                   const slayer3d_properties *payload);
+bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload);
+bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload);
+bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                          const slayer3d_properties *payload);
+bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload);
 static slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
                                                          const slayer3d_properties *payload, const char *key);
 
@@ -225,8 +223,8 @@ static bool update_phase_default(const slayer3d_game_data_runtime *runtime, cons
     return !paused;
 }
 
-static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
-                                const slayer3d_game_data_ui_metrics *metrics);
+bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
+                         const slayer3d_game_data_ui_metrics *metrics);
 
 static bool eval_update_phase_entry(const slayer3d_game_data_runtime *runtime, yyjson_val *entry, bool paused,
                                     bool fallback)
@@ -374,8 +372,8 @@ bool slayer3d_game_data_get_scene_transition(const slayer3d_game_data_runtime *r
     return transition_name != NULL && slayer3d_game_data_get_transition(runtime, transition_name, out_transition);
 }
 
-static bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
-                                const slayer3d_game_data_ui_metrics *metrics);
+bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
+                         const slayer3d_game_data_ui_metrics *metrics);
 
 static const scene_menu_state *active_scene_menu_for_metrics(const slayer3d_game_data_runtime *runtime,
                                                              const slayer3d_game_data_ui_metrics *metrics)

--- a/src/game_data/game_data_sensor_runtime.inc
+++ b/src/game_data/game_data_sensor_runtime.inc
@@ -67,7 +67,7 @@ bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const sl
     return actor->active;
 }
 
-static bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor)
+bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor)
 {
     if (list == NULL || actor == NULL)
         return false;
@@ -85,7 +85,7 @@ static bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_a
     return true;
 }
 
-static void sensor_actor_list_free(sensor_actor_list *list)
+void sensor_actor_list_free(sensor_actor_list *list)
 {
     if (list == NULL)
         return;
@@ -95,8 +95,8 @@ static void sensor_actor_list_free(sensor_actor_list *list)
     list->capacity = 0;
 }
 
-static bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
-                                           sensor_actor_list *out_list)
+bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
+                                    sensor_actor_list *out_list)
 {
     if (runtime == NULL || out_list == NULL)
         return false;
@@ -153,7 +153,7 @@ static bool sensor_contact_name_is_transient(const char *name)
     return name != NULL && SDL_strncmp(name, "noise.", 6) == 0;
 }
 
-static void sensor_contact_pair_destroy(sensor_contact_pair_state *state)
+void sensor_contact_pair_destroy(sensor_contact_pair_state *state)
 {
     if (state == NULL)
         return;
@@ -481,8 +481,8 @@ static int sensor_target_sector_index(const sector_level_runtime *level, const s
     return sector_level_find_sector_name(level, sensor->sector);
 }
 
-static int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
-                                         const slayer3d_registered_actor *actor)
+int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
+                                  const slayer3d_registered_actor *actor)
 {
     if (level == NULL || actor == NULL)
         return -1;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -645,6 +645,8 @@ float scene_state_float(const slayer3d_game_data_runtime *runtime, const char *k
 
 slayer3d_actor_registry *runtime_registry(const slayer3d_game_data_runtime *runtime);
 slayer3d_signal_bus *runtime_bus(const slayer3d_game_data_runtime *runtime);
+slayer3d_timer_pool *runtime_timers(const slayer3d_game_data_runtime *runtime);
+slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *runtime);
 yyjson_val *runtime_root(const slayer3d_game_data_runtime *runtime);
 scene_entry *active_scene_entry(slayer3d_game_data_runtime *runtime);
 const scene_entry *active_scene_entry_const(const slayer3d_game_data_runtime *runtime);
@@ -679,9 +681,23 @@ bool entity_json_has_tags(yyjson_val *entity, const char *const *tags, int tag_c
 bool entity_json_has_all_tags_from_json(yyjson_val *entity, yyjson_val *tags);
 const actor_pool_runtime *find_actor_pool_for_actor_const(const slayer3d_game_data_runtime *runtime,
                                                           const char *actor_name, int *out_index);
+actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
+slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                               int *out_index);
+void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
+                                    actor_lifecycle_state state);
+bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
+void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
+void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
+void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
+bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
+bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
+                                slayer3d_registered_actor *actor, int index, const char *reason);
+void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *properties);
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
 slayer3d_vec3 actor_vec_property(const slayer3d_registered_actor *actor, const char *key);
+float actor_numeric_property(const slayer3d_registered_actor *actor, const char *key, float fallback);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
 slayer3d_audio_bus parse_audio_bus(const char *bus, slayer3d_audio_bus fallback);
 slayer3d_backend parse_backend(const char *value, slayer3d_backend fallback);
@@ -707,6 +723,44 @@ fps_controller_runtime *find_or_add_fps_controller(slayer3d_game_data_runtime *r
 patrol_controller_runtime *find_patrol_controller(slayer3d_game_data_runtime *runtime, const char *entity_name);
 patrol_controller_runtime *find_or_add_patrol_controller(slayer3d_game_data_runtime *runtime, const char *entity_name,
                                                          yyjson_val *component);
+float game_data_random01(slayer3d_game_data_runtime *runtime);
+int action_signal_id(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *key);
+bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload);
+bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload);
+bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
+                                   const slayer3d_properties *payload);
+bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
+                         const slayer3d_game_data_ui_metrics *metrics);
+void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,
+                          const slayer3d_properties *payload);
+void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
+void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
+bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value);
+bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value);
+bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
+                                 const slayer3d_registered_actor *source, yyjson_val *json,
+                                 const slayer3d_properties *payload, const char *fallback_tag,
+                                 bool fallback_exclude_source);
+bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload, slayer3d_registered_actor *actor, float amount);
+bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
+void sensor_actor_list_free(sensor_actor_list *list);
+bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
+                                    sensor_actor_list *out_list);
+void sensor_contact_pair_destroy(sensor_contact_pair_state *state);
+int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
+                                  const slayer3d_registered_actor *actor);
+bool collect_effect_targets(slayer3d_game_data_runtime *runtime, const char *tag, sensor_actor_list *out_list);
+float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
+bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
+bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                          const slayer3d_properties *payload);
+bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload);
+bool execute_projectile_fire_action_for_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                              const slayer3d_properties *payload,
+                                              slayer3d_registered_actor *source_actor);
+void weapon_complete_reload(slayer3d_registered_actor *actor, yyjson_val *json);
 const grid_map_runtime *find_grid_map(const slayer3d_game_data_runtime *runtime, const char *name);
 bool grid_map_normalize_cell(const grid_map_runtime *map, int *col, int *row);
 char grid_map_cell(const grid_map_runtime *map, int col, int row);

--- a/src/game_data_update_runtime.c
+++ b/src/game_data_update_runtime.c
@@ -1,11 +1,14 @@
-/* Controller, motion, sensor, and schedule update helpers.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/* Controller, motion, sensor, and schedule update helpers. */
 
-#include "game_data_controller_runtime.inc"
+#include "game_data_internal.h"
 
-#include "game_data_motion_runtime.inc"
+#include <SDL3/SDL_log.h>
 
-#include "game_data_sensor_runtime.inc"
+#include "game_data/game_data_controller_runtime.inc"
+
+#include "game_data/game_data_motion_runtime.inc"
+
+#include "game_data/game_data_sensor_runtime.inc"
 
 static void update_noise_events(slayer3d_game_data_runtime *runtime, float dt)
 {


### PR DESCRIPTION
## Summary
- move the frame update orchestration from game_data_update_runtime.inc to src/game_data_update_runtime.c
- make the update module's dependencies explicit through game_data_internal.h instead of relying on game_data.c include order
- keep controller, motion, and sensor runtime helpers under the update module for later focused extraction

## Testing
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8
- git diff --check

## Next slice
- Continue extracting the subordinate update helpers, starting with a focused controller/motion/sensor split once their shared helper boundaries are cleaned up.