### PR TITLE
Generalize weapon effect anchors

### DIFF
--- a/demos/brush_geometry_dojo/data/fragments/logic/revolver_runtime.json
+++ b/demos/brush_geometry_dojo/data/fragments/logic/revolver_runtime.json
@@ -66,30 +66,7 @@
           { "type": "entity.set_active", "target": "entity.brush_geometry.revolver_viewmodel", "active": true },
           { "type": "property.animate", "target": "entity.brush_geometry.revolver_viewmodel", "key": "gun_intro_y", "to": 0.0, "duration": 0.24, "easing": "out_quad" },
           { "type": "property.animate", "target": "entity.brush_geometry.revolver_viewmodel", "key": "gun_intro_z", "to": 0.0, "duration": 0.24, "easing": "out_quad" },
-          { "type": "property.animate", "target": "entity.brush_geometry.revolver_viewmodel", "key": "gun_intro_pitch", "to": 0.0, "duration": 0.24, "easing": "out_quad" },
-          {
-            "type": "debug.write_actor_properties",
-            "target": "entity.brush_geometry.revolver_viewmodel",
-            "path": "/tmp/gun-placement-pickup.txt",
-            "label": "pickup.viewmodel.current",
-            "properties": ["gun_x", "gun_y", "gun_z", "gun_scale", "gun_pitch", "gun_yaw", "gun_roll"]
-          },
-          {
-            "type": "debug.write_actor_properties",
-            "target": "entity.brush_geometry.revolver_viewmodel",
-            "path": "/tmp/gun-placement-trace.txt",
-            "append": true,
-            "label": "pickup.viewmodel.current",
-            "properties": ["gun_x", "gun_y", "gun_z", "gun_scale", "gun_pitch", "gun_yaw", "gun_roll"]
-          },
-          {
-            "type": "debug.write_actor_properties",
-            "target": "entity.brush_geometry.player",
-            "path": "/tmp/gun-placement-trace.txt",
-            "append": true,
-            "label": "pickup.player.camera_state",
-            "properties": ["yaw", "pitch", "camera_forward"]
-          }
+          { "type": "property.animate", "target": "entity.brush_geometry.revolver_viewmodel", "key": "gun_intro_pitch", "to": 0.0, "duration": 0.24, "easing": "out_quad" }
         ]
       },
       {
@@ -150,7 +127,10 @@
                       "source": "entity.brush_geometry.revolver_viewmodel",
                       "x": "gun_x",
                       "y": "gun_y",
-                      "z": "gun_z"
+                      "z": "gun_z",
+                      "x_add": ["gun_intro_x", "gun_recoil_x", "gun_bob_x"],
+                      "y_add": ["gun_intro_y", "gun_recoil_y", "gun_bob_y"],
+                      "z_add": ["gun_intro_z", "gun_recoil_z", "gun_bob_z"]
                     },
                     "properties_from_actor": {
                       "source": "entity.brush_geometry.revolver_muzzle_flash_config",
@@ -171,7 +151,10 @@
                       "source": "entity.brush_geometry.revolver_viewmodel",
                       "x": "gun_x",
                       "y": "gun_y",
-                      "z": "gun_z"
+                      "z": "gun_z",
+                      "x_add": ["gun_intro_x", "gun_recoil_x", "gun_bob_x"],
+                      "y_add": ["gun_intro_y", "gun_recoil_y", "gun_bob_y"],
+                      "z_add": ["gun_intro_z", "gun_recoil_z", "gun_bob_z"]
                     },
                     "properties_from_actor": {
                       "source": "entity.brush_geometry.revolver_smoke_config",

--- a/demos/brush_geometry_dojo/data/fragments/logic/revolver_tuning.json
+++ b/demos/brush_geometry_dojo/data/fragments/logic/revolver_tuning.json
@@ -217,22 +217,6 @@
                 "path": "/tmp/gun-placement.txt",
                 "label": "brush_geometry_revolver_viewmodel",
                 "properties": ["gun_x", "gun_y", "gun_z", "gun_scale", "gun_pitch", "gun_yaw", "gun_roll"]
-              },
-              {
-                "type": "debug.write_actor_properties",
-                "target": "entity.brush_geometry.revolver_viewmodel",
-                "path": "/tmp/gun-placement-trace.txt",
-                "append": true,
-                "label": "manual_write.viewmodel.current",
-                "properties": ["gun_x", "gun_y", "gun_z", "gun_scale", "gun_pitch", "gun_yaw", "gun_roll"]
-              },
-              {
-                "type": "debug.write_actor_properties",
-                "target": "entity.brush_geometry.player",
-                "path": "/tmp/gun-placement-trace.txt",
-                "append": true,
-                "label": "manual_write.player.camera_state",
-                "properties": ["yaw", "pitch", "camera_forward"]
               }
             ]
           },
