### PR TITLE
Add editor command transactions

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -38,6 +38,18 @@
           {
             "name": "action.editor.command.preview",
             "bindings": [{ "device": "keyboard", "key": "P" }]
+          },
+          {
+            "name": "action.editor.command.commit",
+            "bindings": [{ "device": "keyboard", "key": "RETURN" }]
+          },
+          {
+            "name": "action.editor.command.undo",
+            "bindings": [{ "device": "keyboard", "key": "Z" }]
+          },
+          {
+            "name": "action.editor.command.redo",
+            "bindings": [{ "device": "keyboard", "key": "Y" }]
           }
         ]
       }
@@ -47,7 +59,10 @@
     "signal.editor.tool.cycle",
     "signal.editor.selection.clear",
     "signal.editor.selection.inspect",
-    "signal.editor.command.preview"
+    "signal.editor.command.preview",
+    "signal.editor.command.commit",
+    "signal.editor.command.undo",
+    "signal.editor.command.redo"
   ],
   "logic": {
     "sensors": [
@@ -70,6 +85,21 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.command.preview",
         "on_pressed": "signal.editor.command.preview"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.command.commit",
+        "on_pressed": "signal.editor.command.commit"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.command.undo",
+        "on_pressed": "signal.editor.command.undo"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.command.redo",
+        "on_pressed": "signal.editor.command.redo"
       }
     ],
     "bindings": [
@@ -139,6 +169,103 @@
               "bounds_min_key": "editor.command_preview.bounds_min",
               "bounds_max_key": "editor.command_preview.bounds_max"
             }
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.command.commit",
+        "actions": [
+          {
+            "type": "editor.command.commit",
+            "message": "committed {editor_command} #{editor_transaction_id_text}",
+            "invalid_message": "nothing to commit",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "transaction_id_key": "editor.transaction.id",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count",
+              "command_key": "editor.transaction.command",
+              "target_key": "editor.transaction.target",
+              "world_key": "editor.transaction.world",
+              "element_key": "editor.transaction.element",
+              "face_index_key": "editor.transaction.face_index",
+              "bounds_min_key": "editor.transaction.bounds_min",
+              "bounds_max_key": "editor.transaction.bounds_max"
+            },
+            "actions": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "commit {editor_command} #{editor_transaction_id_text}"
+              }
+            ],
+            "else": [
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to commit" }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.command.undo",
+        "actions": [
+          {
+            "type": "editor.command.undo",
+            "message": "undo {editor_command} #{editor_transaction_id_text}",
+            "invalid_message": "nothing to undo",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "transaction_id_key": "editor.transaction.id",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count",
+              "command_key": "editor.transaction.command",
+              "target_key": "editor.transaction.target",
+              "world_key": "editor.transaction.world",
+              "element_key": "editor.transaction.element",
+              "face_index_key": "editor.transaction.face_index"
+            },
+            "actions": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "undo {editor_command} #{editor_transaction_id_text}"
+              }
+            ],
+            "else": [{ "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to undo" }]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.command.redo",
+        "actions": [
+          {
+            "type": "editor.command.redo",
+            "message": "redo {editor_command} #{editor_transaction_id_text}",
+            "invalid_message": "nothing to redo",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "transaction_id_key": "editor.transaction.id",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count",
+              "command_key": "editor.transaction.command",
+              "target_key": "editor.transaction.target",
+              "world_key": "editor.transaction.world",
+              "element_key": "editor.transaction.element",
+              "face_index_key": "editor.transaction.face_index"
+            },
+            "actions": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "redo {editor_command} #{editor_transaction_id_text}"
+              }
+            ],
+            "else": [{ "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to redo" }]
           }
         ]
       }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -9,7 +9,11 @@
       "action.exit",
       "action.editor.tool.cycle",
       "action.editor.selection.clear",
