### PR TITLE
Refactor game data scene runtime modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,11 @@ target_sources(
         src/game_data_network_sessions.c
         src/game_data_persistence_audio_actions.c
         src/game_data_property_effect_runtime.c
+        src/game_data_replication_helpers.c
         src/game_data_runtime_collections.c
+        src/game_data_load_runtime.c
+        src/game_data_scene_flow_runtime.c
+        src/game_data_scene_load_runtime.c
         src/game_data_scene_lookup.c
         src/game_data_sensor_runtime.c
         src/game_data_sector_noise_actions.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -68,7 +68,7 @@ void set_errorf(char *buffer, int buffer_size, const char *format, ...)
     va_end(args);
 }
 
-static void clear_menu_text_entry_capture(slayer3d_game_data_runtime *runtime)
+void clear_menu_text_entry_capture(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
         return;
@@ -106,10 +106,6 @@ static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtim
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
-static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
-static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
-static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
-static void storage_config_from_root(yyjson_val *root, slayer3d_storage_config *out_config);
 bool sensor_actor_list_add(sensor_actor_list *list, slayer3d_registered_actor *actor);
 void sensor_actor_list_free(sensor_actor_list *list);
 bool collect_sensor_endpoint_actors(slayer3d_game_data_runtime *runtime, const char *actor_name, const char *tag,
@@ -132,7 +128,7 @@ static bool path_is_absolute(const char *path)
     return SDL_strlen(path) > 2 && path[1] == ':';
 }
 
-static char *path_dirname(const char *path)
+char *path_dirname(const char *path)
 {
     if (path == NULL)
         return NULL;
@@ -226,10 +222,6 @@ void copy_property_value(slayer3d_properties *target, const char *key, const sla
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
 static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
 static int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
-static bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
-                                       bool active);
-static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
-                                                 const char *to_scene);
 bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
                                  const slayer3d_registered_actor *source, yyjson_val *json,
                                  const slayer3d_properties *payload, const char *fallback_tag,
@@ -238,19 +230,11 @@ void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
 #include "game_data/game_data_lua_api.inc"
 
-#include "game_data/game_data_replication_helpers.inc"
-
 #include "game_data/game_data_render_runtime.inc"
-
-#include "game_data/game_data_scene_flow_runtime.inc"
 
 #include "game_data/game_data_menu_ui.inc"
 
 #include "game_data/game_data_actors_input.inc"
-
-#include "game_data/game_data_scene_load_runtime.inc"
-
-#include "game_data/game_data_load_runtime.inc"
 
 #include "game_data/game_data_network_runtime.inc"
 

--- a/src/game_data/game_data_actors_input.inc
+++ b/src/game_data/game_data_actors_input.inc
@@ -170,8 +170,7 @@ static void initialize_actor_from_json(slayer3d_registered_actor *actor, yyjson_
     load_actor_properties(actor, obj_get(entity, "properties"));
 }
 
-static bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                          int error_buffer_size)
+bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     slayer3d_actor_registry *registry = runtime_registry(runtime);
     yyjson_val *entities = obj_get(root, "entities");
@@ -399,8 +398,7 @@ void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime)
     actor_lifecycle_flush(runtime);
 }
 
-static bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index,
-                                       bool active)
+bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index, bool active)
 {
     if (runtime == NULL || pool == NULL || index < 0 || index >= pool->capacity)
         return false;
@@ -433,8 +431,8 @@ bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor
     return true;
 }
 
-static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
-                                                 const char *to_scene)
+bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
+                                          const char *to_scene)
 {
     if (runtime == NULL || from_scene == NULL)
         return true;
@@ -468,8 +466,7 @@ static bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *run
     return true;
 }
 
-static bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                             int error_buffer_size)
+bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     slayer3d_actor_registry *registry = runtime_registry(runtime);
     yyjson_val *pools = obj_get(root, "actor_pools");
@@ -589,8 +586,7 @@ static bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *ro
     return true;
 }
 
