### PR TITLE
Add editor box brush creation

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -706,6 +706,32 @@ pinned or current selection. It supplies payload fields such as
 `selection_point`, and `selection_normal`. `editor.selection.clear` clears the
 active selection and republishes the scene's `outputs` as an empty selection.
 
+Use `editor.brush_world.create_box` to append a new axis-aligned convex box
+brush to a runtime brush world. The action is intended for first-pass editor
+blockout tools: floors, walls, ceilings, platforms, and simple room pieces. It
+validates the target world and bounds at load time, resolves the material at
+runtime, rebuilds brush collision/render data atomically, then marks the world
+dirty only after the rebuild succeeds. If `name` is omitted, the runtime
+generates a unique brush name under the target world.
+
+```json
+{
+  "type": "editor.brush_world.create_box",
+  "world": "brush.level.blockout",
+  "name": "brush.room_01.floor",
+  "material": "mat.stone_floor",
+  "min": [-4.0, -0.25, -4.0],
+  "max": [4.0, 0.0, 4.0],
+  "outputs": {
+    "valid_key": "editor.create.valid",
+    "message_key": "editor.create.message",
+    "brush_key": "editor.create.brush",
+    "dirty_key": "editor.brush_world.dirty",
+    "revision_key": "editor.brush_world.revision"
+  }
+}
+```
+
 Use `editor.command.preview` to declare a non-mutating command intent against
 the active selection. This is the safe scaffolding layer for editor tools:
 commands can publish UI state and draw preview bounds without modifying the

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1926,6 +1926,36 @@ extern "C"
     bool slayer3d_game_data_mark_brush_world_saved(slayer3d_game_data_runtime *runtime, const char *world_name,
                                                    const char *source_path, char *error_buffer, int error_buffer_size);
 
