### PR TITLE
Refactor game data runtime helpers into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ target_sources(
         src/game_data.c
         src/game_data_action_lookup.c
         src/game_data_adapter_helpers.c
+        src/game_data_controller_runtime.c
         src/game_data_controller_binding_helpers.c
         src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ target_sources(
         src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c
         src/game_data_json_helpers.c
+        src/game_data_motion_runtime.c
         src/game_data_property_effect_runtime.c
         src/game_data_runtime_collections.c
         src/game_data_scene_lookup.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,13 +151,16 @@ target_sources(
         src/game_data_adapter_helpers.c
         src/game_data_controller_runtime.c
         src/game_data_controller_binding_helpers.c
+        src/game_data_grid_actions.c
         src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c
         src/game_data_json_helpers.c
         src/game_data_motion_runtime.c
+        src/game_data_network_sessions.c
         src/game_data_property_effect_runtime.c
         src/game_data_runtime_collections.c
         src/game_data_scene_lookup.c
+        src/game_data_sensor_runtime.c
         src/game_data_scripts.c
         src/game_data_update_runtime.c
         src/game_data_world_loaders.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -268,8 +268,6 @@ void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 
 #include "game_data/game_data_scene_flow_runtime.inc"
 
-#include "game_data/game_data_network_sessions.inc"
-
 #include "game_data/game_data_menu_ui.inc"
 
 #include "game_data/game_data_actors_input.inc"

--- a/src/game_data/game_data_actions.inc
+++ b/src/game_data/game_data_actions.inc
@@ -9,8 +9,6 @@
 
 #include "game_data_combat_weapon_actions.inc"
 
-#include "game_data_grid_actions.inc"
-
 #include "game_data_interaction_effect_actions.inc"
 
 #include "game_data_sector_noise_actions.inc"

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -1,5 +1,6 @@
-/* Controller, FPS movement, brush movement, and sector door update helpers. Included by game_data_update_runtime.inc to
- * preserve internal linkage. */
+/* Controller, FPS movement, brush movement, and sector door update helpers. */
+
+#include "game_data_internal.h"
 
 static bool initialize_patrol_controller(slayer3d_game_data_runtime *runtime, patrol_controller_runtime *controller,
                                          yyjson_val *component, slayer3d_registered_actor *actor)
@@ -34,8 +35,8 @@ static bool initialize_patrol_controller(slayer3d_game_data_runtime *runtime, pa
     return true;
 }
 
-static void update_patrol_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
-                                     slayer3d_registered_actor *actor, float dt)
+void update_patrol_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                              slayer3d_registered_actor *actor, float dt)
 {
     patrol_controller_runtime *controller =
         actor != NULL ? find_or_add_patrol_controller(runtime, actor->name, component) : NULL;
@@ -249,9 +250,8 @@ static void resolve_fps_controller_sector_doors(slayer3d_game_data_runtime *runt
     }
 }
 
-static void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
-                                         slayer3d_registered_actor *actor, const slayer3d_input_manager *input,
-                                         float dt)
+void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                  slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
 {
     if (runtime == NULL || component == NULL || actor == NULL)
         return;
@@ -522,8 +522,8 @@ static bool fps_brush_try_step_move(const slayer3d_game_data_runtime *runtime, s
     return true;
 }
 
-static void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
-                                        slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
+void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                 slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
 {
     if (runtime == NULL || component == NULL || actor == NULL)
         return;
@@ -746,9 +746,9 @@ static slayer3d_properties *brush_velocity_impact_payload(const slayer3d_registe
     return payload;
 }
 
-static bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yyjson_val *component,
-                                         slayer3d_registered_actor *actor, int actor_id, int pool_index,
-                                         int actor_index, float dt)
+bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                  slayer3d_registered_actor *actor, int actor_id, int pool_index, int actor_index,
+                                  float dt)
 {
     const char *property = json_string(component, "property", "velocity");
     const slayer3d_vec3 velocity = actor_vec_property(actor, property);
@@ -794,7 +794,7 @@ static bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yy
     return true;
 }
 