-static bool load_signals(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
-                         int error_buffer_size)
+bool load_signals(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *signals = obj_get(root, "signals");
     if (!yyjson_is_arr(signals))
@@ -783,7 +779,7 @@ static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtim
     return true;
 }
 
-static bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
+bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size)
 {
     slayer3d_input_manager *input = runtime_input(runtime);
     yyjson_val *input_root = obj_get(root, "input");

--- a/src/game_data/game_data_menu_ui.inc
+++ b/src/game_data/game_data_menu_ui.inc
@@ -60,7 +60,7 @@ static int menu_authored_item_row_count(const slayer3d_game_data_runtime *runtim
     return menu_item_is_dynamic_list(item) ? menu_dynamic_list_row_count(runtime, item) : 1;
 }
 
-static int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu)
+int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu)
 {
     yyjson_val *items = menu != NULL ? obj_get(menu->menu, "items") : NULL;
     int count = 0;
@@ -282,7 +282,7 @@ static const char *menu_dynamic_scene_state_value(const slayer3d_game_data_runti
     return NULL;
 }
 
-static void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu)
+void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu)
 {
     yyjson_val *item = NULL;
     int dynamic_index = -1;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -24,6 +24,8 @@
 #include "slayer3d/timer_pool.h"
 #include "yyjson.h"
 
+typedef struct slayer3d_replication_field_descriptor slayer3d_replication_field_descriptor;
+
 typedef enum game_data_sensor_type
 {
     GAME_DATA_SENSOR_BOUNDS_EXIT,
@@ -622,6 +624,7 @@ typedef struct slayer3d_game_data_runtime
 void set_error(char *buffer, int buffer_size, const char *message);
 void set_errorf(char *buffer, int buffer_size, const char *format, ...);
 char *path_join(const char *base_dir, const char *path);
+char *path_dirname(const char *path);
 
 yyjson_val *obj_get(yyjson_val *object, const char *key);
 const char *json_string(yyjson_val *object, const char *key, const char *fallback);
@@ -698,6 +701,7 @@ void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
 void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
 void actor_pool_note_spawn_failure(actor_pool_runtime *pool, const char *reason);
 bool initialize_pooled_actor(actor_pool_runtime *pool, slayer3d_registered_actor *actor, int index, bool active);
+bool actor_pool_initialize_slot(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool, int index, bool active);
 bool actor_pool_request_despawn(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool,
                                 slayer3d_registered_actor *actor, int index, const char *reason);
 slayer3d_registered_actor *actor_from_payload_key(slayer3d_game_data_runtime *runtime,
@@ -769,6 +773,11 @@ void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json,
                           const slayer3d_properties *payload);
 void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
+bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, const char *from_scene,
+                                          const char *to_scene);
+void clear_menu_text_entry_capture(slayer3d_game_data_runtime *runtime);
+int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
+void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
 bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value);
 bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value);
 bool start_property_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action);
