### PR TITLE
Add unified editable level export

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -8,6 +8,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
   `4` player start, then `Enter` to place the selected prefab
+- unified editable-level export: `S` publishes one fragment containing the
+  brush world and player starts
 
 Run it with:
 

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -52,6 +52,10 @@
             "bindings": [{ "device": "keyboard", "key": "Y" }]
           },
           {
+            "name": "action.editor.export",
+            "bindings": [{ "device": "keyboard", "key": "S" }]
+          },
+          {
             "name": "action.editor.tool.floor",
             "bindings": [{ "device": "keyboard", "key": "1" }]
           },
@@ -121,6 +125,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.command.redo",
         "on_pressed": "signal.editor.command.redo"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.export",
+        "on_pressed": "signal.editor.export"
       },
       {
         "type": "sensor.input_pressed",
@@ -508,18 +517,23 @@
         "signal": "signal.editor.export",
         "actions": [
           {
-            "type": "editor.brush_world.export",
+            "type": "editor.level.export",
             "world": "brush.editor_shell.target",
             "outputs": {
               "valid_key": "editor.export.valid",
               "message_key": "editor.export.message",
               "json_key": "editor.export.json",
               "size_key": "editor.export.size",
-              "world_key": "editor.brush_world.name",
-              "dirty_key": "editor.brush_world.dirty",
-              "revision_key": "editor.brush_world.revision",
-              "saved_revision_key": "editor.brush_world.saved_revision",
-              "source_path_key": "editor.brush_world.source_path"
+              "brush_world_key": "editor.brush_world.name",
+              "brush_dirty_key": "editor.brush_world.dirty",
+              "brush_revision_key": "editor.brush_world.revision",
+              "brush_saved_revision_key": "editor.brush_world.saved_revision",
+              "brush_source_path_key": "editor.brush_world.source_path",
+              "player_start_count_key": "editor.player_start.count",
+              "player_start_dirty_key": "editor.player_start.dirty",
+              "player_start_revision_key": "editor.player_start.revision",
+              "player_start_saved_revision_key": "editor.player_start.saved_revision",
+              "player_start_source_path_key": "editor.player_start.source_path"
             }
           }
         ]

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -14,6 +14,7 @@
       "action.editor.command.commit",
       "action.editor.command.undo",
       "action.editor.command.redo",
+      "action.editor.export",
       "action.editor.tool.floor",
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
@@ -168,7 +169,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. P preview. Enter commit. Z/Y undo-redo.",
+        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S export. Z/Y undo-redo.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -888,15 +888,28 @@ project pipeline can call `slayer3d_game_data_mark_brush_world_saved()` after
 their write commits. Authored game data does not get a direct arbitrary-file
 save action; file writes stay under editor host control.
 
+Use `editor.level.export` when the editable artifact needs both blockout brush
+geometry and test-run player starts. It serializes a single fragment containing
+the selected `brush_worlds` entry and the runtime `editor_player_starts`
+collection. Native editor hosts can call
+`slayer3d_game_data_export_editable_level_fragment_json()` or
+`slayer3d_game_data_save_editable_level_fragment_file()` for the same canonical
+JSON. A successful native save marks both the selected brush world and
+player-start collection clean at their current revisions. This is the preferred
+first milestone save path for blockout editors because reloading one fragment
+restores floors, walls, ceilings, face materials, and player starts together.
+
 ```json
 {
-  "type": "editor.brush_world.export",
+  "type": "editor.level.export",
   "world": "brush.level.blockout",
   "outputs": {
     "valid_key": "editor.export.valid",
     "message_key": "editor.export.message",
     "json_key": "editor.export.json",
-    "size_key": "editor.export.size"
+    "size_key": "editor.export.size",
+    "brush_revision_key": "editor.brush_world.revision",
+    "player_start_revision_key": "editor.player_start.revision"
   }
 }
 ```

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2053,6 +2053,15 @@ extern "C"
                                                                char **out_json, size_t *out_size, char *error_buffer,
                                                                int error_buffer_size);
 
+    /**
+     * @brief Mark the runtime editor player-start collection as saved.
+     *
+     * @p source_path may be NULL to keep the existing source path, or a
+     * filesystem path to associate with the saved revision.
+     */
+    bool slayer3d_game_data_mark_player_starts_saved(slayer3d_game_data_runtime *runtime, const char *source_path,
+                                                     char *error_buffer, int error_buffer_size);
+
     /** @brief Descriptor for resizing one brush face plane. */
     typedef struct slayer3d_game_data_resize_brush_face_desc
     {
@@ -2117,6 +2126,36 @@ extern "C"
     bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
                                                            const char *path, size_t *out_size, char *error_buffer,
                                                            int error_buffer_size);
