### PR TITLE
Refactor game data action helpers into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,18 +149,22 @@ target_sources(
         src/game_data.c
         src/game_data_action_lookup.c
         src/game_data_adapter_helpers.c
+        src/game_data_combat_weapon_actions.c
         src/game_data_controller_runtime.c
         src/game_data_controller_binding_helpers.c
         src/game_data_grid_actions.c
         src/game_data_grid_runtime.c
         src/game_data_input_device_helpers.c
+        src/game_data_interaction_effect_actions.c
         src/game_data_json_helpers.c
         src/game_data_motion_runtime.c
         src/game_data_network_sessions.c
+        src/game_data_persistence_audio_actions.c
         src/game_data_property_effect_runtime.c
         src/game_data_runtime_collections.c
         src/game_data_scene_lookup.c
         src/game_data_sensor_runtime.c
+        src/game_data_sector_noise_actions.c
         src/game_data_scripts.c
         src/game_data_update_runtime.c
         src/game_data_world_loaders.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -159,7 +159,7 @@ static char *path_dirname(const char *path)
     return dir;
 }
 
-static char *path_basename(const char *path)
+char *path_basename(const char *path)
 {
     if (path == NULL)
         return NULL;
@@ -173,7 +173,7 @@ static char *path_basename(const char *path)
     return SDL_strdup(base);
 }
 
-static const char *asset_path_without_scheme(const char *path)
+const char *asset_path_without_scheme(const char *path)
 {
     return path != NULL && SDL_strncmp(path, "asset://", 8) == 0 ? path + 8 : path;
 }
@@ -250,8 +250,6 @@ bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_
                                 slayer3d_registered_actor *actor, int index, const char *reason);
 static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
                                                  const char *to_scene);
-static slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                      const slayer3d_properties *payload);
 bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
                                  const slayer3d_registered_actor *source, yyjson_val *json,
                                  const slayer3d_properties *payload, const char *fallback_tag,

--- a/src/game_data/game_data_actions.inc
+++ b/src/game_data/game_data_actions.inc
@@ -3,15 +3,7 @@
 
 #include "game_data_conditions_presentation.inc"
 
-#include "game_data_persistence_audio_actions.inc"
-
 #include "game_data_actor_pool_actions.inc"
-
-#include "game_data_combat_weapon_actions.inc"
-
-#include "game_data_interaction_effect_actions.inc"
-
-#include "game_data_sector_noise_actions.inc"
 
 bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
 {

--- a/src/game_data/game_data_actor_pool_actions.inc
+++ b/src/game_data/game_data_actor_pool_actions.inc
@@ -329,15 +329,15 @@ void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *
     }
 }
 
-static slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
-                                                         const slayer3d_properties *payload, const char *key)
+slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_properties *payload, const char *key)
 {
     const char *actor_name = payload != NULL && key != NULL ? slayer3d_properties_get_string(payload, key, NULL) : NULL;
     return slayer3d_game_data_find_actor(runtime, actor_name);
 }
 
