### PR TITLE
Add runner test-run manifest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,14 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     slayer3d_enable_warnings(slayer3d_bundle)
     slayer3d_enable_sanitizers(slayer3d_bundle)
 
-    add_executable(slayer3d_runner tools/slayer3d_runner.c tools/slayer3d_runner_cli.c tools/slayer3d_runner_state.c tools/slayer3d_fused.c)
+    add_executable(
+        slayer3d_runner
+        tools/slayer3d_runner.c
+        tools/slayer3d_runner_cli.c
+        tools/slayer3d_runner_manifest.c
+        tools/slayer3d_runner_state.c
+        tools/slayer3d_fused.c
+    )
     target_link_libraries(slayer3d_runner PRIVATE Slayer3D::slayer3d slayer3d_argtable3)
     target_compile_features(slayer3d_runner PRIVATE c_std_17)
     target_include_directories(slayer3d_runner PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -27,3 +27,10 @@ Test-run the authored player start directly:
 ```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell
 ```
+
+The `T` key publishes the equivalent `slayer3d.editor_test_run.v0` handoff
+manifest to scene state. Editor hosts can write that JSON to disk and launch:
+
+```sh
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest /tmp/editor-test-run.json
+```

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -192,6 +192,12 @@ Optional flags:
   before the first scene-enter signal. If the marker declares a scene and
   `--scene` is omitted, that scene becomes the initial scene. If both are
   supplied, they must reference the same scene.
+- `--test-run-manifest <path-or-asset>` reads a
+  `slayer3d.editor_test_run.v0` handoff manifest produced by editor data. The
+  manifest supplies the runner `--data`, `--scene`, and/or `--player-start`
+  values, while mount flags remain explicit on the runner command line. Explicit
+  `--data`, `--scene`, or `--player-start` arguments must agree with manifest
+  values when both are present.
 - `--state <key=value>` injects one scene-state value before the direct scene
   enter signal runs. The value is parsed as JSON when possible, so
   `--state lives=3`, `--state debug=true`, `--state spawn=[1,2,3]`, and
@@ -205,8 +211,10 @@ Optional flags:
   `SLAYER3D_RUNNER_EMBEDDED_ASSETS` and provides the generic
   `slayer3d_runner_embedded_assets` pack blob symbols.
 
-State inputs are applied in this order: `--state-file`, then `--state-json`,
-then `--state`. Later values overwrite earlier values with the same key.
+Test-run manifests are applied before app config loading so the manifest's data
+asset can become the game entry point. State inputs are applied in this order:
+`--state-file`, then `--state-json`, then `--state`. Later values overwrite
+earlier values with the same key.
 Injected state is available to the scene's `on_enter` signal and to authored
 conditions during scene entry. Direct scene launch also suppresses startup
 app-flow transitions so the requested scene is immediately usable.

--- a/docs/data-only-games.md
+++ b/docs/data-only-games.md
@@ -132,6 +132,21 @@ scene-state conditions and Lua state APIs. Player-start launches also apply the
 target actor's position and view angles before the first scene-enter signal, and
 use the marker's scene when `--scene` is omitted.
 
+Editor hosts can hand the same direct-start data to the runner with a test-run
+manifest:
+
+```sh
+build/debug/slayer3d_runner \
+  --root path/to/game/data \
+  --test-run-manifest /tmp/slayer3d-test-run.json
+```
+
+The manifest uses `schema: "slayer3d.editor_test_run.v0"` and supplies
+`data`, `scene`, and/or `player_start`. Mount options such as `--root`,
+`--pack`, `--embedded`, or fused executable context remain outside the manifest
+so the same handoff can work during loose-file editing, pack-file testing, and
+shipping builds.
+
 Demo targets may compile the same runner source with embedded assets and a
 default root data path. That wrapper should only supply build-time defaults; it
 should not contain game rules.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -934,7 +934,8 @@ action does not spawn a process and does not write files. It produces
 `slayer3d.editor_test_run.v0` JSON containing the root data asset, resolved
 scene, player start, target actor, and runner argument array excluding mount
 flags. Editor hosts combine those arguments with their current `--root`,
-`--pack`, embedded, or fused launch context.
+`--pack`, embedded, or fused launch context. The generic runner can consume the
+manifest directly with `--test-run-manifest <path-or-asset>`.
 
 ```json
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -290,6 +290,7 @@ else()
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_bundle_cli.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_fused.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_cli.c
+            ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_manifest.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_state.c
     )
     target_link_libraries(slayer3d_tool_cli_test PRIVATE slayer3d_argtable3)

--- a/tests/test_tool_cli.cpp
+++ b/tests/test_tool_cli.cpp
@@ -16,6 +16,7 @@ extern "C"
 #include "slayer3d_fused.h"
 #include "slayer3d_pack_cli.h"
 #include "slayer3d_runner_cli.h"
+#include "slayer3d_runner_manifest.h"
 #include "slayer3d_runner_state.h"
 }
 
@@ -115,10 +116,32 @@ TEST(ToolCli, RunnerParsesDirectStartStateInputs)
     slayer3d_runner_args_destroy(&args);
 }
 
+TEST(ToolCli, RunnerParsesTestRunManifestWithoutData)
+{
+    std::vector<char *> argv =
+        argv_from({"slayer3d_runner", "--root", "game/data", "--test-run-manifest", "asset://editor/run.json"});
+    slayer3d_runner_args args;
+    ASSERT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
+    EXPECT_EQ(args.mount_kind, SLAYER3D_RUNNER_MOUNT_DIRECTORY);
+    EXPECT_STREQ(args.mount_path, "game/data");
+    EXPECT_EQ(args.data_asset_path, nullptr);
+    EXPECT_FALSE(args.data_asset_path_explicit);
+    EXPECT_STREQ(args.test_run_manifest_path, "asset://editor/run.json");
+    slayer3d_runner_args_destroy(&args);
+}
+
 TEST(ToolCli, RunnerRejectsEmptyPlayerStart)
 {
     std::vector<char *> argv =
         argv_from({"slayer3d_runner", "--root", "game/data", "--data", "asset://game.game.json", "--player-start", ""});
+    slayer3d_runner_args args;
+    EXPECT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
+    slayer3d_runner_args_destroy(&args);
+}
+
+TEST(ToolCli, RunnerRejectsEmptyTestRunManifestPath)
+{
+    std::vector<char *> argv = argv_from({"slayer3d_runner", "--root", "game/data", "--test-run-manifest", ""});
     slayer3d_runner_args args;
     EXPECT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
     slayer3d_runner_args_destroy(&args);
@@ -318,6 +341,62 @@ TEST(ToolCli, RunnerStateInputsMergeWithExpectedPrecedenceAndTypes)
 
     slayer3d_properties_destroy(props);
     std::filesystem::remove(path);
+}
+
+TEST(ToolCli, RunnerTestRunManifestAppliesCanonicalDirectStartArgs)
+{
+    const char manifest[] = R"json({
+  "schema": "slayer3d.editor_test_run.v0",
+  "data": "asset://game.game.json",
+  "scene": "scene.level1",
+  "player_start": "player_start.level1",
+  "target": "entity.player",
+  "args": ["--data", "asset://game.game.json", "--scene", "scene.level1", "--player-start", "player_start.level1"]
+})json";
+
+    slayer3d_runner_args args{};
+    char error[256]{};
+    ASSERT_TRUE(slayer3d_runner_apply_test_run_manifest_json(&args, manifest, std::strlen(manifest), "manifest", error,
+                                                             sizeof(error)))
+        << error;
+    EXPECT_STREQ(args.data_asset_path, "asset://game.game.json");
+    EXPECT_STREQ(args.scene, "scene.level1");
+    EXPECT_STREQ(args.player_start, "player_start.level1");
+    EXPECT_NE(args.owned_data_asset_path, nullptr);
+    EXPECT_NE(args.owned_scene, nullptr);
+    EXPECT_NE(args.owned_player_start, nullptr);
+    slayer3d_runner_args_destroy(&args);
+}
+
+TEST(ToolCli, RunnerTestRunManifestRejectsConflictingExplicitArgs)
+{
+    const char manifest[] = R"json({
+  "schema": "slayer3d.editor_test_run.v0",
+  "data": "asset://game.game.json",
+  "scene": "scene.level1"
+})json";
+
+    slayer3d_runner_args args{};
+    args.data_asset_path = "asset://other.game.json";
+    args.data_asset_path_explicit = true;
+    char error[256]{};
+    EXPECT_FALSE(slayer3d_runner_apply_test_run_manifest_json(&args, manifest, std::strlen(manifest), "manifest", error,
+                                                              sizeof(error)));
+    EXPECT_NE(std::string(error).find("conflicts"), std::string::npos) << error;
+    slayer3d_runner_args_destroy(&args);
+}
+
+TEST(ToolCli, RunnerTestRunManifestRejectsInvalidSchema)
+{
+    const char manifest[] =
+        R"json({"schema":"slayer3d.game.v0","data":"asset://game.game.json","scene":"scene.level1"})json";
+
+    slayer3d_runner_args args{};
+    char error[256]{};
+    EXPECT_FALSE(slayer3d_runner_apply_test_run_manifest_json(&args, manifest, std::strlen(manifest), "manifest", error,
+                                                              sizeof(error)));
+    EXPECT_NE(std::string(error).find("schema"), std::string::npos) << error;
+    slayer3d_runner_args_destroy(&args);
 }
 
 TEST(ToolCli, RunnerStateInputsRejectMalformedValues)

--- a/tools/slayer3d_runner.c
+++ b/tools/slayer3d_runner.c
@@ -3,6 +3,7 @@
  * @brief Generic SLAYER3D data-game runner.
  */
 
+#include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_stdinc.h>
@@ -13,6 +14,7 @@
 
 #include "slayer3d_fused.h"
 #include "slayer3d_runner_cli.h"
+#include "slayer3d_runner_manifest.h"
 #include "slayer3d_runner_state.h"
 
 #if defined(SLAYER3D_RUNNER_EMBEDDED_ASSETS)
@@ -149,6 +151,51 @@ static bool runner_read_asset_state_file(runner_state *state, const char *path, 
     }
     slayer3d_asset_buffer_free(&buffer);
     slayer3d_asset_resolver_destroy(assets);
+    return ok;
+}
+
+static bool runner_read_text_file(runner_state *state, const char *path, char **out_text, size_t *out_size,
+                                  char *error_buffer, int error_buffer_size)
+{
+    if (runner_is_asset_path(path))
+        return runner_read_asset_state_file(state, path, out_text, out_size, error_buffer, error_buffer_size);
+
+    *out_text = NULL;
+    *out_size = 0u;
+    size_t size = 0u;
+    char *text = (char *)SDL_LoadFile(path, &size);
+    if (text == NULL)
+        return runner_set_errorf(error_buffer, error_buffer_size, "failed to read file '%s'", path);
+
+    char *terminated = (char *)SDL_realloc(text, size + 1u);
+    if (terminated == NULL)
+    {
+        SDL_free(text);
+        runner_set_error(error_buffer, error_buffer_size, "failed to terminate file buffer");
+        return false;
+    }
+    terminated[size] = '\0';
+    *out_text = terminated;
+    *out_size = size;
+    return true;
+}
+
+static bool runner_apply_test_run_manifest(runner_state *state, char *error_buffer, int error_buffer_size)
+{
+    if (state == NULL || state->args.test_run_manifest_path == NULL)
+        return true;
+
+    char *text = NULL;
+    size_t size = 0u;
+    if (!runner_read_text_file(state, state->args.test_run_manifest_path, &text, &size, error_buffer,
+                               error_buffer_size))
+    {
+        return false;
+    }
+
+    const bool ok = slayer3d_runner_apply_test_run_manifest_json(
+        &state->args, text, size, state->args.test_run_manifest_path, error_buffer, error_buffer_size);
+    SDL_free(text);
     return ok;
 }
 
@@ -334,6 +381,12 @@ int main(int argc, char **argv)
     if (!runner_prepare_fused_defaults(&state, error, (int)sizeof(error)))
     {
         fprintf(stderr, "slayer3d_runner: %s\n", error[0] != '\0' ? error : "failed to inspect fused runner");
+        slayer3d_runner_args_destroy(&state.args);
+        return 1;
+    }
+    if (!runner_apply_test_run_manifest(&state, error, (int)sizeof(error)))
+    {
+        fprintf(stderr, "slayer3d_runner: %s\n", error[0] != '\0' ? error : "failed to apply test-run manifest");
         slayer3d_runner_args_destroy(&state.args);
         return 1;
     }

--- a/tools/slayer3d_runner_cli.c
+++ b/tools/slayer3d_runner_cli.c
@@ -16,16 +16,19 @@ void slayer3d_runner_args_print_usage(const char *argv0, FILE *stream)
     fprintf(out,
             "Usage:\n"
             "  %s\n"
-            "  %s --root <asset-root> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "  %s --root <asset-root> (--data <asset://game.json> | --test-run-manifest <path-or-asset>) "
+            "[--media <media-dir>] [--scene <scene>] "
             "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
             "[--state-file <path-or-asset>]\n"
-            "  %s --pack <game.slayer3dpak> --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "  %s --pack <game.slayer3dpak> (--data <asset://game.json> | --test-run-manifest <path-or-asset>) "
+            "[--media <media-dir>] [--scene <scene>] "
             "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
             "[--state-file <path-or-asset>]\n",
             program, program, program);
 #if defined(SLAYER3D_RUNNER_EMBEDDED_ASSETS)
     fprintf(out,
-            "  %s --embedded --data <asset://game.json> [--media <media-dir>] [--scene <scene>] "
+            "  %s --embedded (--data <asset://game.json> | --test-run-manifest <path-or-asset>) "
+            "[--media <media-dir>] [--scene <scene>] "
             "[--player-start <name>] [--state <key=value> ...] [--state-json <object>] "
             "[--state-file <path-or-asset>]\n",
             program);
@@ -55,12 +58,24 @@ void slayer3d_runner_args_destroy(slayer3d_runner_args *args)
 {
     if (args == NULL)
         return;
+    if (args->data_asset_path == args->owned_data_asset_path)
+        args->data_asset_path = NULL;
+    if (args->scene == args->owned_scene)
+        args->scene = NULL;
+    if (args->player_start == args->owned_player_start)
+        args->player_start = NULL;
     SDL_free(args->state_assignments);
     SDL_free(args->state_json_values);
     SDL_free(args->state_files);
+    SDL_free(args->owned_data_asset_path);
+    SDL_free(args->owned_scene);
+    SDL_free(args->owned_player_start);
     args->state_assignments = NULL;
     args->state_json_values = NULL;
     args->state_files = NULL;
+    args->owned_data_asset_path = NULL;
+    args->owned_scene = NULL;
+    args->owned_player_start = NULL;
     args->state_assignment_count = 0;
     args->state_json_count = 0;
     args->state_file_count = 0;
@@ -74,6 +89,8 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
     struct arg_lit *embedded = arg_lit0(NULL, "embedded", "mount the runner's embedded asset pack");
 #endif
     struct arg_str *data = arg_str0(NULL, "data", "<asset://game.json>", "root game-data asset path");
+    struct arg_str *test_run_manifest =
+        arg_str0(NULL, "test-run-manifest", "<path-or-asset>", "editor test-run handoff manifest");
     struct arg_str *media = arg_str0(NULL, "media", "<media-dir>", "built-in media directory");
     struct arg_str *scene = arg_str0(NULL, "scene", "<scene>", "start directly in an authored scene");
     struct arg_str *player_start =
@@ -86,11 +103,15 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
     struct arg_lit *help = arg_lit0("h", "help", "print this help and exit");
     struct arg_end *end = arg_end(20);
     void *argtable[] = {
-        root,     pack,
+        root,         pack,
 #if defined(SLAYER3D_RUNNER_EMBEDDED_ASSETS)
         embedded,
 #endif
-        data,     media, scene, player_start, state, state_json, state_file, help, end,
+        data,         test_run_manifest,
+        media,        scene,
+        player_start, state,
+        state_json,   state_file,
+        help,         end,
     };
     const char *program = argc > 0 && argv != NULL && argv[0] != NULL ? argv[0] : "slayer3d_runner";
     FILE *out = stream != NULL ? stream : stderr;
@@ -161,21 +182,33 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
 #endif
 
     if (data->count > 0)
+    {
         args->data_asset_path = data->sval[0];
+        args->data_asset_path_explicit = true;
+    }
+    if (test_run_manifest->count > 0)
+        args->test_run_manifest_path = test_run_manifest->sval[0];
     if (media->count > 0)
         args->media_dir = media->sval[0];
     if (scene->count > 0)
+    {
         args->scene = scene->sval[0];
+        args->scene_explicit = true;
+    }
     if (player_start->count > 0)
+    {
         args->player_start = player_start->sval[0];
+        args->player_start_explicit = true;
+    }
 
     const bool mount_path_required =
         args->mount_kind == SLAYER3D_RUNNER_MOUNT_DIRECTORY || args->mount_kind == SLAYER3D_RUNNER_MOUNT_PACK;
     if ((mount_path_required && (args->mount_path == NULL || args->mount_path[0] == '\0')) ||
         (args->mount_kind != SLAYER3D_RUNNER_MOUNT_NONE &&
-         (args->data_asset_path == NULL || args->data_asset_path[0] == '\0')))
+         (args->data_asset_path == NULL || args->data_asset_path[0] == '\0') &&
+         (args->test_run_manifest_path == NULL || args->test_run_manifest_path[0] == '\0')))
     {
-        fprintf(out, "%s: explicit asset mounts require --data\n", program);
+        fprintf(out, "%s: explicit asset mounts require --data or --test-run-manifest\n", program);
         fprintf(out, "Try '%s --help' for more information.\n", program);
         arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
         return SLAYER3D_TOOL_CLI_ERROR;
@@ -183,6 +216,7 @@ slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slaye
 
     if ((args->scene != NULL && args->scene[0] == '\0') ||
         (args->player_start != NULL && args->player_start[0] == '\0') ||
+        (args->test_run_manifest_path != NULL && args->test_run_manifest_path[0] == '\0') ||
         !copy_string_list(&args->state_assignments, &args->state_assignment_count, state->sval, state->count) ||
         !copy_string_list(&args->state_json_values, &args->state_json_count, state_json->sval, state_json->count) ||
         !copy_string_list(&args->state_files, &args->state_file_count, state_file->sval, state_file->count))

--- a/tools/slayer3d_runner_cli.h
+++ b/tools/slayer3d_runner_cli.h
@@ -29,9 +29,16 @@ extern "C"
         slayer3d_runner_mount_kind mount_kind;
         const char *mount_path;
         const char *data_asset_path;
+        const char *test_run_manifest_path;
         const char *media_dir;
         const char *scene;
         const char *player_start;
+        bool data_asset_path_explicit;
+        bool scene_explicit;
+        bool player_start_explicit;
+        char *owned_data_asset_path;
+        char *owned_scene;
+        char *owned_player_start;
         const char **state_assignments;
         int state_assignment_count;
         const char **state_json_values;

--- a/tools/slayer3d_runner_manifest.c
+++ b/tools/slayer3d_runner_manifest.c
@@ -1,0 +1,180 @@
+/**
+ * @file slayer3d_runner_manifest.c
+ * @brief Editor test-run manifest helpers for slayer3d_runner.
+ */
+
+#include "slayer3d_runner_manifest.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include "../vendor/yyjson/yyjson.h"
+
+static void runner_manifest_set_error(char *error_buffer, int error_buffer_size, const char *message)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s", message != NULL ? message : "unknown error");
+}
+
+static bool runner_manifest_set_errorf(char *error_buffer, int error_buffer_size, const char *fmt, const char *value)
+{
+    if (error_buffer != NULL && error_buffer_size > 0)
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size, fmt, value != NULL ? value : "");
+    return false;
+}
+
+static const char *runner_manifest_string(yyjson_val *root, const char *key)
+{
+    yyjson_val *value = yyjson_obj_get(root, key);
+    return yyjson_is_str(value) ? yyjson_get_str(value) : NULL;
+}
+
+static bool runner_manifest_string_is_empty(const char *value)
+{
+    return value == NULL || value[0] == '\0';
+}
+
+static bool runner_manifest_matches_explicit(const char *field_name, const char *explicit_value,
+                                             const char *manifest_value, char *error_buffer, int error_buffer_size)
+{
+    if (runner_manifest_string_is_empty(explicit_value) || runner_manifest_string_is_empty(manifest_value) ||
+        SDL_strcmp(explicit_value, manifest_value) == 0)
+    {
+        return true;
+    }
+
+    if (error_buffer != NULL && error_buffer_size > 0)
+    {
+        SDL_snprintf(error_buffer, (size_t)error_buffer_size,
+                     "test-run manifest %s '%s' conflicts with explicit CLI value '%s'", field_name, manifest_value,
+                     explicit_value);
+    }
+    return false;
+}
+
+static bool runner_manifest_assign_owned(const char **target, char **owned, const char *value, char *error_buffer,
+                                         int error_buffer_size)
+{
+    if (target == NULL || owned == NULL || runner_manifest_string_is_empty(value))
+        return true;
+
+    char *copy = SDL_strdup(value);
+    if (copy == NULL)
+        return runner_manifest_set_errorf(error_buffer, error_buffer_size, "failed to allocate manifest value '%s'",
+                                          value);
+    SDL_free(*owned);
+    *owned = copy;
+    *target = copy;
+    return true;
+}
+
+static bool runner_manifest_validate_args_array(yyjson_val *root, char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *args = yyjson_obj_get(root, "args");
+    if (args == NULL)
+        return true;
+    if (!yyjson_is_arr(args))
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size, "test-run manifest args must be an array");
+        return false;
+    }
+
+    for (size_t i = 0; i < yyjson_arr_size(args); ++i)
+    {
+        if (!yyjson_is_str(yyjson_arr_get(args, i)))
+        {
+            runner_manifest_set_error(error_buffer, error_buffer_size,
+                                      "test-run manifest args entries must be strings");
+            return false;
+        }
+    }
+    return true;
+}
+
+bool slayer3d_runner_apply_test_run_manifest_json(slayer3d_runner_args *args, const char *json, size_t json_size,
+                                                  const char *source_name, char *error_buffer, int error_buffer_size)
+{
+    if (args == NULL || json == NULL)
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size,
+                                  "test-run manifest requires runner arguments and JSON text");
+        return false;
+    }
+
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts((char *)json, json_size, YYJSON_READ_NOFLAG, NULL, &err);
+    if (doc == NULL)
+    {
+        if (error_buffer != NULL && error_buffer_size > 0)
+        {
+            SDL_snprintf(error_buffer, (size_t)error_buffer_size, "%s JSON error %u at byte %llu: %s",
+                         source_name != NULL ? source_name : "test-run manifest", err.code, (unsigned long long)err.pos,
+                         err.msg != NULL ? err.msg : "");
+        }
+        return false;
+    }
+
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    const char *schema = runner_manifest_string(root, "schema");
+    const char *data = runner_manifest_string(root, "data");
+    const char *scene = runner_manifest_string(root, "scene");
+    const char *player_start = runner_manifest_string(root, "player_start");
+
+    bool ok = true;
+    if (!yyjson_is_obj(root))
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size, "test-run manifest must be a JSON object");
+        ok = false;
+    }
+    else if (runner_manifest_string_is_empty(schema) || SDL_strcmp(schema, "slayer3d.editor_test_run.v0") != 0)
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size,
+                                  "test-run manifest schema must be slayer3d.editor_test_run.v0");
+        ok = false;
+    }
+    else if (runner_manifest_string_is_empty(data))
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size, "test-run manifest requires non-empty data");
+        ok = false;
+    }
+    else if (runner_manifest_string_is_empty(scene) && runner_manifest_string_is_empty(player_start))
+    {
+        runner_manifest_set_error(error_buffer, error_buffer_size, "test-run manifest requires scene or player_start");
+        ok = false;
+    }
+    else if (!runner_manifest_validate_args_array(root, error_buffer, error_buffer_size))
+    {
+        ok = false;
+    }
+    else if (args->data_asset_path_explicit &&
+             !runner_manifest_matches_explicit("data", args->data_asset_path, data, error_buffer, error_buffer_size))
+    {
+        ok = false;
+    }
+    else if (args->scene_explicit &&
+             !runner_manifest_matches_explicit("scene", args->scene, scene, error_buffer, error_buffer_size))
+    {
+        ok = false;
+    }
+    else if (args->player_start_explicit &&
+             !runner_manifest_matches_explicit("player_start", args->player_start, player_start, error_buffer,
+                                               error_buffer_size))
+    {
+        ok = false;
+    }
+    else
+    {
+        if (!args->data_asset_path_explicit)
+            ok = runner_manifest_assign_owned(&args->data_asset_path, &args->owned_data_asset_path, data, error_buffer,
+                                              error_buffer_size);
+        if (ok && !args->scene_explicit)
+            ok = runner_manifest_assign_owned(&args->scene, &args->owned_scene, scene, error_buffer, error_buffer_size);
+        if (ok && !args->player_start_explicit)
+        {
+            ok = runner_manifest_assign_owned(&args->player_start, &args->owned_player_start, player_start,
+                                              error_buffer, error_buffer_size);
+        }
+    }
+
+    yyjson_doc_free(doc);
+    return ok;
+}

--- a/tools/slayer3d_runner_manifest.h
+++ b/tools/slayer3d_runner_manifest.h
@@ -1,0 +1,27 @@
+/**
+ * @file slayer3d_runner_manifest.h
+ * @brief Editor test-run manifest helpers for slayer3d_runner.
+ */
+
+#ifndef SLAYER3D_RUNNER_MANIFEST_H
+#define SLAYER3D_RUNNER_MANIFEST_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "slayer3d_runner_cli.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    bool slayer3d_runner_apply_test_run_manifest_json(slayer3d_runner_args *args, const char *json, size_t json_size,
+                                                      const char *source_name, char *error_buffer,
+                                                      int error_buffer_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- add `--test-run-manifest <path-or-asset>` to `slayer3d_runner`
- validate and apply `slayer3d.editor_test_run.v0` manifests into runner `--data`, `--scene`, and `--player-start` settings
- keep mount context explicit on the command line and reject conflicting explicit direct-start args
- document the editor shell handoff workflow

## Tests
- `cmake --build build/debug --target slayer3d_runner slayer3d_tool_cli_test slayer3d_game_data_test -j 8`
- `./build/debug/tests/slayer3d_tool_cli_test`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*:GameDataRuntime.RejectsInvalidSceneEditorTooling'`
- `./build/debug/tests/slayer3d_game_data_test`
- `git diff --check`

## Manual
- `./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json`
- press `T` to publish the handoff manifest in scene state
- write the manifest JSON to a file, then launch it with: `./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest /tmp/editor-test-run.json`

## Next Slice
The next issue #360 slice should connect the editor shell's save/export workflow to this manifest bridge so a human can place geometry and a player start, save/export the editable level artifact, emit the run manifest, and launch the runner using that saved output.
