### PR TITLE
Add editor click selection state

### DIFF
--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -14,6 +14,9 @@
   },
   "editor": {
     "selection": {
+      "mode": "click",
+      "select_button": "LEFT",
+      "clear_on_miss": true,
       "trace": {
         "source": "camera_screen",
         "camera": "camera.editor_shell.viewport",
@@ -38,6 +41,11 @@
         "fraction_key": "editor.selection.fraction",
         "point_key": "editor.selection.point",
         "normal_key": "editor.selection.normal"
+      },
+      "hover_outputs": {
+        "hit_key": "editor.hover.hit",
+        "element_key": "editor.hover.element",
+        "face_stable_id_key": "editor.hover.face_stable_id"
       }
     },
     "debug_overlay": {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -633,6 +633,9 @@ face normal through the normal 3D presentation path:
 {
   "editor": {
     "selection": {
+      "mode": "click",
+      "select_button": "LEFT",
+      "clear_on_miss": true,
       "trace": {
         "source": "camera_screen",
         "camera": "camera.editor.viewport",
@@ -649,6 +652,10 @@ face normal through the normal 3D presentation path:
         "material_key": "editor.selection.material",
         "face_stable_id_key": "editor.selection.face_stable_id",
         "face_index_key": "editor.selection.face_index"
+      },
+      "hover_outputs": {
+        "hit_key": "editor.hover.hit",
+        "element_key": "editor.hover.element"
       }
     },
     "debug_overlay": {
@@ -667,6 +674,12 @@ Tooling can override that point with `screen`, `screen_x`/`screen_y`, or
 with `viewport`, `viewport_width`/`viewport_height`, or scene-state keys. This
 lets editor dojos and future editor hosts share the same data-authored picking
 primitive.
+
+Selection mode defaults to `hover`, where `outputs` receives the current pick
+every frame. In `mode: "click"`, `outputs` receives the pinned selection and
+`hover_outputs` can publish the live hover independently. `select_button`
+defaults to `LEFT`; clicking empty space clears the pinned selection unless
+`clear_on_miss` is false.
 
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1877,6 +1877,16 @@ extern "C"
     bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime *runtime);
 
     /**
+     * @brief Copy the active data-authored editor selection.
+     *
+     * Returns false and writes an empty selection when no object has been
+     * selected in the active scene. Selection pointers are runtime-owned and
+     * remain valid until the runtime is destroyed or reloaded.
+     */
+    bool slayer3d_game_data_get_active_editor_selection(const slayer3d_game_data_runtime *runtime,
+                                                        slayer3d_game_data_editor_selection *out_selection);
+
+    /**
      * @brief Iterate data-authored editor debug primitives for the active scene.
      *
      * This reads the active scene's `editor.debug_overlay` and

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -625,6 +625,8 @@ typedef struct slayer3d_game_data_runtime
     bool has_network_schema;
     Uint8 network_schema_hash[SLAYER3D_REPLICATION_SCHEMA_HASH_SIZE];
     const char *active_camera;
+    slayer3d_game_data_editor_selection editor_active_selection;
+    const char *editor_selection_scene;
     scene_activity_state activity;
     float current_dt;
     unsigned int rng_state;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10466,6 +10466,32 @@ static bool validate_scene_editor_trace(validation_context *ctx, yyjson_val *tra
     return true;
 }
 
+static bool validate_scene_editor_selection_options(validation_context *ctx, yyjson_val *selection,
+                                                    const char *selection_path)
+{
+    yyjson_val *mode = obj_get(selection, "mode");
+    if (mode != NULL)
+    {
+        if (!yyjson_is_str(mode) || yyjson_get_str(mode)[0] == '\0')
+            return validation_error(ctx, selection_path, "scene editor selection mode must be a non-empty string");
+        const char *mode_name = yyjson_get_str(mode);
+        if (SDL_strcmp(mode_name, "hover") != 0 && SDL_strcmp(mode_name, "click") != 0)
+            return validation_error(ctx, selection_path, "scene editor selection mode must be 'hover' or 'click'");
+    }
+
+    yyjson_val *select_button = obj_get(selection, "select_button");
+    if (select_button != NULL)
+    {
+        if (!yyjson_is_str(select_button) || !validation_mouse_button_name_valid(yyjson_get_str(select_button)))
+            return validation_error(ctx, selection_path, "scene editor selection select_button must be a mouse button");
+    }
+
+    yyjson_val *clear_on_miss = obj_get(selection, "clear_on_miss");
+    if (clear_on_miss != NULL && !yyjson_is_bool(clear_on_miss))
+        return validation_error(ctx, selection_path, "scene editor selection clear_on_miss must be a boolean");
+    return true;
+}
+
 static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
                                           validation_names *names)
 {
@@ -10482,6 +10508,8 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         format_path(selection_path, sizeof(selection_path), "%s.editor.selection", json_path);
         if (!yyjson_is_obj(selection))
             return validation_error(ctx, selection_path, "scene editor selection must be an object");
+        if (!validate_scene_editor_selection_options(ctx, selection, selection_path))
+            return false;
         yyjson_val *trace = obj_get(selection, "trace");
         if (!yyjson_is_obj(trace))
             return validation_error(ctx, selection_path, "scene editor selection requires a trace object");
@@ -10492,6 +10520,10 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         char outputs_path[PATH_BUFFER_SIZE];
         format_path(outputs_path, sizeof(outputs_path), "%s.outputs", selection_path);
         if (!validate_scene_editor_outputs(ctx, obj_get(selection, "outputs"), outputs_path))
+            return false;
+        char hover_outputs_path[PATH_BUFFER_SIZE];
+        format_path(hover_outputs_path, sizeof(hover_outputs_path), "%s.hover_outputs", selection_path);
+        if (!validate_scene_editor_outputs(ctx, obj_get(selection, "hover_outputs"), hover_outputs_path))
             return false;
     }
 

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1734,6 +1734,39 @@ static bool editor_trace_desc_from_json(const slayer3d_game_data_runtime *runtim
     return true;
 }
 
+static bool editor_selection_mode_is_click(yyjson_val *selection)
+{
+    const char *mode = json_string(selection, "mode", "hover");
+    return SDL_strcmp(mode, "click") == 0;
+}
+
+static bool editor_selection_active_for_scene(const slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return false;
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    return runtime->editor_selection_scene != NULL && active_scene != NULL &&
+           SDL_strcmp(runtime->editor_selection_scene, active_scene) == 0;
+}
+
+static void clear_editor_active_selection(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    init_editor_selection(&runtime->editor_active_selection);
+    runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+}
+
+static bool editor_selection_select_requested(const slayer3d_game_data_runtime *runtime, yyjson_val *selection)
+{
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input == NULL)
+        return false;
+
+    const Uint8 button = mouse_button_from_json(json_string(selection, "select_button", "LEFT"));
+    return button != 0 && slayer3d_input_get_pressed_mouse_button(input) == button;
+}
+
 static const char *editor_selection_type_name(slayer3d_game_data_world_model_type type)
 {
     if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL)
@@ -1822,17 +1855,55 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     yyjson_val *selection_json = obj_get(editor, "selection");
     yyjson_val *outputs = obj_get(selection_json, "outputs");
     if (!yyjson_is_obj(selection_json))
+    {
+        clear_editor_active_selection(runtime);
         return true;
+    }
+    if (!editor_selection_active_for_scene(runtime))
+        clear_editor_active_selection(runtime);
 
     slayer3d_game_data_world_trace_desc trace;
-    slayer3d_game_data_editor_selection selection;
-    init_editor_selection(&selection);
+    slayer3d_game_data_editor_selection hover_selection;
+    init_editor_selection(&hover_selection);
     if (!editor_trace_desc_from_json(runtime, selection_json, &trace) ||
-        !slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection))
+        !slayer3d_game_data_pick_editor_world_model(runtime, &trace, &hover_selection))
     {
         return false;
     }
-    publish_editor_selection(runtime, outputs, &selection);
+
+    if (!editor_selection_mode_is_click(selection_json))
+    {
+        runtime->editor_active_selection = hover_selection;
+        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+        publish_editor_selection(runtime, outputs, &hover_selection);
+        return true;
+    }
+
+    publish_editor_selection(runtime, obj_get(selection_json, "hover_outputs"), &hover_selection);
+    if (editor_selection_select_requested(runtime, selection_json))
+    {
+        if (hover_selection.hit)
+            runtime->editor_active_selection = hover_selection;
+        else if (json_bool(selection_json, "clear_on_miss", true))
+            init_editor_selection(&runtime->editor_active_selection);
+        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+    }
+
+    publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+    return true;
+}
+
+bool slayer3d_game_data_get_active_editor_selection(const slayer3d_game_data_runtime *runtime,
+                                                    slayer3d_game_data_editor_selection *out_selection)
+{
+    if (out_selection != NULL)
+        init_editor_selection(out_selection);
+    if (runtime == NULL || out_selection == NULL || !editor_selection_active_for_scene(runtime) ||
+        !runtime->editor_active_selection.hit)
+    {
+        return false;
+    }
+    *out_selection = runtime->editor_active_selection;
     return true;
 }
 
@@ -1862,8 +1933,16 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
     if (editor_trace_desc_from_json(runtime, selection_json, out_trace))
     {
         out_desc->trace = out_trace;
-        if (out_selection != NULL && slayer3d_game_data_pick_editor_world_model(runtime, out_trace, out_selection))
+        if (out_selection != NULL && editor_selection_mode_is_click(selection_json) &&
+            editor_selection_active_for_scene(runtime) && runtime->editor_active_selection.hit)
+        {
+            *out_selection = runtime->editor_active_selection;
             out_desc->selection = out_selection;
+        }
+        else if (out_selection != NULL && slayer3d_game_data_pick_editor_world_model(runtime, out_trace, out_selection))
+        {
+            out_desc->selection = out_selection;
+        }
     }
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8170,18 +8170,28 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
     const Case cases[] = {
         {
             "bad_source",
-            R"json({ "source": "pointer", "model_filter": "brush_worlds" })json",
+            R"json({ "trace": { "source": "pointer", "model_filter": "brush_worlds" }, "outputs": { "hit_key": "editor.hit" } })json",
             "scene editor selection trace source must be 'world' or 'camera_screen'",
         },
         {
             "bad_camera",
-            R"json({ "source": "camera_screen", "camera": "camera.missing", "viewport": [1280, 720] })json",
+            R"json({ "trace": { "source": "camera_screen", "camera": "camera.missing", "viewport": [1280, 720] }, "outputs": { "hit_key": "editor.hit" } })json",
             "unknown camera",
         },
         {
             "bad_far",
-            R"json({ "source": "camera_screen", "camera": "camera.valid", "near": 10.0, "far": 1.0 })json",
+            R"json({ "trace": { "source": "camera_screen", "camera": "camera.valid", "near": 10.0, "far": 1.0 }, "outputs": { "hit_key": "editor.hit" } })json",
             "far must be greater than near",
+        },
+        {
+            "bad_mode",
+            R"json({ "mode": "drag", "trace": { "source": "camera_screen", "camera": "camera.valid" }, "outputs": { "hit_key": "editor.hit" } })json",
+            "scene editor selection mode must be 'hover' or 'click'",
+        },
+        {
+            "bad_select_button",
+            R"json({ "select_button": "PRIMARY", "trace": { "source": "camera_screen", "camera": "camera.valid" }, "outputs": { "hit_key": "editor.hit" } })json",
+            "scene editor selection select_button must be a mouse button",
         },
     };
 
@@ -8206,11 +8216,8 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
   "name": "scene.play",
   "camera": "camera.valid",
   "editor": {
-    "selection": {
-      "trace": )json") + test_case.trace_json +
-                                       R"json(,
-      "outputs": { "hit_key": "editor.hit" }
-    }
+    "selection": )json") + test_case.trace_json +
+                                       R"json(
   }
 })json";
         write_text(dir / "scenes" / "play.scene.json", scene_json.c_str());
@@ -12190,9 +12197,15 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     motion.motion.y = 392.9f;
     motion.motion.xrel = 0.0f;
     motion.motion.yrel = 0.0f;
+    SDL_Event click{};
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    click.button.button = SDL_BUTTON_LEFT;
+    click.button.x = motion.motion.x;
+    click.button.y = motion.motion.y;
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
     slayer3d_input_process_event(input, &motion);
+    slayer3d_input_process_event(input, &click);
     slayer3d_input_update(input, 1);
 
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
@@ -12207,6 +12220,12 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.face_stable_id", ""),
                  "editor.face.target_cube.left");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.face_index", -1), 1);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.hover.element", ""), "brush.target.cube");
+
+    slayer3d_game_data_editor_selection active_selection{};
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, "brush.target.cube");
 
     struct DebugCapture
     {
@@ -12255,6 +12274,31 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(inspector.values[2], "true");
     EXPECT_EQ(inspector.values[3], "World");
     EXPECT_EQ(inspector.values[4], "brush.editor_shell.target");
+
+    SDL_Event release{};
+    release.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    release.button.button = SDL_BUTTON_LEFT;
+    release.button.x = click.button.x;
+    release.button.y = click.button.y;
+    slayer3d_input_process_event(input, &release);
+    slayer3d_input_update(input, 2);
+
+    SDL_Event miss_motion{};
+    miss_motion.type = SDL_EVENT_MOUSE_MOTION;
+    miss_motion.motion.x = 20.0f;
+    miss_motion.motion.y = 20.0f;
+    SDL_Event miss_click{};
+    miss_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    miss_click.button.button = SDL_BUTTON_LEFT;
+    miss_click.button.x = miss_motion.motion.x;
+    miss_click.button.y = miss_motion.motion.y;
+    slayer3d_input_process_event(input, &miss_motion);
+    slayer3d_input_process_event(input, &miss_click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", true));
+    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add click-pinned editor selection state with separate live hover outputs
- expose the active editor selection through the game-data runtime API
- update the editor shell dojo, docs, and validation for click selection options

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidSceneEditorTooling|EditorShellDojoPublishesSelectionAndDebugOverlay)"
- ctest --test-dir build/debug/tests --output-on-failure -R "GameData"