@@ -246,14 +230,6 @@
                 "path": "/tmp/smoke-placement.txt",
                 "label": "brush_geometry_revolver_smoke",
                 "properties": ["smoke_offset_x", "smoke_offset_y", "smoke_offset_z", "smoke_size_scale", "smoke_alpha_scale", "smoke_emit_rate"]
-              },
-              {
-                "type": "debug.write_actor_properties",
-                "target": "entity.brush_geometry.revolver_smoke_config",
-                "path": "/tmp/smoke-placement-trace.txt",
-                "append": true,
-                "label": "manual_write.smoke.current",
-                "properties": ["smoke_offset_x", "smoke_offset_y", "smoke_offset_z", "smoke_size_scale", "smoke_alpha_scale", "smoke_emit_rate"]
               }
             ]
           },
@@ -266,14 +242,6 @@
                 "target": "entity.brush_geometry.revolver_muzzle_flash_config",
                 "path": "/tmp/muzzle-flash-placement.txt",
                 "label": "brush_geometry_revolver_muzzle_flash",
-                "properties": ["flash_offset_x", "flash_offset_y", "flash_offset_z", "flash_size_scale", "flash_alpha_scale", "flash_intensity"]
-              },
-              {
-                "type": "debug.write_actor_properties",
-                "target": "entity.brush_geometry.revolver_muzzle_flash_config",
-                "path": "/tmp/muzzle-flash-placement-trace.txt",
-                "append": true,
-                "label": "manual_write.muzzle_flash.current",
                 "properties": ["flash_offset_x", "flash_offset_y", "flash_offset_z", "flash_size_scale", "flash_alpha_scale", "flash_intensity"]
               }
             ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1856,19 +1856,21 @@ Use `position_from_payload` for payload Vec3 positions such as hitscan
 `origin` or `hit_position`, and `payload_directional_offset` to push the spawn
 point along a payload Vec3 such as `hit_normal`. `position_from_actor_properties`
 builds a spawn position from three numeric properties on a source actor, with an
-optional local `offset`; use it for authored weapon/effect anchors where the
-effect should follow a tunable viewmodel or actor placement. `velocity_from_payload`
-reads a payload Vec3 direction, normalizes it, multiplies by `speed`, and writes
-it to `velocity` or `velocity_property` on the spawned actor. `properties_from_actor`
-copies same-named properties from a source actor before applying the spawn
-action's explicit `properties` object; use it for opt-in debug/tuning config
-actors that should feed pooled effects without hard-coding the effect in C:
+optional local `offset`. It can also add arrays of source properties through
+`x_add`, `y_add`, and `z_add`. Use those additive fields for authored
+weapon/effect anchors that need to follow a tunable viewmodel plus intro,
+recoil, and bob offsets. `velocity_from_payload` reads a payload Vec3 direction,
+normalizes it, multiplies by `speed`, and writes it to `velocity` or
+`velocity_property` on the spawned actor. `properties_from_actor` copies
+same-named properties from a source actor before applying the spawn action's
+explicit `properties` object; use it for opt-in debug/tuning config actors that
+should feed pooled effects without hard-coding the effect in C:
 
 ```json
 { "type": "actor.spawn", "pool": "pool.explosions", "from_payload": "other_actor_name" }
 { "type": "actor.spawn", "pool": "pool.tracers", "position_from_payload": "origin", "velocity_from_payload": "direction", "speed": 80.0 }
 { "type": "actor.spawn", "pool": "pool.decals", "position_from_payload": "hit_position", "payload_directional_offset": { "property": "hit_normal", "distance": 0.03 } }
-{ "type": "actor.spawn", "pool": "pool.weapon_flash", "position_from_actor_properties": { "source": "entity.weapon_viewmodel", "x": "gun_x", "y": "gun_y", "z": "gun_z" } }
+{ "type": "actor.spawn", "pool": "pool.weapon_flash", "position_from_actor_properties": { "source": "entity.weapon_viewmodel", "x": "gun_x", "y": "gun_y", "z": "gun_z", "x_add": ["gun_intro_x", "gun_recoil_x", "gun_bob_x"], "y_add": ["gun_intro_y", "gun_recoil_y", "gun_bob_y"], "z_add": ["gun_intro_z", "gun_recoil_z", "gun_bob_z"] } }
 { "type": "actor.spawn", "pool": "pool.smoke", "position_from_payload": "origin", "properties_from_actor": { "source": "entity.weapon_smoke_config", "keys": ["smoke_size_scale", "smoke_alpha_scale"] } }
 { "type": "actor.despawn", "target_from_payload": "actor_name" }
 ```
