### PR TITLE
Export runtime brush worlds for editor persistence

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -62,7 +62,8 @@
     "signal.editor.command.preview",
     "signal.editor.command.commit",
     "signal.editor.command.undo",
-    "signal.editor.command.redo"
+    "signal.editor.command.redo",
+    "signal.editor.export"
   ],
   "logic": {
     "sensors": [
@@ -293,6 +294,21 @@
               }
             ],
             "else": [{ "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to redo" }]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.export",
+        "actions": [
+          {
+            "type": "editor.brush_world.export",
+            "world": "brush.editor_shell.target",
+            "outputs": {
+              "valid_key": "editor.export.valid",
+              "message_key": "editor.export.message",
+              "json_key": "editor.export.json",
+              "size_key": "editor.export.size"
+            }
           }
         ]
       }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -779,6 +779,26 @@ Transaction payloads include `editor_transaction_valid`,
 `editor_transaction_undo_count`, `editor_transaction_redo_count`, and
 `editor_transaction_bounds_min`/`editor_transaction_bounds_max`.
 
+Use `editor.brush_world.export` to serialize the current runtime state of one
+brush world as a canonical `slayer3d.fragment.v0` JSON document. The export
+includes runtime editor mutations such as translated brush planes and painted
+face materials. Future editor hosts can write this JSON to their own project
+document or source-control workflow; data-authored dojos can publish it to scene
+state for validation and inspection.
+
+```json
+{
+  "type": "editor.brush_world.export",
+  "world": "brush.level.blockout",
+  "outputs": {
+    "valid_key": "editor.export.valid",
+    "message_key": "editor.export.message",
+    "json_key": "editor.export.json",
+    "size_key": "editor.export.size"
+  }
+}
+```
+
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
 `selection_bounds`, `trace_ray`, `face_normal`, `hit_marker`, and

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1905,6 +1905,19 @@ extern "C"
         const slayer3d_game_data_runtime *runtime, slayer3d_game_data_editor_debug_primitive_fn callback,
         void *userdata);
 
+    /**
+     * @brief Export one runtime brush world as a canonical JSON fragment.
+     *
+     * The exported document uses `schema: "slayer3d.fragment.v0"` and contains a
+     * single `brush_worlds` entry. Runtime editor mutations such as brush
+     * translation and face material painting are reflected in the exported
+     * planes and material references. The returned string is allocated with
+     * SDL_malloc and must be released with SDL_free().
+     */
+    bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_data_runtime *runtime,
+                                                             const char *world_name, char **out_json, size_t *out_size,
+                                                             char *error_buffer, int error_buffer_size);
+
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity
     {

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -221,6 +221,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.command.redo") == 0)
         return slayer3d_game_data_redo_editor_command(runtime, action, payload);
 
+    if (SDL_strcmp(type, "editor.brush_world.export") == 0)
+        return slayer3d_game_data_export_editor_brush_world_action(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -843,6 +843,7 @@ bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime,
                                             const slayer3d_properties *payload);
 bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                             const slayer3d_properties *payload);
+bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8157,6 +8157,23 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             return false;
         return else_actions == NULL || validate_action_array(ctx, else_actions, else_path, names);
     }
