### PR TITLE
Refactor game data action and presentation modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,12 @@ target_sources(
         src/game.c
         src/game_data_brush.c
         src/game_data.c
+        src/game_data_actions.c
         src/game_data_action_lookup.c
+        src/game_data_actor_pool_runtime.c
         src/game_data_adapter_helpers.c
         src/game_data_combat_weapon_actions.c
+        src/game_data_conditions_presentation.c
         src/game_data_controller_runtime.c
         src/game_data_controller_binding_helpers.c
         src/game_data_grid_actions.c
@@ -167,6 +170,7 @@ target_sources(
         src/game_data_sector_noise_actions.c
         src/game_data_scripts.c
         src/game_data_update_runtime.c
+        src/game_data_ui_animation_runtime.c
         src/game_data_world_loaders.c
         src/game_data_world_queries.c
         src/game_data_standard_options.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -223,31 +223,11 @@ slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *runtime)
 
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
-actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
-static const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name);
-static actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
-                                                     int *out_index);
-const actor_pool_runtime *find_actor_pool_for_actor_const(const slayer3d_game_data_runtime *runtime,
-                                                          const char *actor_name, int *out_index);
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
-slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                               int *out_index);
-static actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index);
-void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
-                                    actor_lifecycle_state state);
-bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
-static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor,
-                                          int index);
 static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
 static int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
-void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
-void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
-void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
-bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
 static bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
                                        bool active);
-bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
-                                slayer3d_registered_actor *actor, int index, const char *reason);
 static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
                                                  const char *to_scene);
 bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
@@ -262,15 +242,11 @@ void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 
 #include "game_data/game_data_render_runtime.inc"
 
-#include "game_data/game_data_ui_animation_runtime.inc"
-
 #include "game_data/game_data_scene_flow_runtime.inc"
 
 #include "game_data/game_data_menu_ui.inc"
 
 #include "game_data/game_data_actors_input.inc"
-
-#include "game_data/game_data_actions.inc"
 
 #include "game_data/game_data_scene_load_runtime.inc"
 

--- a/src/game_data/game_data_actors_input.inc
+++ b/src/game_data/game_data_actors_input.inc
@@ -18,8 +18,7 @@ void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *
         slayer3d_properties_set_vec3(actor->props, key, json_vec3_value(value, slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
 }
 
-static bool format_payload_string(const slayer3d_properties *payload, const char *format, char *buffer,
-                                  size_t buffer_size)
+bool format_payload_string(const slayer3d_properties *payload, const char *format, char *buffer, size_t buffer_size)
 {
     if (buffer == NULL || buffer_size == 0U)
         return false;
@@ -83,8 +82,8 @@ static bool format_payload_string(const slayer3d_properties *payload, const char
     return cursor[0] == '\0';
 }
 
-static bool set_property_from_json_with_payload(slayer3d_properties *props, const char *key, yyjson_val *value,
-                                                const slayer3d_properties *payload)
+bool set_property_from_json_with_payload(slayer3d_properties *props, const char *key, yyjson_val *value,
+                                         const slayer3d_properties *payload)
 {
     if (props == NULL || key == NULL || value == NULL)
         return false;
@@ -99,7 +98,7 @@ static bool set_property_from_json_with_payload(slayer3d_properties *props, cons
     return set_property_from_json(props, key, value);
 }
 
-static slayer3d_properties *properties_from_json_payload(yyjson_val *json, const slayer3d_properties *source_payload)
+slayer3d_properties *properties_from_json_payload(yyjson_val *json, const slayer3d_properties *source_payload)
 {
     slayer3d_properties *payload = slayer3d_properties_create();
     if (payload == NULL)
@@ -243,7 +242,7 @@ static const char *actor_lifecycle_state_name(actor_lifecycle_state state)
     }
 }
 
-static actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index)
+actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index)
 {
     if (pool == NULL || index < 0 || index >= pool->capacity || pool->lifecycle_states == NULL)
         return ACTOR_LIFECYCLE_INACTIVE;
@@ -293,15 +292,14 @@ bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_r
             actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_ACTIVE);
 }
 