@@ -2393,10 +2395,11 @@ can also use `payload.compare` with the same comparison operators:
 }
 ```
 
-`debug.write_actor_properties` is a development-only action for placement and
-tuning workflows. It writes selected actor properties to a host filesystem path.
-Set `append` to true to add another diagnostic block instead of replacing the
-file:
+`debug.write_actor_properties` is a development-only action for explicit
+placement and tuning workflows. It writes selected actor properties to a host
+filesystem path when the action runs. Keep it behind opt-in tuning controls or
+debug-only bindings; do not run it continuously during normal gameplay. Set
+`append` to true to add another diagnostic block instead of replacing the file:
 
 ```json
 {

--- a/src/game_data_actor_pool_runtime.c
+++ b/src/game_data_actor_pool_runtime.c
@@ -383,6 +383,19 @@ static bool actor_property_float_value(const slayer3d_properties *props, const c
     return false;
 }
 
+static float actor_property_float_sum(const slayer3d_properties *props, yyjson_val *keys)
+{
+    float sum = 0.0f;
+    for (size_t i = 0; props != NULL && yyjson_is_arr(keys) && i < yyjson_arr_size(keys); ++i)
+    {
+        yyjson_val *key = yyjson_arr_get(keys, i);
+        float value = 0.0f;
+        if (yyjson_is_str(key) && actor_property_float_value(props, yyjson_get_str(key), &value))
+            sum += value;
+    }
+    return sum;
+}
+
 static const slayer3d_registered_actor *actor_property_position_from_json(slayer3d_game_data_runtime *runtime,
                                                                           yyjson_val *position_from_actor_properties,
                                                                           slayer3d_vec3 *out_position)
@@ -413,6 +426,9 @@ static const slayer3d_registered_actor *actor_property_position_from_json(slayer
         position.y += offset.y;
         position.z += offset.z;
     }
+    position.x += actor_property_float_sum(source->props, obj_get(position_from_actor_properties, "x_add"));
+    position.y += actor_property_float_sum(source->props, obj_get(position_from_actor_properties, "y_add"));
+    position.z += actor_property_float_sum(source->props, obj_get(position_from_actor_properties, "z_add"));
     *out_position = position;
     return source;
 }

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7955,6 +7955,26 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             if (property_offset != NULL && !is_vec_array(property_offset, 3))
                 return validation_error(ctx, json_path,
                                         "actor.spawn position_from_actor_properties offset must be a vec3");
+            const char *additive_fields[] = {"x_add", "y_add", "z_add"};
+            for (size_t additive_index = 0; additive_index < SDL_arraysize(additive_fields); ++additive_index)
+            {
+                yyjson_val *additive = obj_get(position_from_actor_properties, additive_fields[additive_index]);
+                if (additive == NULL)
+                    continue;
+                if (!yyjson_is_arr(additive))
+                    return validation_error(
+                        ctx, json_path, "actor.spawn position_from_actor_properties additive fields must be arrays");
+                for (size_t property_index = 0; property_index < yyjson_arr_size(additive); ++property_index)
+                {
+                    yyjson_val *property = yyjson_arr_get(additive, property_index);
+                    if (!yyjson_is_str(property) || yyjson_get_str(property)[0] == '\0')
+                    {
+                        return validation_error(ctx, json_path,
+                                                "actor.spawn position_from_actor_properties additive fields must "
+                                                "contain non-empty strings");
+                    }
+                }
+            }
         }
         yyjson_val *offset = obj_get(action, "offset");
         if (offset != NULL && !is_vec_array(offset, 3))

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -1727,74 +1727,6 @@ static bool model_has_euler_rotation(slayer3d_vec3 rotation)
     return SDL_fabsf(rotation.x) > 0.000001f || SDL_fabsf(rotation.y) > 0.000001f || SDL_fabsf(rotation.z) > 0.000001f;
 }
 