-      "action.editor.selection.inspect"
+      "action.editor.selection.inspect",
+      "action.editor.command.preview",
+      "action.editor.command.commit",
+      "action.editor.command.undo",
+      "action.editor.command.redo"
     ]
   },
   "world": {
@@ -130,6 +134,10 @@
           {
             "label": "Preview",
             "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
+          },
+          {
+            "label": "Txn",
+            "binding": { "type": "scene_state", "key": "editor.transaction.message", "default": "none" }
           }
         ]
       }
@@ -148,7 +156,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. I inspect. P previews. Tab changes tool. Backspace clears.",
+        "text": "Click select. P preview. Enter commit. Z/Y undo-redo. Tab tool. Backspace clear.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -733,6 +733,47 @@ and `delete`; supported `target` values are `selection`, `world`, `element`,
 `editor.command.clear_preview` clears that preview state and can publish the
 same `outputs` keys with `active_key`/`valid_key` set to false.
 
+Use `editor.command.commit`, `editor.command.undo`, and `editor.command.redo` to
+record validated editor command transactions without mutating authored world data
+yet. This gives editor tools a stable command history and payload contract before
+brush editing commands are introduced. A commit requires an active command
+preview in the current scene. Undo and redo move the command-history cursor and
+publish the selected transaction; they do not change geometry in this slice.
+
+```json
+{
+  "type": "editor.command.commit",
+  "message": "committed {editor_command} #{editor_transaction_id_text}",
+  "invalid_message": "nothing to commit",
+  "outputs": {
+    "valid_key": "editor.transaction.valid",
+    "event_key": "editor.transaction.event",
+    "message_key": "editor.transaction.message",
+    "transaction_id_key": "editor.transaction.id",
+    "undo_count_key": "editor.transaction.undo_count",
+    "redo_count_key": "editor.transaction.redo_count"
+  },
+  "actions": [
+    {
+      "type": "scene_state.set",
+      "key": "editor.tool.last_action",
+      "value": "commit {editor_command} #{editor_transaction_id_text}"
+    }
+  ],
+  "else": [
+    { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to commit" }
+  ]
+}
+```
+
+Transaction payloads include `editor_transaction_valid`,
+`editor_transaction_event`, `editor_transaction_id`,
+`editor_transaction_id_text`, `editor_command`, `editor_command_target`, `editor_transaction_scene`,
+`editor_transaction_world`, `editor_transaction_element`,
+`editor_transaction_material`, `editor_transaction_face_index`,
+`editor_transaction_undo_count`, `editor_transaction_redo_count`, and
+`editor_transaction_bounds_min`/`editor_transaction_bounds_max`.
+
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
 `selection_bounds`, `trace_ray`, `face_normal`, `hit_marker`, and

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -212,6 +212,15 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.command.clear_preview") == 0)
         return slayer3d_game_data_clear_editor_command_preview(runtime, action);
 
+    if (SDL_strcmp(type, "editor.command.commit") == 0)
+        return slayer3d_game_data_commit_editor_command(runtime, action, payload);
+
+    if (SDL_strcmp(type, "editor.command.undo") == 0)
+        return slayer3d_game_data_undo_editor_command(runtime, action, payload);
+
+    if (SDL_strcmp(type, "editor.command.redo") == 0)
+        return slayer3d_game_data_redo_editor_command(runtime, action, payload);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -155,9 +155,35 @@ typedef struct editor_command_preview_state
     const char *element_name;
     const char *material_name;
     int face_index;
+    yyjson_val *outputs;
     bool has_bounds;
     slayer3d_bounding_box bounds;
 } editor_command_preview_state;
