### PR TITLE
Add editor UI tooling primitives

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1926,6 +1926,61 @@ Supported brush metrics are `brush.trace_count`,
 `brush.render_mesh_culled`, `brush.render_mesh_draws`, and
 `brush.render_triangles_submitted`.
 
+For editor-like tools and diagnostics, `ui.panels` and `ui.inspectors` provide
+reusable higher-level overlay widgets while still rendering through the normal
+UI rectangle and text path. A panel emits one filled rectangle plus optional
+border rectangles. An inspector emits a background panel, optional row
+backgrounds, a title, and label/value rows. Inspector row values can be scalar
+literals or bindings to scene state, actor properties, or UI metrics:
+
+```json
+{
+  "ui": {
+    "panels": [
+      {
+        "name": "ui.editor.sidebar",
+        "x": 12,
+        "y": 12,
+        "w": 280,
+        "h": 180,
+        "color": [20, 28, 40, 220],
+        "border_color": [90, 130, 210, 255],
+        "border_thickness": 2
+      }
+    ],
+    "inspectors": [
+      {
+        "name": "ui.editor.selection",
+        "font": "font.hud",
+        "x": 24,
+        "y": 24,
+        "w": 248,
+        "row_height": 22,
+        "padding": 8,
+        "title": "Selection",
+        "rows": [
+          {
+            "label": "World",
+            "binding": { "type": "scene_state", "key": "editor.world", "default": "none" }
+          },
+          {
+            "label": "Health",
+            "binding": { "type": "property", "entity": "entity.player", "key": "health" }
+          },
+          {
+            "label": "FPS",
+            "binding": { "type": "metric", "metric": "fps", "default": 0 }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+These widgets are project-agnostic. Use them for debug HUDs, editor shells,
+inspectors, and simple tool panels before reaching for custom native UI code.
+
 `property.set` and `property.add` normally target a fixed actor:
 
 ```json

--- a/src/game_data_menu_ui.c
+++ b/src/game_data_menu_ui.c
@@ -1333,6 +1333,198 @@ static bool for_each_authored_ui_text_root(yyjson_val *root, slayer3d_game_data_
     return true;
 }
 
