### PR TITLE
Add generic editor host wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,32 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     target_compile_definitions(slayer3d_runner PRIVATE SLAYER3D_MEDIA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/media")
     slayer3d_enable_warnings(slayer3d_runner)
     slayer3d_enable_sanitizers(slayer3d_runner)
+
+    add_executable(
+        slayer3d_editor
+        tools/slayer3d_editor.c
+        tools/slayer3d_editor_cli.c
+        tools/slayer3d_runner.c
+        tools/slayer3d_runner_cli.c
+        tools/slayer3d_runner_manifest.c
+        tools/slayer3d_runner_state.c
+        tools/slayer3d_fused.c
+    )
+    target_link_libraries(slayer3d_editor PRIVATE Slayer3D::slayer3d slayer3d_argtable3)
+    target_compile_features(slayer3d_editor PRIVATE c_std_17)
+    target_include_directories(slayer3d_editor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+    target_compile_definitions(
+        slayer3d_editor
+        PRIVATE
+            SLAYER3D_MEDIA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/media"
+            SLAYER3D_RUNNER_NO_MAIN
+            SLAYER3D_EDITOR_DEFAULT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/demos/editor_shell_dojo/data"
+            SLAYER3D_EDITOR_DEFAULT_DATA="asset://editor_shell_dojo.game.json"
+            SLAYER3D_EDITOR_DEFAULT_SAVE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/demos/editor_shell_dojo/data/generated/editable_level.fragment.json"
+            SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH="${CMAKE_CURRENT_BINARY_DIR}/editor_shell_dojo/test-run.json"
+    )
+    slayer3d_enable_warnings(slayer3d_editor)
+    slayer3d_enable_sanitizers(slayer3d_editor)
 endif()
 
 if(SLAYER3D_BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ game authors a different value.
 
 - `include/`: public C headers
 - `src/`: engine implementation
-- `tools/`: command-line tools such as `slayer3d_runner`, `slayer3d_pack`, and `slayer3d_bundle`
+- `tools/`: command-line tools such as `slayer3d_runner`, `slayer3d_editor`,
+  `slayer3d_pack`, and `slayer3d_bundle`
 - `demos/`: data-authored and low-level capability demos
 - `docs/`: engine documentation
 - `tests/`: GoogleTest and renderer tests registered with CTest

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -19,6 +19,14 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 Run it with:
 
 ```sh
+./build/debug/slayer3d_editor
+```
+
+The editor host is a thin wrapper around the generic runner. In the build tree it
+defaults to this dojo, injects `editor.save.path` and `editor.test_run.path`,
+and leaves all editor behavior data-authored. The equivalent runner command is:
+
+```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
 ```
 
@@ -35,4 +43,10 @@ imported by the dojo on the next launch. `T` writes
 
 ```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
+```
+
+For another editor project, pass explicit paths:
+
+```sh
+./build/debug/slayer3d_editor --root path/to/editor/data --data asset://editor.game.json --save path/to/generated/editable_level.fragment.json --test-run-output build/editor/test-run.json
 ```

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -169,6 +169,27 @@ build/debug/slayer3d_bundle \
 build/MyGame
 ```
 
+## Generic Editor Host
+
+`slayer3d_editor` is a thin host over the same managed runtime and renderer. It
+launches a data-authored editor project, injects editor output paths as scene
+state, and leaves the actual tool behavior in JSON/Lua. The build-tree default
+opens the editor shell dojo:
+
+```sh
+build/debug/slayer3d_editor
+```
+
+For another editor project, pass explicit paths:
+
+```sh
+build/debug/slayer3d_editor \
+  --root path/to/editor/data \
+  --data asset://editor.game.json \
+  --save path/to/generated/editable_level.fragment.json \
+  --test-run-output build/editor/test-run.json
+```
+
 The fused executable path is still the same generic runner. The game data is
 stored as an appended `.slayer3dpak`, and the runner auto-mounts it only when no
 explicit mount flags are provided.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -288,6 +288,7 @@ else()
         PRIVATE
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_pack_cli.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_bundle_cli.c
+            ${CMAKE_SOURCE_DIR}/tools/slayer3d_editor_cli.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_fused.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_cli.c
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_manifest.c

--- a/tests/test_tool_cli.cpp
+++ b/tests/test_tool_cli.cpp
@@ -13,6 +13,7 @@ extern "C"
 #include "slayer3d/math.h"
 #include "slayer3d/properties.h"
 #include "slayer3d_bundle_cli.h"
+#include "slayer3d_editor_cli.h"
 #include "slayer3d_fused.h"
 #include "slayer3d_pack_cli.h"
 #include "slayer3d_runner_cli.h"
@@ -145,6 +146,46 @@ TEST(ToolCli, RunnerRejectsEmptyTestRunManifestPath)
     slayer3d_runner_args args;
     EXPECT_EQ(slayer3d_runner_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
     slayer3d_runner_args_destroy(&args);
+}
+
+TEST(ToolCli, EditorParsesDefaultsAndBuildsRunnerInvocation)
+{
+    std::vector<char *> argv = argv_from({"slayer3d_editor", "--state", "editor.tool.mode=floor"});
+    slayer3d_editor_args args;
+    ASSERT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
+    slayer3d_editor_args_apply_defaults(&args, "editor/data", "asset://editor.game.json", "build/editor/level.json",
+                                        "build/editor/run.json");
+
+    slayer3d_editor_runner_invocation invocation;
+    ASSERT_TRUE(slayer3d_editor_build_runner_invocation(&args, "slayer3d_editor", &invocation));
+    ASSERT_GE(invocation.argc, 11);
+    EXPECT_STREQ(invocation.argv[0], "slayer3d_editor");
+    EXPECT_STREQ(invocation.argv[1], "--root");
+    EXPECT_STREQ(invocation.argv[2], "editor/data");
+    EXPECT_STREQ(invocation.argv[3], "--data");
+    EXPECT_STREQ(invocation.argv[4], "asset://editor.game.json");
+    std::string joined;
+    for (int i = 0; i < invocation.argc; ++i)
+    {
+        if (!joined.empty())
+            joined += "\n";
+        joined += invocation.argv[i];
+    }
+    EXPECT_NE(joined.find("editor.save.path=build/editor/level.json"), std::string::npos);
+    EXPECT_NE(joined.find("editor.test_run.path=build/editor/run.json"), std::string::npos);
+    EXPECT_NE(joined.find("editor.tool.mode=floor"), std::string::npos);
+    slayer3d_editor_runner_invocation_destroy(&invocation);
+    slayer3d_editor_args_destroy(&args);
+}
+
+TEST(ToolCli, EditorRequiresProjectAndOutputPathsAfterDefaults)
+{
+    std::vector<char *> argv = argv_from({"slayer3d_editor"});
+    slayer3d_editor_args args;
+    ASSERT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
+    slayer3d_editor_runner_invocation invocation;
+    EXPECT_FALSE(slayer3d_editor_build_runner_invocation(&args, "slayer3d_editor", &invocation));
+    slayer3d_editor_args_destroy(&args);
 }
 
 TEST(ToolCli, PackParsesRepeatedFiles)

--- a/tools/slayer3d_editor.c
+++ b/tools/slayer3d_editor.c
@@ -1,0 +1,56 @@
+/**
+ * @file slayer3d_editor.c
+ * @brief Generic SLAYER3D data-authored editor host.
+ */
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_main.h>
+
+#include <stdio.h>
+
+#include "slayer3d_editor_cli.h"
+#include "slayer3d_runner_cli.h"
+
+#if !defined(SLAYER3D_EDITOR_DEFAULT_ROOT)
+#define SLAYER3D_EDITOR_DEFAULT_ROOT ""
+#endif
+
+#if !defined(SLAYER3D_EDITOR_DEFAULT_DATA)
+#define SLAYER3D_EDITOR_DEFAULT_DATA ""
+#endif
+
+#if !defined(SLAYER3D_EDITOR_DEFAULT_SAVE_PATH)
+#define SLAYER3D_EDITOR_DEFAULT_SAVE_PATH ""
+#endif
+
+#if !defined(SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH)
+#define SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH ""
+#endif
+
+int main(int argc, char **argv)
+{
+    slayer3d_editor_args args;
+    const slayer3d_tool_cli_result cli_result = slayer3d_editor_args_parse(argc, argv, &args, stderr);
+    if (cli_result != SLAYER3D_TOOL_CLI_OK)
+        return cli_result == SLAYER3D_TOOL_CLI_HELP ? 0 : 2;
+
+    slayer3d_editor_args_apply_defaults(&args, SLAYER3D_EDITOR_DEFAULT_ROOT, SLAYER3D_EDITOR_DEFAULT_DATA,
+                                        SLAYER3D_EDITOR_DEFAULT_SAVE_PATH, SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH);
+    slayer3d_editor_runner_invocation invocation;
+    if (!slayer3d_editor_build_runner_invocation(&args, argc > 0 && argv != NULL ? argv[0] : "slayer3d_editor",
+                                                 &invocation))
+    {
+        fprintf(stderr,
+                "slayer3d_editor: --root, --data, --save, and --test-run-output are required unless build defaults "
+                "provide them\n");
+        slayer3d_editor_args_destroy(&args);
+        return 2;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor save path: %s", args.save_path);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor test-run manifest: %s", args.test_run_path);
+    const int result = slayer3d_runner_main(invocation.argc, invocation.argv);
+    slayer3d_editor_runner_invocation_destroy(&invocation);
+    slayer3d_editor_args_destroy(&args);
+    return result;
+}

--- a/tools/slayer3d_editor_cli.c
+++ b/tools/slayer3d_editor_cli.c
@@ -1,0 +1,261 @@
+/**
+ * @file slayer3d_editor_cli.c
+ * @brief Command-line parser for the SLAYER3D editor host.
+ */
+
+#include "slayer3d_editor_cli.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+#include <argtable3.h>
+
+void slayer3d_editor_args_print_usage(const char *argv0, FILE *stream)
+{
+    FILE *out = stream != NULL ? stream : stderr;
+    const char *program = argv0 != NULL ? argv0 : "slayer3d_editor";
+    fprintf(out,
+            "Usage:\n"
+            "  %s [--root <asset-root>] [--data <asset://editor.game.json>] [--media <media-dir>] "
+            "[--scene <scene>] [--save <path>] [--test-run-output <path>] [--state <key=value> ...]\n",
+            program);
+}
+
+static bool copy_string_list(const char ***out_values, int *out_count, const char **values, int count)
+{
+    if (out_values == NULL || out_count == NULL)
+        return false;
+    *out_values = NULL;
+    *out_count = 0;
+    if (count <= 0)
+        return true;
+
+    const char **copy = (const char **)SDL_calloc((size_t)count, sizeof(*copy));
+    if (copy == NULL)
+        return false;
+    for (int i = 0; i < count; ++i)
+        copy[i] = values[i];
+    *out_values = copy;
+    *out_count = count;
+    return true;
+}
+
+slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slayer3d_editor_args *args, FILE *stream)
+{
+    struct arg_str *root = arg_str0(NULL, "root", "<asset-root>", "mount an editor project asset root");
+    struct arg_str *data = arg_str0(NULL, "data", "<asset://editor.game.json>", "editor game-data asset path");
+    struct arg_str *media = arg_str0(NULL, "media", "<media-dir>", "built-in media directory");
+    struct arg_str *scene = arg_str0(NULL, "scene", "<scene>", "start directly in an editor scene");
+    struct arg_str *save = arg_str0(NULL, "save", "<path>", "editable level fragment output path");
+    struct arg_str *test_run_output =
+        arg_str0(NULL, "test-run-output", "<path>", "runner test-run manifest output path");
+    struct arg_str *state = arg_strn(NULL, "state", "<key=value>", 0, argc > 0 ? argc : 1, "scene-state override");
+    struct arg_lit *help = arg_lit0("h", "help", "print this help and exit");
+    struct arg_end *end = arg_end(20);
+    void *argtable[] = {root, data, media, scene, save, test_run_output, state, help, end};
+    const char *program = argc > 0 && argv != NULL && argv[0] != NULL ? argv[0] : "slayer3d_editor";
+    FILE *out = stream != NULL ? stream : stderr;
+
+    if (args == NULL || arg_nullcheck(argtable) != 0)
+    {
+        if (out != NULL)
+            fprintf(out, "%s: insufficient memory\n", program);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+
+    SDL_zero(*args);
+    const int errors = arg_parse(argc, argv, argtable);
+    if (help->count > 0)
+    {
+        slayer3d_editor_args_print_usage(program, out);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_HELP;
+    }
+    if (errors > 0)
+    {
+        arg_print_errors(out, end, program);
+        fprintf(out, "Try '%s --help' for more information.\n", program);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+
+    args->root = root->count > 0 ? root->sval[0] : NULL;
+    args->data_asset_path = data->count > 0 ? data->sval[0] : NULL;
+    args->media_dir = media->count > 0 ? media->sval[0] : NULL;
+    args->scene = scene->count > 0 ? scene->sval[0] : NULL;
+    args->save_path = save->count > 0 ? save->sval[0] : NULL;
+    args->test_run_path = test_run_output->count > 0 ? test_run_output->sval[0] : NULL;
+
+    if ((args->root != NULL && args->root[0] == '\0') ||
+        (args->data_asset_path != NULL && args->data_asset_path[0] == '\0') ||
+        (args->scene != NULL && args->scene[0] == '\0') || (args->save_path != NULL && args->save_path[0] == '\0') ||
+        (args->test_run_path != NULL && args->test_run_path[0] == '\0') ||
+        !copy_string_list(&args->state_assignments, &args->state_assignment_count, state->sval, state->count))
+    {
+        fprintf(out, "%s: invalid or out-of-memory editor arguments\n", program);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        slayer3d_editor_args_destroy(args);
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+
+    arg_freetable(argtable, SDL_arraysize(argtable));
+    return SLAYER3D_TOOL_CLI_OK;
+}
+
+void slayer3d_editor_args_destroy(slayer3d_editor_args *args)
+{
+    if (args == NULL)
+        return;
+    SDL_free(args->state_assignments);
+    args->state_assignments = NULL;
+    args->state_assignment_count = 0;
+}
+
+void slayer3d_editor_args_apply_defaults(slayer3d_editor_args *args, const char *root, const char *data_asset_path,
+                                         const char *save_path, const char *test_run_path)
+{
+    if (args == NULL)
+        return;
+    if ((args->root == NULL || args->root[0] == '\0') && root != NULL && root[0] != '\0')
+        args->root = root;
+    if ((args->data_asset_path == NULL || args->data_asset_path[0] == '\0') && data_asset_path != NULL &&
+        data_asset_path[0] != '\0')
+    {
+        args->data_asset_path = data_asset_path;
+    }
+    if ((args->save_path == NULL || args->save_path[0] == '\0') && save_path != NULL && save_path[0] != '\0')
+        args->save_path = save_path;
+    if ((args->test_run_path == NULL || args->test_run_path[0] == '\0') && test_run_path != NULL &&
+        test_run_path[0] != '\0')
+    {
+        args->test_run_path = test_run_path;
+    }
+}
+
+static char *editor_state_assignment(const char *key, const char *value)
+{
+    const size_t key_len = SDL_strlen(key);
+    const size_t value_len = SDL_strlen(value);
+    char *assignment = (char *)SDL_malloc(key_len + 1u + value_len + 1u);
+    if (assignment == NULL)
+        return NULL;
+    SDL_memcpy(assignment, key, key_len);
+    assignment[key_len] = '=';
+    SDL_memcpy(assignment + key_len + 1u, value, value_len);
+    assignment[key_len + 1u + value_len] = '\0';
+    return assignment;
+}
+
+static bool editor_add_arg(slayer3d_editor_runner_invocation *invocation, int *index, char *arg)
+{
+    if (invocation == NULL || index == NULL || *index >= invocation->argc)
+        return false;
+    invocation->argv[*index] = arg;
+    ++(*index);
+    return true;
+}
+
+bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_args *args, const char *program,
+                                             slayer3d_editor_runner_invocation *out_invocation)
+{
+    if (out_invocation == NULL)
+        return false;
+    SDL_zero(*out_invocation);
+    if (args == NULL || args->root == NULL || args->root[0] == '\0' || args->data_asset_path == NULL ||
+        args->data_asset_path[0] == '\0' || args->save_path == NULL || args->save_path[0] == '\0' ||
+        args->test_run_path == NULL || args->test_run_path[0] == '\0')
+    {
+        return false;
+    }
+
+    int argc = 9 + args->state_assignment_count * 2;
+    if (args->media_dir != NULL && args->media_dir[0] != '\0')
+        argc += 2;
+    if (args->scene != NULL && args->scene[0] != '\0')
+        argc += 2;
+
+    char **argv = (char **)SDL_calloc((size_t)argc + 1u, sizeof(*argv));
+    if (argv == NULL)
+        return false;
+
+    out_invocation->argv = argv;
+    out_invocation->argc = argc;
+    int index = 0;
+    char *save_assignment = editor_state_assignment("editor.save.path", args->save_path);
+    char *test_run_assignment = editor_state_assignment("editor.test_run.path", args->test_run_path);
+    if (save_assignment == NULL || test_run_assignment == NULL)
+    {
+        SDL_free(save_assignment);
+        SDL_free(test_run_assignment);
+        slayer3d_editor_runner_invocation_destroy(out_invocation);
+        return false;
+    }
+    out_invocation->owned_save_assignment = save_assignment;
+    out_invocation->owned_test_run_assignment = test_run_assignment;
+
+    if (!editor_add_arg(out_invocation, &index, (char *)(program != NULL ? program : "slayer3d_editor")) ||
+        !editor_add_arg(out_invocation, &index, "--root") ||
+        !editor_add_arg(out_invocation, &index, (char *)args->root) ||
+        !editor_add_arg(out_invocation, &index, "--data") ||
+        !editor_add_arg(out_invocation, &index, (char *)args->data_asset_path))
+    {
+        slayer3d_editor_runner_invocation_destroy(out_invocation);
+        return false;
+    }
+    if (args->media_dir != NULL && args->media_dir[0] != '\0')
+    {
+        if (!editor_add_arg(out_invocation, &index, "--media") ||
+            !editor_add_arg(out_invocation, &index, (char *)args->media_dir))
+        {
+            slayer3d_editor_runner_invocation_destroy(out_invocation);
+            return false;
+        }
+    }
+    if (args->scene != NULL && args->scene[0] != '\0')
+    {
+        if (!editor_add_arg(out_invocation, &index, "--scene") ||
+            !editor_add_arg(out_invocation, &index, (char *)args->scene))
+        {
+            slayer3d_editor_runner_invocation_destroy(out_invocation);
+            return false;
+        }
+    }
+
+    if (!editor_add_arg(out_invocation, &index, "--state") ||
+        !editor_add_arg(out_invocation, &index, save_assignment) ||
+        !editor_add_arg(out_invocation, &index, "--state") ||
+        !editor_add_arg(out_invocation, &index, test_run_assignment))
+    {
+        slayer3d_editor_runner_invocation_destroy(out_invocation);
+        return false;
+    }
+
+    for (int i = 0; i < args->state_assignment_count; ++i)
+    {
+        if (!editor_add_arg(out_invocation, &index, "--state") ||
+            !editor_add_arg(out_invocation, &index, (char *)args->state_assignments[i]))
+        {
+            slayer3d_editor_runner_invocation_destroy(out_invocation);
+            return false;
+        }
+    }
+    if (index != argc)
+    {
+        slayer3d_editor_runner_invocation_destroy(out_invocation);
+        return false;
+    }
+    return true;
+}
+
+void slayer3d_editor_runner_invocation_destroy(slayer3d_editor_runner_invocation *invocation)
+{
+    if (invocation == NULL)
+        return;
+    SDL_free(invocation->owned_save_assignment);
+    SDL_free(invocation->owned_test_run_assignment);
+    SDL_free(invocation->argv);
+    invocation->argv = NULL;
+    invocation->argc = 0;
+    invocation->owned_save_assignment = NULL;
+    invocation->owned_test_run_assignment = NULL;
+}

--- a/tools/slayer3d_editor_cli.h
+++ b/tools/slayer3d_editor_cli.h
@@ -1,0 +1,53 @@
+/**
+ * @file slayer3d_editor_cli.h
+ * @brief Command-line parser for the SLAYER3D editor host.
+ */
+
+#ifndef SLAYER3D_EDITOR_CLI_H
+#define SLAYER3D_EDITOR_CLI_H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "slayer3d_tool_cli.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct slayer3d_editor_args
+    {
+        const char *root;
+        const char *data_asset_path;
+        const char *media_dir;
+        const char *scene;
+        const char *save_path;
+        const char *test_run_path;
+        const char **state_assignments;
+        int state_assignment_count;
+    } slayer3d_editor_args;
+
+    typedef struct slayer3d_editor_runner_invocation
+    {
+        char **argv;
+        int argc;
+        char *owned_save_assignment;
+        char *owned_test_run_assignment;
+    } slayer3d_editor_runner_invocation;
+
+    slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slayer3d_editor_args *args,
+                                                        FILE *stream);
+    void slayer3d_editor_args_destroy(slayer3d_editor_args *args);
+    void slayer3d_editor_args_apply_defaults(slayer3d_editor_args *args, const char *root, const char *data_asset_path,
+                                             const char *save_path, const char *test_run_path);
+    bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_args *args, const char *program,
+                                                 slayer3d_editor_runner_invocation *out_invocation);
+    void slayer3d_editor_runner_invocation_destroy(slayer3d_editor_runner_invocation *invocation);
+    void slayer3d_editor_args_print_usage(const char *argv0, FILE *stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tools/slayer3d_runner.c
+++ b/tools/slayer3d_runner.c
@@ -366,7 +366,7 @@ static void runner_shutdown(slayer3d_game_context *ctx, void *userdata)
     }
 }
 
-int main(int argc, char **argv)
+int slayer3d_runner_main(int argc, char **argv)
 {
     runner_state state;
     SDL_zero(state);
@@ -416,3 +416,10 @@ int main(int argc, char **argv)
     slayer3d_runner_args_destroy(&state.args);
     return result;
 }
+
+#if !defined(SLAYER3D_RUNNER_NO_MAIN)
+int main(int argc, char **argv)
+{
+    return slayer3d_runner_main(argc, argv);
+}
+#endif

--- a/tools/slayer3d_runner.c
+++ b/tools/slayer3d_runner.c
@@ -5,7 +5,9 @@
 
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_log.h>
+#if !defined(SLAYER3D_RUNNER_NO_MAIN)
 #include <SDL3/SDL_main.h>
+#endif
 #include <SDL3/SDL_stdinc.h>
 
 #include <stdio.h>

--- a/tools/slayer3d_runner_cli.h
+++ b/tools/slayer3d_runner_cli.h
@@ -49,6 +49,7 @@ extern "C"
 
     slayer3d_tool_cli_result slayer3d_runner_args_parse(int argc, char **argv, slayer3d_runner_args *args,
                                                         FILE *stream);
+    int slayer3d_runner_main(int argc, char **argv);
     void slayer3d_runner_args_destroy(slayer3d_runner_args *args);
     void slayer3d_runner_args_print_usage(const char *argv0, FILE *stream);
 


### PR DESCRIPTION
## Summary
- add `slayer3d_editor`, a thin editor host that reuses the generic runner/runtime instead of adding editor-specific game loop code
- add editor CLI parsing for project root/data, save path, test-run manifest path, scene override, and scene-state overrides
- default the build-tree editor host to the editor shell dojo so `./build/debug/slayer3d_editor` opens the current milestone workflow
- document the editor host and keep the existing runner/test-run path documented

## Tests
- `cmake -S . -B build/debug`
- `cmake --build build/debug --target slayer3d_editor slayer3d_runner slayer3d_tool_cli_test slayer3d_game_data_test -j 8`
- `./build/debug/tests/slayer3d_tool_cli_test`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*:GameDataRuntime.RejectsInvalidEditorSelectionActions'`
- `./build/debug/tests/slayer3d_game_data_test`
- `./build/debug/slayer3d_editor --help`
- `git diff --check`

## Manual verification
Run the current editor shell milestone:

```sh
./build/debug/slayer3d_editor
```

Equivalent explicit project launch:

```sh
./build/debug/slayer3d_editor --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --save demos/editor_shell_dojo/data/generated/editable_level.fragment.json --test-run-output build/editor_shell_dojo/test-run.json
```

Current workflow in the editor shell:
- `1` floor, `2` wall, `3` ceiling, `4` player start
- `Enter` commits the selected prefab/tool
- `S` saves the unified editable level fragment
- `T` writes the runner test-run manifest

Then test-run the saved handoff:

```sh
./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
```

## Editor status
This PR gives us a dedicated editor entry point, but the editing behavior is still data-authored. The current milestone can already place fixed floor/wall/ceiling box prefabs, place a player start, save the editable fragment, and produce a runner manifest. The remaining gap for a truly usable first editor is UX: placement is still fixed prefab placement rather than interactive click/drag drawing and resizing in the viewport.

## Next slice
Add interactive placement from selection/hover context: floor, wall, ceiling, and player-start tools should commit at the clicked/hovered world position instead of hard-coded coordinates. That is the main remaining step before the first editor milestone feels usable for building small rooms.