+
+    /**
+     * @brief Export one editable level fragment containing brushes and starts.
+     *
+     * The exported document uses `schema: "slayer3d.fragment.v0"` and contains
+     * the selected `brush_worlds` entry plus the runtime `editor_player_starts`
+     * collection. This is the canonical first-pass editor level artifact for
+     * blockout workflows that need geometry and test-run spawn points to reload
+     * together. The returned string is allocated with SDL_malloc and must be
+     * released with SDL_free().
+     */
+    bool slayer3d_game_data_export_editable_level_fragment_json(const slayer3d_game_data_runtime *runtime,
+                                                                const char *world_name, char **out_json,
+                                                                size_t *out_size, char *error_buffer,
+                                                                int error_buffer_size);
+
+    /**
+     * @brief Atomically save one editable level fragment file.
+     *
+     * This saves the same JSON produced by
+     * @ref slayer3d_game_data_export_editable_level_fragment_json. Parent
+     * directories are created automatically, and the target path is updated via
+     * a same-directory temporary file. On success, both the selected brush world
+     * and the player-start collection are marked saved at their current
+     * revisions and @p path becomes their editor source path.
+     */
+    bool slayer3d_game_data_save_editable_level_fragment_file(slayer3d_game_data_runtime *runtime,
+                                                              const char *world_name, const char *path,
+                                                              size_t *out_size, char *error_buffer,
+                                                              int error_buffer_size);
 
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -400,6 +400,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.brush_world.export") == 0)
         return slayer3d_game_data_export_editor_brush_world_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.level.export") == 0)
+        return slayer3d_game_data_export_editor_level_action(runtime, action);
+
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
         return slayer3d_game_data_publish_editor_brush_world_status_action(runtime, action);
 

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -865,6 +865,7 @@ bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime,
 bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                             const slayer3d_properties *payload);
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
                                                                  yyjson_val *action);
 bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8564,6 +8564,37 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.level.export") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.level.export outputs must be an object");
+        static const char *const output_keys[] = {
+            "valid_key",
+            "message_key",
+            "json_key",
+            "size_key",
+            "brush_world_key",
+            "brush_source_path_key",
+            "brush_dirty_key",
+            "brush_revision_key",
+            "brush_saved_revision_key",
+            "player_start_source_path_key",
+            "player_start_count_key",
+            "player_start_dirty_key",
+            "player_start_revision_key",
+            "player_start_saved_revision_key",
+        };
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path, "editor.level.export output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
     {
         if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -982,6 +982,36 @@ static void mark_editor_player_starts_dirty(slayer3d_game_data_runtime *runtime)
     runtime->editor_player_start_dirty = true;
 }
 
+static bool editor_player_starts_set_source_path(slayer3d_game_data_runtime *runtime, const char *source_path)
+{
+    if (runtime == NULL || source_path == NULL)
+        return true;
+    char *copy = SDL_strdup(source_path);
+    if (copy == NULL)
+        return false;
+    SDL_free(runtime->editor_player_start_source_path);
+    runtime->editor_player_start_source_path = copy;
+    return true;
+}
+
+bool slayer3d_game_data_mark_player_starts_saved(slayer3d_game_data_runtime *runtime, const char *source_path,
+                                                 char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "player start save state requires runtime");
+        return false;
+    }
+    if (!editor_player_starts_set_source_path(runtime, source_path))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to update player start save state");
+        return false;
+    }
+    runtime->editor_player_start_saved_revision = runtime->editor_player_start_revision;
+    runtime->editor_player_start_dirty = false;
+    return true;
+}
+
 bool slayer3d_game_data_place_editor_player_start(slayer3d_game_data_runtime *runtime,
                                                   const slayer3d_game_data_place_player_start_desc *desc,
                                                   char *error_buffer, int error_buffer_size)
@@ -1437,6 +1467,70 @@ bool slayer3d_game_data_export_player_starts_fragment_json(const slayer3d_game_d
     return true;
 }
 
