### PR TITLE
Add editor save-to-test-run workflow

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -8,10 +8,10 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
   `4` player start, then `Enter` to place the selected prefab
-- unified editable-level export: `S` publishes one fragment containing the
-  brush world and player starts
-- test-run handoff manifest: `T` publishes runner arguments for the authored
-  player start
+- unified editable-level save/export: `S` saves and publishes one fragment
+  containing the brush world and player starts
+- test-run handoff manifest: `T` publishes and saves runner arguments for the
+  authored player start
 - generic runner test-run support: `--player-start player_start.editor_shell`
   enters the playable FPS scene through the same runtime path a data-only game
   uses
@@ -28,9 +28,11 @@ Test-run the authored player start directly:
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell
 ```
 
-The `T` key publishes the equivalent `slayer3d.editor_test_run.v0` handoff
-manifest to scene state. Editor hosts can write that JSON to disk and launch:
+By default, `S` writes
+`demos/editor_shell_dojo/data/generated/editable_level.fragment.json`, which is
+imported by the dojo on the next launch. `T` writes
+`build/editor_shell_dojo/test-run.json`. Launch that saved manifest with:
 
 ```sh
-./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest /tmp/editor-test-run.json
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
 ```

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1,5 +1,6 @@
 {
   "schema": "slayer3d.game.v0",
+  "imports": [{ "path": "generated/editable_level.fragment.json", "sections": ["brush_worlds", "editor_player_starts"] }],
   "metadata": {
     "name": "Slayer 3D Editor Shell Dojo",
     "id": "demo.editor_shell_dojo",
@@ -549,6 +550,28 @@
         "signal": "signal.editor.export",
         "actions": [
           {
+            "type": "editor.level.save",
+            "world": "brush.editor_shell.target",
+            "path_from_state": "editor.save.path",
+            "message": "editable level saved",
+            "outputs": {
+              "valid_key": "editor.save.valid",
+              "message_key": "editor.save.message",
+              "path_key": "editor.save.path",
+              "size_key": "editor.save.size",
+              "brush_world_key": "editor.brush_world.name",
+              "brush_dirty_key": "editor.brush_world.dirty",
+              "brush_revision_key": "editor.brush_world.revision",
+              "brush_saved_revision_key": "editor.brush_world.saved_revision",
+              "brush_source_path_key": "editor.brush_world.source_path",
+              "player_start_count_key": "editor.player_start.count",
+              "player_start_dirty_key": "editor.player_start.dirty",
+              "player_start_revision_key": "editor.player_start.revision",
+              "player_start_saved_revision_key": "editor.player_start.saved_revision",
+              "player_start_source_path_key": "editor.player_start.source_path"
+            }
+          },
+          {
             "type": "editor.level.export",
             "world": "brush.editor_shell.target",
             "outputs": {
@@ -581,6 +604,24 @@
             "outputs": {
               "valid_key": "editor.test_run.valid",
               "message_key": "editor.test_run.message",
+              "manifest_json_key": "editor.test_run.manifest_json",
+              "size_key": "editor.test_run.size",
+              "data_asset_key": "editor.test_run.data_asset",
+              "scene_key": "editor.test_run.scene",
+              "player_start_key": "editor.test_run.player_start",
+              "target_key": "editor.test_run.target"
+            }
+          },
+          {
+            "type": "editor.test_run.save_manifest",
+            "data_asset": "asset://editor_shell_dojo.game.json",
+            "player_start": "player_start.editor_shell",
+            "path_from_state": "editor.test_run.path",
+            "message": "test run manifest saved",
+            "outputs": {
+              "valid_key": "editor.test_run.saved",
+              "message_key": "editor.test_run.save_message",
+              "path_key": "editor.test_run.path",
               "manifest_json_key": "editor.test_run.manifest_json",
               "size_key": "editor.test_run.size",
               "data_asset_key": "editor.test_run.data_asset",
@@ -662,81 +703,6 @@
           "step_height": 0.55,
           "ceiling_clearance": 0.1,
           "mouse_sensitivity": 0.002
-        }
-      ]
-    }
-  ],
-  "editor_player_starts": [
-    {
-      "name": "player_start.editor_shell",
-      "scene": "scene.editor_shell.test_run",
-      "target": "entity.editor_shell.player",
-      "position": [0.0, 1.6, 4.0],
-      "yaw": 3.14159,
-      "pitch": 0.0
-    }
-  ],
-  "brush_worlds": [
-    {
-      "name": "brush.editor_shell.target",
-      "editor": {
-        "stable_id": "editor.world.target",
-        "display_name": "Target Brush World",
-        "category": "editor/dojo"
-      },
-      "materials": [
-        {
-          "name": "mat.editor.wall",
-          "albedo": [0.58, 0.18, 0.16, 1.0],
-          "roughness": 0.8,
-          "editor": {
-            "stable_id": "editor.material.wall",
-            "display_name": "Red Wall Material"
-          }
-        },
-        {
-          "name": "mat.editor.floor",
-          "albedo": [0.22, 0.24, 0.28, 1.0],
-          "roughness": 0.9,
-          "editor": {
-            "stable_id": "editor.material.floor",
-            "display_name": "Dark Floor Material"
-          }
-        },
-        {
-          "name": "mat.editor.ceiling",
-          "albedo": [0.42, 0.44, 0.48, 1.0],
-          "roughness": 0.85,
-          "editor": {
-            "stable_id": "editor.material.ceiling",
-            "display_name": "Soft Ceiling Material"
-          }
-        }
-      ],
-      "brushes": [
-        {
-          "name": "brush.target.cube",
-          "contents": ["solid", "player_clip"],
-          "editor": {
-            "stable_id": "editor.brush.target_cube",
-            "display_name": "Selectable Cube",
-            "prefab": "prefab.editor_shell.cube"
-          },
-          "faces": [
-            { "plane": { "normal": [1, 0, 0], "distance": 2 }, "material": "mat.editor.wall" },
-            {
-              "plane": { "normal": [-1, 0, 0], "distance": 0 },
-              "material": "mat.editor.wall",
-              "editor": {
-                "stable_id": "editor.face.target_cube.left",
-                "display_name": "Left Face"
-              }
-            },
-            { "plane": { "normal": [0, 1, 0], "distance": 2 }, "material": "mat.editor.wall" },
-            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.editor.floor" },
-            { "plane": { "normal": [0, 0, 1], "distance": 2 }, "material": "mat.editor.wall" },
-            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.editor.wall" }
-          ]
         }
       ]
     }

--- a/demos/editor_shell_dojo/data/generated/editable_level.fragment.json
+++ b/demos/editor_shell_dojo/data/generated/editable_level.fragment.json
@@ -1,0 +1,78 @@
+{
+  "schema": "slayer3d.fragment.v0",
+  "editor_player_starts": [
+    {
+      "name": "player_start.editor_shell",
+      "scene": "scene.editor_shell.test_run",
+      "target": "entity.editor_shell.player",
+      "position": [0.0, 1.6, 4.0],
+      "yaw": 3.14159,
+      "pitch": 0.0
+    }
+  ],
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "editor": {
+        "stable_id": "editor.world.target",
+        "display_name": "Target Brush World",
+        "category": "editor/dojo"
+      },
+      "materials": [
+        {
+          "name": "mat.editor.wall",
+          "albedo": [0.58, 0.18, 0.16, 1.0],
+          "roughness": 0.8,
+          "editor": {
+            "stable_id": "editor.material.wall",
+            "display_name": "Red Wall Material"
+          }
+        },
+        {
+          "name": "mat.editor.floor",
+          "albedo": [0.22, 0.24, 0.28, 1.0],
+          "roughness": 0.9,
+          "editor": {
+            "stable_id": "editor.material.floor",
+            "display_name": "Dark Floor Material"
+          }
+        },
+        {
+          "name": "mat.editor.ceiling",
+          "albedo": [0.42, 0.44, 0.48, 1.0],
+          "roughness": 0.85,
+          "editor": {
+            "stable_id": "editor.material.ceiling",
+            "display_name": "Soft Ceiling Material"
+          }
+        }
+      ],
+      "brushes": [
+        {
+          "name": "brush.target.cube",
+          "contents": ["solid", "player_clip"],
+          "editor": {
+            "stable_id": "editor.brush.target_cube",
+            "display_name": "Selectable Cube",
+            "prefab": "prefab.editor_shell.cube"
+          },
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 2 }, "material": "mat.editor.wall" },
+            {
+              "plane": { "normal": [-1, 0, 0], "distance": 0 },
+              "material": "mat.editor.wall",
+              "editor": {
+                "stable_id": "editor.face.target_cube.left",
+                "display_name": "Left Face"
+              }
+            },
+            { "plane": { "normal": [0, 1, 0], "distance": 2 }, "material": "mat.editor.wall" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.editor.floor" },
+            { "plane": { "normal": [0, 0, 1], "distance": 2 }, "material": "mat.editor.wall" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.editor.wall" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -4,6 +4,14 @@
   "camera": "camera.editor_shell.viewport",
   "updates_game": true,
   "renders_world": true,
+  "on_enter": [
+    {
+      "type": "scene_state.set",
+      "key": "editor.save.path",
+      "value": "demos/editor_shell_dojo/data/generated/editable_level.fragment.json"
+    },
+    { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" }
+  ],
   "input": {
     "actions": [
       "action.exit",
@@ -150,6 +158,10 @@
             "binding": { "type": "scene_state", "key": "editor.test_run.message", "default": "none" }
           },
           {
+            "label": "Saved",
+            "binding": { "type": "scene_state", "key": "editor.save.path", "default": "none" }
+          },
+          {
             "label": "Preview",
             "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
           },
@@ -174,7 +186,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S export. T run manifest. Z/Y undo-redo.",
+        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S save. T run manifest. Z/Y undo-redo.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -899,8 +899,9 @@ state for validation and inspection. Native editor hosts can also call
 same fragment JSON to a chosen filesystem path; a successful save marks the
 world clean and records the saved source path. Hosts that save through their own
 project pipeline can call `slayer3d_game_data_mark_brush_world_saved()` after
-their write commits. Authored game data does not get a direct arbitrary-file
-save action; file writes stay under editor host control.
+their write commits. Authored save actions are available for controlled editor
+shells, but they require explicit filesystem paths and never accept `asset://`
+destinations.
 
 Use `editor.level.export` when the editable artifact needs both blockout brush
 geometry and test-run player starts. It serializes a single fragment containing
