### PR TITLE
Add editor shell playable test-run scene

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -10,9 +10,18 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
   `4` player start, then `Enter` to place the selected prefab
 - unified editable-level export: `S` publishes one fragment containing the
   brush world and player starts
+- generic runner test-run support: `--player-start player_start.editor_shell`
+  enters the playable FPS scene through the same runtime path a data-only game
+  uses
 
 Run it with:
 
 ```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
+```
+
+Test-run the authored player start directly:
+
+```sh
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell
 ```

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -70,6 +70,26 @@
           {
             "name": "action.editor.tool.player_start",
             "bindings": [{ "device": "keyboard", "key": "4" }]
+          },
+          {
+            "name": "action.move.forward",
+            "bindings": [{ "device": "keyboard", "key": "W" }]
+          },
+          {
+            "name": "action.move.back",
+            "bindings": [{ "device": "keyboard", "key": "S" }]
+          },
+          {
+            "name": "action.move.left",
+            "bindings": [{ "device": "keyboard", "key": "A" }]
+          },
+          {
+            "name": "action.move.right",
+            "bindings": [{ "device": "keyboard", "key": "D" }]
+          },
+          {
+            "name": "action.jump",
+            "bindings": [{ "device": "keyboard", "key": "SPACE" }]
           }
         ]
       }
@@ -371,7 +391,8 @@
                           {
                             "type": "editor.player_start.place",
                             "name": "player_start.editor_shell",
-                            "scene": "scene.editor_shell.dojo",
+                            "scene": "scene.editor_shell.test_run",
+                            "target": "entity.editor_shell.player",
                             "position": [0.0, 1.6, 4.0],
                             "yaw": 3.14159,
                             "pitch": 0.0,
@@ -380,6 +401,7 @@
                               "message_key": "editor.player_start.message",
                               "player_start_key": "editor.player_start.name",
                               "scene_key": "editor.player_start.scene",
+                              "target_key": "editor.player_start.target",
                               "position_key": "editor.player_start.position",
                               "yaw_key": "editor.player_start.yaw",
                               "pitch_key": "editor.player_start.pitch",
@@ -556,6 +578,13 @@
         "fov": 70.0,
         "fov_axis": "horizontal",
         "active": true
+      },
+      {
+        "name": "camera.editor_shell.player",
+        "type": "fps",
+        "target_entity": "entity.editor_shell.player",
+        "fov": 90.0,
+        "fov_axis": "horizontal"
       }
     ]
   },
@@ -569,6 +598,52 @@
     "bloom": false,
     "clear_color": [0.04, 0.045, 0.055]
   },
+  "entities": [
+    {
+      "name": "entity.editor_shell.player",
+      "active": true,
+      "transform": { "position": [0.0, 1.6, 4.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 3.14159 },
+        "pitch": { "type": "float", "value": 0.0 },
+        "camera_forward": { "type": "vec3", "value": [0.0, 0.0, -1.0] },
+        "on_ground": { "type": "bool", "value": false },
+        "vertical_velocity": { "type": "float", "value": 0.0 }
+      },
+      "components": [
+        {
+          "type": "controller.fps_brush",
+          "brush_world": "brush.editor_shell.target",
+          "contents_mask": ["solid", "player_clip"],
+          "actions": {
+            "forward": "action.move.forward",
+            "back": "action.move.back",
+            "left": "action.move.left",
+            "right": "action.move.right",
+            "jump": "action.jump"
+          },
+          "move_speed": 6.0,
+          "jump_velocity": 5.8,
+          "gravity": 14.0,
+          "player_height": 1.6,
+          "player_radius": 0.35,
+          "step_height": 0.55,
+          "ceiling_clearance": 0.1,
+          "mouse_sensitivity": 0.002
+        }
+      ]
+    }
+  ],
+  "editor_player_starts": [
+    {
+      "name": "player_start.editor_shell",
+      "scene": "scene.editor_shell.test_run",
+      "target": "entity.editor_shell.player",
+      "position": [0.0, 1.6, 4.0],
+      "yaw": 3.14159,
+      "pitch": 0.0
+    }
+  ],
   "brush_worlds": [
     {
       "name": "brush.editor_shell.target",
@@ -636,6 +711,6 @@
   ],
   "scenes": {
     "initial": "scene.editor_shell.dojo",
-    "files": ["scenes/editor_shell.scene.json"]
+    "files": ["scenes/editor_shell.scene.json", "scenes/test_run.scene.json"]
   }
 }

--- a/demos/editor_shell_dojo/data/scenes/test_run.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/test_run.scene.json
@@ -1,0 +1,38 @@
+{
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.editor_shell.test_run",
+  "camera": "camera.editor_shell.player",
+  "updates_game": true,
+  "renders_world": true,
+  "entities": ["entity.editor_shell.player"],
+  "input": {
+    "mouse_capture": "unpaused",
+    "actions": [
+      "action.move.forward",
+      "action.move.back",
+      "action.move.left",
+      "action.move.right",
+      "action.jump",
+      "action.exit"
+    ]
+  },
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.editor_shell.target", "position": [0.0, 0.0, 0.0], "acceleration": true, "lighting": true }
+    ]
+  },
+  "ui": {
+    "text": [
+      {
+        "name": "ui.editor_shell.test_run.help",
+        "text": "Test Run: WASD move  Space jump  Esc quit",
+        "font": "font.editor_shell.ui",
+        "x": 0.03,
+        "y": 0.05,
+        "normalized": true,
+        "color": [235, 245, 255, 230],
+        "scale": 0.65
+      }
+    ]
+  }
+}

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14084,9 +14084,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.name", ""),
                  "player_start.editor_shell");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.scene", ""),