-static bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor,
-                                          int index)
+bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index)
 {
     return actor != NULL && !actor->active &&
            (pool == NULL || pool->lifecycle_states == NULL ||
             actor_pool_lifecycle_state(pool, index) == ACTOR_LIFECYCLE_INACTIVE);
 }
 
-static void actor_pool_copy_reason(char *target, size_t target_size, const char *reason)
+void actor_pool_copy_reason(char *target, size_t target_size, const char *reason)
 {
     if (target == NULL || target_size == 0U)
         return;

--- a/src/game_data/game_data_menu_ui.inc
+++ b/src/game_data/game_data_menu_ui.inc
@@ -303,7 +303,7 @@ static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runt
         slayer3d_properties_set_string(runtime->scene_state, selected_value_key, selected_value);
 }
 
-static bool json_value_matches_property(yyjson_val *value, const slayer3d_value *property);
+bool json_value_matches_property(yyjson_val *value, const slayer3d_value *property);
 static slayer3d_game_data_menu_pause_command parse_menu_pause_command(const char *pause)
 {
     if (pause == NULL)
@@ -1097,7 +1097,7 @@ slayer3d_game_data_text_entry_capture_status slayer3d_game_data_update_menu_text
     return SLAYER3D_GAME_DATA_TEXT_ENTRY_CAPTURE_WAITING;
 }
 