-static slayer3d_vec3 actor_spawn_position_from_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                      const slayer3d_properties *payload, slayer3d_vec3 fallback)
+slayer3d_vec3 actor_spawn_position_from_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload, slayer3d_vec3 fallback)
 {
     slayer3d_vec3 position = fallback;
     yyjson_val *position_json = obj_get(action, "position");

--- a/src/game_data/game_data_actors_input.inc
+++ b/src/game_data/game_data_actors_input.inc
@@ -1,7 +1,7 @@
 /* Actor, pool, and input-profile runtime helpers.
  * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
 
-static void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *key, yyjson_val *value)
+void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *key, yyjson_val *value)
 {
     if (actor == NULL || key == NULL || value == NULL)
         return;

--- a/src/game_data/game_data_lua_api.inc
+++ b/src/game_data/game_data_lua_api.inc
@@ -26,8 +26,6 @@ static slayer3d_registered_actor *lua_actor_arg(lua_State *lua, slayer3d_game_da
     return slayer3d_game_data_find_actor(runtime, actor_name);
 }
 
-static bool ensure_runtime_storage(slayer3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size);
-
 static int lua_get_position(lua_State *lua)
 {
     slayer3d_game_data_runtime *runtime = lua_runtime(lua);

--- a/src/game_data/game_data_scene_flow_runtime.inc
+++ b/src/game_data/game_data_scene_flow_runtime.inc
@@ -99,9 +99,6 @@ bool execute_fps_controller_launch_action(slayer3d_game_data_runtime *runtime, y
                                           const slayer3d_properties *payload);
 bool execute_fps_controller_teleport_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                             const slayer3d_properties *payload);
-static slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
-                                                         const slayer3d_properties *payload, const char *key);
-
 void slayer3d_game_data_timeline_state_init(slayer3d_game_data_timeline_state *state)
 {
     if (state != NULL)

--- a/src/game_data_combat_weapon_actions.c
+++ b/src/game_data_combat_weapon_actions.c
@@ -1,5 +1,14 @@
-/* Combat, resource, pickup, and weapon action helpers. Included by game_data_actions.inc to preserve internal linkage.
- */
+/* Combat, resource, pickup, and weapon action helpers. */
+
+#include "game_data_internal.h"
+
+typedef enum weapon_fire_status
+{
+    WEAPON_FIRE_READY,
+    WEAPON_FIRE_COOLDOWN,
+    WEAPON_FIRE_RELOADING,
+    WEAPON_FIRE_EMPTY
+} weapon_fire_status;
 
 static bool weapon_value_as_float(const slayer3d_value *value, float *out_value)
 {
@@ -260,7 +269,7 @@ static bool action_float_value(slayer3d_game_data_runtime *runtime, yyjson_val *
     return false;
 }
 
-static void set_actor_numeric_property(slayer3d_registered_actor *actor, const char *key, float value)
+void set_actor_numeric_property(slayer3d_registered_actor *actor, const char *key, float value)
 {
     if (actor == NULL || actor->props == NULL || key == NULL)
         return;
@@ -327,8 +336,8 @@ static void emit_combat_signal(slayer3d_game_data_runtime *runtime, yyjson_val *
 bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                   const slayer3d_properties *payload, slayer3d_registered_actor *actor, float amount);
 
-static bool execute_combat_damage_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                         const slayer3d_properties *payload)
+bool execute_combat_damage_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = action_target_actor(runtime, action, payload);
     float amount = 0.0f;
@@ -386,8 +395,8 @@ bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_va
     return true;
 }
 
-static bool execute_combat_heal_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                       const slayer3d_properties *payload)
+bool execute_combat_heal_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = action_target_actor(runtime, action, payload);
     float amount = 0.0f;
@@ -421,8 +430,8 @@ static bool execute_combat_heal_action(slayer3d_game_data_runtime *runtime, yyjs
     return true;
 }
 
-static bool execute_combat_kill_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                       const slayer3d_properties *payload)
+bool execute_combat_kill_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = action_target_actor(runtime, action, payload);
     if (actor == NULL)
@@ -456,8 +465,8 @@ static bool execute_combat_kill_action(slayer3d_game_data_runtime *runtime, yyjs
     return true;
 }
 
-static bool execute_combat_revive_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                         const slayer3d_properties *payload)
+bool execute_combat_revive_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = action_target_actor(runtime, action, payload);
     if (actor == NULL)
@@ -614,8 +623,8 @@ static bool apply_resource_delta_to_actor(slayer3d_game_data_runtime *runtime, s
     return true;
 }
 
-static bool execute_resource_amount_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                           const slayer3d_properties *payload, bool consume)
+bool execute_resource_amount_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload, bool consume)
 {
     slayer3d_registered_actor *target = action_target_actor(runtime, action, payload);
     float amount = 0.0f;
@@ -624,8 +633,8 @@ static bool execute_resource_amount_action(slayer3d_game_data_runtime *runtime, 
     return apply_resource_delta_to_actor(runtime, target, action, payload, amount, consume);
 }
 
-static bool execute_resource_set_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                        const slayer3d_properties *payload)
+bool execute_resource_set_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                 const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *target = action_target_actor(runtime, action, payload);
     const char *resource = resource_name(action);
@@ -687,8 +696,8 @@ static bool apply_resource_grants(slayer3d_game_data_runtime *runtime, slayer3d_
     return ok;
 }
 
-static bool execute_pickup_collect_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                          const slayer3d_properties *payload)
+bool execute_pickup_collect_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                   const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *collector = action_target_actor(runtime, action, payload);
     slayer3d_registered_actor *pickup = slayer3d_game_data_find_actor(runtime, json_string(action, "pickup", NULL));
@@ -725,8 +734,8 @@ static bool execute_pickup_collect_action(slayer3d_game_data_runtime *runtime, y
     return true;
 }
 