-                 "scene.editor_shell.dojo");
+                 "scene.editor_shell.test_run");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.target", ""),
+                 "entity.editor_shell.player");
     slayer3d_game_data_editor_player_start start{};
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
+    EXPECT_STREQ(start.target, "entity.editor_shell.player");
     EXPECT_NEAR(start.position.x, 0.0f, 0.001f);
     EXPECT_NEAR(start.position.y, 1.6f, 0.001f);
     EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
@@ -14129,6 +14132,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
 
     write_text(save_dir / "scenes" / "play.scene.json",
                R"json({ "schema": "slayer3d.scene.v0", "name": "scene.editor_shell.dojo" })json");
+    write_text(save_dir / "scenes" / "test_run.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.editor_shell.test_run" })json");
     write_text(save_dir / "roundtrip.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
@@ -14140,7 +14145,20 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
   ],
   "metadata": { "name": "Editor Unified Level Roundtrip" },
   "world": { "name": "world.editor_unified_level_roundtrip", "kind": "brush" },
-  "scenes": { "initial": "scene.editor_shell.dojo", "files": ["scenes/play.scene.json"] }
+  "entities": [
+    {
+      "name": "entity.editor_shell.player",
+      "transform": { "position": [0.0, 1.6, 0.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.0 },
+        "pitch": { "type": "float", "value": 0.0 }
+      }
+    }
+  ],
+  "scenes": {
+    "initial": "scene.editor_shell.dojo",
+    "files": ["scenes/play.scene.json", "scenes/test_run.scene.json"]
+  }
 })json");
     slayer3d_game_session *roundtrip_session = nullptr;
     ASSERT_TRUE(slayer3d_game_session_create(nullptr, &roundtrip_session));
@@ -14153,6 +14171,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_EQ(roundtrip_world.brush_count, 4);
     EXPECT_STREQ(roundtrip_world.brushes[3].faces[0].material_name, "mat.editor.ceiling");
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(roundtrip_runtime, "player_start.editor_shell", &start));
+    EXPECT_STREQ(start.scene, "scene.editor_shell.test_run");
+    EXPECT_STREQ(start.target, "entity.editor_shell.player");
     EXPECT_NEAR(start.position.z, 4.0f, 0.001f);
     EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
 
@@ -14161,6 +14181,55 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     remove_test_dir(save_dir);
 
     slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoDirectStartsPlayableSceneFromPlayerStart)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    const std::string root = dojo_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + dojo_path.filename().string();
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+
+    slayer3d_data_game_runtime_desc desc{};
+    slayer3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SLAYER3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+    desc.initial_player_start = "player_start.editor_shell";
+    desc.skip_app_flow_startup = true;
+
+    char error[512]{};
+    slayer3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    slayer3d_game_data_runtime *data = slayer3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_scene(data), "scene.editor_shell.test_run");
+    EXPECT_STREQ(slayer3d_game_data_active_camera(data), "camera.editor_shell.player");
+    EXPECT_TRUE(slayer3d_game_data_active_scene_updates_game(data));
+    EXPECT_TRUE(slayer3d_game_data_active_scene_renders_world(data));
+    EXPECT_TRUE(slayer3d_game_data_active_scene_has_entity(data, "entity.editor_shell.player"));
+
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(data, "entity.editor_shell.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(player->position.x, 0.0f, 0.001f);
+    EXPECT_NEAR(player->position.y, 1.6f, 0.001f);
+    EXPECT_NEAR(player->position.z, 4.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "yaw", 0.0f), 3.14159f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "pitch", 1.0f), 0.0f, 0.001f);
+
+    slayer3d_camera3d camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(data, "camera.editor_shell.player", &camera));
+    EXPECT_NEAR(camera.position.x, player->position.x, 0.001f);
+    EXPECT_NEAR(camera.position.y, player->position.y, 0.001f);
+    EXPECT_NEAR(camera.position.z, player->position.z, 0.001f);
+
+    slayer3d_data_game_runtime_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 


### PR DESCRIPTION
## Summary
- add a data-authored FPS test-run scene to the editor shell dojo
- target editor player starts at the playable test-run actor/camera so `--player-start` uses the generic runtime path
- extend editor shell tests to prove prefab/export round-trip preserves target/scene metadata and direct-start enters the playable scene
- document the editor shell test-run command

## Tests
- `python3 -m json.tool demos/editor_shell_dojo/data/editor_shell_dojo.game.json >/dev/null`
- `python3 -m json.tool demos/editor_shell_dojo/data/scenes/test_run.scene.json >/dev/null`
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*'`
- `./build/debug/tests/slayer3d_game_data_test`

## Manual test
- `./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell`

## Next slice
- add a host/editor-facing save-and-run handoff: produce a small run manifest or command payload after saving an editable level so a future editor executable can launch the generic runner against the saved fragment without custom game code.