### PR TITLE
Add editor work-plane grid overlay

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -5,7 +5,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - a normal Slayer3D runtime viewport
 - authored brush-world selection trace metadata with a ground work-plane
   fallback for placing the first brush in empty space
-- data-authored world/selection/normal/hit debug overlay drawing
+- data-authored world/selection/normal/hit debug overlay drawing, including a
+  visible work-plane grid for empty-space placement
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
   `4` player start, then click a brush face or the ground work plane and press

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -78,13 +78,24 @@
     },
     "debug_overlay": {
       "enabled": true,
-      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker", "command_preview"],
+      "flags": [
+        "work_plane_grid",
+        "world_bounds",
+        "selection_bounds",
+        "trace_ray",
+        "face_normal",
+        "hit_marker",
+        "command_preview"
+      ],
       "world_bounds_color": [80, 170, 255, 190],
       "selection_bounds_color": [255, 220, 40, 255],
       "trace_color": [255, 255, 255, 210],
       "face_normal_color": [40, 255, 120, 255],
       "hit_marker_color": [255, 70, 70, 255],
       "command_preview_color": [80, 255, 255, 235],
+      "work_plane_grid_color": [80, 140, 170, 95],
+      "work_plane_grid_size": 24.0,
+      "work_plane_grid_spacing": 1.0,
       "normal_length": 0.65,
       "hit_marker_size": 0.12
     }

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -666,7 +666,17 @@ face normal through the normal 3D presentation path:
     },
     "debug_overlay": {
       "enabled": true,
-      "flags": ["world_bounds", "selection_bounds", "trace_ray", "face_normal", "hit_marker"]
+      "flags": [
+        "work_plane_grid",
+        "world_bounds",
+        "selection_bounds",
+        "trace_ray",
+        "face_normal",
+        "hit_marker"
+      ],
+      "work_plane_grid_color": [80, 140, 170, 95],
+      "work_plane_grid_size": 24.0,
+      "work_plane_grid_spacing": 1.0
     }
   }
 }
@@ -687,6 +697,12 @@ plane described by `dot(normal, point) = distance` and publishes that as a hit
 with `selection_type: "none"`. This is intended for blockout tools: a blank
 scene can still place the first floor on the ground plane, while later clicks on
 real brush faces keep returning normal brush-world selections.
+
+Add `work_plane_grid` (or `grid`) to `editor.debug_overlay.flags` to visualize
+the authored work plane with reusable debug lines. `work_plane_grid_size` is the
+grid half-extent in world units, and `work_plane_grid_spacing` controls line
+spacing. The grid uses the same `work_plane.normal` and `work_plane.distance`
+as placement, so visual feedback and picking stay aligned.
 
 Selection mode defaults to `hover`, where `outputs` receives the current pick
 every frame. In `mode: "click"`, `outputs` receives the pinned selection and

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -802,6 +802,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER = 5,
         /** @brief Non-mutating editor command preview bounds edge. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE = 6,
+        /** @brief Authored editor work-plane grid line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID = 7,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -818,11 +820,14 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER = 1u << 4,
         /** @brief Emit active non-mutating editor command preview bounds. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW = 1u << 5,
+        /** @brief Emit authored editor work-plane grid lines. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID = 1u << 6,
         /** @brief Emit every supported editor debug primitive. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_TRACE_RAY | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_FACE_NORMAL |
-            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW,
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW |
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID,
     };
 
     /** @brief One renderer-agnostic editor debug line segment. */
@@ -865,6 +870,18 @@ extern "C"
         slayer3d_color hit_marker_color;
         /** @brief Color for command preview bounds, or alpha 0 for default. */
         slayer3d_color command_preview_color;