-static bool set_property_from_json(slayer3d_properties *props, const char *key, yyjson_val *value)
+bool set_property_from_json(slayer3d_properties *props, const char *key, yyjson_val *value)
 {
     if (props == NULL || key == NULL || value == NULL)
         return false;
@@ -1124,7 +1124,7 @@ static bool set_property_from_json(slayer3d_properties *props, const char *key, 
     return false;
 }
 
-static bool json_value_matches_property(yyjson_val *value, const slayer3d_value *property)
+bool json_value_matches_property(yyjson_val *value, const slayer3d_value *property)
 {
     if (value == NULL || property == NULL)
         return false;

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -1,9 +1,11 @@
-/* Data action execution and presentation helpers.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_actions.c
+ * @brief Data-authored action dispatcher.
+ */
 
-#include "game_data_conditions_presentation.inc"
+#include "game_data_internal.h"
 
-#include "game_data_actor_pool_actions.inc"
+#include <SDL3/SDL_log.h>
 
 bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
 {

--- a/src/game_data_actor_pool_runtime.c
+++ b/src/game_data_actor_pool_runtime.c
@@ -1,5 +1,11 @@
-/* Actor property snapshots and actor pool action helpers. Included by game_data_actions.inc to preserve internal
- * linkage. */
+/**
+ * @file game_data_actor_pool_runtime.c
+ * @brief Actor property snapshots, actor pool allocation, and actor pool data actions.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
 
 static bool json_string_array_contains(yyjson_val *array, const char *value)
 {
@@ -90,7 +96,7 @@ static void copy_selected_properties(slayer3d_properties *target, const slayer3d
     }
 }
 
-static bool snapshot_actor_properties(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool snapshot_actor_properties(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *target = json_string(action, "target", NULL);
     const char *name = json_string(action, "name", NULL);
@@ -104,7 +110,7 @@ static bool snapshot_actor_properties(slayer3d_game_data_runtime *runtime, yyjso
     return true;
 }
 
-static bool restore_actor_property_snapshot(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool restore_actor_property_snapshot(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *target = json_string(action, "target", NULL);
     const char *name = json_string(action, "name", NULL);
@@ -117,7 +123,7 @@ static bool restore_actor_property_snapshot(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
-static bool reset_actor_properties_to_authored_defaults(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool reset_actor_properties_to_authored_defaults(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *target = json_string(action, "target", NULL);
     slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, target);
@@ -156,7 +162,7 @@ actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const c
     return NULL;
 }
 
-static const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name)
+const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name)
 {
     if (runtime == NULL || name == NULL)
         return NULL;
@@ -180,8 +186,8 @@ static int actor_pool_index_for_actor(const actor_pool_runtime *pool, const char
     return -1;
 }
 
-static actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
-                                                     int *out_index)
+actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
+                                              int *out_index)
 {
     if (out_index != NULL)
         *out_index = -1;
@@ -365,8 +371,8 @@ slayer3d_vec3 actor_spawn_position_from_action(slayer3d_game_data_runtime *runti
     return position;
 }
 
-static bool execute_actor_spawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                       const slayer3d_properties *payload)
+bool execute_actor_spawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload)
 {
     actor_pool_runtime *pool = find_actor_pool(runtime, json_string(action, "pool", NULL));
     actor_pool_note_spawn_attempt(pool);
@@ -406,7 +412,7 @@ static bool execute_actor_spawn_action(slayer3d_game_data_runtime *runtime, yyjs
     return true;
 }
 
-static bool execute_actor_despawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_actor_despawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *target = json_string(action, "target", NULL);
     slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, target);
@@ -422,8 +428,8 @@ static bool execute_actor_despawn_action(slayer3d_game_data_runtime *runtime, yy
     return true;
 }
 
-static bool execute_actor_despawn_action_with_payload(slayer3d_game_data_runtime *runtime, yyjson_val *action,
-                                                      const slayer3d_properties *payload)
+bool execute_actor_despawn_action_with_payload(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload)
 {
     slayer3d_registered_actor *actor =
         actor_from_payload_key(runtime, payload, json_string(action, "target_from_payload", NULL));
@@ -439,7 +445,7 @@ static bool execute_actor_despawn_action_with_payload(slayer3d_game_data_runtime
     return true;
 }
 
-static bool execute_actor_despawn_by_tag_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+bool execute_actor_despawn_by_tag_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     const char *tag = json_string(action, "tag", NULL);
     if (runtime == NULL || tag == NULL || tag[0] == '\0')

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -1,18 +1,14 @@
-/* Conditions, UI binding, presentation clock, and animation helpers. Included by game_data_actions.inc to preserve
- * internal linkage. */
+/**
+ * @file game_data_conditions_presentation.c
+ * @brief Data condition evaluation, UI binding resolution, and presentation clocks.
+ */
+
+#include "game_data_internal.h"
 
 int action_signal_id(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *key)
 {
     return slayer3d_game_data_find_signal(runtime, json_string(action, key, NULL));
 }
-
-bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload);
-bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
-                                   const slayer3d_properties *payload);
-int actor_sector_index_for_sensor(const sector_level_runtime *level, const sensor_entry *sensor,
-                                  const slayer3d_registered_actor *actor);
-float sector_door_distance_sq_xz(const slayer3d_door *door, slayer3d_vec3 point);
-bool sector_door_is_in_front(const slayer3d_door *door, slayer3d_vec3 point, float yaw, float min_dot);
 
 static bool compare_value(const slayer3d_value *left, const char *op, yyjson_val *right)
 {
@@ -859,171 +855,4 @@ bool slayer3d_game_data_format_ui_text(const slayer3d_game_data_runtime *runtime
         return true;
     }
     return false;
-}
-
-static slayer3d_value_type property_type_from_name(const char *name, slayer3d_value_type fallback)
-{
-    if (name == NULL)
-        return fallback;
-    if (SDL_strcmp(name, "int") == 0)
-        return SLAYER3D_VALUE_INT;
-    if (SDL_strcmp(name, "float") == 0 || SDL_strcmp(name, "number") == 0)
-        return SLAYER3D_VALUE_FLOAT;
-    if (SDL_strcmp(name, "vec3") == 0)
-        return SLAYER3D_VALUE_VEC3;
-    if (SDL_strcmp(name, "color") == 0)
-        return SLAYER3D_VALUE_COLOR;
-    return fallback;
-}
-
-static bool start_property_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action)
-{
-    slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
-    const char *key = json_string(action, "key", NULL);
-    yyjson_val *to_json = obj_get(action, "to");
-    if (to_json == NULL)
-        to_json = obj_get(action, "value");
-    if (actor == NULL || key == NULL || to_json == NULL)
-        return false;
-
-    const slayer3d_value *current = slayer3d_properties_get_value(actor->props, key);
-    const char *value_type = json_string(action, "value_type", NULL);
-    const game_data_tween_value_type preferred = tween_preferred_type(value_type, current, NULL);
-
-    game_data_animation animation;
-    SDL_zero(animation);
-    animation.target_type = GAME_DATA_TWEEN_PROPERTY;
-    animation.target = actor->name;
-    animation.key = key;
-    animation.scene = slayer3d_game_data_active_scene(runtime);
-    animation.duration = json_float(action, "duration", 0.0f);
-    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
-    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
-    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
-    animation.property_type =
-        current != NULL ? current->type : property_type_from_name(value_type, SLAYER3D_VALUE_FLOAT);
-
-    yyjson_val *from_json = obj_get(action, "from");
-    if (from_json != NULL)
-    {
-        if (!json_tween_value(from_json, preferred, &animation.from))
-            return false;
-    }
-    else if (!current_property_tween_value(current, preferred, &animation.from, &animation.property_type))
-    {
-        animation.from = preferred == GAME_DATA_TWEEN_COLOR  ? tween_color((slayer3d_color){255, 255, 255, 255})
-                         : preferred == GAME_DATA_TWEEN_VEC3 ? tween_vec3(slayer3d_vec3_make(0.0f, 0.0f, 0.0f))
-                                                             : tween_float(0.0f);
-    }
-
-    if (!json_tween_value(to_json, preferred, &animation.to))
-        return false;
-    if (animation.from.type != animation.to.type)
-        return false;
-    if (animation.to.type == GAME_DATA_TWEEN_VEC3)
-        animation.property_type = SLAYER3D_VALUE_VEC3;
-    else if (animation.to.type == GAME_DATA_TWEEN_COLOR)
-        animation.property_type = SLAYER3D_VALUE_COLOR;
-    else
-        animation.property_type = property_type_from_name(value_type, animation.property_type);
-
-    return start_animation(runtime, &animation);
-}
-
-static bool start_ui_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action)
-{
-    const char *target = json_string(action, "target", json_string(action, "ui", NULL));
-    const char *property = json_string(action, "property", NULL);
-    yyjson_val *to_json = obj_get(action, "to");
-    if (to_json == NULL)
-        to_json = obj_get(action, "value");
-    if (target == NULL || property == NULL || to_json == NULL)
-        return false;
-
-    slayer3d_game_data_ui_state state;
-    slayer3d_game_data_ui_state_init(&state);
-    (void)slayer3d_game_data_get_ui_state(runtime, target, &state);
-    const game_data_tween_value_type preferred =
-        tween_preferred_type(json_string(action, "value_type", NULL), NULL, property);
-
-    game_data_animation animation;
-    SDL_zero(animation);
-    animation.target_type = GAME_DATA_TWEEN_UI;
-    animation.target = target;
-    animation.property = property;
-    animation.scene = slayer3d_game_data_active_scene(runtime);
-    animation.duration = json_float(action, "duration", 0.0f);
-    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
-    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
-    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
-    animation.property_type = SLAYER3D_VALUE_FLOAT;
-
-    yyjson_val *from_json = obj_get(action, "from");
-    if (from_json != NULL)
-    {
-        if (!json_tween_value(from_json, preferred, &animation.from))
-            return false;
-    }
-    else if (!current_ui_tween_value(&state, property, &animation.from))
-    {
-        return false;
-    }
-
-    if (!json_tween_value(to_json, preferred, &animation.to))
-        return false;
-    if (animation.from.type != animation.to.type)
-        return false;
-    return start_animation(runtime, &animation);
-}
-
-bool slayer3d_game_data_update_animations(slayer3d_game_data_runtime *runtime, float dt)
-{
-    if (runtime == NULL)
-        return false;
-
-    reset_animation_scope_if_needed(runtime);
-    const float step = dt > 0.0f ? dt : 0.0f;
-    slayer3d_signal_bus *bus = runtime_bus(runtime);
-    for (int i = 0; i < runtime->animation_count;)
-    {
-        game_data_animation *animation = &runtime->animations[i];
-        animation->elapsed += step;
-
-        bool complete = false;
-        float t = 1.0f;
-        if (animation->duration > 0.0f)
-        {
-            if (animation->repeat == GAME_DATA_TWEEN_REPEAT_LOOP)
-            {
-                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
-            }
-            else if (animation->repeat == GAME_DATA_TWEEN_REPEAT_PING_PONG)
-            {
-                const float cycle_float = SDL_floorf(animation->elapsed / animation->duration);
-                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
-                if (((int)cycle_float % 2) != 0)
-                    t = 1.0f - t;
-            }
-            else
-            {
-                complete = animation->elapsed >= animation->duration;
-                t = complete ? 1.0f : animation->elapsed / animation->duration;
-            }
-        }
-
-        const float eased = apply_tween_easing(animation->easing, t);
-        const game_data_tween_value value = interpolate_tween_value(&animation->from, &animation->to, eased);
-        apply_animation_value(runtime, animation, &value);
-
-        if (complete)
-        {
-            if (animation->done_signal_id >= 0 && bus != NULL)
-                slayer3d_signal_emit(bus, animation->done_signal_id, NULL);
-            runtime->animations[i] = runtime->animations[runtime->animation_count - 1];
-            --runtime->animation_count;
-            continue;
-        }
-        ++i;
-    }
-    return true;
 }

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -682,12 +682,18 @@ bool entity_json_has_all_tags_from_json(yyjson_val *entity, yyjson_val *tags);
 const actor_pool_runtime *find_actor_pool_for_actor_const(const slayer3d_game_data_runtime *runtime,
                                                           const char *actor_name, int *out_index);
 actor_pool_runtime *find_actor_pool(slayer3d_game_data_runtime *runtime, const char *name);
