### PR TITLE
Add data-authored editor shell dojo

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -1,0 +1,15 @@
+# Editor Shell Dojo
+
+This data-only dojo demonstrates the first reusable editor shell pieces:
+
+- a normal Slayer3D runtime viewport
+- authored brush-world selection trace metadata
+- data-authored world/selection/normal/hit debug overlay drawing
+- reusable `ui.panels` and `ui.inspectors` populated from scene state
+
+Run it with:
+
+```sh
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
+```
+

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1,0 +1,119 @@
+{
+  "schema": "slayer3d.game.v0",
+  "metadata": {
+    "name": "Slayer 3D Editor Shell Dojo",
+    "id": "demo.editor_shell_dojo",
+    "version": "0.1.0"
+  },
+  "app": {
+    "title": "Slayer 3D Editor Shell Dojo",
+    "logical_width": 1280,
+    "logical_height": 720,
+    "backend": "opengl",
+    "window": { "renderer": "opengl", "vsync": true },
+    "quit": { "action": "action.exit" },
+    "input_policy": { "global_actions": ["action.exit"] }
+  },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.editor_shell",
+        "actions": [
+          {
+            "name": "action.exit",
+            "bindings": [{ "device": "keyboard", "key": "ESCAPE" }]
+          }
+        ]
+      }
+    ]
+  },
+  "world": {
+    "name": "world.editor_shell_dojo",
+    "kind": "brush",
+    "units": "meters",
+    "meters_per_unit": 1.0,
+    "ambient_light": [0.22, 0.23, 0.25],
+    "cameras": [
+      {
+        "name": "camera.editor_shell.viewport",
+        "type": "perspective",
+        "position": [-5.0, 3.2, 5.0],
+        "target": [1.0, 1.0, 1.0],
+        "up": [0.0, 1.0, 0.0],
+        "fov": 70.0,
+        "fov_axis": "horizontal",
+        "active": true
+      }
+    ]
+  },
+  "assets": {
+    "fonts": [
+      { "id": "font.editor_shell.ui", "builtin": "Inter", "size": 18 }
+    ]
+  },
+  "render": {
+    "lighting": true,
+    "bloom": false,
+    "clear_color": [0.04, 0.045, 0.055]
+  },
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "editor": {
+        "stable_id": "editor.world.target",
+        "display_name": "Target Brush World",
+        "category": "editor/dojo"
+      },
+      "materials": [
+        {
+          "name": "mat.editor.wall",
+          "albedo": [0.58, 0.18, 0.16, 1.0],
+          "roughness": 0.8,
+          "editor": {
+            "stable_id": "editor.material.wall",
+            "display_name": "Red Wall Material"
+          }
+        },
+        {
+          "name": "mat.editor.floor",
+          "albedo": [0.22, 0.24, 0.28, 1.0],
+          "roughness": 0.9,
+          "editor": {
+            "stable_id": "editor.material.floor",
+            "display_name": "Dark Floor Material"
+          }
+        }
+      ],
+      "brushes": [
+        {
+          "name": "brush.target.cube",
+          "contents": ["solid", "player_clip"],
+          "editor": {
+            "stable_id": "editor.brush.target_cube",
+            "display_name": "Selectable Cube",
+            "prefab": "prefab.editor_shell.cube"
+          },
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 2 }, "material": "mat.editor.wall" },
+            {
+              "plane": { "normal": [-1, 0, 0], "distance": 0 },
+              "material": "mat.editor.wall",
+              "editor": {
+                "stable_id": "editor.face.target_cube.left",
+                "display_name": "Left Face"
+              }
+            },
+            { "plane": { "normal": [0, 1, 0], "distance": 2 }, "material": "mat.editor.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.editor.floor" },
+            { "plane": { "normal": [0, 0, 1], "distance": 2 }, "material": "mat.editor.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.editor.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": {
+    "initial": "scene.editor_shell.dojo",
+    "files": ["scenes/editor_shell.scene.json"]
+  }
+}

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -1,0 +1,133 @@
+{
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.editor_shell.dojo",
+  "camera": "camera.editor_shell.viewport",
+  "updates_game": true,
+  "renders_world": true,
+  "input": {
+    "actions": ["action.exit"]
+  },
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.editor_shell.target", "position": [0.0, 0.0, 0.0] }
+    ]
+  },
+  "editor": {
+    "selection": {
+      "trace": {
+        "start": [-2.0, 1.0, 1.0],
+        "end": [1.25, 1.0, 1.0],
+        "model_filter": "brush_worlds",
+        "contents_mask": "solid"
+      },
+      "outputs": {
+        "hit_key": "editor.selection.hit",
+        "type_key": "editor.selection.type",
+        "world_key": "editor.selection.world",
+        "element_key": "editor.selection.element",
+        "material_key": "editor.selection.material",
+        "world_stable_id_key": "editor.selection.world_stable_id",
+        "element_stable_id_key": "editor.selection.element_stable_id",
+        "material_stable_id_key": "editor.selection.material_stable_id",
+        "face_stable_id_key": "editor.selection.face_stable_id",
+        "element_index_key": "editor.selection.element_index",
+        "face_index_key": "editor.selection.face_index",
+        "fraction_key": "editor.selection.fraction",
+        "point_key": "editor.selection.point",
+        "normal_key": "editor.selection.normal"
+      }
+    },
+    "debug_overlay": {
+      "enabled": true,
+      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker"],
+      "world_bounds_color": [80, 170, 255, 190],
+      "selection_bounds_color": [255, 220, 40, 255],
+      "trace_color": [255, 255, 255, 210],
+      "face_normal_color": [40, 255, 120, 255],
+      "hit_marker_color": [255, 70, 70, 255],
+      "normal_length": 0.65,
+      "hit_marker_size": 0.12
+    }
+  },
+  "ui": {
+    "panels": [
+      {
+        "name": "ui.editor_shell.sidebar",
+        "x": 18,
+        "y": 18,
+        "w": 340,
+        "h": 270,
+        "color": [10, 14, 22, 215],
+        "border_color": [80, 140, 230, 230],
+        "border_thickness": 2
+      }
+    ],
+    "inspectors": [
+      {
+        "name": "ui.editor_shell.inspector",
+        "font": "font.editor_shell.ui",
+        "x": 34,
+        "y": 32,
+        "w": 308,
+        "row_height": 22,
+        "padding": 8,
+        "title": "Editor Selection",
+        "background_color": [0, 0, 0, 0],
+        "row_color": [255, 255, 255, 12],
+        "title_color": [235, 245, 255, 255],
+        "label_color": [145, 175, 220, 255],
+        "value_color": [245, 248, 255, 255],
+        "rows": [
+          {
+            "label": "Hit",
+            "binding": { "type": "scene_state", "key": "editor.selection.hit", "default": false }
+          },
+          {
+            "label": "World",
+            "binding": { "type": "scene_state", "key": "editor.selection.world", "default": "none" }
+          },
+          {
+            "label": "Brush",
+            "binding": { "type": "scene_state", "key": "editor.selection.element", "default": "none" }
+          },
+          {
+            "label": "Material",
+            "binding": { "type": "scene_state", "key": "editor.selection.material", "default": "none" }
+          },
+          {
+            "label": "Face",
+            "binding": { "type": "scene_state", "key": "editor.selection.face_index", "default": -1 }
+          },
+          {
+            "label": "Stable",
+            "binding": { "type": "scene_state", "key": "editor.selection.face_stable_id", "default": "none" }
+          }
+        ]
+      }
+    ],
+    "text": [
+      {
+        "name": "ui.editor_shell.title",
+        "text": "Editor Shell Dojo",
+        "font": "font.editor_shell.ui",
+        "x": 0.98,
+        "y": 0.035,
+        "normalized": true,
+        "align": "right",
+        "color": [235, 242, 255, 230],
+        "scale": 0.8
+      },
+      {
+        "name": "ui.editor_shell.help",
+        "text": "Data-authored viewport, selection overlay, and inspector",
+        "font": "font.editor_shell.ui",
+        "x": 0.98,
+        "y": 0.075,
+        "normalized": true,
+        "align": "right",
+        "color": [190, 205, 230, 215],
+        "scale": 0.6
+      }
+    ]
+  }
+}

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -621,6 +621,45 @@ bounds, trace rays, hit markers, and face normals. These helpers are
 renderer-agnostic/data-driven editor substrate; authored gameplay JSON does
 not need to contain one-off debug actors for selection visualization.
 