+        /** @brief Color for work-plane grid lines, or alpha 0 for default. */
+        slayer3d_color work_plane_grid_color;
+        /** @brief True when work-plane grid settings are valid. */
+        bool has_work_plane_grid;
+        /** @brief Work-plane normal. */
+        slayer3d_vec3 work_plane_normal;
+        /** @brief Work-plane distance for dot(normal, point) = distance. */
+        float work_plane_distance;
+        /** @brief Half-extent of the grid in world units. Defaults to 16. */
+        float work_plane_grid_size;
+        /** @brief Grid line spacing in world units. Defaults to 1. */
+        float work_plane_grid_spacing;
         /** @brief Face-normal line length in world units. Defaults to 0.75. */
         float normal_length;
         /** @brief Hit-marker half-size in world units. Defaults to 0.1. */

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -11095,7 +11095,8 @@ static bool editor_debug_flag_name_valid(const char *value)
     return value != NULL && (SDL_strcmp(value, "all") == 0 || SDL_strcmp(value, "world_bounds") == 0 ||
                              SDL_strcmp(value, "selection_bounds") == 0 || SDL_strcmp(value, "trace_ray") == 0 ||
                              SDL_strcmp(value, "face_normal") == 0 || SDL_strcmp(value, "hit_marker") == 0 ||
-                             SDL_strcmp(value, "command_preview") == 0);
+                             SDL_strcmp(value, "command_preview") == 0 || SDL_strcmp(value, "work_plane_grid") == 0 ||
+                             SDL_strcmp(value, "grid") == 0);
 }
 
 static bool editor_command_name_valid(const char *value)
@@ -11404,9 +11405,9 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         if (!validate_string_or_string_array_names(ctx, obj_get(overlay, "flags"), flags_path, "editor debug flag",
                                                    editor_debug_flag_name_valid))
             return false;
-        static const char *const color_keys[] = {"world_bounds_color", "selection_bounds_color",
-                                                 "trace_color",        "face_normal_color",
-                                                 "hit_marker_color",   "command_preview_color"};
+        static const char *const color_keys[] = {
+            "world_bounds_color", "selection_bounds_color", "trace_color",          "face_normal_color",
+            "hit_marker_color",   "command_preview_color",  "work_plane_grid_color"};
         for (size_t i = 0; i < SDL_arraysize(color_keys); ++i)
         {
             yyjson_val *color = obj_get(overlay, color_keys[i]);
@@ -11420,6 +11421,14 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         yyjson_val *hit_marker_size = obj_get(overlay, "hit_marker_size");
         if (hit_marker_size != NULL && (!yyjson_is_num(hit_marker_size) || yyjson_get_num(hit_marker_size) <= 0.0))
             return validation_error(ctx, overlay_path, "scene editor debug_overlay hit_marker_size must be positive");
+        yyjson_val *grid_size = obj_get(overlay, "work_plane_grid_size");
+        if (grid_size != NULL && (!yyjson_is_num(grid_size) || yyjson_get_num(grid_size) <= 0.0))
+            return validation_error(ctx, overlay_path,
+                                    "scene editor debug_overlay work_plane_grid_size must be positive");
+        yyjson_val *grid_spacing = obj_get(overlay, "work_plane_grid_spacing");
+        if (grid_spacing != NULL && (!yyjson_is_num(grid_spacing) || yyjson_get_num(grid_spacing) <= 0.0))
+            return validation_error(ctx, overlay_path,
+                                    "scene editor debug_overlay work_plane_grid_spacing must be positive");
     }
     return true;
 }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2694,6 +2694,58 @@ static bool emit_editor_debug_bounds(editor_debug_iteration_context *context, sl
     return true;
 }
 
