### PR TITLE
Add editor work-plane placement fallback

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -3,12 +3,13 @@
 This data-only dojo demonstrates the first reusable editor shell pieces:
 
 - a normal Slayer3D runtime viewport
-- authored brush-world selection trace metadata
+- authored brush-world selection trace metadata with a ground work-plane
+  fallback for placing the first brush in empty space
 - data-authored world/selection/normal/hit debug overlay drawing
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
-  `4` player start, then click a placement point and press `Enter` to place the
-  selected prefab at that point
+  `4` player start, then click a brush face or the ground work plane and press
+  `Enter` to place the selected prefab at that point
 - unified editable-level save/export: `S` saves and publishes one fragment
   containing the brush world and player starts
 - test-run handoff manifest: `T` publishes and saves runner arguments for the

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -47,7 +47,12 @@
         "near": 0.05,
         "far": 100.0,
         "model_filter": "brush_worlds",
-        "contents_mask": "solid"
+        "contents_mask": "solid",
+        "work_plane": {
+          "enabled": true,
+          "normal": [0.0, 1.0, 0.0],
+          "distance": 0.0
+        }
       },
       "outputs": {
         "hit_key": "editor.selection.hit",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -644,7 +644,12 @@ face normal through the normal 3D presentation path:
         "near": 0.05,
         "far": 100.0,
         "model_filter": "brush_worlds",
-        "contents_mask": "solid"
+        "contents_mask": "solid",
+        "work_plane": {
+          "enabled": true,
+          "normal": [0, 1, 0],
+          "distance": 0.0
+        }
       },
       "outputs": {
         "hit_key": "editor.selection.hit",
@@ -675,6 +680,13 @@ Tooling can override that point with `screen`, `screen_x`/`screen_y`, or
 with `viewport`, `viewport_width`/`viewport_height`, or scene-state keys. This
 lets editor dojos and future editor hosts share the same data-authored picking
 primitive.
+
+Selection traces may also author `work_plane` as a fallback placement plane.
+When the ray misses world geometry, the editor intersects the same ray with the
+plane described by `dot(normal, point) = distance` and publishes that as a hit
+with `selection_type: "none"`. This is intended for blockout tools: a blank
+scene can still place the first floor on the ground plane, while later clicks on
+real brush faces keep returning normal brush-world selections.
 
 Selection mode defaults to `hover`, where `outputs` receives the current pick
 every frame. In `mode: "click"`, `outputs` receives the pinned selection and

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -748,12 +748,12 @@ extern "C"
         slayer3d_game_data_brush_diagnostics brush;
     } slayer3d_game_data_world_model_diagnostics;
 
-    /** @brief Editor/tooling selection produced by world-model picking. */
+    /** @brief Editor/tooling selection produced by world picking or an authored work plane. */
     typedef struct slayer3d_game_data_editor_selection
     {
-        /** @brief True when the selection hit a world model. */
+        /** @brief True when the selection hit a world model or work plane. */
         bool hit;
-        /** @brief Implementation kind that produced the selection. */
+        /** @brief Implementation kind that produced the selection, or INVALID for a work-plane hit. */
         slayer3d_game_data_world_model_type type;
         /** @brief Authored world model name. */
         const char *world_name;

--- a/include/slayer3d/input.h
+++ b/include/slayer3d/input.h
@@ -413,12 +413,29 @@ extern "C"
     float slayer3d_input_get_mouse_dy(const slayer3d_input_manager *input);
 
     /**
+     * @brief Map subsequent absolute SDL mouse positions into logical space.
+     *
+     * SDL mouse events report window-space coordinates. The managed game loop
+     * sets this to the current letterbox transform so callers that use
+     * absolute mouse positions, such as UI and editor picking, receive
+     * coordinates in the authored logical viewport. Relative mouse deltas are
+     * not transformed.
+     *
+     * logical_x = (window_x - offset_x) * scale_x
+     * logical_y = (window_y - offset_y) * scale_y
+     *
+     * Pass scale 1 and offset 0 to restore identity mapping.
+     */
+    void slayer3d_input_set_mouse_position_transform(slayer3d_input_manager *input, float scale_x, float scale_y,
+                                                     float offset_x, float offset_y);
+
+    /**
      * @brief Return the latest absolute mouse position observed from SDL events.
      *
-     * Coordinates are in the window/logical space reported by SDL for the
-     * source event. Returns false when no absolute mouse position has been
-     * observed yet or live mouse input is unavailable, such as during demo
-     * playback.
+     * Coordinates are transformed by
+     * slayer3d_input_set_mouse_position_transform. Returns false when no
+     * absolute mouse position has been observed yet or live mouse input is
+     * unavailable, such as during demo playback.
      */
     bool slayer3d_input_get_mouse_position(const slayer3d_input_manager *input, float *out_x, float *out_y);
 

--- a/src/game.c
+++ b/src/game.c
@@ -453,6 +453,37 @@ static float slayer3d_game_frame_delta(Uint64 now, Uint64 last)
     return (float)(now - last) / (float)frequency;
 }
 