+Scenes can opt into a data-authored editor overlay with `editor.selection` and
+`editor.debug_overlay`. This is useful for editor dojos and future in-engine
+tools that should run through the generic runner instead of a custom native
+host. `editor.selection.trace` describes a pick ray; `outputs` publishes the
+latest selection to scene state so UI inspectors can display it. The debug
+overlay renders world bounds, selected bounds, the trace ray, hit marker, and
+face normal through the normal 3D presentation path:
+
+```json
+{
+  "editor": {
+    "selection": {
+      "trace": {
+        "start": [-2.0, 1.0, 1.0],
+        "end": [1.25, 1.0, 1.0],
+        "model_filter": "brush_worlds",
+        "contents_mask": "solid"
+      },
+      "outputs": {
+        "hit_key": "editor.selection.hit",
+        "world_key": "editor.selection.world",
+        "element_key": "editor.selection.element",
+        "material_key": "editor.selection.material",
+        "face_stable_id_key": "editor.selection.face_stable_id",
+        "face_index_key": "editor.selection.face_index"
+      }
+    },
+    "debug_overlay": {
+      "enabled": true,
+      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker"]
+    }
+  }
+}
+```
+
+Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
+`brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
+`selection_bounds`, `trace_ray`, `face_normal`, and `hit_marker`.
+
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:
 

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1866,6 +1866,29 @@ extern "C"
                                                             slayer3d_game_data_editor_debug_primitive_fn callback,
                                                             void *userdata);
 
+    /**
+     * @brief Update authored active-scene editor tooling state.
+     *
+     * Scenes may author an `editor.selection` block with a trace descriptor and
+     * scene-state output keys. This helper runs that generic pick query and
+     * publishes stable selection metadata for UI inspectors. It is intended for
+     * editor dojos and tools that run through the same managed loop as games.
+     */
+    bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime *runtime);
+
+    /**
+     * @brief Iterate data-authored editor debug primitives for the active scene.
+     *
+     * This reads the active scene's `editor.debug_overlay` and
+     * `editor.selection` blocks, performs the authored trace when present, and
+     * emits world bounds, selected bounds, trace rays, face normals, and hit
+     * markers using the same primitive callback contract as
+     * @ref slayer3d_game_data_for_each_editor_debug_primitive.
+     */
+    bool slayer3d_game_data_for_each_active_editor_debug_primitive(
+        const slayer3d_game_data_runtime *runtime, slayer3d_game_data_editor_debug_primitive_fn callback,
+        void *userdata);
+
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity
     {

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -385,6 +385,17 @@ extern "C"
                                                          const slayer3d_game_data_editor_debug_desc *desc);
 
     /**
+     * @brief Draw active-scene data-authored editor/debug primitives.
+     *
+     * Scenes opt into this through their `editor.debug_overlay` block. The
+     * helper remains game-agnostic and delegates primitive generation to
+     * @ref slayer3d_game_data_for_each_active_editor_debug_primitive. Call
+     * inside an active 3D pass after the scene camera is configured.
+     */
+    bool slayer3d_game_data_draw_active_editor_debug_primitives(const slayer3d_game_data_runtime *runtime,
+                                                                slayer3d_render_context *renderer);
+
+    /**
      * @brief Initialize a world sprite asset cache.
      *
      * @param cache Cache to initialize.

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10274,6 +10274,136 @@ static bool validate_scene_skybox(validation_context *ctx, yyjson_val *scene_roo
     return true;
 }
 
+static bool editor_model_filter_name_valid(const char *value)
+{
+    return value != NULL && (SDL_strcmp(value, "all") == 0 || SDL_strcmp(value, "sector_levels") == 0 ||
+                             SDL_strcmp(value, "sector") == 0 || SDL_strcmp(value, "brush_worlds") == 0 ||
+                             SDL_strcmp(value, "brush") == 0);
+}
+
+static bool editor_debug_flag_name_valid(const char *value)
+{
+    return value != NULL && (SDL_strcmp(value, "all") == 0 || SDL_strcmp(value, "world_bounds") == 0 ||
+                             SDL_strcmp(value, "selection_bounds") == 0 || SDL_strcmp(value, "trace_ray") == 0 ||
+                             SDL_strcmp(value, "face_normal") == 0 || SDL_strcmp(value, "hit_marker") == 0);
+}
+
+static bool validate_string_or_string_array_names(validation_context *ctx, yyjson_val *value, const char *path,
+                                                  const char *label, bool (*name_valid)(const char *name))
+{
+    if (value == NULL)
+        return true;
+    if (yyjson_is_str(value))
+        return name_valid(yyjson_get_str(value))
+                   ? true
+                   : validation_error(ctx, path, "unsupported %s '%s'", label, yyjson_get_str(value));
+    if (!yyjson_is_arr(value))
+        return validation_error(ctx, path, "%s must be a string or string array", label);
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        char entry_path[PATH_BUFFER_SIZE];
+        format_path(entry_path, sizeof(entry_path), "%s[%zu]", path, i);
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (!yyjson_is_str(entry) || !name_valid(yyjson_get_str(entry)))
+            return validation_error(ctx, entry_path, "unsupported %s '%s'", label,
+                                    yyjson_is_str(entry) ? yyjson_get_str(entry) : "<non-string>");
+    }
+    return true;
+}
+
+static bool validate_scene_editor_outputs(validation_context *ctx, yyjson_val *outputs, const char *json_path)
+{
+    if (outputs == NULL)
+        return true;
+    if (!yyjson_is_obj(outputs))
+        return validation_error(ctx, json_path, "scene editor selection outputs must be an object");
+
+    yyjson_val *key;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(outputs, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        yyjson_val *value = yyjson_obj_iter_get_val(key);
+        if (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0')
+            return validation_error(ctx, json_path, "scene editor selection output values must be non-empty strings");
+    }
+    return true;
+}
+
+static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path)
+{
+    yyjson_val *editor = obj_get(scene_root, "editor");
+    if (editor == NULL)
+        return true;
+    if (!yyjson_is_obj(editor))
+        return validation_error(ctx, json_path, "scene editor must be an object");
+
+    yyjson_val *selection = obj_get(editor, "selection");
+    if (selection != NULL)
+    {
+        char selection_path[PATH_BUFFER_SIZE];
+        format_path(selection_path, sizeof(selection_path), "%s.editor.selection", json_path);
+        if (!yyjson_is_obj(selection))
+            return validation_error(ctx, selection_path, "scene editor selection must be an object");
+        yyjson_val *trace = obj_get(selection, "trace");
+        if (!yyjson_is_obj(trace))
+            return validation_error(ctx, selection_path, "scene editor selection requires a trace object");
+        char trace_path[PATH_BUFFER_SIZE];
+        format_path(trace_path, sizeof(trace_path), "%s.trace", selection_path);
+        if (!is_exact_vec_array(obj_get(trace, "start"), 3))
+            return validation_error(ctx, trace_path, "scene editor selection trace requires a start vec3");
+        if (!is_exact_vec_array(obj_get(trace, "end"), 3))
+            return validation_error(ctx, trace_path, "scene editor selection trace requires an end vec3");
+        char contents_path[PATH_BUFFER_SIZE];
+        format_path(contents_path, sizeof(contents_path), "%s.contents_mask", trace_path);
+        if (!validate_brush_string_or_string_array(ctx, obj_get(trace, "contents_mask"), contents_path, "brush content",
+                                                   brush_content_name_valid, false))
+            return false;
+        char filter_path[PATH_BUFFER_SIZE];
+        format_path(filter_path, sizeof(filter_path), "%s.model_filter", trace_path);
+        if (!validate_string_or_string_array_names(ctx, obj_get(trace, "model_filter"), filter_path,
+                                                   "world model filter", editor_model_filter_name_valid))
+            return false;
+        char outputs_path[PATH_BUFFER_SIZE];
+        format_path(outputs_path, sizeof(outputs_path), "%s.outputs", selection_path);
+        if (!validate_scene_editor_outputs(ctx, obj_get(selection, "outputs"), outputs_path))
+            return false;
+    }
+
+    yyjson_val *overlay = obj_get(editor, "debug_overlay");
+    if (overlay != NULL)
+    {
+        char overlay_path[PATH_BUFFER_SIZE];
+        format_path(overlay_path, sizeof(overlay_path), "%s.editor.debug_overlay", json_path);
+        if (!yyjson_is_obj(overlay))
+            return validation_error(ctx, overlay_path, "scene editor debug_overlay must be an object");
+        yyjson_val *enabled = obj_get(overlay, "enabled");
+        if (enabled != NULL && !yyjson_is_bool(enabled))
+            return validation_error(ctx, overlay_path, "scene editor debug_overlay enabled must be a boolean");
+        char flags_path[PATH_BUFFER_SIZE];
+        format_path(flags_path, sizeof(flags_path), "%s.flags", overlay_path);
+        if (!validate_string_or_string_array_names(ctx, obj_get(overlay, "flags"), flags_path, "editor debug flag",
+                                                   editor_debug_flag_name_valid))
+            return false;
+        static const char *const color_keys[] = {"world_bounds_color", "selection_bounds_color", "trace_color",
+                                                 "face_normal_color", "hit_marker_color"};
+        for (size_t i = 0; i < SDL_arraysize(color_keys); ++i)
+        {
+            yyjson_val *color = obj_get(overlay, color_keys[i]);
+            if (color != NULL && !is_exact_vec3_or_vec4_array(color))
+                return validation_error(ctx, overlay_path, "scene editor debug_overlay %s must be a vec3 or vec4 color",
+                                        color_keys[i]);
+        }
+        yyjson_val *normal_length = obj_get(overlay, "normal_length");
+        if (normal_length != NULL && (!yyjson_is_num(normal_length) || yyjson_get_num(normal_length) <= 0.0))
+            return validation_error(ctx, overlay_path, "scene editor debug_overlay normal_length must be positive");
+        yyjson_val *hit_marker_size = obj_get(overlay, "hit_marker_size");
+        if (hit_marker_size != NULL && (!yyjson_is_num(hit_marker_size) || yyjson_get_num(hit_marker_size) <= 0.0))
+            return validation_error(ctx, overlay_path, "scene editor debug_overlay hit_marker_size must be positive");
+    }
+    return true;
+}
+
 static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yyjson_val *game_root,
                                    validation_names *names, const char *json_path)
 {
@@ -10304,6 +10434,8 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
     if (!validate_scene_brush_worlds(ctx, root, json_path, names))
         return false;
     if (!validate_scene_skybox(ctx, root, json_path, names))
+        return false;
+    if (!validate_scene_editor_tooling(ctx, root, json_path))
         return false;
 
     char phases_path[PATH_BUFFER_SIZE];

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1543,6 +1543,247 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
     return true;
 }
 
+static yyjson_val *active_editor_tooling_root(const slayer3d_game_data_runtime *runtime)
+{
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    return obj_get(scene != NULL ? scene->root : NULL, "editor");
+}
+
+static unsigned int editor_model_filter_flag_from_string(const char *value)
+{
+    if (SDL_strcmp(value != NULL ? value : "", "all") == 0)
+        return SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_ALL;
+    if (SDL_strcmp(value != NULL ? value : "", "sector_levels") == 0 ||
+        SDL_strcmp(value != NULL ? value : "", "sector") == 0)
+    {
+        return SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_SECTOR_LEVELS;
+    }
+    if (SDL_strcmp(value != NULL ? value : "", "brush_worlds") == 0 ||
+        SDL_strcmp(value != NULL ? value : "", "brush") == 0)
+    {
+        return SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS;
+    }
+    return 0u;
+}
+
+static unsigned int editor_model_filter_from_json(yyjson_val *value)
+{
+    if (yyjson_is_str(value))
+        return editor_model_filter_flag_from_string(yyjson_get_str(value));
+    if (!yyjson_is_arr(value))
+        return SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_ALL;
+
+    unsigned int flags = 0u;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (yyjson_is_str(entry))
+            flags |= editor_model_filter_flag_from_string(yyjson_get_str(entry));
+    }
+    return flags != 0u ? flags : SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_ALL;
+}
+
+static unsigned int editor_debug_flag_from_string(const char *value)
+{
+    if (SDL_strcmp(value != NULL ? value : "", "all") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if (SDL_strcmp(value != NULL ? value : "", "world_bounds") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS;
+    if (SDL_strcmp(value != NULL ? value : "", "selection_bounds") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS;
+    if (SDL_strcmp(value != NULL ? value : "", "trace_ray") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY;
+    if (SDL_strcmp(value != NULL ? value : "", "face_normal") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL;
+    if (SDL_strcmp(value != NULL ? value : "", "hit_marker") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER;
+    return 0u;
+}
+
+static unsigned int editor_debug_flags_from_json(yyjson_val *value)
+{
+    if (yyjson_is_str(value))
+        return editor_debug_flag_from_string(yyjson_get_str(value));
+    if (!yyjson_is_arr(value))
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+
+    unsigned int flags = 0u;
+    for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+    {
+        yyjson_val *entry = yyjson_arr_get(value, i);
+        if (yyjson_is_str(entry))
+            flags |= editor_debug_flag_from_string(yyjson_get_str(entry));
+    }
+    return flags != 0u ? flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+}
+
+static bool editor_trace_desc_from_json(yyjson_val *selection, slayer3d_game_data_world_trace_desc *out_trace)
+{
+    if (out_trace != NULL)
+        SDL_zero(*out_trace);
+    yyjson_val *trace = obj_get(selection, "trace");
+    if (!yyjson_is_obj(trace) || out_trace == NULL)
+        return false;
+
+    out_trace->shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    out_trace->start = json_vec3(trace, "start", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    out_trace->end = json_vec3(trace, "end", out_trace->start);
+    out_trace->contents_mask =
+        brush_flags_from_json(obj_get(trace, "contents_mask"), brush_content_flag_from_string,
+                              SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+    out_trace->model_filter = editor_model_filter_from_json(obj_get(trace, "model_filter"));
+    return true;
+}
+
+static const char *editor_selection_type_name(slayer3d_game_data_world_model_type type)
+{
+    if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL)
+        return "sector_level";
+    if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
+        return "brush_world";
+    return "none";
+}
+
+static const char *editor_metadata_stable_id(const slayer3d_game_data_editor_metadata *metadata)
+{
+    return metadata != NULL && metadata->stable_id != NULL ? metadata->stable_id : "";
+}
+
+static void editor_set_string_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name,
+                                     const char *value)
+{
+    const char *key = json_string(outputs, key_name, NULL);
+    if (props != NULL && key != NULL)
+        slayer3d_properties_set_string(props, key, value != NULL ? value : "");
+}
+
+static void editor_set_bool_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, bool value)
+{
+    const char *key = json_string(outputs, key_name, NULL);
+    if (props != NULL && key != NULL)
+        slayer3d_properties_set_bool(props, key, value);
+}
+
+static void editor_set_int_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, int value)
+{
+    const char *key = json_string(outputs, key_name, NULL);
+    if (props != NULL && key != NULL)
+        slayer3d_properties_set_int(props, key, value);
+}
+
+static void editor_set_float_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, float value)
+{
+    const char *key = json_string(outputs, key_name, NULL);
+    if (props != NULL && key != NULL)
+        slayer3d_properties_set_float(props, key, value);
+}
+
+static void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name,
+                                   slayer3d_vec3 value)
+{
+    const char *key = json_string(outputs, key_name, NULL);
+    if (props != NULL && key != NULL)
+        slayer3d_properties_set_vec3(props, key, value);
+}
+
+static void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
+                                     const slayer3d_game_data_editor_selection *selection)
+{
+    if (runtime == NULL || outputs == NULL || selection == NULL)
+        return;
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "hit_key", selection->hit);
+    editor_set_string_output(scene_state, outputs, "type_key", editor_selection_type_name(selection->type));
+    editor_set_string_output(scene_state, outputs, "world_key", selection->hit ? selection->world_name : "");
+    editor_set_string_output(scene_state, outputs, "element_key", selection->hit ? selection->element_name : "");
+    editor_set_string_output(scene_state, outputs, "material_key", selection->hit ? selection->material_name : "");
+    editor_set_string_output(scene_state, outputs, "world_stable_id_key",
+                             selection->hit ? editor_metadata_stable_id(selection->world_editor) : "");
+    editor_set_string_output(scene_state, outputs, "element_stable_id_key",
+                             selection->hit ? editor_metadata_stable_id(selection->element_editor) : "");
+    editor_set_string_output(scene_state, outputs, "material_stable_id_key",
+                             selection->hit ? editor_metadata_stable_id(selection->material_editor) : "");
+    editor_set_string_output(scene_state, outputs, "face_stable_id_key",
+                             selection->hit ? editor_metadata_stable_id(selection->face_editor) : "");
+    editor_set_int_output(scene_state, outputs, "element_index_key", selection->hit ? selection->element_index : -1);
+    editor_set_int_output(scene_state, outputs, "face_index_key", selection->hit ? selection->face_index : -1);
+    editor_set_float_output(scene_state, outputs, "fraction_key", selection->hit ? selection->fraction : 1.0f);
+    editor_set_vec3_output(scene_state, outputs, "point_key",
+                           selection->hit ? selection->point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_vec3_output(scene_state, outputs, "normal_key",
+                           selection->hit ? selection->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+}
+
+bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return false;
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    yyjson_val *selection_json = obj_get(editor, "selection");
+    yyjson_val *outputs = obj_get(selection_json, "outputs");
+    if (!yyjson_is_obj(selection_json))
+        return true;
+
+    slayer3d_game_data_world_trace_desc trace;
+    slayer3d_game_data_editor_selection selection;
+    init_editor_selection(&selection);
+    if (!editor_trace_desc_from_json(selection_json, &trace) ||
+        !slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection))
+    {
+        return false;
+    }
+    publish_editor_selection(runtime, outputs, &selection);
+    return true;
+}
+
+static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime *runtime,
+                                               slayer3d_game_data_editor_debug_desc *out_desc,
+                                               slayer3d_game_data_world_trace_desc *out_trace,
+                                               slayer3d_game_data_editor_selection *out_selection)
+{
+    if (runtime == NULL)
+        return false;
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    yyjson_val *overlay = obj_get(editor, "debug_overlay");
+    if (!yyjson_is_obj(overlay) || !json_bool(overlay, "enabled", true) || out_desc == NULL)
+        return false;
+
+    SDL_zero(*out_desc);
+    out_desc->flags = editor_debug_flags_from_json(obj_get(overlay, "flags"));
+    out_desc->world_bounds_color = json_color(overlay, "world_bounds_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->selection_bounds_color = json_color(overlay, "selection_bounds_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->trace_color = json_color(overlay, "trace_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->face_normal_color = json_color(overlay, "face_normal_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->hit_marker_color = json_color(overlay, "hit_marker_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->normal_length = json_float(overlay, "normal_length", 0.75f);
+    out_desc->hit_marker_size = json_float(overlay, "hit_marker_size", 0.1f);
+
+    yyjson_val *selection_json = obj_get(editor, "selection");
+    if (editor_trace_desc_from_json(selection_json, out_trace))
+    {
+        out_desc->trace = out_trace;
+        if (out_selection != NULL && slayer3d_game_data_pick_editor_world_model(runtime, out_trace, out_selection))
+            out_desc->selection = out_selection;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_for_each_active_editor_debug_primitive(const slayer3d_game_data_runtime *runtime,
+                                                               slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                               void *userdata)
+{
+    if (runtime == NULL || callback == NULL)
+        return false;
+
+    slayer3d_game_data_editor_debug_desc desc;
+    slayer3d_game_data_world_trace_desc trace;
+    slayer3d_game_data_editor_selection selection;
+    if (!active_editor_debug_desc_from_json(runtime, &desc, &trace, &selection))
+        return true;
+    return slayer3d_game_data_for_each_editor_debug_primitive(runtime, &desc, callback, userdata);
+}
+
 bool slayer3d_game_data_query_world_model_point(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 point,
                                                 unsigned int model_filter, unsigned int brush_contents_mask,
                                                 slayer3d_game_data_world_point_result *out_result)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2408,6 +2408,21 @@ bool slayer3d_game_data_draw_editor_debug_primitives(const slayer3d_game_data_ru
     return context.ok;
 }
 
+bool slayer3d_game_data_draw_active_editor_debug_primitives(const slayer3d_game_data_runtime *runtime,
+                                                            slayer3d_render_context *renderer)
+{
+    if (runtime == NULL || renderer == NULL)
+        return false;
+
+    editor_debug_draw_context context;
+    SDL_zero(context);
+    context.renderer = renderer;
+    context.ok = true;
+    if (!slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, draw_editor_debug_primitive, &context))
+        return false;
+    return context.ok;
+}
+
 bool slayer3d_game_data_draw_ui_text(const slayer3d_game_data_runtime *runtime, slayer3d_render_context *renderer,
                                      slayer3d_game_data_font_cache *font_cache,
                                      const slayer3d_game_data_ui_metrics *metrics, float pulse_phase)
@@ -2846,6 +2861,8 @@ bool slayer3d_game_data_update_frame(slayer3d_game_data_frame_state *state,
     if (slayer3d_game_data_active_scene_update_phase(runtime, "presentation", ctx->paused))
     {
         state->time += desc->dt;
+        if (!slayer3d_game_data_update_active_editor_tooling(runtime))
+            return false;
         if (!slayer3d_game_data_update_presentation_clocks(runtime, desc->dt, ctx->paused, pause_entered))
             return false;
         if (!slayer3d_game_data_update_animations(runtime, desc->dt))
@@ -3466,6 +3483,7 @@ bool slayer3d_game_data_draw_frame(const slayer3d_game_data_frame_desc *frame)
                      frame->runtime, frame->renderer, frame->render_eval, frame->image_cache, frame->sprite_cache,
                      frame->model_cache, frame->mesh_primitive_cache, &camera) &&
                  ok;
+            ok = slayer3d_game_data_draw_active_editor_debug_primitives(frame->runtime, frame->renderer) && ok;
             ok = run_frame_hook(frame, frame->after_world_3d) && ok;
             slayer3d_end_mode_3d(frame->renderer);
         }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12100,6 +12100,81 @@ TEST(GameDataRuntime, EditorPickingPreservesRepeatedBrushWorldInstancePlacement)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
+{
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file("demos/editor_shell_dojo/data/editor_shell_dojo.game.json", session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.type", ""), "brush_world");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.world", ""),
+                 "brush.editor_shell.target");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), "brush.target.cube");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.material", ""), "mat.editor.wall");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.face_stable_id", ""),
+                 "editor.face.target_cube.left");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.face_index", -1), 1);
+
+    struct DebugCapture
+    {
+        int world_edges = 0;
+        int selection_edges = 0;
+        int rays = 0;
+        int normals = 0;
+        int markers = 0;
+    } debug;
+    auto capture_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<DebugCapture *>(userdata);
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE)
+            capture->world_edges++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
+            capture->selection_edges++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_TRACE_RAY)
+            capture->rays++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL)
+            capture->normals++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER)
+            capture->markers++;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_debug, &debug));
+    EXPECT_EQ(debug.world_edges, 12);
+    EXPECT_EQ(debug.selection_edges, 12);
+    EXPECT_EQ(debug.rays, 1);
+    EXPECT_EQ(debug.normals, 1);
+    EXPECT_EQ(debug.markers, 3);
+
+    struct InspectorText
+    {
+        std::vector<std::string> values;
+    } inspector;
+    auto capture_inspector = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+        auto *capture = static_cast<InspectorText *>(userdata);
+        if (std::string(text->name) == "ui.editor_shell.inspector")
+            capture->values.emplace_back(text->text != nullptr ? text->text : "");
+        return true;
+    };
+    slayer3d_game_data_ui_metrics metrics{};
+    ASSERT_TRUE(slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture_inspector, &inspector));
+    ASSERT_GE(inspector.values.size(), 13U);
+    EXPECT_EQ(inspector.values[0], "Editor Selection");
+    EXPECT_EQ(inspector.values[1], "Hit");
+    EXPECT_EQ(inspector.values[2], "true");
+    EXPECT_EQ(inspector.values[3], "World");
+    EXPECT_EQ(inspector.values[4], "brush.editor_shell.target");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
 {
     const std::filesystem::path dir = unique_test_dir("fps_brush_controller");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -424,6 +424,11 @@ std::filesystem::path brush_geometry_dojo_data_path()
     return demo_data_path("brush_geometry_dojo", "brush_geometry_dojo.game.json");
 }
 
+std::filesystem::path editor_shell_dojo_data_path()
+{
+    return demo_data_path("editor_shell_dojo", "editor_shell_dojo.game.json");
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -12102,12 +12107,14 @@ TEST(GameDataRuntime, EditorPickingPreservesRepeatedBrushWorldInstancePlacement)
 
 TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
 {
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
     slayer3d_game_session *session = nullptr;
     ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
     char error[512]{};
     slayer3d_game_data_runtime *runtime = nullptr;
-    ASSERT_TRUE(slayer3d_game_data_load_file("demos/editor_shell_dojo/data/editor_shell_dojo.game.json", session,
-                                             &runtime, error, sizeof(error)))
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
 
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));


### PR DESCRIPTION
## Summary
- add active-scene editor tooling that publishes authored selection trace results into scene state
- render data-authored editor debug overlays from the generic presentation path
- add a data-only editor shell dojo with viewport selection, debug primitives, and inspector UI
- document scene editor selection/debug overlay authoring

## Tests
- cmake --build build/debug -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay:GameDataRuntime.UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives:GameDataValidation.RejectsInvalidUiTooling'
- ./build/debug/tests/slayer3d_game_data_test

## Notes
Completes the minimal editor shell dojo slice for #323.