+static bool emit_editor_debug_work_plane_grid(const slayer3d_game_data_editor_debug_desc *desc,
+                                              slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    if (desc == NULL || callback == NULL || !desc->has_work_plane_grid ||
+        slayer3d_vec3_length_squared(desc->work_plane_normal) <= 0.000001f)
+    {
+        return true;
+    }
+
+    const slayer3d_vec3 normal = slayer3d_vec3_normalize(desc->work_plane_normal);
+    slayer3d_vec3 reference =
+        SDL_fabsf(normal.y) < 0.95f ? slayer3d_vec3_make(0.0f, 1.0f, 0.0f) : slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    slayer3d_vec3 tangent = slayer3d_vec3_cross(reference, normal);
+    if (slayer3d_vec3_length_squared(tangent) <= 0.000001f)
+        tangent = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    tangent = slayer3d_vec3_normalize(tangent);
+    const slayer3d_vec3 bitangent = slayer3d_vec3_normalize(slayer3d_vec3_cross(normal, tangent));
+    const slayer3d_vec3 center = slayer3d_vec3_scale(normal, desc->work_plane_distance);
+    const float half_size = desc->work_plane_grid_size > 0.0f ? desc->work_plane_grid_size : 16.0f;
+    const float spacing = desc->work_plane_grid_spacing > 0.0f ? desc->work_plane_grid_spacing : 1.0f;
+    const int line_count = SDL_min((int)SDL_floorf(half_size / spacing), 512);
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.color = editor_debug_color_or_default(desc->work_plane_grid_color, (slayer3d_color){90, 160, 190, 120});
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID;
+    context.face_index = -1;
+
+    for (int i = -line_count; i <= line_count; ++i)
+    {
+        const float offset = (float)i * spacing;
+        const slayer3d_vec3 tangent_offset = slayer3d_vec3_scale(tangent, offset);
+        const slayer3d_vec3 bitangent_offset = slayer3d_vec3_scale(bitangent, offset);
+        if (!emit_editor_debug_line(&context,
+                                    slayer3d_vec3_add(slayer3d_vec3_add(center, tangent_offset),
+                                                      slayer3d_vec3_scale(bitangent, -half_size)),
+                                    slayer3d_vec3_add(slayer3d_vec3_add(center, tangent_offset),
+                                                      slayer3d_vec3_scale(bitangent, half_size))) ||
+            !emit_editor_debug_line(&context,
+                                    slayer3d_vec3_add(slayer3d_vec3_add(center, bitangent_offset),
+                                                      slayer3d_vec3_scale(tangent, -half_size)),
+                                    slayer3d_vec3_add(slayer3d_vec3_add(center, bitangent_offset),
+                                                      slayer3d_vec3_scale(tangent, half_size))))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 typedef struct editor_world_bounds_context
 {
     const slayer3d_game_data_editor_debug_desc *desc;
@@ -2736,6 +2788,12 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
         return false;
 
     const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID) != 0u &&
+        !emit_editor_debug_work_plane_grid(desc, callback, userdata))
+    {
+        return true;
+    }
+
     if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS) != 0u)
     {
         editor_world_bounds_context bounds_context;
@@ -2907,6 +2965,9 @@ static unsigned int editor_debug_flag_from_string(const char *value)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER;
     if (SDL_strcmp(value != NULL ? value : "", "command_preview") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW;
+    if (SDL_strcmp(value != NULL ? value : "", "work_plane_grid") == 0 ||
+        SDL_strcmp(value != NULL ? value : "", "grid") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID;
     return 0u;
 }
 
@@ -3077,6 +3138,22 @@ static bool editor_work_plane_selection_from_trace(yyjson_val *selection,
     out_selection->fraction = fraction;
     out_selection->point = slayer3d_vec3_add(trace->start, slayer3d_vec3_scale(direction, fraction));
     out_selection->normal = normal;
+    return true;
+}
+
+static bool editor_work_plane_desc_from_trace_json(yyjson_val *trace, slayer3d_vec3 *out_normal, float *out_distance)
+{
+    yyjson_val *work_plane = obj_get(trace, "work_plane");
+    if (!yyjson_is_obj(work_plane) || !json_bool(work_plane, "enabled", true) || out_normal == NULL ||
+        out_distance == NULL)
+    {
+        return false;
+    }
+    slayer3d_vec3 normal = json_vec3(work_plane, "normal", slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
+    if (slayer3d_vec3_length_squared(normal) <= 0.000001f)
+        return false;
+    *out_normal = slayer3d_vec3_normalize(normal);
+    *out_distance = json_float(work_plane, "distance", 0.0f);
     return true;
 }
 
@@ -4681,13 +4758,18 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
     out_desc->face_normal_color = json_color(overlay, "face_normal_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->hit_marker_color = json_color(overlay, "hit_marker_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->command_preview_color = json_color(overlay, "command_preview_color", (slayer3d_color){0, 0, 0, 0});
+    out_desc->work_plane_grid_color = json_color(overlay, "work_plane_grid_color", (slayer3d_color){0, 0, 0, 0});
     out_desc->normal_length = json_float(overlay, "normal_length", 0.75f);
     out_desc->hit_marker_size = json_float(overlay, "hit_marker_size", 0.1f);
+    out_desc->work_plane_grid_size = json_float(overlay, "work_plane_grid_size", 16.0f);
+    out_desc->work_plane_grid_spacing = json_float(overlay, "work_plane_grid_spacing", 1.0f);
 
     yyjson_val *selection_json = obj_get(editor, "selection");
     if (editor_trace_desc_from_json(runtime, selection_json, out_trace))
     {
         out_desc->trace = out_trace;
+        out_desc->has_work_plane_grid = editor_work_plane_desc_from_trace_json(
+            obj_get(selection_json, "trace"), &out_desc->work_plane_normal, &out_desc->work_plane_distance);
         if (out_selection != NULL && editor_selection_mode_is_click(selection_json) &&
             editor_selection_active_for_scene(runtime) && runtime->editor_active_selection.hit)
         {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8604,6 +8604,7 @@ TEST(GameDataRuntime, RejectsInvalidWorldDisplayAndCameraConventions)
         EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
             << test_case.name << ": " << error;
     }
+
     remove_test_dir(dir);
 }
 
@@ -8737,6 +8738,39 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
         EXPECT_NE(std::string(error).find(test_case.expected_error), std::string::npos)
             << test_case.name << ": " << error;
     }
+
+    write_text(dir / "bad_grid_overlay.game.json", R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Scene Editor Grid" },
+  "world": {
+    "name": "world.bad_scene_editor_grid",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.valid", "type": "perspective", "position": [0, 0, 5], "target": [0, 0, 0], "up": [0, 1, 0] }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json", R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.valid",
+  "editor": {
+    "selection": {
+      "trace": { "source": "camera_screen", "camera": "camera.valid" },
+      "outputs": { "hit_key": "editor.hit" }
+    },
+    "debug_overlay": {
+      "flags": ["work_plane_grid"],
+      "work_plane_grid_spacing": 0
+    }
+  }
+})json");
+    char grid_error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_grid_overlay.game.json").string().c_str(), nullptr,
+                                                  grid_error, sizeof(grid_error)));
+    EXPECT_NE(std::string(grid_error).find("work_plane_grid_spacing must be positive"), std::string::npos)
+        << grid_error;
     remove_test_dir(dir);
 }
 