-static bool viewmodel_trace_enabled_for_entity(const char *entity_name)
-{
-    const char *enabled = SDL_getenv("SLAYER3D_TRACE_VIEWMODEL_TRANSFORMS");
-    if (enabled == NULL || enabled[0] == '\0' || SDL_strcmp(enabled, "0") == 0)
-        return false;
-    const char *filter = SDL_getenv("SLAYER3D_TRACE_VIEWMODEL_ENTITY");
-    return filter == NULL || filter[0] == '\0' || (entity_name != NULL && SDL_strcmp(entity_name, filter) == 0);
-}
-
-static bool viewmodel_trace_write_all(SDL_IOStream *stream, const char *text)
-{
-    const size_t length = SDL_strlen(text);
-    return SDL_WriteIO(stream, text, length) == length;
-}
-
-static void trace_viewmodel_transform(const slayer3d_game_data_render_primitive *primitive,
-                                      const slayer3d_camera3d *camera, slayer3d_vec3 model_position,
-                                      slayer3d_vec3 model_rotation)
-{
-    static int trace_count = 0;
-    if (trace_count >= 128 || primitive == NULL || !primitive->view_space ||
-        !viewmodel_trace_enabled_for_entity(primitive->entity_name))
-    {
-        return;
-    }
-
-    SDL_IOStream *stream = SDL_IOFromFile("/tmp/gun-placement-render-trace.txt", trace_count == 0 ? "wb" : "r+b");
-    if (stream == NULL)
-        return;
-    if (trace_count > 0 && SDL_SeekIO(stream, 0, SDL_IO_SEEK_END) < 0)
-    {
-        SDL_CloseIO(stream);
-        return;
-    }
-
-    const slayer3d_vec3 camera_position = camera != NULL ? camera->position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const slayer3d_vec3 camera_target = camera != NULL ? camera->target : slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
-    const slayer3d_vec3 camera_up = camera != NULL ? camera->up : slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
-    const slayer3d_vec3 forward_raw = slayer3d_vec3_sub(camera_target, camera_position);
-    const slayer3d_vec3 camera_forward = slayer3d_vec3_length_squared(forward_raw) > 0.000001f
-                                             ? slayer3d_vec3_normalize(forward_raw)
-                                             : slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
-    char buffer[1536];
-    SDL_snprintf(buffer, sizeof(buffer),
-                 "# Slayer 3D viewmodel render transform\n"
-                 "index=%d\n"
-                 "actor=%s\n"
-                 "local_offset=[%.6f, %.6f, %.6f]\n"
-                 "local_euler=[%.6f, %.6f, %.6f]\n"
-                 "model_scale=[%.6f, %.6f, %.6f]\n"
-                 "camera_position=[%.6f, %.6f, %.6f]\n"
-                 "camera_target=[%.6f, %.6f, %.6f]\n"
-                 "camera_up=[%.6f, %.6f, %.6f]\n"
-                 "camera_forward=[%.6f, %.6f, %.6f]\n"
-                 "render_position=[%.6f, %.6f, %.6f]\n"
-                 "render_euler=[%.6f, %.6f, %.6f]\n\n",
-                 trace_count, primitive->entity_name != NULL ? primitive->entity_name : "<none>", primitive->position.x,
-                 primitive->position.y, primitive->position.z, primitive->euler_rotation.x, primitive->euler_rotation.y,
-                 primitive->euler_rotation.z, primitive->model_scale.x, primitive->model_scale.y,
-                 primitive->model_scale.z, camera_position.x, camera_position.y, camera_position.z, camera_target.x,
-                 camera_target.y, camera_target.z, camera_up.x, camera_up.y, camera_up.z, camera_forward.x,
-                 camera_forward.y, camera_forward.z, model_position.x, model_position.y, model_position.z,
-                 model_rotation.x, model_rotation.y, model_rotation.z);
-    if (viewmodel_trace_write_all(stream, buffer))
-        ++trace_count;
-    SDL_CloseIO(stream);
-}
-
 static bool draw_model_with_matrix(slayer3d_render_context *renderer, const slayer3d_asset_resolver *assets,
                                    const slayer3d_model *model, slayer3d_mat4 matrix, slayer3d_color tint)
 {
@@ -1921,7 +1853,6 @@ static bool draw_primitive(void *userdata, const slayer3d_game_data_render_primi
             model_rotation = primitive->euler_rotation;
             use_model_matrix = true;
         }
-        trace_viewmodel_transform(primitive, context->camera, model_position, model_rotation);
         if (primitive->animation_clip >= 0 && entry->model.skeleton != NULL && entry->model.animation_count > 0)
         {
             int clip_index = primitive->animation_clip;

--- a/src/network.c
+++ b/src/network.c
@@ -202,6 +202,7 @@ static void slayer3d_network_destroy_remote_address(slayer3d_network_session *se
 
     if (session->remote_address != NULL)
     {
+        (void)NET_WaitUntilResolved(session->remote_address, -1);
         NET_UnrefAddress(session->remote_address);
         session->remote_address = NULL;
     }
@@ -218,6 +219,7 @@ static void slayer3d_network_discovery_destroy_target_address(slayer3d_network_d
     {
         if (session->target_addresses[i] != NULL)
         {
+            (void)NET_WaitUntilResolved(session->target_addresses[i], -1);
             NET_UnrefAddress(session->target_addresses[i]);
             session->target_addresses[i] = NULL;
         }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -6998,7 +6998,10 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
       "properties": {
         "anchor_x": { "type": "float", "value": 2.0 },
         "anchor_y": { "type": "float", "value": 3.0 },
-        "anchor_z": { "type": "float", "value": 4.0 }
+        "anchor_z": { "type": "float", "value": 4.0 },
+        "anchor_x_add": { "type": "float", "value": 0.75 },
+        "anchor_y_add": { "type": "float", "value": -0.25 },
+        "anchor_z_add": { "type": "float", "value": 0.125 }
       }
     }
   ],
@@ -7122,7 +7125,10 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
               "x": "anchor_x",
               "y": "anchor_y",
               "z": "anchor_z",
-              "offset": [0.25, 0.5, -0.25]
+              "offset": [0.25, 0.5, -0.25],
+              "x_add": ["anchor_x_add"],
+              "y_add": ["anchor_y_add"],
+              "z_add": ["anchor_z_add"]
             },
             "offset": [1.0, 0.0, 0.0]
           }
@@ -7221,7 +7227,7 @@ TEST(GameDataRuntime, ActorPoolsSpawnDespawnAndResetActors)
 
     slayer3d_signal_emit(bus, slayer3d_game_data_find_signal(runtime, "signal.spawn.property_position"), nullptr);
     EXPECT_TRUE(shot0->active);
-    expect_vec3_near(shot0->position, slayer3d_vec3_make(3.25f, 3.5f, 3.75f));
+    expect_vec3_near(shot0->position, slayer3d_vec3_make(4.0f, 3.25f, 3.875f));
 
     slayer3d_signal_emit(bus, slayer3d_game_data_find_signal(runtime, "signal.despawn.projectiles"), nullptr);
     EXPECT_FALSE(shot0->active);
@@ -7944,19 +7950,11 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
         slayer3d_game_data_for_each_render_primitive(runtime, find_revolver_pickup_model, &saw_revolver_pickup));
     EXPECT_TRUE(saw_revolver_pickup);
     const std::filesystem::path placement_path = "/tmp/gun-placement.txt";