@@ -929,11 +938,50 @@ void lua_push_actor_wrapper(lua_State *lua, const slayer3d_registered_actor *act
 
 void register_lua_api(slayer3d_game_data_runtime *runtime, slayer3d_script_engine *engine);
 bool load_timers(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);
+bool load_signals(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);
+bool load_sensors(slayer3d_game_data_runtime *runtime, yyjson_val *logic);
+bool load_wave_schedules(slayer3d_game_data_runtime *runtime, yyjson_val *logic);
+void load_active_camera(slayer3d_game_data_runtime *runtime, yyjson_val *root);
+bool load_scenes(slayer3d_game_data_runtime *runtime, yyjson_val *root, const slayer3d_game_data_load_options *options,
+                 char *error_buffer, int error_buffer_size);
 bool load_script_index_into_engine(slayer3d_game_data_runtime *runtime, slayer3d_asset_resolver *assets,
                                    slayer3d_script_engine *engine, int index, slayer3d_script_ref *module_refs,
                                    bool *loading, bool *loaded, char *error_buffer, int error_buffer_size);
 bool load_scripts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_lua_adapters(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                        int error_buffer_size);
+
+yyjson_val *game_data_find_replication_channel_by_name(const slayer3d_game_data_runtime *runtime,
+                                                       const char *replication_name, int *out_index);
+yyjson_val *game_data_find_replication_channel_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index);
+bool game_data_replication_channel_is_host_to_client(yyjson_val *channel);
+bool game_data_replication_channel_is_client_to_host(yyjson_val *channel);
+size_t game_data_replication_channel_field_count(const slayer3d_game_data_runtime *runtime, yyjson_val *channel);
+bool game_data_replication_channel_packet_size(const slayer3d_game_data_runtime *runtime, yyjson_val *channel,
+                                               size_t *out_size);
+size_t game_data_replication_channel_input_count(yyjson_val *channel);
+bool game_data_replication_input_packet_size(yyjson_val *channel, size_t *out_size);
+const char *game_data_replication_input_action(yyjson_val *input);
+int game_data_replication_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *input);
+slayer3d_game_data_network_direction game_data_network_direction_from_string(const char *direction);
+const char *game_data_network_direction_name(slayer3d_game_data_network_direction direction);
+yyjson_val *game_data_find_network_control_by_name(const slayer3d_game_data_runtime *runtime, const char *control_name,
+                                                   int *out_index);
+yyjson_val *game_data_find_network_control_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index);
+bool game_data_network_control_packet_size(size_t *out_size);
+int game_data_network_control_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *control);
+bool game_data_read_actor_replication_field(const slayer3d_registered_actor *actor,
+                                            const slayer3d_replication_field_descriptor *field,
+                                            game_data_snapshot_value *out_value);
+bool game_data_write_snapshot_value(slayer3d_replication_writer *writer, const game_data_snapshot_value *value);
+bool game_data_read_snapshot_value(slayer3d_replication_reader *reader, slayer3d_replication_field_type type,
+                                   game_data_snapshot_value *out_value);
+bool game_data_apply_actor_replication_field(slayer3d_game_data_runtime *runtime, slayer3d_registered_actor *actor,
+                                             const slayer3d_replication_field_descriptor *field,
+                                             const game_data_snapshot_value *value);
 
 #endif

--- a/src/game_data_load_runtime.c
+++ b/src/game_data_load_runtime.c
@@ -1,5 +1,17 @@
-/* Runtime registration, script reload, app config, asset load, and storage helpers. Included by src/game_data.c to
- * preserve internal linkage. */
+/**
+ * @file game_data_load_runtime.c
+ * @brief Runtime registration, script reload, app config, asset loading, and storage helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include "game_data_validation.h"
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_log.h>
+
+static void storage_config_from_root(yyjson_val *root, slayer3d_storage_config *out_config);
+static void load_storage_config(slayer3d_game_data_runtime *runtime, yyjson_val *root);
 
 bool slayer3d_game_data_register_adapter(slayer3d_game_data_runtime *runtime, const char *name,
                                          slayer3d_game_data_adapter_fn callback, void *userdata)

--- a/src/game_data_replication_helpers.c
+++ b/src/game_data_replication_helpers.c
@@ -1,7 +1,16 @@
-/* Network replication and control codec helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_replication_helpers.c
+ * @brief Network replication and control codec helpers for authored game data.
+ */
 
-static yyjson_val *game_data_find_replication_channel_by_name(const slayer3d_game_data_runtime *runtime,
-                                                              const char *replication_name, int *out_index)
+#include "game_data_internal.h"
+
+#include "network_replication_schema.h"
+
+#include <stdint.h>
+
+yyjson_val *game_data_find_replication_channel_by_name(const slayer3d_game_data_runtime *runtime,
+                                                       const char *replication_name, int *out_index)
 {
     yyjson_val *replication = obj_get(obj_get(runtime_root(runtime), "network"), "replication");
     for (size_t i = 0; yyjson_is_arr(replication) && i < yyjson_arr_size(replication); ++i)
@@ -17,19 +26,19 @@ static yyjson_val *game_data_find_replication_channel_by_name(const slayer3d_gam
     return NULL;
 }
 
-static yyjson_val *game_data_find_replication_channel_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index)
+yyjson_val *game_data_find_replication_channel_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index)
 {
     yyjson_val *replication = obj_get(obj_get(runtime_root(runtime), "network"), "replication");
     return yyjson_is_arr(replication) && index < yyjson_arr_size(replication) ? yyjson_arr_get(replication, index)
                                                                               : NULL;
 }
 