@@ -928,6 +929,27 @@ restores floors, walls, ceilings, face materials, and player starts together.
 }
 ```
 
+Use `editor.level.save` for the same unified artifact when an authored editor
+shell is allowed to write a filesystem path directly. `path` is a literal host
+path; `path_from_state` reads the path from scene state so a host/editor UI can
+choose the destination. Exactly one must be provided. The action writes
+atomically, creates parent directories, and publishes the same brush/player-start
+revision state as `editor.level.export`.
+
+```json
+{
+  "type": "editor.level.save",
+  "world": "brush.level.blockout",
+  "path_from_state": "editor.save.path",
+  "outputs": {
+    "valid_key": "editor.save.valid",
+    "message_key": "editor.save.message",
+    "path_key": "editor.save.path",
+    "size_key": "editor.save.size"
+  }
+}
+```
+
 Use `editor.test_run.prepare` to publish a game-agnostic handoff manifest for
 launching the generic runner from an editor-selected scene or player start. The
 action does not spawn a process and does not write files. It produces
@@ -948,6 +970,25 @@ manifest directly with `--test-run-manifest <path-or-asset>`.
     "manifest_json_key": "editor.test_run.manifest_json",
     "scene_key": "editor.test_run.scene",
     "player_start_key": "editor.test_run.player_start"
+  }
+}
+```
+
+Use `editor.test_run.save_manifest` when the editor shell should write the
+handoff manifest directly for `slayer3d_runner --test-run-manifest`. It accepts
+the same `data_asset`, `scene`, and `player_start` fields as
+`editor.test_run.prepare`, plus exactly one of `path` or `path_from_state`.
+
+```json
+{
+  "type": "editor.test_run.save_manifest",
+  "data_asset": "asset://game.game.json",
+  "player_start": "player_start.level_01",
+  "path_from_state": "editor.test_run.path",
+  "outputs": {
+    "valid_key": "editor.test_run.saved",
+    "message_key": "editor.test_run.save_message",
+    "path_key": "editor.test_run.path"
   }
 }
 ```

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -403,8 +403,14 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.level.export") == 0)
         return slayer3d_game_data_export_editor_level_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.level.save") == 0)