+static bool ui_tool_value_to_string(const slayer3d_value *value, char *buffer, size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0)
+        return false;
+    buffer[0] = '\0';
+    if (value == NULL)
+        return false;
+
+    switch (value->type)
+    {
+    case SLAYER3D_VALUE_INT:
+        SDL_snprintf(buffer, buffer_size, "%d", value->as_int);
+        return true;
+    case SLAYER3D_VALUE_FLOAT:
+        SDL_snprintf(buffer, buffer_size, "%.3f", value->as_float);
+        return true;
+    case SLAYER3D_VALUE_BOOL:
+        SDL_snprintf(buffer, buffer_size, "%s", value->as_bool ? "true" : "false");
+        return true;
+    case SLAYER3D_VALUE_VEC3:
+        SDL_snprintf(buffer, buffer_size, "%.3f, %.3f, %.3f", value->as_vec3.x, value->as_vec3.y, value->as_vec3.z);
+        return true;
+    case SLAYER3D_VALUE_STRING:
+        SDL_snprintf(buffer, buffer_size, "%s", value->as_string != NULL ? value->as_string : "");
+        return true;
+    case SLAYER3D_VALUE_COLOR:
+        SDL_snprintf(buffer, buffer_size, "%u, %u, %u, %u", (unsigned)value->as_color.r, (unsigned)value->as_color.g,
+                     (unsigned)value->as_color.b, (unsigned)value->as_color.a);
+        return true;
+    }
+    return false;
+}
+
+static bool ui_tool_json_scalar_to_string(yyjson_val *value, char *buffer, size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0)
+        return false;
+    buffer[0] = '\0';
+    if (yyjson_is_str(value))
+        SDL_snprintf(buffer, buffer_size, "%s", yyjson_get_str(value));
+    else if (yyjson_is_int(value))
+        SDL_snprintf(buffer, buffer_size, "%lld", (long long)yyjson_get_sint(value));
+    else if (yyjson_is_real(value))
+        SDL_snprintf(buffer, buffer_size, "%.3f", yyjson_get_real(value));
+    else if (yyjson_is_bool(value))
+        SDL_snprintf(buffer, buffer_size, "%s", yyjson_get_bool(value) ? "true" : "false");
+    else
+        return false;
+    return true;
+}
+
+static bool ui_tool_metric_to_string(const slayer3d_game_data_ui_metrics *metrics, const char *metric, char *buffer,
+                                     size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0)
+        return false;
+    buffer[0] = '\0';
+    if (metrics == NULL || metric == NULL)
+        return false;
+    if (SDL_strcmp(metric, "fps") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->fps);
+    else if (SDL_strcmp(metric, "frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%llu", (unsigned long long)metrics->frame);
+    else if (SDL_strcmp(metric, "paused") == 0)
+        SDL_snprintf(buffer, buffer_size, "%s", metrics->paused ? "true" : "false");
+    else
+        return false;
+    return true;
+}
+
+static bool ui_tool_binding_to_string(const slayer3d_game_data_runtime *runtime,
+                                      const slayer3d_game_data_ui_metrics *metrics, yyjson_val *binding, char *buffer,
+                                      size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0)
+        return false;
+    buffer[0] = '\0';
+    const char *type = json_string(binding, "type", "");
+    bool formatted = false;
+    if (SDL_strcmp(type, "scene_state") == 0)
+    {
+        const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+        const slayer3d_value *value =
+            scene_state != NULL ? slayer3d_properties_get_value(scene_state, json_string(binding, "key", NULL)) : NULL;
+        formatted = ui_tool_value_to_string(value, buffer, buffer_size);
+    }
+    else if (SDL_strcmp(type, "property") == 0)
+    {
+        const slayer3d_registered_actor *actor =
+            slayer3d_game_data_find_actor(runtime, json_string(binding, "entity", NULL));
+        const slayer3d_value *value =
+            actor != NULL ? slayer3d_properties_get_value(actor->props, json_string(binding, "key", NULL)) : NULL;
+        formatted = ui_tool_value_to_string(value, buffer, buffer_size);
+    }
+    else if (SDL_strcmp(type, "metric") == 0)
+    {
+        formatted = ui_tool_metric_to_string(metrics, json_string(binding, "metric", NULL), buffer, buffer_size);
+    }
+    if (!formatted)
+        formatted = ui_tool_json_scalar_to_string(obj_get(binding, "default"), buffer, buffer_size);
+    return formatted;
+}
+
+static bool ui_tool_row_value_to_string(const slayer3d_game_data_runtime *runtime,
+                                        const slayer3d_game_data_ui_metrics *metrics, yyjson_val *row, char *buffer,
+                                        size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0)
+        return false;
+    buffer[0] = '\0';
+    yyjson_val *binding = obj_get(row, "binding");
+    if (yyjson_is_obj(binding))
+        return ui_tool_binding_to_string(runtime, metrics, binding, buffer, buffer_size);
+    return ui_tool_json_scalar_to_string(obj_get(row, "value"), buffer, buffer_size);
+}
+
+static bool emit_inspector_text(const slayer3d_game_data_runtime *runtime, const slayer3d_game_data_ui_metrics *metrics,
+                                yyjson_val *inspector, const char *text_value, float x, float y, slayer3d_color color,
+                                slayer3d_game_data_ui_align align, slayer3d_game_data_ui_text_fn callback,
+                                void *userdata)
+{
+    if (text_value == NULL || text_value[0] == '\0')
+        return true;
+
+    yyjson_val *active_if = obj_get(inspector, "visible_if");
+    if (active_if != NULL && !eval_data_condition(runtime, active_if, metrics))
+        return true;
+
+    slayer3d_game_data_ui_text text;
+    SDL_zero(text);
+    text.name = json_string(inspector, "name", NULL);
+    text.font = json_string(inspector, "font", NULL);
+    text.text = text_value;
+    text.visible = "always";
+    text.x = x;
+    text.y = y;
+    text.normalized = json_bool(inspector, "normalized", false);
+    text.align = align;
+    text.centered = align == SLAYER3D_GAME_DATA_UI_ALIGN_CENTER;
+    text.scale = json_float(inspector, "scale", 1.0f);
+    text.color = color;
+    return callback(userdata, &text);
+}
+
+static bool for_each_ui_inspector_text_root(const slayer3d_game_data_runtime *runtime,
+                                            const slayer3d_game_data_ui_metrics *metrics, yyjson_val *root,
+                                            slayer3d_game_data_ui_text_fn callback, void *userdata)
+{
+    yyjson_val *inspectors = obj_get(obj_get(root, "ui"), "inspectors");
+    for (size_t i = 0; yyjson_is_arr(inspectors) && i < yyjson_arr_size(inspectors); ++i)
+    {
+        yyjson_val *inspector = yyjson_arr_get(inspectors, i);
+        const bool normalized = json_bool(inspector, "normalized", false);
+        const float x = json_float(inspector, "x", 0.0f);
+        float y = json_float(inspector, "y", 0.0f);
+        const float width = json_float(inspector, "w", json_float(inspector, "width", normalized ? 0.25f : 280.0f));
+        const float row_height = json_float(inspector, "row_height", normalized ? 0.032f : 24.0f);
+        const float label_width = json_float(inspector, "label_width", width * 0.42f);
+        const float padding = json_float(inspector, "padding", normalized ? 0.012f : 10.0f);
+        const float value_x = x + padding + label_width;
+        const float row_x = x + padding;
+        const slayer3d_color title_color = json_color(inspector, "title_color", (slayer3d_color){235, 240, 255, 255});
+        const slayer3d_color label_color = json_color(inspector, "label_color", (slayer3d_color){160, 176, 205, 255});
+        const slayer3d_color value_color = json_color(inspector, "value_color", (slayer3d_color){255, 255, 255, 255});
+        const char *title = json_string(inspector, "title", NULL);
+        if (title != NULL && title[0] != '\0')
+        {
+            if (!emit_inspector_text(runtime, metrics, inspector, title, row_x, y + padding, title_color,
+                                     SLAYER3D_GAME_DATA_UI_ALIGN_LEFT, callback, userdata))
+                return false;
+            y += row_height;
+        }
+
+        yyjson_val *rows = obj_get(inspector, "rows");
+        for (size_t row_index = 0; yyjson_is_arr(rows) && row_index < yyjson_arr_size(rows); ++row_index)
+        {
+            yyjson_val *row = yyjson_arr_get(rows, row_index);
+            const float row_y = y + padding + row_height * (float)row_index;
+            if (!emit_inspector_text(runtime, metrics, inspector, json_string(row, "label", ""), row_x, row_y,
+                                     label_color, SLAYER3D_GAME_DATA_UI_ALIGN_LEFT, callback, userdata))
+                return false;
+            char value[128];
+            if (!ui_tool_row_value_to_string(runtime, metrics, row, value, sizeof(value)))
+                SDL_strlcpy(value, json_string(row, "empty", "-"), sizeof(value));
+            if (!emit_inspector_text(runtime, metrics, inspector, value, value_x, row_y, value_color,
+                                     SLAYER3D_GAME_DATA_UI_ALIGN_LEFT, callback, userdata))
+                return false;
+        }
+    }
+    return true;
+}
+
 static bool emit_ui_menu_cursor(yyjson_val *presenter, float row_y, slayer3d_game_data_ui_text_fn callback,
                                 void *userdata)
 {
@@ -1595,6 +1787,7 @@ bool slayer3d_game_data_for_each_ui_text_for_metrics(const slayer3d_game_data_ru
 
     for (int root_index = 0; root_index < 2; ++root_index)
         if (!for_each_authored_ui_text_root(roots[root_index], callback, userdata) ||
+            !for_each_ui_inspector_text_root(runtime, metrics, roots[root_index], callback, userdata) ||
             !for_each_ui_menu_root(runtime, scene, metrics, roots[root_index], callback, userdata))
             return true;
     return true;
@@ -1686,6 +1879,110 @@ static bool for_each_authored_ui_rect_root(yyjson_val *root, slayer3d_game_data_
     return true;
 }
 
+static bool emit_ui_rect_from_values(yyjson_val *source, const char *name, float x, float y, float w, float h,
+                                     slayer3d_color color, slayer3d_game_data_ui_rect_fn callback, void *userdata)
+{
+    if (color.a == 0 || w <= 0.0f || h <= 0.0f)
+        return true;
+
+    slayer3d_game_data_ui_rect rect;
+    SDL_zero(rect);
+    rect.name = name;
+    rect.visible = "always";
+    rect.x = x;
+    rect.y = y;
+    rect.w = w;
+    rect.h = h;
+    rect.normalized = json_bool(source, "normalized", false);
+    rect.align = parse_ui_align(json_string(source, "align", NULL), SLAYER3D_GAME_DATA_UI_ALIGN_LEFT);
+    rect.valign = parse_ui_valign(json_string(source, "valign", NULL), SLAYER3D_GAME_DATA_UI_VALIGN_TOP);
+    rect.scale = json_float(source, "scale", 1.0f);
+    rect.color = color;
+    return callback(userdata, &rect);
+}
+
+static bool emit_ui_panel_rects(const slayer3d_game_data_runtime *runtime, yyjson_val *panel,
+                                slayer3d_game_data_ui_rect_fn callback, void *userdata)
+{
+    yyjson_val *active_if = obj_get(panel, "visible_if");
+    if (active_if != NULL && !eval_data_condition(runtime, active_if, NULL))
+        return true;
+
+    const char *name = json_string(panel, "name", NULL);
+    const float x = json_float(panel, "x", 0.0f);
+    const float y = json_float(panel, "y", 0.0f);
+    const float w = json_float(panel, "w", json_float(panel, "width", 0.0f));
+    const float h = json_float(panel, "h", json_float(panel, "height", 0.0f));
+    const slayer3d_color color = json_color(panel, "color", (slayer3d_color){16, 22, 32, 210});
+    if (!emit_ui_rect_from_values(panel, name, x, y, w, h, color, callback, userdata))
+        return false;
+
+    const float border = json_float(panel, "border_thickness", 0.0f);
+    const slayer3d_color border_color = json_color(panel, "border_color", (slayer3d_color){0, 0, 0, 0});
+    if (border <= 0.0f || border_color.a == 0)
+        return true;
+
+    return emit_ui_rect_from_values(panel, name, x, y, w, border, border_color, callback, userdata) &&
+           emit_ui_rect_from_values(panel, name, x, y + h - border, w, border, border_color, callback, userdata) &&
+           emit_ui_rect_from_values(panel, name, x, y, border, h, border_color, callback, userdata) &&
+           emit_ui_rect_from_values(panel, name, x + w - border, y, border, h, border_color, callback, userdata);
+}
+
+static bool for_each_ui_panel_rect_root(const slayer3d_game_data_runtime *runtime, yyjson_val *root,
+                                        slayer3d_game_data_ui_rect_fn callback, void *userdata)
+{
+    yyjson_val *panels = obj_get(obj_get(root, "ui"), "panels");
+    for (size_t i = 0; yyjson_is_arr(panels) && i < yyjson_arr_size(panels); ++i)
+    {
+        if (!emit_ui_panel_rects(runtime, yyjson_arr_get(panels, i), callback, userdata))
+            return false;
+    }
+    return true;
+}
+
+static bool for_each_ui_inspector_rect_root(const slayer3d_game_data_runtime *runtime, yyjson_val *root,
+                                            slayer3d_game_data_ui_rect_fn callback, void *userdata)
+{
+    yyjson_val *inspectors = obj_get(obj_get(root, "ui"), "inspectors");
+    for (size_t i = 0; yyjson_is_arr(inspectors) && i < yyjson_arr_size(inspectors); ++i)
+    {
+        yyjson_val *inspector = yyjson_arr_get(inspectors, i);
+        yyjson_val *active_if = obj_get(inspector, "visible_if");
+        if (active_if != NULL && !eval_data_condition(runtime, active_if, NULL))
+            continue;
+
+        const bool normalized = json_bool(inspector, "normalized", false);
+        const float x = json_float(inspector, "x", 0.0f);
+        const float y = json_float(inspector, "y", 0.0f);
+        const float w = json_float(inspector, "w", json_float(inspector, "width", normalized ? 0.25f : 280.0f));
+        const float row_height = json_float(inspector, "row_height", normalized ? 0.032f : 24.0f);
+        const float padding = json_float(inspector, "padding", normalized ? 0.012f : 10.0f);
+        const size_t row_count = yyjson_arr_size(obj_get(inspector, "rows"));
+        const bool has_title = json_string(inspector, "title", NULL) != NULL;
+        const float total_rows = (float)row_count + (has_title ? 1.0f : 0.0f);
+        const float h =
+            json_float(inspector, "h", json_float(inspector, "height", padding * 2.0f + row_height * total_rows));
+        const slayer3d_color color = json_color(inspector, "background_color", (slayer3d_color){10, 14, 20, 215});
+        if (json_bool(inspector, "panel", true) &&
+            !emit_ui_rect_from_values(inspector, json_string(inspector, "name", NULL), x, y, w, h, color, callback,
+                                      userdata))
+            return false;
+
+        const slayer3d_color row_color = json_color(inspector, "row_color", (slayer3d_color){255, 255, 255, 0});
+        if (row_color.a == 0)
+            continue;
+        const float row_y0 = y + padding + (has_title ? row_height : 0.0f);
+        for (size_t row_index = 0; row_index < row_count; ++row_index)
+        {
+            if (!emit_ui_rect_from_values(inspector, json_string(inspector, "name", NULL), x + padding,
+                                          row_y0 + row_height * (float)row_index, w - padding * 2.0f,
+                                          SDL_max(1.0f, row_height - 1.0f), row_color, callback, userdata))
+                return false;
+        }
+    }
+    return true;
+}
+
 bool slayer3d_game_data_for_each_ui_image(const slayer3d_game_data_runtime *runtime,
                                           slayer3d_game_data_ui_image_fn callback, void *userdata)
 {
@@ -1715,7 +2012,9 @@ bool slayer3d_game_data_for_each_ui_rect(const slayer3d_game_data_runtime *runti
     roots[1] = scene != NULL ? scene->root : NULL;
 
     for (int root_index = 0; root_index < 2; ++root_index)
-        if (!for_each_authored_ui_rect_root(roots[root_index], callback, userdata))
+        if (!for_each_authored_ui_rect_root(roots[root_index], callback, userdata) ||
+            !for_each_ui_panel_rect_root(runtime, roots[root_index], callback, userdata) ||
+            !for_each_ui_inspector_rect_root(runtime, roots[root_index], callback, userdata))
             return true;
     return true;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -9337,6 +9337,167 @@ static bool ui_metric_name_valid(const char *metric)
     return false;
 }
 
+static bool is_json_scalar(yyjson_val *value)
+{
+    return yyjson_is_str(value) || yyjson_is_int(value) || yyjson_is_real(value) || yyjson_is_bool(value);
+}
+
+static bool validate_ui_tool_color(validation_context *ctx, yyjson_val *object, const char *key, const char *path)
+{
+    yyjson_val *value = obj_get(object, key);
+    if (value != NULL && !is_exact_vec3_or_vec4_array(value))
+        return validation_error(ctx, path, "UI tooling %s must be a vec3 or vec4 color", key);
+    return true;
+}
+
+static bool validate_ui_tool_binding(validation_context *ctx, yyjson_val *binding, const char *path,
+                                     validation_names *names)
+{
+    if (!yyjson_is_obj(binding))
+        return validation_error(ctx, path, "UI tooling binding must be an object");
+    const char *type = json_string(binding, "type");
+    if (SDL_strcmp(type != NULL ? type : "", "scene_state") == 0)
+    {
+        if (!is_non_empty_string(binding, "key"))
+            return validation_error(ctx, path, "UI tooling scene_state binding requires a non-empty key");
+    }
+    else if (SDL_strcmp(type != NULL ? type : "", "property") == 0)
+    {
+        if (!require_ref(ctx, &names->entities, "entity", json_string(binding, "entity"), path))
+            return false;
+        if (!is_non_empty_string(binding, "key"))
+            return validation_error(ctx, path, "UI tooling property binding requires a non-empty key");
+    }
+    else if (SDL_strcmp(type != NULL ? type : "", "metric") == 0)
+    {
+        const char *metric = json_string(binding, "metric");
+        if (!ui_metric_name_valid(metric))
+            return validation_error(ctx, path, "unsupported UI tooling metric '%s'",
+                                    metric != NULL ? metric : "<missing>");
+    }
+    else
+    {
+        return validation_error(ctx, path, "unsupported UI tooling binding type '%s'",
+                                type != NULL ? type : "<missing>");
+    }
+
+    yyjson_val *fallback = obj_get(binding, "default");
+    if (fallback != NULL && !is_json_scalar(fallback))
+        return validation_error(ctx, path, "UI tooling binding default must be scalar");
+    return true;
+}
+
+static bool validate_ui_panels(validation_context *ctx, yyjson_val *panels, const char *path, validation_names *names)
+{
+    if (panels == NULL)
+        return true;
+    if (!yyjson_is_arr(panels))
+        return validation_error(ctx, path, "UI panels must be an array");
+    for (size_t i = 0; i < yyjson_arr_size(panels); ++i)
+    {
+        char panel_path[PATH_BUFFER_SIZE];
+        format_path(panel_path, sizeof(panel_path), "%s[%zu]", path, i);
+        yyjson_val *panel = yyjson_arr_get(panels, i);
+        if (!yyjson_is_obj(panel))
+            return validation_error(ctx, panel_path, "UI panel entries must be objects");
+        if (!is_non_empty_string(panel, "name"))
+            return validation_error(ctx, panel_path, "UI panel requires a non-empty name");
+        yyjson_val *width = obj_get(panel, "w");
+        if (width == NULL)
+            width = obj_get(panel, "width");
+        yyjson_val *height = obj_get(panel, "h");
+        if (height == NULL)
+            height = obj_get(panel, "height");
+        if (!yyjson_is_num(width) || yyjson_get_num(width) <= 0.0)
+            return validation_error(ctx, panel_path, "UI panel width must be positive");
+        if (!yyjson_is_num(height) || yyjson_get_num(height) <= 0.0)
+            return validation_error(ctx, panel_path, "UI panel height must be positive");
+        yyjson_val *border = obj_get(panel, "border_thickness");
+        if (border != NULL && (!yyjson_is_num(border) || yyjson_get_num(border) < 0.0))
+            return validation_error(ctx, panel_path, "UI panel border_thickness must be non-negative");
+        if (!validate_ui_tool_color(ctx, panel, "color", panel_path) ||
+            !validate_ui_tool_color(ctx, panel, "border_color", panel_path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", panel_path);
+        if (!validate_data_condition(ctx, obj_get(panel, "visible_if"), condition_path, names))
+            return false;
+    }
+    return true;
+}
+
+static bool validate_ui_inspectors(validation_context *ctx, yyjson_val *inspectors, const char *path,
+                                   validation_names *names)
+{
+    if (inspectors == NULL)
+        return true;
+    if (!yyjson_is_arr(inspectors))
+        return validation_error(ctx, path, "UI inspectors must be an array");
+    for (size_t i = 0; i < yyjson_arr_size(inspectors); ++i)
+    {
+        char inspector_path[PATH_BUFFER_SIZE];
+        format_path(inspector_path, sizeof(inspector_path), "%s[%zu]", path, i);
+        yyjson_val *inspector = yyjson_arr_get(inspectors, i);
+        if (!yyjson_is_obj(inspector))
+            return validation_error(ctx, inspector_path, "UI inspector entries must be objects");
+        if (!is_non_empty_string(inspector, "name"))
+            return validation_error(ctx, inspector_path, "UI inspector requires a non-empty name");
+        if (json_string(inspector, "font") != NULL &&
+            !require_ref(ctx, &names->fonts, "font asset", json_string(inspector, "font"), inspector_path))
+            return false;
+        yyjson_val *width = obj_get(inspector, "w");
+        if (width == NULL)
+            width = obj_get(inspector, "width");
+        if (width != NULL && (!yyjson_is_num(width) || yyjson_get_num(width) <= 0.0))
+            return validation_error(ctx, inspector_path, "UI inspector width must be positive");
+        yyjson_val *row_height = obj_get(inspector, "row_height");
+        if (row_height != NULL && (!yyjson_is_num(row_height) || yyjson_get_num(row_height) <= 0.0))
+            return validation_error(ctx, inspector_path, "UI inspector row_height must be positive");
+        yyjson_val *rows = obj_get(inspector, "rows");
+        if (!yyjson_is_arr(rows))
+            return validation_error(ctx, inspector_path, "UI inspector requires a rows array");
+        if (!validate_ui_tool_color(ctx, inspector, "background_color", inspector_path) ||
+            !validate_ui_tool_color(ctx, inspector, "row_color", inspector_path) ||
+            !validate_ui_tool_color(ctx, inspector, "title_color", inspector_path) ||
+            !validate_ui_tool_color(ctx, inspector, "label_color", inspector_path) ||
+            !validate_ui_tool_color(ctx, inspector, "value_color", inspector_path))
+            return false;
+        char condition_path[PATH_BUFFER_SIZE];
+        format_path(condition_path, sizeof(condition_path), "%s.visible_if", inspector_path);
+        if (!validate_data_condition(ctx, obj_get(inspector, "visible_if"), condition_path, names))
+            return false;
+        for (size_t row_index = 0; row_index < yyjson_arr_size(rows); ++row_index)
+        {
+            char row_path[PATH_BUFFER_SIZE];
+            format_path(row_path, sizeof(row_path), "%s.rows[%zu]", inspector_path, row_index);
+            yyjson_val *row = yyjson_arr_get(rows, row_index);
+            if (!yyjson_is_obj(row))
+                return validation_error(ctx, row_path, "UI inspector rows must be objects");
+            if (!is_non_empty_string(row, "label"))
+                return validation_error(ctx, row_path, "UI inspector row requires a non-empty label");
+            yyjson_val *binding = obj_get(row, "binding");
+            yyjson_val *value = obj_get(row, "value");
+            if ((binding == NULL) == (value == NULL))
+                return validation_error(ctx, row_path, "UI inspector row requires exactly one of binding or value");
+            if (binding != NULL)
+            {
+                char binding_path[PATH_BUFFER_SIZE];
+                format_path(binding_path, sizeof(binding_path), "%s.binding", row_path);
+                if (!validate_ui_tool_binding(ctx, binding, binding_path, names))
+                    return false;
+            }
+            else if (!is_json_scalar(value))
+            {
+                return validation_error(ctx, row_path, "UI inspector row value must be scalar");
+            }
+            yyjson_val *empty = obj_get(row, "empty");
+            if (empty != NULL && !yyjson_is_str(empty))
+                return validation_error(ctx, row_path, "UI inspector row empty value must be a string");
+        }
+    }
+    return true;
+}
+
 static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *ui = obj_get(root, "ui");
@@ -9344,7 +9505,9 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
     yyjson_val *images = obj_get(ui, "images");
     yyjson_val *rects = obj_get(ui, "rects");
     yyjson_val *menus = obj_get(ui, "menus");
-    if (texts == NULL && images == NULL && rects == NULL && menus == NULL)
+    yyjson_val *panels = obj_get(ui, "panels");
+    yyjson_val *inspectors = obj_get(ui, "inspectors");
+    if (texts == NULL && images == NULL && rects == NULL && menus == NULL && panels == NULL && inspectors == NULL)
         return true;
     if (texts != NULL && !yyjson_is_arr(texts))
         return validation_error(ctx, "$.ui.text", "UI text must be an array");
@@ -9354,6 +9517,9 @@ static bool validate_ui(validation_context *ctx, yyjson_val *root, validation_na
         return validation_error(ctx, "$.ui.rects", "UI rectangles must be an array");
     if (menus != NULL && !yyjson_is_arr(menus))
         return validation_error(ctx, "$.ui.menus", "UI menus must be an array");
+    if (!validate_ui_panels(ctx, panels, "$.ui.panels", names) ||
+        !validate_ui_inspectors(ctx, inspectors, "$.ui.inspectors", names))
+        return false;
 
     for (size_t i = 0; i < yyjson_arr_size(texts); ++i)
     {
@@ -10330,12 +10496,21 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     yyjson_val *images = obj_get(obj_get(root, "ui"), "images");
     yyjson_val *rects = obj_get(obj_get(root, "ui"), "rects");
     yyjson_val *ui_menus = obj_get(obj_get(root, "ui"), "menus");
+    yyjson_val *panels = obj_get(obj_get(root, "ui"), "panels");
+    yyjson_val *inspectors = obj_get(obj_get(root, "ui"), "inspectors");
     if (images != NULL && !yyjson_is_arr(images))
         return validation_error(ctx, json_path, "scene UI images must be an array");
     if (rects != NULL && !yyjson_is_arr(rects))
         return validation_error(ctx, json_path, "scene UI rectangles must be an array");
     if (ui_menus != NULL && !yyjson_is_arr(ui_menus))
         return validation_error(ctx, json_path, "scene UI menus must be an array");
+    char panels_path[PATH_BUFFER_SIZE];
+    format_path(panels_path, sizeof(panels_path), "%s.ui.panels", json_path);
+    char inspectors_path[PATH_BUFFER_SIZE];
+    format_path(inspectors_path, sizeof(inspectors_path), "%s.ui.inspectors", json_path);
+    if (!validate_ui_panels(ctx, panels, panels_path, names) ||
+        !validate_ui_inspectors(ctx, inspectors, inspectors_path, names))
+        return false;
     for (size_t i = 0; yyjson_is_arr(ui_menus) && i < yyjson_arr_size(ui_menus); ++i)
     {
         char menu_path[PATH_BUFFER_SIZE];

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4778,6 +4778,173 @@ TEST(GameDataRuntime, DynamicListMenuReadsRuntimeCollections)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives)
+{
+    const std::filesystem::path dir = unique_test_dir("ui_tooling");
+    write_text(dir / "ui_tooling.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "UI Tooling", "id": "test.ui_tooling", "version": "0.1.0" },
+  "world": { "name": "world.ui_tooling", "kind": "fixed_screen" },
+  "assets": { "fonts": [{ "id": "font.tool", "builtin": "Inter", "size": 16 }] },
+  "entities": [
+    {
+      "name": "entity.selection",
+      "properties": {
+        "health": { "type": "int", "value": 100 }
+      }
+    }
+  ],
+  "scenes": { "initial": "scene.editor", "files": ["scenes/editor.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "editor.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.editor",
+  "entities": ["entity.selection"],
+  "ui": {
+    "panels": [
+      {
+        "name": "ui.editor.sidebar",
+        "x": 12,
+        "y": 12,
+        "w": 260,
+        "h": 160,
+        "color": [20, 28, 40, 220],
+        "border_color": [90, 130, 210, 255],
+        "border_thickness": 2
+      }
+    ],
+    "inspectors": [
+      {
+        "name": "ui.editor.inspector",
+        "font": "font.tool",
+        "x": 24,
+        "y": 24,
+        "w": 232,
+        "row_height": 22,
+        "padding": 8,
+        "title": "Selection",
+        "background_color": [8, 10, 16, 180],
+        "row_color": [255, 255, 255, 18],
+        "rows": [
+          {
+            "label": "World",
+            "binding": { "type": "scene_state", "key": "editor.world", "default": "none" }
+          },
+          {
+            "label": "Health",
+            "binding": { "type": "property", "entity": "entity.selection", "key": "health" }
+          },
+          {
+            "label": "FPS",
+            "binding": { "type": "metric", "metric": "fps", "default": 0 }
+          }
+        ]
+      }
+    ]
+  }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "ui_tooling.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_properties_set_string(scene_state, "editor.world", "brush.dojo");
+
+    struct Rects
+    {
+        int sidebar_rects = 0;
+        int inspector_rects = 0;
+    } rects;
+    auto capture_tool_rects = [](void *userdata, const slayer3d_game_data_ui_rect *rect) -> bool {
+        auto *capture = static_cast<Rects *>(userdata);
+        if (std::string(rect->name) == "ui.editor.sidebar")
+            capture->sidebar_rects++;
+        if (std::string(rect->name) == "ui.editor.inspector")
+            capture->inspector_rects++;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_tool_rects, &rects));
+    EXPECT_EQ(rects.sidebar_rects, 5);
+    EXPECT_EQ(rects.inspector_rects, 4);
+
+    slayer3d_game_data_ui_metrics metrics{};
+    metrics.fps = 59.75f;
+    struct Texts
+    {
+        std::vector<std::string> values;
+    } texts;
+    auto capture_tool_texts = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+        auto *capture = static_cast<Texts *>(userdata);
+        if (std::string(text->name) == "ui.editor.inspector")
+            capture->values.emplace_back(text->text != nullptr ? text->text : "");
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture_tool_texts, &texts));
+    ASSERT_EQ(texts.values.size(), 7U);
+    EXPECT_EQ(texts.values[0], "Selection");
+    EXPECT_EQ(texts.values[1], "World");
+    EXPECT_EQ(texts.values[2], "brush.dojo");
+    EXPECT_EQ(texts.values[3], "Health");
+    EXPECT_EQ(texts.values[4], "100");
+    EXPECT_EQ(texts.values[5], "FPS");
+    EXPECT_EQ(texts.values[6], "59.8");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataValidation, RejectsInvalidUiTooling)
+{
+    const std::filesystem::path dir = unique_test_dir("ui_tooling_validation");
+    write_text(dir / "bad_ui_tooling.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad UI Tooling", "id": "test.bad_ui_tooling", "version": "0.1.0" },
+  "world": { "name": "world.bad_ui_tooling", "kind": "fixed_screen" },
+  "assets": { "fonts": [{ "id": "font.tool", "builtin": "Inter", "size": 16 }] },
+  "entities": [],
+  "scenes": { "initial": "scene.editor", "files": ["scenes/editor.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "editor.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.editor",
+  "ui": {
+    "inspectors": [
+      {
+        "name": "ui.editor.inspector",
+        "font": "font.tool",
+        "rows": [
+          {
+            "label": "Broken",
+            "binding": { "type": "property", "entity": "entity.missing", "key": "health" }
+          }
+        ]
+      }
+    ]
+  }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(slayer3d_game_data_load_file((dir / "bad_ui_tooling.game.json").string().c_str(), session, &runtime,
+                                              error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("$.scenes.resolved[0].ui.inspectors[0].rows[0].binding"), std::string::npos)
+        << error;
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, RejectsInvalidDynamicListMenuSchema)
 {
     const std::filesystem::path dir = unique_test_dir("menu_dynamic_list_validation");


### PR DESCRIPTION
## Summary
- add authored `ui.panels` overlay widgets that expand to normal UI rectangle primitives
- add authored `ui.inspectors` with label/value rows bound to scene state, actor properties, metrics, or scalar literals
- validate tooling widgets in root and scene UI data and document the reusable schema

## Tests
- `cmake --build build/debug -j 8`
- `./build/debug/tests/slayer3d_game_data_test`

Next slice: minimal editor shell dojo that uses world picking/debug overlays plus these inspector widgets to prove a data-authored editor viewport without game-specific C.