-static void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt)
+void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt)
 {
     for (int i = 0; runtime != NULL && i < runtime->sector_door_count; ++i)
     {

--- a/src/game_data_grid_actions.c
+++ b/src/game_data_grid_actions.c
@@ -1,4 +1,6 @@
-/* Grid spawn and pickup action helpers. Included by game_data_actions.inc to preserve internal linkage. */
+/* Grid spawn and pickup action helpers. */
+
+#include "game_data_internal.h"
 
 static bool grid_spawn_rule_matches(yyjson_val *rule, char glyph)
 {
@@ -6,7 +8,7 @@ static bool grid_spawn_rule_matches(yyjson_val *rule, char glyph)
     return rule_glyph != NULL && rule_glyph[0] == glyph && rule_glyph[1] == '\0';
 }
 
-static bool execute_grid_spawn_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_grid_spawn_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const grid_map_runtime *map = find_grid_map(runtime, json_string(action, "map", NULL));
     yyjson_val *spawns = obj_get(action, "spawns");
@@ -175,7 +177,7 @@ static bool spawn_grid_run_actor(slayer3d_game_data_runtime *runtime, const grid
     return true;
 }
 
-static bool execute_grid_spawn_runs_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_grid_spawn_runs_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const grid_map_runtime *map = find_grid_map(runtime, json_string(action, "map", NULL));
     yyjson_val *spawns = obj_get(action, "spawns");
@@ -248,7 +250,7 @@ static bool execute_grid_spawn_runs_from_glyphs_action(slayer3d_game_data_runtim
     return ok;
 }
 
-static bool execute_grid_pickup_layer_reset_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_grid_pickup_layer_reset_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     grid_pickup_layer_runtime *layer = find_grid_pickup_layer(runtime, json_string(action, "layer", NULL));
     if (layer == NULL || !grid_pickup_layer_reset(runtime, layer))

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -696,6 +696,9 @@ bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_
                                 slayer3d_registered_actor *actor, int index, const char *reason);
 void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *properties);
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
+bool execute_grid_spawn_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_grid_spawn_runs_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_grid_pickup_layer_reset_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 slayer3d_vec3 actor_vec_property(const slayer3d_registered_actor *actor, const char *key);
 float actor_numeric_property(const slayer3d_registered_actor *actor, const char *key, float fallback);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
@@ -757,6 +760,7 @@ void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt);
 bool update_sector_platforms(slayer3d_game_data_runtime *runtime, float dt);
 void update_control_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt);
 void update_motion_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt);
+void update_sensors(slayer3d_game_data_runtime *runtime);
 void update_patrol_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
                               slayer3d_registered_actor *actor, float dt);
 void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -753,6 +753,16 @@ int actor_sector_index_for_sensor(const sector_level_runtime *level, const senso
 bool collect_effect_targets(slayer3d_game_data_runtime *runtime, const char *tag, sensor_actor_list *out_list);
 float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
 bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
+void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt);
+void update_patrol_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                              slayer3d_registered_actor *actor, float dt);
+void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                  slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt);
+void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                 slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt);
+bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                  slayer3d_registered_actor *actor, int actor_id, int pool_index, int actor_index,
+                                  float dt);
 bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                           const slayer3d_properties *payload);
 bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -754,6 +754,9 @@ bool collect_effect_targets(slayer3d_game_data_runtime *runtime, const char *tag
 float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
 bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
 void update_sector_doors(slayer3d_game_data_runtime *runtime, float dt);
+bool update_sector_platforms(slayer3d_game_data_runtime *runtime, float dt);
+void update_control_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt);
+void update_motion_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt);
 void update_patrol_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
                               slayer3d_registered_actor *actor, float dt);
 void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,

