### PR TITLE
Add editor player start placement

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -45,6 +45,7 @@ Every root game file is a JSON object.
 | `sector_levels` | no | Authored sector/portal worlds for Doom/Quake-style indoor levels. |
 | `sector_level_fragments` | no | Composition-only material/sector/light fragments merged into named sector levels before validation. |
 | `brush_worlds` | no | Native convex-brush worlds for true 3D FPS-style spaces. |
+| `editor_player_starts` | no | Editor-authored player spawn markers for test-run workflows and level-editing tools. |
 | `sector_navigation` | no | Authored sector navigation graphs for AI/path queries in sector worlds. |
 | `sector_doors` | no | Runtime sliding doors for sector/FPS worlds. |
 | `sector_platforms` | no | Runtime moving floor/ceiling sectors for lifts, elevators, and oscillating platforms. |
@@ -706,6 +707,27 @@ pinned or current selection. It supplies payload fields such as
 `selection_point`, and `selection_normal`. `editor.selection.clear` clears the
 active selection and republishes the scene's `outputs` as an empty selection.
 
+`editor_player_starts` is a mergeable editor/runtime section for player spawn
+markers. It is deliberately separate from `entities`: a start records where a
+test-run should place an existing actor, while the actor remains defined by the
+game or template data. Each entry has a unique `name`, a required `position`
+vec3, and optional `scene`, `target`, `yaw`, and `pitch` fields.
+
+```json
+{
+  "editor_player_starts": [
+    {
+      "name": "player_start.level_01",
+      "scene": "scene.level_01",
+      "target": "entity.player",
+      "position": [2.0, 1.6, -4.0],
+      "yaw": 1.5708,
+      "pitch": 0.0
+    }
+  ]
+}
+```
+
 Use `editor.brush_world.create_box` to append a new axis-aligned convex box
 brush to a runtime brush world. The action is intended for first-pass editor
 blockout tools: floors, walls, ceilings, platforms, and simple room pieces. It