-static bool execute_resource_station_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                const slayer3d_properties *payload)
+bool execute_resource_station_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                         const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *target = action_target_actor(runtime, action, payload);
     slayer3d_registered_actor *station = slayer3d_game_data_find_actor(runtime, json_string(action, "station", NULL));
@@ -767,8 +776,8 @@ static bool execute_resource_station_use_action(slayer3d_game_data_runtime *runt
     return true;
 }
 
-static bool execute_status_effect_apply_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                               const slayer3d_properties *payload)
+bool execute_status_effect_apply_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                        const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *target = action_target_actor(runtime, action, payload);
     const char *property = json_string(action, "property", NULL);
@@ -949,8 +958,8 @@ static slayer3d_properties *weapon_hitscan_payload(const slayer3d_registered_act
     return payload;
 }
 
-static bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                          const slayer3d_properties *payload)
+bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                   const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *source = action_target_actor(runtime, action, payload);
     if (source == NULL || !runtime_actor_is_active(runtime, source))
@@ -1052,8 +1061,8 @@ void weapon_complete_reload(slayer3d_registered_actor *actor, yyjson_val *json)
     slayer3d_properties_set_float(actor->props, timer_property, 0.0f);
 }
 
-static bool execute_weapon_reload_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                         const slayer3d_properties *payload)
+bool execute_weapon_reload_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor = action_target_actor(runtime, action, payload);
     if (actor == NULL)
@@ -1084,8 +1093,8 @@ static bool execute_weapon_reload_action(slayer3d_game_data_runtime *runtime, yy
     return true;
 }
 
-static bool execute_projectile_fire_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                           const slayer3d_properties *payload)
+bool execute_projectile_fire_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload)
 {
     return execute_projectile_fire_action_for_actor(runtime, action, payload, NULL);
 }

--- a/src/game_data_interaction_effect_actions.c
+++ b/src/game_data_interaction_effect_actions.c
@@ -1,5 +1,6 @@
-/* Target filtering, interaction, and effect action helpers. Included by game_data_actions.inc to preserve internal
- * linkage. */
+/* Target filtering, interaction, and effect action helpers. */
+
+#include "game_data_internal.h"
 
 static yyjson_val *actor_component_json(const slayer3d_game_data_runtime *runtime,
                                         const slayer3d_registered_actor *actor, const char *type)
@@ -159,8 +160,8 @@ static const char *faction_relationship(const slayer3d_game_data_runtime *runtim
     return SDL_strcmp(source_faction, target_faction) == 0 ? "friendly" : "hostile";
 }
 
-static slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                      const slayer3d_properties *payload)
+slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *source =
         actor_from_payload_key(runtime, payload, target_filter_string(action, "source_from_payload", NULL));
@@ -361,7 +362,7 @@ static bool interaction_requirement_met(slayer3d_registered_actor *source, yyjso
     if (source == NULL || property == NULL || property[0] == '\0')
         return false;
     const float amount = SDL_max(json_float(requirement, "amount", 1.0f), 0.0f);
-    return weapon_actor_numeric_property(source, property, 0.0f) + 0.0001f >= amount;
+    return actor_numeric_property(source, property, 0.0f) + 0.0001f >= amount;
 }
 
 static void interaction_consume_requirement(slayer3d_registered_actor *source, yyjson_val *component)
@@ -373,8 +374,8 @@ static void interaction_consume_requirement(slayer3d_registered_actor *source, y
     if (property == NULL || property[0] == '\0')
         return;
     const float amount = SDL_max(json_float(requirement, "amount", 1.0f), 0.0f);
-    const float current = weapon_actor_numeric_property(source, property, 0.0f);
-    weapon_set_actor_numeric_property(source, property, SDL_max(current - amount, 0.0f));
+    const float current = actor_numeric_property(source, property, 0.0f);
+    set_actor_numeric_property(source, property, SDL_max(current - amount, 0.0f));
 }
 
 static slayer3d_properties *interaction_payload(const slayer3d_registered_actor *source,
@@ -414,8 +415,8 @@ static bool interaction_emit_or_run(slayer3d_game_data_runtime *runtime, yyjson_
     return true;
 }
 
-static bool execute_interaction_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                           const slayer3d_properties *payload)
+bool execute_interaction_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *source =
         actor_from_payload_key(runtime, payload, json_string(action, "actor_from_payload", NULL));
