### PR TITLE
Add editor command previews

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -34,6 +34,10 @@
           {
             "name": "action.editor.selection.inspect",
             "bindings": [{ "device": "keyboard", "key": "I" }]
+          },
+          {
+            "name": "action.editor.command.preview",
+            "bindings": [{ "device": "keyboard", "key": "P" }]
           }
         ]
       }
@@ -42,7 +46,8 @@
   "signals": [
     "signal.editor.tool.cycle",
     "signal.editor.selection.clear",
-    "signal.editor.selection.inspect"
+    "signal.editor.selection.inspect",
+    "signal.editor.command.preview"
   ],
   "logic": {
     "sensors": [
@@ -60,6 +65,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.selection.inspect",
         "on_pressed": "signal.editor.selection.inspect"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.command.preview",
+        "on_pressed": "signal.editor.command.preview"
       }
     ],
     "bindings": [
@@ -78,6 +88,15 @@
         "signal": "signal.editor.selection.clear",
         "actions": [
           { "type": "editor.selection.clear" },
+          {
+            "type": "editor.command.clear_preview",
+            "message": "preview cleared",
+            "outputs": {
+              "active_key": "editor.command_preview.active",
+              "valid_key": "editor.command_preview.valid",
+              "message_key": "editor.command_preview.message"
+            }
+          },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "selection cleared" }
         ]
       },
@@ -96,6 +115,30 @@
             "else": [
               { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing selected" }
             ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.command.preview",
+        "actions": [
+          {
+            "type": "editor.command.preview",
+            "command": "translate",
+            "target": "element",
+            "offset": [0.0, 0.35, 0.0],
+            "message": "preview translate {selection_element}",
+            "outputs": {
+              "active_key": "editor.command_preview.active",
+              "valid_key": "editor.command_preview.valid",
+              "command_key": "editor.command_preview.command",
+              "target_key": "editor.command_preview.target",
+              "message_key": "editor.command_preview.message",
+              "world_key": "editor.command_preview.world",
+              "element_key": "editor.command_preview.element",
+              "face_index_key": "editor.command_preview.face_index",
+              "bounds_min_key": "editor.command_preview.bounds_min",
+              "bounds_max_key": "editor.command_preview.bounds_max"
+            }
           }
         ]
       }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -55,12 +55,13 @@
     },
     "debug_overlay": {
       "enabled": true,
-      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker"],
+      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker", "command_preview"],
       "world_bounds_color": [80, 170, 255, 190],
       "selection_bounds_color": [255, 220, 40, 255],
       "trace_color": [255, 255, 255, 210],
       "face_normal_color": [40, 255, 120, 255],
       "hit_marker_color": [255, 70, 70, 255],
+      "command_preview_color": [80, 255, 255, 235],
       "normal_length": 0.65,
       "hit_marker_size": 0.12
     }
@@ -125,6 +126,10 @@
           {
             "label": "Action",
             "binding": { "type": "scene_state", "key": "editor.tool.last_action", "default": "none" }
+          },
+          {
+            "label": "Preview",
+            "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
           }
         ]
       }
@@ -143,7 +148,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Data-authored viewport, selection overlay, and inspector",
+        "text": "Click select. I inspect. P previews. Tab changes tool. Backspace clears.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -706,9 +706,37 @@ pinned or current selection. It supplies payload fields such as
 `selection_point`, and `selection_normal`. `editor.selection.clear` clears the
 active selection and republishes the scene's `outputs` as an empty selection.
 