+static void slayer3d_game_sync_input_mouse_transform(const slayer3d_game_context *ctx)
+{
+    if (ctx == NULL || ctx->window == NULL || ctx->renderer == NULL || ctx->session == NULL)
+        return;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(ctx->session);
+    if (input == NULL)
+        return;
+
+    const int logical_width = slayer3d_get_render_context_width(ctx->renderer);
+    const int logical_height = slayer3d_get_render_context_height(ctx->renderer);
+    int window_width = 0;
+    int window_height = 0;
+    SDL_GetWindowSize(ctx->window, &window_width, &window_height);
+    if (logical_width <= 0 || logical_height <= 0 || window_width <= 0 || window_height <= 0)
+    {
+        slayer3d_input_set_mouse_position_transform(input, 1.0f, 1.0f, 0.0f, 0.0f);
+        return;
+    }
+
+    const float scale_x = (float)window_width / (float)logical_width;
+    const float scale_y = (float)window_height / (float)logical_height;
+    const float scale = scale_x < scale_y ? scale_x : scale_y;
+    const float viewport_width = (float)logical_width * scale;
+    const float viewport_height = (float)logical_height * scale;
+    const float viewport_x = ((float)window_width - viewport_width) * 0.5f;
+    const float viewport_y = ((float)window_height - viewport_height) * 0.5f;
+    slayer3d_input_set_mouse_position_transform(input, (float)logical_width / viewport_width,
+                                                (float)logical_height / viewport_height, viewport_x, viewport_y);
+}
+
 int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_callbacks *callbacks, void *userdata)
 {
     slayer3d_game_context ctx;
@@ -513,6 +544,7 @@ int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_ca
         Uint64 present_start_counter;
         Uint64 present_end_counter;
         SDL_Event event;
+        slayer3d_game_sync_input_mouse_transform(&ctx);
         while (SDL_PollEvent(&event))
         {
             ctx.input_event_consumed = false;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -11252,6 +11252,42 @@ static bool validate_scene_editor_camera_screen_trace(validation_context *ctx, y
     return true;
 }
 
+static bool validate_scene_editor_work_plane(validation_context *ctx, yyjson_val *trace, const char *trace_path)
+{
+    yyjson_val *work_plane = obj_get(trace, "work_plane");
+    if (work_plane == NULL)
+        return true;
+    char work_plane_path[PATH_BUFFER_SIZE];
+    format_path(work_plane_path, sizeof(work_plane_path), "%s.work_plane", trace_path);
+    if (!yyjson_is_obj(work_plane))
+        return validation_error(ctx, work_plane_path, "scene editor selection work_plane must be an object");
+
+    yyjson_val *enabled = obj_get(work_plane, "enabled");
+    if (enabled != NULL && !yyjson_is_bool(enabled))
+        return validation_error(ctx, work_plane_path, "scene editor selection work_plane enabled must be a boolean");
+
+    yyjson_val *normal = obj_get(work_plane, "normal");
+    if (normal != NULL)
+    {
+        if (!is_exact_vec_array(normal, 3))
+            return validation_error(ctx, work_plane_path, "scene editor selection work_plane normal must be a vec3");
+        const double x = yyjson_get_num(yyjson_arr_get(normal, 0));
+        const double y = yyjson_get_num(yyjson_arr_get(normal, 1));
+        const double z = yyjson_get_num(yyjson_arr_get(normal, 2));
+        if ((x * x + y * y + z * z) <= 0.000001)
+            return validation_error(ctx, work_plane_path, "scene editor selection work_plane normal must be non-zero");
+    }
+
+    char distance_path[PATH_BUFFER_SIZE];
+    format_path(distance_path, sizeof(distance_path), "%s.distance", work_plane_path);
+    if (!validate_optional_number(ctx, obj_get(work_plane, "distance"), distance_path,
+                                  "scene editor selection work_plane distance"))
+    {
+        return false;
+    }
+    return true;
+}
+
 static bool validate_scene_editor_trace(validation_context *ctx, yyjson_val *trace, const char *trace_path,
                                         validation_names *names)
 {
@@ -11286,6 +11322,8 @@ static bool validate_scene_editor_trace(validation_context *ctx, yyjson_val *tra
     format_path(filter_path, sizeof(filter_path), "%s.model_filter", trace_path);
     if (!validate_string_or_string_array_names(ctx, obj_get(trace, "model_filter"), filter_path, "world model filter",
                                                editor_model_filter_name_valid))
+        return false;
+    if (!validate_scene_editor_work_plane(ctx, trace, trace_path))
         return false;
     return true;
 }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -3043,6 +3043,60 @@ static bool editor_trace_desc_from_json(const slayer3d_game_data_runtime *runtim
     return true;
 }
 
+static bool editor_work_plane_selection_from_trace(yyjson_val *selection,
+                                                   const slayer3d_game_data_world_trace_desc *trace,
+                                                   slayer3d_game_data_editor_selection *out_selection)
+{
+    init_editor_selection(out_selection);
+    yyjson_val *work_plane = obj_get(obj_get(selection, "trace"), "work_plane");
+    if (!yyjson_is_obj(work_plane) || !json_bool(work_plane, "enabled", true) || trace == NULL || out_selection == NULL)
+    {
+        return false;
+    }
+
+    slayer3d_vec3 normal = json_vec3(work_plane, "normal", slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
+    const float normal_length_squared = slayer3d_vec3_length_squared(normal);
+    if (normal_length_squared <= 0.000001f)
+        return false;
+    normal = slayer3d_vec3_normalize(normal);
+
+    const slayer3d_vec3 direction = slayer3d_vec3_sub(trace->end, trace->start);
+    const float denominator = slayer3d_vec3_dot(normal, direction);
+    if (SDL_fabsf(denominator) <= 0.000001f)
+        return false;
+
+    const float distance = json_float(work_plane, "distance", 0.0f);
+    const float fraction = (distance - slayer3d_vec3_dot(normal, trace->start)) / denominator;
+    if (fraction < 0.0f || fraction > 1.0f)
+        return false;
+
+    out_selection->hit = true;
+    out_selection->type = SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+    out_selection->element_index = -1;
+    out_selection->face_index = -1;
+    out_selection->fraction = fraction;
+    out_selection->point = slayer3d_vec3_add(trace->start, slayer3d_vec3_scale(direction, fraction));
+    out_selection->normal = normal;
+    return true;
+}
+
+static bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
+                                            const slayer3d_game_data_world_trace_desc *trace,
+                                            slayer3d_game_data_editor_selection *out_selection)
+{
+    init_editor_selection(out_selection);
+    if (runtime == NULL || selection == NULL || trace == NULL || out_selection == NULL)
+        return false;
+
+    if (!slayer3d_game_data_pick_editor_world_model(runtime, trace, out_selection))
+        return editor_work_plane_selection_from_trace(selection, trace, out_selection);
+    if (out_selection->hit)
+        return true;
+    if (editor_work_plane_selection_from_trace(selection, trace, out_selection))
+        return true;
+    return true;
+}
+
 static bool editor_selection_mode_is_click(yyjson_val *selection)
 {
     const char *mode = json_string(selection, "mode", "hover");
@@ -3629,7 +3683,7 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     slayer3d_game_data_editor_selection hover_selection;
     init_editor_selection(&hover_selection);
     if (!editor_trace_desc_from_json(runtime, selection_json, &trace) ||
-        !slayer3d_game_data_pick_editor_world_model(runtime, &trace, &hover_selection))
+        !editor_pick_selection_from_json(runtime, selection_json, &trace, &hover_selection))
     {
         return false;
     }
@@ -4640,7 +4694,8 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
             *out_selection = runtime->editor_active_selection;
             out_desc->selection = out_selection;
         }
-        else if (out_selection != NULL && slayer3d_game_data_pick_editor_world_model(runtime, out_trace, out_selection))
+        else if (out_selection != NULL &&
+                 editor_pick_selection_from_json(runtime, selection_json, out_trace, out_selection))
         {
             out_desc->selection = out_selection;
         }

--- a/src/input.c
+++ b/src/input.c
@@ -65,6 +65,10 @@ struct slayer3d_input_manager
     float mouse_wheel_y_accum;
     float mouse_x;
     float mouse_y;
+    float mouse_position_scale_x;
+    float mouse_position_scale_y;
+    float mouse_position_offset_x;
+    float mouse_position_offset_y;
     bool has_mouse_position;
     bool discard_mouse_motion_until_update;
     bool discard_next_mouse_motion;
@@ -108,8 +112,8 @@ static void slayer3d_input_set_mouse_position(slayer3d_input_manager *input, flo
 {
     if (input == NULL)
         return;
-    input->mouse_x = x;
-    input->mouse_y = y;
+    input->mouse_x = (x - input->mouse_position_offset_x) * input->mouse_position_scale_x;
+    input->mouse_y = (y - input->mouse_position_offset_y) * input->mouse_position_scale_y;
     input->has_mouse_position = true;
 }
 
@@ -1012,6 +1016,8 @@ slayer3d_input_manager *slayer3d_input_create(void)
     }
 
     input->deadzone = SLAYER3D_INPUT_DEFAULT_DEADZONE;
+    input->mouse_position_scale_x = 1.0f;
+    input->mouse_position_scale_y = 1.0f;
     input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
     input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
     slayer3d_input_refresh_gamepads(input);
@@ -1540,6 +1546,17 @@ float slayer3d_input_get_mouse_dx(const slayer3d_input_manager *input)
 float slayer3d_input_get_mouse_dy(const slayer3d_input_manager *input)
 {
     return input != NULL ? input->snapshot.mouse_dy : 0.0f;
+}
+
+void slayer3d_input_set_mouse_position_transform(slayer3d_input_manager *input, float scale_x, float scale_y,
+                                                 float offset_x, float offset_y)
+{
+    if (input == NULL)
+        return;
+    input->mouse_position_scale_x = scale_x > 0.0f ? scale_x : 1.0f;
+    input->mouse_position_scale_y = scale_y > 0.0f ? scale_y : 1.0f;
+    input->mouse_position_offset_x = offset_x;
+    input->mouse_position_offset_y = offset_y;
 }
 
 bool slayer3d_input_get_mouse_position(const slayer3d_input_manager *input, float *out_x, float *out_y)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8678,6 +8678,11 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
             "scene editor selection trace source must be 'world' or 'camera_screen'",
         },
         {
+            "bad_work_plane_normal",
+            R"json({ "trace": { "source": "camera_screen", "camera": "camera.valid", "work_plane": { "normal": [0.0, 0.0, 0.0] } }, "outputs": { "hit_key": "editor.hit" } })json",
+            "scene editor selection work_plane normal must be non-zero",
+        },
+        {
             "bad_camera",
             R"json({ "trace": { "source": "camera_screen", "camera": "camera.missing", "viewport": [1280, 720] }, "outputs": { "hit_key": "editor.hit" } })json",
             "unknown camera",
@@ -14067,7 +14072,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     SDL_Event miss_motion{};
     miss_motion.type = SDL_EVENT_MOUSE_MOTION;
     miss_motion.motion.x = 20.0f;
-    miss_motion.motion.y = 20.0f;
+    miss_motion.motion.y = 700.0f;
     SDL_Event miss_click{};
     miss_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     miss_click.button.button = SDL_BUTTON_LEFT;
@@ -14077,9 +14082,19 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_input_process_event(input, &miss_click);
     slayer3d_input_update(input, 3);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", true));
-    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.type", ""), "none");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.world", "not-empty"), "");
+    const slayer3d_value *work_plane_point = slayer3d_properties_get_value(scene_state, "editor.selection.point");
+    ASSERT_NE(work_plane_point, nullptr);
+    ASSERT_EQ(work_plane_point->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(work_plane_point->as_vec3.y, 0.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_TRUE(active_selection.hit);
+    EXPECT_EQ(active_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID);
+    EXPECT_NEAR(active_selection.point.y, 0.0f, 0.001f);
+    EXPECT_NEAR(active_selection.normal.y, 1.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -14127,8 +14142,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_NE(input, nullptr);
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
-    motion.motion.x = 564.8f;
-    motion.motion.y = 392.9f;
+    motion.motion.x = 20.0f;
+    motion.motion.y = 700.0f;
     SDL_Event click{};
     click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     click.button.button = SDL_BUTTON_LEFT;
@@ -14141,6 +14156,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_data_editor_selection placement_selection{};
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &placement_selection));
     ASSERT_TRUE(placement_selection.hit);
+    EXPECT_EQ(placement_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID);
     const slayer3d_vec3 placement_origin = slayer3d_vec3_make(SDL_roundf(placement_selection.point.x / 0.5f) * 0.5f,
                                                               SDL_roundf(placement_selection.point.y / 0.5f) * 0.5f,
                                                               SDL_roundf(placement_selection.point.z / 0.5f) * 0.5f);

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -283,6 +283,30 @@ TEST(Input, TracksAbsoluteMousePosition)
     EXPECT_FLOAT_EQ(456.0f, y);
 }
 
