### PR TITLE
Add runner player-start direct launch

### DIFF
--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -188,6 +188,10 @@ Optional flags:
 - `--scene <scene-id>` starts directly in a loaded scene instead of
   `scenes.initial`. This is intended for editor and developer workflows such as
   play-testing a level without sitting through splash, title, or cutscene flow.
+- `--player-start <name>` applies an authored `editor_player_starts` marker
+  before the first scene-enter signal. If the marker declares a scene and
+  `--scene` is omitted, that scene becomes the initial scene. If both are
+  supplied, they must reference the same scene.
 - `--state <key=value>` injects one scene-state value before the direct scene
   enter signal runs. The value is parsed as JSON when possible, so
   `--state lives=3`, `--state debug=true`, `--state spawn=[1,2,3]`, and

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -116,10 +116,21 @@ build/debug/slayer3d_runner \
   --state lives=3
 ```
 
+Start from an editor-authored player spawn marker:
+
+```sh
+build/debug/slayer3d_runner \
+  --root path/to/game/data \
+  --data asset://game.game.json \
+  --player-start player_start.level_1
+```
+
 For larger setup payloads, use `--state-json '{"checkpoint":"midboss"}'` or
 `--state-file dev/level_1_state.json`. Direct-start state is applied before the
 scene enter signal runs, so authored setup logic can read it through normal
-scene-state conditions and Lua state APIs.
+scene-state conditions and Lua state APIs. Player-start launches also apply the
+target actor's position and view angles before the first scene-enter signal, and
+use the marker's scene when `--scene` is omitted.
 
 Demo targets may compile the same runner source with embedded assets and a
 default root data path. That wrapper should only supply build-time defaults; it
@@ -160,6 +171,8 @@ build/debug/slayer3d_runner \
 Focused dojo scenes should use authored scene-enter setup to place the player
 near the mechanic being tuned. That keeps the workflow equivalent to the final
 runner path while avoiding splash/title/campaign flow during development.
+As dojos add `editor_player_starts`, prefer `--player-start` for exact
+spawn-point test runs.
 
 `demos/mesh_primitives_dojo` is a graybox showcase for procedural 3D placeholder
 geometry. It uses a sector-bounded room, one directional sun light, an FPS

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -728,6 +728,20 @@ vec3, and optional `scene`, `target`, `yaw`, and `pitch` fields.
 }
 ```
 
+The generic runner can apply a marker directly:
+
+```sh
+build/debug/slayer3d_runner \
+  --root path/to/game/data \
+  --data asset://game.game.json \
+  --player-start player_start.level_01
+```
+
+When the marker has a `scene`, that scene is used as the initial scene unless
+`--scene` is also provided. Supplying both is allowed only when they agree. The
+target actor's position, `yaw`, and `pitch` are applied before camera setup and
+before the first scene-enter signal runs.
+
 Use `editor.brush_world.create_box` to append a new axis-aligned convex box
 brush to a runtime brush world. The action is intended for first-pass editor
 blockout tools: floors, walls, ceilings, platforms, and simple room pieces. It

--- a/include/slayer3d/data_game.h
+++ b/include/slayer3d/data_game.h
@@ -62,6 +62,8 @@ extern "C"
         const slayer3d_properties *initial_scene_state;
         /** @brief Optional transient payload passed to the first scene-enter signal. */
         const slayer3d_properties *initial_scene_payload;