@@ -13864,6 +13898,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
 
     struct DebugCapture
     {
+        int grid_lines = 0;
         int world_edges = 0;
         int selection_edges = 0;
         int command_preview_edges = 0;
@@ -13873,7 +13908,13 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     } debug;
     auto capture_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
         auto *capture = static_cast<DebugCapture *>(userdata);
-        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE)
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID)
+        {
+            capture->grid_lines++;
+            EXPECT_NEAR(primitive->start.y, 0.0f, 0.001f);
+            EXPECT_NEAR(primitive->end.y, 0.0f, 0.001f);
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE)
             capture->world_edges++;
         else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
             capture->selection_edges++;
@@ -13888,6 +13929,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
         return true;
     };
     ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_debug, &debug));
+    EXPECT_EQ(debug.grid_lines, 98);
     EXPECT_EQ(debug.world_edges, 12);
     EXPECT_EQ(debug.selection_edges, 12);
     EXPECT_EQ(debug.command_preview_edges, 12);


### PR DESCRIPTION
## Summary
- add a renderer-agnostic editor debug primitive for authored work-plane grid lines
- extend scene editor debug overlay data with `work_plane_grid` flags, color, size, and spacing
- enable the grid in the editor shell dojo so empty-space prefab placement has visible spatial feedback
- update validation, docs, and editor shell tests

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RejectsInvalidSceneEditorTooling:GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools'`
- `./build/debug/tests/slayer3d_game_data_test`