+Use `editor.command.preview` to declare a non-mutating command intent against
+the active selection. This is the safe scaffolding layer for editor tools:
+commands can publish UI state and draw preview bounds without modifying the
+authored world. Supported `command` values are `translate`, `paint`, `extrude`,
+and `delete`; supported `target` values are `selection`, `world`, `element`,
+`face`, and `material`.
+
+```json
+{
+  "type": "editor.command.preview",
+  "command": "translate",
+  "target": "element",
+  "offset": [0.0, 0.35, 0.0],
+  "message": "preview translate {selection_element}",
+  "outputs": {
+    "active_key": "editor.command_preview.active",
+    "valid_key": "editor.command_preview.valid",
+    "message_key": "editor.command_preview.message",
+    "bounds_min_key": "editor.command_preview.bounds_min",
+    "bounds_max_key": "editor.command_preview.bounds_max"
+  }
+}
+```
+
+`editor.command.clear_preview` clears that preview state and can publish the
+same `outputs` keys with `active_key`/`valid_key` set to false.
+
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
-`selection_bounds`, `trace_ray`, `face_normal`, and `hit_marker`.
+`selection_bounds`, `trace_ray`, `face_normal`, `hit_marker`, and
+`command_preview`.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -800,6 +800,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL = 4,
         /** @brief Hit-point marker line. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER = 5,
+        /** @brief Non-mutating editor command preview bounds edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE = 6,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -814,11 +816,13 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL = 1u << 3,
         /** @brief Emit a small marker at the selected hit point. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER = 1u << 4,
+        /** @brief Emit active non-mutating editor command preview bounds. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW = 1u << 5,
         /** @brief Emit every supported editor debug primitive. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL |
-            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER,
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW,
     };
 
     /** @brief One renderer-agnostic editor debug line segment. */
@@ -859,6 +863,8 @@ extern "C"
         slayer3d_color face_normal_color;
         /** @brief Color for hit markers, or alpha 0 for default. */
         slayer3d_color hit_marker_color;
+        /** @brief Color for command preview bounds, or alpha 0 for default. */
+        slayer3d_color command_preview_color;
         /** @brief Face-normal line length in world units. Defaults to 0.75. */
         float normal_length;
         /** @brief Hit-marker half-size in world units. Defaults to 0.1. */

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -206,6 +206,12 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         return execute_optional_action_array(runtime, obj_get(action, "else"), payload);
     }
 
+    if (SDL_strcmp(type, "editor.command.preview") == 0)
+        return slayer3d_game_data_preview_editor_command(runtime, action);
+
+    if (SDL_strcmp(type, "editor.command.clear_preview") == 0)
+        return slayer3d_game_data_clear_editor_command_preview(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -145,6 +145,20 @@ typedef struct sensor_entry
     int contact_pair_capacity;
 } sensor_entry;
 