+        /** @brief Optional editor player start applied before first scene-enter. */
+        const char *initial_player_start;
         /** @brief Suppress the authored app startup transition when using direct-start tooling. */
         bool skip_app_flow_startup;
         /**

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2045,6 +2045,16 @@ extern "C"
                                                       char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Apply one editor player start to its target actor.
+     *
+     * The start must exist and define a target actor. The target actor position
+     * and yaw/pitch properties are updated to match the stored marker. This is
+     * intended for editor test-run and direct-start workflows.
+     */
+    bool slayer3d_game_data_apply_editor_player_start(slayer3d_game_data_runtime *runtime, const char *name,
+                                                      char *error_buffer, int error_buffer_size);
+
+    /**
      * @brief Export all runtime editor player starts as a fragment JSON string.
      *
      * The caller owns @p out_json and must release it with SDL_free().
@@ -2231,7 +2241,10 @@ extern "C"
      * `initial_scene_override` to enter a different scene before any enter
      * signal fires. `initial_scene_state` is copied into the persistent
      * scene-state bag before the first enter signal; `initial_scene_payload`
-     * is passed only to that initial scene-enter signal.
+     * is passed only to that initial scene-enter signal. `initial_player_start`
+     * applies an editor-authored player start before camera setup and the first
+     * enter signal; when it has a scene and no explicit scene override is set,
+     * that scene becomes the initial scene.
      */
     typedef struct slayer3d_game_data_load_options
     {
@@ -2243,6 +2256,8 @@ extern "C"
         const slayer3d_properties *initial_scene_state;
         /** @brief Optional transient payload passed to the first scene-enter signal. */
         const slayer3d_properties *initial_scene_payload;
+        /** @brief Optional editor player start to apply for direct test-run workflows. */
+        const char *initial_player_start;
     } slayer3d_game_data_load_options;
 
     /**

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -967,6 +967,7 @@ bool slayer3d_data_game_runtime_create(const slayer3d_data_game_runtime_desc *de
     load_options.initial_scene_override = desc->initial_scene_override;
     load_options.initial_scene_state = desc->initial_scene_state;
     load_options.initial_scene_payload = desc->initial_scene_payload;
+    load_options.initial_player_start = desc->initial_player_start;
     if (!slayer3d_game_data_load_asset_with_options(runtime->assets, desc->data_asset_path, &load_options,
                                                     &runtime->data, load_error, (int)sizeof(load_error)))
     {

--- a/src/game_data_scene_load_runtime.c
+++ b/src/game_data_scene_load_runtime.c
@@ -627,22 +627,51 @@ bool load_scenes(slayer3d_game_data_runtime *runtime, yyjson_val *root, const sl
     runtime->active_scene_index = runtime->scene_count > 0 ? 0 : -1;
     const bool using_initial_override =
         options != NULL && options->initial_scene_override != NULL && options->initial_scene_override[0] != '\0';
+    const char *initial_player_start_name =
+        options != NULL && options->initial_player_start != NULL && options->initial_player_start[0] != '\0'
+            ? options->initial_player_start
+            : NULL;
+    slayer3d_game_data_editor_player_start initial_player_start;
+    SDL_zero(initial_player_start);
+    const bool using_initial_player_start = initial_player_start_name != NULL;
+    if (using_initial_player_start &&
+        !slayer3d_game_data_get_editor_player_start(runtime, initial_player_start_name, &initial_player_start))
+    {
+        set_error(error_buffer, error_buffer_size, "initial player start does not reference a loaded player start");
+        return false;
+    }
+    if (using_initial_override && using_initial_player_start && initial_player_start.scene != NULL &&
+        initial_player_start.scene[0] != '\0' &&
+        SDL_strcmp(options->initial_scene_override, initial_player_start.scene) != 0)
+    {
+        set_error(error_buffer, error_buffer_size, "initial scene override conflicts with player start scene");
+        return false;
+    }
     const char *initial =
-        using_initial_override ? options->initial_scene_override : json_string(scenes, "initial", NULL);
+        using_initial_override ? options->initial_scene_override
+        : using_initial_player_start && initial_player_start.scene != NULL && initial_player_start.scene[0] != '\0'
+            ? initial_player_start.scene
+            : json_string(scenes, "initial", NULL);
     if (initial != NULL)
     {
         scene_entry *scene = find_scene(runtime, initial);
         if (scene == NULL)
         {
             set_error(error_buffer, error_buffer_size,
-                      using_initial_override ? "initial scene override does not reference a loaded scene"
-                                             : "initial scene does not reference a loaded scene");
+                      using_initial_override       ? "initial scene override does not reference a loaded scene"
+                      : using_initial_player_start ? "initial player start scene does not reference a loaded scene"
+                                                   : "initial scene does not reference a loaded scene");
             return false;
         }
         runtime->active_scene_index = (int)(scene - runtime->scenes);
     }
     if (options != NULL && options->initial_scene_state != NULL)
         copy_all_properties(runtime->scene_state, options->initial_scene_state);
+    if (using_initial_player_start && !slayer3d_game_data_apply_editor_player_start(runtime, initial_player_start_name,
+                                                                                    error_buffer, error_buffer_size))
+    {
+        return false;
+    }
     apply_scene_camera(runtime, active_scene_entry(runtime));
     SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D game data initial scene: %s",
                  slayer3d_game_data_active_scene(runtime) != NULL ? slayer3d_game_data_active_scene(runtime)

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1108,6 +1108,34 @@ bool slayer3d_game_data_place_editor_player_start(slayer3d_game_data_runtime *ru
     return true;
 }
 
+bool slayer3d_game_data_apply_editor_player_start(slayer3d_game_data_runtime *runtime, const char *name,
+                                                  char *error_buffer, int error_buffer_size)
+{
+    const editor_player_start_runtime *start = find_editor_player_start(runtime, name);
+    if (runtime == NULL || name == NULL || name[0] == '\0' || start == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "player start '%s' not found", name);
+        return false;
+    }
+    if (start->target == NULL || start->target[0] == '\0')
+    {
+        set_errorf(error_buffer, error_buffer_size, "player start '%s' has no target actor", name);
+        return false;
+    }
+
+    slayer3d_registered_actor *target = slayer3d_game_data_find_actor(runtime, start->target);
+    if (target == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "player start target '%s' not found", start->target);
+        return false;
+    }
+
+    actor_set_position(target, start->position);
+    slayer3d_properties_set_float(target->props, "yaw", start->yaw);
+    slayer3d_properties_set_float(target->props, "pitch", start->pitch);
+    return true;
+}
+
 static bool export_add_vec3(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec3 value)
 {
     yyjson_mut_val *arr = yyjson_mut_arr(doc);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -756,6 +756,26 @@ void write_direct_start_json(const std::filesystem::path &dir)
   "metadata": { "name": "Direct Start", "id": "test.direct_start", "version": "0.1.0" },
   "world": { "name": "world.direct_start", "kind": "fixed_screen" },
   "signals": ["signal.intro.enter", "signal.level.enter"],
+  "entities": [
+    {
+      "name": "entity.player",
+      "transform": { "position": [0.0, 1.6, 0.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "editor_player_starts": [
+    {
+      "name": "player_start.level1",
+      "scene": "scene.level1",
+      "target": "entity.player",
+      "position": [3.0, 1.75, 4.0],
+      "yaw": 1.25,
+      "pitch": -0.2
+    }
+  ],
   "logic": {
     "bindings": [
       {
@@ -2144,6 +2164,78 @@ TEST(GameDataRuntime, DirectStartRejectsUnknownScene)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, DirectStartPlayerStartSelectsSceneAndPlacesTarget)
+{
+    const std::filesystem::path dir = unique_test_dir("direct_start_player_start");
+    write_direct_start_json(dir);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    slayer3d_asset_resolver *assets = slayer3d_asset_resolver_create();
+    ASSERT_NE(assets, nullptr);
+    char error[512]{};
+    ASSERT_TRUE(slayer3d_asset_resolver_mount_directory(assets, dir.string().c_str(), error, sizeof(error))) << error;
+
+    slayer3d_game_data_load_options options{};
+    options.session = session;
+    options.initial_player_start = "player_start.level1";
+
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_asset_with_options(assets, "asset://direct_start.game.json", &options, &runtime,
+                                                           error, sizeof(error)))
+        << error;
+    ASSERT_NE(runtime, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.level1");
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "intro_entered", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "level_entered", false));
+
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(player->position.x, 3.0f, 0.001f);
+    EXPECT_NEAR(player->position.y, 1.75f, 0.001f);
+    EXPECT_NEAR(player->position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "yaw", 0.0f), 1.25f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "pitch", 0.0f), -0.2f, 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_asset_resolver_destroy(assets);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, DirectStartPlayerStartRejectsConflictingSceneOverride)
+{
+    const std::filesystem::path dir = unique_test_dir("direct_start_player_start_conflict");
+    write_direct_start_json(dir);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    slayer3d_asset_resolver *assets = slayer3d_asset_resolver_create();
+    ASSERT_NE(assets, nullptr);
+    char error[512]{};
+    ASSERT_TRUE(slayer3d_asset_resolver_mount_directory(assets, dir.string().c_str(), error, sizeof(error))) << error;
+
+    slayer3d_game_data_load_options options{};
+    options.session = session;
+    options.initial_scene_override = "scene.intro";
+    options.initial_player_start = "player_start.level1";
+
+    slayer3d_game_data_runtime *runtime = nullptr;
+    EXPECT_FALSE(slayer3d_game_data_load_asset_with_options(assets, "asset://direct_start.game.json", &options,
+                                                            &runtime, error, sizeof(error)));
+    EXPECT_EQ(runtime, nullptr);
+    EXPECT_NE(std::string(error).find("conflicts with player start scene"), std::string::npos) << error;
+
+    slayer3d_asset_resolver_destroy(assets);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, DataGameRuntimeDirectStartPassesSceneState)
 {
     const std::filesystem::path dir = unique_test_dir("data_runtime_direct_start");
@@ -2178,6 +2270,41 @@ TEST(GameDataRuntime, DataGameRuntimeDirectStartPassesSceneState)
 
     slayer3d_data_game_runtime_destroy(runtime);
     slayer3d_properties_destroy(initial_state);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, DataGameRuntimeDirectStartAppliesPlayerStart)
+{
+    const std::filesystem::path dir = unique_test_dir("data_runtime_direct_start_player_start");
+    write_direct_start_json(dir);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    slayer3d_data_game_runtime_desc desc{};
+    const std::string root = dir.string();
+    slayer3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.data_asset_path = "asset://direct_start.game.json";
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+    desc.initial_player_start = "player_start.level1";
+    desc.skip_app_flow_startup = true;
+
+    char error[512]{};
+    slayer3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    slayer3d_game_data_runtime *data = slayer3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_scene(data), "scene.level1");
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(data, "entity.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(player->position.x, 3.0f, 0.001f);
+    EXPECT_NEAR(player->position.y, 1.75f, 0.001f);
+    EXPECT_NEAR(player->position.z, 4.0f, 0.001f);
+
+    slayer3d_data_game_runtime_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);
 }

--- a/tests/test_tool_cli.cpp
+++ b/tests/test_tool_cli.cpp
@@ -97,12 +97,14 @@ TEST(ToolCli, RunnerAllowsFusedExecutableWithoutExplicitMount)
 
 TEST(ToolCli, RunnerParsesDirectStartStateInputs)
 {
-    std::vector<char *> argv = argv_from({"slayer3d_runner", "--root", "game/data", "--data", "asset://game.game.json",
-                                          "--scene", "scene.level1", "--state-file", "dev/level1.json", "--state-json",
-                                          "{\"lives\":3}", "--state", "checkpoint=midboss", "--state", "debug=true"});
+    std::vector<char *> argv =
+        argv_from({"slayer3d_runner", "--root", "game/data", "--data", "asset://game.game.json", "--scene",
+                   "scene.level1", "--player-start", "player_start.level1", "--state-file", "dev/level1.json",
+                   "--state-json", "{\"lives\":3}", "--state", "checkpoint=midboss", "--state", "debug=true"});
     slayer3d_runner_args args;
     ASSERT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
     EXPECT_STREQ(args.scene, "scene.level1");
+    EXPECT_STREQ(args.player_start, "player_start.level1");
     ASSERT_EQ(args.state_file_count, 1);
     EXPECT_STREQ(args.state_files[0], "dev/level1.json");
     ASSERT_EQ(args.state_json_count, 1);
@@ -110,6 +112,15 @@ TEST(ToolCli, RunnerParsesDirectStartStateInputs)
     ASSERT_EQ(args.state_assignment_count, 2);
     EXPECT_STREQ(args.state_assignments[0], "checkpoint=midboss");
     EXPECT_STREQ(args.state_assignments[1], "debug=true");
+    slayer3d_runner_args_destroy(&args);
+}
+
+TEST(ToolCli, RunnerRejectsEmptyPlayerStart)
+{
+    std::vector<char *> argv =
+        argv_from({"slayer3d_runner", "--root", "game/data", "--data", "asset://game.game.json", "--player-start", ""});
+    slayer3d_runner_args args;
+    EXPECT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
     slayer3d_runner_args_destroy(&args);
 }
 

--- a/tools/slayer3d_runner.c
+++ b/tools/slayer3d_runner.c
@@ -267,9 +267,11 @@ static bool runner_init(slayer3d_game_context *ctx, void *userdata)
     desc.mount_userdata = state;
     desc.enable_managed_network = true;
     desc.initial_scene_override = state->args.scene;
+    desc.initial_player_start = state->args.player_start;
     desc.initial_scene_state = initial_state;
     desc.initial_scene_payload = initial_state;
-    desc.skip_app_flow_startup = state->args.scene != NULL && state->args.scene[0] != '\0';
+    desc.skip_app_flow_startup = (state->args.scene != NULL && state->args.scene[0] != '\0') ||
+                                 (state->args.player_start != NULL && state->args.player_start[0] != '\0');
 
     if (!slayer3d_data_game_runtime_create(&desc, &state->runtime, error, (int)sizeof(error)))
     {

--- a/tools/slayer3d_runner_cli.c
+++ b/tools/slayer3d_runner_cli.c
@@ -17,14 +17,17 @@ void slayer3d_runner_args_print_usage(const char *argv0, FILE *stream)
             "Usage:\n"
             "  %s\n"
             "  %s --root <asset-root> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
-            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n"
+            "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
+            "[--state-file <path-or-asset>]\n"
             "  %s --pack <game.slayer3dpak> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
-            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n",
+            "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
+            "[--state-file <path-or-asset>]\n",
             program, program, program);
 #if defined(SLAYER3D_RUNNER_EMBEDDED_ASSETS)
     fprintf(out,
             "  %s --embedded --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
-            "[--state <key=value> ...] [--state-json <object>] [--state-file <path-or-asset>]\n",
+            "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
+            "[--state-file <path-or-asset>]\n",
             program);
 #endif
 }
@@ -73,6 +76,8 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
     struct arg_str *data = arg_str0(NULL, "data", "<asset://game.json>", "root game-data asset path");
     struct arg_str *media = arg_str0(NULL, "media", "<media-dir>", "built-in media directory");
     struct arg_str *scene = arg_str0(NULL, "scene", "<scene>", "start directly in an authored scene");
+    struct arg_str *player_start =
+        arg_str0(NULL, "player-start", "<name>", "apply an editor player start before first scene enter");
     struct arg_str *state = arg_strn(NULL, "state", "<key=value>", 0, argc > 0 ? argc : 1, "scene-state override");
     struct arg_str *state_json =
         arg_strn(NULL, "state-json", "<json-object>", 0, argc > 0 ? argc : 1, "scene-state JSON object");
@@ -85,7 +90,7 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
 #if defined(SLAYER3D_RUNNER_EMBEDDED_ASSETS)
         embedded,
 #endif
-        data,     media, scene, state, state_json, state_file, help, end,
+        data,     media, scene, player_start, state, state_json, state_file, help, end,
     };
     const char *program = argc > 0 && argv != NULL && argv[0] != NULL ? argv[0] : "slayer3d_runner";
     FILE *out = stream != NULL ? stream : stderr;
@@ -161,6 +166,8 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
         args->media_dir = media->sval[0];
     if (scene->count > 0)
         args->scene = scene->sval[0];
+    if (player_start->count > 0)
+        args->player_start = player_start->sval[0];
 
     const bool mount_path_required =
         args->mount_kind == SLAYER3D_RUNNER_MOUNT_DIRECTORY || args->mount_kind == SLAYER3D_RUNNER_MOUNT_PACK;
@@ -175,6 +182,7 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
     }
 
     if ((args->scene != NULL && args->scene[0] == '\0') ||
+        (args->player_start != NULL && args->player_start[0] == '\0') ||
         !copy_string_list(&args->state_assignments, &args->state_assignment_count, state->sval, state->count) ||
         !copy_string_list(&args->state_json_values, &args->state_json_count, state_json->sval, state_json->count) ||
         !copy_string_list(&args->state_files, &args->state_file_count, state_file->sval, state_file->count))

--- a/tools/slayer3d_runner_cli.h
+++ b/tools/slayer3d_runner_cli.h
@@ -31,6 +31,7 @@ extern "C"
         const char *data_asset_path;
         const char *media_dir;
         const char *scene;
+        const char *player_start;
         const char **state_assignments;
         int state_assignment_count;
         const char **state_json_values;


### PR DESCRIPTION
## Summary
- add runner/game-data support for `--player-start` direct launches from authored `editor_player_starts`
- apply player-start target position and yaw/pitch before camera setup and first scene-enter signal
- reject conflicting `--scene` and player-start scene requests, and document the workflow

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_tool_cli_test -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.DirectStart*:GameDataRuntime.DataGameRuntimeDirectStart*'`
- `./build/debug/tests/slayer3d_tool_cli_test --gtest_filter='ToolCli.RunnerParsesDirectStartStateInputs:ToolCli.RunnerRejectsEmptyPlayerStart'`
- `./build/debug/tests/slayer3d_tool_cli_test`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug --target slayer3d_runner -j 8`

## Next slice
- wire the editor shell/test-run path to export or invoke runner launches from selected scene/player-start data, so the blockout editor has a practical "run from here" workflow.