### PR TITLE
Add editor selection action plumbing

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -22,6 +22,80 @@
           {
             "name": "action.exit",
             "bindings": [{ "device": "keyboard", "key": "ESCAPE" }]
+          },
+          {
+            "name": "action.editor.tool.cycle",
+            "bindings": [{ "device": "keyboard", "key": "TAB" }]
+          },
+          {
+            "name": "action.editor.selection.clear",
+            "bindings": [{ "device": "keyboard", "key": "BACKSPACE" }]
+          },
+          {
+            "name": "action.editor.selection.inspect",
+            "bindings": [{ "device": "keyboard", "key": "I" }]
+          }
+        ]
+      }
+    ]
+  },
+  "signals": [
+    "signal.editor.tool.cycle",
+    "signal.editor.selection.clear",
+    "signal.editor.selection.inspect"
+  ],
+  "logic": {
+    "sensors": [
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.tool.cycle",
+        "on_pressed": "signal.editor.tool.cycle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.selection.clear",
+        "on_pressed": "signal.editor.selection.clear"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.selection.inspect",
+        "on_pressed": "signal.editor.selection.inspect"
+      }
+    ],
+    "bindings": [
+      {
+        "signal": "signal.editor.tool.cycle",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "editor.tool.mode",
+            "default": "select",
+            "values": ["select", "move", "paint"]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.selection.clear",
+        "actions": [
+          { "type": "editor.selection.clear" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "selection cleared" }
+        ]
+      },
+      {
+        "signal": "signal.editor.selection.inspect",
+        "actions": [
+          {
+            "type": "editor.selection.run",
+            "actions": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "inspect {selection_element} face {selection_face_stable_id}"
+              }
+            ],
+            "else": [
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing selected" }
+            ]
           }
         ]
       }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -5,7 +5,12 @@
   "updates_game": true,
   "renders_world": true,
   "input": {
-    "actions": ["action.exit"]
+    "actions": [
+      "action.exit",
+      "action.editor.tool.cycle",
+      "action.editor.selection.clear",
+      "action.editor.selection.inspect"
+    ]
   },
   "world": {
     "brush_worlds": [
@@ -112,6 +117,14 @@
           {
             "label": "Stable",
             "binding": { "type": "scene_state", "key": "editor.selection.face_stable_id", "default": "none" }
+          },
+          {
+            "label": "Tool",
+            "binding": { "type": "scene_state", "key": "editor.tool.mode", "default": "select" }
+          },
+          {
+            "label": "Action",
+            "binding": { "type": "scene_state", "key": "editor.tool.last_action", "default": "none" }
           }
         ]
       }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -681,6 +681,31 @@ every frame. In `mode: "click"`, `outputs` receives the pinned selection and
 defaults to `LEFT`; clicking empty space clears the pinned selection unless
 `clear_on_miss` is false.
 
+Editor selections can also drive generic logic actions:
+
+```json
+{
+  "type": "editor.selection.run",
+  "actions": [
+    {
+      "type": "scene_state.set",
+      "key": "editor.last_action",
+      "value": "inspect {selection_element} face {selection_face_stable_id}"
+    }
+  ],
+  "else": [
+    { "type": "scene_state.set", "key": "editor.last_action", "value": "nothing selected" }
+  ]
+}
+```
+
+`editor.selection.run` executes `actions` only when the active scene has a
+pinned or current selection. It supplies payload fields such as
+`selection_type`, `selection_world`, `selection_element`,
+`selection_material`, `selection_face_index`, `selection_face_stable_id`,
+`selection_point`, and `selection_normal`. `editor.selection.clear` clears the
+active selection and republishes the scene's `outputs` as an empty selection.
+
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
 `selection_bounds`, `trace_ray`, `face_normal`, and `hit_marker`.

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -188,6 +188,24 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         return set_property_from_json(runtime->scene_state, key, yyjson_arr_get(values, next));
     }
 
+    if (SDL_strcmp(type, "editor.selection.clear") == 0)
+        return slayer3d_game_data_clear_active_editor_selection(runtime);
+
+    if (SDL_strcmp(type, "editor.selection.run") == 0)
+    {
+        slayer3d_game_data_editor_selection selection;
+        if (slayer3d_game_data_get_active_editor_selection(runtime, &selection))
+        {
+            slayer3d_properties *selection_payload = slayer3d_game_data_create_editor_selection_payload(&selection);
+            if (selection_payload == NULL)
+                return false;
+            const bool ok = execute_action_array(runtime, obj_get(action, "actions"), selection_payload);
+            slayer3d_properties_destroy(selection_payload);
+            return ok;
+        }
+        return execute_optional_action_array(runtime, obj_get(action, "else"), payload);
+    }
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -782,6 +782,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 bool execute_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions, const slayer3d_properties *payload);
 bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
                                    const slayer3d_properties *payload);
+bool slayer3d_game_data_clear_active_editor_selection(slayer3d_game_data_runtime *runtime);
+slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(
+    const slayer3d_game_data_editor_selection *selection);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8048,6 +8048,19 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return validation_error(ctx, json_path, "scene_state.cycle default must be scalar");
         return true;
     }