+typedef struct editor_command_preview_state
+{
+    bool active;
+    const char *scene;
+    const char *command;
+    const char *target;
+    const char *world_name;
+    const char *element_name;
+    const char *material_name;
+    int face_index;
+    bool has_bounds;
+    slayer3d_bounding_box bounds;
+} editor_command_preview_state;
+
 typedef struct wave_schedule_entry
 {
     yyjson_val *schedule;
@@ -627,6 +641,7 @@ typedef struct slayer3d_game_data_runtime
     const char *active_camera;
     slayer3d_game_data_editor_selection editor_active_selection;
     const char *editor_selection_scene;
+    editor_command_preview_state editor_command_preview;
     scene_activity_state activity;
     float current_dt;
     unsigned int rng_state;
@@ -785,6 +800,8 @@ bool execute_optional_action_array(slayer3d_game_data_runtime *runtime, yyjson_v
 bool slayer3d_game_data_clear_active_editor_selection(slayer3d_game_data_runtime *runtime);
 slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(
     const slayer3d_game_data_editor_selection *selection);
+bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_clear_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -858,6 +858,8 @@ static bool validate_managed_network_scene_state(validation_context *ctx, yyjson
 
 static bool validate_action_array(validation_context *ctx, yyjson_val *actions, const char *json_path,
                                   validation_names *names);
+static bool editor_command_name_valid(const char *value);
+static bool editor_command_target_name_valid(const char *value);
 
 static bool validate_network_session_string_map(validation_context *ctx, yyjson_val *map, const char *json_path,
                                                 const char *label, const name_table *scene_names)
@@ -8061,6 +8063,61 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *else_actions = obj_get(action, "else");
         return else_actions == NULL || validate_action_array(ctx, else_actions, else_path, names);
     }
+    if (SDL_strcmp(type, "editor.command.preview") == 0)
+    {
+        const char *command = json_string(action, "command");
+        const char *target = json_string(action, "target");
+        if (target == NULL)
+            target = "selection";
+        if (!editor_command_name_valid(command))
+            return validation_error(ctx, json_path,
+                                    "editor.command.preview command must be translate, paint, extrude, or delete");
+        if (!editor_command_target_name_valid(target))
+            return validation_error(
+                ctx, json_path, "editor.command.preview target must be selection, world, element, face, or material");
+        yyjson_val *offset = obj_get(action, "offset");
+        if (offset != NULL && !is_vec_array(offset, 3))
+            return validation_error(ctx, json_path, "editor.command.preview offset must be a vec3");
+        yyjson_val *distance = obj_get(action, "distance");
+        if (distance != NULL && !yyjson_is_num(distance))
+            return validation_error(ctx, json_path, "editor.command.preview distance must be numeric");
+        yyjson_val *message = obj_get(action, "message");
+        if (message != NULL && !yyjson_is_str(message))
+            return validation_error(ctx, json_path, "editor.command.preview message must be a string");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.command.preview outputs must be an object");
+        static const char *const output_keys[] = {"active_key",     "valid_key",     "command_key", "target_key",
+                                                  "message_key",    "world_key",     "element_key", "face_index_key",
+                                                  "bounds_min_key", "bounds_max_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path, "editor.command.preview output keys must be non-empty strings");
+        }
+        return true;
+    }
+    if (SDL_strcmp(type, "editor.command.clear_preview") == 0)
+    {
+        yyjson_val *message = obj_get(action, "message");
+        if (message != NULL && !yyjson_is_str(message))
+            return validation_error(ctx, json_path, "editor.command.clear_preview message must be a string");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.command.clear_preview outputs must be an object");
+        static const char *const output_keys[] = {"active_key",     "valid_key",     "command_key", "target_key",
+                                                  "message_key",    "world_key",     "element_key", "face_index_key",
+                                                  "bounds_min_key", "bounds_max_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.command.clear_preview output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))
@@ -10298,7 +10355,21 @@ static bool editor_debug_flag_name_valid(const char *value)
 {
     return value != NULL && (SDL_strcmp(value, "all") == 0 || SDL_strcmp(value, "world_bounds") == 0 ||
                              SDL_strcmp(value, "selection_bounds") == 0 || SDL_strcmp(value, "trace_ray") == 0 ||
-                             SDL_strcmp(value, "face_normal") == 0 || SDL_strcmp(value, "hit_marker") == 0);
+                             SDL_strcmp(value, "face_normal") == 0 || SDL_strcmp(value, "hit_marker") == 0 ||
+                             SDL_strcmp(value, "command_preview") == 0);
+}
+
+static bool editor_command_name_valid(const char *value)
+{
+    return value != NULL && (SDL_strcmp(value, "translate") == 0 || SDL_strcmp(value, "paint") == 0 ||
+                             SDL_strcmp(value, "extrude") == 0 || SDL_strcmp(value, "delete") == 0);
+}
+
+static bool editor_command_target_name_valid(const char *value)
+{
+    return value != NULL &&
+           (SDL_strcmp(value, "selection") == 0 || SDL_strcmp(value, "world") == 0 ||
+            SDL_strcmp(value, "element") == 0 || SDL_strcmp(value, "face") == 0 || SDL_strcmp(value, "material") == 0);
 }
 
 static bool validate_string_or_string_array_names(validation_context *ctx, yyjson_val *value, const char *path,
@@ -10555,8 +10626,9 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         if (!validate_string_or_string_array_names(ctx, obj_get(overlay, "flags"), flags_path, "editor debug flag",
                                                    editor_debug_flag_name_valid))
             return false;
-        static const char *const color_keys[] = {"world_bounds_color", "selection_bounds_color", "trace_color",
-                                                 "face_normal_color", "hit_marker_color"};
+        static const char *const color_keys[] = {"world_bounds_color", "selection_bounds_color",
+                                                 "trace_color",        "face_normal_color",
+                                                 "hit_marker_color",   "command_preview_color"};
         for (size_t i = 0; i < SDL_arraysize(color_keys); ++i)
         {
             yyjson_val *color = obj_get(overlay, color_keys[i]);

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1414,6 +1414,8 @@ typedef struct editor_world_bounds_context
     bool stopped;
 } editor_world_bounds_context;
 
+static bool editor_command_preview_active_for_scene(const slayer3d_game_data_runtime *runtime);
+
 static bool emit_editor_debug_world_bounds(void *userdata, const slayer3d_game_data_world_model_instance *instance)
 {
     editor_world_bounds_context *bounds_context = (editor_world_bounds_context *)userdata;
@@ -1541,6 +1543,23 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
             return true;
         }
     }
+
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW) != 0u &&
+        editor_command_preview_active_for_scene(runtime) && runtime->editor_command_preview.has_bounds)
+    {
+        const editor_command_preview_state *preview = &runtime->editor_command_preview;
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color = editor_debug_color_or_default(desc->command_preview_color, (slayer3d_color){80, 255, 255, 220});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE;
+        context.world_name = preview->world_name;
+        context.element_name = preview->element_name;
+        context.face_index = preview->face_index;
+        if (!emit_editor_debug_bounds(&context, preview->bounds))
+            return true;
+    }
     return true;
 }
 