-    const std::filesystem::path pickup_placement_path = "/tmp/gun-placement-pickup.txt";
-    const std::filesystem::path placement_trace_path = "/tmp/gun-placement-trace.txt";
     const std::filesystem::path smoke_placement_path = "/tmp/smoke-placement.txt";
-    const std::filesystem::path smoke_trace_path = "/tmp/smoke-placement-trace.txt";
     const std::filesystem::path muzzle_flash_placement_path = "/tmp/muzzle-flash-placement.txt";
-    const std::filesystem::path muzzle_flash_trace_path = "/tmp/muzzle-flash-placement-trace.txt";
     std::filesystem::remove(placement_path);
-    std::filesystem::remove(pickup_placement_path);
-    std::filesystem::remove(placement_trace_path);
     std::filesystem::remove(smoke_placement_path);
-    std::filesystem::remove(smoke_trace_path);
     std::filesystem::remove(muzzle_flash_placement_path);
-    std::filesystem::remove(muzzle_flash_trace_path);
     slayer3d_properties_set_float(revolver->props, "gun_x", 9.0f);
     slayer3d_properties_set_float(revolver->props, "gun_yaw", 9.0f);
     const int revolver_pickup_signal = slayer3d_game_data_find_signal(runtime, "signal.brush_geometry.revolver.pickup");
