### PR TITLE
Add editor test-run handoff manifests

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -10,6 +10,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
   `4` player start, then `Enter` to place the selected prefab
 - unified editable-level export: `S` publishes one fragment containing the
   brush world and player starts
+- test-run handoff manifest: `T` publishes runner arguments for the authored
+  player start
 - generic runner test-run support: `--player-start player_start.editor_shell`
   enters the playable FPS scene through the same runtime path a data-only game
   uses

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -56,6 +56,10 @@
             "bindings": [{ "device": "keyboard", "key": "S" }]
           },
           {
+            "name": "action.editor.test_run.prepare",
+            "bindings": [{ "device": "keyboard", "key": "T" }]
+          },
+          {
             "name": "action.editor.tool.floor",
             "bindings": [{ "device": "keyboard", "key": "1" }]
           },
@@ -107,7 +111,8 @@
     "signal.editor.tool.wall",
     "signal.editor.tool.ceiling",
     "signal.editor.tool.player_start",
-    "signal.editor.export"
+    "signal.editor.export",
+    "signal.editor.test_run.prepare"
   ],
   "logic": {
     "sensors": [
@@ -150,6 +155,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.export",
         "on_pressed": "signal.editor.export"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.test_run.prepare",
+        "on_pressed": "signal.editor.test_run.prepare"
       },
       {
         "type": "sensor.input_pressed",
@@ -558,6 +568,28 @@
               "player_start_source_path_key": "editor.player_start.source_path"
             }
           }
+        ]
+      },
+      {
+        "signal": "signal.editor.test_run.prepare",
+        "actions": [
+          {
+            "type": "editor.test_run.prepare",
+            "data_asset": "asset://editor_shell_dojo.game.json",
+            "player_start": "player_start.editor_shell",
+            "message": "test run handoff prepared",
+            "outputs": {
+              "valid_key": "editor.test_run.valid",
+              "message_key": "editor.test_run.message",
+              "manifest_json_key": "editor.test_run.manifest_json",
+              "size_key": "editor.test_run.size",
+              "data_asset_key": "editor.test_run.data_asset",
+              "scene_key": "editor.test_run.scene",
+              "player_start_key": "editor.test_run.player_start",
+              "target_key": "editor.test_run.target"
+            }
+          },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "test run handoff prepared" }
         ]
       }
     ]

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -15,6 +15,7 @@
       "action.editor.command.undo",
       "action.editor.command.redo",
       "action.editor.export",
+      "action.editor.test_run.prepare",
       "action.editor.tool.floor",
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
@@ -145,6 +146,10 @@
             "binding": { "type": "scene_state", "key": "editor.player_start.name", "default": "none" }
           },
           {
+            "label": "Run",
+            "binding": { "type": "scene_state", "key": "editor.test_run.message", "default": "none" }
+          },
+          {
             "label": "Preview",
             "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
           },