@@ -562,8 +563,8 @@ static void effect_apply_impulse(slayer3d_registered_actor *actor, slayer3d_vec3
                                                     velocity.z + delta.z * strength));
 }
 
-static bool execute_effect_explosion_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                            const slayer3d_properties *payload)
+bool execute_effect_explosion_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                     const slayer3d_properties *payload)
 {
     if (runtime == NULL || action == NULL)
         return false;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -694,19 +694,37 @@ void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason)
 bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
 bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                 slayer3d_registered_actor *actor, int index, const char *reason);
+slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_properties *payload, const char *key);
+slayer3d_vec3 actor_spawn_position_from_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload, slayer3d_vec3 fallback);
 void apply_actor_spawn_properties(slayer3d_registered_actor *actor, yyjson_val *properties);
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
 bool execute_grid_spawn_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool execute_grid_spawn_runs_from_glyphs_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool execute_grid_pickup_layer_reset_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_sector_door_state_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                      const slayer3d_properties *payload, const char *kind);
+bool execute_sector_door_interact_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_noise_emit_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                               const slayer3d_properties *payload);
+slayer3d_registered_actor *action_target_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload);
+bool execute_persistence_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *type);
+bool execute_audio_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload,
+                          const char *type);
 slayer3d_vec3 actor_vec_property(const slayer3d_registered_actor *actor, const char *key);
 float actor_numeric_property(const slayer3d_registered_actor *actor, const char *key, float fallback);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
+void set_actor_numeric_property(slayer3d_registered_actor *actor, const char *key, float value);
 slayer3d_audio_bus parse_audio_bus(const char *bus, slayer3d_audio_bus fallback);
 slayer3d_backend parse_backend(const char *value, slayer3d_backend fallback);
 slayer3d_window_mode parse_window_mode(const char *value, slayer3d_window_mode fallback);
 slayer3d_tonemap_mode parse_tonemap(const char *value, slayer3d_tonemap_mode fallback);
 bool parse_render_profile(const char *value, slayer3d_render_profile *out_profile);
+char *path_basename(const char *path);
+const char *asset_path_without_scheme(const char *path);
+bool ensure_runtime_storage(slayer3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size);
 float camera_fov_degrees(const slayer3d_game_data_runtime *runtime, yyjson_val *camera_json, float fallback);
 slayer3d_camera_fov_axis camera_fov_axis(const slayer3d_game_data_runtime *runtime, yyjson_val *camera_json);
 slayer3d_transition_type parse_transition_type(const char *value, slayer3d_transition_type fallback);
@@ -716,6 +734,7 @@ slayer3d_game_data_ui_align parse_ui_align(const char *value, slayer3d_game_data
 slayer3d_game_data_ui_valign parse_ui_valign(const char *value, slayer3d_game_data_ui_valign fallback);
 const char *parse_ui_image_effect(const char *value);
 int axis_index(const char *axis);
+void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *key, yyjson_val *value);
 float vec_axis(slayer3d_vec3 value, int axis);
 void set_vec_axis(slayer3d_vec3 *value, int axis, float component);
 fps_controller_runtime *find_fps_controller(slayer3d_game_data_runtime *runtime, const char *entity_name);
@@ -744,8 +763,38 @@ bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, cons
                                  const slayer3d_registered_actor *source, yyjson_val *json,
                                  const slayer3d_properties *payload, const char *fallback_tag,
                                  bool fallback_exclude_source);
+bool execute_interaction_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload);
+bool execute_effect_explosion_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                     const slayer3d_properties *payload);
+slayer3d_registered_actor *action_source_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload);
 bool apply_combat_damage_to_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                   const slayer3d_properties *payload, slayer3d_registered_actor *actor, float amount);
+bool execute_combat_damage_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload);
+bool execute_combat_heal_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload);
+bool execute_combat_kill_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload);
+bool execute_combat_revive_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload);
+bool execute_resource_amount_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload, bool consume);
+bool execute_resource_set_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                 const slayer3d_properties *payload);
+bool execute_pickup_collect_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                   const slayer3d_properties *payload);
+bool execute_resource_station_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                         const slayer3d_properties *payload);
+bool execute_status_effect_apply_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                        const slayer3d_properties *payload);
+bool execute_weapon_reload_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                  const slayer3d_properties *payload);
+bool execute_weapon_hitscan_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                   const slayer3d_properties *payload);
+bool execute_projectile_fire_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                    const slayer3d_properties *payload);
 bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
 void sensor_actor_list_free(sensor_actor_list *list);
 bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,