@@ -7986,16 +7984,6 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_NEAR(slayer3d_properties_get_float(revolver->props, "gun_recoil_z", 1.0f), 0.0f, 0.0001f);
     EXPECT_NEAR(slayer3d_properties_get_float(revolver->props, "gun_recoil_pitch", 1.0f), 0.0f, 0.0001f);
     ASSERT_FALSE(std::filesystem::exists(placement_path));
-    ASSERT_TRUE(std::filesystem::exists(pickup_placement_path));
-    ASSERT_TRUE(std::filesystem::exists(placement_trace_path));
-    const std::string pickup_placement_text = read_text(pickup_placement_path);
-    EXPECT_NE(pickup_placement_text.find("label=pickup.viewmodel.current"), std::string::npos);
-    EXPECT_NE(pickup_placement_text.find("gun_yaw=-1.549999"), std::string::npos);
-    const std::string pickup_trace_text = read_text(placement_trace_path);
-    EXPECT_NE(pickup_trace_text.find("label=pickup.viewmodel.current"), std::string::npos);
-    EXPECT_NE(pickup_trace_text.find("label=pickup.player.camera_state"), std::string::npos);
-    EXPECT_LT(pickup_trace_text.find("label=pickup.viewmodel.current"),
-              pickup_trace_text.find("label=pickup.player.camera_state"));
     bool saw_revolver_viewmodel = false;
     auto find_revolver_model = [](void *userdata, const slayer3d_game_data_render_primitive *primitive) -> bool {
         bool *saw = static_cast<bool *>(userdata);
@@ -8040,12 +8028,24 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     EXPECT_EQ(slayer3d_game_data_find_actor(runtime, "pool.brush_geometry.revolver_impact_decals.0"), nullptr);
     EXPECT_TRUE(muzzle_flash->active);
     EXPECT_TRUE(smoke->active);
-    EXPECT_NEAR(muzzle_flash->position.x, 0.2f, 0.0001f);
-    EXPECT_NEAR(muzzle_flash->position.y, -0.26f, 0.0001f);
-    EXPECT_NEAR(muzzle_flash->position.z, 0.58f, 0.0001f);
-    EXPECT_NEAR(smoke->position.x, 0.2f, 0.0001f);
-    EXPECT_NEAR(smoke->position.y, -0.26f, 0.0001f);
-    EXPECT_NEAR(smoke->position.z, 0.58f, 0.0001f);
+    const float effect_anchor_x = slayer3d_properties_get_float(revolver->props, "gun_x", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_intro_x", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_recoil_x", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_bob_x", 0.0f);
+    const float effect_anchor_y = slayer3d_properties_get_float(revolver->props, "gun_y", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_intro_y", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_recoil_y", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_bob_y", 0.0f);
+    const float effect_anchor_z = slayer3d_properties_get_float(revolver->props, "gun_z", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_intro_z", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_recoil_z", 0.0f) +
+                                  slayer3d_properties_get_float(revolver->props, "gun_bob_z", 0.0f);
+    EXPECT_NEAR(muzzle_flash->position.x, effect_anchor_x, 0.0001f);
+    EXPECT_NEAR(muzzle_flash->position.y, effect_anchor_y, 0.0001f);
+    EXPECT_NEAR(muzzle_flash->position.z, effect_anchor_z, 0.0001f);
+    EXPECT_NEAR(smoke->position.x, effect_anchor_x, 0.0001f);
+    EXPECT_NEAR(smoke->position.y, effect_anchor_y, 0.0001f);
+    EXPECT_NEAR(smoke->position.z, effect_anchor_z, 0.0001f);
     EXPECT_NEAR(slayer3d_properties_get_float(muzzle_flash->props, "flash_offset_x", 0.0f), 0.09f, 0.0001f);
     EXPECT_NEAR(slayer3d_properties_get_float(muzzle_flash->props, "flash_size_scale", 0.0f), 1.4f, 0.0001f);
     EXPECT_NEAR(slayer3d_properties_get_float(muzzle_flash->props, "flash_alpha_scale", 0.0f), 0.8f, 0.0001f);
@@ -8230,11 +8230,6 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     const std::string placement_text = read_text(placement_path);
     EXPECT_NE(placement_text.find("actor=entity.brush_geometry.revolver_viewmodel"), std::string::npos);
     EXPECT_NE(placement_text.find("gun_x="), std::string::npos);
-    const std::string full_trace_text = read_text(placement_trace_path);
-    EXPECT_NE(full_trace_text.find("label=pickup.viewmodel.current"), std::string::npos);
-    EXPECT_NE(full_trace_text.find("label=pickup.player.camera_state"), std::string::npos);
-    EXPECT_NE(full_trace_text.find("label=manual_write.viewmodel.current"), std::string::npos);
-    EXPECT_NE(full_trace_text.find("label=manual_write.player.camera_state"), std::string::npos);
     slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "debug.revolver_tuning.enabled",
                                  false);
     slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "debug.revolver_smoke_tuning.enabled",
@@ -8255,12 +8250,8 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
               std::string::npos);
     EXPECT_NE(muzzle_flash_placement_text.find("flash_size_scale="), std::string::npos);
     std::filesystem::remove(placement_path);
-    std::filesystem::remove(pickup_placement_path);
-    std::filesystem::remove(placement_trace_path);
     std::filesystem::remove(smoke_placement_path);
-    std::filesystem::remove(smoke_trace_path);
     std::filesystem::remove(muzzle_flash_placement_path);
-    std::filesystem::remove(muzzle_flash_trace_path);
     EXPECT_GT(slayer3d_properties_get_int(visible->props, "spotted", 0), 0);
     EXPECT_EQ(slayer3d_properties_get_int(occluded->props, "spotted", 0), 0);
 
@@ -18065,6 +18056,45 @@ TEST(GameDataRuntime, RejectsInvalidActorPoolsAndSpawnActions)
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
 })json",
             "position_from_actor_properties",
