### PR TITLE
Save exported brush worlds atomically

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -784,7 +784,10 @@ brush world as a canonical `slayer3d.fragment.v0` JSON document. The export
 includes runtime editor mutations such as translated brush planes and painted
 face materials. Future editor hosts can write this JSON to their own project
 document or source-control workflow; data-authored dojos can publish it to scene
-state for validation and inspection.
+state for validation and inspection. Native editor hosts can also call
+`slayer3d_game_data_save_brush_world_fragment_file()` to atomically write the
+same fragment JSON to a chosen filesystem path. Authored game data does not get
+a direct arbitrary-file save action; file writes stay under editor host control.
 
 ```json
 {

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1918,6 +1918,19 @@ extern "C"
                                                              const char *world_name, char **out_json, size_t *out_size,
                                                              char *error_buffer, int error_buffer_size);
 
+    /**
+     * @brief Atomically save one runtime brush world as a JSON fragment file.
+     *
+     * This is the filesystem-facing companion to
+     * @ref slayer3d_game_data_export_brush_world_fragment_json for editor
+     * hosts. Parent directories are created automatically. The write uses a
+     * temporary file in the target directory and renames it into place, so
+     * callers never observe a partially written fragment.
+     */
+    bool slayer3d_game_data_save_brush_world_fragment_file(const slayer3d_game_data_runtime *runtime,
+                                                           const char *world_name, const char *path, size_t *out_size,
+                                                           char *error_buffer, int error_buffer_size);
+
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity
     {

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -12,6 +12,9 @@
 #include "slayer3d/game.h"
 #include "slayer3d/math.h"
 
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_timer.h>
 #include <stdlib.h>
 
 const char *slayer3d_game_data_active_scene(const slayer3d_game_data_runtime *runtime)
@@ -895,6 +898,154 @@ bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_dat
     SDL_memcpy(copy, json, size + 1u);
     free(json);
     *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+static bool editor_save_write_all(SDL_IOStream *stream, const void *data, size_t size)
+{
+    const Uint8 *bytes = (const Uint8 *)data;
+    size_t written = 0u;
+    while (written < size)
+    {
+        const size_t chunk = SDL_WriteIO(stream, bytes + written, size - written);
+        if (chunk == 0u)
+            return false;
+        written += chunk;
+    }
+    return true;
+}
+
+static bool editor_save_make_directory_recursive(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+
+    SDL_PathInfo info;
+    SDL_zero(info);
+    if (SDL_GetPathInfo(path, &info))
+        return info.type == SDL_PATHTYPE_DIRECTORY;
+
+    char *copy = SDL_strdup(path);
+    if (copy == NULL)
+        return false;
+
+    bool ok = true;
+    for (char *p = copy + 1; *p != '\0'; ++p)
+    {
+        if (*p != '/' && *p != '\\')
+            continue;
+        const char saved = *p;
+        *p = '\0';
+        if (copy[0] != '\0')
+        {
+            SDL_zero(info);
+            if (!SDL_GetPathInfo(copy, &info))
+                ok = SDL_CreateDirectory(copy);
+            else
+                ok = info.type == SDL_PATHTYPE_DIRECTORY;
+        }
+        *p = saved;
+        if (!ok)
+            break;
+    }
+
+    if (ok)
+    {
+        SDL_zero(info);
+        if (!SDL_GetPathInfo(copy, &info))
+            ok = SDL_CreateDirectory(copy);
+        else
+            ok = info.type == SDL_PATHTYPE_DIRECTORY;
+    }
+
+    SDL_free(copy);
+    return ok;
+}
+
+static char *editor_save_parent_directory(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    const char *slash = SDL_strrchr(path, '/');
+    const char *backslash = SDL_strrchr(path, '\\');
+    if (backslash != NULL && (slash == NULL || backslash > slash))
+        slash = backslash;
+    if (slash == NULL)
+        return SDL_strdup(".");
+    const size_t len = (size_t)(slash - path);
+    if (len == 0u)
+        return SDL_strdup("/");
+    char *parent = (char *)SDL_malloc(len + 1u);
+    if (parent == NULL)
+        return NULL;
+    SDL_memcpy(parent, path, len);
+    parent[len] = '\0';
+    return parent;
+}
+
+bool slayer3d_game_data_save_brush_world_fragment_file(const slayer3d_game_data_runtime *runtime,
+                                                       const char *world_name, const char *path, size_t *out_size,
+                                                       char *error_buffer, int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush world save requires a filesystem path");
+        return false;
+    }
+
+    char *json = NULL;
+    size_t size = 0u;
+    if (!slayer3d_game_data_export_brush_world_fragment_json(runtime, world_name, &json, &size, error_buffer,
+                                                             error_buffer_size))
+    {
+        return false;
+    }
+
+    char *parent = editor_save_parent_directory(path);
+    if (parent == NULL || !editor_save_make_directory_recursive(parent))
+    {
+        SDL_free(parent);
+        SDL_free(json);
+        set_error(error_buffer, error_buffer_size, "failed to create brush world save directory");
+        return false;
+    }
+    SDL_free(parent);
+
+    bool ok = false;
+    char temp_path[4096];
+    for (int attempt = 0; attempt < 16 && !ok; ++attempt)
+    {
+        SDL_snprintf(temp_path, sizeof(temp_path), "%s.tmp.%llu.%d", path, (unsigned long long)SDL_GetTicksNS(),
+                     attempt);
+        SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
+        if (stream == NULL)
+            continue;
+        ok = editor_save_write_all(stream, json, size) && SDL_FlushIO(stream);
+        ok = SDL_CloseIO(stream) && ok;
+        if (!ok)
+        {
+            SDL_RemovePath(temp_path);
+            continue;
+        }
+        if (!SDL_RenamePath(temp_path, path))
+        {
+            SDL_RemovePath(path);
+            ok = SDL_RenamePath(temp_path, path);
+        }
+        if (!ok)
+            SDL_RemovePath(temp_path);
+    }
+
+    SDL_free(json);
+    if (!ok)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to save brush world fragment");
+        return false;
+    }
     if (out_size != NULL)
         *out_size = size;
     return true;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12586,13 +12586,19 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.export.size", 0), 0);
 
     const std::filesystem::path export_dir = unique_test_dir("editor_brush_export");
-    write_text(export_dir / "fragments" / "exported.json", export_json);
+    size_t saved_size = 0U;
+    const std::filesystem::path saved_path = export_dir / "saved" / "world.fragment.json";
+    ASSERT_TRUE(slayer3d_game_data_save_brush_world_fragment_file(
+        runtime, "brush.editor_shell.target", saved_path.string().c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    EXPECT_GT(saved_size, 0U);
+    EXPECT_TRUE(std::filesystem::exists(saved_path));
     write_text(export_dir / "scenes" / "play.scene.json",
                R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
     write_text(export_dir / "exported.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
-  "imports": [{ "path": "fragments/exported.json", "sections": ["brush_worlds"] }],
+  "imports": [{ "path": "saved/world.fragment.json", "sections": ["brush_worlds"] }],
   "metadata": { "name": "Exported Brush World" },
   "world": { "name": "world.exported", "kind": "brush" },
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }


### PR DESCRIPTION
## Summary
- add a host-facing API for atomically saving exported brush-world fragments to filesystem paths
- create parent directories and write through a same-directory temporary file before rename
- document that arbitrary file writes stay under native editor host control, not authored game data
- extend the editor shell test to save a painted brush world fragment, import it back, and verify the material persists

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"
- ctest --test-dir build/debug/tests --output-on-failure -R "GameData"
- git diff --check

## Next slice
Add editor dirty-state/source tracking for brush worlds: mark worlds dirty after translate/paint, publish dirty status to scene state, and let editor hosts clear it after saving.