### PR TITLE
Add editor blockout prefab palette

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -6,10 +6,11 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - authored brush-world selection trace metadata
 - data-authored world/selection/normal/hit debug overlay drawing
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
+- a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
+  `4` player start, then `Enter` to place the selected prefab
 
 Run it with:
 
 ```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
 ```
-

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -50,6 +50,22 @@
           {
             "name": "action.editor.command.redo",
             "bindings": [{ "device": "keyboard", "key": "Y" }]
+          },
+          {
+            "name": "action.editor.tool.floor",
+            "bindings": [{ "device": "keyboard", "key": "1" }]
+          },
+          {
+            "name": "action.editor.tool.wall",
+            "bindings": [{ "device": "keyboard", "key": "2" }]
+          },
+          {
+            "name": "action.editor.tool.ceiling",
+            "bindings": [{ "device": "keyboard", "key": "3" }]
+          },
+          {
+            "name": "action.editor.tool.player_start",
+            "bindings": [{ "device": "keyboard", "key": "4" }]
           }
         ]
       }
@@ -63,6 +79,10 @@
     "signal.editor.command.commit",
     "signal.editor.command.undo",
     "signal.editor.command.redo",
+    "signal.editor.tool.floor",
+    "signal.editor.tool.wall",
+    "signal.editor.tool.ceiling",
+    "signal.editor.tool.player_start",
     "signal.editor.export"
   ],
   "logic": {
@@ -101,6 +121,26 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.command.redo",
         "on_pressed": "signal.editor.command.redo"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.tool.floor",
+        "on_pressed": "signal.editor.tool.floor"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.tool.wall",
+        "on_pressed": "signal.editor.tool.wall"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.tool.ceiling",
+        "on_pressed": "signal.editor.tool.ceiling"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.tool.player_start",
+        "on_pressed": "signal.editor.tool.player_start"
       }
     ],
     "bindings": [
@@ -111,8 +151,36 @@
             "type": "scene_state.cycle",
             "key": "editor.tool.mode",
             "default": "select",
-            "values": ["select", "move", "paint"]
+            "values": ["select", "move", "paint", "floor", "wall", "ceiling", "player_start"]
           }