+TEST(Input, MapsAbsoluteMousePositionThroughLogicalTransform)
+{
+    InputPtr input;
+    slayer3d_input_set_mouse_position_transform(input.input, 0.5f, 0.5f, 100.0f, 50.0f);
+
+    push_mouse_motion_at(input.input, 740.0f, 410.0f, 10.0f, -6.0f);
+    slayer3d_input_update(input.input, 10);
+
+    float x = 0.0f;
+    float y = 0.0f;
+    ASSERT_TRUE(slayer3d_input_get_mouse_position(input.input, &x, &y));
+    EXPECT_FLOAT_EQ(320.0f, x);
+    EXPECT_FLOAT_EQ(180.0f, y);
+    EXPECT_FLOAT_EQ(10.0f, slayer3d_input_get_mouse_dx(input.input));
+    EXPECT_FLOAT_EQ(-6.0f, slayer3d_input_get_mouse_dy(input.input));
+
+    slayer3d_input_set_mouse_position_transform(input.input, 1.0f, 1.0f, 0.0f, 0.0f);
+    push_mouse_motion_at(input.input, 12.0f, 34.0f, 0.0f, 0.0f);
+    slayer3d_input_update(input.input, 11);
+    ASSERT_TRUE(slayer3d_input_get_mouse_position(input.input, &x, &y));
+    EXPECT_FLOAT_EQ(12.0f, x);
+    EXPECT_FLOAT_EQ(34.0f, y);
+}
+
 TEST(Input, DiscardsMouseMotionUntilNextSnapshot)
 {
     InputPtr input;


### PR DESCRIPTION
## Summary
- add `editor.selection.trace.work_plane` as a fallback ray target when world-model picking misses
- enable a ground work plane in the editor shell dojo so prefab placement works in empty space
- map absolute SDL mouse coordinates into the engine logical letterboxed viewport before editor picking reads them, keeping the 3D cursor aligned with the OS cursor under window scaling
- document the authored work-plane selection behavior and update editor dojo guidance

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test -j 8`
- `cmake --build build/debug --target slayer3d_input_test slayer3d_game_data_test slayer3d_editor -j 8`
- `./build/debug/tests/slayer3d_input_test --gtest_filter='Input.TracksAbsoluteMousePosition:Input.MapsAbsoluteMousePositionThroughLogicalTransform'`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RejectsInvalidSceneEditorTooling:GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools:GameDataRuntime.EditorShellDojoDirectStartsPlayableSceneFromPlayerStart'`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug --target slayer3d_editor -j 8`