+        return slayer3d_game_data_save_editor_level_action(runtime, action);
+
     if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
         return slayer3d_game_data_prepare_editor_test_run_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.test_run.save_manifest") == 0)
+        return slayer3d_game_data_save_editor_test_run_manifest_action(runtime, action);
 
     if (SDL_strcmp(type, "editor.brush_world.status") == 0)
         return slayer3d_game_data_publish_editor_brush_world_status_action(runtime, action);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -866,7 +866,9 @@ bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime,
                                             const slayer3d_properties *payload);
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_save_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_save_editor_test_run_manifest_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
                                                                  yyjson_val *action);
 bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8620,6 +8620,46 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.level.save") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        yyjson_val *path = obj_get(action, "path");
+        yyjson_val *path_from_state = obj_get(action, "path_from_state");
+        if ((path == NULL && path_from_state == NULL) || (path != NULL && path_from_state != NULL))
+            return validation_error(ctx, json_path,
+                                    "editor.level.save requires exactly one of path or path_from_state");
+        if (path != NULL && (!yyjson_is_str(path) || yyjson_get_str(path)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.level.save path must be a non-empty string");
+        if (path_from_state != NULL && (!yyjson_is_str(path_from_state) || yyjson_get_str(path_from_state)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.level.save path_from_state must be a non-empty string");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.level.save outputs must be an object");
+        static const char *const output_keys[] = {
+            "valid_key",
+            "message_key",
+            "path_key",
+            "size_key",
+            "brush_world_key",
+            "brush_source_path_key",
+            "brush_dirty_key",
+            "brush_revision_key",
+            "brush_saved_revision_key",
+            "player_start_source_path_key",
+            "player_start_count_key",
+            "player_start_dirty_key",
+            "player_start_revision_key",
+            "player_start_saved_revision_key",
+        };
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path, "editor.level.save output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
     {
         if (!is_non_empty_string(action, "data_asset"))
@@ -8648,6 +8688,49 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
             if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
                 return validation_error(ctx, json_path,
                                         "editor.test_run.prepare output keys must be non-empty strings");
+        }
+        return true;
+    }
+    if (SDL_strcmp(type, "editor.test_run.save_manifest") == 0)
+    {
+        if (!is_non_empty_string(action, "data_asset"))
+            return validation_error(ctx, json_path, "editor.test_run.save_manifest requires a non-empty data_asset");
+        yyjson_val *path = obj_get(action, "path");
+        yyjson_val *path_from_state = obj_get(action, "path_from_state");
+        if ((path == NULL && path_from_state == NULL) || (path != NULL && path_from_state != NULL))
+            return validation_error(ctx, json_path,
+                                    "editor.test_run.save_manifest requires exactly one of path or path_from_state");
+        if (path != NULL && (!yyjson_is_str(path) || yyjson_get_str(path)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.test_run.save_manifest path must be a non-empty string");
+        if (path_from_state != NULL && (!yyjson_is_str(path_from_state) || yyjson_get_str(path_from_state)[0] == '\0'))
+            return validation_error(ctx, json_path,
+                                    "editor.test_run.save_manifest path_from_state must be a non-empty string");
+        const char *scene = json_string(action, "scene");
+        if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, json_path))
+            return false;
+        yyjson_val *player_start = obj_get(action, "player_start");
+        if (player_start != NULL && (!yyjson_is_str(player_start) || yyjson_get_str(player_start)[0] == '\0'))
+            return validation_error(ctx, json_path,
+                                    "editor.test_run.save_manifest player_start must be a non-empty string");
+        if (player_start != NULL && !require_ref(ctx, &names->editor_player_starts, "editor player start",
+                                                 yyjson_get_str(player_start), json_path))
+        {
+            return false;
+        }
+        if (scene == NULL && player_start == NULL)
+            return validation_error(ctx, json_path, "editor.test_run.save_manifest requires scene or player_start");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.test_run.save_manifest outputs must be an object");
+        static const char *const output_keys[] = {"valid_key",         "message_key",      "path_key",
+                                                  "manifest_json_key", "size_key",         "data_asset_key",
+                                                  "scene_key",         "player_start_key", "target_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.test_run.save_manifest output keys must be non-empty strings");
         }
         return true;
     }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -3169,6 +3169,71 @@ static int editor_revision_to_int(Uint64 revision)
     return revision > (Uint64)SDL_MAX_SINT32 ? SDL_MAX_SINT32 : (int)revision;
 }
 