-static bool game_data_replication_channel_is_host_to_client(yyjson_val *channel)
+bool game_data_replication_channel_is_host_to_client(yyjson_val *channel)
 {
     return SDL_strcmp(json_string(channel, "direction", ""), "host_to_client") == 0;
 }
 
-static bool game_data_replication_channel_is_client_to_host(yyjson_val *channel)
+bool game_data_replication_channel_is_client_to_host(yyjson_val *channel)
 {
     return SDL_strcmp(json_string(channel, "direction", ""), "client_to_host") == 0;
 }
@@ -39,7 +48,7 @@ static size_t game_data_replication_field_array_count(yyjson_val *fields)
     return yyjson_is_arr(fields) ? yyjson_arr_size(fields) : 0U;
 }
 
-static size_t game_data_replication_channel_field_count(const slayer3d_game_data_runtime *runtime, yyjson_val *channel)
+size_t game_data_replication_channel_field_count(const slayer3d_game_data_runtime *runtime, yyjson_val *channel)
 {
     size_t count = 0U;
     yyjson_val *actors = obj_get(channel, "actors");
@@ -80,8 +89,8 @@ static bool game_data_add_replication_fields_packet_size(yyjson_val *fields, siz
     return true;
 }
 
-static bool game_data_replication_channel_packet_size(const slayer3d_game_data_runtime *runtime, yyjson_val *channel,
-                                                      size_t *out_size)
+bool game_data_replication_channel_packet_size(const slayer3d_game_data_runtime *runtime, yyjson_val *channel,
+                                               size_t *out_size)
 {
     if (out_size != NULL)
         *out_size = 0U;
@@ -114,13 +123,13 @@ static bool game_data_replication_channel_packet_size(const slayer3d_game_data_r
     return true;
 }
 
-static size_t game_data_replication_channel_input_count(yyjson_val *channel)
+size_t game_data_replication_channel_input_count(yyjson_val *channel)
 {
     yyjson_val *inputs = obj_get(channel, "inputs");
     return yyjson_is_arr(inputs) ? yyjson_arr_size(inputs) : 0U;
 }
 
-static bool game_data_replication_input_packet_size(yyjson_val *channel, size_t *out_size)
+bool game_data_replication_input_packet_size(yyjson_val *channel, size_t *out_size)
 {
     if (out_size != NULL)
         *out_size = 0U;
@@ -139,17 +148,17 @@ static bool game_data_replication_input_packet_size(yyjson_val *channel, size_t 
     return true;
 }
 
-static const char *game_data_replication_input_action(yyjson_val *input)
+const char *game_data_replication_input_action(yyjson_val *input)
 {
     return json_string(input, "action", NULL);
 }
 
-static int game_data_replication_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *input)
+int game_data_replication_action_id(const slayer3d_game_data_runtime *runtime, yyjson_val *input)
 {
     return slayer3d_game_data_find_action(runtime, game_data_replication_input_action(input));
 }
 
-static slayer3d_game_data_network_direction game_data_network_direction_from_string(const char *direction)
+slayer3d_game_data_network_direction game_data_network_direction_from_string(const char *direction)
 {
     if (direction == NULL)
         return SLAYER3D_GAME_DATA_NETWORK_DIRECTION_INVALID;
@@ -162,7 +171,7 @@ static slayer3d_game_data_network_direction game_data_network_direction_from_str
     return SLAYER3D_GAME_DATA_NETWORK_DIRECTION_INVALID;
 }
 
-static const char *game_data_network_direction_name(slayer3d_game_data_network_direction direction)
+const char *game_data_network_direction_name(slayer3d_game_data_network_direction direction)
 {
     switch (direction)
     {
@@ -177,8 +186,8 @@ static const char *game_data_network_direction_name(slayer3d_game_data_network_d
     }
 }
 
-static yyjson_val *game_data_find_network_control_by_name(const slayer3d_game_data_runtime *runtime,
-                                                          const char *control_name, int *out_index)
+yyjson_val *game_data_find_network_control_by_name(const slayer3d_game_data_runtime *runtime, const char *control_name,
+                                                   int *out_index)
 {
     yyjson_val *controls = obj_get(obj_get(runtime_root(runtime), "network"), "control_messages");
     for (size_t i = 0; yyjson_is_arr(controls) && i < yyjson_arr_size(controls); ++i)
@@ -194,13 +203,13 @@ static yyjson_val *game_data_find_network_control_by_name(const slayer3d_game_da
     return NULL;
 }
 
-static yyjson_val *game_data_find_network_control_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index)
+yyjson_val *game_data_find_network_control_by_index(const slayer3d_game_data_runtime *runtime, Uint32 index)
 {
     yyjson_val *controls = obj_get(obj_get(runtime_root(runtime), "network"), "control_messages");
     return yyjson_is_arr(controls) && index < yyjson_arr_size(controls) ? yyjson_arr_get(controls, index) : NULL;
 }
 
-static bool game_data_network_control_packet_size(size_t *out_size)
+bool game_data_network_control_packet_size(size_t *out_size)
 {
     const size_t size = 4U + 4U + 4U + 4U + SLAYER3D_REPLICATION_SCHEMA_HASH_SIZE;
     if (out_size != NULL)
@@ -208,7 +217,7 @@ static bool game_data_network_control_packet_size(size_t *out_size)
     return true;
 }
 
-static int game_data_network_control_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *control)
+int game_data_network_control_signal_id(const slayer3d_game_data_runtime *runtime, yyjson_val *control)
 {
     return slayer3d_game_data_find_signal(runtime, json_string(control, "signal", NULL));
 }
@@ -220,9 +229,9 @@ static const char *game_data_replication_property_key(const char *path)
     return path != NULL && SDL_strncmp(path, prefix, prefix_len) == 0 ? path + prefix_len : NULL;
 }
 
-static bool game_data_read_actor_replication_field(const slayer3d_registered_actor *actor,
-                                                   const slayer3d_replication_field_descriptor *field,
-                                                   game_data_snapshot_value *out_value)
+bool game_data_read_actor_replication_field(const slayer3d_registered_actor *actor,
+                                            const slayer3d_replication_field_descriptor *field,
+                                            game_data_snapshot_value *out_value)
 {
     if (actor == NULL || field == NULL || out_value == NULL || field->path == NULL)
         return false;
@@ -289,7 +298,7 @@ static bool game_data_read_actor_replication_field(const slayer3d_registered_act
     }
 }
 
-static bool game_data_write_snapshot_value(slayer3d_replication_writer *writer, const game_data_snapshot_value *value)
+bool game_data_write_snapshot_value(slayer3d_replication_writer *writer, const game_data_snapshot_value *value)
 {
     if (writer == NULL || value == NULL || !slayer3d_replication_write_field_type(writer, value->type))
         return false;
@@ -313,9 +322,8 @@ static bool game_data_write_snapshot_value(slayer3d_replication_writer *writer, 
     }
 }
 
-static bool game_data_read_snapshot_value(slayer3d_replication_reader *reader,
-                                          slayer3d_replication_field_type expected_type,
-                                          game_data_snapshot_value *out_value)
+bool game_data_read_snapshot_value(slayer3d_replication_reader *reader, slayer3d_replication_field_type expected_type,
+                                   game_data_snapshot_value *out_value)
 {
     if (reader == NULL || out_value == NULL)
         return false;
@@ -344,10 +352,9 @@ static bool game_data_read_snapshot_value(slayer3d_replication_reader *reader,
     }
 }
 
-static bool game_data_apply_actor_replication_field(slayer3d_game_data_runtime *runtime,
-                                                    slayer3d_registered_actor *actor,
-                                                    const slayer3d_replication_field_descriptor *field,
-                                                    const game_data_snapshot_value *value)
+bool game_data_apply_actor_replication_field(slayer3d_game_data_runtime *runtime, slayer3d_registered_actor *actor,
+                                             const slayer3d_replication_field_descriptor *field,
+                                             const game_data_snapshot_value *value)
 {
     if (actor == NULL || field == NULL || value == NULL || field->path == NULL || field->type != value->type)
         return false;

--- a/src/game_data_scene_flow_runtime.c
+++ b/src/game_data_scene_flow_runtime.c
@@ -1,5 +1,11 @@
-/* Scene timeline, transition, activity, and menu runtime helpers. Included by src/game_data.c to preserve internal
- * linkage. */
+/**
+ * @file game_data_scene_flow_runtime.c
+ * @brief Scene timeline, transition, activity, and menu selection runtime helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
 
 static yyjson_val *active_skip_policy_json(const slayer3d_game_data_runtime *runtime)
 {

--- a/src/game_data_scene_load_runtime.c
+++ b/src/game_data_scene_load_runtime.c
@@ -1,5 +1,13 @@
-/* Scene activity, bindings, sensors, waves, and scene loading helpers. Included by src/game_data.c to preserve internal
- * linkage. */
+/**
+ * @file game_data_scene_load_runtime.c
+ * @brief Scene activity, bindings, sensors, waves, and scene loading helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include "game_data_standard_options.h"
+
+#include <SDL3/SDL_log.h>
 
 float slayer3d_game_data_delta_time(const slayer3d_game_data_runtime *runtime)
 {
@@ -192,8 +200,7 @@ static void execute_binding(void *userdata, int signal_id, const slayer3d_proper
         execute_action_array(binding->runtime, binding->actions, payload);
 }
 
-static bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer,
-                          int error_buffer_size)
+bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size)
 {
     yyjson_val *bindings = obj_get(logic, "bindings");
     if (!yyjson_is_arr(bindings))
@@ -228,7 +235,7 @@ static bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic
     return true;
 }
 
-static bool load_sensors(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
+bool load_sensors(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
 {
     yyjson_val *sensors = obj_get(logic, "sensors");
     if (!yyjson_is_arr(sensors))
@@ -311,7 +318,7 @@ static bool load_sensors(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
     return true;
 }
 
-static bool load_wave_schedules(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
+bool load_wave_schedules(slayer3d_game_data_runtime *runtime, yyjson_val *logic)
 {
     yyjson_val *schedules = obj_get(logic, "wave_schedules");
     if (!yyjson_is_arr(schedules))
@@ -332,7 +339,7 @@ static bool load_wave_schedules(slayer3d_game_data_runtime *runtime, yyjson_val 
     return true;
 }
 
-static void load_active_camera(slayer3d_game_data_runtime *runtime, yyjson_val *root)
+void load_active_camera(slayer3d_game_data_runtime *runtime, yyjson_val *root)
 {
     yyjson_val *cameras = obj_get(obj_get(root, "world"), "cameras");
     for (size_t i = 0; yyjson_is_arr(cameras) && i < yyjson_arr_size(cameras); ++i)
@@ -566,8 +573,8 @@ static void copy_all_properties(slayer3d_properties *target, const slayer3d_prop
     }
 }
 
-static bool load_scenes(slayer3d_game_data_runtime *runtime, yyjson_val *root,
-                        const slayer3d_game_data_load_options *options, char *error_buffer, int error_buffer_size)
+bool load_scenes(slayer3d_game_data_runtime *runtime, yyjson_val *root, const slayer3d_game_data_load_options *options,
+                 char *error_buffer, int error_buffer_size)
 {
     yyjson_val *scenes = obj_get(root, "scenes");
     yyjson_val *files = obj_get(scenes, "files");


### PR DESCRIPTION
## Summary
- Move scene flow, scene loading, runtime loading, and replication helper slices out of textual .inc includes and into normal C translation units.
- Register the new modules in CMake and make their internal helper boundaries explicit through game_data_internal.h.
- Leave the remaining large slices visible for follow-up batching: network runtime, Lua API, menu UI, render runtime, and actors/input.

## Verification
- git diff --check
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8