@@ -731,6 +753,40 @@ generates a unique brush name under the target world.
   }
 }
 ```
+
+Use `editor.player_start.place` to create or update one runtime player start.
+The action can be bound to editor tools that place a marker at a clicked point,
+or to direct UI controls that place a known target actor at an explicit
+position. `position` is optional when there is an active editor selection or a
+target actor; otherwise it is required. `apply_to_target` defaults to true and
+updates the target actor's position/yaw/pitch immediately so test-run previews
+match the saved marker.
+
+```json
+{
+  "type": "editor.player_start.place",
+  "name": "player_start.level_01",
+  "scene": "scene.level_01",
+  "target": "entity.player",
+  "position": [2.0, 1.6, -4.0],
+  "yaw": 1.5708,
+  "pitch": 0.0,
+  "outputs": {
+    "valid_key": "editor.player_start.valid",
+    "message_key": "editor.player_start.message",
+    "player_start_key": "editor.player_start.name",
+    "position_key": "editor.player_start.position",
+    "dirty_key": "editor.player_start.dirty",
+    "revision_key": "editor.player_start.revision"
+  }
+}
+```
+
+Native editor hosts can call
+`slayer3d_game_data_export_player_starts_fragment_json()` to serialize the
+current player-start collection as a `slayer3d.fragment.v0` document containing
+`editor_player_starts`. File writing remains host-owned, matching brush-world
+exports.
 
 Use `editor.command.preview` to declare a non-mutating command intent against
 the active selection. This is the safe scaffolding layer for editor tools:

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -1956,6 +1956,97 @@ extern "C"
                                              const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,
                                              size_t out_brush_name_size, char *error_buffer, int error_buffer_size);
 
+    /** @brief Runtime-authored player start marker for editor and test-run workflows. */
+    typedef struct slayer3d_game_data_editor_player_start
+    {
+        /** @brief Stable player start name. Pointer is runtime-owned. */
+        const char *name;
+        /** @brief Scene where this start is valid, or NULL for scene-agnostic starts. */
+        const char *scene;
+        /** @brief Optional actor/entity to place when test-running from this start. */
+        const char *target;
+        /** @brief Spawn position in world meters. */
+        slayer3d_vec3 position;
+        /** @brief Spawn yaw in radians. */
+        float yaw;
+        /** @brief Spawn pitch in radians. */
+        float pitch;
+    } slayer3d_game_data_editor_player_start;
+
+    /** @brief Editor save state for the player-start collection. */
+    typedef struct slayer3d_game_data_player_start_editor_state
+    {
+        /** @brief Last known host save/source path, or NULL when unknown. Pointer is runtime-owned. */
+        const char *source_path;
+        /** @brief True when runtime mutations have not been marked saved. */
+        bool dirty;
+        /** @brief Monotonic runtime mutation revision. */
+        Uint64 revision;
+        /** @brief Revision that was last marked saved. */
+        Uint64 saved_revision;
+        /** @brief Number of player starts currently loaded in the runtime. */
+        int count;
+    } slayer3d_game_data_player_start_editor_state;
+
+    /** @brief Descriptor for creating or updating one editor player start. */
+    typedef struct slayer3d_game_data_place_player_start_desc
+    {
+        /** @brief Player start name. Required. */
+        const char *name;
+        /** @brief Optional scene reference. Defaults to the active scene when omitted. */
+        const char *scene;
+        /** @brief Optional actor/entity to place when applying the start. */
+        const char *target;
+        /** @brief Spawn position. Used only when @p has_position is true. */
+        slayer3d_vec3 position;
+        /** @brief Whether @p position is explicit. Defaults to selection point, then target actor position. */
+        bool has_position;
+        /** @brief Spawn yaw in radians. Used only when @p has_yaw is true. */
+        float yaw;
+        /** @brief Whether @p yaw is explicit. */
+        bool has_yaw;
+        /** @brief Spawn pitch in radians. Used only when @p has_pitch is true. */
+        float pitch;
+        /** @brief Whether @p pitch is explicit. */
+        bool has_pitch;
+        /** @brief Apply the start to @p target immediately when a target actor exists. */
+        bool apply_to_target;
+    } slayer3d_game_data_place_player_start_desc;
+
+    /**
+     * @brief Query one editor player start by name.
+     *
+     * Returned pointers are runtime-owned and remain valid until player starts
+     * are mutated or the runtime is destroyed.
+     */
+    bool slayer3d_game_data_get_editor_player_start(const slayer3d_game_data_runtime *runtime, const char *name,
+                                                    slayer3d_game_data_editor_player_start *out_start);
+
+    /** @brief Query editor save state for runtime player-start markers. */
+    bool slayer3d_game_data_get_player_start_editor_state(const slayer3d_game_data_runtime *runtime,
+                                                          slayer3d_game_data_player_start_editor_state *out_state);
+
+    /**
+     * @brief Create or update one runtime editor player start.
+     *
+     * The operation marks the player-start collection dirty and increments its
+     * revision. When @p apply_to_target is true and the target actor exists,
+     * the actor position/yaw/pitch are updated atomically after the marker is
+     * stored.
+     */
+    bool slayer3d_game_data_place_editor_player_start(slayer3d_game_data_runtime *runtime,
+                                                      const slayer3d_game_data_place_player_start_desc *desc,
+                                                      char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Export all runtime editor player starts as a fragment JSON string.
+     *
+     * The caller owns @p out_json and must release it with SDL_free().
+     */
+    bool slayer3d_game_data_export_player_starts_fragment_json(const slayer3d_game_data_runtime *runtime,
+                                                               char **out_json, size_t *out_size, char *error_buffer,
+                                                               int error_buffer_size);
+
     /** @brief Descriptor for resizing one brush face plane. */
     typedef struct slayer3d_game_data_resize_brush_face_desc
     {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -330,6 +330,12 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
         SDL_free((void *)world->materials);
         SDL_free((void *)world->brushes);
     }
+    for (int i = 0; i < runtime->editor_player_start_count; ++i)
+    {
+        SDL_free(runtime->editor_player_starts[i].name);
+        SDL_free(runtime->editor_player_starts[i].scene);
+        SDL_free(runtime->editor_player_starts[i].target);
+    }
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {
         SDL_free(runtime->actor_pools[i].name);
@@ -392,6 +398,8 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_pickup_layers);
     SDL_free(runtime->sector_levels);
     SDL_free(runtime->brush_worlds);
+    SDL_free(runtime->editor_player_starts);
+    SDL_free(runtime->editor_player_start_source_path);
     SDL_free(runtime->sector_doors);
     SDL_free(runtime->sector_platforms);
     SDL_free(runtime->fps_controllers);

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -230,6 +230,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.brush_world.create_box") == 0)
         return slayer3d_game_data_create_box_brush_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.player_start.place") == 0)
+        return slayer3d_game_data_place_editor_player_start_action(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_actors_input.c
+++ b/src/game_data_actors_input.c
@@ -212,6 +212,51 @@ bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *
     return true;
 }
 
+bool load_editor_player_starts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                               int error_buffer_size)
+{
+    yyjson_val *starts = obj_get(root, "editor_player_starts");
+    if (!yyjson_is_arr(starts))
+        return true;
+
+    const size_t count = yyjson_arr_size(starts);
+    if (count > (size_t)SDL_MAX_SINT32)
+    {
+        set_error(error_buffer, error_buffer_size, "too many editor player starts");
+        return false;
+    }
+    runtime->editor_player_start_count = (int)count;
+    runtime->editor_player_start_capacity = (int)count;
+    runtime->editor_player_starts =
+        (editor_player_start_runtime *)SDL_calloc(count, sizeof(*runtime->editor_player_starts));
+    if (runtime->editor_player_starts == NULL && count > 0u)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate editor player starts");
+        return false;
+    }
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        yyjson_val *start = yyjson_arr_get(starts, i);
+        editor_player_start_runtime *entry = &runtime->editor_player_starts[i];
+        const char *name = json_string(start, "name", NULL);
+        const char *scene = json_string(start, "scene", NULL);
+        const char *target = json_string(start, "target", NULL);
+        entry->name = name != NULL ? SDL_strdup(name) : NULL;
+        entry->scene = scene != NULL ? SDL_strdup(scene) : NULL;
+        entry->target = target != NULL ? SDL_strdup(target) : NULL;
+        entry->position = json_vec3(start, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        entry->yaw = json_float(start, "yaw", 0.0f);
+        entry->pitch = json_float(start, "pitch", 0.0f);
+        if (entry->name == NULL || (scene != NULL && entry->scene == NULL) || (target != NULL && entry->target == NULL))
+        {
+            set_error(error_buffer, error_buffer_size, "failed to allocate editor player start");
+            return false;
+        }
+    }
+    return true;
+}
+
 static yyjson_val *find_actor_archetype_json(yyjson_val *root, const char *name)
 {
     yyjson_val *archetypes = obj_get(root, "actor_archetypes");

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -193,6 +193,16 @@ typedef struct editor_command_history_state
     int next_id;
 } editor_command_history_state;
 
+typedef struct editor_player_start_runtime
+{
+    char *name;
+    char *scene;
+    char *target;
+    slayer3d_vec3 position;
+    float yaw;
+    float pitch;
+} editor_player_start_runtime;
+
 typedef struct wave_schedule_entry
 {
     yyjson_val *schedule;
@@ -644,6 +654,13 @@ typedef struct slayer3d_game_data_runtime
     int sector_level_count;
     brush_world_runtime *brush_worlds;
     int brush_world_count;
+    editor_player_start_runtime *editor_player_starts;
+    int editor_player_start_count;
+    int editor_player_start_capacity;
+    char *editor_player_start_source_path;
+    Uint64 editor_player_start_revision;
+    Uint64 editor_player_start_saved_revision;
+    bool editor_player_start_dirty;
     slayer3d_game_data_brush_diagnostics brush_diagnostics;
     Uint64 world_model_trace_count;
     Uint64 world_model_point_query_count;
@@ -851,6 +868,7 @@ bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runt
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
                                                                  yyjson_val *action);
 bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 void emit_optional_signal(slayer3d_game_data_runtime *runtime, yyjson_val *json, const char *signal_key,
@@ -1030,6 +1048,8 @@ void register_lua_api(slayer3d_game_data_runtime *runtime, slayer3d_script_engin
 bool load_timers(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);
 bool load_signals(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
+bool load_editor_player_starts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                               int error_buffer_size);
 bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);

--- a/src/game_data_load_runtime.c
+++ b/src/game_data_load_runtime.c
@@ -409,6 +409,7 @@ bool slayer3d_game_data_load_asset_with_options(slayer3d_asset_resolver *assets,
     load_active_camera(runtime, root);
     bool ok = load_signals(runtime, root, error_buffer, error_buffer_size) &&
               load_entities(runtime, root, error_buffer, error_buffer_size) &&
+              load_editor_player_starts(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_maps(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_pickup_layers(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_levels(runtime, root, error_buffer, error_buffer_size) &&

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -1911,6 +1911,7 @@ static bool import_section_name_allowed(const char *name)
                                           "sector_levels",
                                           "sector_level_fragments",
                                           "brush_worlds",
+                                          "editor_player_starts",
                                           "sector_navigation",
                                           "sector_doors",
                                           "sector_platforms",
@@ -6734,6 +6735,45 @@ static bool validate_editor_metadata_tree(validation_context *ctx, yyjson_val *r
     return true;
 }
 
+static bool validate_editor_player_starts(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *starts = obj_get(root, "editor_player_starts");
+    if (starts == NULL)
+        return true;
+    if (!yyjson_is_arr(starts))
+        return validation_error(ctx, "$.editor_player_starts", "editor_player_starts must be an array");
+
+    name_table start_names;
+    SDL_zero(start_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(starts); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.editor_player_starts[%zu]", i);
+        yyjson_val *start = yyjson_arr_get(starts, i);
+        if (!yyjson_is_obj(start))
+        {
+            ok = validation_error(ctx, path, "editor player start entries must be objects");
+            break;
+        }
+        const char *scene = json_string(start, "scene");
+        const char *target = json_string(start, "target");
+        yyjson_val *yaw = obj_get(start, "yaw");
+        yyjson_val *pitch = obj_get(start, "pitch");
+        ok = require_unique_name(ctx, &start_names, "editor player start", json_string(start, "name"), path) &&
+             (scene == NULL || require_ref(ctx, &names->scenes, "scene", scene, path)) &&
+             (target == NULL || require_actor_ref(ctx, names, target, path)) &&
+             is_exact_vec_array(obj_get(start, "position"), 3) && (yaw == NULL || yyjson_is_num(yaw)) &&
+             (pitch == NULL || yyjson_is_num(pitch));
+        if (ok)
+            continue;
+        if (!ctx->failed)
+            ok = validation_error(ctx, path, "editor player start requires position vec3 and numeric yaw/pitch");
+    }
+    name_table_destroy(&start_names);
+    return ok;
+}
+
 static bool require_unique_editor_stable_id(validation_context *ctx, name_table *stable_ids, yyjson_val *json,
                                             const char *json_path)
 {
@@ -8237,6 +8277,46 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
                 return validation_error(ctx, json_path,
                                         "editor.brush_world.create_box output keys must be non-empty strings");
+        }
+        return true;
+    }
+    if (SDL_strcmp(type, "editor.player_start.place") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "editor.player_start.place requires a non-empty name");
+        const char *scene = json_string(action, "scene");
+        const char *target = json_string(action, "target");
+        if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, json_path))
+            return false;
+        if (target != NULL && !require_actor_ref(ctx, names, target, json_path))
+            return false;
+        yyjson_val *position = obj_get(action, "position");
+        if (position != NULL && !is_exact_vec_array(position, 3))
+            return validation_error(ctx, json_path, "editor.player_start.place position must be a vec3");
+        const char *position_from = json_string(action, "position_from");
+        if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0)
+            return validation_error(ctx, json_path, "editor.player_start.place position_from must be selection_point");
+        yyjson_val *yaw = obj_get(action, "yaw");
+        yyjson_val *pitch = obj_get(action, "pitch");
+        yyjson_val *apply_to_target = obj_get(action, "apply_to_target");
+        if ((yaw != NULL && !yyjson_is_num(yaw)) || (pitch != NULL && !yyjson_is_num(pitch)) ||
+            (apply_to_target != NULL && !yyjson_is_bool(apply_to_target)))
+        {
+            return validation_error(ctx, json_path,
+                                    "editor.player_start.place yaw/pitch must be numeric and apply_to_target bool");
+        }
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.player_start.place outputs must be an object");
+        static const char *const output_keys[] = {"valid_key",  "message_key",  "player_start_key",  "scene_key",
+                                                  "target_key", "position_key", "yaw_key",           "pitch_key",
+                                                  "dirty_key",  "revision_key", "saved_revision_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.player_start.place output keys must be non-empty strings");
         }
         return true;
     }
@@ -11298,9 +11378,10 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_sector_navigation(ctx, root, names) && validate_components(ctx, root, names) &&
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
-           validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
-           validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
-           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_editor_player_starts(ctx, root, names) && validate_sector_doors(ctx, root, names) &&
+           validate_sector_platforms(ctx, root, names) && validate_actor_archetypes_and_pools(ctx, root, names) &&
+           validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
+           validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_settings(ctx, root) &&
            validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
            validate_haptics(ctx, root, names) && validate_editor_metadata_tree(ctx, root, names) &&

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -880,6 +880,204 @@ bool slayer3d_game_data_mark_brush_world_saved(slayer3d_game_data_runtime *runti
     return true;
 }
 
+static editor_player_start_runtime *find_editor_player_start_mutable(slayer3d_game_data_runtime *runtime,
+                                                                     const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->editor_player_start_count; ++i)
+    {
+        if (runtime->editor_player_starts[i].name != NULL &&
+            SDL_strcmp(runtime->editor_player_starts[i].name, name) == 0)
+        {
+            return &runtime->editor_player_starts[i];
+        }
+    }
+    return NULL;
+}
+
+static const editor_player_start_runtime *find_editor_player_start(const slayer3d_game_data_runtime *runtime,
+                                                                   const char *name)
+{
+    return find_editor_player_start_mutable((slayer3d_game_data_runtime *)runtime, name);
+}
+
+static bool runtime_scene_exists(const slayer3d_game_data_runtime *runtime, const char *scene)
+{
+    if (scene == NULL || scene[0] == '\0')
+        return true;
+    for (int i = 0; runtime != NULL && i < runtime->scene_count; ++i)
+    {
+        if (runtime->scenes[i].name != NULL && SDL_strcmp(runtime->scenes[i].name, scene) == 0)
+            return true;
+    }
+    return false;
+}
+
+bool slayer3d_game_data_get_editor_player_start(const slayer3d_game_data_runtime *runtime, const char *name,
+                                                slayer3d_game_data_editor_player_start *out_start)
+{
+    if (out_start != NULL)
+        SDL_zero(*out_start);
+    const editor_player_start_runtime *start = find_editor_player_start(runtime, name);
+    if (start == NULL || out_start == NULL)
+        return false;
+    out_start->name = start->name;
+    out_start->scene = start->scene;
+    out_start->target = start->target;
+    out_start->position = start->position;
+    out_start->yaw = start->yaw;
+    out_start->pitch = start->pitch;
+    return true;
+}
+
+bool slayer3d_game_data_get_player_start_editor_state(const slayer3d_game_data_runtime *runtime,
+                                                      slayer3d_game_data_player_start_editor_state *out_state)
+{
+    if (out_state != NULL)
+        SDL_zero(*out_state);
+    if (runtime == NULL || out_state == NULL)
+        return false;
+    out_state->source_path = runtime->editor_player_start_source_path;
+    out_state->dirty = runtime->editor_player_start_dirty;
+    out_state->revision = runtime->editor_player_start_revision;
+    out_state->saved_revision = runtime->editor_player_start_saved_revision;
+    out_state->count = runtime->editor_player_start_count;
+    return true;
+}
+
+static bool ensure_editor_player_start_capacity(slayer3d_game_data_runtime *runtime, int required_capacity)
+{
+    if (runtime == NULL || required_capacity <= runtime->editor_player_start_capacity)
+        return runtime != NULL;
+    int capacity = runtime->editor_player_start_capacity > 0 ? runtime->editor_player_start_capacity : 4;
+    while (capacity < required_capacity)
+        capacity *= 2;
+    editor_player_start_runtime *starts =
+        (editor_player_start_runtime *)SDL_realloc(runtime->editor_player_starts, (size_t)capacity * sizeof(*starts));
+    if (starts == NULL)
+        return false;
+    SDL_memset(starts + runtime->editor_player_start_capacity, 0,
+               (size_t)(capacity - runtime->editor_player_start_capacity) * sizeof(*starts));
+    runtime->editor_player_starts = starts;
+    runtime->editor_player_start_capacity = capacity;
+    return true;
+}
+
+static bool duplicate_optional_string(const char *value, char **out_copy)
+{
+    if (out_copy != NULL)
+        *out_copy = NULL;
+    if (out_copy == NULL)
+        return false;
+    if (value == NULL || value[0] == '\0')
+        return true;
+    *out_copy = SDL_strdup(value);
+    return *out_copy != NULL;
+}
+
+static void mark_editor_player_starts_dirty(slayer3d_game_data_runtime *runtime)
+{
+    runtime->editor_player_start_revision++;
+    runtime->editor_player_start_dirty = true;
+}
+
+bool slayer3d_game_data_place_editor_player_start(slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_place_player_start_desc *desc,
+                                                  char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL || desc == NULL || desc->name == NULL || desc->name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "player start placement requires a runtime and name");
+        return false;
+    }
+
+    const char *scene = first_non_empty_string(desc->scene, slayer3d_game_data_active_scene(runtime), NULL);
+    if (!runtime_scene_exists(runtime, scene))
+    {
+        set_errorf(error_buffer, error_buffer_size, "player start scene '%s' not found", scene);
+        return false;
+    }
+
+    slayer3d_registered_actor *target =
+        desc->target != NULL && desc->target[0] != '\0' ? slayer3d_game_data_find_actor(runtime, desc->target) : NULL;
+    if (desc->target != NULL && desc->target[0] != '\0' && target == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "player start target '%s' not found", desc->target);
+        return false;
+    }
+
+    slayer3d_vec3 position = desc->position;
+    if (!desc->has_position)
+    {
+        slayer3d_game_data_editor_selection selection;
+        SDL_zero(selection);
+        if (slayer3d_game_data_get_active_editor_selection(runtime, &selection) && selection.hit)
+            position = selection.point;
+        else if (target != NULL)
+            position = target->position;
+        else
+        {
+            set_error(error_buffer, error_buffer_size, "player start placement requires a position or target");
+            return false;
+        }
+    }
+
+    const float yaw =
+        desc->has_yaw || target == NULL ? desc->yaw : slayer3d_properties_get_float(target->props, "yaw", 0.0f);
+    const float pitch =
+        desc->has_pitch || target == NULL ? desc->pitch : slayer3d_properties_get_float(target->props, "pitch", 0.0f);
+
+    char *scene_copy = NULL;
+    char *target_copy = NULL;
+    if (!duplicate_optional_string(scene, &scene_copy) || !duplicate_optional_string(desc->target, &target_copy))
+    {
+        SDL_free(scene_copy);
+        SDL_free(target_copy);
+        set_error(error_buffer, error_buffer_size, "failed to allocate player start fields");
+        return false;
+    }
+
+    editor_player_start_runtime *entry = find_editor_player_start_mutable(runtime, desc->name);
+    if (entry == NULL)
+    {
+        if (!ensure_editor_player_start_capacity(runtime, runtime->editor_player_start_count + 1))
+        {
+            SDL_free(scene_copy);
+            SDL_free(target_copy);
+            set_error(error_buffer, error_buffer_size, "failed to allocate player start");
+            return false;
+        }
+        entry = &runtime->editor_player_starts[runtime->editor_player_start_count];
+        entry->name = SDL_strdup(desc->name);
+        if (entry->name == NULL)
+        {
+            SDL_free(scene_copy);
+            SDL_free(target_copy);
+            set_error(error_buffer, error_buffer_size, "failed to allocate player start name");
+            return false;
+        }
+        runtime->editor_player_start_count++;
+    }
+
+    SDL_free(entry->scene);
+    SDL_free(entry->target);
+    entry->scene = scene_copy;
+    entry->target = target_copy;
+    entry->position = position;
+    entry->yaw = yaw;
+    entry->pitch = pitch;
+    mark_editor_player_starts_dirty(runtime);
+
+    if (desc->apply_to_target && target != NULL)
+    {
+        actor_set_position(target, position);
+        slayer3d_properties_set_float(target->props, "yaw", yaw);
+        slayer3d_properties_set_float(target->props, "pitch", pitch);
+    }
+    return true;
+}
+
 static bool export_add_vec3(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec3 value)
 {
     yyjson_mut_val *arr = yyjson_mut_arr(doc);
@@ -1157,6 +1355,78 @@ bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_dat
     {
         free(json);
         set_error(error_buffer, error_buffer_size, "failed to allocate brush world export JSON");
+        return false;
+    }
+    SDL_memcpy(copy, json, size + 1u);
+    free(json);
+    *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+static bool export_add_player_start(yyjson_mut_doc *doc, yyjson_mut_val *starts,
+                                    const editor_player_start_runtime *start)
+{
+    yyjson_mut_val *obj = yyjson_mut_obj(doc);
+    if (obj == NULL || !yyjson_mut_arr_add_val(starts, obj) ||
+        !yyjson_mut_obj_add_strcpy(doc, obj, "name", start->name != NULL ? start->name : "") ||
+        !export_add_vec3(doc, obj, "position", start->position) ||
+        !yyjson_mut_obj_add_real(doc, obj, "yaw", start->yaw) ||
+        !yyjson_mut_obj_add_real(doc, obj, "pitch", start->pitch))
+    {
+        return false;
+    }
+    if (start->scene != NULL && !yyjson_mut_obj_add_strcpy(doc, obj, "scene", start->scene))
+        return false;
+    if (start->target != NULL && !yyjson_mut_obj_add_strcpy(doc, obj, "target", start->target))
+        return false;
+    return true;
+}
+
+bool slayer3d_game_data_export_player_starts_fragment_json(const slayer3d_game_data_runtime *runtime, char **out_json,
+                                                           size_t *out_size, char *error_buffer, int error_buffer_size)
+{
+    if (out_json != NULL)
+        *out_json = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (runtime == NULL || out_json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "player start export requires runtime and output");
+        return false;
+    }
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    yyjson_mut_val *starts = doc != NULL ? yyjson_mut_arr(doc) : NULL;
+    if (doc == NULL || root == NULL || starts == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to allocate player start export document");
+        return false;
+    }
+
+    yyjson_mut_doc_set_root(doc, root);
+    bool ok = yyjson_mut_obj_add_strcpy(doc, root, "schema", "slayer3d.fragment.v0") &&
+              yyjson_mut_obj_add_val(doc, root, "editor_player_starts", starts);
+    for (int i = 0; ok && i < runtime->editor_player_start_count; ++i)
+        ok = export_add_player_start(doc, starts, &runtime->editor_player_starts[i]);
+
+    size_t size = 0u;
+    char *json = ok ? yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size) : NULL;
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to write player start export JSON");
+        return false;
+    }
+
+    char *copy = (char *)SDL_malloc(size + 1u);
+    if (copy == NULL)
+    {
+        free(json);
+        set_error(error_buffer, error_buffer_size, "failed to allocate player start export JSON");
         return false;
     }
     SDL_memcpy(copy, json, size + 1u);
@@ -2618,6 +2888,29 @@ static bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtim
     return ok;
 }
 
+static void publish_editor_player_start_state(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
+                                              const editor_player_start_runtime *start)
+{
+    if (runtime == NULL || outputs == NULL)
+        return;
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    slayer3d_game_data_player_start_editor_state state;
+    SDL_zero(state);
+    (void)slayer3d_game_data_get_player_start_editor_state(runtime, &state);
+    editor_set_string_output(scene_state, outputs, "player_start_key", start != NULL ? start->name : "");
+    editor_set_string_output(scene_state, outputs, "scene_key",
+                             start != NULL && start->scene != NULL ? start->scene : "");
+    editor_set_string_output(scene_state, outputs, "target_key",
+                             start != NULL && start->target != NULL ? start->target : "");
+    editor_set_vec3_output(scene_state, outputs, "position_key",
+                           start != NULL ? start->position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_float_output(scene_state, outputs, "yaw_key", start != NULL ? start->yaw : 0.0f);
+    editor_set_float_output(scene_state, outputs, "pitch_key", start != NULL ? start->pitch : 0.0f);
+    editor_set_bool_output(scene_state, outputs, "dirty_key", state.dirty);
+    editor_set_int_output(scene_state, outputs, "revision_key", editor_revision_to_int(state.revision));
+    editor_set_int_output(scene_state, outputs, "saved_revision_key", editor_revision_to_int(state.saved_revision));
+}
+
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     yyjson_val *outputs = obj_get(action, "outputs");
@@ -2671,6 +2964,37 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
                                 : (error[0] != '\0' ? error : "box brush creation failed"));
     editor_set_string_output(scene_state, outputs, "brush_key", ok ? brush_name : "");
     (void)publish_editor_brush_world_status(runtime, outputs, desc.world_name, NULL, false);
+    return true;
+}
+
+bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_game_data_place_player_start_desc desc;
+    SDL_zero(desc);
+    desc.name = json_string(action, "name", NULL);
+    desc.scene = json_string(action, "scene", NULL);
+    desc.target = json_string(action, "target", NULL);
+    yyjson_val *position = obj_get(action, "position");
+    desc.has_position = position != NULL;
+    desc.position = json_vec3(action, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    yyjson_val *yaw = obj_get(action, "yaw");
+    yyjson_val *pitch = obj_get(action, "pitch");
+    desc.has_yaw = yaw != NULL;
+    desc.yaw = json_float(action, "yaw", 0.0f);
+    desc.has_pitch = pitch != NULL;
+    desc.pitch = json_float(action, "pitch", 0.0f);
+    desc.apply_to_target = json_bool(action, "apply_to_target", true);
+
+    char error[256];
+    error[0] = '\0';
+    const bool ok = slayer3d_game_data_place_editor_player_start(runtime, &desc, error, (int)sizeof(error));
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "player start placed")
+                                : (error[0] != '\0' ? error : "player start placement failed"));
+    publish_editor_player_start_state(runtime, outputs, ok ? find_editor_player_start(runtime, desc.name) : NULL);
     return true;
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8410,6 +8410,57 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_create_box_action.game.json").string().c_str(), nullptr,
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
+
+    write_text(dir / "bad_player_start_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Player Start Action" },
+  "world": { "name": "world.bad_editor_player_start_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.place_player_start"],
+  "entities": [{ "name": "entity.player" }],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.place_player_start",
+        "actions": [
+          {
+            "type": "editor.player_start.place",
+            "name": "player_start.bad",
+            "scene": "scene.missing",
+            "target": "entity.player",
+            "position": [0.0, 1.6, 0.0]
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_player_start_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown scene reference"), std::string::npos) << error;
+
+    write_text(dir / "bad_player_start_section.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Player Start Section" },
+  "world": { "name": "world.bad_editor_player_start_section", "kind": "fixed_screen" },
+  "entities": [{ "name": "entity.player" }],
+  "editor_player_starts": [
+    {
+      "name": "player_start.bad",
+      "scene": "scene.play",
+      "target": "entity.player",
+      "position": [0.0, 1.6]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_player_start_section.game.json").string().c_str(),
+                                                  nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("editor player start requires position vec3"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -12528,6 +12579,153 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     EXPECT_NEAR(roundtrip_world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     EXPECT_STREQ(roundtrip_world.brushes[2].name, "brush.editor.level.box.1");
     EXPECT_STREQ(roundtrip_world.brushes[2].faces[0].material_name, "mat.floor");
+
+    slayer3d_game_data_destroy(roundtrip_runtime);
+    slayer3d_game_session_destroy(roundtrip_session);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorPlayerStartPlacesTargetAndRoundTrips)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_player_start");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play", "entities": ["entity.player"] })json");
+    write_text(dir / "player_start.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Editor Player Start Test" },
+  "world": { "name": "world.editor_player_start", "kind": "brush" },
+  "signals": ["signal.editor.place_player_start"],
+  "entities": [
+    {
+      "name": "entity.player",
+      "transform": { "position": [0.0, 1.6, 0.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "editor_player_starts": [
+    {
+      "name": "player_start.initial",
+      "scene": "scene.play",
+      "target": "entity.player",
+      "position": [1.0, 1.6, 2.0],
+      "yaw": 0.25,
+      "pitch": 0.0
+    }
+  ],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.place_player_start",
+        "actions": [
+          {
+            "type": "editor.player_start.place",
+            "name": "player_start.initial",
+            "scene": "scene.play",
+            "target": "entity.player",
+            "position": [3.0, 1.75, 4.0],
+            "yaw": 1.25,
+            "pitch": -0.1,
+            "outputs": {
+              "valid_key": "editor.player_start.valid",
+              "message_key": "editor.player_start.message",
+              "player_start_key": "editor.player_start.name",
+              "scene_key": "editor.player_start.scene",
+              "target_key": "editor.player_start.target",
+              "position_key": "editor.player_start.position",
+              "yaw_key": "editor.player_start.yaw",
+              "pitch_key": "editor.player_start.pitch",
+              "dirty_key": "editor.player_start.dirty",
+              "revision_key": "editor.player_start.revision",
+              "saved_revision_key": "editor.player_start.saved_revision"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "player_start.game.json").string().c_str(), session, &runtime,
+                                             error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_editor_player_start start{};
+    ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.initial", &start));
+    EXPECT_STREQ(start.scene, "scene.play");
+    EXPECT_STREQ(start.target, "entity.player");
+    EXPECT_NEAR(start.position.x, 1.0f, 0.001f);
+    slayer3d_game_data_player_start_editor_state state{};
+    ASSERT_TRUE(slayer3d_game_data_get_player_start_editor_state(runtime, &state));
+    EXPECT_FALSE(state.dirty);
+    EXPECT_EQ(state.count, 1);
+
+    const int place_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.place_player_start");
+    ASSERT_GE(place_signal, 0);
+    slayer3d_signal_emit(slayer3d_game_session_get_signal_bus(session), place_signal, nullptr);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.name", ""), "player_start.initial");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.scene", ""), "scene.play");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
+
+    ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.initial", &start));
+    EXPECT_NEAR(start.position.x, 3.0f, 0.001f);
+    EXPECT_NEAR(start.position.y, 1.75f, 0.001f);
+    EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(start.yaw, 1.25f, 0.001f);
+    EXPECT_NEAR(start.pitch, -0.1f, 0.001f);
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(player->position.x, 3.0f, 0.001f);
+    EXPECT_NEAR(player->position.y, 1.75f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "yaw", 0.0f), 1.25f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "pitch", 0.0f), -0.1f, 0.001f);
+
+    char *export_json = nullptr;
+    size_t export_size = 0U;
+    ASSERT_TRUE(slayer3d_game_data_export_player_starts_fragment_json(runtime, &export_json, &export_size, error,
+                                                                      sizeof(error)))
+        << error;
+    ASSERT_NE(export_json, nullptr);
+    EXPECT_GT(export_size, 0U);
+    write_text(dir / "fragments" / "player_starts.fragment.json", export_json);
+    SDL_free(export_json);
+    write_text(dir / "roundtrip.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "imports": [{ "path": "fragments/player_starts.fragment.json", "sections": ["editor_player_starts"] }],
+  "metadata": { "name": "Editor Player Start Roundtrip" },
+  "world": { "name": "world.editor_player_start_roundtrip", "kind": "brush" },
+  "entities": [{ "name": "entity.player" }],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *roundtrip_session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &roundtrip_session));
+    slayer3d_game_data_runtime *roundtrip_runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "roundtrip.game.json").string().c_str(), roundtrip_session,
+                                             &roundtrip_runtime, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(roundtrip_runtime, "player_start.initial", &start));
+    EXPECT_NEAR(start.position.x, 3.0f, 0.001f);
+    EXPECT_NEAR(start.position.y, 1.75f, 0.001f);
+    EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(start.yaw, 1.25f, 0.001f);
+    EXPECT_NEAR(start.pitch, -0.1f, 0.001f);
 
     slayer3d_game_data_destroy(roundtrip_runtime);
     slayer3d_game_session_destroy(roundtrip_session);


### PR DESCRIPTION
## Summary
- add mergeable editor_player_starts data and runtime load/export/query APIs
- add editor.player_start.place action with dirty/revision outputs and optional immediate target actor placement
- validate authored player starts, action refs, import section composition, and document the workflow

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test

## Notes
This is the player-start placement slice for issue #360. It gives the editor milestone a durable, data-authored start marker that can round-trip through fragment imports. The next slice should wire this into an editor/test-run flow so a saved player start can launch the runtime directly into the edited scene.