+static const char *editor_action_path(slayer3d_game_data_runtime *runtime, yyjson_val *action, const char *fallback)
+{
+    const char *path_key = json_string(action, "path_from_state", NULL);
+    if (path_key != NULL && path_key[0] != '\0' && runtime != NULL && runtime->scene_state != NULL)
+    {
+        const char *path = slayer3d_properties_get_string(runtime->scene_state, path_key, NULL);
+        if (path != NULL && path[0] != '\0')
+            return path;
+    }
+    return json_string(action, "path", fallback);
+}
+
+static bool editor_save_text_file(const char *path, const char *text, size_t size, char *error_buffer,
+                                  int error_buffer_size)
+{
+    if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editor save requires a filesystem path");
+        return false;
+    }
+    if (text == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "editor save requires text");
+        return false;
+    }
+
+    char *parent = editor_save_parent_directory(path);
+    if (parent == NULL || !editor_save_make_directory_recursive(parent))
+    {
+        SDL_free(parent);
+        set_error(error_buffer, error_buffer_size, "failed to create editor save directory");
+        return false;
+    }
+    SDL_free(parent);
+
+    bool ok = false;
+    char temp_path[4096];
+    for (int attempt = 0; attempt < 16 && !ok; ++attempt)
+    {
+        SDL_snprintf(temp_path, sizeof(temp_path), "%s.tmp.%llu.%d", path, (unsigned long long)SDL_GetTicksNS(),
+                     attempt);
+        SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
+        if (stream == NULL)
+            continue;
+        ok = editor_save_write_all(stream, text, size) && SDL_FlushIO(stream);
+        ok = SDL_CloseIO(stream) && ok;
+        if (!ok)
+        {
+            SDL_RemovePath(temp_path);
+            continue;
+        }
+        if (!SDL_RenamePath(temp_path, path))
+        {
+            SDL_RemovePath(path);
+            ok = SDL_RenamePath(temp_path, path);
+        }
+        if (!ok)
+            SDL_RemovePath(temp_path);
+    }
+
+    if (!ok)
+        set_error(error_buffer, error_buffer_size, "failed to save editor file");
+    return ok;
+}
+
 static bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
                                               const char *world_name, const char *message, bool publish_result)
 {
@@ -3285,6 +3350,57 @@ bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *r
     return true;
 }
 