+bool slayer3d_game_data_export_editable_level_fragment_json(const slayer3d_game_data_runtime *runtime,
+                                                            const char *world_name, char **out_json, size_t *out_size,
+                                                            char *error_buffer, int error_buffer_size)
+{
+    if (out_json != NULL)
+        *out_json = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (runtime == NULL || out_json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editable level export requires runtime and output");
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "brush world '%s' not found", world_name);
+        return false;
+    }
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    yyjson_mut_val *worlds = doc != NULL ? yyjson_mut_arr(doc) : NULL;
+    yyjson_mut_val *starts = doc != NULL ? yyjson_mut_arr(doc) : NULL;
+    if (doc == NULL || root == NULL || worlds == NULL || starts == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to allocate editable level export document");
+        return false;
+    }
+
+    yyjson_mut_doc_set_root(doc, root);
+    bool ok = yyjson_mut_obj_add_strcpy(doc, root, "schema", "slayer3d.fragment.v0") &&
+              yyjson_mut_obj_add_val(doc, root, "brush_worlds", worlds) &&
+              export_add_brush_world(doc, worlds, &world_runtime->desc) &&
+              yyjson_mut_obj_add_val(doc, root, "editor_player_starts", starts);
+    for (int i = 0; ok && i < runtime->editor_player_start_count; ++i)
+        ok = export_add_player_start(doc, starts, &runtime->editor_player_starts[i]);
+
+    size_t size = 0u;
+    char *json = ok ? yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size) : NULL;
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to write editable level export JSON");
+        return false;
+    }
+
+    char *copy = (char *)SDL_malloc(size + 1u);
+    if (copy == NULL)
+    {
+        free(json);
+        set_error(error_buffer, error_buffer_size, "failed to allocate editable level export JSON");
+        return false;
+    }
+    SDL_memcpy(copy, json, size + 1u);
+    free(json);
+    *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
 static bool editor_save_write_all(SDL_IOStream *stream, const void *data, size_t size)
 {
     const Uint8 *bytes = (const Uint8 *)data;
@@ -1581,6 +1675,76 @@ bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtim
         return false;
     }
     if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size))
+        return false;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+bool slayer3d_game_data_save_editable_level_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                          const char *path, size_t *out_size, char *error_buffer,
+                                                          int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editable level save requires a filesystem path");
+        return false;
+    }
+
+    char *json = NULL;
+    size_t size = 0u;
+    if (!slayer3d_game_data_export_editable_level_fragment_json(runtime, world_name, &json, &size, error_buffer,
+                                                                error_buffer_size))
+    {
+        return false;
+    }
+
+    char *parent = editor_save_parent_directory(path);
+    if (parent == NULL || !editor_save_make_directory_recursive(parent))
+    {
+        SDL_free(parent);
+        SDL_free(json);
+        set_error(error_buffer, error_buffer_size, "failed to create editable level save directory");
+        return false;
+    }
+    SDL_free(parent);
+
+    bool ok = false;
+    char temp_path[4096];
+    for (int attempt = 0; attempt < 16 && !ok; ++attempt)
+    {
+        SDL_snprintf(temp_path, sizeof(temp_path), "%s.tmp.%llu.%d", path, (unsigned long long)SDL_GetTicksNS(),
+                     attempt);
+        SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
+        if (stream == NULL)
+            continue;
+        ok = editor_save_write_all(stream, json, size) && SDL_FlushIO(stream);
+        ok = SDL_CloseIO(stream) && ok;
+        if (!ok)
+        {
+            SDL_RemovePath(temp_path);
+            continue;
+        }
+        if (!SDL_RenamePath(temp_path, path))
+        {
+            SDL_RemovePath(path);
+            ok = SDL_RenamePath(temp_path, path);
+        }
+        if (!ok)
+            SDL_RemovePath(temp_path);
+    }
+
+    SDL_free(json);
+    if (!ok)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to save editable level fragment");
+        return false;
+    }
+    if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size))
+        return false;
+    if (!slayer3d_game_data_mark_player_starts_saved(runtime, path, error_buffer, error_buffer_size))
         return false;
     if (out_size != NULL)
         *out_size = size;
@@ -2929,6 +3093,51 @@ bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runt
     editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
     editor_set_string_output(scene_state, outputs, "json_key", ok && json != NULL ? json : "");
     (void)publish_editor_brush_world_status(runtime, outputs, world_name, NULL, false);