+    /** @brief Descriptor for creating one axis-aligned convex box brush. */
+    typedef struct slayer3d_game_data_create_box_brush_desc
+    {
+        /** @brief Target brush world name. Required. */
+        const char *world_name;
+        /** @brief Optional brush name. If NULL/empty, a unique editor name is generated. */
+        const char *brush_name;
+        /** @brief Brush material assigned to all six faces. Required. */
+        const char *material_name;
+        /** @brief Minimum XYZ corner. Each component must be less than @p max. */
+        slayer3d_vec3 min;
+        /** @brief Maximum XYZ corner. Each component must be greater than @p min. */
+        slayer3d_vec3 max;
+        /** @brief Brush contents bitmask. Zero defaults to solid. */
+        unsigned int contents;
+    } slayer3d_game_data_create_box_brush_desc;
+
+    /**
+     * @brief Append one axis-aligned box brush to a runtime brush world.
+     *
+     * The operation is atomic from the runtime caller's perspective: the brush
+     * is visible only after allocations, acceleration rebuild, and render-model
+     * compilation all succeed. Success marks the brush world dirty and
+     * increments its editor revision. @p out_brush_name receives the final
+     * runtime brush name when non-NULL.
+     */
+    bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
+                                             const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,
+                                             size_t out_brush_name_size, char *error_buffer, int error_buffer_size);
+
     /**
      * @brief Iterate data-authored editor debug primitives for the active scene.
      *

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -227,6 +227,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
         return slayer3d_game_data_publish_editor_brush_world_status_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.brush_world.create_box") == 0)
+        return slayer3d_game_data_create_box_brush_action(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -850,6 +850,7 @@ bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime,
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
                                                                  yyjson_val *action);
+bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8198,6 +8198,43 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.brush_world.create_box") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        if (!is_non_empty_string(action, "material"))
+            return validation_error(ctx, json_path, "editor.brush_world.create_box requires a non-empty material");
+        yyjson_val *name = obj_get(action, "name");
+        if (name != NULL && (!yyjson_is_str(name) || yyjson_get_str(name)[0] == '\0'))
+            return validation_error(ctx, json_path,
+                                    "editor.brush_world.create_box name must be non-empty when present");
+        yyjson_val *min = obj_get(action, "min");
+        yyjson_val *max = obj_get(action, "max");
+        if (!is_exact_vec_array(min, 3) || !is_exact_vec_array(max, 3))
+            return validation_error(ctx, json_path, "editor.brush_world.create_box requires min and max vec3 values");
+        const double min_x = yyjson_get_num(yyjson_arr_get(min, 0));
+        const double min_y = yyjson_get_num(yyjson_arr_get(min, 1));
+        const double min_z = yyjson_get_num(yyjson_arr_get(min, 2));
+        const double max_x = yyjson_get_num(yyjson_arr_get(max, 0));
+        const double max_y = yyjson_get_num(yyjson_arr_get(max, 1));
+        const double max_z = yyjson_get_num(yyjson_arr_get(max, 2));
+        if (!(min_x < max_x && min_y < max_y && min_z < max_z))
+            return validation_error(ctx, json_path, "editor.brush_world.create_box bounds require min < max");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.brush_world.create_box outputs must be an object");
+        static const char *const output_keys[] = {"valid_key",    "message_key",       "brush_key",
+                                                  "world_key",    "source_path_key",   "dirty_key",
+                                                  "revision_key", "saved_revision_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.brush_world.create_box output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -616,6 +616,8 @@ const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_run
     return find_brush_world_runtime_mutable((slayer3d_game_data_runtime *)runtime, name);
 }
 
+static int find_editor_brush_material_index(const brush_world_runtime *world_runtime, const char *material_name);
+
 static bool editor_brush_world_set_source_path(brush_world_runtime *world_runtime, const char *source_path)
 {
     if (world_runtime == NULL || source_path == NULL)
@@ -646,6 +648,202 @@ static bool editor_brush_world_mark_saved(brush_world_runtime *world_runtime, co
         return false;
     world_runtime->editor_saved_revision = world_runtime->editor_revision;
     world_runtime->editor_dirty = false;
+    return true;
+}
+
+static bool editor_brush_world_name_exists(const brush_world_runtime *world_runtime, const char *brush_name)
+{
+    if (world_runtime == NULL || brush_name == NULL || brush_name[0] == '\0')
+        return false;
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[i];
+        if (brush->name != NULL && SDL_strcmp(brush->name, brush_name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool editor_brush_world_generate_brush_name(const brush_world_runtime *world_runtime, char *buffer,
+                                                   size_t buffer_size)
+{
+    if (world_runtime == NULL || buffer == NULL || buffer_size == 0u)
+        return false;
+    const char *world_name = world_runtime->desc.name != NULL ? world_runtime->desc.name : "brush_world";
+    for (int i = 0; i < 1000000; ++i)
+    {
+        SDL_snprintf(buffer, buffer_size, "%s.box.%d", world_name, i + 1);
+        if (buffer[0] == '\0')
+            return false;
+        if (!editor_brush_world_name_exists(world_runtime, buffer))
+            return true;
+    }
+    return false;
+}
+
+static void free_editor_runtime_brush(slayer3d_game_data_brush *brush)
+{
+    if (brush == NULL)
+        return;
+    SDL_free((void *)brush->name);
+    for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
+        SDL_free((void *)brush->tags[tag_index]);
+    SDL_free((void *)brush->tags);
+    for (int face_index = 0; face_index < brush->face_count; ++face_index)
+    {
+        slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[face_index];
+        free_editor_metadata(&face->editor);
+    }
+    SDL_free((void *)brush->faces);
+    free_editor_metadata(&brush->editor);
+    SDL_zero(*brush);
+}
+
+static void init_box_brush_face(slayer3d_game_data_brush_face *face, slayer3d_vec3 normal, float distance,
+                                int material_index, const char *material_name)
+{
+    SDL_zero(*face);
+    face->normal = normal;
+    face->distance = distance;
+    face->material_index = material_index;
+    face->material_name = material_name;
+    face->uv_scale[0] = 1.0f;
+    face->uv_scale[1] = 1.0f;
+}
+
+static bool init_editor_box_brush(const brush_world_runtime *world_runtime,
+                                  const slayer3d_game_data_create_box_brush_desc *desc, const char *brush_name,
+                                  int material_index, slayer3d_game_data_brush *out_brush)
+{
+    if (world_runtime == NULL || desc == NULL || brush_name == NULL || out_brush == NULL || material_index < 0 ||
+        material_index >= world_runtime->desc.material_count)
+    {
+        return false;
+    }
+
+    SDL_zero(*out_brush);
+    out_brush->name = SDL_strdup(brush_name);
+    out_brush->contents = desc->contents != 0u ? desc->contents : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    out_brush->face_count = 6;
+    out_brush->faces = (slayer3d_game_data_brush_face *)SDL_calloc(6u, sizeof(*out_brush->faces));
+    if (out_brush->name == NULL || out_brush->faces == NULL)
+    {
+        free_editor_runtime_brush(out_brush);
+        return false;
+    }
+
+    const char *material_name = world_runtime->desc.materials[material_index].name;
+    slayer3d_game_data_brush_face *faces = (slayer3d_game_data_brush_face *)out_brush->faces;
+    init_box_brush_face(&faces[0], slayer3d_vec3_make(1.0f, 0.0f, 0.0f), desc->max.x, material_index, material_name);
+    init_box_brush_face(&faces[1], slayer3d_vec3_make(-1.0f, 0.0f, 0.0f), -desc->min.x, material_index, material_name);
+    init_box_brush_face(&faces[2], slayer3d_vec3_make(0.0f, 1.0f, 0.0f), desc->max.y, material_index, material_name);
+    init_box_brush_face(&faces[3], slayer3d_vec3_make(0.0f, -1.0f, 0.0f), -desc->min.y, material_index, material_name);
+    init_box_brush_face(&faces[4], slayer3d_vec3_make(0.0f, 0.0f, 1.0f), desc->max.z, material_index, material_name);
+    init_box_brush_face(&faces[5], slayer3d_vec3_make(0.0f, 0.0f, -1.0f), -desc->min.z, material_index, material_name);
+    return true;
+}
+
+bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
+                                         const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,
+                                         size_t out_brush_name_size, char *error_buffer, int error_buffer_size)
+{
+    if (out_brush_name != NULL && out_brush_name_size > 0u)
+        out_brush_name[0] = '\0';
+    if (runtime == NULL || desc == NULL || desc->world_name == NULL || desc->world_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "box brush creation requires a brush world");
+        return false;
+    }
+    if (desc->material_name == NULL || desc->material_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "box brush creation requires a material");
+        return false;
+    }
+    if (!(desc->min.x < desc->max.x && desc->min.y < desc->max.y && desc->min.z < desc->max.z))
+    {
+        set_error(error_buffer, error_buffer_size, "box brush bounds must have min < max on all axes");
+        return false;
+    }
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, desc->world_name);
+    if (world_runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush world not found");
+        return false;
+    }
+    const int material_index = find_editor_brush_material_index(world_runtime, desc->material_name);
+    if (material_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "box brush material not found");
+        return false;
+    }
+
+    char generated_name[256];
+    const char *brush_name = desc->brush_name;
+    if (brush_name == NULL || brush_name[0] == '\0')
+    {
+        if (!editor_brush_world_generate_brush_name(world_runtime, generated_name, sizeof(generated_name)))
+        {
+            set_error(error_buffer, error_buffer_size, "failed to generate box brush name");
+            return false;
+        }
+        brush_name = generated_name;
+    }
+    else if (editor_brush_world_name_exists(world_runtime, brush_name))
+    {
+        set_error(error_buffer, error_buffer_size, "box brush name already exists");
+        return false;
+    }
+
+    slayer3d_game_data_brush new_brush;
+    if (!init_editor_box_brush(world_runtime, desc, brush_name, material_index, &new_brush))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate box brush");
+        return false;
+    }
+
+    slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    slayer3d_game_data_brush *old_brushes = (slayer3d_game_data_brush *)world->brushes;
+    const int old_count = world->brush_count;
+    slayer3d_game_data_brush *brushes =
+        (slayer3d_game_data_brush *)SDL_calloc((size_t)old_count + 1u, sizeof(*brushes));
+    if (brushes == NULL)
+    {
+        free_editor_runtime_brush(&new_brush);
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush world entries");
+        return false;
+    }
+    if (old_count > 0)
+        SDL_memcpy(brushes, old_brushes, sizeof(*brushes) * (size_t)old_count);
+    brushes[old_count] = new_brush;
+    world->brushes = brushes;
+    world->brush_count = old_count + 1;
+
+    slayer3d_model render_model;
+    SDL_zero(render_model);
+    const bool rebuilt = slayer3d_game_data_brush_world_build_acceleration(world) &&
+                         slayer3d_game_data_brush_world_compile_render_model(world, &render_model);
+    if (!rebuilt)
+    {
+        slayer3d_free_model(&render_model);
+        world->brushes = old_brushes;
+        world->brush_count = old_count;
+        free_editor_runtime_brush(&brushes[old_count]);
+        SDL_free(brushes);
+        (void)slayer3d_game_data_brush_world_build_acceleration(world);
+        set_error(error_buffer, error_buffer_size, "failed to rebuild brush world after box creation");
+        return false;
+    }
+
+    SDL_free(old_brushes);
+    slayer3d_free_model(&world_runtime->render_model);
+    world_runtime->render_model = render_model;
+    world->render_model = &world_runtime->render_model;
+    editor_brush_world_mark_dirty(world_runtime);
+    if (out_brush_name != NULL && out_brush_name_size > 0u)
+        SDL_strlcpy(out_brush_name, brushes[old_count].name != NULL ? brushes[old_count].name : "",
+                    out_brush_name_size);
     return true;
 }
 
@@ -2332,7 +2530,6 @@ static bool editor_command_target_name_valid(const char *target)
                               SDL_strcmp(target, "material") == 0);
 }
 
-static int find_editor_brush_material_index(const brush_world_runtime *world_runtime, const char *material_name);
 static bool resolve_editor_paint_material(slayer3d_game_data_runtime *runtime,
                                           const slayer3d_game_data_editor_selection *selection,
                                           const char *material_name, const char **out_material_name,
@@ -2447,6 +2644,33 @@ bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_d
 {
     return publish_editor_brush_world_status(runtime, obj_get(action, "outputs"), json_string(action, "world", NULL),
                                              json_string(action, "message", "brush world status published"), true);
+}
+
+bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_game_data_create_box_brush_desc desc;
+    SDL_zero(desc);
+    desc.world_name = json_string(action, "world", NULL);
+    desc.brush_name = json_string(action, "name", NULL);
+    desc.material_name = json_string(action, "material", NULL);
+    desc.min = json_vec3(action, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.max = json_vec3(action, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+
+    char error[256];
+    error[0] = '\0';
+    char brush_name[256];
+    brush_name[0] = '\0';
+    const bool ok =
+        slayer3d_game_data_create_box_brush(runtime, &desc, brush_name, sizeof(brush_name), error, (int)sizeof(error));
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "box brush created")
+                                : (error[0] != '\0' ? error : "box brush creation failed"));
+    editor_set_string_output(scene_state, outputs, "brush_key", ok ? brush_name : "");
+    (void)publish_editor_brush_world_status(runtime, outputs, desc.world_name, NULL, false);
+    return true;
 }
 
 static void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8380,6 +8380,35 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_status_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
+
+    write_text(dir / "bad_create_box_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Create Box Action" },
+  "world": { "name": "world.bad_editor_create_box_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.create_box"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.create_box",
+        "actions": [
+          {
+            "type": "editor.brush_world.create_box",
+            "world": "missing.world",
+            "material": "mat.wall",
+            "min": [0, 0, 0],
+            "max": [1, 1, 1]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_create_box_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -12326,6 +12355,159 @@ TEST(GameDataRuntime, EditorPickingPreservesRepeatedBrushWorldInstancePlacement)
     EXPECT_NEAR(selection.bounds.min.x, 10.0f, 0.001f);
     EXPECT_NEAR(selection.bounds.max.x, 12.0f, 0.001f);
 
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_create_box_brush");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
+    write_text(dir / "create_box.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Editor Create Box Brush Test" },
+  "world": { "name": "world.editor_create_box", "kind": "brush" },
+  "signals": ["signal.editor.create_box"],
+  "brush_worlds": [
+    {
+      "name": "brush.editor.level",
+      "materials": [
+        { "name": "mat.wall", "albedo": [0.7, 0.7, 0.7, 1.0] },
+        { "name": "mat.floor", "albedo": [0.2, 0.2, 0.2, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.seed",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.create_box",
+        "actions": [
+          {
+            "type": "editor.brush_world.create_box",
+            "world": "brush.editor.level",
+            "name": "brush.created.wall",
+            "material": "mat.wall",
+            "min": [2.0, 0.0, 0.0],
+            "max": [4.0, 2.0, 0.5],
+            "outputs": {
+              "valid_key": "editor.create.valid",
+              "message_key": "editor.create.message",
+              "brush_key": "editor.create.brush",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision",
+              "saved_revision_key": "editor.brush_world.saved_revision"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "create_box.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_EQ(world.brush_count, 1);
+    slayer3d_game_data_brush_world_editor_state editor_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_FALSE(editor_state.dirty);
+    EXPECT_EQ(editor_state.revision, 0U);
+
+    const int create_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.create_box");
+    ASSERT_GE(create_signal, 0);
+    slayer3d_signal_emit(slayer3d_game_session_get_signal_bus(session), create_signal, nullptr);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""), "brush.created.wall");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 1);
+
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_EQ(world.brush_count, 2);
+    const slayer3d_game_data_brush &created = world.brushes[1];
+    EXPECT_STREQ(created.name, "brush.created.wall");
+    EXPECT_TRUE(created.has_bounds);
+    EXPECT_NEAR(created.bounds.min.x, 2.0f, 0.001f);
+    EXPECT_NEAR(created.bounds.max.y, 2.0f, 0.001f);
+    ASSERT_EQ(created.face_count, 6);
+    for (int i = 0; i < created.face_count; ++i)
+        EXPECT_STREQ(created.faces[i].material_name, "mat.wall");
+
+    slayer3d_game_data_create_box_brush_desc desc{};
+    desc.world_name = "brush.editor.level";
+    desc.material_name = "mat.floor";
+    desc.min = slayer3d_vec3_make(0.0f, -0.25f, 2.0f);
+    desc.max = slayer3d_vec3_make(3.0f, 0.0f, 4.0f);
+    char generated_name[256]{};
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &desc, generated_name, sizeof(generated_name), error,
+                                                    sizeof(error)))
+        << error;
+    EXPECT_STREQ(generated_name, "brush.editor.level.box.1");
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_TRUE(editor_state.dirty);
+    EXPECT_EQ(editor_state.revision, 2U);
+    EXPECT_EQ(editor_state.saved_revision, 0U);
+
+    char *export_json = nullptr;
+    size_t export_size = 0U;
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_fragment_json(runtime, "brush.editor.level", &export_json,
+                                                                    &export_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(export_json, nullptr);
+    EXPECT_GT(export_size, 0U);
+    write_text(dir / "fragments" / "exported.fragment.json", export_json);
+    SDL_free(export_json);
+    write_text(dir / "roundtrip.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "imports": [{ "path": "fragments/exported.fragment.json", "sections": ["brush_worlds"] }],
+  "metadata": { "name": "Roundtrip Created Brushes" },
+  "world": { "name": "world.roundtrip", "kind": "brush" },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *roundtrip_session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &roundtrip_session));
+    slayer3d_game_data_runtime *roundtrip_runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "roundtrip.game.json").string().c_str(), roundtrip_session,
+                                             &roundtrip_runtime, error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world roundtrip_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(roundtrip_runtime, "brush.editor.level", &roundtrip_world));
+    ASSERT_EQ(roundtrip_world.brush_count, 3);
+    EXPECT_STREQ(roundtrip_world.brushes[1].name, "brush.created.wall");
+    EXPECT_STREQ(roundtrip_world.brushes[2].name, "brush.editor.level.box.1");
+    EXPECT_STREQ(roundtrip_world.brushes[2].faces[0].material_name, "mat.floor");
+
+    slayer3d_game_data_destroy(roundtrip_runtime);
+    slayer3d_game_session_destroy(roundtrip_session);
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary
- add a host API and data action for creating axis-aligned box brushes in runtime brush worlds
- rebuild brush collision/render data atomically and mark worlds dirty only after success
- publish created brush and dirty/revision outputs for editor UI
- validate authored create-box actions and document the blockout workflow
- add export/import round-trip coverage for created brushes

Closes first slice of #356.

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorCreateBoxBrushAppendsAndRoundTrips|EditorShellDojoPublishesSelectionAndDebugOverlay)"`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameData"`
- `git diff --check`

## Next slice
Add brush resize/extrude basics so the editor can shape created boxes into rooms without hand-authored JSON.