@@ -169,7 +174,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S export. Z/Y undo-redo.",
+        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S export. T run manifest. Z/Y undo-redo.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -928,6 +928,29 @@ restores floors, walls, ceilings, face materials, and player starts together.
 }
 ```
 
+Use `editor.test_run.prepare` to publish a game-agnostic handoff manifest for
+launching the generic runner from an editor-selected scene or player start. The
+action does not spawn a process and does not write files. It produces
+`slayer3d.editor_test_run.v0` JSON containing the root data asset, resolved
+scene, player start, target actor, and runner argument array excluding mount
+flags. Editor hosts combine those arguments with their current `--root`,
+`--pack`, embedded, or fused launch context.
+
+```json
+{
+  "type": "editor.test_run.prepare",
+  "data_asset": "asset://game.game.json",
+  "player_start": "player_start.level_01",
+  "outputs": {
+    "valid_key": "editor.test_run.valid",
+    "message_key": "editor.test_run.message",
+    "manifest_json_key": "editor.test_run.manifest_json",
+    "scene_key": "editor.test_run.scene",
+    "player_start_key": "editor.test_run.player_start"
+  }
+}
+```
+
 Use `editor.brush_world.status` to publish the current dirty/source state of a
 brush world without exporting its JSON. Outputs support `valid_key`,
 `message_key`, `world_key`, `dirty_key`, `revision_key`, `saved_revision_key`,

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2167,6 +2167,33 @@ extern "C"
                                                               size_t *out_size, char *error_buffer,
                                                               int error_buffer_size);
 
+    /** @brief Descriptor for creating an editor test-run handoff manifest. */
+    typedef struct slayer3d_game_data_editor_test_run_desc
+    {
+        /** @brief Root game-data asset path to pass to the generic runner. Required. */
+        const char *data_asset_path;
+        /** @brief Optional scene to direct-start. Must match the player start scene when both are set. */
+        const char *scene;
+        /** @brief Optional editor player start to apply before scene enter. */
+        const char *player_start;
+    } slayer3d_game_data_editor_test_run_desc;
+
+    /**
+     * @brief Export a small JSON handoff manifest for editor test-run workflows.
+     *
+     * The manifest uses `schema: "slayer3d.editor_test_run.v0"` and contains
+     * the runner data asset, resolved scene when known, player start when
+     * provided, and a runner argument array excluding mount flags. Editor hosts
+     * combine this with their current `--root`, `--pack`, or fused executable
+     * context to launch the generic runner without game-specific native code.
+     * The returned string is allocated with SDL_malloc and must be released
+     * with SDL_free().
+     */
+    bool slayer3d_game_data_export_editor_test_run_manifest_json(const slayer3d_game_data_runtime *runtime,
+                                                                 const slayer3d_game_data_editor_test_run_desc *desc,
+                                                                 char **out_json, size_t *out_size, char *error_buffer,
+                                                                 int error_buffer_size);
+
     /** @brief Authored game data diagnostic severity. */
     typedef enum slayer3d_game_data_diagnostic_severity
     {

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -403,6 +403,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.level.export") == 0)
         return slayer3d_game_data_export_editor_level_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
+        return slayer3d_game_data_prepare_editor_test_run_action(runtime, action);
+
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
         return slayer3d_game_data_publish_editor_brush_world_status_action(runtime, action);
 

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -866,6 +866,7 @@ bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime,
                                             const slayer3d_properties *payload);
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
                                                                  yyjson_val *action);
 bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -82,6 +82,7 @@ typedef struct validation_names
     name_table sector_navigation;
     name_table sector_doors;
     name_table sector_platforms;
+    name_table editor_player_starts;
     name_table signals;
     name_table scripts;
     name_table script_modules;
@@ -3780,6 +3781,30 @@ static bool collect_sector_platforms(validation_context *ctx, yyjson_val *root, 
     return true;
 }
 
+static bool collect_editor_player_starts(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *starts = obj_get(root, "editor_player_starts");
+    if (starts == NULL)
+        return true;
+    if (!yyjson_is_arr(starts))
+        return validation_error(ctx, "$.editor_player_starts", "editor_player_starts must be an array");
+
+    for (size_t i = 0; i < yyjson_arr_size(starts); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.editor_player_starts[%zu]", i);
+        yyjson_val *start = yyjson_arr_get(starts, i);
+        if (!yyjson_is_obj(start))
+            return validation_error(ctx, path, "editor player start entries must be objects");
+        if (!require_unique_name(ctx, &names->editor_player_starts, "editor player start", json_string(start, "name"),
+                                 path))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool collect_actor_archetypes(validation_context *ctx, yyjson_val *root, validation_names *names)
 {
     yyjson_val *archetypes = obj_get(root, "actor_archetypes");
@@ -4405,15 +4430,15 @@ static bool collect_names(validation_context *ctx, yyjson_val *root, validation_
            collect_grid_maps(ctx, root, names) && collect_grid_pickup_layers(ctx, root, names) &&
            collect_sector_levels(ctx, root, names) && collect_brush_worlds(ctx, root, names) &&
            collect_sector_navigation(ctx, root, names) && collect_sector_doors(ctx, root, names) &&
-           collect_sector_platforms(ctx, root, names) && collect_actor_archetypes(ctx, root, names) &&
-           collect_actor_pools(ctx, root, names) && collect_scripts(ctx, root, names) &&
-           collect_adapters(ctx, root, names) && collect_input_actions(ctx, root, names) &&
-           collect_input_assignment_sets(ctx, root, names) && collect_input_profiles(ctx, root, names) &&
-           collect_network_input_channels(ctx, root, names) && collect_cameras(ctx, root, names) &&
-           collect_fonts(ctx, root, names) && collect_sprite_assets(ctx, root, names) &&
-           collect_images(ctx, root, names) && collect_models(ctx, root, names) &&
-           collect_audio_assets(ctx, root, names) && collect_timers(ctx, root, names) &&
-           collect_sensors(ctx, root, names);
+           collect_sector_platforms(ctx, root, names) && collect_editor_player_starts(ctx, root, names) &&
+           collect_actor_archetypes(ctx, root, names) && collect_actor_pools(ctx, root, names) &&
+           collect_scripts(ctx, root, names) && collect_adapters(ctx, root, names) &&
+           collect_input_actions(ctx, root, names) && collect_input_assignment_sets(ctx, root, names) &&
+           collect_input_profiles(ctx, root, names) && collect_network_input_channels(ctx, root, names) &&
+           collect_cameras(ctx, root, names) && collect_fonts(ctx, root, names) &&
+           collect_sprite_assets(ctx, root, names) && collect_images(ctx, root, names) &&
+           collect_models(ctx, root, names) && collect_audio_assets(ctx, root, names) &&
+           collect_timers(ctx, root, names) && collect_sensors(ctx, root, names);
 }
 
 static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
@@ -8595,6 +8620,37 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
+    {
+        if (!is_non_empty_string(action, "data_asset"))
+            return validation_error(ctx, json_path, "editor.test_run.prepare requires a non-empty data_asset");
+        const char *scene = json_string(action, "scene");
+        if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, json_path))
+            return false;
+        yyjson_val *player_start = obj_get(action, "player_start");
+        if (player_start != NULL && (!yyjson_is_str(player_start) || yyjson_get_str(player_start)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.test_run.prepare player_start must be a non-empty string");
+        if (player_start != NULL && !require_ref(ctx, &names->editor_player_starts, "editor player start",
+                                                 yyjson_get_str(player_start), json_path))
+        {
+            return false;
+        }
+        if (scene == NULL && player_start == NULL)
+            return validation_error(ctx, json_path, "editor.test_run.prepare requires scene or player_start");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.test_run.prepare outputs must be an object");
+        static const char *const output_keys[] = {"valid_key",      "message_key", "manifest_json_key", "size_key",
+                                                  "data_asset_key", "scene_key",   "player_start_key",  "target_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.test_run.prepare output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
     {
         if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
@@ -11793,6 +11849,7 @@ static void validation_names_destroy(validation_names *names)
     name_table_destroy(&names->sector_navigation);
     name_table_destroy(&names->sector_doors);
     name_table_destroy(&names->sector_platforms);
+    name_table_destroy(&names->editor_player_starts);
     name_table_destroy(&names->signals);
     name_table_destroy(&names->scripts);
     name_table_destroy(&names->script_modules);

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1779,6 +1779,121 @@ bool slayer3d_game_data_save_editable_level_fragment_file(slayer3d_game_data_run
     return true;
 }
 
+static bool editor_test_run_add_arg(yyjson_mut_doc *doc, yyjson_mut_val *args, const char *value)
+{
+    yyjson_mut_val *arg = yyjson_mut_strcpy(doc, value != NULL ? value : "");
+    return arg != NULL && yyjson_mut_arr_append(args, arg);
+}
+
+bool slayer3d_game_data_export_editor_test_run_manifest_json(const slayer3d_game_data_runtime *runtime,
+                                                             const slayer3d_game_data_editor_test_run_desc *desc,
+                                                             char **out_json, size_t *out_size, char *error_buffer,
+                                                             int error_buffer_size)
+{
+    if (out_json != NULL)
+        *out_json = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (runtime == NULL || desc == NULL || out_json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editor test run manifest requires runtime, descriptor, and output");
+        return false;
+    }
+    if (desc->data_asset_path == NULL || desc->data_asset_path[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "editor test run manifest requires a data asset path");
+        return false;
+    }
+
+    const char *scene = desc->scene != NULL && desc->scene[0] != '\0' ? desc->scene : NULL;
+    const char *player_start_name =
+        desc->player_start != NULL && desc->player_start[0] != '\0' ? desc->player_start : NULL;
+    slayer3d_game_data_editor_player_start player_start;
+    SDL_zero(player_start);
+    if (player_start_name != NULL)
+    {
+        if (!slayer3d_game_data_get_editor_player_start(runtime, player_start_name, &player_start))
+        {
+            set_errorf(error_buffer, error_buffer_size, "player start '%s' not found", player_start_name);
+            return false;
+        }
+        if (player_start.target == NULL || player_start.target[0] == '\0')
+        {
+            set_errorf(error_buffer, error_buffer_size, "player start '%s' has no target actor", player_start_name);
+            return false;
+        }
+        if (scene != NULL && player_start.scene != NULL && player_start.scene[0] != '\0' &&
+            SDL_strcmp(scene, player_start.scene) != 0)
+        {
+            set_error(error_buffer, error_buffer_size, "editor test run scene conflicts with player start scene");
+            return false;
+        }
+        if (scene == NULL && player_start.scene != NULL && player_start.scene[0] != '\0')
+            scene = player_start.scene;
+    }
+    if (scene == NULL && player_start_name == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editor test run manifest requires a scene or player start");
+        return false;
+    }
+    if (scene != NULL && find_scene_const(runtime, scene) == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "scene '%s' not found", scene);
+        return false;
+    }
+
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    yyjson_mut_val *args = doc != NULL ? yyjson_mut_arr(doc) : NULL;
+    if (doc == NULL || root == NULL || args == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to allocate editor test run manifest");
+        return false;
+    }
+    yyjson_mut_doc_set_root(doc, root);
+
+    bool ok = yyjson_mut_obj_add_strcpy(doc, root, "schema", "slayer3d.editor_test_run.v0") &&
+              yyjson_mut_obj_add_strcpy(doc, root, "data", desc->data_asset_path) &&
+              yyjson_mut_obj_add_val(doc, root, "args", args) && editor_test_run_add_arg(doc, args, "--data") &&
+              editor_test_run_add_arg(doc, args, desc->data_asset_path);
+    if (ok && scene != NULL)
+    {
+        ok = yyjson_mut_obj_add_strcpy(doc, root, "scene", scene) && editor_test_run_add_arg(doc, args, "--scene") &&
+             editor_test_run_add_arg(doc, args, scene);
+    }
+    if (ok && player_start_name != NULL)
+    {
+        ok = yyjson_mut_obj_add_strcpy(doc, root, "player_start", player_start_name) &&
+             yyjson_mut_obj_add_strcpy(doc, root, "target", player_start.target) &&
+             editor_test_run_add_arg(doc, args, "--player-start") &&
+             editor_test_run_add_arg(doc, args, player_start_name);
+    }
+
+    size_t size = 0u;
+    char *json = ok ? yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size) : NULL;
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to write editor test run manifest JSON");
+        return false;
+    }
+
+    char *copy = (char *)SDL_malloc(size + 1u);
+    if (copy == NULL)
+    {
+        free(json);
+        set_error(error_buffer, error_buffer_size, "failed to allocate editor test run manifest JSON");
+        return false;
+    }
+    SDL_memcpy(copy, json, size + 1u);
+    free(json);
+    *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
 bool slayer3d_game_data_get_brush_world(const slayer3d_game_data_runtime *runtime, const char *name,
                                         slayer3d_game_data_brush_world *out_world)
 {
@@ -3166,6 +3281,46 @@ bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *r
                           has_start_state ? editor_revision_to_int(start_state.saved_revision) : 0);
     editor_set_string_output(scene_state, outputs, "player_start_source_path_key",
                              has_start_state && start_state.source_path != NULL ? start_state.source_path : "");
+    SDL_free(json);
+    return true;
+}
+
+bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_game_data_editor_test_run_desc desc;
+    SDL_zero(desc);
+    desc.data_asset_path = json_string(action, "data_asset", NULL);
+    desc.scene = json_string(action, "scene", NULL);
+    desc.player_start = json_string(action, "player_start", NULL);
+
+    char error[256];
+    error[0] = '\0';
+    char *json = NULL;
+    size_t size = 0u;
+    const bool ok = slayer3d_game_data_export_editor_test_run_manifest_json(runtime, &desc, &json, &size, error,
+                                                                            (int)sizeof(error));
+
+    slayer3d_game_data_editor_player_start start;
+    SDL_zero(start);
+    const bool has_start = ok && desc.player_start != NULL && desc.player_start[0] != '\0' &&
+                           slayer3d_game_data_get_editor_player_start(runtime, desc.player_start, &start);
+    const char *resolved_scene = desc.scene != NULL && desc.scene[0] != '\0'
+                                     ? desc.scene
+                                     : (has_start && start.scene != NULL ? start.scene : "");
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "editor test run prepared")
+                                : (error[0] != '\0' ? error : "editor test run preparation failed"));
+    editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "manifest_json_key", ok && json != NULL ? json : "");
+    editor_set_string_output(scene_state, outputs, "data_asset_key", ok ? desc.data_asset_path : "");
+    editor_set_string_output(scene_state, outputs, "scene_key", ok ? resolved_scene : "");
+    editor_set_string_output(scene_state, outputs, "player_start_key",
+                             ok && desc.player_start != NULL ? desc.player_start : "");
+    editor_set_string_output(scene_state, outputs, "target_key", has_start && start.target != NULL ? start.target : "");
     SDL_free(json);
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8863,6 +8863,29 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown brush world reference"), std::string::npos) << error;
 
+    write_text(dir / "bad_test_run_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Test Run Action" },
+  "world": { "name": "world.bad_editor_test_run_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.test_run"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.test_run",
+        "actions": [
+          { "type": "editor.test_run.prepare", "data_asset": "asset://bad.game.json", "player_start": "player_start.missing" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_test_run_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown editor player start reference"), std::string::npos) << error;
+
     write_text(dir / "bad_status_action.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
@@ -14015,12 +14038,14 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int player_start_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start");
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
     const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
+    const int test_run_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.test_run.prepare");
     ASSERT_GE(floor_signal, 0);
     ASSERT_GE(wall_signal, 0);
     ASSERT_GE(ceiling_signal, 0);
     ASSERT_GE(player_start_signal, 0);
     ASSERT_GE(commit_signal, 0);
     ASSERT_GE(export_signal, 0);
+    ASSERT_GE(test_run_signal, 0);
 
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
@@ -14106,6 +14131,25 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NE(std::string(export_json).find("\"editor_player_starts\""), std::string::npos);
     EXPECT_NE(std::string(export_json).find("\"mat.editor.ceiling\""), std::string::npos);
     EXPECT_NE(std::string(export_json).find("\"player_start.editor_shell\""), std::string::npos);
+
+    slayer3d_signal_emit(bus, test_run_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.message", ""),
+                 "test run handoff prepared");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.data_asset", ""),
+                 "asset://editor_shell_dojo.game.json");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.scene", ""),
+                 "scene.editor_shell.test_run");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.player_start", ""),
+                 "player_start.editor_shell");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.target", ""),
+                 "entity.editor_shell.player");
+    const char *manifest_json = slayer3d_properties_get_string(scene_state, "editor.test_run.manifest_json", "");
+    ASSERT_NE(manifest_json, nullptr);
+    EXPECT_NE(std::string(manifest_json).find("\"schema\": \"slayer3d.editor_test_run.v0\""), std::string::npos);
+    EXPECT_NE(std::string(manifest_json).find("\"--player-start\""), std::string::npos);
+    EXPECT_NE(std::string(manifest_json).find("\"player_start.editor_shell\""), std::string::npos);
+    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.test_run.size", 0), 0);
 
     const std::filesystem::path save_dir = unique_test_dir("editor_unified_level_save");
     const std::filesystem::path saved_path = save_dir / "saved" / "editable_level.fragment.json";


### PR DESCRIPTION
## Summary
- add a public editor test-run manifest exporter for generic runner handoff workflows
- add `editor.test_run.prepare` so authored editor UI can publish runner args, scene, player start, and target metadata into scene state
- wire the editor shell dojo to prepare a test-run manifest with `T`, and document the workflow

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*:GameDataRuntime.RejectsInvalidSceneEditorTooling'`
- `./build/debug/tests/slayer3d_game_data_test`
- `git diff --check`

## Manual
- `./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json`
- press `T` in the editor shell to publish the handoff manifest
- direct test-run path: `./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell`

## Next Slice
The next practical slice for issue #360 is a host-side editor/test-run bridge: consume the manifest from the editor shell, persist it or expose it to a launcher command, and make the save -> launch -> return loop explicit enough for human verification.
