### PR TITLE
Add camera-screen editor picking

### DIFF
--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -15,8 +15,11 @@
   "editor": {
     "selection": {
       "trace": {
-        "start": [-2.0, 1.0, 1.0],
-        "end": [1.25, 1.0, 1.0],
+        "source": "camera_screen",
+        "camera": "camera.editor_shell.viewport",
+        "viewport": [1280.0, 720.0],
+        "near": 0.05,
+        "far": 100.0,
         "model_filter": "brush_worlds",
         "contents_mask": "solid"
       },

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -634,8 +634,11 @@ face normal through the normal 3D presentation path:
   "editor": {
     "selection": {
       "trace": {
-        "start": [-2.0, 1.0, 1.0],
-        "end": [1.25, 1.0, 1.0],
+        "source": "camera_screen",
+        "camera": "camera.editor.viewport",
+        "viewport": [1280, 720],
+        "near": 0.05,
+        "far": 100.0,
         "model_filter": "brush_worlds",
         "contents_mask": "solid"
       },
@@ -655,6 +658,15 @@ face normal through the normal 3D presentation path:
   }
 }
 ```
+
+Selection traces default to `source: "world"`, where `start` and `end` are
+authored world-space vec3 values. `source: "camera_screen"` derives the ray
+from a camera and screen point using the latest live mouse position by default.
+Tooling can override that point with `screen`, `screen_x`/`screen_y`, or
+`screen_x_key`/`screen_y_key`; viewport dimensions can likewise be authored
+with `viewport`, `viewport_width`/`viewport_height`, or scene-state keys. This
+lets editor dojos and future editor hosts share the same data-authored picking
+primitive.
 
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,

--- a/include/slayer3d/camera.h
+++ b/include/slayer3d/camera.h
@@ -47,6 +47,18 @@ extern "C"
                                             int backbuffer_height, float near_plane, float far_plane,
                                             slayer3d_mat4 *out_view, slayer3d_mat4 *out_projection);
 
+    /**
+     * @brief Build a world-space picking ray from a camera and screen point.
+     *
+     * The screen point is in the same pixel/logical coordinate space as the
+     * supplied viewport dimensions, with (0,0) at the top-left corner. The
+     * generated segment starts at @p near_distance and ends at @p far_distance
+     * along the camera ray.
+     */
+    bool slayer3d_camera3d_screen_ray(const slayer3d_camera3d *camera, float viewport_width, float viewport_height,
+                                      float screen_x, float screen_y, float near_distance, float far_distance,
+                                      slayer3d_vec3 *out_start, slayer3d_vec3 *out_end);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/slayer3d/input.h
+++ b/include/slayer3d/input.h
@@ -413,6 +413,16 @@ extern "C"
     float slayer3d_input_get_mouse_dy(const slayer3d_input_manager *input);
 
     /**
+     * @brief Return the latest absolute mouse position observed from SDL events.
+     *
+     * Coordinates are in the window/logical space reported by SDL for the
+     * source event. Returns false when no absolute mouse position has been
+     * observed yet or live mouse input is unavailable, such as during demo
+     * playback.
+     */
+    bool slayer3d_input_get_mouse_position(const slayer3d_input_manager *input, float *out_x, float *out_y);
+
+    /**
      * @brief Build a 2D axis pair from four action IDs.
      *
      * The result is (positive_x - negative_x, positive_y - negative_y).

--- a/src/camera.c
+++ b/src/camera.c
@@ -60,3 +60,70 @@ bool slayer3d_camera3d_compute_matrices(const slayer3d_camera3d *camera, int bac
         return SDL_SetError("Unknown camera projection: %d", (int)camera->projection);
     }
 }
+
+bool slayer3d_camera3d_screen_ray(const slayer3d_camera3d *camera, float viewport_width, float viewport_height,
+                                  float screen_x, float screen_y, float near_distance, float far_distance,
+                                  slayer3d_vec3 *out_start, slayer3d_vec3 *out_end)
+{
+    if (camera == NULL)
+        return SDL_InvalidParamError("camera");
+    if (out_start == NULL)
+        return SDL_InvalidParamError("out_start");
+    if (out_end == NULL)
+        return SDL_InvalidParamError("out_end");
+    if (viewport_width <= 0.0f || viewport_height <= 0.0f)
+        return SDL_SetError("Camera screen ray requires positive viewport dimensions.");
+    if (near_distance < 0.0f || far_distance <= near_distance)
+        return SDL_SetError("Camera screen ray requires 0 <= near < far.");
+
+    const float aspect = viewport_width / viewport_height;
+    const float ndc_x = (screen_x / viewport_width) * 2.0f - 1.0f;
+    const float ndc_y = 1.0f - (screen_y / viewport_height) * 2.0f;
+    const slayer3d_vec3 forward = slayer3d_vec3_normalize(slayer3d_vec3_sub(camera->target, camera->position));
+    const slayer3d_vec3 right = slayer3d_vec3_normalize(slayer3d_vec3_cross(forward, camera->up));
+    const slayer3d_vec3 up = slayer3d_vec3_normalize(slayer3d_vec3_cross(right, forward));
+    if (slayer3d_vec3_length_squared(forward) <= 0.0f || slayer3d_vec3_length_squared(right) <= 0.0f ||
+        slayer3d_vec3_length_squared(up) <= 0.0f)
+    {
+        return SDL_SetError("Camera screen ray requires a valid view basis.");
+    }
+
+    if (camera->projection == SLAYER3D_CAMERA_ORTHOGRAPHIC)
+    {
+        const float half_height = SDL_max(camera->fovy, 0.0f) * 0.5f;
+        const float half_width = half_height * aspect;
+        const slayer3d_vec3 offset = slayer3d_vec3_add(slayer3d_vec3_scale(right, ndc_x * half_width),
+                                                       slayer3d_vec3_scale(up, ndc_y * half_height));
+        *out_start =
+            slayer3d_vec3_add(slayer3d_vec3_add(camera->position, offset), slayer3d_vec3_scale(forward, near_distance));
+        *out_end =
+            slayer3d_vec3_add(slayer3d_vec3_add(camera->position, offset), slayer3d_vec3_scale(forward, far_distance));
+        return true;
+    }
+
+    if (camera->projection != SLAYER3D_CAMERA_PERSPECTIVE)
+        return SDL_SetError("Unknown camera projection: %d", (int)camera->projection);
+
+    const float fov_radians = slayer3d_degrees_to_radians(camera->fovy);
+    float tan_x = 0.0f;
+    float tan_y = 0.0f;
+    if (camera->fov_axis == SLAYER3D_CAMERA_FOV_HORIZONTAL)
+    {
+        tan_x = SDL_tanf(fov_radians * 0.5f);
+        tan_y = tan_x / aspect;
+    }
+    else
+    {
+        tan_y = SDL_tanf(fov_radians * 0.5f);
+        tan_x = tan_y * aspect;
+    }
+
+    const slayer3d_vec3 ray_dir = slayer3d_vec3_normalize(slayer3d_vec3_add(
+        forward, slayer3d_vec3_add(slayer3d_vec3_scale(right, ndc_x * tan_x), slayer3d_vec3_scale(up, ndc_y * tan_y))));
+    if (slayer3d_vec3_length_squared(ray_dir) <= 0.0f)
+        return SDL_SetError("Camera screen ray produced an invalid direction.");
+
+    *out_start = slayer3d_vec3_add(camera->position, slayer3d_vec3_scale(ray_dir, near_distance));
+    *out_end = slayer3d_vec3_add(camera->position, slayer3d_vec3_scale(ray_dir, far_distance));
+    return true;
+}

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10330,7 +10330,144 @@ static bool validate_scene_editor_outputs(validation_context *ctx, yyjson_val *o
     return true;
 }
 
-static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path)
+static bool validate_optional_non_empty_string(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                               const char *description)
+{
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0')
+        return validation_error(ctx, json_path, "%s must be a non-empty string", description);
+    return true;
+}
+
+static bool validate_optional_number(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                     const char *description)
+{
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_num(value))
+        return validation_error(ctx, json_path, "%s must be a number", description);
+    return true;
+}
+
+static bool validate_optional_positive_number(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                              const char *description)
+{
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_num(value) || yyjson_get_num(value) <= 0.0)
+        return validation_error(ctx, json_path, "%s must be positive", description);
+    return true;
+}
+
+static bool validate_optional_non_negative_number(validation_context *ctx, yyjson_val *value, const char *json_path,
+                                                  const char *description)
+{
+    if (value == NULL)
+        return true;
+    if (!yyjson_is_num(value) || yyjson_get_num(value) < 0.0)
+        return validation_error(ctx, json_path, "%s must be non-negative", description);
+    return true;
+}
+
+static bool validate_scene_editor_camera_screen_trace(validation_context *ctx, yyjson_val *trace,
+                                                      const char *trace_path, validation_names *names)
+{
+    yyjson_val *camera_value = obj_get(trace, "camera");
+    if (!validate_optional_non_empty_string(ctx, camera_value, trace_path, "scene editor camera_screen trace camera"))
+        return false;
+    const char *camera = json_string(trace, "camera");
+    if (camera != NULL && !require_ref(ctx, &names->cameras, "camera", camera, trace_path))
+        return false;
+
+    yyjson_val *screen = obj_get(trace, "screen");
+    if (screen != NULL && !is_exact_vec_array(screen, 2))
+        return validation_error(ctx, trace_path, "scene editor camera_screen trace screen must be a vec2");
+    yyjson_val *viewport = obj_get(trace, "viewport");
+    if (viewport != NULL &&
+        (!is_exact_vec_array(viewport, 2) || !numeric_array_values_in_range(viewport, 0.000001, DBL_MAX)))
+        return validation_error(ctx, trace_path, "scene editor camera_screen trace viewport must be a positive vec2");
+
+    char field_path[PATH_BUFFER_SIZE];
+    static const char *const numeric_keys[] = {"screen_x", "screen_y"};
+    for (size_t i = 0; i < SDL_arraysize(numeric_keys); ++i)
+    {
+        format_path(field_path, sizeof(field_path), "%s.%s", trace_path, numeric_keys[i]);
+        if (!validate_optional_number(ctx, obj_get(trace, numeric_keys[i]), field_path,
+                                      "scene editor camera_screen trace coordinate"))
+            return false;
+    }
+
+    static const char *const positive_keys[] = {"viewport_width", "viewport_height", "far"};
+    for (size_t i = 0; i < SDL_arraysize(positive_keys); ++i)
+    {
+        format_path(field_path, sizeof(field_path), "%s.%s", trace_path, positive_keys[i]);
+        if (!validate_optional_positive_number(ctx, obj_get(trace, positive_keys[i]), field_path,
+                                               "scene editor camera_screen trace value"))
+            return false;
+    }
+    format_path(field_path, sizeof(field_path), "%s.near", trace_path);
+    if (!validate_optional_non_negative_number(ctx, obj_get(trace, "near"), field_path,
+                                               "scene editor camera_screen trace near"))
+        return false;
+
+    static const char *const string_keys[] = {"screen_x_key", "screen_y_key", "viewport_width_key",
+                                              "viewport_height_key"};
+    for (size_t i = 0; i < SDL_arraysize(string_keys); ++i)
+    {
+        format_path(field_path, sizeof(field_path), "%s.%s", trace_path, string_keys[i]);
+        if (!validate_optional_non_empty_string(ctx, obj_get(trace, string_keys[i]), field_path,
+                                                "scene editor camera_screen trace key"))
+            return false;
+    }
+
+    yyjson_val *near_value = obj_get(trace, "near");
+    yyjson_val *far_value = obj_get(trace, "far");
+    if (near_value != NULL && far_value != NULL && yyjson_get_num(far_value) <= yyjson_get_num(near_value))
+        return validation_error(ctx, trace_path, "scene editor camera_screen trace far must be greater than near");
+    return true;
+}
+
+static bool validate_scene_editor_trace(validation_context *ctx, yyjson_val *trace, const char *trace_path,
+                                        validation_names *names)
+{
+    yyjson_val *source_value = obj_get(trace, "source");
+    if (!validate_optional_non_empty_string(ctx, source_value, trace_path, "scene editor selection trace source"))
+        return false;
+    const char *source = source_value != NULL ? yyjson_get_str(source_value) : "world";
+    if (SDL_strcmp(source, "world") == 0)
+    {
+        if (!is_exact_vec_array(obj_get(trace, "start"), 3))
+            return validation_error(ctx, trace_path, "scene editor selection trace requires a start vec3");
+        if (!is_exact_vec_array(obj_get(trace, "end"), 3))
+            return validation_error(ctx, trace_path, "scene editor selection trace requires an end vec3");
+    }
+    else if (SDL_strcmp(source, "camera_screen") == 0)
+    {
+        if (!validate_scene_editor_camera_screen_trace(ctx, trace, trace_path, names))
+            return false;
+    }
+    else
+    {
+        return validation_error(ctx, trace_path,
+                                "scene editor selection trace source must be 'world' or 'camera_screen'");
+    }
+
+    char contents_path[PATH_BUFFER_SIZE];
+    format_path(contents_path, sizeof(contents_path), "%s.contents_mask", trace_path);
+    if (!validate_brush_string_or_string_array(ctx, obj_get(trace, "contents_mask"), contents_path, "brush content",
+                                               brush_content_name_valid, false))
+        return false;
+    char filter_path[PATH_BUFFER_SIZE];
+    format_path(filter_path, sizeof(filter_path), "%s.model_filter", trace_path);
+    if (!validate_string_or_string_array_names(ctx, obj_get(trace, "model_filter"), filter_path, "world model filter",
+                                               editor_model_filter_name_valid))
+        return false;
+    return true;
+}
+
+static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
+                                          validation_names *names)
 {
     yyjson_val *editor = obj_get(scene_root, "editor");
     if (editor == NULL)
@@ -10350,19 +10487,7 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
             return validation_error(ctx, selection_path, "scene editor selection requires a trace object");
         char trace_path[PATH_BUFFER_SIZE];
         format_path(trace_path, sizeof(trace_path), "%s.trace", selection_path);
-        if (!is_exact_vec_array(obj_get(trace, "start"), 3))
-            return validation_error(ctx, trace_path, "scene editor selection trace requires a start vec3");
-        if (!is_exact_vec_array(obj_get(trace, "end"), 3))
-            return validation_error(ctx, trace_path, "scene editor selection trace requires an end vec3");
-        char contents_path[PATH_BUFFER_SIZE];
-        format_path(contents_path, sizeof(contents_path), "%s.contents_mask", trace_path);
-        if (!validate_brush_string_or_string_array(ctx, obj_get(trace, "contents_mask"), contents_path, "brush content",
-                                                   brush_content_name_valid, false))
-            return false;
-        char filter_path[PATH_BUFFER_SIZE];
-        format_path(filter_path, sizeof(filter_path), "%s.model_filter", trace_path);
-        if (!validate_string_or_string_array_names(ctx, obj_get(trace, "model_filter"), filter_path,
-                                                   "world model filter", editor_model_filter_name_valid))
+        if (!validate_scene_editor_trace(ctx, trace, trace_path, names))
             return false;
         char outputs_path[PATH_BUFFER_SIZE];
         format_path(outputs_path, sizeof(outputs_path), "%s.outputs", selection_path);
@@ -10435,7 +10560,7 @@ static bool validate_scene_details(validation_context *ctx, yyjson_val *root, yy
         return false;
     if (!validate_scene_skybox(ctx, root, json_path, names))
         return false;
-    if (!validate_scene_editor_tooling(ctx, root, json_path))
+    if (!validate_scene_editor_tooling(ctx, root, json_path, names))
         return false;
 
     char phases_path[PATH_BUFFER_SIZE];

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -9,6 +9,7 @@
 
 #include "game_data_brush_internal.h"
 #include "slayer3d/collision.h"
+#include "slayer3d/game.h"
 #include "slayer3d/math.h"
 
 const char *slayer3d_game_data_active_scene(const slayer3d_game_data_runtime *runtime)
@@ -1617,7 +1618,96 @@ static unsigned int editor_debug_flags_from_json(yyjson_val *value)
     return flags != 0u ? flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
 }
 
-static bool editor_trace_desc_from_json(yyjson_val *selection, slayer3d_game_data_world_trace_desc *out_trace)
+static float editor_scene_state_float(const slayer3d_game_data_runtime *runtime, const char *key, float fallback)
+{
+    return runtime != NULL && key != NULL ? slayer3d_properties_get_float(runtime->scene_state, key, fallback)
+                                          : fallback;
+}
+
+static void editor_default_viewport(const slayer3d_game_data_runtime *runtime, float *out_width, float *out_height)
+{
+    if (out_width == NULL || out_height == NULL)
+        return;
+
+    yyjson_val *app = obj_get(runtime_root(runtime), "app");
+    yyjson_val *window = obj_get(app, "window");
+    const int width =
+        json_int(app, "logical_width",
+                 json_int(window, "logical_width", json_int(app, "width", SLAYER3D_GAME_DEFAULT_LOGICAL_WIDTH)));
+    const int height =
+        json_int(app, "logical_height",
+                 json_int(window, "logical_height", json_int(app, "height", SLAYER3D_GAME_DEFAULT_LOGICAL_HEIGHT)));
+    *out_width = (float)SDL_max(width, 1);
+    *out_height = (float)SDL_max(height, 1);
+}
+
+static bool editor_trace_screen_point(const slayer3d_game_data_runtime *runtime, yyjson_val *trace,
+                                      float viewport_width, float viewport_height, float *out_x, float *out_y)
+{
+    if (out_x == NULL || out_y == NULL)
+        return false;
+
+    *out_x = viewport_width * 0.5f;
+    *out_y = viewport_height * 0.5f;
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    float mouse_x = 0.0f;
+    float mouse_y = 0.0f;
+    if (slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+    {
+        *out_x = mouse_x;
+        *out_y = mouse_y;
+    }
+
+    if (!json_vec2_value(obj_get(trace, "screen"), *out_x, *out_y, out_x, out_y))
+        return false;
+
+    *out_x = json_float(trace, "screen_x", *out_x);
+    *out_y = json_float(trace, "screen_y", *out_y);
+    *out_x = editor_scene_state_float(runtime, json_string(trace, "screen_x_key", NULL), *out_x);
+    *out_y = editor_scene_state_float(runtime, json_string(trace, "screen_y_key", NULL), *out_y);
+    return true;
+}
+
+static bool editor_trace_viewport(const slayer3d_game_data_runtime *runtime, yyjson_val *trace, float *out_width,
+                                  float *out_height)
+{
+    editor_default_viewport(runtime, out_width, out_height);
+    if (!json_vec2_value(obj_get(trace, "viewport"), *out_width, *out_height, out_width, out_height))
+        return false;
+    *out_width = json_float(trace, "viewport_width", *out_width);
+    *out_height = json_float(trace, "viewport_height", *out_height);
+    *out_width = editor_scene_state_float(runtime, json_string(trace, "viewport_width_key", NULL), *out_width);
+    *out_height = editor_scene_state_float(runtime, json_string(trace, "viewport_height_key", NULL), *out_height);
+    return *out_width > 0.0f && *out_height > 0.0f;
+}
+
+static bool editor_camera_screen_trace_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *trace,
+                                                 slayer3d_game_data_world_trace_desc *out_trace)
+{
+    const char *camera_name = json_string(trace, "camera", slayer3d_game_data_active_camera(runtime));
+    slayer3d_camera3d camera;
+    if (!slayer3d_game_data_get_camera(runtime, camera_name, &camera))
+        return false;
+
+    float viewport_width = 0.0f;
+    float viewport_height = 0.0f;
+    if (!editor_trace_viewport(runtime, trace, &viewport_width, &viewport_height))
+        return false;
+
+    float screen_x = 0.0f;
+    float screen_y = 0.0f;
+    if (!editor_trace_screen_point(runtime, trace, viewport_width, viewport_height, &screen_x, &screen_y))
+        return false;
+
+    const float near_distance = SDL_max(json_float(trace, "near", 0.05f), 0.0f);
+    const float far_distance = SDL_max(json_float(trace, "far", 1000.0f), near_distance + 0.001f);
+    return slayer3d_camera3d_screen_ray(&camera, viewport_width, viewport_height, screen_x, screen_y, near_distance,
+                                        far_distance, &out_trace->start, &out_trace->end);
+}
+
+static bool editor_trace_desc_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
+                                        slayer3d_game_data_world_trace_desc *out_trace)
 {
     if (out_trace != NULL)
         SDL_zero(*out_trace);
@@ -1626,8 +1716,17 @@ static bool editor_trace_desc_from_json(yyjson_val *selection, slayer3d_game_dat
         return false;
 
     out_trace->shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
-    out_trace->start = json_vec3(trace, "start", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
-    out_trace->end = json_vec3(trace, "end", out_trace->start);
+    const char *source = json_string(trace, "source", "world");
+    if (SDL_strcmp(source, "camera_screen") == 0)
+    {
+        if (!editor_camera_screen_trace_from_json(runtime, trace, out_trace))
+            return false;
+    }
+    else
+    {
+        out_trace->start = json_vec3(trace, "start", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        out_trace->end = json_vec3(trace, "end", out_trace->start);
+    }
     out_trace->contents_mask =
         brush_flags_from_json(obj_get(trace, "contents_mask"), brush_content_flag_from_string,
                               SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
@@ -1728,7 +1827,7 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     slayer3d_game_data_world_trace_desc trace;
     slayer3d_game_data_editor_selection selection;
     init_editor_selection(&selection);
-    if (!editor_trace_desc_from_json(selection_json, &trace) ||
+    if (!editor_trace_desc_from_json(runtime, selection_json, &trace) ||
         !slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection))
     {
         return false;
@@ -1760,7 +1859,7 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
     out_desc->hit_marker_size = json_float(overlay, "hit_marker_size", 0.1f);
 
     yyjson_val *selection_json = obj_get(editor, "selection");
-    if (editor_trace_desc_from_json(selection_json, out_trace))
+    if (editor_trace_desc_from_json(runtime, selection_json, out_trace))
     {
         out_desc->trace = out_trace;
         if (out_selection != NULL && slayer3d_game_data_pick_editor_world_model(runtime, out_trace, out_selection))

--- a/src/input.c
+++ b/src/input.c
@@ -63,6 +63,9 @@ struct slayer3d_input_manager
     float mouse_dy_accum;
     float mouse_wheel_x_accum;
     float mouse_wheel_y_accum;
+    float mouse_x;
+    float mouse_y;
+    bool has_mouse_position;
     bool discard_mouse_motion_until_update;
     bool discard_next_mouse_motion;
     bool discarded_mouse_motion_since_request;
@@ -99,6 +102,15 @@ struct slayer3d_input_manager
 static bool slayer3d_input_action_id_valid(int action_id)
 {
     return action_id >= 0 && action_id < SLAYER3D_INPUT_MAX_ACTIONS;
+}
+
+static void slayer3d_input_set_mouse_position(slayer3d_input_manager *input, float x, float y)
+{
+    if (input == NULL)
+        return;
+    input->mouse_x = x;
+    input->mouse_y = y;
+    input->has_mouse_position = true;
 }
 
 static int slayer3d_input_modifier_mask_from_sdl(SDL_Keymod mod)
@@ -1247,6 +1259,7 @@ void slayer3d_input_process_event(slayer3d_input_manager *input, const SDL_Event
         }
         break;
     case SDL_EVENT_MOUSE_MOTION: {
+        slayer3d_input_set_mouse_position(input, event->motion.x, event->motion.y);
         const bool discard_motion = input->discard_mouse_motion_until_update || input->discard_next_mouse_motion;
         if (discard_motion)
         {
@@ -1264,10 +1277,12 @@ void slayer3d_input_process_event(slayer3d_input_manager *input, const SDL_Event
         break;
     }
     case SDL_EVENT_MOUSE_WHEEL:
+        slayer3d_input_set_mouse_position(input, event->wheel.mouse_x, event->wheel.mouse_y);
         input->mouse_wheel_x_accum += event->wheel.x;
         input->mouse_wheel_y_accum += event->wheel.y;
         break;
     case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        slayer3d_input_set_mouse_position(input, event->button.x, event->button.y);
         if (slayer3d_input_mouse_button_valid(event->button.button))
         {
             input->mouse_down[event->button.button] = true;
@@ -1275,6 +1290,7 @@ void slayer3d_input_process_event(slayer3d_input_manager *input, const SDL_Event
         }
         break;
     case SDL_EVENT_MOUSE_BUTTON_UP:
+        slayer3d_input_set_mouse_position(input, event->button.x, event->button.y);
         if (slayer3d_input_mouse_button_valid(event->button.button))
         {
             input->mouse_down[event->button.button] = false;
@@ -1395,6 +1411,7 @@ const slayer3d_input_snapshot *slayer3d_input_update(slayer3d_input_manager *inp
         if (player->cursor < player->count)
         {
             input->snapshot = player->snapshots[player->cursor++];
+            input->has_mouse_position = false;
             input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
             input->pressed_mouse_button = 0;
             input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
@@ -1523,6 +1540,19 @@ float slayer3d_input_get_mouse_dx(const slayer3d_input_manager *input)
 float slayer3d_input_get_mouse_dy(const slayer3d_input_manager *input)
 {
     return input != NULL ? input->snapshot.mouse_dy : 0.0f;
+}
+
+bool slayer3d_input_get_mouse_position(const slayer3d_input_manager *input, float *out_x, float *out_y)
+{
+    if (out_x != NULL)
+        *out_x = 0.0f;
+    if (out_y != NULL)
+        *out_y = 0.0f;
+    if (input == NULL || out_x == NULL || out_y == NULL || !input->has_mouse_position)
+        return false;
+    *out_x = input->mouse_x;
+    *out_y = input->mouse_y;
+    return true;
 }
 
 slayer3d_vec2 slayer3d_input_get_axis_pair(const slayer3d_input_manager *input, int negative_x_action,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16,6 +16,7 @@
 
 extern "C"
 {
+#include <SDL3/SDL_events.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
@@ -8157,6 +8158,72 @@ TEST(GameDataRuntime, RejectsInvalidEditorMetadata)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
+{
+    struct Case
+    {
+        const char *name;
+        const char *trace_json;
+        const char *expected_error;
+    };
+
+    const Case cases[] = {
+        {
+            "bad_source",
+            R"json({ "source": "pointer", "model_filter": "brush_worlds" })json",
+            "scene editor selection trace source must be 'world' or 'camera_screen'",
+        },
+        {
+            "bad_camera",
+            R"json({ "source": "camera_screen", "camera": "camera.missing", "viewport": [1280, 720] })json",
+            "unknown camera",
+        },
+        {
+            "bad_far",
+            R"json({ "source": "camera_screen", "camera": "camera.valid", "near": 10.0, "far": 1.0 })json",
+            "far must be greater than near",
+        },
+    };
+
+    const std::filesystem::path dir = unique_test_dir("scene_editor_tooling");
+    for (const Case &test_case : cases)
+    {
+        const std::filesystem::path root_path = dir / (std::string(test_case.name) + ".game.json");
+        write_text(root_path, R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Scene Editor" },
+  "world": {
+    "name": "world.bad_scene_editor",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.valid", "type": "perspective", "position": [0, 0, 5], "target": [0, 0, 0], "up": [0, 1, 0] }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+        const std::string scene_json = std::string(R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.valid",
+  "editor": {
+    "selection": {
+      "trace": )json") + test_case.trace_json +
+                                       R"json(,
+      "outputs": { "hit_key": "editor.hit" }
+    }
+  }
+})json";
+        write_text(dir / "scenes" / "play.scene.json", scene_json.c_str());
+
+        char error[512]{};
+        EXPECT_FALSE(slayer3d_game_data_validate_file(root_path.string().c_str(), nullptr, error, sizeof(error)))
+            << test_case.name;
+        EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
+            << test_case.name << ": " << error;
+    }
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, CombatActionsApplyHealthArmorDeathAndRevive)
 {
     const std::filesystem::path dir = unique_test_dir("combat_actions");
@@ -12116,6 +12183,17 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
+
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 564.8f;
+    motion.motion.y = 392.9f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = 0.0f;
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
 
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -121,6 +121,19 @@ void push_mouse_motion(slayer3d_input_manager *input, float dx, float dy)
 {
     SDL_Event event{};
     event.type = SDL_EVENT_MOUSE_MOTION;
+    event.motion.x = dx;
+    event.motion.y = dy;
+    event.motion.xrel = dx;
+    event.motion.yrel = dy;
+    slayer3d_input_process_event(input, &event);
+}
+
+void push_mouse_motion_at(slayer3d_input_manager *input, float x, float y, float dx, float dy)
+{
+    SDL_Event event{};
+    event.type = SDL_EVENT_MOUSE_MOTION;
+    event.motion.x = x;
+    event.motion.y = y;
     event.motion.xrel = dx;
     event.motion.yrel = dy;
     slayer3d_input_process_event(input, &event);
@@ -246,6 +259,28 @@ TEST(Input, MouseDeltaAccumulation)
     slayer3d_input_update(input.input, 11);
     EXPECT_FLOAT_EQ(0.0f, slayer3d_input_get_mouse_dx(input.input));
     EXPECT_FLOAT_EQ(0.0f, slayer3d_input_get_mouse_dy(input.input));
+}
+
+TEST(Input, TracksAbsoluteMousePosition)
+{
+    InputPtr input;
+    float x = -1.0f;
+    float y = -1.0f;
+    EXPECT_FALSE(slayer3d_input_get_mouse_position(input.input, &x, &y));
+    EXPECT_FLOAT_EQ(0.0f, x);
+    EXPECT_FLOAT_EQ(0.0f, y);
+
+    push_mouse_motion_at(input.input, 123.0f, 456.0f, 4.0f, -2.0f);
+    slayer3d_input_update(input.input, 10);
+
+    ASSERT_TRUE(slayer3d_input_get_mouse_position(input.input, &x, &y));
+    EXPECT_FLOAT_EQ(123.0f, x);
+    EXPECT_FLOAT_EQ(456.0f, y);
+
+    slayer3d_input_update(input.input, 11);
+    ASSERT_TRUE(slayer3d_input_get_mouse_position(input.input, &x, &y));
+    EXPECT_FLOAT_EQ(123.0f, x);
+    EXPECT_FLOAT_EQ(456.0f, y);
 }
 
 TEST(Input, DiscardsMouseMotionUntilNextSnapshot)
@@ -712,6 +747,11 @@ TEST(Input, NullSafety)
     EXPECT_FLOAT_EQ(0.0f, slayer3d_input_get_value(nullptr, 0));
     EXPECT_FLOAT_EQ(0.0f, slayer3d_input_get_mouse_dx(nullptr));
     EXPECT_FLOAT_EQ(0.0f, slayer3d_input_get_mouse_dy(nullptr));
+    float mouse_x = 1.0f;
+    float mouse_y = 1.0f;
+    EXPECT_FALSE(slayer3d_input_get_mouse_position(nullptr, &mouse_x, &mouse_y));
+    EXPECT_FLOAT_EQ(0.0f, mouse_x);
+    EXPECT_FLOAT_EQ(0.0f, mouse_y);
     EXPECT_EQ(nullptr, slayer3d_input_get_snapshot(nullptr));
     slayer3d_input_bind_fps_defaults(nullptr);
     slayer3d_input_bind_ui_defaults(nullptr);

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -334,6 +334,43 @@ TEST(SLAYER3DCamera, OrthographicProducesUnitNDC)
     EXPECT_PRED_FORMAT3(Near, clip_bot.y / clip_bot.w, -1.0f, 1e-4f);
 }
 
+TEST(SLAYER3DCamera, ScreenRayMatchesPerspectiveCenterAndFovAxis)
+{
+    slayer3d_camera3d camera = {
+        {0.0f, 0.0f, 5.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, 90.0f, SLAYER3D_CAMERA_PERSPECTIVE};
+    camera.fov_axis = SLAYER3D_CAMERA_FOV_HORIZONTAL;
+
+    slayer3d_vec3 start{};
+    slayer3d_vec3 end{};
+    ASSERT_TRUE(slayer3d_camera3d_screen_ray(&camera, 1600.0f, 900.0f, 800.0f, 450.0f, 1.0f, 10.0f, &start, &end));
+    EXPECT_PRED_FORMAT3(Near, start.x, 0.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, start.y, 0.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, start.z, 4.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, end.z, -5.0f, 1e-5f);
+
+    ASSERT_TRUE(slayer3d_camera3d_screen_ray(&camera, 1600.0f, 900.0f, 1600.0f, 450.0f, 1.0f, 10.0f, &start, &end));
+    const slayer3d_vec3 dir = slayer3d_vec3_normalize(slayer3d_vec3_sub(end, start));
+    EXPECT_PRED_FORMAT3(Near, dir.x, 0.7071067f, 1e-4f);
+    EXPECT_PRED_FORMAT3(Near, dir.y, 0.0f, 1e-4f);
+    EXPECT_PRED_FORMAT3(Near, dir.z, -0.7071067f, 1e-4f);
+}
+
+TEST(SLAYER3DCamera, ScreenRayOffsetsOrthographicStart)
+{
+    const slayer3d_camera3d camera = {
+        {0.0f, 0.0f, 5.0f}, {0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, 10.0f, SLAYER3D_CAMERA_ORTHOGRAPHIC};
+
+    slayer3d_vec3 start{};
+    slayer3d_vec3 end{};
+    ASSERT_TRUE(slayer3d_camera3d_screen_ray(&camera, 100.0f, 100.0f, 100.0f, 0.0f, 1.0f, 10.0f, &start, &end));
+    EXPECT_PRED_FORMAT3(Near, start.x, 5.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, start.y, 5.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, start.z, 4.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, end.x, 5.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, end.y, 5.0f, 1e-5f);
+    EXPECT_PRED_FORMAT3(Near, end.z, -5.0f, 1e-5f);
+}
+
 TEST(SLAYER3DCamera, RejectsInvalidArguments)
 {
     const slayer3d_camera3d camera = {


### PR DESCRIPTION
## Summary
- add a reusable camera screen-to-world picking ray helper and absolute mouse position tracking
- allow data-authored editor selection traces to use camera_screen source with viewport/screen overrides
- update the editor shell dojo, docs, and validation coverage for interactive editor picking

## Tests
- cmake --build build/debug --target slayer3d_input_test slayer3d_math_test slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "SLAYER3DCamera\.|Input\.|GameData"