+    if (SDL_strcmp(type, "editor.selection.clear") == 0)
+        return true;
+    if (SDL_strcmp(type, "editor.selection.run") == 0)
+    {
+        char actions_path[PATH_BUFFER_SIZE];
+        char else_path[PATH_BUFFER_SIZE];
+        format_path(actions_path, sizeof(actions_path), "%s.actions", json_path);
+        format_path(else_path, sizeof(else_path), "%s.else", json_path);
+        if (!validate_action_array(ctx, obj_get(action, "actions"), actions_path, names))
+            return false;
+        yyjson_val *else_actions = obj_get(action, "else");
+        return else_actions == NULL || validate_action_array(ctx, else_actions, else_path, names);
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1907,6 +1907,53 @@ bool slayer3d_game_data_get_active_editor_selection(const slayer3d_game_data_run
     return true;
 }
 
+bool slayer3d_game_data_clear_active_editor_selection(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return false;
+    clear_editor_active_selection(runtime);
+    yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
+    publish_editor_selection(runtime, obj_get(selection_json, "outputs"), &runtime->editor_active_selection);
+    return true;
+}
+
+slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(
+    const slayer3d_game_data_editor_selection *selection)
+{
+    slayer3d_properties *payload = slayer3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    const bool hit = selection != NULL && selection->hit;
+    slayer3d_properties_set_bool(payload, "selection_hit", hit);
+    slayer3d_properties_set_string(payload, "selection_type",
+                                   hit ? editor_selection_type_name(selection->type) : "none");
+    slayer3d_properties_set_string(payload, "selection_world",
+                                   hit && selection->world_name != NULL ? selection->world_name : "");
+    slayer3d_properties_set_string(payload, "selection_element",
+                                   hit && selection->element_name != NULL ? selection->element_name : "");
+    slayer3d_properties_set_string(payload, "selection_material",
+                                   hit && selection->material_name != NULL ? selection->material_name : "");
+    slayer3d_properties_set_string(payload, "selection_world_stable_id",
+                                   hit ? editor_metadata_stable_id(selection->world_editor) : "");
+    slayer3d_properties_set_string(payload, "selection_element_stable_id",
+                                   hit ? editor_metadata_stable_id(selection->element_editor) : "");
+    slayer3d_properties_set_string(payload, "selection_material_stable_id",
+                                   hit ? editor_metadata_stable_id(selection->material_editor) : "");
+    slayer3d_properties_set_string(payload, "selection_face_stable_id",
+                                   hit ? editor_metadata_stable_id(selection->face_editor) : "");
+    slayer3d_properties_set_int(payload, "selection_element_index", hit ? selection->element_index : -1);
+    slayer3d_properties_set_int(payload, "selection_face_index", hit ? selection->face_index : -1);
+    slayer3d_properties_set_float(payload, "selection_fraction", hit ? selection->fraction : 1.0f);
+    slayer3d_properties_set_vec3(payload, "selection_world_position",
+                                 hit ? selection->world_position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(payload, "selection_point",
+                                 hit ? selection->point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(payload, "selection_normal",
+                                 hit ? selection->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return payload;
+}
+
 static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime *runtime,
                                                slayer3d_game_data_editor_debug_desc *out_desc,
                                                slayer3d_game_data_world_trace_desc *out_trace,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8231,6 +8231,38 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_selection_actions");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
+
+    write_text(dir / "bad_selection_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Selection Action" },
+  "world": { "name": "world.bad_editor_selection_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.inspect"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.inspect",
+        "actions": [
+          { "type": "editor.selection.run", "else": [] }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_selection_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("logic action list must be an array"), std::string::npos) << error;
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, CombatActionsApplyHealthArmorDeathAndRevive)
 {
     const std::filesystem::path dir = unique_test_dir("combat_actions");
@@ -12227,6 +12259,23 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
     EXPECT_STREQ(active_selection.element_name, "brush.target.cube");
 
+    auto press_key = [&](SDL_Scancode scancode, Uint64 frame) {
+        SDL_Event key{};
+        key.type = SDL_EVENT_KEY_DOWN;
+        key.key.scancode = scancode;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, frame);
+    };
+
+    press_key(SDL_SCANCODE_I, 4);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "inspect brush.target.cube face editor.face.target_cube.left");
+
+    press_key(SDL_SCANCODE_TAB, 5);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "move");
+
     struct DebugCapture
     {
         int world_edges = 0;
@@ -12274,6 +12323,12 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(inspector.values[2], "true");
     EXPECT_EQ(inspector.values[3], "World");
     EXPECT_EQ(inspector.values[4], "brush.editor_shell.target");
+
+    press_key(SDL_SCANCODE_BACKSPACE, 6);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "selection cleared");
+    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
 
     SDL_Event release{};
     release.type = SDL_EVENT_MOUSE_BUTTON_UP;


### PR DESCRIPTION
## Summary
- add generic editor.selection.clear and editor.selection.run actions
- expose selection metadata as an action payload for data-authored editor tools
- update the editor shell dojo with keyboard-driven tool mode, inspect, and clear commands
- document the editor selection action payload and add validation/test coverage

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidSceneEditorTooling|RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"
- ctest --test-dir build/debug/tests --output-on-failure -R "GameData"