+static void publish_editor_level_state_outputs(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
+                                               const char *world_name)
+{
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    slayer3d_game_data_brush_world_editor_state brush_state;
+    SDL_zero(brush_state);
+    const bool has_brush_state = slayer3d_game_data_get_brush_world_editor_state(runtime, world_name, &brush_state);
+    slayer3d_game_data_player_start_editor_state start_state;
+    SDL_zero(start_state);
+    const bool has_start_state = slayer3d_game_data_get_player_start_editor_state(runtime, &start_state);
+    editor_set_string_output(scene_state, outputs, "brush_world_key",
+                             has_brush_state && brush_state.world_name != NULL ? brush_state.world_name : "");
+    editor_set_bool_output(scene_state, outputs, "brush_dirty_key", has_brush_state && brush_state.dirty);
+    editor_set_int_output(scene_state, outputs, "brush_revision_key",
+                          has_brush_state ? editor_revision_to_int(brush_state.revision) : 0);
+    editor_set_int_output(scene_state, outputs, "brush_saved_revision_key",
+                          has_brush_state ? editor_revision_to_int(brush_state.saved_revision) : 0);
+    editor_set_string_output(scene_state, outputs, "brush_source_path_key",
+                             has_brush_state && brush_state.source_path != NULL ? brush_state.source_path : "");
+    editor_set_bool_output(scene_state, outputs, "player_start_dirty_key", has_start_state && start_state.dirty);
+    editor_set_int_output(scene_state, outputs, "player_start_count_key", has_start_state ? start_state.count : 0);
+    editor_set_int_output(scene_state, outputs, "player_start_revision_key",
+                          has_start_state ? editor_revision_to_int(start_state.revision) : 0);
+    editor_set_int_output(scene_state, outputs, "player_start_saved_revision_key",
+                          has_start_state ? editor_revision_to_int(start_state.saved_revision) : 0);
+    editor_set_string_output(scene_state, outputs, "player_start_source_path_key",
+                             has_start_state && start_state.source_path != NULL ? start_state.source_path : "");
+}
+
+bool slayer3d_game_data_save_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    const char *world_name = json_string(action, "world", NULL);
+    const char *path = editor_action_path(runtime, action, NULL);
+    char error[256];
+    error[0] = '\0';
+    size_t size = 0u;
+    const bool ok = slayer3d_game_data_save_editable_level_fragment_file(runtime, world_name, path, &size, error,
+                                                                         (int)sizeof(error));
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "editable level saved")
+                                : (error[0] != '\0' ? error : "editable level save failed"));
+    editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "path_key", ok && path != NULL ? path : "");
+    publish_editor_level_state_outputs(runtime, outputs, world_name);
+    return true;
+}
+
 bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     yyjson_val *outputs = obj_get(action, "outputs");