+
+#define SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY 32
+
+typedef struct editor_command_transaction_entry
+{
+    int id;
+    const char *scene;
+    const char *command;
+    const char *target;
+    const char *world_name;
+    const char *element_name;
+    const char *material_name;
+    int face_index;
+    bool has_bounds;
+    slayer3d_bounding_box bounds;
+    char message[128];
+} editor_command_transaction_entry;
+
+typedef struct editor_command_history_state
+{
+    editor_command_transaction_entry entries[SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY];
+    int count;
+    int cursor;
+    int next_id;
+} editor_command_history_state;
 
 typedef struct wave_schedule_entry
 {
@@ -642,6 +668,7 @@ typedef struct slayer3d_game_data_runtime
     slayer3d_game_data_editor_selection editor_active_selection;
     const char *editor_selection_scene;
     editor_command_preview_state editor_command_preview;
+    editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;
     unsigned int rng_state;
@@ -802,6 +829,12 @@ slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(
     const slayer3d_game_data_editor_selection *selection);
 bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_clear_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_commit_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                              const slayer3d_properties *payload);
+bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload);
+bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8118,6 +8118,38 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.command.commit") == 0 || SDL_strcmp(type, "editor.command.undo") == 0 ||
+        SDL_strcmp(type, "editor.command.redo") == 0)
+    {
+        yyjson_val *message = obj_get(action, "message");
+        yyjson_val *invalid_message = obj_get(action, "invalid_message");
+        if (message != NULL && !yyjson_is_str(message))
+            return validation_error(ctx, json_path, "%s message must be a string", type);
+        if (invalid_message != NULL && !yyjson_is_str(invalid_message))
+            return validation_error(ctx, json_path, "%s invalid_message must be a string", type);
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "%s outputs must be an object", type);
+        static const char *const output_keys[] = {
+            "valid_key",      "event_key",      "message_key",   "transaction_id_key", "undo_count_key",
+            "redo_count_key", "command_key",    "target_key",    "world_key",          "element_key",
+            "face_index_key", "bounds_min_key", "bounds_max_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path, "%s output keys must be non-empty strings", type);
+        }
+        char actions_path[PATH_BUFFER_SIZE];
+        char else_path[PATH_BUFFER_SIZE];
+        format_path(actions_path, sizeof(actions_path), "%s.actions", json_path);
+        format_path(else_path, sizeof(else_path), "%s.else", json_path);
+        yyjson_val *actions = obj_get(action, "actions");
+        yyjson_val *else_actions = obj_get(action, "else");
+        if (actions != NULL && !validate_action_array(ctx, actions, actions_path, names))
+            return false;
+        return else_actions == NULL || validate_action_array(ctx, else_actions, else_path, names);
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2137,6 +2137,7 @@ bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runti
     preview->element_name = selection.element_name;
     preview->material_name = selection.material_name;
     preview->face_index = selection.face_index;
+    preview->outputs = outputs;
     preview->has_bounds = true;
     preview->bounds = bounds;
 