+    if (SDL_strcmp(type, "editor.brush_world.export") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.brush_world.export outputs must be an object");
+        static const char *const output_keys[] = {"valid_key", "message_key", "json_key", "size_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.brush_world.export output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -12,6 +12,8 @@
 #include "slayer3d/game.h"
 #include "slayer3d/math.h"
 
+#include <stdlib.h>
+
 const char *slayer3d_game_data_active_scene(const slayer3d_game_data_runtime *runtime)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
@@ -609,6 +611,293 @@ static brush_world_runtime *find_brush_world_runtime_mutable(slayer3d_game_data_
 const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name)
 {
     return find_brush_world_runtime_mutable((slayer3d_game_data_runtime *)runtime, name);
+}
+
+static bool export_add_vec3(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec3 value)
+{
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    return arr != NULL && yyjson_mut_arr_add_real(doc, arr, value.x) && yyjson_mut_arr_add_real(doc, arr, value.y) &&
+           yyjson_mut_arr_add_real(doc, arr, value.z) && yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_vec4(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec4 value)
+{
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    return arr != NULL && yyjson_mut_arr_add_real(doc, arr, value.x) && yyjson_mut_arr_add_real(doc, arr, value.y) &&
+           yyjson_mut_arr_add_real(doc, arr, value.z) && yyjson_mut_arr_add_real(doc, arr, value.w) &&
+           yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_vec2_values(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, float x, float y)
+{
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    return arr != NULL && yyjson_mut_arr_add_real(doc, arr, x) && yyjson_mut_arr_add_real(doc, arr, y) &&
+           yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_optional_string(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, const char *value)
+{
+    return value == NULL || value[0] == '\0' || yyjson_mut_obj_add_strcpy(doc, obj, key, value);
+}
+
+static bool export_add_string_array(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key,
+                                    const char *const *values, int count)
+{
+    if (count <= 0)
+        return true;
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    if (arr == NULL)
+        return false;
+    for (int i = 0; i < count; ++i)
+    {
+        if (values[i] == NULL || !yyjson_mut_arr_add_strcpy(doc, arr, values[i]))
+            return false;
+    }
+    return yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_editor_metadata(yyjson_mut_doc *doc, yyjson_mut_val *obj,
+                                       const slayer3d_game_data_editor_metadata *metadata)
+{
+    if (metadata == NULL)
+        return true;
+    const bool has_snap =
+        metadata->has_snap_grid || metadata->snap_rotation_degrees > 0.0f || metadata->snap_align_to_floor;
+    if (metadata->stable_id == NULL && metadata->display_name == NULL && metadata->description == NULL &&
+        metadata->category == NULL && metadata->group == NULL && metadata->prefab == NULL &&
+        metadata->archetype == NULL && metadata->icon == NULL && metadata->preview_asset == NULL &&
+        metadata->tag_count <= 0 && !has_snap)
+    {
+        return true;
+    }
+
+    yyjson_mut_val *editor = yyjson_mut_obj(doc);
+    if (editor == NULL || !yyjson_mut_obj_add_val(doc, obj, "editor", editor))
+        return false;
+    if (!export_add_optional_string(doc, editor, "stable_id", metadata->stable_id) ||
+        !export_add_optional_string(doc, editor, "display_name", metadata->display_name) ||
+        !export_add_optional_string(doc, editor, "description", metadata->description) ||
+        !export_add_optional_string(doc, editor, "category", metadata->category) ||
+        !export_add_optional_string(doc, editor, "group", metadata->group) ||
+        !export_add_optional_string(doc, editor, "prefab", metadata->prefab) ||
+        !export_add_optional_string(doc, editor, "archetype", metadata->archetype) ||
+        !export_add_optional_string(doc, editor, "icon", metadata->icon) ||
+        !export_add_optional_string(doc, editor, "preview_asset", metadata->preview_asset) ||
+        !export_add_string_array(doc, editor, "tags", metadata->tags, metadata->tag_count))
+    {
+        return false;
+    }
+    if (has_snap)
+    {
+        yyjson_mut_val *snap = yyjson_mut_obj(doc);
+        if (snap == NULL || !yyjson_mut_obj_add_val(doc, editor, "snap", snap))
+            return false;
+        if (metadata->has_snap_grid && !export_add_vec3(doc, snap, "grid", metadata->snap_grid))
+            return false;
+        if (metadata->snap_rotation_degrees > 0.0f &&
+            !yyjson_mut_obj_add_real(doc, snap, "rotation_degrees", metadata->snap_rotation_degrees))
+        {
+            return false;
+        }
+        if (metadata->snap_align_to_floor && !yyjson_mut_obj_add_bool(doc, snap, "align_to_floor", true))
+            return false;
+    }
+    return true;
+}
+
+typedef struct brush_flag_export_entry
+{
+    unsigned int flag;
+    const char *name;
+} brush_flag_export_entry;
+
+static bool export_add_flag_array(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, unsigned int flags,
+                                  const brush_flag_export_entry *entries, size_t entry_count)
+{
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    if (arr == NULL)
+        return false;
+    for (size_t i = 0; i < entry_count; ++i)
+    {
+        if ((flags & entries[i].flag) != 0u && !yyjson_mut_arr_add_strcpy(doc, arr, entries[i].name))
+            return false;
+    }
+    return yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_brush_contents(yyjson_mut_doc *doc, yyjson_mut_val *brush, unsigned int flags)
+{
+    static const brush_flag_export_entry entries[] = {
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, "solid"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP, "player_clip"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP, "projectile_clip"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_TRIGGER, "trigger"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER, "water"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA, "lava"},
+        {SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY, "sky"},
+    };
+    return export_add_flag_array(doc, brush, "contents", flags != 0u ? flags : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+                                 entries, SDL_arraysize(entries));
+}
+
+static bool export_add_surface_flags(yyjson_mut_doc *doc, yyjson_mut_val *face, unsigned int flags)
+{
+    if (flags == 0u)
+        return true;
+    static const brush_flag_export_entry entries[] = {
+        {SLAYER3D_GAME_DATA_BRUSH_SURFACE_NO_COLLIDE, "nocollide"},
+        {SLAYER3D_GAME_DATA_BRUSH_SURFACE_SLICK, "slick"},
+        {SLAYER3D_GAME_DATA_BRUSH_SURFACE_LADDER, "ladder"},
+        {SLAYER3D_GAME_DATA_BRUSH_SURFACE_EMISSIVE, "emissive"},
+        {SLAYER3D_GAME_DATA_BRUSH_SURFACE_PORTAL_CANDIDATE, "portal_candidate"},
+    };
+    return export_add_flag_array(doc, face, "surface_flags", flags, entries, SDL_arraysize(entries));
+}
+
+static bool export_add_brush_material(yyjson_mut_doc *doc, yyjson_mut_val *materials,
+                                      const slayer3d_game_data_brush_material *material)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    return obj != NULL && yyjson_mut_arr_add_val(materials, obj) &&
+           yyjson_mut_obj_add_strcpy(doc, obj, "name", material->name != NULL ? material->name : "") &&
+           export_add_optional_string(doc, obj, "texture", material->texture) &&
+           export_add_vec4(doc, obj, "albedo", material->albedo) &&
+           yyjson_mut_obj_add_real(doc, obj, "metallic", material->metallic) &&
+           yyjson_mut_obj_add_real(doc, obj, "roughness", material->roughness) &&
+           export_add_vec3(doc, obj, "emissive", material->emissive) &&
+           yyjson_mut_obj_add_real(doc, obj, "tex_scale", material->tex_scale) &&
+           export_add_editor_metadata(doc, obj, &material->editor);
+}
+
+static bool export_add_brush_face(yyjson_mut_doc *doc, yyjson_mut_val *faces,
+                                  const slayer3d_game_data_brush_world *world,
+                                  const slayer3d_game_data_brush_face *face)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    yyjson_mut_val *plane = yyjson_mut_obj(doc);
+    yyjson_mut_val *uv = yyjson_mut_obj(doc);
+    const char *material = face->material_name;
+    if (material == NULL && face->material_index >= 0 && face->material_index < world->material_count)
+        material = world->materials[face->material_index].name;
+    return obj != NULL && plane != NULL && uv != NULL && yyjson_mut_arr_add_val(faces, obj) &&
+           yyjson_mut_obj_add_val(doc, obj, "plane", plane) && export_add_vec3(doc, plane, "normal", face->normal) &&
+           yyjson_mut_obj_add_real(doc, plane, "distance", face->distance) &&
+           yyjson_mut_obj_add_strcpy(doc, obj, "material", material != NULL ? material : "") &&
+           yyjson_mut_obj_add_val(doc, obj, "uv", uv) &&
+           export_add_vec2_values(doc, uv, "scale", face->uv_scale[0], face->uv_scale[1]) &&
+           export_add_vec2_values(doc, uv, "offset", face->uv_offset[0], face->uv_offset[1]) &&
+           yyjson_mut_obj_add_real(doc, uv, "rotation_degrees", face->uv_rotation_degrees) &&
+           export_add_surface_flags(doc, obj, face->surface_flags) &&
+           export_add_editor_metadata(doc, obj, &face->editor);
+}
+
+static bool export_add_brush(yyjson_mut_doc *doc, yyjson_mut_val *brushes, const slayer3d_game_data_brush_world *world,
+                             const slayer3d_game_data_brush *brush)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    yyjson_mut_val *faces = yyjson_mut_arr(doc);
+    if (obj == NULL || faces == NULL || !yyjson_mut_arr_add_val(brushes, obj) ||
+        !yyjson_mut_obj_add_strcpy(doc, obj, "name", brush->name != NULL ? brush->name : "") ||
+        !export_add_brush_contents(doc, obj, brush->contents) ||
+        !export_add_string_array(doc, obj, "tags", brush->tags, brush->tag_count) ||
+        !export_add_editor_metadata(doc, obj, &brush->editor) || !yyjson_mut_obj_add_val(doc, obj, "faces", faces))
+    {
+        return false;
+    }
+    for (int i = 0; i < brush->face_count; ++i)
+    {
+        if (!export_add_brush_face(doc, faces, world, &brush->faces[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool export_add_brush_world(yyjson_mut_doc *doc, yyjson_mut_val *worlds,
+                                   const slayer3d_game_data_brush_world *world)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    yyjson_mut_val *materials = yyjson_mut_arr(doc);
+    yyjson_mut_val *brushes = yyjson_mut_arr(doc);
+    if (obj == NULL || materials == NULL || brushes == NULL || !yyjson_mut_arr_add_val(worlds, obj) ||
+        !yyjson_mut_obj_add_strcpy(doc, obj, "name", world->name != NULL ? world->name : "") ||
+        !yyjson_mut_obj_add_strcpy(doc, obj, "units", world->units != NULL ? world->units : "meters") ||
+        !yyjson_mut_obj_add_real(doc, obj, "meters_per_unit", world->meters_per_unit) ||
+        !export_add_editor_metadata(doc, obj, &world->editor) ||
+        !yyjson_mut_obj_add_val(doc, obj, "materials", materials) ||
+        !yyjson_mut_obj_add_val(doc, obj, "brushes", brushes))
+    {
+        return false;
+    }
+    for (int i = 0; i < world->material_count; ++i)
+    {
+        if (!export_add_brush_material(doc, materials, &world->materials[i]))
+            return false;
+    }
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        if (!export_add_brush(doc, brushes, world, &world->brushes[i]))
+            return false;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_data_runtime *runtime,
+                                                         const char *world_name, char **out_json, size_t *out_size,
+                                                         char *error_buffer, int error_buffer_size)
+{
+    if (out_json != NULL)
+        *out_json = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || out_json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush world export requires runtime, world name, and output");
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "brush world '%s' not found", world_name);
+        return false;
+    }
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    yyjson_mut_val *worlds = doc != NULL ? yyjson_mut_arr(doc) : NULL;
+    if (doc == NULL || root == NULL || worlds == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush world export document");
+        return false;
+    }
+
+    yyjson_mut_doc_set_root(doc, root);
+    bool ok = yyjson_mut_obj_add_strcpy(doc, root, "schema", "slayer3d.fragment.v0") &&
+              yyjson_mut_obj_add_val(doc, root, "brush_worlds", worlds) &&
+              export_add_brush_world(doc, worlds, &world_runtime->desc);
+    size_t size = 0u;
+    char *json = ok ? yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size) : NULL;
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to write brush world export JSON");
+        return false;
+    }
+
+    char *copy = (char *)SDL_malloc(size + 1u);
+    if (copy == NULL)
+    {
+        free(json);
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush world export JSON");
+        return false;
+    }
+    SDL_memcpy(copy, json, size + 1u);
+    free(json);
+    *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
 }
 
 bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtime, const char *name,
@@ -1879,6 +2168,27 @@ static void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outpu
     const char *key = json_string(outputs, key_name, NULL);
     if (props != NULL && key != NULL)
         slayer3d_properties_set_vec3(props, key, value);
+}
+
+bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    const char *world_name = json_string(action, "world", NULL);
+    char error[256];
+    error[0] = '\0';
+    char *json = NULL;
+    size_t size = 0u;
+    const bool ok = slayer3d_game_data_export_brush_world_fragment_json(runtime, world_name, &json, &size, error,
+                                                                        (int)sizeof(error));
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "brush world exported")
+                                : (error[0] != '\0' ? error : "brush world export failed"));
+    editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "json_key", ok && json != NULL ? json : "");
+    SDL_free(json);
+    return true;
 }
 
 static void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8334,6 +8334,29 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("editor.command.commit output keys must be non-empty strings"), std::string::npos)
         << error;