@@ -1598,6 +1617,8 @@ static unsigned int editor_debug_flag_from_string(const char *value)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL;
     if (SDL_strcmp(value != NULL ? value : "", "hit_marker") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER;
+    if (SDL_strcmp(value != NULL ? value : "", "command_preview") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW;
     return 0u;
 }
 
@@ -1749,12 +1770,21 @@ static bool editor_selection_active_for_scene(const slayer3d_game_data_runtime *
            SDL_strcmp(runtime->editor_selection_scene, active_scene) == 0;
 }
 
+static void clear_editor_command_preview(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    SDL_zero(runtime->editor_command_preview);
+    runtime->editor_command_preview.face_index = -1;
+}
+
 static void clear_editor_active_selection(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
         return;
     init_editor_selection(&runtime->editor_active_selection);
     runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+    clear_editor_command_preview(runtime);
 }
 
 static bool editor_selection_select_requested(const slayer3d_game_data_runtime *runtime, yyjson_val *selection)
@@ -1765,6 +1795,28 @@ static bool editor_selection_select_requested(const slayer3d_game_data_runtime *
 
     const Uint8 button = mouse_button_from_json(json_string(selection, "select_button", "LEFT"));
     return button != 0 && slayer3d_input_get_pressed_mouse_button(input) == button;
+}
+
+static bool editor_command_preview_active_for_scene(const slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || !runtime->editor_command_preview.active)
+        return false;
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    return active_scene != NULL && runtime->editor_command_preview.scene != NULL &&
+           SDL_strcmp(runtime->editor_command_preview.scene, active_scene) == 0;
+}
+
+static bool editor_command_name_valid(const char *command)
+{
+    return command != NULL && (SDL_strcmp(command, "translate") == 0 || SDL_strcmp(command, "paint") == 0 ||
+                               SDL_strcmp(command, "extrude") == 0 || SDL_strcmp(command, "delete") == 0);
+}
+
+static bool editor_command_target_name_valid(const char *target)
+{
+    return target != NULL && (SDL_strcmp(target, "selection") == 0 || SDL_strcmp(target, "world") == 0 ||
+                              SDL_strcmp(target, "element") == 0 || SDL_strcmp(target, "face") == 0 ||
+                              SDL_strcmp(target, "material") == 0);
 }
 
 static const char *editor_selection_type_name(slayer3d_game_data_world_model_type type)
@@ -1954,6 +2006,166 @@ slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(
     return payload;
 }
 
