### PR TITLE
Track dirty brush world editor state

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -220,7 +220,11 @@
               "element_key": "editor.transaction.element",
               "face_index_key": "editor.transaction.face_index",
               "bounds_min_key": "editor.transaction.bounds_min",
-              "bounds_max_key": "editor.transaction.bounds_max"
+              "bounds_max_key": "editor.transaction.bounds_max",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision",
+              "saved_revision_key": "editor.brush_world.saved_revision",
+              "source_path_key": "editor.brush_world.source_path"
             },
             "actions": [
               {
@@ -253,7 +257,11 @@
               "target_key": "editor.transaction.target",
               "world_key": "editor.transaction.world",
               "element_key": "editor.transaction.element",
-              "face_index_key": "editor.transaction.face_index"
+              "face_index_key": "editor.transaction.face_index",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision",
+              "saved_revision_key": "editor.brush_world.saved_revision",
+              "source_path_key": "editor.brush_world.source_path"
             },
             "actions": [
               {
@@ -284,7 +292,11 @@
               "target_key": "editor.transaction.target",
               "world_key": "editor.transaction.world",
               "element_key": "editor.transaction.element",
-              "face_index_key": "editor.transaction.face_index"
+              "face_index_key": "editor.transaction.face_index",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision",
+              "saved_revision_key": "editor.brush_world.saved_revision",
+              "source_path_key": "editor.brush_world.source_path"
             },
             "actions": [
               {
@@ -307,7 +319,12 @@
               "valid_key": "editor.export.valid",
               "message_key": "editor.export.message",
               "json_key": "editor.export.json",
-              "size_key": "editor.export.size"
+              "size_key": "editor.export.size",
+              "world_key": "editor.brush_world.name",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision",
+              "saved_revision_key": "editor.brush_world.saved_revision",
+              "source_path_key": "editor.brush_world.source_path"
             }
           }
         ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -743,6 +743,10 @@ targeting a brush `face` replace that face's material and rebuild the compiled
 render mesh. Undo and redo apply the inverse/forward mutation and move the
 command-history cursor. Other command names are accepted as transaction records
 so editor UI can be authored ahead of future mutation implementations.
+Successful brush-world mutations mark the affected runtime brush world dirty and
+increment its editor revision. Transaction outputs can publish `dirty_key`,
+`revision_key`, `saved_revision_key`, and `source_path_key` alongside the
+transaction payload so editor UI can show unsaved state without host-specific C.
 
 ```json
 {
@@ -786,8 +790,11 @@ face materials. Future editor hosts can write this JSON to their own project
 document or source-control workflow; data-authored dojos can publish it to scene
 state for validation and inspection. Native editor hosts can also call
 `slayer3d_game_data_save_brush_world_fragment_file()` to atomically write the
-same fragment JSON to a chosen filesystem path. Authored game data does not get
-a direct arbitrary-file save action; file writes stay under editor host control.
+same fragment JSON to a chosen filesystem path; a successful save marks the
+world clean and records the saved source path. Hosts that save through their own
+project pipeline can call `slayer3d_game_data_mark_brush_world_saved()` after
+their write commits. Authored game data does not get a direct arbitrary-file
+save action; file writes stay under editor host control.
 
 ```json
 {
@@ -798,6 +805,24 @@ a direct arbitrary-file save action; file writes stay under editor host control.
     "message_key": "editor.export.message",
     "json_key": "editor.export.json",
     "size_key": "editor.export.size"
+  }
+}
+```
+
+Use `editor.brush_world.status` to publish the current dirty/source state of a
+brush world without exporting its JSON. Outputs support `valid_key`,
+`message_key`, `world_key`, `dirty_key`, `revision_key`, `saved_revision_key`,
+and `source_path_key`.
+
+```json
+{
+  "type": "editor.brush_world.status",
+  "world": "brush.level.blockout",
+  "outputs": {
+    "dirty_key": "editor.brush_world.dirty",
+    "revision_key": "editor.brush_world.revision",
+    "saved_revision_key": "editor.brush_world.saved_revision",
+    "source_path_key": "editor.brush_world.source_path"
   }
 }
 ```

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1892,6 +1892,40 @@ extern "C"
     bool slayer3d_game_data_get_active_editor_selection(const slayer3d_game_data_runtime *runtime,
                                                         slayer3d_game_data_editor_selection *out_selection);
 
+    /** @brief Runtime editor state for one mutable brush world. */
+    typedef struct slayer3d_game_data_brush_world_editor_state
+    {
+        /** @brief Brush world name. Pointer is runtime-owned. */
+        const char *world_name;
+        /** @brief Last known host save/source path, or NULL when unknown. Pointer is runtime-owned. */
+        const char *source_path;
+        /** @brief True when runtime mutations have not been marked saved. */
+        bool dirty;
+        /** @brief Monotonic runtime mutation revision. */
+        Uint64 revision;
+        /** @brief Revision that was last marked saved. */
+        Uint64 saved_revision;
+    } slayer3d_game_data_brush_world_editor_state;
+
+    /**
+     * @brief Query editor save state for one runtime brush world.
+     *
+     * The returned pointers are runtime-owned and remain valid until the brush
+     * world is saved/marked saved again or the runtime is destroyed.
+     */
+    bool slayer3d_game_data_get_brush_world_editor_state(const slayer3d_game_data_runtime *runtime,
+                                                         const char *world_name,
+                                                         slayer3d_game_data_brush_world_editor_state *out_state);
+
+    /**
+     * @brief Mark one runtime brush world as saved by an editor host.
+     *
+     * @p source_path may be NULL to keep the existing source path, or a
+     * filesystem path to associate with the saved revision.
+     */
+    bool slayer3d_game_data_mark_brush_world_saved(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                   const char *source_path, char *error_buffer, int error_buffer_size);
+
     /**
      * @brief Iterate data-authored editor debug primitives for the active scene.
      *
@@ -1925,11 +1959,12 @@ extern "C"
      * @ref slayer3d_game_data_export_brush_world_fragment_json for editor
      * hosts. Parent directories are created automatically. The write uses a
      * temporary file in the target directory and renames it into place, so
-     * callers never observe a partially written fragment.
+     * callers never observe a partially written fragment. On success the brush
+     * world is marked saved and @p path becomes its editor source path.
      */
-    bool slayer3d_game_data_save_brush_world_fragment_file(const slayer3d_game_data_runtime *runtime,
-                                                           const char *world_name, const char *path, size_t *out_size,
-                                                           char *error_buffer, int error_buffer_size);
+    bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                           const char *path, size_t *out_size, char *error_buffer,
+                                                           int error_buffer_size);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -300,6 +300,7 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     {
         slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
         slayer3d_free_model(&runtime->brush_worlds[i].render_model);
+        SDL_free(runtime->brush_worlds[i].editor_source_path);
         free_editor_metadata(&world->editor);
         SDL_free((void *)world->name);
         SDL_free((void *)world->units);

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -224,6 +224,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.brush_world.export") == 0)
         return slayer3d_game_data_export_editor_brush_world_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.brush_world.status") == 0)
+        return slayer3d_game_data_publish_editor_brush_world_status_action(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -420,6 +420,10 @@ typedef struct brush_world_runtime
 {
     slayer3d_game_data_brush_world desc;
     slayer3d_model render_model;
+    char *editor_source_path;
+    Uint64 editor_revision;
+    Uint64 editor_saved_revision;
+    bool editor_dirty;
 } brush_world_runtime;
 
 typedef struct sector_door_runtime
@@ -844,6 +848,8 @@ bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime,
 bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                             const slayer3d_properties *payload);
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
+                                                                 yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8138,9 +8138,10 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "%s outputs must be an object", type);
         static const char *const output_keys[] = {
-            "valid_key",      "event_key",      "message_key",   "transaction_id_key", "undo_count_key",
-            "redo_count_key", "command_key",    "target_key",    "world_key",          "element_key",
-            "face_index_key", "bounds_min_key", "bounds_max_key"};
+            "valid_key",      "event_key",         "message_key",    "transaction_id_key", "undo_count_key",
+            "redo_count_key", "command_key",       "target_key",     "world_key",          "element_key",
+            "face_index_key", "bounds_min_key",    "bounds_max_key", "source_path_key",    "dirty_key",
+            "revision_key",   "saved_revision_key"};
         for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
         {
             yyjson_val *output = obj_get(outputs, output_keys[i]);
@@ -8164,13 +8165,36 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *outputs = obj_get(action, "outputs");
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "editor.brush_world.export outputs must be an object");
-        static const char *const output_keys[] = {"valid_key", "message_key", "json_key", "size_key"};
+        static const char *const output_keys[] = {"valid_key", "message_key",  "json_key",
+                                                  "size_key",  "world_key",    "source_path_key",
+                                                  "dirty_key", "revision_key", "saved_revision_key"};
         for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
         {
             yyjson_val *output = obj_get(outputs, output_keys[i]);
             if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
                 return validation_error(ctx, json_path,
                                         "editor.brush_world.export output keys must be non-empty strings");
+        }
+        return true;
+    }
+    if (SDL_strcmp(type, "editor.brush_world.status") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        yyjson_val *message = obj_get(action, "message");
+        if (message != NULL && !yyjson_is_str(message))
+            return validation_error(ctx, json_path, "editor.brush_world.status message must be a string");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.brush_world.status outputs must be an object");
+        static const char *const output_keys[] = {"valid_key", "message_key",  "world_key",         "source_path_key",
+                                                  "dirty_key", "revision_key", "saved_revision_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.brush_world.status output keys must be non-empty strings");
         }
         return true;
     }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -616,6 +616,72 @@ const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_run
     return find_brush_world_runtime_mutable((slayer3d_game_data_runtime *)runtime, name);
 }
 
+static bool editor_brush_world_set_source_path(brush_world_runtime *world_runtime, const char *source_path)
+{
+    if (world_runtime == NULL || source_path == NULL)
+        return world_runtime != NULL;
+
+    char *copy = SDL_strdup(source_path);
+    if (copy == NULL)
+        return false;
+    SDL_free(world_runtime->editor_source_path);
+    world_runtime->editor_source_path = copy;
+    return true;
+}
+
+static void editor_brush_world_mark_dirty(brush_world_runtime *world_runtime)
+{
+    if (world_runtime == NULL)
+        return;
+    if (world_runtime->editor_revision < SDL_MAX_UINT64)
+        world_runtime->editor_revision++;
+    world_runtime->editor_dirty = true;
+}
+
+static bool editor_brush_world_mark_saved(brush_world_runtime *world_runtime, const char *source_path)
+{
+    if (world_runtime == NULL)
+        return false;
+    if (!editor_brush_world_set_source_path(world_runtime, source_path))
+        return false;
+    world_runtime->editor_saved_revision = world_runtime->editor_revision;
+    world_runtime->editor_dirty = false;
+    return true;
+}
+
+bool slayer3d_game_data_get_brush_world_editor_state(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                     slayer3d_game_data_brush_world_editor_state *out_state)
+{
+    if (out_state != NULL)
+        SDL_zero(*out_state);
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL || out_state == NULL)
+        return false;
+    out_state->world_name = world_runtime->desc.name;
+    out_state->source_path = world_runtime->editor_source_path;
+    out_state->dirty = world_runtime->editor_dirty;
+    out_state->revision = world_runtime->editor_revision;
+    out_state->saved_revision = world_runtime->editor_saved_revision;
+    return true;
+}
+
+bool slayer3d_game_data_mark_brush_world_saved(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                               const char *source_path, char *error_buffer, int error_buffer_size)
+{
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush world not found");
+        return false;
+    }
+    if (!editor_brush_world_mark_saved(world_runtime, source_path))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to update brush world save state");
+        return false;
+    }
+    return true;
+}
+
 static bool export_add_vec3(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec3 value)
 {
     yyjson_mut_val *arr = yyjson_mut_arr(doc);
@@ -985,9 +1051,9 @@ static char *editor_save_parent_directory(const char *path)
     return parent;
 }
 
-bool slayer3d_game_data_save_brush_world_fragment_file(const slayer3d_game_data_runtime *runtime,
-                                                       const char *world_name, const char *path, size_t *out_size,
-                                                       char *error_buffer, int error_buffer_size)
+bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                       const char *path, size_t *out_size, char *error_buffer,
+                                                       int error_buffer_size)
 {
     if (out_size != NULL)
         *out_size = 0u;
@@ -1046,6 +1112,8 @@ bool slayer3d_game_data_save_brush_world_fragment_file(const slayer3d_game_data_
         set_error(error_buffer, error_buffer_size, "failed to save brush world fragment");
         return false;
     }
+    if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size))
+        return false;
     if (out_size != NULL)
         *out_size = size;
     return true;
@@ -2321,6 +2389,37 @@ static void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outpu
         slayer3d_properties_set_vec3(props, key, value);
 }
 
+static int editor_revision_to_int(Uint64 revision)
+{
+    return revision > (Uint64)SDL_MAX_SINT32 ? SDL_MAX_SINT32 : (int)revision;
+}
+
+static bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
+                                              const char *world_name, const char *message, bool publish_result)
+{
+    if (runtime == NULL || outputs == NULL)
+        return true;
+
+    slayer3d_game_data_brush_world_editor_state state;
+    const bool ok = slayer3d_game_data_get_brush_world_editor_state(runtime, world_name, &state);
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    if (publish_result)
+    {
+        editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+        editor_set_string_output(scene_state, outputs, "message_key",
+                                 ok ? (message != NULL ? message : "brush world status published")
+                                    : "brush world status unavailable");
+    }
+    editor_set_string_output(scene_state, outputs, "world_key", ok && state.world_name != NULL ? state.world_name : "");
+    editor_set_string_output(scene_state, outputs, "source_path_key",
+                             ok && state.source_path != NULL ? state.source_path : "");
+    editor_set_bool_output(scene_state, outputs, "dirty_key", ok && state.dirty);
+    editor_set_int_output(scene_state, outputs, "revision_key", ok ? editor_revision_to_int(state.revision) : 0);
+    editor_set_int_output(scene_state, outputs, "saved_revision_key",
+                          ok ? editor_revision_to_int(state.saved_revision) : 0);
+    return ok;
+}
+
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     yyjson_val *outputs = obj_get(action, "outputs");
@@ -2338,8 +2437,16 @@ bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runt
                                 : (error[0] != '\0' ? error : "brush world export failed"));
     editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
     editor_set_string_output(scene_state, outputs, "json_key", ok && json != NULL ? json : "");
+    (void)publish_editor_brush_world_status(runtime, outputs, world_name, NULL, false);
     SDL_free(json);
     return true;
+}
+
+bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
+                                                                 yyjson_val *action)
+{
+    return publish_editor_brush_world_status(runtime, obj_get(action, "outputs"), json_string(action, "world", NULL),
+                                             json_string(action, "message", "brush world status published"), true);
 }
 
 static void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
@@ -2761,6 +2868,8 @@ static void publish_editor_transaction(slayer3d_game_data_runtime *runtime, yyjs
     editor_set_vec3_output(scene_state, outputs, "bounds_max_key",
                            valid && entry != NULL && entry->has_bounds ? entry->bounds.max
                                                                        : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    (void)publish_editor_brush_world_status(runtime, outputs, valid && entry != NULL ? entry->world_name : NULL, NULL,
+                                            false);
 }
 
 static bool run_editor_transaction_action_array(slayer3d_game_data_runtime *runtime, yyjson_val *actions,
@@ -2919,7 +3028,10 @@ static bool apply_editor_brush_translate(slayer3d_game_data_runtime *runtime,
 
     translate_editor_brush_planes(brush, offset);
     if (rebuild_editor_brush_world(world_runtime))
+    {
+        editor_brush_world_mark_dirty(world_runtime);
         return true;
+    }
 
     translate_editor_brush_planes(brush, slayer3d_vec3_scale(offset, -1.0f));
     (void)rebuild_editor_brush_world(world_runtime);
@@ -2956,7 +3068,10 @@ static bool apply_editor_brush_paint(slayer3d_game_data_runtime *runtime, const 
     if (!set_editor_brush_face_material(world_runtime, brush, entry->face_index, material_index))
         return false;
     if (rebuild_editor_brush_world(world_runtime))
+    {
+        editor_brush_world_mark_dirty(world_runtime);
         return true;
+    }
 
     (void)set_editor_brush_face_material(world_runtime, brush, entry->face_index, rollback_index);
     (void)rebuild_editor_brush_world(world_runtime);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8357,6 +8357,29 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_export_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
+
+    write_text(dir / "bad_status_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Status Action" },
+  "world": { "name": "world.bad_editor_status_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.status"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.status",
+        "actions": [
+          { "type": "editor.brush_world.status", "world": "missing.world" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_status_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -12355,6 +12378,13 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_data_editor_selection active_selection{};
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
     EXPECT_STREQ(active_selection.element_name, "brush.target.cube");
+    slayer3d_game_data_brush_world_editor_state editor_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &editor_state));
+    EXPECT_STREQ(editor_state.world_name, "brush.editor_shell.target");
+    EXPECT_EQ(editor_state.source_path, nullptr);
+    EXPECT_FALSE(editor_state.dirty);
+    EXPECT_EQ(editor_state.revision, 0U);
+    EXPECT_EQ(editor_state.saved_revision, 0U);
 
     auto press_key = [&](SDL_Scancode scancode, Uint64 frame) {
         SDL_Event key{};
@@ -12508,6 +12538,13 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.element", ""), "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "commit translate #1");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 0);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &editor_state));
+    EXPECT_TRUE(editor_state.dirty);
+    EXPECT_EQ(editor_state.revision, 1U);
+    EXPECT_EQ(editor_state.saved_revision, 0U);
     EXPECT_NEAR(target_cube_min_y(), 0.35f, 0.001f);
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
     ASSERT_TRUE(active_selection.has_bounds);
@@ -12584,15 +12621,25 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_NE(std::string(export_json).find("\"schema\": \"slayer3d.fragment.v0\""), std::string::npos);
     EXPECT_NE(std::string(export_json).find("\"material\": \"mat.editor.floor\""), std::string::npos);
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.export.size", 0), 0);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 6);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 0);
 
     const std::filesystem::path export_dir = unique_test_dir("editor_brush_export");
     size_t saved_size = 0U;
     const std::filesystem::path saved_path = export_dir / "saved" / "world.fragment.json";
+    const std::string saved_path_string = saved_path.string();
     ASSERT_TRUE(slayer3d_game_data_save_brush_world_fragment_file(
-        runtime, "brush.editor_shell.target", saved_path.string().c_str(), &saved_size, error, sizeof(error)))
+        runtime, "brush.editor_shell.target", saved_path_string.c_str(), &saved_size, error, sizeof(error)))
         << error;
     EXPECT_GT(saved_size, 0U);
     EXPECT_TRUE(std::filesystem::exists(saved_path));
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &editor_state));
+    EXPECT_FALSE(editor_state.dirty);
+    EXPECT_EQ(editor_state.revision, 6U);
+    EXPECT_EQ(editor_state.saved_revision, 6U);
+    ASSERT_NE(editor_state.source_path, nullptr);
+    EXPECT_EQ(std::string(editor_state.source_path), saved_path_string);
     write_text(export_dir / "scenes" / "play.scene.json",
                R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
     write_text(export_dir / "exported.game.json",


### PR DESCRIPTION
## Summary
- track dirty/source/revision state on runtime brush worlds after successful editor mutations
- expose host APIs to query brush-world editor state and mark a world saved
- mark worlds clean after successful atomic fragment saves
- publish dirty/source state through editor transaction/export outputs and a new editor.brush_world.status action
- update the editor shell dojo, validation, docs, and tests for the dirty-state workflow

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorShellDojoPublishesSelectionAndDebugOverlay)"
- ctest --test-dir build/debug/tests --output-on-failure -R "GameData"
- git diff --check

## Next slice
Add editor creation primitives for brush blockout work: data actions/API to create a new convex box brush from bounds/material, append it to a brush world, rebuild acceleration/render data, mark the world dirty, and cover it with import/export round-trip tests.