--- a/src/game_data_motion_runtime.c
+++ b/src/game_data_motion_runtime.c
@@ -1,5 +1,8 @@
-/* Sector platform, component state, and motion update helpers. Included by game_data_update_runtime.inc to preserve
- * internal linkage. */
+/* Sector platform, component state, and motion update helpers. */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
 
 static slayer3d_properties *sector_platform_crush_payload(const sector_platform_runtime *platform,
                                                           const slayer3d_registered_actor *actor, float floor_y,
@@ -75,7 +78,7 @@ static bool sector_platform_apply_crush_policy(slayer3d_game_data_runtime *runti
     return ok;
 }
 
-static bool update_sector_platforms(slayer3d_game_data_runtime *runtime, float dt)
+bool update_sector_platforms(slayer3d_game_data_runtime *runtime, float dt)
 {
     if (runtime == NULL)
         return false;
@@ -236,7 +239,7 @@ static void update_interactable_component(yyjson_val *component, slayer3d_regist
         slayer3d_properties_set_float(actor->props, cooldown_property, SDL_max(cooldown - dt, 0.0f));
 }
 
-static void update_control_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt)
+void update_control_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     slayer3d_input_manager *input = runtime_input(runtime);
     yyjson_val *entities = obj_get(root, "entities");
@@ -321,7 +324,7 @@ static void update_control_components(slayer3d_game_data_runtime *runtime, yyjso
     }
 }
 
-static void update_motion_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt)
+void update_motion_components(slayer3d_game_data_runtime *runtime, yyjson_val *root, float dt)
 {
     (void)root;
     for (int actor_id = 0; actor_id < runtime->actor_pool_count + 1; ++actor_id)

--- a/src/game_data_network_sessions.c
+++ b/src/game_data_network_sessions.c
@@ -1,5 +1,6 @@
-/* Runtime-owned network direct-connect, host, and discovery session helpers. Included by src/game_data.c to preserve
- * internal linkage. */
+/* Runtime-owned network direct-connect, host, and discovery session helpers. */
+
+#include "game_data_internal.h"
 
 static const char *game_data_network_state_name(slayer3d_network_state state)
 {

--- a/src/game_data_sensor_runtime.c
+++ b/src/game_data_sensor_runtime.c
@@ -1,4 +1,6 @@
-/* Sensor runtime update helpers. Included by game_data_update_runtime.inc to preserve internal linkage. */
+/* Sensor runtime update helpers. */
+
+#include "game_data_internal.h"
 
 static void emit_sensor_signal(slayer3d_game_data_runtime *runtime, const sensor_entry *sensor,
                                slayer3d_registered_actor *a, slayer3d_registered_actor *b)
@@ -1077,7 +1079,7 @@ static void update_hearing_sensor(slayer3d_game_data_runtime *runtime, sensor_en
     sensor_actor_list_free(&listeners);
 }
 
-static void update_sensors(slayer3d_game_data_runtime *runtime)
+void update_sensors(slayer3d_game_data_runtime *runtime)
 {
     for (int i = 0; i < runtime->sensor_count; ++i)
     {

--- a/src/game_data_update_runtime.c
+++ b/src/game_data_update_runtime.c
@@ -4,8 +4,6 @@
 
 #include <SDL3/SDL_log.h>
 
-#include "game_data/game_data_sensor_runtime.inc"
-
 static void update_noise_events(slayer3d_game_data_runtime *runtime, float dt)
 {
     if (runtime == NULL || runtime->noise_event_count <= 0)

--- a/src/game_data_update_runtime.c
+++ b/src/game_data_update_runtime.c
@@ -4,8 +4,6 @@
 
 #include <SDL3/SDL_log.h>
 
-#include "game_data/game_data_controller_runtime.inc"
-
 #include "game_data/game_data_motion_runtime.inc"
 
 #include "game_data/game_data_sensor_runtime.inc"

--- a/src/game_data_update_runtime.c
+++ b/src/game_data_update_runtime.c
@@ -4,8 +4,6 @@
 
 #include <SDL3/SDL_log.h>
 
-#include "game_data/game_data_motion_runtime.inc"
-
 #include "game_data/game_data_sensor_runtime.inc"
 
 static void update_noise_events(slayer3d_game_data_runtime *runtime, float dt)


### PR DESCRIPTION
## Summary
- move controller/FPS/brush-velocity runtime helpers into src/game_data_controller_runtime.c
- move sector platform/control/motion update helpers into src/game_data_motion_runtime.c
- move sensor update helpers into src/game_data_sensor_runtime.c
- move runtime-owned network direct-connect/host/discovery session helpers into src/game_data_network_sessions.c
- move grid spawn/pickup action helpers into src/game_data_grid_actions.c
- remove the corresponding textual .inc includes from the update/action/runtime paths and expose only narrow internal entry points through game_data_internal.h

## Verification
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8
- git diff --check