+        ]
+      },
+      {
+        "signal": "signal.editor.tool.floor",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "floor" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "floor prefab selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.tool.wall",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "wall" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "wall prefab selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.tool.ceiling",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "ceiling" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "ceiling prefab selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.tool.player_start",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "player_start" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start tool selected" }
         ]
       },
       {
@@ -204,37 +272,164 @@
         "signal": "signal.editor.command.commit",
         "actions": [
           {
-            "type": "editor.command.commit",
-            "message": "committed {editor_command} #{editor_transaction_id_text}",
-            "invalid_message": "nothing to commit",
-            "outputs": {
-              "valid_key": "editor.transaction.valid",
-              "event_key": "editor.transaction.event",
-              "message_key": "editor.transaction.message",
-              "transaction_id_key": "editor.transaction.id",
-              "undo_count_key": "editor.transaction.undo_count",
-              "redo_count_key": "editor.transaction.redo_count",
-              "command_key": "editor.transaction.command",
-              "target_key": "editor.transaction.target",
-              "world_key": "editor.transaction.world",
-              "element_key": "editor.transaction.element",
-              "face_index_key": "editor.transaction.face_index",
-              "bounds_min_key": "editor.transaction.bounds_min",
-              "bounds_max_key": "editor.transaction.bounds_max",
-              "dirty_key": "editor.brush_world.dirty",
-              "revision_key": "editor.brush_world.revision",
-              "saved_revision_key": "editor.brush_world.saved_revision",
-              "source_path_key": "editor.brush_world.source_path"
-            },
-            "actions": [
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "floor" },
+            "then": [
               {
-                "type": "scene_state.set",
-                "key": "editor.tool.last_action",
-                "value": "commit {editor_command} #{editor_transaction_id_text}"
-              }
+                "type": "editor.brush_world.create_box",
+                "world": "brush.editor_shell.target",
+                "material": "mat.editor.floor",
+                "min": [-3.0, -0.2, -3.0],
+                "max": [3.0, 0.0, 3.0],
+                "message": "floor prefab created",
+                "outputs": {
+                  "valid_key": "editor.create.valid",
+                  "message_key": "editor.create.message",
+                  "brush_key": "editor.create.brush",
+                  "world_key": "editor.brush_world.name",
+                  "dirty_key": "editor.brush_world.dirty",
+                  "revision_key": "editor.brush_world.revision",
+                  "saved_revision_key": "editor.brush_world.saved_revision",
+                  "source_path_key": "editor.brush_world.source_path"
+                }
+              },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "floor prefab created" }
             ],
             "else": [
-              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "nothing to commit" }
+              {
+                "type": "branch",
+                "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "wall" },
+                "then": [
+                  {
+                    "type": "editor.brush_world.create_box",
+                    "world": "brush.editor_shell.target",
+                    "material": "mat.editor.wall",
+                    "min": [3.0, 0.0, -3.0],
+                    "max": [3.25, 2.5, 3.0],
+                    "message": "wall prefab created",
+                    "outputs": {
+                      "valid_key": "editor.create.valid",
+                      "message_key": "editor.create.message",
+                      "brush_key": "editor.create.brush",
+                      "world_key": "editor.brush_world.name",
+                      "dirty_key": "editor.brush_world.dirty",
+                      "revision_key": "editor.brush_world.revision",
+                      "saved_revision_key": "editor.brush_world.saved_revision",
+                      "source_path_key": "editor.brush_world.source_path"
+                    }
+                  },
+                  { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "wall prefab created" }
+                ],
+                "else": [
+                  {
+                    "type": "branch",
+                    "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "ceiling" },
+                    "then": [
+                      {
+                        "type": "editor.brush_world.create_box",
+                        "world": "brush.editor_shell.target",
+                        "material": "mat.editor.ceiling",
+                        "min": [-3.0, 2.5, -3.0],
+                        "max": [3.0, 2.7, 3.0],
+                        "message": "ceiling prefab created",
+                        "outputs": {
+                          "valid_key": "editor.create.valid",
+                          "message_key": "editor.create.message",
+                          "brush_key": "editor.create.brush",
+                          "world_key": "editor.brush_world.name",
+                          "dirty_key": "editor.brush_world.dirty",
+                          "revision_key": "editor.brush_world.revision",
+                          "saved_revision_key": "editor.brush_world.saved_revision",
+                          "source_path_key": "editor.brush_world.source_path"
+                        }
+                      },
+                      {
+                        "type": "scene_state.set",
+                        "key": "editor.tool.last_action",
+                        "value": "ceiling prefab created"
+                      }
+                    ],
+                    "else": [
+                      {
+                        "type": "branch",
+                        "if": {
+                          "type": "scene_state.compare",
+                          "key": "editor.tool.mode",
+                          "op": "==",
+                          "value": "player_start"
+                        },
+                        "then": [
+                          {
+                            "type": "editor.player_start.place",
+                            "name": "player_start.editor_shell",
+                            "scene": "scene.editor_shell.dojo",
+                            "position": [0.0, 1.6, 4.0],
+                            "yaw": 3.14159,
+                            "pitch": 0.0,
+                            "outputs": {
+                              "valid_key": "editor.player_start.valid",
+                              "message_key": "editor.player_start.message",
+                              "player_start_key": "editor.player_start.name",
+                              "scene_key": "editor.player_start.scene",
+                              "position_key": "editor.player_start.position",
+                              "yaw_key": "editor.player_start.yaw",
+                              "pitch_key": "editor.player_start.pitch",
+                              "dirty_key": "editor.player_start.dirty",
+                              "revision_key": "editor.player_start.revision",
+                              "saved_revision_key": "editor.player_start.saved_revision"
+                            }
+                          },
+                          {
+                            "type": "scene_state.set",
+                            "key": "editor.tool.last_action",
+                            "value": "player start placed"
+                          }
+                        ],
+                        "else": [
+                          {
+                            "type": "editor.command.commit",
+                            "message": "committed {editor_command} #{editor_transaction_id_text}",
+                            "invalid_message": "nothing to commit",
+                            "outputs": {
+                              "valid_key": "editor.transaction.valid",
+                              "event_key": "editor.transaction.event",
+                              "message_key": "editor.transaction.message",
+                              "transaction_id_key": "editor.transaction.id",
+                              "undo_count_key": "editor.transaction.undo_count",
+                              "redo_count_key": "editor.transaction.redo_count",
+                              "command_key": "editor.transaction.command",
+                              "target_key": "editor.transaction.target",
+                              "world_key": "editor.transaction.world",
+                              "element_key": "editor.transaction.element",
+                              "face_index_key": "editor.transaction.face_index",
+                              "bounds_min_key": "editor.transaction.bounds_min",
+                              "bounds_max_key": "editor.transaction.bounds_max",
+                              "dirty_key": "editor.brush_world.dirty",
+                              "revision_key": "editor.brush_world.revision",
+                              "saved_revision_key": "editor.brush_world.saved_revision",
+                              "source_path_key": "editor.brush_world.source_path"
+                            },
+                            "actions": [
+                              {
+                                "type": "scene_state.set",
+                                "key": "editor.tool.last_action",
+                                "value": "commit {editor_command} #{editor_transaction_id_text}"
+                              }
+                            ],
+                            "else": [
+                              {
+                                "type": "scene_state.set",
+                                "key": "editor.tool.last_action",
+                                "value": "nothing to commit"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
             ]
           }
         ]
@@ -385,6 +580,15 @@
           "editor": {
             "stable_id": "editor.material.floor",
             "display_name": "Dark Floor Material"
+          }
+        },
+        {
+          "name": "mat.editor.ceiling",
+          "albedo": [0.42, 0.44, 0.48, 1.0],
+          "roughness": 0.85,
+          "editor": {
+            "stable_id": "editor.material.ceiling",
+            "display_name": "Soft Ceiling Material"
           }
         }
       ],

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -13,7 +13,11 @@
       "action.editor.command.preview",
       "action.editor.command.commit",
       "action.editor.command.undo",
-      "action.editor.command.redo"
+      "action.editor.command.redo",
+      "action.editor.tool.floor",
+      "action.editor.tool.wall",
+      "action.editor.tool.ceiling",
+      "action.editor.tool.player_start"
     ]
   },
   "world": {
@@ -77,7 +81,7 @@
         "x": 18,
         "y": 18,
         "w": 340,
-        "h": 270,
+        "h": 320,
         "color": [10, 14, 22, 215],
         "border_color": [80, 140, 230, 230],
         "border_thickness": 2
@@ -132,6 +136,14 @@
             "binding": { "type": "scene_state", "key": "editor.tool.last_action", "default": "none" }
           },
           {
+            "label": "Created",
+            "binding": { "type": "scene_state", "key": "editor.create.message", "default": "none" }
+          },
+          {
+            "label": "Start",
+            "binding": { "type": "scene_state", "key": "editor.player_start.name", "default": "none" }
+          },
+          {
             "label": "Preview",
             "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
           },
@@ -156,7 +168,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. P preview. Enter commit. Z/Y undo-redo. Tab tool. Backspace clear.",
+        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. P preview. Enter commit. Z/Y undo-redo.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -734,7 +734,12 @@ blockout tools: floors, walls, ceilings, platforms, and simple room pieces. It
 validates the target world and bounds at load time, resolves the material at
 runtime, rebuilds brush collision/render data atomically, then marks the world
 dirty only after the rebuild succeeds. If `name` is omitted, the runtime
-generates a unique brush name under the target world.
+generates a unique brush name under the target world. The editor shell dojo
+demonstrates the current blockout palette pattern: number-key tool selection is
+represented by scene-state strings, and the shared commit signal branches to
+prefab-specific `editor.brush_world.create_box` or
+`editor.player_start.place` actions. That keeps the first editor workflow
+data-authored while a dedicated editor frontend is still evolving.
 
 ```json
 {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13868,6 +13868,108 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int floor_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.floor");
+    const int wall_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.wall");
+    const int ceiling_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.ceiling");
+    const int player_start_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start");
+    const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
+    ASSERT_GE(floor_signal, 0);
+    ASSERT_GE(wall_signal, 0);
+    ASSERT_GE(ceiling_signal, 0);
+    ASSERT_GE(player_start_signal, 0);
+    ASSERT_GE(commit_signal, 0);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    auto latest_brush = [&]() -> const slayer3d_game_data_brush * {
+        slayer3d_game_data_brush_world brush_world = world();
+        if (brush_world.brush_count <= 0)
+            return nullptr;
+        return &brush_world.brushes[brush_world.brush_count - 1];
+    };
+
+    EXPECT_EQ(world().brush_count, 1);
+
+    slayer3d_signal_emit(bus, floor_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "floor");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "floor prefab selected");
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
+                 "brush.editor_shell.target.box.1");
+    ASSERT_NE(latest_brush(), nullptr);
+    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.floor");
+    EXPECT_NEAR(latest_brush()->bounds.min.y, -0.2f, 0.001f);
+    EXPECT_NEAR(latest_brush()->bounds.max.y, 0.0f, 0.001f);
+
+    slayer3d_signal_emit(bus, wall_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
+                 "brush.editor_shell.target.box.2");
+    ASSERT_NE(latest_brush(), nullptr);
+    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.wall");
+    EXPECT_NEAR(latest_brush()->bounds.min.x, 3.0f, 0.001f);
+    EXPECT_NEAR(latest_brush()->bounds.max.y, 2.5f, 0.001f);
+
+    slayer3d_signal_emit(bus, ceiling_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "ceiling");
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "ceiling prefab created");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
+                 "brush.editor_shell.target.box.3");
+    ASSERT_NE(latest_brush(), nullptr);
+    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.ceiling");
+    EXPECT_NEAR(latest_brush()->bounds.min.y, 2.5f, 0.001f);
+    EXPECT_NEAR(latest_brush()->bounds.max.y, 2.7f, 0.001f);
+    EXPECT_EQ(world().brush_count, 4);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 3);
+
+    slayer3d_signal_emit(bus, player_start_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "player_start");
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.name", ""),
+                 "player_start.editor_shell");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.scene", ""),
+                 "scene.editor_shell.dojo");
+    slayer3d_game_data_editor_player_start start{};
+    ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
+    EXPECT_NEAR(start.position.x, 0.0f, 0.001f);
+    EXPECT_NEAR(start.position.y, 1.6f, 0.001f);
+    EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.dirty", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, RunsAuthoredFpsBrushController)
 {
     const std::filesystem::path dir = unique_test_dir("fps_brush_controller");


### PR DESCRIPTION
## Summary
- add a data-authored editor shell blockout palette for floor, wall, ceiling, and player-start tools
- bind number keys 1-4 to tool selection and route Enter through the selected prefab action or the existing editor command commit path
- update editor shell UI/docs and add regression coverage against the real dojo data

## Tests
- jq empty demos/editor_shell_dojo/data/editor_shell_dojo.game.json demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8

## Notes
This targets issue #360 slice 2. The next slice should make save/reload cover the unified editable level state: brush geometry plus editor player starts, with a reload parity test.