@@ -3315,6 +3431,50 @@ bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtim
                              ok ? json_string(action, "message", "editor test run prepared")
                                 : (error[0] != '\0' ? error : "editor test run preparation failed"));
     editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "manifest_json_key", ok && json != NULL ? json : "");
+    editor_set_string_output(scene_state, outputs, "data_asset_key", ok ? desc.data_asset_path : "");
+    editor_set_string_output(scene_state, outputs, "scene_key", ok ? resolved_scene : "");
+    editor_set_string_output(scene_state, outputs, "player_start_key",
+                             ok && desc.player_start != NULL ? desc.player_start : "");
+    editor_set_string_output(scene_state, outputs, "target_key", has_start && start.target != NULL ? start.target : "");
+    SDL_free(json);
+    return true;
+}
+
+bool slayer3d_game_data_save_editor_test_run_manifest_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_game_data_editor_test_run_desc desc;
+    SDL_zero(desc);
+    desc.data_asset_path = json_string(action, "data_asset", NULL);
+    desc.scene = json_string(action, "scene", NULL);
+    desc.player_start = json_string(action, "player_start", NULL);
+    const char *path = editor_action_path(runtime, action, NULL);
+
+    char error[256];
+    error[0] = '\0';
+    char *json = NULL;
+    size_t size = 0u;
+    bool ok = slayer3d_game_data_export_editor_test_run_manifest_json(runtime, &desc, &json, &size, error,
+                                                                      (int)sizeof(error));
+    if (ok)
+        ok = editor_save_text_file(path, json, size, error, (int)sizeof(error));
+
+    slayer3d_game_data_editor_player_start start;
+    SDL_zero(start);
+    const bool has_start = ok && desc.player_start != NULL && desc.player_start[0] != '\0' &&
+                           slayer3d_game_data_get_editor_player_start(runtime, desc.player_start, &start);
+    const char *resolved_scene = desc.scene != NULL && desc.scene[0] != '\0'
+                                     ? desc.scene
+                                     : (has_start && start.scene != NULL ? start.scene : "");
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "editor test run manifest saved")
+                                : (error[0] != '\0' ? error : "editor test run manifest save failed"));
+    editor_set_int_output(scene_state, outputs, "size_key", ok ? (int)size : 0);
+    editor_set_string_output(scene_state, outputs, "path_key", ok && path != NULL ? path : "");
     editor_set_string_output(scene_state, outputs, "manifest_json_key", ok && json != NULL ? json : "");
     editor_set_string_output(scene_state, outputs, "data_asset_key", ok ? desc.data_asset_path : "");
     editor_set_string_output(scene_state, outputs, "scene_key", ok ? resolved_scene : "");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8886,6 +8886,73 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown editor player start reference"), std::string::npos) << error;
 