+        },
+        {
+            "bad_spawn_property_position_additive",
+            R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Invalid", "id": "test.invalid", "version": "0.1.0" },
+  "entities": [
+    { "name": "entity.weapon" }
+  ],
+  "actor_archetypes": [
+    { "name": "archetype.shot" }
+  ],
+  "actor_pools": [
+    { "name": "pool.shots", "archetype": "archetype.shot", "capacity": 1 }
+  ],
+  "signals": ["signal.spawn"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.spawn",
+        "actions": [
+          {
+            "type": "actor.spawn",
+            "pool": "pool.shots",
+            "position_from_actor_properties": {
+              "source": "entity.weapon",
+              "x": "gun_x",
+              "y": "gun_y",
+              "z": "gun_z",
+              "x_add": "gun_recoil_x"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json",
+            "additive fields must be arrays",
         },
         {
             "bad_despawn_target",


### PR DESCRIPTION
## Summary
- add additive source-property arrays to actor.spawn position_from_actor_properties for reusable weapon/effect anchors
- update the brush geometry revolver smoke and muzzle flash to follow intro/recoil/bob placement automatically
- remove temporary revolver placement trace diagnostics while keeping explicit tuning exports
- document the additive anchor pattern and debug write guidance

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase:GameDataRuntime.ActorPoolsSpawnDespawnAndResetActors:GameDataRuntime.ViewmodelBobComposesWithAdditiveRenderProperties:GameDataRuntime.RejectsInvalidActorPoolsAndSpawnActions'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8