+static bool editor_command_target_compatible(const slayer3d_game_data_editor_selection *selection, const char *command,
+                                             const char *target, const char **out_reason)
+{
+    if (out_reason != NULL)
+        *out_reason = NULL;
+    if (selection == NULL || !selection->hit)
+    {
+        if (out_reason != NULL)
+            *out_reason = "no active selection";
+        return false;
+    }
+    if (SDL_strcmp(target, "world") == 0 && (selection->world_name == NULL || selection->world_name[0] == '\0'))
+    {
+        if (out_reason != NULL)
+            *out_reason = "selection has no world target";
+        return false;
+    }
+    if (SDL_strcmp(target, "element") == 0 && (selection->element_name == NULL || selection->element_name[0] == '\0'))
+    {
+        if (out_reason != NULL)
+            *out_reason = "selection has no element target";
+        return false;
+    }
+    if (SDL_strcmp(target, "face") == 0 && selection->face_index < 0)
+    {
+        if (out_reason != NULL)
+            *out_reason = "selection has no face target";
+        return false;
+    }
+    if (SDL_strcmp(target, "material") == 0 &&
+        (selection->material_name == NULL || selection->material_name[0] == '\0'))
+    {
+        if (out_reason != NULL)
+            *out_reason = "selection has no material target";
+        return false;
+    }
+    if ((SDL_strcmp(command, "translate") == 0 || SDL_strcmp(command, "delete") == 0) && !selection->has_bounds)
+    {
+        if (out_reason != NULL)
+            *out_reason = "selection has no previewable bounds";
+        return false;
+    }
+    if (SDL_strcmp(command, "extrude") == 0 && selection->face_index < 0)
+    {
+        if (out_reason != NULL)
+            *out_reason = "extrude preview requires a face selection";
+        return false;
+    }
+    if (SDL_strcmp(command, "paint") == 0 && selection->face_index < 0 &&
+        (selection->material_name == NULL || selection->material_name[0] == '\0'))
+    {
+        if (out_reason != NULL)
+            *out_reason = "paint preview requires a face or material selection";
+        return false;
+    }
+    return true;
+}
+
+static slayer3d_vec3 editor_command_preview_offset(yyjson_val *action,
+                                                   const slayer3d_game_data_editor_selection *selection)
+{
+    yyjson_val *offset = obj_get(action, "offset");
+    if (offset != NULL)
+        return json_vec3(action, "offset", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const float distance = json_float(action, "distance", 0.0f);
+    if (distance != 0.0f && selection != NULL && slayer3d_vec3_length_squared(selection->normal) > 0.000001f)
+        return slayer3d_vec3_scale(slayer3d_vec3_normalize(selection->normal), distance);
+    return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+}
+
+static void publish_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,
+                                           const char *command, const char *target, const char *message,
+                                           const slayer3d_game_data_editor_selection *selection,
+                                           const slayer3d_bounding_box *bounds)
+{
+    if (runtime == NULL || outputs == NULL)
+        return;
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "active_key", valid);
+    editor_set_bool_output(scene_state, outputs, "valid_key", valid);
+    editor_set_string_output(scene_state, outputs, "command_key", command != NULL ? command : "");
+    editor_set_string_output(scene_state, outputs, "target_key", target != NULL ? target : "");
+    editor_set_string_output(scene_state, outputs, "message_key", message != NULL ? message : "");
+    editor_set_string_output(scene_state, outputs, "world_key",
+                             valid && selection != NULL && selection->world_name != NULL ? selection->world_name : "");
+    editor_set_string_output(scene_state, outputs, "element_key",
+                             valid && selection != NULL && selection->element_name != NULL ? selection->element_name
+                                                                                           : "");
+    editor_set_int_output(scene_state, outputs, "face_index_key",
+                          valid && selection != NULL ? selection->face_index : -1);
+    editor_set_vec3_output(scene_state, outputs, "bounds_min_key",
+                           valid && bounds != NULL ? bounds->min : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_vec3_output(scene_state, outputs, "bounds_max_key",
+                           valid && bounds != NULL ? bounds->max : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+}
+
+bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    const char *command = json_string(action, "command", NULL);
+    const char *target = json_string(action, "target", "selection");
+    yyjson_val *outputs = obj_get(action, "outputs");
+    if (runtime == NULL || !editor_command_name_valid(command) || !editor_command_target_name_valid(target))
+        return false;
+
+    slayer3d_game_data_editor_selection selection;
+    const bool has_selection = slayer3d_game_data_get_active_editor_selection(runtime, &selection);
+    const char *reason = NULL;
+    const bool valid = has_selection && editor_command_target_compatible(&selection, command, target, &reason);
+    if (!valid)
+    {
+        clear_editor_command_preview(runtime);
+        publish_editor_command_preview(runtime, outputs, false, command, target, reason != NULL ? reason : "no preview",
+                                       NULL, NULL);
+        return true;
+    }
+
+    const slayer3d_vec3 offset = editor_command_preview_offset(action, &selection);
+    slayer3d_bounding_box bounds = selection.has_bounds ? translated_bounds(selection.bounds, offset)
+                                                        : (slayer3d_bounding_box){selection.point, selection.point};
+
+    editor_command_preview_state *preview = &runtime->editor_command_preview;
+    SDL_zero(*preview);
+    preview->active = true;
+    preview->scene = slayer3d_game_data_active_scene(runtime);
+    preview->command = command;
+    preview->target = target;
+    preview->world_name = selection.world_name;
+    preview->element_name = selection.element_name;
+    preview->material_name = selection.material_name;
+    preview->face_index = selection.face_index;
+    preview->has_bounds = true;
+    preview->bounds = bounds;
+
+    slayer3d_properties *payload = slayer3d_game_data_create_editor_selection_payload(&selection);
+    char message[256];
+    bool formatted = false;
+    if (payload != NULL)
+    {
+        slayer3d_properties_set_string(payload, "editor_command", command);
+        slayer3d_properties_set_string(payload, "editor_command_target", target);
+        formatted = format_payload_string(payload, json_string(action, "message", "preview"), message, sizeof(message));
+        slayer3d_properties_destroy(payload);
+    }
+    publish_editor_command_preview(runtime, outputs, true, command, target,
+                                   formatted ? message : json_string(action, "message", "preview"), &selection,
+                                   &bounds);
+    return true;
+}
+
+bool slayer3d_game_data_clear_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    if (runtime == NULL)
+        return false;
+    clear_editor_command_preview(runtime);
+    publish_editor_command_preview(runtime, obj_get(action, "outputs"), false, "", "",
+                                   json_string(action, "message", "preview cleared"), NULL, NULL);
+    return true;
+}
+
 static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime *runtime,
                                                slayer3d_game_data_editor_debug_desc *out_desc,
                                                slayer3d_game_data_world_trace_desc *out_trace,