+    SDL_free(json);
+    return true;
+}
+
+bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    const char *world_name = json_string(action, "world", NULL);
+    char error[256];
+    error[0] = '\0';
+    char *json = NULL;
+    size_t size = 0u;
+    const bool ok = slayer3d_game_data_export_editable_level_fragment_json(runtime, world_name, &json, &size, error,
+                                                                           (int)sizeof(error));
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "editable level exported")
+                                : (error[0] != '\0' ? error : "editable level export failed"));
+    editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "json_key", ok && json != NULL ? json : "");
+
+    slayer3d_game_data_brush_world_editor_state brush_state;
+    SDL_zero(brush_state);
+    const bool has_brush_state = slayer3d_game_data_get_brush_world_editor_state(runtime, world_name, &brush_state);
+    slayer3d_game_data_player_start_editor_state start_state;
+    SDL_zero(start_state);
+    const bool has_start_state = slayer3d_game_data_get_player_start_editor_state(runtime, &start_state);
+    editor_set_string_output(scene_state, outputs, "brush_world_key",
+                             has_brush_state && brush_state.world_name != NULL ? brush_state.world_name : "");
+    editor_set_bool_output(scene_state, outputs, "brush_dirty_key", has_brush_state && brush_state.dirty);
+    editor_set_int_output(scene_state, outputs, "brush_revision_key",
+                          has_brush_state ? editor_revision_to_int(brush_state.revision) : 0);
+    editor_set_int_output(scene_state, outputs, "brush_saved_revision_key",
+                          has_brush_state ? editor_revision_to_int(brush_state.saved_revision) : 0);
+    editor_set_string_output(scene_state, outputs, "brush_source_path_key",
+                             has_brush_state && brush_state.source_path != NULL ? brush_state.source_path : "");
+    editor_set_bool_output(scene_state, outputs, "player_start_dirty_key", has_start_state && start_state.dirty);
+    editor_set_int_output(scene_state, outputs, "player_start_count_key", has_start_state ? start_state.count : 0);
+    editor_set_int_output(scene_state, outputs, "player_start_revision_key",
+                          has_start_state ? editor_revision_to_int(start_state.revision) : 0);
+    editor_set_int_output(scene_state, outputs, "player_start_saved_revision_key",
+                          has_start_state ? editor_revision_to_int(start_state.saved_revision) : 0);
+    editor_set_string_output(scene_state, outputs, "player_start_source_path_key",
+                             has_start_state && start_state.source_path != NULL ? start_state.source_path : "");
     SDL_free(json);
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13887,11 +13887,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int ceiling_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.ceiling");
     const int player_start_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start");
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
+    const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
     ASSERT_GE(floor_signal, 0);
     ASSERT_GE(wall_signal, 0);
     ASSERT_GE(ceiling_signal, 0);
     ASSERT_GE(player_start_signal, 0);
     ASSERT_GE(commit_signal, 0);
+    ASSERT_GE(export_signal, 0);
 
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
@@ -13900,13 +13902,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
-    auto latest_brush = [&]() -> const slayer3d_game_data_brush * {
-        slayer3d_game_data_brush_world brush_world = world();
-        if (brush_world.brush_count <= 0)
-            return nullptr;
-        return &brush_world.brushes[brush_world.brush_count - 1];
-    };
-
     EXPECT_EQ(world().brush_count, 1);
 
     slayer3d_signal_emit(bus, floor_signal, nullptr);
@@ -13917,10 +13912,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
                  "brush.editor_shell.target.box.1");
-    ASSERT_NE(latest_brush(), nullptr);
-    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.floor");
-    EXPECT_NEAR(latest_brush()->bounds.min.y, -0.2f, 0.001f);
-    EXPECT_NEAR(latest_brush()->bounds.max.y, 0.0f, 0.001f);
+    slayer3d_game_data_brush_world brush_world = world();
+    ASSERT_GT(brush_world.brush_count, 0);
+    const slayer3d_game_data_brush *brush = &brush_world.brushes[brush_world.brush_count - 1];
+    EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.floor");
+    EXPECT_NEAR(brush->bounds.min.y, -0.2f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.y, 0.0f, 0.001f);
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
@@ -13929,10 +13926,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
                  "brush.editor_shell.target.box.2");
-    ASSERT_NE(latest_brush(), nullptr);
-    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.wall");
-    EXPECT_NEAR(latest_brush()->bounds.min.x, 3.0f, 0.001f);
-    EXPECT_NEAR(latest_brush()->bounds.max.y, 2.5f, 0.001f);
+    brush_world = world();
+    ASSERT_GT(brush_world.brush_count, 0);
+    brush = &brush_world.brushes[brush_world.brush_count - 1];
+    EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.wall");
+    EXPECT_NEAR(brush->bounds.min.x, 3.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.y, 2.5f, 0.001f);
 
     slayer3d_signal_emit(bus, ceiling_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "ceiling");
@@ -13941,10 +13940,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "ceiling prefab created");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),
                  "brush.editor_shell.target.box.3");