--- a/src/game_data_persistence_audio_actions.c
+++ b/src/game_data_persistence_audio_actions.c
@@ -1,4 +1,8 @@
-/* Persistence and audio action helpers. Included by game_data_actions.inc to preserve internal linkage. */
+/* Persistence and audio action helpers. */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
 
 static bool ensure_audio_file_capacity(slayer3d_game_data_runtime *runtime, int required)
 {
@@ -65,7 +69,7 @@ static char *make_safe_audio_filename(const char *path)
     return filename;
 }
 
-static bool ensure_runtime_storage(slayer3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size)
+bool ensure_runtime_storage(slayer3d_game_data_runtime *runtime, char *error_buffer, int error_buffer_size)
 {
     if (runtime == NULL)
     {
@@ -110,8 +114,8 @@ static const char *persistence_property_key(yyjson_val *property)
     return json_string(property, "key", NULL);
 }
 
-static slayer3d_registered_actor *action_target_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                      const slayer3d_properties *payload)
+slayer3d_registered_actor *action_target_actor(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload)
 {
     const char *target_from_payload = json_string(action, "target_from_payload", NULL);
     if (target_from_payload != NULL)
@@ -267,7 +271,7 @@ static bool execute_persistence_load(slayer3d_game_data_runtime *runtime, yyjson
     return true;
 }
 
-static bool execute_persistence_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *type)
+bool execute_persistence_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *type)
 {
     if (SDL_strcmp(type, "persistence.save") == 0)
         return execute_persistence_save(runtime, action);
@@ -622,8 +626,8 @@ static float action_float_or_property(slayer3d_game_data_runtime *runtime, yyjso
     return json_float(action, key, fallback);
 }
 
-static bool execute_audio_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                 const slayer3d_properties *payload, const char *type)
+bool execute_audio_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload,
+                          const char *type)
 {
     slayer3d_audio_engine *audio = slayer3d_game_session_get_audio(runtime != NULL ? runtime->session : NULL);
     if (SDL_strcmp(type, "audio.play_sfx") == 0)

--- a/src/game_data_sector_noise_actions.c
+++ b/src/game_data_sector_noise_actions.c
@@ -1,4 +1,6 @@
-/* Sector door and noise action helpers. Included by game_data_actions.inc to preserve internal linkage. */
+/* Sector door and noise action helpers. */
+
+#include "game_data_internal.h"
 
 static const char *sector_door_action_target_name(yyjson_val *action, const slayer3d_properties *payload)
 {
@@ -12,8 +14,8 @@ static const char *sector_door_action_target_name(yyjson_val *action, const slay
     return json_string(action, "target", NULL);
 }
 
-static bool execute_sector_door_state_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                             const slayer3d_properties *payload, const char *kind)
+bool execute_sector_door_state_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                      const slayer3d_properties *payload, const char *kind)
 {
     sector_door_runtime *door = find_sector_door(runtime, sector_door_action_target_name(action, payload));
     if (door == NULL || !sector_door_in_active_scene(runtime, door))
@@ -63,7 +65,7 @@ static sector_door_runtime *find_interactable_sector_door(slayer3d_game_data_run
     return best;
 }
 
-static bool execute_sector_door_interact_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_sector_door_interact_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, json_string(action, "actor", NULL));
     if (actor == NULL)
@@ -147,8 +149,8 @@ static bool runtime_add_noise_event(slayer3d_game_data_runtime *runtime, const c
     return true;
 }
 
-static bool execute_noise_emit_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                      const slayer3d_properties *payload)
+bool execute_noise_emit_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                               const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *source = noise_source_actor(runtime, action, payload);
     const slayer3d_vec3 fallback = source != NULL ? source->position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);


### PR DESCRIPTION
## Summary
- move combat/resource/weapon action helpers into src/game_data_combat_weapon_actions.c
- move target-filtering, interaction, and explosion-effect actions into src/game_data_interaction_effect_actions.c
- move persistence/audio action helpers into src/game_data_persistence_audio_actions.c
- move sector-door/noise action helpers into src/game_data_sector_noise_actions.c
- make the shared actor/payload, storage, path, and numeric-property helpers explicit internal APIs instead of relying on textual include ordering
- reduce the action dispatcher include chain while preserving behavior

## Verification
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8
- git diff --check