@@ -2164,6 +2165,244 @@ bool slayer3d_game_data_clear_editor_command_preview(slayer3d_game_data_runtime 
     publish_editor_command_preview(runtime, obj_get(action, "outputs"), false, "", "",
                                    json_string(action, "message", "preview cleared"), NULL, NULL);
     return true;
+}
+
+static int editor_command_history_undo_count(const editor_command_history_state *history)
+{
+    return history != NULL ? history->cursor : 0;
+}
+
+static int editor_command_history_redo_count(const editor_command_history_state *history)
+{
+    return history != NULL ? history->count - history->cursor : 0;
+}
+
+static slayer3d_properties *create_editor_transaction_payload(const slayer3d_game_data_runtime *runtime,
+                                                              const char *event, bool valid,
+                                                              const editor_command_transaction_entry *entry,
+                                                              const char *message)
+{
+    slayer3d_properties *payload = slayer3d_properties_create();
+    if (payload == NULL)
+        return NULL;
+
+    const editor_command_history_state *history = runtime != NULL ? &runtime->editor_command_history : NULL;
+    slayer3d_properties_set_bool(payload, "editor_transaction_valid", valid);
+    slayer3d_properties_set_string(payload, "editor_transaction_event", event != NULL ? event : "");
+    slayer3d_properties_set_string(payload, "editor_transaction_message", message != NULL ? message : "");
+    slayer3d_properties_set_int(payload, "editor_transaction_undo_count", editor_command_history_undo_count(history));
+    slayer3d_properties_set_int(payload, "editor_transaction_redo_count", editor_command_history_redo_count(history));
+
+    if (entry != NULL)
+    {
+        char id_text[32];
+        SDL_snprintf(id_text, sizeof(id_text), "%d", entry->id);
+        slayer3d_properties_set_int(payload, "editor_transaction_id", entry->id);
+        slayer3d_properties_set_string(payload, "editor_transaction_id_text", id_text);
+        slayer3d_properties_set_string(payload, "editor_command", entry->command != NULL ? entry->command : "");
+        slayer3d_properties_set_string(payload, "editor_command_target", entry->target != NULL ? entry->target : "");
+        slayer3d_properties_set_string(payload, "editor_transaction_scene", entry->scene != NULL ? entry->scene : "");
+        slayer3d_properties_set_string(payload, "editor_transaction_world",
+                                       entry->world_name != NULL ? entry->world_name : "");
+        slayer3d_properties_set_string(payload, "editor_transaction_element",
+                                       entry->element_name != NULL ? entry->element_name : "");
+        slayer3d_properties_set_string(payload, "editor_transaction_material",
+                                       entry->material_name != NULL ? entry->material_name : "");
+        slayer3d_properties_set_int(payload, "editor_transaction_face_index", entry->face_index);
+        slayer3d_properties_set_vec3(payload, "editor_transaction_bounds_min",
+                                     entry->has_bounds ? entry->bounds.min : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        slayer3d_properties_set_vec3(payload, "editor_transaction_bounds_max",
+                                     entry->has_bounds ? entry->bounds.max : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    }
+    else
+    {
+        slayer3d_properties_set_int(payload, "editor_transaction_id", -1);
+        slayer3d_properties_set_string(payload, "editor_transaction_id_text", "");
+        slayer3d_properties_set_string(payload, "editor_command", "");
+        slayer3d_properties_set_string(payload, "editor_command_target", "");
+        slayer3d_properties_set_string(payload, "editor_transaction_scene", "");
+        slayer3d_properties_set_string(payload, "editor_transaction_world", "");
+        slayer3d_properties_set_string(payload, "editor_transaction_element", "");
+        slayer3d_properties_set_string(payload, "editor_transaction_material", "");
+        slayer3d_properties_set_int(payload, "editor_transaction_face_index", -1);
+        slayer3d_properties_set_vec3(payload, "editor_transaction_bounds_min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        slayer3d_properties_set_vec3(payload, "editor_transaction_bounds_max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    }
+    return payload;
+}
+
+static void publish_editor_transaction(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, const char *event,
+                                       bool valid, const editor_command_transaction_entry *entry, const char *message)
+{
+    if (runtime == NULL || outputs == NULL)
+        return;
+
+    const editor_command_history_state *history = &runtime->editor_command_history;
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", valid);
+    editor_set_string_output(scene_state, outputs, "event_key", event != NULL ? event : "");
+    editor_set_string_output(scene_state, outputs, "message_key", message != NULL ? message : "");
+    editor_set_int_output(scene_state, outputs, "transaction_id_key", valid && entry != NULL ? entry->id : -1);
+    editor_set_int_output(scene_state, outputs, "undo_count_key", editor_command_history_undo_count(history));
+    editor_set_int_output(scene_state, outputs, "redo_count_key", editor_command_history_redo_count(history));
+    editor_set_string_output(scene_state, outputs, "command_key",
+                             valid && entry != NULL && entry->command != NULL ? entry->command : "");
+    editor_set_string_output(scene_state, outputs, "target_key",
+                             valid && entry != NULL && entry->target != NULL ? entry->target : "");
+    editor_set_string_output(scene_state, outputs, "world_key",
+                             valid && entry != NULL && entry->world_name != NULL ? entry->world_name : "");
+    editor_set_string_output(scene_state, outputs, "element_key",
+                             valid && entry != NULL && entry->element_name != NULL ? entry->element_name : "");
+    editor_set_int_output(scene_state, outputs, "face_index_key", valid && entry != NULL ? entry->face_index : -1);
+    editor_set_vec3_output(scene_state, outputs, "bounds_min_key",
+                           valid && entry != NULL && entry->has_bounds ? entry->bounds.min
+                                                                       : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_vec3_output(scene_state, outputs, "bounds_max_key",
+                           valid && entry != NULL && entry->has_bounds ? entry->bounds.max
+                                                                       : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+}
+
+static bool run_editor_transaction_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
+                                                const char *event, bool valid,
+                                                const editor_command_transaction_entry *entry, const char *message)
+{
+    if (actions == NULL)
+        return true;
+    slayer3d_properties *payload = create_editor_transaction_payload(runtime, event, valid, entry, message);
+    if (payload == NULL)
+        return false;
+    const bool ok = execute_optional_action_array(runtime, actions, payload);
+    slayer3d_properties_destroy(payload);
+    return ok;
+}
+
+static void format_editor_transaction_message(const slayer3d_game_data_runtime *runtime, const char *event, bool valid,
+                                              const editor_command_transaction_entry *entry, const char *format,
+                                              char *buffer, size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0U)
+        return;
+    SDL_strlcpy(buffer, format != NULL ? format : "", buffer_size);
+    slayer3d_properties *payload = create_editor_transaction_payload(runtime, event, valid, entry, buffer);
+    if (payload != NULL)
+    {
+        (void)format_payload_string(payload, format != NULL ? format : "", buffer, buffer_size);
+        slayer3d_properties_destroy(payload);
+    }
+}
+
+static editor_command_transaction_entry *editor_command_history_append(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return NULL;
+    editor_command_history_state *history = &runtime->editor_command_history;
+    if (history->cursor < history->count)
+        history->count = history->cursor;
+    if (history->count >= SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY)
+    {
+        SDL_memmove(&history->entries[0], &history->entries[1],
+                    sizeof(history->entries[0]) * (SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY - 1));
+        history->count = SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY - 1;
+        history->cursor = history->count;
+    }
+
+    editor_command_transaction_entry *entry = &history->entries[history->count];
+    SDL_zero(*entry);
+    entry->id = ++history->next_id;
+    entry->face_index = -1;
+    history->count++;
+    history->cursor = history->count;
+    return entry;
+}
+
+bool slayer3d_game_data_commit_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                              const slayer3d_properties *payload)
+{
+    (void)payload;
+    yyjson_val *outputs = obj_get(action, "outputs");
+    if (runtime == NULL)
+        return false;
+
+    if (!editor_command_preview_active_for_scene(runtime))
+    {
+        const char *message = json_string(action, "invalid_message", "no active editor command preview");
+        publish_editor_transaction(runtime, outputs, "commit", false, NULL, message);
+        return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "commit", false, NULL, message);
+    }
+
+    const editor_command_preview_state *preview = &runtime->editor_command_preview;
+    editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+    if (entry == NULL)
+        return false;
+
+    entry->scene = preview->scene;
+    entry->command = preview->command;
+    entry->target = preview->target;
+    entry->world_name = preview->world_name;
+    entry->element_name = preview->element_name;
+    entry->material_name = preview->material_name;
+    entry->face_index = preview->face_index;
+    entry->has_bounds = preview->has_bounds;
+    entry->bounds = preview->bounds;
+    format_editor_transaction_message(runtime, "commit", true, entry,
+                                      json_string(action, "message", "committed {editor_command}"), entry->message,
+                                      sizeof(entry->message));
+
+    publish_editor_command_preview(runtime, preview->outputs, false, "", "", "preview committed", NULL, NULL);
+    clear_editor_command_preview(runtime);
+    publish_editor_transaction(runtime, outputs, "commit", true, entry, entry->message);
+    return run_editor_transaction_action_array(runtime, obj_get(action, "actions"), "commit", true, entry,
+                                               entry->message);
+}
+
+bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload)
+{
+    (void)payload;
+    yyjson_val *outputs = obj_get(action, "outputs");
+    if (runtime == NULL)
+        return false;
+    editor_command_history_state *history = &runtime->editor_command_history;
+    if (history->cursor <= 0)
+    {
+        const char *message = json_string(action, "invalid_message", "nothing to undo");
+        publish_editor_transaction(runtime, outputs, "undo", false, NULL, message);
+        return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "undo", false, NULL, message);
+    }
+
+    history->cursor--;
+    editor_command_transaction_entry *entry = &history->entries[history->cursor];
+    char message[128];
+    format_editor_transaction_message(runtime, "undo", true, entry,
+                                      json_string(action, "message", "undo {editor_command}"), message,
+                                      sizeof(message));
+    publish_editor_transaction(runtime, outputs, "undo", true, entry, message);
+    return run_editor_transaction_action_array(runtime, obj_get(action, "actions"), "undo", true, entry, message);
+}
+
+bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                            const slayer3d_properties *payload)
+{
+    (void)payload;
+    yyjson_val *outputs = obj_get(action, "outputs");
+    if (runtime == NULL)
+        return false;
+    editor_command_history_state *history = &runtime->editor_command_history;
+    if (history->cursor >= history->count)
+    {
+        const char *message = json_string(action, "invalid_message", "nothing to redo");
+        publish_editor_transaction(runtime, outputs, "redo", false, NULL, message);
+        return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "redo", false, NULL, message);
+    }
+
+    editor_command_transaction_entry *entry = &history->entries[history->cursor];
+    history->cursor++;
+    char message[128];
+    format_editor_transaction_message(runtime, "redo", true, entry,
+                                      json_string(action, "message", "redo {editor_command}"), message,
+                                      sizeof(message));
+    publish_editor_transaction(runtime, outputs, "redo", true, entry, message);
+    return run_editor_transaction_action_array(runtime, obj_get(action, "actions"), "redo", true, entry, message);
 }
 
 static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime *runtime,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8283,6 +8283,33 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_preview_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("editor.command.preview command must be"), std::string::npos) << error;