-    ASSERT_NE(latest_brush(), nullptr);
-    EXPECT_STREQ(latest_brush()->faces[0].material_name, "mat.editor.ceiling");
-    EXPECT_NEAR(latest_brush()->bounds.min.y, 2.5f, 0.001f);
-    EXPECT_NEAR(latest_brush()->bounds.max.y, 2.7f, 0.001f);
+    brush_world = world();
+    ASSERT_GT(brush_world.brush_count, 0);
+    brush = &brush_world.brushes[brush_world.brush_count - 1];
+    EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.ceiling");
+    EXPECT_NEAR(brush->bounds.min.y, 2.5f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.y, 2.7f, 0.001f);
     EXPECT_EQ(world().brush_count, 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 3);
@@ -13965,6 +13966,72 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.dirty", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
+
+    slayer3d_signal_emit(bus, export_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.count", 0), 1);
+    const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
+    ASSERT_NE(export_json, nullptr);
+    EXPECT_NE(std::string(export_json).find("\"brush_worlds\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"editor_player_starts\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"mat.editor.ceiling\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"player_start.editor_shell\""), std::string::npos);
+
+    const std::filesystem::path save_dir = unique_test_dir("editor_unified_level_save");
+    const std::filesystem::path saved_path = save_dir / "saved" / "editable_level.fragment.json";
+    size_t saved_size = 0U;
+    ASSERT_TRUE(slayer3d_game_data_save_editable_level_fragment_file(
+        runtime, "brush.editor_shell.target", saved_path.string().c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    EXPECT_GT(saved_size, 0U);
+    EXPECT_TRUE(std::filesystem::exists(saved_path));
+    slayer3d_game_data_brush_world_editor_state brush_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &brush_state));
+    EXPECT_FALSE(brush_state.dirty);
+    EXPECT_EQ(brush_state.revision, 3U);
+    EXPECT_EQ(brush_state.saved_revision, 3U);
+    ASSERT_NE(brush_state.source_path, nullptr);
+    EXPECT_EQ(std::string(brush_state.source_path), saved_path.string());
+    slayer3d_game_data_player_start_editor_state player_start_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_player_start_editor_state(runtime, &player_start_state));
+    EXPECT_FALSE(player_start_state.dirty);
+    EXPECT_EQ(player_start_state.revision, 1U);
+    EXPECT_EQ(player_start_state.saved_revision, 1U);
+    ASSERT_NE(player_start_state.source_path, nullptr);
+    EXPECT_EQ(std::string(player_start_state.source_path), saved_path.string());
+
+    write_text(save_dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.editor_shell.dojo" })json");
+    write_text(save_dir / "roundtrip.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "imports": [
+    {
+      "path": "saved/editable_level.fragment.json",
+      "sections": ["brush_worlds", "editor_player_starts"]
+    }
+  ],
+  "metadata": { "name": "Editor Unified Level Roundtrip" },
+  "world": { "name": "world.editor_unified_level_roundtrip", "kind": "brush" },
+  "scenes": { "initial": "scene.editor_shell.dojo", "files": ["scenes/play.scene.json"] }
+})json");
+    slayer3d_game_session *roundtrip_session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &roundtrip_session));
+    slayer3d_game_data_runtime *roundtrip_runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((save_dir / "roundtrip.game.json").string().c_str(), roundtrip_session,
+                                             &roundtrip_runtime, error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world roundtrip_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(roundtrip_runtime, "brush.editor_shell.target", &roundtrip_world));
+    ASSERT_EQ(roundtrip_world.brush_count, 4);
+    EXPECT_STREQ(roundtrip_world.brushes[3].faces[0].material_name, "mat.editor.ceiling");
+    ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(roundtrip_runtime, "player_start.editor_shell", &start));
+    EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
+
+    slayer3d_game_data_destroy(roundtrip_runtime);
+    slayer3d_game_session_destroy(roundtrip_session);
+    remove_test_dir(save_dir);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add unified editable-level export/save APIs that serialize one brush world together with editor player starts
- add editor.level.export data action and wire the editor shell export flow to publish the unified fragment
- mark player-start collections saved alongside brush worlds after native editable-level saves
- extend editor shell tests to save/reload a floor/wall/ceiling/player-start blockout fragment as one artifact

## Tests
- jq empty demos/editor_shell_dojo/data/editor_shell_dojo.game.json demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
- cmake --build build/debug --target slayer3d_game_data_test -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools'
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug -j 8

## Notes
This is issue #360 slice 3. The next slice should add the test-run flow: direct-start the edited scene and apply the selected editor player start to the FPS/player actor before gameplay begins.