### PR TITLE
Add editor world picking and debug primitives

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -610,6 +610,17 @@ stable selection ids, hierarchy grouping, palette filtering, snap hints,
 prefab/archetype references, and face inspectors while still previewing the
 same runtime brush mesh that the game renders.
 
+Editor viewports should pick brush and sector geometry through
+`slayer3d_game_data_pick_editor_world_model()`. This wraps the generic
+world-model trace API and returns a stable selection record with world,
+sector/brush, material, face indexes, hit point, hit normal, bounds, and
+runtime-owned editor metadata pointers. Debug overlays should consume
+`slayer3d_game_data_for_each_editor_debug_primitive()` or
+`slayer3d_game_data_draw_editor_debug_primitives()` for world bounds, selected
+bounds, trace rays, hit markers, and face normals. These helpers are
+renderer-agnostic/data-driven editor substrate; authored gameplay JSON does
+not need to contain one-off debug actors for selection visualization.
+
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:
 

--- a/docs/game-data-model.md
+++ b/docs/game-data-model.md
@@ -102,7 +102,13 @@ the underlying sector level or brush world. Sector and brush implementations
 remain distinct internally, but tools can start from the shared
 `slayer3d_game_data_for_each_world_model_instance`,
 `slayer3d_game_data_trace_world_models`, and
-`slayer3d_game_data_query_world_model_point` APIs.
+`slayer3d_game_data_query_world_model_point` APIs. Editor viewport picking can
+use `slayer3d_game_data_pick_editor_world_model` to turn a trace into stable
+selection metadata, including brush/material/face editor metadata when the hit
+comes from a brush world. Debug overlays should use
+`slayer3d_game_data_for_each_editor_debug_primitive` or the presentation-layer
+draw helper rather than duplicating bounds, normal, and hit-marker rendering in
+tool code.
 
 ## Data Boundary
 

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -568,6 +568,8 @@ extern "C"
         slayer3d_vec3 normal;
         /** @brief Authored brush world name. */
         const char *world_name;
+        /** @brief World-space translation of the hit brush-world instance. */
+        slayer3d_vec3 world_position;
         /** @brief Authored brush name. */
         const char *brush_name;
         /** @brief Authored face material name for plane hits, or NULL. */
@@ -688,6 +690,8 @@ extern "C"
         slayer3d_game_data_world_model_type type;
         /** @brief Authored world model name. */
         const char *world_name;
+        /** @brief World-space translation of the hit world-model instance. */
+        slayer3d_vec3 world_position;
         /** @brief Authored sector/brush name when available. */
         const char *element_name;
         /** @brief Authored material name for brush face hits, or NULL. */
@@ -719,6 +723,8 @@ extern "C"
         slayer3d_game_data_world_model_type type;
         /** @brief Authored world model name. */
         const char *world_name;
+        /** @brief World-space translation of the selected world-model instance. */
+        slayer3d_vec3 world_position;
         /** @brief Authored sector/brush name when available. */
         const char *element_name;
         /** @brief Sector or brush index, or -1 when unavailable. */
@@ -741,6 +747,127 @@ extern "C"
         /** @brief Existing brush-world trace/render diagnostics. */
         slayer3d_game_data_brush_diagnostics brush;
     } slayer3d_game_data_world_model_diagnostics;