+    write_text(dir / "bad_level_save_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Level Save Action" },
+  "world": { "name": "world.bad_editor_level_save_action", "kind": "fixed_screen" },
+  "brush_worlds": [
+    {
+      "name": "world.editable",
+      "materials": [{ "name": "mat.default", "albedo": [1, 1, 1, 1] }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.default" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.default" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.default" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.default" },
+            { "plane": { "normal": [0, 0, 1], "distance": 1 }, "material": "mat.default" },
+            { "plane": { "normal": [0, 0, -1], "distance": 1 }, "material": "mat.default" }
+          ]
+        }
+      ]
+    }
+  ],
+  "signals": ["signal.editor.save"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.save",
+        "actions": [
+          { "type": "editor.level.save", "world": "world.editable" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_level_save_action.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires exactly one of path or path_from_state"), std::string::npos) << error;
+
+    write_text(dir / "bad_test_run_save_manifest_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Test Run Save Manifest Action" },
+  "world": { "name": "world.bad_editor_test_run_save_manifest_action", "kind": "fixed_screen" },
+  "editor_player_starts": [{ "name": "player_start.test", "scene": "scene.play", "target": "entity.player", "position": [0, 1, 0] }],
+  "entities": [{ "name": "entity.player" }],
+  "signals": ["signal.editor.test_run"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.test_run",
+        "actions": [
+          { "type": "editor.test_run.save_manifest", "data_asset": "asset://bad.game.json", "player_start": "player_start.test" }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file(
+        (dir / "bad_test_run_save_manifest_action.game.json").string().c_str(), nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("requires exactly one of path or path_from_state"), std::string::npos) << error;
+
     write_text(dir / "bad_status_action.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
@@ -14049,6 +14116,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
 
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
+    const std::filesystem::path save_dir = unique_test_dir("editor_unified_level_save");
+    const std::filesystem::path saved_path = save_dir / "saved" / "editable_level.fragment.json";
+    const std::filesystem::path manifest_path = save_dir / "saved" / "test-run.json";
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.save.path",
+                                   saved_path.string().c_str());
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.test_run.path",
+                                   manifest_path.string().c_str());
     auto world = [&]() {
         slayer3d_game_data_brush_world brush_world{};
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
@@ -14123,6 +14197,11 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
 
     slayer3d_signal_emit(bus, export_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""), "editable level saved");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.path", ""), saved_path.string().c_str());
+    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.save.size", 0), 0);
+    EXPECT_TRUE(std::filesystem::exists(saved_path));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.count", 0), 1);
     const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
@@ -14131,34 +14210,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NE(std::string(export_json).find("\"editor_player_starts\""), std::string::npos);
     EXPECT_NE(std::string(export_json).find("\"mat.editor.ceiling\""), std::string::npos);
     EXPECT_NE(std::string(export_json).find("\"player_start.editor_shell\""), std::string::npos);
-
-    slayer3d_signal_emit(bus, test_run_signal, nullptr);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.message", ""),
-                 "test run handoff prepared");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.data_asset", ""),
-                 "asset://editor_shell_dojo.game.json");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.scene", ""),
-                 "scene.editor_shell.test_run");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.player_start", ""),
-                 "player_start.editor_shell");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.target", ""),
-                 "entity.editor_shell.player");
-    const char *manifest_json = slayer3d_properties_get_string(scene_state, "editor.test_run.manifest_json", "");
-    ASSERT_NE(manifest_json, nullptr);
-    EXPECT_NE(std::string(manifest_json).find("\"schema\": \"slayer3d.editor_test_run.v0\""), std::string::npos);
-    EXPECT_NE(std::string(manifest_json).find("\"--player-start\""), std::string::npos);
-    EXPECT_NE(std::string(manifest_json).find("\"player_start.editor_shell\""), std::string::npos);
-    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.test_run.size", 0), 0);
-
-    const std::filesystem::path save_dir = unique_test_dir("editor_unified_level_save");
-    const std::filesystem::path saved_path = save_dir / "saved" / "editable_level.fragment.json";
-    size_t saved_size = 0U;
-    ASSERT_TRUE(slayer3d_game_data_save_editable_level_fragment_file(
-        runtime, "brush.editor_shell.target", saved_path.string().c_str(), &saved_size, error, sizeof(error)))
-        << error;
-    EXPECT_GT(saved_size, 0U);
-    EXPECT_TRUE(std::filesystem::exists(saved_path));
     slayer3d_game_data_brush_world_editor_state brush_state{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &brush_state));
     EXPECT_FALSE(brush_state.dirty);