+const actor_pool_runtime *find_actor_pool_const(const slayer3d_game_data_runtime *runtime, const char *name);
+actor_pool_runtime *find_actor_pool_for_actor(slayer3d_game_data_runtime *runtime, const char *actor_name,
+                                              int *out_index);
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
 slayer3d_registered_actor *actor_pool_allocate(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                                int *out_index);
+actor_lifecycle_state actor_pool_lifecycle_state(const actor_pool_runtime *pool, int index);
 void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index,
                                     actor_lifecycle_state state);
 bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
+bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
+void actor_pool_copy_reason(char *target, size_t target_size, const char *reason);
 void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
 void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
 void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
@@ -735,6 +741,12 @@ slayer3d_game_data_ui_valign parse_ui_valign(const char *value, slayer3d_game_da
 const char *parse_ui_image_effect(const char *value);
 int axis_index(const char *axis);
 void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *key, yyjson_val *value);
+bool set_property_from_json(slayer3d_properties *props, const char *key, yyjson_val *value);
+bool set_property_from_json_with_payload(slayer3d_properties *props, const char *key, yyjson_val *value,
+                                         const slayer3d_properties *payload);
+bool json_value_matches_property(yyjson_val *value, const slayer3d_value *property);
+bool format_payload_string(const slayer3d_properties *payload, const char *format, char *buffer, size_t buffer_size);
+slayer3d_properties *properties_from_json_payload(yyjson_val *json, const slayer3d_properties *source_payload);
 float vec_axis(slayer3d_vec3 value, int axis);
 void set_vec_axis(slayer3d_vec3 *value, int axis, float component);
 fps_controller_runtime *find_fps_controller(slayer3d_game_data_runtime *runtime, const char *entity_name);