+
+    /** @brief Editor/tooling selection produced by world-model picking. */
+    typedef struct slayer3d_game_data_editor_selection
+    {
+        /** @brief True when the selection hit a world model. */
+        bool hit;
+        /** @brief Implementation kind that produced the selection. */
+        slayer3d_game_data_world_model_type type;
+        /** @brief Authored world model name. */
+        const char *world_name;
+        /** @brief World-space translation of the selected world-model instance. */
+        slayer3d_vec3 world_position;
+        /** @brief Authored sector/brush name when available. */
+        const char *element_name;
+        /** @brief Authored brush material name for face selections, or NULL. */
+        const char *material_name;
+        /** @brief Sector or brush index, or -1 when unavailable. */
+        int element_index;
+        /** @brief Brush face index, or -1 when unavailable. */
+        int face_index;
+        /** @brief Trace fraction in [0, 1]. */
+        float fraction;
+        /** @brief World-space hit point. */
+        slayer3d_vec3 point;
+        /** @brief World-space hit normal when available. */
+        slayer3d_vec3 normal;
+        /** @brief World-space selection bounds when known. */
+        slayer3d_bounding_box bounds;
+        /** @brief True when @p bounds contains usable world-space bounds. */
+        bool has_bounds;
+        /** @brief Optional world-level editor metadata. */
+        const slayer3d_game_data_editor_metadata *world_editor;
+        /** @brief Optional sector/brush editor metadata. */
+        const slayer3d_game_data_editor_metadata *element_editor;
+        /** @brief Optional material editor metadata for brush face hits. */
+        const slayer3d_game_data_editor_metadata *material_editor;
+        /** @brief Optional face editor metadata for brush face hits. */
+        const slayer3d_game_data_editor_metadata *face_editor;
+    } slayer3d_game_data_editor_selection;
+
+    /** @brief Editor debug primitive kind emitted by tooling helpers. */
+    typedef enum slayer3d_game_data_editor_debug_primitive_type
+    {
+        /** @brief Active world-model bounds edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE = 1,
+        /** @brief Selected object bounds edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE = 2,
+        /** @brief Selection trace ray. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_TRACE_RAY = 3,
+        /** @brief Selected face normal line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL = 4,
+        /** @brief Hit-point marker line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER = 5,
+    } slayer3d_game_data_editor_debug_primitive_type;
+
+    enum
+    {
+        /** @brief Emit active world-model bounds. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS = 1u << 0,
+        /** @brief Emit selected element bounds when known. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS = 1u << 1,
+        /** @brief Emit the trace ray stored in the debug descriptor. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY = 1u << 2,
+        /** @brief Emit selected face normal when known. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL = 1u << 3,
+        /** @brief Emit a small marker at the selected hit point. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER = 1u << 4,
+        /** @brief Emit every supported editor debug primitive. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL |
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER,
+    };
+
+    /** @brief One renderer-agnostic editor debug line segment. */
+    typedef struct slayer3d_game_data_editor_debug_primitive
+    {
+        /** @brief Semantic line type. */
+        slayer3d_game_data_editor_debug_primitive_type type;
+        /** @brief World-space line start. */
+        slayer3d_vec3 start;
+        /** @brief World-space line end. */
+        slayer3d_vec3 end;
+        /** @brief Display color. */
+        slayer3d_color color;
+        /** @brief Associated world name when available. */
+        const char *world_name;
+        /** @brief Associated sector/brush name when available. */
+        const char *element_name;
+        /** @brief Associated brush face index, or -1. */
+        int face_index;
+    } slayer3d_game_data_editor_debug_primitive;
+
+    /** @brief Editor debug overlay generation options. */
+    typedef struct slayer3d_game_data_editor_debug_desc
+    {
+        /** @brief Bitmask of SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_* flags. */
+        unsigned int flags;
+        /** @brief Optional current selection. */
+        const slayer3d_game_data_editor_selection *selection;
+        /** @brief Optional trace descriptor used for trace-ray visualization. */
+        const slayer3d_game_data_world_trace_desc *trace;
+        /** @brief Color for active world-model bounds, or alpha 0 for default. */
+        slayer3d_color world_bounds_color;
+        /** @brief Color for selected element bounds, or alpha 0 for default. */
+        slayer3d_color selection_bounds_color;
+        /** @brief Color for trace rays, or alpha 0 for default. */
+        slayer3d_color trace_color;
+        /** @brief Color for face normals, or alpha 0 for default. */
+        slayer3d_color face_normal_color;
+        /** @brief Color for hit markers, or alpha 0 for default. */
+        slayer3d_color hit_marker_color;
+        /** @brief Face-normal line length in world units. Defaults to 0.75. */
+        float normal_length;
+        /** @brief Hit-marker half-size in world units. Defaults to 0.1. */
+        float hit_marker_size;
+    } slayer3d_game_data_editor_debug_desc;
+
+    /** @brief Callback for renderer-agnostic editor debug primitive iteration. */
+    typedef bool (*slayer3d_game_data_editor_debug_primitive_fn)(
+        void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive);
 
     /**
      * @brief Callback for active authored sector level instances.
@@ -1691,6 +1818,19 @@ extern "C"
                                                slayer3d_game_data_world_trace_result *out_result);
 
     /**
+     * @brief Pick an active world model and return editor-facing selection metadata.
+     *
+     * This is a convenience layer over @ref slayer3d_game_data_trace_world_models
+     * for editor viewports. The returned selection includes the raw trace hit,
+     * stable authored names and indexes, world-space bounds where available, and
+     * pointers to runtime-owned editor metadata for the selected world, element,
+     * material, and face. Pointers remain valid until the runtime is destroyed.
+     */
+    bool slayer3d_game_data_pick_editor_world_model(const slayer3d_game_data_runtime *runtime,
+                                                    const slayer3d_game_data_world_trace_desc *desc,
+                                                    slayer3d_game_data_editor_selection *out_selection);
+
+    /**
      * @brief Query which active world model volume contains a point.
      *
      * The first matching sector or brush volume in active-scene order is
@@ -1712,6 +1852,19 @@ extern "C"
      */
     bool slayer3d_game_data_get_world_model_diagnostics(const slayer3d_game_data_runtime *runtime,
                                                         slayer3d_game_data_world_model_diagnostics *out_diagnostics);
+
+    /**
+     * @brief Iterate renderer-agnostic editor/debug line primitives.
+     *
+     * The helper emits deterministic line segments for active world bounds,
+     * current selection bounds, trace rays, selected face normals, and hit
+     * markers. Editors can draw these through any backend, while runtime hosts
+     * can use the companion presentation helper.
+     */
+    bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data_runtime *runtime,
+                                                            const slayer3d_game_data_editor_debug_desc *desc,
+                                                            slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                            void *userdata);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -374,6 +374,17 @@ extern "C"
                                                              const slayer3d_game_data_render_eval *eval);
 
     /**
+     * @brief Draw editor/debug world-model overlay primitives.
+     *
+     * Draws the renderer-agnostic line primitives emitted by
+     * @ref slayer3d_game_data_for_each_editor_debug_primitive. Call inside an
+     * active 3D pass after the scene camera is configured.
+     */
+    bool slayer3d_game_data_draw_editor_debug_primitives(const slayer3d_game_data_runtime *runtime,
+                                                         slayer3d_render_context *renderer,
+                                                         const slayer3d_game_data_editor_debug_desc *desc);
+
+    /**
      * @brief Initialize a world sprite asset cache.
      *
      * @param cache Cache to initialize.

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -691,6 +691,7 @@ static bool trace_brush_world_instance(void *userdata, const slayer3d_game_data_
     {
         local_result.end_position = slayer3d_vec3_add(local_result.end_position, instance->position);
         local_result.point = slayer3d_vec3_add(local_result.point, instance->position);
+        local_result.world_position = instance->position;
         context->closest = local_result;
     }
     return true;
@@ -1135,6 +1136,7 @@ static bool trace_sector_world_instance(void *userdata, const slayer3d_game_data
     context->result->hit = true;
     context->result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL;
     context->result->world_name = instance->level_name;
+    context->result->world_position = instance->position;
     context->result->element_index = sector_hit.end_sector;
     context->result->face_index = -1;
     context->result->fraction = sector_hit.fraction;
@@ -1196,6 +1198,7 @@ bool slayer3d_game_data_trace_world_models(const slayer3d_game_data_runtime *run
             out_result->all_solid = brush_result.all_solid;
             out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
             out_result->world_name = brush_result.world_name;
+            out_result->world_position = brush_result.world_position;
             out_result->element_name = brush_result.brush_name;
             out_result->material_name = brush_result.material_name;
             out_result->element_index = brush_result.brush_index;
@@ -1206,6 +1209,335 @@ bool slayer3d_game_data_trace_world_models(const slayer3d_game_data_runtime *run
             out_result->normal = brush_result.normal;
             out_result->contents = brush_result.contents;
             out_result->surface_flags = brush_result.surface_flags;
+        }
+    }
+    return true;
+}
+
+static void init_editor_selection(slayer3d_game_data_editor_selection *selection)
+{
+    if (selection == NULL)
+        return;
+    SDL_zero(*selection);
+    selection->type = SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+    selection->element_index = -1;
+    selection->face_index = -1;
+    selection->fraction = 1.0f;
+}
+
+typedef struct world_model_instance_lookup_context
+{
+    const char *world_name;
+    slayer3d_vec3 position;
+    slayer3d_game_data_world_model_type type;
+    slayer3d_bounding_box bounds;
+    bool has_bounds;
+    bool found;
+} world_model_instance_lookup_context;
+
+static bool capture_matching_world_model_instance(void *userdata,
+                                                  const slayer3d_game_data_world_model_instance *instance)
+{
+    world_model_instance_lookup_context *context = (world_model_instance_lookup_context *)userdata;
+    if (context == NULL || context->world_name == NULL || instance == NULL || instance->name == NULL)
+        return false;
+    if (context->type != SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID && instance->type != context->type)
+        return true;
+    if (SDL_strcmp(context->world_name, instance->name) != 0)
+        return true;
+    if (slayer3d_vec3_length_squared(slayer3d_vec3_sub(context->position, instance->position)) > 0.000001f)
+        return true;
+
+    context->bounds = instance->bounds;
+    context->has_bounds = instance->has_bounds;
+    context->found = true;
+    return false;
+}
+
+static bool active_world_model_bounds(const slayer3d_game_data_runtime *runtime,
+                                      slayer3d_game_data_world_model_type type, const char *world_name,
+                                      slayer3d_vec3 position, slayer3d_bounding_box *out_bounds)
+{
+    if (out_bounds != NULL)
+        SDL_zero(*out_bounds);
+    if (runtime == NULL || world_name == NULL || out_bounds == NULL)
+        return false;
+
+    world_model_instance_lookup_context context;
+    SDL_zero(context);
+    context.world_name = world_name;
+    context.position = position;
+    context.type = type;
+    if (!slayer3d_game_data_for_each_world_model_instance(runtime, capture_matching_world_model_instance, &context))
+        return false;
+    if (!context.found || !context.has_bounds)
+        return false;
+    *out_bounds = context.bounds;
+    return true;
+}
+
+static bool populate_brush_editor_selection(const slayer3d_game_data_runtime *runtime,
+                                            const slayer3d_game_data_world_trace_result *trace,
+                                            slayer3d_game_data_editor_selection *selection)
+{
+    if (runtime == NULL || trace == NULL || selection == NULL || trace->world_name == NULL)
+        return false;
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, trace->world_name);
+    if (world_runtime == NULL)
+        return true;
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    selection->world_editor = &world->editor;
+    if (trace->element_index < 0 || trace->element_index >= world->brush_count)
+        return true;
+
+    const slayer3d_game_data_brush *brush = &world->brushes[trace->element_index];
+    selection->element_editor = &brush->editor;
+    if (brush->has_bounds)
+    {
+        selection->bounds = translated_bounds(brush->bounds, trace->world_position);
+        selection->has_bounds = true;
+    }
+
+    if (trace->face_index >= 0 && trace->face_index < brush->face_count)
+    {
+        const slayer3d_game_data_brush_face *face = &brush->faces[trace->face_index];
+        selection->face_editor = &face->editor;
+        if (face->material_index >= 0 && face->material_index < world->material_count)
+            selection->material_editor = &world->materials[face->material_index].editor;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_pick_editor_world_model(const slayer3d_game_data_runtime *runtime,
+                                                const slayer3d_game_data_world_trace_desc *desc,
+                                                slayer3d_game_data_editor_selection *out_selection)
+{
+    init_editor_selection(out_selection);
+    if (runtime == NULL || desc == NULL || out_selection == NULL)
+        return false;
+
+    slayer3d_game_data_world_trace_result trace;
+    if (!slayer3d_game_data_trace_world_models(runtime, desc, &trace))
+        return false;
+    if (!trace.hit)
+        return true;
+
+    out_selection->hit = true;
+    out_selection->type = trace.type;
+    out_selection->world_name = trace.world_name;
+    out_selection->world_position = trace.world_position;
+    out_selection->element_name = trace.element_name;
+    out_selection->material_name = trace.material_name;
+    out_selection->element_index = trace.element_index;
+    out_selection->face_index = trace.face_index;
+    out_selection->fraction = trace.fraction;
+    out_selection->point = trace.point;
+    out_selection->normal = trace.normal;
+
+    if (trace.type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
+        return populate_brush_editor_selection(runtime, &trace, out_selection);
+
+    if (active_world_model_bounds(runtime, trace.type, trace.world_name, trace.world_position, &out_selection->bounds))
+        out_selection->has_bounds = true;
+    return true;
+}
+
+typedef struct editor_debug_iteration_context
+{
+    slayer3d_game_data_editor_debug_primitive_fn callback;
+    void *userdata;
+    slayer3d_color color;
+    slayer3d_game_data_editor_debug_primitive_type type;
+    const char *world_name;
+    const char *element_name;
+    int face_index;
+    bool stopped;
+} editor_debug_iteration_context;
+
+static slayer3d_color editor_debug_color_or_default(slayer3d_color color, slayer3d_color fallback)
+{
+    return color.a != 0 ? color : fallback;
+}
+
+static bool emit_editor_debug_line(editor_debug_iteration_context *context, slayer3d_vec3 start, slayer3d_vec3 end)
+{
+    if (context == NULL || context->callback == NULL)
+        return false;
+
+    slayer3d_game_data_editor_debug_primitive primitive;
+    SDL_zero(primitive);
+    primitive.type = context->type;
+    primitive.start = start;
+    primitive.end = end;
+    primitive.color = context->color;
+    primitive.world_name = context->world_name;
+    primitive.element_name = context->element_name;
+    primitive.face_index = context->face_index;
+    if (!context->callback(context->userdata, &primitive))
+    {
+        context->stopped = true;
+        return false;
+    }
+    return true;
+}
+
+static bool emit_editor_debug_bounds(editor_debug_iteration_context *context, slayer3d_bounding_box bounds)
+{
+    const slayer3d_vec3 min = bounds.min;
+    const slayer3d_vec3 max = bounds.max;
+    const slayer3d_vec3 corners[8] = {
+        slayer3d_vec3_make(min.x, min.y, min.z), slayer3d_vec3_make(max.x, min.y, min.z),
+        slayer3d_vec3_make(max.x, min.y, max.z), slayer3d_vec3_make(min.x, min.y, max.z),
+        slayer3d_vec3_make(min.x, max.y, min.z), slayer3d_vec3_make(max.x, max.y, min.z),
+        slayer3d_vec3_make(max.x, max.y, max.z), slayer3d_vec3_make(min.x, max.y, max.z),
+    };
+    static const int edges[12][2] = {
+        {0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 6}, {6, 7}, {7, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7},
+    };
+
+    for (int i = 0; i < 12; ++i)
+    {
+        if (!emit_editor_debug_line(context, corners[edges[i][0]], corners[edges[i][1]]))
+            return false;
+    }
+    return true;
+}
+
+typedef struct editor_world_bounds_context
+{
+    const slayer3d_game_data_editor_debug_desc *desc;
+    slayer3d_game_data_editor_debug_primitive_fn callback;
+    void *userdata;
+    bool stopped;
+} editor_world_bounds_context;
+
+static bool emit_editor_debug_world_bounds(void *userdata, const slayer3d_game_data_world_model_instance *instance)
+{
+    editor_world_bounds_context *bounds_context = (editor_world_bounds_context *)userdata;
+    if (bounds_context == NULL || bounds_context->desc == NULL || instance == NULL || !instance->has_bounds)
+        return true;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = bounds_context->callback;
+    context.userdata = bounds_context->userdata;
+    context.color =
+        editor_debug_color_or_default(bounds_context->desc->world_bounds_color, (slayer3d_color){80, 170, 255, 220});
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE;
+    context.world_name = instance->name;
+    context.face_index = -1;
+    if (!emit_editor_debug_bounds(&context, instance->bounds))
+    {
+        bounds_context->stopped = context.stopped;
+        return false;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data_runtime *runtime,
+                                                        const slayer3d_game_data_editor_debug_desc *desc,
+                                                        slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                        void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL)
+        return false;
+
+    const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS) != 0u)
+    {
+        editor_world_bounds_context bounds_context;
+        SDL_zero(bounds_context);
+        bounds_context.desc = desc;
+        bounds_context.callback = callback;
+        bounds_context.userdata = userdata;
+        if (!slayer3d_game_data_for_each_world_model_instance(runtime, emit_editor_debug_world_bounds, &bounds_context))
+        {
+            return false;
+        }
+        if (bounds_context.stopped)
+            return true;
+    }
+
+    const slayer3d_game_data_editor_selection *selection = desc->selection;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS) != 0u && selection != NULL && selection->hit &&
+        selection->has_bounds)
+    {
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color =
+            editor_debug_color_or_default(desc->selection_bounds_color, (slayer3d_color){255, 220, 40, 255});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE;
+        context.world_name = selection->world_name;
+        context.element_name = selection->element_name;
+        context.face_index = selection->face_index;
+        if (!emit_editor_debug_bounds(&context, selection->bounds))
+            return true;
+    }
+
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY) != 0u && desc->trace != NULL)
+    {
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color = editor_debug_color_or_default(desc->trace_color, (slayer3d_color){255, 255, 255, 180});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_TRACE_RAY;
+        context.world_name = selection != NULL ? selection->world_name : NULL;
+        context.element_name = selection != NULL ? selection->element_name : NULL;
+        context.face_index = selection != NULL ? selection->face_index : -1;
+        if (!emit_editor_debug_line(&context, desc->trace->start, desc->trace->end))
+            return true;
+    }
+
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL) != 0u && selection != NULL && selection->hit &&
+        slayer3d_vec3_length_squared(selection->normal) > 0.000001f)
+    {
+        const float length = desc->normal_length > 0.0f ? desc->normal_length : 0.75f;
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color = editor_debug_color_or_default(desc->face_normal_color, (slayer3d_color){40, 255, 120, 255});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL;
+        context.world_name = selection->world_name;
+        context.element_name = selection->element_name;
+        context.face_index = selection->face_index;
+        if (!emit_editor_debug_line(
+                &context, selection->point,
+                slayer3d_vec3_add(selection->point,
+                                  slayer3d_vec3_scale(slayer3d_vec3_normalize(selection->normal), length))))
+        {
+            return true;
+        }
+    }
+
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER) != 0u && selection != NULL && selection->hit)
+    {
+        const float size = desc->hit_marker_size > 0.0f ? desc->hit_marker_size : 0.1f;
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color = editor_debug_color_or_default(desc->hit_marker_color, (slayer3d_color){255, 80, 80, 255});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER;
+        context.world_name = selection->world_name;
+        context.element_name = selection->element_name;
+        context.face_index = selection->face_index;
+        if (!emit_editor_debug_line(&context,
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(-size, 0.0f, 0.0f)),
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(size, 0.0f, 0.0f))) ||
+            !emit_editor_debug_line(&context,
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(0.0f, -size, 0.0f)),
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(0.0f, size, 0.0f))) ||
+            !emit_editor_debug_line(&context,
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(0.0f, 0.0f, -size)),
+                                    slayer3d_vec3_add(selection->point, slayer3d_vec3_make(0.0f, 0.0f, size))))
+        {
+            return true;
         }
     }
     return true;
@@ -1252,6 +1584,7 @@ bool slayer3d_game_data_query_world_model_point(const slayer3d_game_data_runtime
                 out_result->inside = true;
                 out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL;
                 out_result->world_name = level_runtime->name;
+                out_result->world_position = position;
                 out_result->element_name = level_runtime->sector_names[sector_index];
                 out_result->element_index = sector_index;
                 return true;
@@ -1275,6 +1608,7 @@ bool slayer3d_game_data_query_world_model_point(const slayer3d_game_data_runtime
             out_result->inside = true;
             out_result->type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
             out_result->world_name = result.world_name;
+            out_result->world_position = result.world_position;
             out_result->element_name = result.brush_name;
             out_result->element_index = result.brush_index;
             out_result->contents = result.contents;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2373,6 +2373,41 @@ bool slayer3d_game_data_draw_render_primitives_evaluated(const slayer3d_game_dat
     return draw_render_primitives_evaluated_with_cache(runtime, renderer, eval, NULL, NULL, NULL, NULL, NULL);
 }
 
+typedef struct editor_debug_draw_context
+{
+    slayer3d_render_context *renderer;
+    bool ok;
+} editor_debug_draw_context;
+
+static bool draw_editor_debug_primitive(void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive)
+{
+    editor_debug_draw_context *context = (editor_debug_draw_context *)userdata;
+    if (context == NULL || context->renderer == NULL || primitive == NULL)
+        return false;
+    if (!slayer3d_draw_line_3d(context->renderer, primitive->start, primitive->end, primitive->color))
+    {
+        context->ok = false;
+        return false;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_draw_editor_debug_primitives(const slayer3d_game_data_runtime *runtime,
+                                                     slayer3d_render_context *renderer,
+                                                     const slayer3d_game_data_editor_debug_desc *desc)
+{
+    if (runtime == NULL || renderer == NULL || desc == NULL)
+        return false;
+
+    editor_debug_draw_context context;
+    SDL_zero(context);
+    context.renderer = renderer;
+    context.ok = true;
+    if (!slayer3d_game_data_for_each_editor_debug_primitive(runtime, desc, draw_editor_debug_primitive, &context))
+        return false;
+    return context.ok;
+}
+
 bool slayer3d_game_data_draw_ui_text(const slayer3d_game_data_runtime *runtime, slayer3d_render_context *renderer,
                                      slayer3d_game_data_font_cache *font_cache,
                                      const slayer3d_game_data_ui_metrics *metrics, float pulse_phase)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -11674,14 +11674,26 @@ TEST(GameDataRuntime, WorldModelInterfaceEnumeratesQueriesAndTracesSectorAndBrus
   "brush_worlds": [
     {
       "name": "brush.world_model",
-      "materials": [{ "name": "mat.wall", "albedo": [0.8, 0.2, 0.2, 1.0] }],
+      "editor": { "stable_id": "editor.world.brush" },
+      "materials": [
+        {
+          "name": "mat.wall",
+          "albedo": [0.8, 0.2, 0.2, 1.0],
+          "editor": { "stable_id": "editor.material.wall", "display_name": "Wall Material" }
+        }
+      ],
       "brushes": [
         {
           "name": "brush.cube",
+          "editor": { "stable_id": "editor.brush.cube", "display_name": "Cube Brush" },
           "contents": ["solid", "player_clip"],
           "faces": [
             { "plane": { "normal": [ 1,  0,  0], "distance":  2 }, "material": "mat.wall" },
-            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            {
+              "plane": { "normal": [-1,  0,  0], "distance":  0 },
+              "material": "mat.wall",
+              "editor": { "stable_id": "editor.face.cube.left", "display_name": "Cube Left Face" }
+            },
             { "plane": { "normal": [ 0,  1,  0], "distance":  2 }, "material": "mat.wall" },
             { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
             { "plane": { "normal": [ 0,  0,  1], "distance":  2 }, "material": "mat.wall" },
@@ -11758,13 +11770,163 @@ TEST(GameDataRuntime, WorldModelInterfaceEnumeratesQueriesAndTracesSectorAndBrus
     EXPECT_NEAR(result.end_position.x, 10.0f, 0.001f);
     EXPECT_NEAR(result.normal.x, -1.0f, 0.001f);
 
+    slayer3d_game_data_editor_selection selection{};
+    ASSERT_TRUE(slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection));
+    EXPECT_TRUE(selection.hit);
+    EXPECT_EQ(selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
+    EXPECT_STREQ(selection.world_name, "brush.world_model");
+    EXPECT_NEAR(selection.world_position.x, 10.0f, 0.001f);
+    EXPECT_STREQ(selection.element_name, "brush.cube");
+    EXPECT_STREQ(selection.material_name, "mat.wall");
+    EXPECT_EQ(selection.element_index, 0);
+    EXPECT_EQ(selection.face_index, 1);
+    EXPECT_TRUE(selection.has_bounds);
+    EXPECT_NEAR(selection.bounds.min.x, 10.0f, 0.001f);
+    EXPECT_NEAR(selection.bounds.max.x, 12.0f, 0.001f);
+    ASSERT_NE(selection.world_editor, nullptr);
+    EXPECT_STREQ(selection.world_editor->stable_id, "editor.world.brush");
+    ASSERT_NE(selection.element_editor, nullptr);
+    EXPECT_STREQ(selection.element_editor->stable_id, "editor.brush.cube");
+    ASSERT_NE(selection.material_editor, nullptr);
+    EXPECT_STREQ(selection.material_editor->stable_id, "editor.material.wall");
+    ASSERT_NE(selection.face_editor, nullptr);
+    EXPECT_STREQ(selection.face_editor->stable_id, "editor.face.cube.left");
+
+    struct EditorDebugCapture
+    {
+        int world_edges = 0;
+        int selection_edges = 0;
+        int rays = 0;
+        int normals = 0;
+        int markers = 0;
+        bool saw_selection_world = false;
+        bool saw_normal = false;
+    } debug_capture;
+    auto capture_editor_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<EditorDebugCapture *>(userdata);
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE)
+            capture->world_edges++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
+        {
+            capture->selection_edges++;
+            if (primitive->world_name != nullptr && std::string(primitive->world_name) == "brush.world_model" &&
+                primitive->element_name != nullptr && std::string(primitive->element_name) == "brush.cube")
+            {
+                capture->saw_selection_world = true;
+            }
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_TRACE_RAY)
+        {
+            capture->rays++;
+            EXPECT_NEAR(primitive->start.x, 8.0f, 0.001f);
+            EXPECT_NEAR(primitive->end.x, 11.0f, 0.001f);
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL)
+        {
+            capture->normals++;
+            capture->saw_normal = primitive->end.x < primitive->start.x;
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER)
+        {
+            capture->markers++;
+        }
+        return true;
+    };
+    slayer3d_game_data_editor_debug_desc debug_desc{};
+    debug_desc.flags = SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    debug_desc.selection = &selection;
+    debug_desc.trace = &trace;
+    debug_desc.normal_length = 0.5f;
+    debug_desc.hit_marker_size = 0.125f;
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_editor_debug_primitive(runtime, &debug_desc, capture_editor_debug, &debug_capture));
+    EXPECT_EQ(debug_capture.world_edges, 24);
+    EXPECT_EQ(debug_capture.selection_edges, 12);
+    EXPECT_EQ(debug_capture.rays, 1);
+    EXPECT_EQ(debug_capture.normals, 1);
+    EXPECT_EQ(debug_capture.markers, 3);
+    EXPECT_TRUE(debug_capture.saw_selection_world);
+    EXPECT_TRUE(debug_capture.saw_normal);
+
     slayer3d_game_data_world_model_diagnostics diagnostics{};
     ASSERT_TRUE(slayer3d_game_data_get_world_model_diagnostics(runtime, &diagnostics));
     EXPECT_EQ(diagnostics.active_sector_level_instances, 1u);
     EXPECT_EQ(diagnostics.active_brush_world_instances, 1u);
-    EXPECT_EQ(diagnostics.world_trace_count, 2u);
+    EXPECT_EQ(diagnostics.world_trace_count, 3u);
     EXPECT_EQ(diagnostics.point_query_count, 2u);
     EXPECT_GE(diagnostics.brush.trace_count, 2u);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorPickingPreservesRepeatedBrushWorldInstancePlacement)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_repeated_brush_pick");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.repeated", "position": [0.0, 0.0, 0.0] },
+      { "world": "brush.repeated", "position": [10.0, 0.0, 0.0] }
+    ]
+  }
+})json");
+    write_text(dir / "editor_repeated_pick.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Repeated Brush Pick Test" },
+  "world": { "name": "world.repeated_pick", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.repeated",
+      "materials": [{ "name": "mat.wall", "albedo": [0.8, 0.2, 0.2, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.cube",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "editor_repeated_pick.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_world_trace_desc trace{};
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.model_filter = SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS;
+    trace.start = slayer3d_vec3_make(8.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(11.0f, 1.0f, 1.0f);
+
+    slayer3d_game_data_editor_selection selection{};
+    ASSERT_TRUE(slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection));
+    EXPECT_TRUE(selection.hit);
+    EXPECT_STREQ(selection.world_name, "brush.repeated");
+    EXPECT_STREQ(selection.element_name, "brush.cube");
+    EXPECT_NEAR(selection.world_position.x, 10.0f, 0.001f);
+    ASSERT_TRUE(selection.has_bounds);
+    EXPECT_NEAR(selection.bounds.min.x, 10.0f, 0.001f);
+    EXPECT_NEAR(selection.bounds.max.x, 12.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -5,6 +5,7 @@
 extern "C"
 {
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_timer.h>
 
 #include "slayer3d/network.h"
 }
@@ -13,6 +14,8 @@ namespace
 {
 constexpr Uint16 kBasePort = 27183;
 constexpr int kPumpLimit = 400;
+constexpr float kConnectTimeoutSeconds = 8.0f;
+constexpr Uint32 kPumpSleepMs = 2;
 
 struct NetworkPair
 {
@@ -55,8 +58,8 @@ bool create_host_client_pair(NetworkPair *pair)
         slayer3d_network_session_desc_init(&host_desc);
         host_desc.role = SLAYER3D_NETWORK_ROLE_HOST;
         host_desc.port = port;
-        host_desc.handshake_timeout = 2.0f;
-        host_desc.idle_timeout = 2.0f;
+        host_desc.handshake_timeout = kConnectTimeoutSeconds;
+        host_desc.idle_timeout = kConnectTimeoutSeconds;
         host_desc.session_name = "SLAYER3D Test Host";
 
         if (!slayer3d_network_session_create(&host_desc, &pair->host))
@@ -69,8 +72,8 @@ bool create_host_client_pair(NetworkPair *pair)
         client_desc.role = SLAYER3D_NETWORK_ROLE_CLIENT;
         client_desc.host = "127.0.0.1";
         client_desc.port = port;
-        client_desc.handshake_timeout = 2.0f;
-        client_desc.idle_timeout = 2.0f;
+        client_desc.handshake_timeout = kConnectTimeoutSeconds;
+        client_desc.idle_timeout = kConnectTimeoutSeconds;
 
         if (!slayer3d_network_session_create(&client_desc, &pair->client))
         {
@@ -88,10 +91,25 @@ bool create_host_client_pair(NetworkPair *pair)
 
 bool pump_until_connected(NetworkPair *pair)
 {
-    for (int i = 0; i < kPumpLimit; ++i)
+    if (pair == nullptr || pair->host == nullptr || pair->client == nullptr)
     {
-        EXPECT_TRUE(slayer3d_network_session_update(pair->host, 0.016f));
-        EXPECT_TRUE(slayer3d_network_session_update(pair->client, 0.016f));
+        return false;
+    }
+
+    const Uint64 start = SDL_GetTicks();
+    Uint64 last = start;
+    while ((SDL_GetTicks() - start) < (Uint64)(kConnectTimeoutSeconds * 1000.0f))
+    {
+        const Uint64 now = SDL_GetTicks();
+        float dt = (float)(now - last) / 1000.0f;
+        if (dt <= 0.0f)
+        {
+            dt = 0.001f;
+        }
+        last = now;
+
+        EXPECT_TRUE(slayer3d_network_session_update(pair->host, dt));
+        EXPECT_TRUE(slayer3d_network_session_update(pair->client, dt));
         if (slayer3d_network_session_is_connected(pair->host) && slayer3d_network_session_is_connected(pair->client))
         {
             return true;
@@ -102,6 +120,7 @@ bool pump_until_connected(NetworkPair *pair)
         {
             return false;
         }
+        SDL_Delay(kPumpSleepMs);
     }
     return false;
 }
@@ -134,8 +153,8 @@ bool create_discovery_pair(DiscoveryPair *pair)
         host_desc.role = SLAYER3D_NETWORK_ROLE_HOST;
         host_desc.port = port;
         host_desc.session_name = "SLAYER3D Discovery Host";
-        host_desc.handshake_timeout = 2.0f;
-        host_desc.idle_timeout = 2.0f;
+        host_desc.handshake_timeout = kConnectTimeoutSeconds;
+        host_desc.idle_timeout = kConnectTimeoutSeconds;
 
         if (!slayer3d_network_session_create(&host_desc, &pair->host))
         {
@@ -169,10 +188,20 @@ bool pump_until_discovered(DiscoveryPair *pair, slayer3d_network_discovery_resul
     }
 
     EXPECT_TRUE(slayer3d_network_discovery_session_refresh(pair->scanner));
-    for (int i = 0; i < kPumpLimit; ++i)
+    const Uint64 start = SDL_GetTicks();
+    Uint64 last = start;
+    while ((SDL_GetTicks() - start) < (Uint64)(kConnectTimeoutSeconds * 1000.0f))
     {
-        EXPECT_TRUE(slayer3d_network_session_update(pair->host, 0.016f));
-        EXPECT_TRUE(slayer3d_network_discovery_session_update(pair->scanner, 0.016f));
+        const Uint64 now = SDL_GetTicks();
+        float dt = (float)(now - last) / 1000.0f;
+        if (dt <= 0.0f)
+        {
+            dt = 0.001f;
+        }
+        last = now;
+
+        EXPECT_TRUE(slayer3d_network_session_update(pair->host, dt));
+        EXPECT_TRUE(slayer3d_network_discovery_session_update(pair->scanner, dt));
         if (slayer3d_network_discovery_session_result_count(pair->scanner) > 0)
         {
             if (out_result != nullptr)
@@ -181,6 +210,44 @@ bool pump_until_discovered(DiscoveryPair *pair, slayer3d_network_discovery_resul
             }
             return true;
         }
+        SDL_Delay(kPumpSleepMs);
+    }
+    return false;
+}
+
+bool pump_sessions_until_connected(slayer3d_network_session *host, slayer3d_network_session *client,
+                                   float timeout_seconds)
+{
+    if (host == nullptr || client == nullptr || timeout_seconds <= 0.0f)
+    {
+        return false;
+    }
+
+    const Uint64 start = SDL_GetTicks();
+    Uint64 last = start;
+    while ((SDL_GetTicks() - start) < (Uint64)(timeout_seconds * 1000.0f))
+    {
+        const Uint64 now = SDL_GetTicks();
+        float dt = (float)(now - last) / 1000.0f;
+        if (dt <= 0.0f)
+        {
+            dt = 0.001f;
+        }
+        last = now;
+
+        EXPECT_TRUE(slayer3d_network_session_update(host, dt));
+        EXPECT_TRUE(slayer3d_network_session_update(client, dt));
+        if (slayer3d_network_session_is_connected(host) && slayer3d_network_session_is_connected(client))
+        {
+            return true;
+        }
+        if (slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_REJECTED ||
+            slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_TIMED_OUT ||
+            slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_ERROR)
+        {
+            return false;
+        }
+        SDL_Delay(kPumpSleepMs);
     }
     return false;
 }
@@ -248,31 +315,17 @@ TEST(NetworkSession, ClientCanConnectToDiscoveredHost)
     client_desc.role = SLAYER3D_NETWORK_ROLE_CLIENT;
     client_desc.host = result.host;
     client_desc.port = result.port;
-    client_desc.handshake_timeout = 2.0f;
-    client_desc.idle_timeout = 2.0f;
+    client_desc.handshake_timeout = kConnectTimeoutSeconds;
+    client_desc.idle_timeout = kConnectTimeoutSeconds;
 
     slayer3d_network_session *client = nullptr;
     ASSERT_TRUE(slayer3d_network_session_create(&client_desc, &client));
 
-    bool connected = false;
-    for (int i = 0; i < kPumpLimit; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(pair.host, 0.016f));
-        EXPECT_TRUE(slayer3d_network_session_update(client, 0.016f));
-        if (slayer3d_network_session_is_connected(pair.host) && slayer3d_network_session_is_connected(client))
-        {
-            connected = true;
-            break;
-        }
-        if (slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_REJECTED ||
-            slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_TIMED_OUT ||
-            slayer3d_network_session_state(client) == SLAYER3D_NETWORK_STATE_ERROR)
-        {
-            break;
-        }
-    }
+    const bool connected = pump_sessions_until_connected(pair.host, client, kConnectTimeoutSeconds);
 
-    EXPECT_TRUE(connected);
+    EXPECT_TRUE(connected) << "discovered_host=" << result.host << " port=" << result.port
+                           << " host_status=" << slayer3d_network_session_status(pair.host)
+                           << " client_status=" << slayer3d_network_session_status(client);
     EXPECT_TRUE(slayer3d_network_session_is_connected(pair.host));
     EXPECT_TRUE(slayer3d_network_session_is_connected(client));
 


### PR DESCRIPTION
## Summary
- add editor-facing world-model pick results with brush/material/face metadata and instance placement
- add renderer-agnostic editor debug line primitives for world bounds, selection bounds, trace rays, hit markers, and face normals
- add a presentation helper to draw those debug primitives in a 3D pass
- document the editor picking/debug overlay substrate

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.WorldModelInterfaceEnumeratesQueriesAndTracesSectorAndBrushWorlds:GameDataRuntime.EditorPickingPreservesRepeatedBrushWorldInstancePlacement:GameDataRuntime.LoadsAuthoredBrushWorlds:GameDataRuntime.RejectsInvalidBrushWorlds:GameDataRuntime.EditorMetadataValidatesAndFpsMechanicsDojoLoads:GameDataRuntime.RejectsInvalidEditorMetadata'
- ./build/debug/tests/slayer3d_game_data_test

Refs #323