### PR TITLE
Refactor remaining game data runtime includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ target_sources(
         src/game_data_actions.c
         src/game_data_action_lookup.c
         src/game_data_actor_pool_runtime.c
+        src/game_data_actors_input.c
         src/game_data_adapter_helpers.c
         src/game_data_combat_weapon_actions.c
         src/game_data_conditions_presentation.c
@@ -161,12 +162,16 @@ target_sources(
         src/game_data_interaction_effect_actions.c
         src/game_data_json_helpers.c
         src/game_data_motion_runtime.c
+        src/game_data_network_runtime.c
         src/game_data_network_sessions.c
         src/game_data_persistence_audio_actions.c
         src/game_data_property_effect_runtime.c
+        src/game_data_render_runtime.c
         src/game_data_replication_helpers.c
         src/game_data_runtime_collections.c
         src/game_data_load_runtime.c
+        src/game_data_lua_api.c
+        src/game_data_menu_ui.c
         src/game_data_scene_flow_runtime.c
         src/game_data_scene_load_runtime.c
         src/game_data_scene_lookup.c

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -9,7 +9,6 @@
 #include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_log.h>
-#include <SDL3/SDL_scancode.h>
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_timer.h>
 
@@ -37,15 +36,6 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
-
-#define SLAYER3D_GAME_DATA_SIGNAL_BASE 20000
-#define SLAYER3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC 0x53335253u /* "S3RS" */
-#define SLAYER3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION 1u
-#define SLAYER3D_GAME_DATA_NETWORK_INPUT_MAGIC 0x49335253u /* "S3RI" */
-#define SLAYER3D_GAME_DATA_NETWORK_INPUT_VERSION 1u
-#define SLAYER3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
-#define SLAYER3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
-#define SLAYER3D_GAME_DATA_MENU_TEXT_MAX_BYTES 255
 
 #include "game_data_internal.h"
 
@@ -80,7 +70,7 @@ void clear_menu_text_entry_capture(slayer3d_game_data_runtime *runtime)
     runtime->text_capture.original = NULL;
 }
 
-static bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char *format, ...)
+bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char *format, ...)
 {
     if (buffer == NULL || buffer_size == 0U || offset == NULL || *offset >= buffer_size || format == NULL)
         return false;
@@ -99,10 +89,6 @@ static bool append_format(char *buffer, size_t buffer_size, size_t *offset, cons
     return true;
 }
 
-static bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
-static bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime, const char *action, Uint8 button);
-static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtime, const char *action,
-                                              SDL_GamepadButton button);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
@@ -220,24 +206,12 @@ slayer3d_input_manager *runtime_input(const slayer3d_game_data_runtime *runtime)
 void actor_set_position(slayer3d_registered_actor *actor, slayer3d_vec3 position);
 void copy_property_value(slayer3d_properties *target, const char *key, const slayer3d_value *value);
 bool actor_pool_in_scene(const actor_pool_runtime *pool, const char *scene_name);
-static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
-static int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
 bool actor_matches_target_filter(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *target,
                                  const slayer3d_registered_actor *source, yyjson_val *json,
                                  const slayer3d_properties *payload, const char *fallback_tag,
                                  bool fallback_exclude_source);
 void actor_lifecycle_defer_begin(slayer3d_game_data_runtime *runtime);
 void actor_lifecycle_defer_end(slayer3d_game_data_runtime *runtime);
-#include "game_data/game_data_lua_api.inc"
-
-#include "game_data/game_data_render_runtime.inc"
-
-#include "game_data/game_data_menu_ui.inc"
-
-#include "game_data/game_data_actors_input.inc"
-
-#include "game_data/game_data_network_runtime.inc"
-
 void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)