+
+    write_text(dir / "bad_export_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Export Action" },
+  "world": { "name": "world.bad_editor_export_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.export"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.export",
+        "actions": [
+          { "type": "editor.brush_world.export", "world": "missing.world" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_export_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -12551,6 +12574,43 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 2);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_EQ(target_cube_face_material(), "mat.editor.floor");
+
+    const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
+    ASSERT_GE(export_signal, 0);
+    slayer3d_signal_emit(slayer3d_game_session_get_signal_bus(session), export_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
+    const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
+    ASSERT_NE(export_json, nullptr);
+    EXPECT_NE(std::string(export_json).find("\"schema\": \"slayer3d.fragment.v0\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"material\": \"mat.editor.floor\""), std::string::npos);
+    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.export.size", 0), 0);
+
+    const std::filesystem::path export_dir = unique_test_dir("editor_brush_export");
+    write_text(export_dir / "fragments" / "exported.json", export_json);
+    write_text(export_dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
+    write_text(export_dir / "exported.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "imports": [{ "path": "fragments/exported.json", "sections": ["brush_worlds"] }],
+  "metadata": { "name": "Exported Brush World" },
+  "world": { "name": "world.exported", "kind": "brush" },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    slayer3d_game_session *export_session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &export_session));
+    slayer3d_game_data_runtime *export_runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((export_dir / "exported.game.json").string().c_str(), export_session,
+                                             &export_runtime, error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world exported_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(export_runtime, "brush.editor_shell.target", &exported_world));
+    ASSERT_GT(exported_world.brush_count, 0);
+    ASSERT_GT(exported_world.brushes[0].face_count, 1);
+    EXPECT_STREQ(exported_world.brushes[0].faces[1].material_name, "mat.editor.floor");
+    slayer3d_game_data_destroy(export_runtime);
+    slayer3d_game_session_destroy(export_session);
+    remove_test_dir(export_dir);
 
     press_key(SDL_SCANCODE_BACKSPACE, 15);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));


### PR DESCRIPTION
## Summary
- add a public API to export a runtime brush world as a canonical slayer3d.fragment.v0 JSON document
- add editor.brush_world.export so data-authored editor shells can publish export JSON, status, and size to scene state
- serialize brush-world materials, faces, contents, UVs, surface flags, and editor metadata so runtime translate/paint edits survive export
- extend the editor shell dojo test to export a mutated brush world, re-import it as a fragment, and verify the painted face persists

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"
- ctest --test-dir build/debug/tests --output-on-failure -R "GameData"
- git diff --check

## Next slice
The next editor slice should add a real editor document save path: either a host-facing write helper that writes exported brush fragments atomically to a chosen filesystem path, or an editor project document model that tracks source files and dirty brush worlds before writing them.