@@ -1973,6 +2185,7 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
     out_desc->trace_color = json_color(overlay, "trace_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->face_normal_color = json_color(overlay, "face_normal_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->hit_marker_color = json_color(overlay, "hit_marker_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->command_preview_color = json_color(overlay, "command_preview_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->normal_length = json_float(overlay, "normal_length", 0.75f);
     out_desc->hit_marker_size = json_float(overlay, "hit_marker_size", 0.1f);
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8260,6 +8260,29 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_selection_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("logic action list must be an array"), std::string::npos) << error;
+
+    write_text(dir / "bad_preview_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Preview Action" },
+  "world": { "name": "world.bad_editor_preview_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.preview"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.preview",
+        "actions": [
+          { "type": "editor.command.preview", "command": "resize", "target": "element" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_preview_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("editor.command.preview command must be"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -12276,10 +12299,24 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "move");
 
+    press_key(SDL_SCANCODE_P, 6);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.active", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.command", ""), "translate");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.target", ""), "element");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.message", ""),
+                 "preview translate brush.target.cube");
+    const slayer3d_value *preview_min = slayer3d_properties_get_value(scene_state, "editor.command_preview.bounds_min");
+    ASSERT_NE(preview_min, nullptr);
+    ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(preview_min->as_vec3.y, 0.35f, 0.001f);
+
     struct DebugCapture
     {
         int world_edges = 0;
         int selection_edges = 0;
+        int command_preview_edges = 0;
         int rays = 0;
         int normals = 0;
         int markers = 0;
@@ -12290,6 +12327,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
             capture->world_edges++;
         else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
             capture->selection_edges++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE)
+            capture->command_preview_edges++;
         else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_TRACE_RAY)
             capture->rays++;
         else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_FACE_NORMAL)
@@ -12301,6 +12340,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_debug, &debug));
     EXPECT_EQ(debug.world_edges, 12);
     EXPECT_EQ(debug.selection_edges, 12);
+    EXPECT_EQ(debug.command_preview_edges, 12);
     EXPECT_EQ(debug.rays, 1);
     EXPECT_EQ(debug.normals, 1);
     EXPECT_EQ(debug.markers, 3);
@@ -12324,9 +12364,11 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(inspector.values[3], "World");
     EXPECT_EQ(inspector.values[4], "brush.editor_shell.target");
 
-    press_key(SDL_SCANCODE_BACKSPACE, 6);
+    press_key(SDL_SCANCODE_BACKSPACE, 7);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.message", ""), "preview cleared");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "selection cleared");
     EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
 


### PR DESCRIPTION
## Summary
- add non-mutating `editor.command.preview` and `editor.command.clear_preview` actions
- store active editor command preview state and expose preview bounds through the editor debug overlay
- wire the editor shell dojo to preview a translate command with `P`, clear previews with selection clear, and show preview state in the inspector
- document command preview actions, validation, and the new `command_preview` debug flag

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameData"`
- `git diff --check`

## Next slice
The next editor slice should add a command transaction/apply substrate: validated edit operations with dry-run metadata, apply hooks, and undo/redo records before we mutate brush worlds directly.