--- a/src/game_data_actors_input.c
+++ b/src/game_data_actors_input.c
@@ -1,5 +1,12 @@
-/* Actor, pool, and input-profile runtime helpers.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_actors_input.c
+ * @brief Actor, pool, and input-profile runtime helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include "game_data_validation.h"
+#include "slayer3d/input.h"
 
 void set_actor_property_from_json(slayer3d_registered_actor *actor, const char *key, yyjson_val *value)
 {
@@ -305,7 +312,7 @@ void actor_pool_copy_reason(char *target, size_t target_size, const char *reason
     SDL_strlcpy(target, reason != NULL && reason[0] != '\0' ? reason : "none", target_size);
 }
 
-static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
+int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
 {
     int count = 0;
     for (int i = 0; runtime != NULL && pool != NULL && i < pool->capacity; ++i)
@@ -317,7 +324,7 @@ static int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, co
     return count;
 }
 
-static int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
+int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool)
 {
     int count = 0;
     for (int i = 0; runtime != NULL && pool != NULL && i < pool->capacity; ++i)
@@ -676,7 +683,7 @@ static void rebind_action_from_specs(slayer3d_game_data_runtime *runtime, int ac
     }
 }
 
-static bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode)
+bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode)
 {
     const int action_id = slayer3d_game_data_find_action(runtime, action);
     if (runtime == NULL || action == NULL || action_id < 0 || scancode == SDL_SCANCODE_UNKNOWN)
@@ -710,7 +717,7 @@ static bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, con
     return true;
 }
 
-static bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime, const char *action, Uint8 button)
+bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime, const char *action, Uint8 button)
 {
     const int action_id = slayer3d_game_data_find_action(runtime, action);
     if (runtime == NULL || action == NULL || action_id < 0 || button == 0)
@@ -744,8 +751,8 @@ static bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
-static bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtime, const char *action,
-                                              SDL_GamepadButton button)
+bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtime, const char *action,
+                                       SDL_GamepadButton button)
 {
     const int action_id = slayer3d_game_data_find_action(runtime, action);
     if (runtime == NULL || action == NULL || action_id < 0 || button == SDL_GAMEPAD_BUTTON_INVALID)

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -26,6 +26,15 @@
 
 typedef struct slayer3d_replication_field_descriptor slayer3d_replication_field_descriptor;
 
+#define SLAYER3D_GAME_DATA_SIGNAL_BASE 20000
+#define SLAYER3D_GAME_DATA_MENU_TEXT_MAX_BYTES 255
+#define SLAYER3D_GAME_DATA_NETWORK_SNAPSHOT_MAGIC 0x53335253u /* "S3RS" */
+#define SLAYER3D_GAME_DATA_NETWORK_SNAPSHOT_VERSION 1u
+#define SLAYER3D_GAME_DATA_NETWORK_INPUT_MAGIC 0x49335253u /* "S3RI" */
+#define SLAYER3D_GAME_DATA_NETWORK_INPUT_VERSION 1u
+#define SLAYER3D_GAME_DATA_NETWORK_CONTROL_MAGIC 0x43335253u /* "S3RC" */
+#define SLAYER3D_GAME_DATA_NETWORK_CONTROL_VERSION 1u
+
 typedef enum game_data_sensor_type
 {
     GAME_DATA_SENSOR_BOUNDS_EXIT,
@@ -623,6 +632,7 @@ typedef struct slayer3d_game_data_runtime
 
 void set_error(char *buffer, int buffer_size, const char *message);
 void set_errorf(char *buffer, int buffer_size, const char *format, ...);
+bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char *format, ...);
 char *path_join(const char *base_dir, const char *path);
 char *path_dirname(const char *path);
 