@@ -759,10 +771,21 @@ void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value);
 bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value);
+bool start_property_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool start_ui_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
                                  const slayer3d_registered_actor *source, yyjson_val *json,
                                  const slayer3d_properties *payload, const char *fallback_tag,
                                  bool fallback_exclude_source);
+bool snapshot_actor_properties(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool restore_actor_property_snapshot(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool reset_actor_properties_to_authored_defaults(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_actor_spawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                const slayer3d_properties *payload);
+bool execute_actor_despawn_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool execute_actor_despawn_action_with_payload(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                               const slayer3d_properties *payload);
+bool execute_actor_despawn_by_tag_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool execute_interaction_use_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                     const slayer3d_properties *payload);
 bool execute_effect_explosion_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,

--- a/src/game_data_ui_animation_runtime.c
+++ b/src/game_data_ui_animation_runtime.c
@@ -1,4 +1,9 @@
-/* UI state and animation runtime helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_ui_animation_runtime.c
+ * @brief Runtime UI state and authored animation helpers.
+ */
+
+#include "game_data_internal.h"
 
 void slayer3d_game_data_ui_state_init(slayer3d_game_data_ui_state *state)
 {
@@ -482,5 +487,172 @@ static bool start_animation(slayer3d_game_data_runtime *runtime, const game_data
         return false;
     runtime->animations[runtime->animation_count] = *animation;
     ++runtime->animation_count;
+    return true;
+}
+
+static slayer3d_value_type property_type_from_name(const char *name, slayer3d_value_type fallback)
+{
+    if (name == NULL)
+        return fallback;
+    if (SDL_strcmp(name, "int") == 0)
+        return SLAYER3D_VALUE_INT;
+    if (SDL_strcmp(name, "float") == 0 || SDL_strcmp(name, "number") == 0)
+        return SLAYER3D_VALUE_FLOAT;
+    if (SDL_strcmp(name, "vec3") == 0)
+        return SLAYER3D_VALUE_VEC3;
+    if (SDL_strcmp(name, "color") == 0)
+        return SLAYER3D_VALUE_COLOR;
+    return fallback;
+}
+
+bool start_property_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    slayer3d_registered_actor *actor = slayer3d_game_data_find_actor(runtime, json_string(action, "target", NULL));
+    const char *key = json_string(action, "key", NULL);
+    yyjson_val *to_json = obj_get(action, "to");
+    if (to_json == NULL)
+        to_json = obj_get(action, "value");
+    if (actor == NULL || key == NULL || to_json == NULL)
+        return false;
+
+    const slayer3d_value *current = slayer3d_properties_get_value(actor->props, key);
+    const char *value_type = json_string(action, "value_type", NULL);
+    const game_data_tween_value_type preferred = tween_preferred_type(value_type, current, NULL);
+
+    game_data_animation animation;
+    SDL_zero(animation);
+    animation.target_type = GAME_DATA_TWEEN_PROPERTY;
+    animation.target = actor->name;
+    animation.key = key;
+    animation.scene = slayer3d_game_data_active_scene(runtime);
+    animation.duration = json_float(action, "duration", 0.0f);
+    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
+    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
+    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
+    animation.property_type =
+        current != NULL ? current->type : property_type_from_name(value_type, SLAYER3D_VALUE_FLOAT);
+
+    yyjson_val *from_json = obj_get(action, "from");
+    if (from_json != NULL)
+    {
+        if (!json_tween_value(from_json, preferred, &animation.from))
+            return false;
+    }
+    else if (!current_property_tween_value(current, preferred, &animation.from, &animation.property_type))
+    {
+        animation.from = preferred == GAME_DATA_TWEEN_COLOR  ? tween_color((slayer3d_color){255, 255, 255, 255})
+                         : preferred == GAME_DATA_TWEEN_VEC3 ? tween_vec3(slayer3d_vec3_make(0.0f, 0.0f, 0.0f))
+                                                             : tween_float(0.0f);
+    }
+
+    if (!json_tween_value(to_json, preferred, &animation.to))
+        return false;
+    if (animation.from.type != animation.to.type)
+        return false;
+    if (animation.to.type == GAME_DATA_TWEEN_VEC3)
+        animation.property_type = SLAYER3D_VALUE_VEC3;
+    else if (animation.to.type == GAME_DATA_TWEEN_COLOR)
+        animation.property_type = SLAYER3D_VALUE_COLOR;
+    else
+        animation.property_type = property_type_from_name(value_type, animation.property_type);
+
+    return start_animation(runtime, &animation);
+}
+
+bool start_ui_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *target = json_string(action, "target", json_string(action, "ui", NULL));
+    const char *property = json_string(action, "property", NULL);
+    yyjson_val *to_json = obj_get(action, "to");
+    if (to_json == NULL)
+        to_json = obj_get(action, "value");
+    if (target == NULL || property == NULL || to_json == NULL)
+        return false;
+
+    slayer3d_game_data_ui_state state;
+    slayer3d_game_data_ui_state_init(&state);
+    (void)slayer3d_game_data_get_ui_state(runtime, target, &state);
+    const game_data_tween_value_type preferred =
+        tween_preferred_type(json_string(action, "value_type", NULL), NULL, property);
+
+    game_data_animation animation;
+    SDL_zero(animation);
+    animation.target_type = GAME_DATA_TWEEN_UI;
+    animation.target = target;
+    animation.property = property;
+    animation.scene = slayer3d_game_data_active_scene(runtime);
+    animation.duration = json_float(action, "duration", 0.0f);
+    animation.easing = parse_tween_easing(json_string(action, "easing", NULL));
+    animation.repeat = parse_tween_repeat(json_string(action, "repeat", NULL));
+    animation.done_signal_id = action_signal_id(runtime, action, "done_signal");
+    animation.property_type = SLAYER3D_VALUE_FLOAT;
+
+    yyjson_val *from_json = obj_get(action, "from");
+    if (from_json != NULL)
+    {
+        if (!json_tween_value(from_json, preferred, &animation.from))
+            return false;
+    }
+    else if (!current_ui_tween_value(&state, property, &animation.from))
+    {
+        return false;
+    }
+
+    if (!json_tween_value(to_json, preferred, &animation.to))
+        return false;
+    if (animation.from.type != animation.to.type)
+        return false;
+    return start_animation(runtime, &animation);
+}
+
+bool slayer3d_game_data_update_animations(slayer3d_game_data_runtime *runtime, float dt)
+{
+    if (runtime == NULL)
+        return false;
+
+    reset_animation_scope_if_needed(runtime);
+    const float step = dt > 0.0f ? dt : 0.0f;
+    slayer3d_signal_bus *bus = runtime_bus(runtime);
+    for (int i = 0; i < runtime->animation_count;)
+    {
+        game_data_animation *animation = &runtime->animations[i];
+        animation->elapsed += step;
+
+        bool complete = false;
+        float t = 1.0f;
+        if (animation->duration > 0.0f)
+        {
+            if (animation->repeat == GAME_DATA_TWEEN_REPEAT_LOOP)
+            {
+                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
+            }
+            else if (animation->repeat == GAME_DATA_TWEEN_REPEAT_PING_PONG)
+            {
+                const float cycle_float = SDL_floorf(animation->elapsed / animation->duration);
+                t = SDL_fmodf(animation->elapsed, animation->duration) / animation->duration;
+                if (((int)cycle_float % 2) != 0)
+                    t = 1.0f - t;
+            }
+            else
+            {
+                complete = animation->elapsed >= animation->duration;
+                t = complete ? 1.0f : animation->elapsed / animation->duration;
+            }
+        }
+
+        const float eased = apply_tween_easing(animation->easing, t);
+        const game_data_tween_value value = interpolate_tween_value(&animation->from, &animation->to, eased);
+        apply_animation_value(runtime, animation, &value);
+
+        if (complete)
+        {
+            if (animation->done_signal_id >= 0 && bus != NULL)
+                slayer3d_signal_emit(bus, animation->done_signal_id, NULL);
+            runtime->animations[i] = runtime->animations[runtime->animation_count - 1];
+            --runtime->animation_count;
+            continue;
+        }
+        ++i;
+    }
     return true;
 }


### PR DESCRIPTION
## Summary
- move game data action dispatch, actor pool action/runtime helpers, presentation conditions, and UI animation runtime out of textual includes into focused C modules
- make the cross-module helper boundaries explicit in game_data_internal.h
- reduce src/game_data.c to the remaining core glue and large runtime includes

## Verification
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8
- git diff --check