+
+    write_text(dir / "bad_transaction_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Transaction Action" },
+  "world": { "name": "world.bad_editor_transaction_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.commit"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.commit",
+        "actions": [
+          {
+            "type": "editor.command.commit",
+            "outputs": { "transaction_id_key": "" }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_transaction_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("editor.command.commit output keys must be non-empty strings"), std::string::npos)
+        << error;
     remove_test_dir(dir);
 }
 
@@ -12364,7 +12391,37 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(inspector.values[3], "World");
     EXPECT_EQ(inspector.values[4], "brush.editor_shell.target");
 
-    press_key(SDL_SCANCODE_BACKSPACE, 7);
+    press_key(SDL_SCANCODE_RETURN, 7);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.active", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.event", ""), "commit");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
+                 "committed translate #1");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.id", -1), 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.element", ""), "brush.target.cube");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "commit translate #1");
+
+    press_key(SDL_SCANCODE_Z, 8);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.event", ""), "undo");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "undo translate #1");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 1);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "undo translate #1");
+
+    press_key(SDL_SCANCODE_Y, 9);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.event", ""), "redo");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "redo translate #1");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
+
+    press_key(SDL_SCANCODE_BACKSPACE, 10);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.active", true));


### PR DESCRIPTION
## Summary
- add editor command transaction history with `editor.command.commit`, `editor.command.undo`, and `editor.command.redo` actions
- publish transaction metadata and payloads for data-authored UI/hooks without mutating brush worlds yet
- clear stale preview scene-state when a preview is committed
- wire the editor shell dojo to commit with Enter and undo/redo with Z/Y
- document the transaction payload contract and add validation/test coverage

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameData"`
- `git diff --check`

## Next slice
Next should be the first real brush mutation command: implement a constrained translate operation against selected brush elements using the transaction substrate, with apply/undo correctness tests and invalid-geometry rejection before serialization/export.