@@ -696,6 +706,8 @@ void actor_pool_set_lifecycle_state(actor_pool_runtime *pool, slayer3d_registere
                                     actor_lifecycle_state state);
 bool actor_pool_actor_is_active(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
 bool actor_pool_actor_is_available(const actor_pool_runtime *pool, const slayer3d_registered_actor *actor, int index);
+int actor_pool_active_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
+int actor_pool_available_count(const slayer3d_game_data_runtime *runtime, const actor_pool_runtime *pool);
 void actor_pool_copy_reason(char *target, size_t target_size, const char *reason);
 void actor_pool_note_spawn_attempt(actor_pool_runtime *pool);
 void actor_pool_note_spawn_success(slayer3d_game_data_runtime *runtime, actor_pool_runtime *pool);
@@ -778,6 +790,10 @@ bool apply_actor_pool_scene_exit_policies(slayer3d_game_data_runtime *runtime, c
 void clear_menu_text_entry_capture(slayer3d_game_data_runtime *runtime);
 int menu_runtime_item_count(const slayer3d_game_data_runtime *runtime, const scene_menu_state *menu);
 void update_dynamic_list_selection_state(slayer3d_game_data_runtime *runtime, scene_menu_state *menu);
+bool set_action_keyboard_binding(slayer3d_game_data_runtime *runtime, const char *action, SDL_Scancode scancode);
+bool set_action_mouse_button_binding(slayer3d_game_data_runtime *runtime, const char *action, Uint8 button);
+bool set_action_gamepad_button_binding(slayer3d_game_data_runtime *runtime, const char *action,
+                                       SDL_GamepadButton button);
 bool json_scalar_to_value(yyjson_val *json, slayer3d_value *out_value);
 bool set_property_from_value(slayer3d_properties *props, const char *key, const slayer3d_value *value);
 bool start_property_animation_from_json(slayer3d_game_data_runtime *runtime, yyjson_val *action);

--- a/src/game_data_lua_api.c
+++ b/src/game_data_lua_api.c
@@ -1,4 +1,14 @@
-/* Lua scripting bridge helpers. Included by src/game_data.c to preserve internal linkage. */
+/**
+ * @file game_data_lua_api.c
+ * @brief Lua scripting bridge helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
+
+#include "lauxlib.h"
+#include "lua.h"
 
 static slayer3d_game_data_runtime *lua_runtime(lua_State *lua)
 {

--- a/src/game_data_menu_ui.c
+++ b/src/game_data_menu_ui.c
@@ -1,5 +1,13 @@
-/* Menu and authored UI runtime helpers.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_menu_ui.c
+ * @brief Menu and authored UI runtime helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
+
+#include "slayer3d/input.h"
 
 static slayer3d_game_data_menu_control_type parse_menu_control_type(const char *type)
 {

--- a/src/game_data_network_runtime.c
+++ b/src/game_data_network_runtime.c
@@ -1,6 +1,14 @@
-/* Network runtime bindings, packets, and diagnostics.
- * Included by src/game_data.c to keep private runtime helpers in one translation unit. */
+/**
+ * @file game_data_network_runtime.c
+ * @brief Network runtime bindings, packets, and diagnostics.
+ */
 
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_timer.h>
+
+#include "network_replication_schema.h"
 bool slayer3d_game_data_has_network_schema(const slayer3d_game_data_runtime *runtime)
 {
     return runtime != NULL && runtime->has_network_schema;

--- a/src/game_data_render_runtime.c
+++ b/src/game_data_render_runtime.c
@@ -1,5 +1,11 @@
-/* App control, asset, camera, light, render, particle, and transition helpers. Included by src/game_data.c to preserve
- * internal linkage. */
+/**
+ * @file game_data_render_runtime.c
+ * @brief App control, asset, camera, light, render, particle, and transition helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include "game_data_standard_options.h"
 
 bool slayer3d_game_data_get_app_control(const slayer3d_game_data_runtime *runtime,
                                         slayer3d_game_data_app_control *out_control)


### PR DESCRIPTION
## Summary
- Move the remaining game data runtime include slices into normal C translation units: actors/input, Lua API, menu/UI, network runtime, and render runtime.
- Register the new modules in CMake and make shared internal boundaries explicit in game_data_internal.h.
- Leave game_data.c as the lifecycle/destructor host instead of a textual aggregation unit.

## Verification
- git diff --check
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- cmake --build build/debug -j 8
- ctest --test-dir build/debug --output-on-failure -j 8