@@ -14173,6 +14224,31 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_EQ(player_start_state.saved_revision, 1U);
     ASSERT_NE(player_start_state.source_path, nullptr);
     EXPECT_EQ(std::string(player_start_state.source_path), saved_path.string());
+
+    slayer3d_signal_emit(bus, test_run_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.valid", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.saved", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.message", ""),
+                 "test run handoff prepared");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.save_message", ""),
+                 "test run manifest saved");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.path", ""),
+                 manifest_path.string().c_str());
+    EXPECT_TRUE(std::filesystem::exists(manifest_path));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.data_asset", ""),
+                 "asset://editor_shell_dojo.game.json");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.scene", ""),
+                 "scene.editor_shell.test_run");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.player_start", ""),
+                 "player_start.editor_shell");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.target", ""),
+                 "entity.editor_shell.player");
+    const char *manifest_json = slayer3d_properties_get_string(scene_state, "editor.test_run.manifest_json", "");
+    ASSERT_NE(manifest_json, nullptr);
+    EXPECT_NE(std::string(manifest_json).find("\"schema\": \"slayer3d.editor_test_run.v0\""), std::string::npos);
+    EXPECT_NE(std::string(manifest_json).find("\"--player-start\""), std::string::npos);
+    EXPECT_NE(std::string(manifest_json).find("\"player_start.editor_shell\""), std::string::npos);
+    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.test_run.size", 0), 0);
 
     write_text(save_dir / "scenes" / "play.scene.json",
                R"json({ "schema": "slayer3d.scene.v0", "name": "scene.editor_shell.dojo" })json");


### PR DESCRIPTION
## Summary
- add authored `editor.level.save` and `editor.test_run.save_manifest` actions for controlled editor shell file writes
- move the editor shell dojo editable brush/player-start data into an imported generated fragment
- wire `S` to save the unified editable level fragment and `T` to save a runner test-run manifest
- document the new editor save actions and update the editor shell workflow

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_runner -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*:GameDataRuntime.RejectsInvalidEditorSelectionActions'`
- `./build/debug/tests/slayer3d_game_data_test`
- `git diff --check`

## Manual verification
Run the editor shell:

```sh
./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
```

In the editor shell, place/edit prefabs, press `S` to save `demos/editor_shell_dojo/data/generated/editable_level.fragment.json`, then press `T` to save `build/editor_shell_dojo/test-run.json`.

Launch the saved test-run handoff:

```sh
./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
```

## Next slice
Add the first dedicated editor host/runtime shell around this workflow, so the editor can own save/run paths and eventually launch the runner without relying on hard-coded dojo scene-state defaults.
