### PR TITLE
Add editor brush face resizing

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -735,10 +735,13 @@ generates a unique brush name under the target world.
 Use `editor.command.preview` to declare a non-mutating command intent against
 the active selection. This is the safe scaffolding layer for editor tools:
 commands can publish UI state and draw preview bounds without modifying the
-authored world. Supported `command` values are `translate`, `paint`, `extrude`,
-and `delete`; supported `target` values are `selection`, `world`, `element`,
-`face`, and `material`. Paint previews require a `material` string naming a
-material in the selected brush world's material palette.
+authored world. Supported `command` values are `translate`, `paint`, `resize`,
+`extrude`, and `delete`; supported `target` values are `selection`, `world`,
+`element`, `face`, and `material`. Paint previews require a `material` string
+naming a material in the selected brush world's material palette. Resize and
+extrude previews currently target brush faces and use `distance` along the
+selected face normal; positive values grow the brush outward and negative values
+shrink it.
 
 ```json
 {
@@ -764,6 +767,8 @@ Use `editor.command.commit`, `editor.command.undo`, and `editor.command.redo` to
 record validated editor command transactions. A commit requires an active command
 preview in the current scene. `translate` commands targeting a brush `element`
 mutate the selected runtime brush by shifting its planes by the preview offset,
+then rebuild brush bounds and the compiled render mesh. `resize` and `extrude`
+commands targeting a brush `face` move that face plane by the preview distance,
 then rebuild brush bounds and the compiled render mesh. `paint` commands
 targeting a brush `face` replace that face's material and rebuild the compiled
 render mesh. Undo and redo apply the inverse/forward mutation and move the

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1956,6 +1956,31 @@ extern "C"
                                              const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,
                                              size_t out_brush_name_size, char *error_buffer, int error_buffer_size);
 
+    /** @brief Descriptor for resizing one brush face plane. */
+    typedef struct slayer3d_game_data_resize_brush_face_desc
+    {
+        /** @brief Target brush world name. Required. */
+        const char *world_name;
+        /** @brief Target brush name. Required. */
+        const char *brush_name;
+        /** @brief Zero-based face index on the target brush. */
+        int face_index;
+        /** @brief Signed face-plane distance. Positive expands the brush outward. */
+        float distance;
+    } slayer3d_game_data_resize_brush_face_desc;
+
+    /**
+     * @brief Move one brush face plane along its normal.
+     *
+     * Positive distances grow the brush outward along the selected face normal;
+     * negative distances shrink it. The operation rebuilds brush collision and
+     * render data before committing and rolls back if the result is invalid.
+     * Success marks the brush world dirty and increments its editor revision.
+     */
+    bool slayer3d_game_data_resize_brush_face(slayer3d_game_data_runtime *runtime,
+                                              const slayer3d_game_data_resize_brush_face_desc *desc, char *error_buffer,
+                                              int error_buffer_size);
+
     /**
      * @brief Iterate data-authored editor debug primitives for the active scene.
      *

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8070,11 +8070,16 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (target == NULL)
             target = "selection";
         if (!editor_command_name_valid(command))
-            return validation_error(ctx, json_path,
-                                    "editor.command.preview command must be translate, paint, extrude, or delete");
+            return validation_error(
+                ctx, json_path, "editor.command.preview command must be translate, paint, resize, extrude, or delete");
         if (!editor_command_target_name_valid(target))
             return validation_error(
                 ctx, json_path, "editor.command.preview target must be selection, world, element, face, or material");
+        if ((SDL_strcmp(command, "resize") == 0 || SDL_strcmp(command, "extrude") == 0) &&
+            SDL_strcmp(target, "face") != 0)
+        {
+            return validation_error(ctx, json_path, "editor.command.preview resize/extrude target must be face");
+        }
         yyjson_val *material = obj_get(action, "material");
         if (SDL_strcmp(command, "paint") == 0 && (!yyjson_is_str(material) || yyjson_get_str(material)[0] == '\0'))
         {
@@ -10478,8 +10483,9 @@ static bool editor_debug_flag_name_valid(const char *value)
 
 static bool editor_command_name_valid(const char *value)
 {
-    return value != NULL && (SDL_strcmp(value, "translate") == 0 || SDL_strcmp(value, "paint") == 0 ||
-                             SDL_strcmp(value, "extrude") == 0 || SDL_strcmp(value, "delete") == 0);
+    return value != NULL &&
+           (SDL_strcmp(value, "translate") == 0 || SDL_strcmp(value, "paint") == 0 ||
+            SDL_strcmp(value, "resize") == 0 || SDL_strcmp(value, "extrude") == 0 || SDL_strcmp(value, "delete") == 0);
 }
 
 static bool editor_command_target_name_valid(const char *value)

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2520,7 +2520,8 @@ static bool editor_command_preview_active_for_scene(const slayer3d_game_data_run
 static bool editor_command_name_valid(const char *command)
 {
     return command != NULL && (SDL_strcmp(command, "translate") == 0 || SDL_strcmp(command, "paint") == 0 ||
-                               SDL_strcmp(command, "extrude") == 0 || SDL_strcmp(command, "delete") == 0);
+                               SDL_strcmp(command, "resize") == 0 || SDL_strcmp(command, "extrude") == 0 ||
+                               SDL_strcmp(command, "delete") == 0);
 }
 
 static bool editor_command_target_name_valid(const char *target)
@@ -2845,16 +2846,22 @@ static bool editor_command_target_compatible(const slayer3d_game_data_editor_sel
             *out_reason = "selection has no material target";
         return false;
     }
+    if ((SDL_strcmp(command, "resize") == 0 || SDL_strcmp(command, "extrude") == 0) && SDL_strcmp(target, "face") != 0)
+    {
+        if (out_reason != NULL)
+            *out_reason = "resize/extrude target must be face";
+        return false;
+    }
     if ((SDL_strcmp(command, "translate") == 0 || SDL_strcmp(command, "delete") == 0) && !selection->has_bounds)
     {
         if (out_reason != NULL)
             *out_reason = "selection has no previewable bounds";
         return false;
     }
-    if (SDL_strcmp(command, "extrude") == 0 && selection->face_index < 0)
+    if ((SDL_strcmp(command, "resize") == 0 || SDL_strcmp(command, "extrude") == 0) && selection->face_index < 0)
     {
         if (out_reason != NULL)
-            *out_reason = "extrude preview requires a face selection";
+            *out_reason = "resize/extrude preview requires a face selection";
         return false;
     }
     if (SDL_strcmp(command, "paint") == 0 && selection->face_index < 0 &&
@@ -2877,6 +2884,49 @@ static slayer3d_vec3 editor_command_preview_offset(yyjson_val *action,
     if (distance != 0.0f && selection != NULL && slayer3d_vec3_length_squared(selection->normal) > 0.000001f)
         return slayer3d_vec3_scale(slayer3d_vec3_normalize(selection->normal), distance);
     return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+}
+
+static float editor_command_face_distance_delta(const char *command, slayer3d_vec3 offset,
+                                                const slayer3d_game_data_editor_selection *selection)
+{
+    if (command == NULL || selection == NULL ||
+        (SDL_strcmp(command, "resize") != 0 && SDL_strcmp(command, "extrude") != 0) ||
+        slayer3d_vec3_length_squared(selection->normal) <= 0.000001f)
+    {
+        return 0.0f;
+    }
+    return slayer3d_vec3_dot(slayer3d_vec3_normalize(selection->normal), offset);
+}
+
+static slayer3d_bounding_box editor_resized_preview_bounds(slayer3d_bounding_box bounds, slayer3d_vec3 normal,
+                                                           float distance)
+{
+    normal = slayer3d_vec3_normalize(normal);
+    const float ax = SDL_fabsf(normal.x);
+    const float ay = SDL_fabsf(normal.y);
+    const float az = SDL_fabsf(normal.z);
+    if (ax >= ay && ax >= az)
+    {
+        if (normal.x >= 0.0f)
+            bounds.max.x += distance;
+        else
+            bounds.min.x -= distance;
+    }
+    else if (ay >= ax && ay >= az)
+    {
+        if (normal.y >= 0.0f)
+            bounds.max.y += distance;
+        else
+            bounds.min.y -= distance;
+    }
+    else
+    {
+        if (normal.z >= 0.0f)
+            bounds.max.z += distance;
+        else
+            bounds.min.z -= distance;
+    }
+    return bounds;
 }
 
 static void publish_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,
@@ -2942,8 +2992,13 @@ bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runti
         }
     }
 
-    slayer3d_bounding_box bounds = selection.has_bounds ? translated_bounds(selection.bounds, offset)
-                                                        : (slayer3d_bounding_box){selection.point, selection.point};
+    const bool face_resize = SDL_strcmp(command, "resize") == 0 || SDL_strcmp(command, "extrude") == 0;
+    const float face_distance = editor_command_face_distance_delta(command, offset, &selection);
+    slayer3d_bounding_box bounds =
+        selection.has_bounds
+            ? (face_resize ? editor_resized_preview_bounds(selection.bounds, selection.normal, face_distance)
+                           : translated_bounds(selection.bounds, offset))
+            : (slayer3d_bounding_box){selection.point, selection.point};
 
     editor_command_preview_state *preview = &runtime->editor_command_preview;
     SDL_zero(*preview);
@@ -3200,6 +3255,68 @@ static bool rebuild_editor_brush_world(brush_world_runtime *world_runtime)
     return true;
 }
 
+static bool editor_brush_bounds_valid(const slayer3d_game_data_brush *brush)
+{
+    if (brush == NULL || !brush->has_bounds)
+        return false;
+    const float epsilon = 0.0001f;
+    return brush->bounds.max.x - brush->bounds.min.x > epsilon && brush->bounds.max.y - brush->bounds.min.y > epsilon &&
+           brush->bounds.max.z - brush->bounds.min.z > epsilon;
+}
+
+static bool resize_editor_brush_face_plane(slayer3d_game_data_brush *brush, int face_index, float distance)
+{
+    if (brush == NULL || face_index < 0 || face_index >= brush->face_count)
+        return false;
+    slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[face_index];
+    face->distance += distance;
+    return true;
+}
+
+bool slayer3d_game_data_resize_brush_face(slayer3d_game_data_runtime *runtime,
+                                          const slayer3d_game_data_resize_brush_face_desc *desc, char *error_buffer,
+                                          int error_buffer_size)
+{
+    if (runtime == NULL || desc == NULL || desc->world_name == NULL || desc->world_name[0] == '\0' ||
+        desc->brush_name == NULL || desc->brush_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "invalid brush face resize request");
+        return false;
+    }
+    if (SDL_fabsf(desc->distance) <= 0.0000001f)
+        return true;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, desc->world_name);
+    slayer3d_game_data_brush *brush = find_editor_mutable_brush(world_runtime, desc->brush_name);
+    if (brush == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush not found");
+        return false;
+    }
+    if (desc->face_index < 0 || desc->face_index >= brush->face_count)
+    {
+        set_error(error_buffer, error_buffer_size, "brush face index out of range");
+        return false;
+    }
+
+    if (!resize_editor_brush_face_plane(brush, desc->face_index, desc->distance))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to resize brush face");
+        return false;
+    }
+
+    if (rebuild_editor_brush_world(world_runtime) && editor_brush_bounds_valid(brush))
+    {
+        editor_brush_world_mark_dirty(world_runtime);
+        return true;
+    }
+
+    (void)resize_editor_brush_face_plane(brush, desc->face_index, -desc->distance);
+    (void)rebuild_editor_brush_world(world_runtime);
+    set_error(error_buffer, error_buffer_size, "brush face resize would create invalid geometry");
+    return false;
+}
+
 static bool resolve_editor_paint_material(slayer3d_game_data_runtime *runtime,
                                           const slayer3d_game_data_editor_selection *selection,
                                           const char *material_name, const char **out_material_name,
@@ -3302,6 +3419,32 @@ static bool apply_editor_brush_paint(slayer3d_game_data_runtime *runtime, const 
     return false;
 }
 
+static bool apply_editor_brush_face_resize(slayer3d_game_data_runtime *runtime,
+                                           const editor_command_transaction_entry *entry, bool forward)
+{
+    if (runtime == NULL || entry == NULL || entry->world_name == NULL || entry->element_name == NULL ||
+        entry->face_index < 0)
+    {
+        return false;
+    }
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, entry->world_name);
+    slayer3d_game_data_brush *brush = find_editor_mutable_brush(world_runtime, entry->element_name);
+    if (brush == NULL || entry->face_index >= brush->face_count)
+        return false;
+
+    const slayer3d_game_data_brush_face *face = &brush->faces[entry->face_index];
+    const float distance = slayer3d_vec3_dot(slayer3d_vec3_normalize(face->normal),
+                                             forward ? entry->offset : slayer3d_vec3_scale(entry->offset, -1.0f));
+    slayer3d_game_data_resize_brush_face_desc desc;
+    SDL_zero(desc);
+    desc.world_name = entry->world_name;
+    desc.brush_name = entry->element_name;
+    desc.face_index = entry->face_index;
+    desc.distance = distance;
+    return slayer3d_game_data_resize_brush_face(runtime, &desc, NULL, 0);
+}
+
 static void translate_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
                                                               const editor_command_transaction_entry *entry,
                                                               slayer3d_vec3 offset)
@@ -3322,6 +3465,51 @@ static void translate_active_editor_selection_for_transaction(slayer3d_game_data
     selection->world_position = slayer3d_vec3_add(selection->world_position, offset);
     if (selection->has_bounds)
         selection->bounds = translated_bounds(selection->bounds, offset);
+
+    yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
+    publish_editor_selection(runtime, obj_get(selection_json, "outputs"), selection);
+}
+
+static void resize_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
+                                                           const editor_command_transaction_entry *entry, bool forward)
+{
+    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit)
+        return;
+    slayer3d_game_data_editor_selection *selection = &runtime->editor_active_selection;
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || entry->scene == NULL || SDL_strcmp(active_scene, entry->scene) != 0 ||
+        selection->world_name == NULL || entry->world_name == NULL ||
+        SDL_strcmp(selection->world_name, entry->world_name) != 0 || selection->element_name == NULL ||
+        entry->element_name == NULL || SDL_strcmp(selection->element_name, entry->element_name) != 0 ||
+        selection->face_index != entry->face_index)
+    {
+        return;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, entry->world_name);
+    const slayer3d_game_data_brush *brush = NULL;
+    if (world_runtime != NULL)
+    {
+        const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+        for (int i = 0; i < world->brush_count; ++i)
+        {
+            if (world->brushes[i].name != NULL && SDL_strcmp(world->brushes[i].name, entry->element_name) == 0)
+            {
+                brush = &world->brushes[i];
+                break;
+            }
+        }
+    }
+
+    const slayer3d_vec3 offset = forward ? entry->offset : slayer3d_vec3_scale(entry->offset, -1.0f);
+    selection->point = slayer3d_vec3_add(selection->point, offset);
+    selection->world_position = slayer3d_vec3_add(selection->world_position, offset);
+    if (brush != NULL && brush->has_bounds)
+        selection->bounds = brush->bounds;
+    else if (selection->has_bounds)
+        selection->bounds = editor_resized_preview_bounds(selection->bounds, selection->normal,
+                                                          slayer3d_vec3_dot(selection->normal, offset));
+    selection->has_bounds = brush != NULL ? brush->has_bounds : selection->has_bounds;
 
     yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
     publish_editor_selection(runtime, obj_get(selection_json, "outputs"), selection);
@@ -3364,7 +3552,9 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
         return false;
     }
     return (SDL_strcmp(entry->command, "translate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
-           (SDL_strcmp(entry->command, "paint") == 0 && SDL_strcmp(entry->target, "face") == 0);
+           (SDL_strcmp(entry->command, "paint") == 0 && SDL_strcmp(entry->target, "face") == 0) ||
+           ((SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0) &&
+            SDL_strcmp(entry->target, "face") == 0);
 }
 
 static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtime,
@@ -3377,6 +3567,13 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         if (!apply_editor_brush_paint(runtime, entry, forward))
             return false;
         update_active_editor_selection_material_for_transaction(runtime, entry, forward);
+        return true;
+    }
+    if (SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0)
+    {
+        if (!apply_editor_brush_face_resize(runtime, entry, forward))
+            return false;
+        resize_active_editor_selection_for_transaction(runtime, entry, forward);
         return true;
     }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8282,7 +8282,8 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     SDL_zeroa(error);
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_preview_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
-    EXPECT_NE(std::string(error).find("editor.command.preview command must be"), std::string::npos) << error;
+    EXPECT_NE(std::string(error).find("editor.command.preview resize/extrude target must be face"), std::string::npos)
+        << error;
 
     write_text(dir / "bad_paint_preview_action.game.json",
                R"json({
@@ -12475,6 +12476,27 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     EXPECT_EQ(editor_state.revision, 2U);
     EXPECT_EQ(editor_state.saved_revision, 0U);
 
+    slayer3d_game_data_resize_brush_face_desc resize_desc{};
+    resize_desc.world_name = "brush.editor.level";
+    resize_desc.brush_name = "brush.created.wall";
+    resize_desc.face_index = 0;
+    resize_desc.distance = 0.75f;
+    ASSERT_TRUE(slayer3d_game_data_resize_brush_face(runtime, &resize_desc, error, sizeof(error))) << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_EQ(world.brush_count, 3);
+    EXPECT_NEAR(world.brushes[1].bounds.max.x, 4.75f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_EQ(editor_state.revision, 3U);
+
+    resize_desc.face_index = 1;
+    resize_desc.distance = -3.0f;
+    EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize_desc, error, sizeof(error)));
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_NEAR(world.brushes[1].bounds.max.x, 4.75f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 2.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_EQ(editor_state.revision, 3U);
+
     char *export_json = nullptr;
     size_t export_size = 0U;
     ASSERT_TRUE(slayer3d_game_data_export_brush_world_fragment_json(runtime, "brush.editor.level", &export_json,
@@ -12503,11 +12525,200 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(roundtrip_runtime, "brush.editor.level", &roundtrip_world));
     ASSERT_EQ(roundtrip_world.brush_count, 3);
     EXPECT_STREQ(roundtrip_world.brushes[1].name, "brush.created.wall");
+    EXPECT_NEAR(roundtrip_world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     EXPECT_STREQ(roundtrip_world.brushes[2].name, "brush.editor.level.box.1");
     EXPECT_STREQ(roundtrip_world.brushes[2].faces[0].material_name, "mat.floor");
 
     slayer3d_game_data_destroy(roundtrip_runtime);
     slayer3d_game_session_destroy(roundtrip_session);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorExtrudeCommandResizesSelectedBrushFace)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_extrude_face_command");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": { "brush_worlds": [{ "world": "brush.editor.level" }] },
+  "editor": {
+    "selection": {
+      "mode": "hover",
+      "trace": {
+        "source": "world",
+        "start": [2.0, 0.5, 0.5],
+        "end": [0.0, 0.5, 0.5],
+        "model_filter": "brush_worlds"
+      },
+      "outputs": {
+        "hit_key": "editor.selection.hit",
+        "world_key": "editor.selection.world",
+        "element_key": "editor.selection.element",
+        "face_index_key": "editor.selection.face_index"
+      }
+    }
+  }
+})json");
+    write_text(dir / "extrude_command.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Editor Extrude Face Command Test" },
+  "world": { "name": "world.editor_extrude", "kind": "brush" },
+  "signals": ["signal.editor.preview_extrude", "signal.editor.commit", "signal.editor.undo", "signal.editor.redo"],
+  "brush_worlds": [
+    {
+      "name": "brush.editor.level",
+      "materials": [{ "name": "mat.wall", "albedo": [0.7, 0.7, 0.7, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.seed",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.preview_extrude",
+        "actions": [
+          {
+            "type": "editor.command.preview",
+            "command": "extrude",
+            "target": "face",
+            "distance": 0.5,
+            "message": "preview extrude {selection_element}",
+            "outputs": {
+              "active_key": "editor.command_preview.active",
+              "valid_key": "editor.command_preview.valid",
+              "command_key": "editor.command_preview.command",
+              "target_key": "editor.command_preview.target",
+              "message_key": "editor.command_preview.message",
+              "bounds_min_key": "editor.command_preview.bounds_min",
+              "bounds_max_key": "editor.command_preview.bounds_max"
+            }
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.commit",
+        "actions": [
+          {
+            "type": "editor.command.commit",
+            "message": "committed {editor_command} #{editor_transaction_id_text}",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count",
+              "dirty_key": "editor.brush_world.dirty",
+              "revision_key": "editor.brush_world.revision"
+            }
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.undo",
+        "actions": [
+          {
+            "type": "editor.command.undo",
+            "message": "undo {editor_command} #{editor_transaction_id_text}",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count"
+            }
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.redo",
+        "actions": [
+          {
+            "type": "editor.command.redo",
+            "message": "redo {editor_command} #{editor_transaction_id_text}",
+            "outputs": {
+              "valid_key": "editor.transaction.valid",
+              "event_key": "editor.transaction.event",
+              "message_key": "editor.transaction.message",
+              "undo_count_key": "editor.transaction.undo_count",
+              "redo_count_key": "editor.transaction.redo_count"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "extrude_command.game.json").string().c_str(), session, &runtime,
+                                             error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), "brush.seed");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.face_index", -1), 0);
+
+    const int preview_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.preview_extrude");
+    const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.commit");
+    const int undo_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.undo");
+    const int redo_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.redo");
+    ASSERT_GE(preview_signal, 0);
+    ASSERT_GE(commit_signal, 0);
+    ASSERT_GE(undo_signal, 0);
+    ASSERT_GE(redo_signal, 0);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    slayer3d_signal_emit(bus, preview_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.command_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.command", ""), "extrude");
+    const slayer3d_value *preview_max = slayer3d_properties_get_value(scene_state, "editor.command_preview.bounds_max");
+    ASSERT_NE(preview_max, nullptr);
+    ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(preview_max->as_vec3.x, 1.5f, 0.001f);
+
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "committed extrude #1");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 1);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 1);
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 1.5f, 0.001f);
+
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "undo extrude #1");
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 1.0f, 0.001f);
+
+    slayer3d_signal_emit(bus, redo_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "redo extrude #1");
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 1.5f, 0.001f);
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary
- add a public runtime API for resizing one brush face plane with rollback on invalid geometry
- make `resize` and `extrude` editor command previews real face mutations through the existing commit/undo/redo path
- update validation and docs for face-targeted resize/extrude commands
- add focused coverage for public face resizing, invalid shrink rollback, export round-trip, and command undo/redo

Continues #356.

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameDataRuntime\.(RejectsInvalidEditorSelectionActions|EditorCreateBoxBrushAppendsAndRoundTrips|EditorExtrudeCommandResizesSelectedBrushFace|EditorShellDojoPublishesSelectionAndDebugOverlay)"`
- `ctest --test-dir build/debug/tests --output-on-failure -R "GameData"`
- `git diff --check`

## Manual editor status
There is not a standalone `slayer3d_editor` executable yet. The current front-end proof is still the data-authored editor shell dojo, run with:

`./build/debug/sdl3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json`

This PR is mostly editor data/model logic: the dojo can select, preview, commit, undo/redo, paint, export, and save. A dedicated editor binary/UI shell should come after the core creation/resizing/player-start/test-run model is stable.

## Next slice
Add player-start placement as a data/runtime primitive so an editor-authored brush scene can define where the test run begins.