### PR TITLE
Add data-authored editor camera navigation

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -3,6 +3,8 @@
 This data-only dojo demonstrates the first reusable editor shell pieces:
 
 - a normal Slayer3D runtime viewport
+- a data-authored editor camera controller: arrow keys move horizontally,
+  `Q`/`E` move down/up, and right mouse button + drag looks around
 - authored brush-world selection trace metadata with a ground work-plane
   fallback for placing the first brush in empty space
 - data-authored world/selection/normal/hit debug overlay drawing, including a

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -77,6 +77,38 @@
             "bindings": [{ "device": "keyboard", "key": "4" }]
           },
           {
+            "name": "action.editor.camera.forward",
+            "bindings": [{ "device": "keyboard", "key": "UP" }]
+          },
+          {
+            "name": "action.editor.camera.back",
+            "bindings": [{ "device": "keyboard", "key": "DOWN" }]
+          },
+          {
+            "name": "action.editor.camera.left",
+            "bindings": [{ "device": "keyboard", "key": "LEFT" }]
+          },
+          {
+            "name": "action.editor.camera.right",
+            "bindings": [{ "device": "keyboard", "key": "RIGHT" }]
+          },
+          {
+            "name": "action.editor.camera.up",
+            "bindings": [{ "device": "keyboard", "key": "E" }]
+          },
+          {
+            "name": "action.editor.camera.down",
+            "bindings": [{ "device": "keyboard", "key": "Q" }]
+          },
+          {
+            "name": "action.editor.camera.look",
+            "bindings": [{ "device": "mouse", "button": "RIGHT" }]
+          },
+          {
+            "name": "action.editor.camera.fast",
+            "bindings": [{ "device": "keyboard", "key": "LSHIFT" }]
+          },
+          {
             "name": "action.move.forward",
             "bindings": [{ "device": "keyboard", "key": "W" }]
           },
@@ -659,10 +691,8 @@
     "cameras": [
       {
         "name": "camera.editor_shell.viewport",
-        "type": "perspective",
-        "position": [-5.0, 3.2, 5.0],
-        "target": [1.0, 1.0, 1.0],
-        "up": [0.0, 1.0, 0.0],
+        "type": "fps",
+        "target_entity": "entity.editor_shell.camera",
         "fov": 70.0,
         "fov_axis": "horizontal",
         "active": true
@@ -687,6 +717,36 @@
     "clear_color": [0.04, 0.045, 0.055]
   },
   "entities": [
+    {
+      "name": "entity.editor_shell.camera",
+      "active": true,
+      "transform": { "position": [-5.0, 3.2, 5.0] },
+      "properties": {
+        "yaw": { "type": "float", "value": 0.98279 },
+        "pitch": { "type": "float", "value": -0.29566 },
+        "camera_forward": { "type": "vec3", "value": [0.79584, -0.29161, -0.53056] }
+      },
+      "components": [
+        {
+          "type": "controller.editor_camera",
+          "actions": {
+            "forward": "action.editor.camera.forward",
+            "back": "action.editor.camera.back",
+            "left": "action.editor.camera.left",
+            "right": "action.editor.camera.right",
+            "up": "action.editor.camera.up",
+            "down": "action.editor.camera.down",
+            "look": "action.editor.camera.look",
+            "fast": "action.editor.camera.fast"
+          },
+          "move_speed": 8.0,
+          "fast_speed": 22.0,
+          "mouse_sensitivity": 0.002,
+          "pitch_min": -1.45,
+          "pitch_max": 1.45
+        }
+      ]
+    },
     {
       "name": "entity.editor_shell.player",
       "active": true,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -27,9 +27,18 @@
       "action.editor.tool.floor",
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
-      "action.editor.tool.player_start"
+      "action.editor.tool.player_start",
+      "action.editor.camera.forward",
+      "action.editor.camera.back",
+      "action.editor.camera.left",
+      "action.editor.camera.right",
+      "action.editor.camera.up",
+      "action.editor.camera.down",
+      "action.editor.camera.look",
+      "action.editor.camera.fast"
     ]
   },
+  "entities": ["entity.editor_shell.camera"],
   "world": {
     "brush_worlds": [
       { "world": "brush.editor_shell.target", "position": [0.0, 0.0, 0.0] }
@@ -202,7 +211,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S save. T run manifest. Z/Y undo-redo.",
+        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S save.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1050,7 +1050,51 @@ and `source_path_key`.
 Supported `model_filter` values are `all`, `sector_levels`/`sector`, and
 `brush_worlds`/`brush`. Supported debug flags are `all`, `world_bounds`,
 `selection_bounds`, `trace_ray`, `face_normal`, `hit_marker`, and
-`command_preview`.
+`command_preview`, plus `work_plane_grid` when a selection work plane is
+authored.
+
+Use `controller.editor_camera` on an actor to drive an editor/free-flight
+viewport camera without collision:
+
+```json
+{
+  "name": "entity.editor.camera",
+  "active": true,
+  "transform": { "position": [-5.0, 3.2, 5.0] },
+  "properties": {
+    "yaw": { "type": "float", "value": 0.98 },
+    "pitch": { "type": "float", "value": -0.3 }
+  },
+  "components": [
+    {
+      "type": "controller.editor_camera",
+      "actions": {
+        "forward": "action.editor.camera.forward",
+        "back": "action.editor.camera.back",
+        "left": "action.editor.camera.left",
+        "right": "action.editor.camera.right",
+        "up": "action.editor.camera.up",
+        "down": "action.editor.camera.down",
+        "look": "action.editor.camera.look",
+        "fast": "action.editor.camera.fast"
+      },
+      "move_speed": 8.0,
+      "fast_speed": 22.0,
+      "mouse_sensitivity": 0.002,
+      "pitch_min": -1.45,
+      "pitch_max": 1.45
+    }
+  ]
+}
+```
+
+Pair it with an `fps` camera targeting the camera actor. Movement uses the
+actor's yaw on the horizontal plane; `up` and `down` move along world Y. The
+optional `look` action gates mouse-look, which is useful for editors that need
+normal mouse clicking and right-button camera look in the same scene. If `look`
+is omitted, mouse-look is active whenever `mouse_look` is true. The controller
+writes `yaw`, `pitch`, and `camera_forward` by default; override those names
+with `yaw_property`, `pitch_property`, and `forward_property`.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -275,6 +275,88 @@ static void fps_controller_publish_actor_state(const fps_controller_runtime *con
                                 controller->mover.current_sector);
 }
 
+static void publish_editor_camera_actor_state(yyjson_val *component, slayer3d_registered_actor *actor, float yaw,
+                                              float pitch)
+{
+    if (component == NULL || actor == NULL)
+        return;
+
+    const float cos_pitch = SDL_cosf(pitch);
+    const slayer3d_vec3 forward =
+        slayer3d_vec3_make(SDL_sinf(yaw) * cos_pitch, SDL_sinf(pitch), -SDL_cosf(yaw) * cos_pitch);
+    slayer3d_properties_set_float(actor->props, json_string(component, "yaw_property", "yaw"), yaw);
+    slayer3d_properties_set_float(actor->props, json_string(component, "pitch_property", "pitch"), pitch);
+    slayer3d_properties_set_vec3(actor->props, json_string(component, "forward_property", "camera_forward"), forward);
+}
+
+static float editor_camera_clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value)
+        return min_value;
+    if (value > max_value)
+        return max_value;
+    return value;
+}
+
+void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                     slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
+{
+    if (runtime == NULL || component == NULL || actor == NULL)
+        return;
+
+    const char *yaw_property = json_string(component, "yaw_property", "yaw");
+    const char *pitch_property = json_string(component, "pitch_property", "pitch");
+    float yaw = slayer3d_properties_get_float(actor->props, yaw_property, json_float(component, "spawn_yaw", 0.0f));
+    float pitch =
+        slayer3d_properties_get_float(actor->props, pitch_property, json_float(component, "spawn_pitch", 0.0f));
+
+    const int look_action = fps_controller_action_id(runtime, component, "look");
+    const bool look_active =
+        input != NULL && (look_action < 0 || fps_controller_action_value(runtime, input, look_action) > 0.0f);
+    if (json_bool(component, "mouse_look", true) && look_active)
+    {
+        const float sensitivity = json_float(component, "mouse_sensitivity", 0.002f);
+        yaw += slayer3d_input_get_mouse_dx(input) * sensitivity;
+        pitch -= slayer3d_input_get_mouse_dy(input) * sensitivity;
+    }
+    const float pitch_min = json_float(component, "pitch_min", -1.4f);
+    const float pitch_max = json_float(component, "pitch_max", 1.4f);
+    pitch = editor_camera_clampf(pitch, SDL_min(pitch_min, pitch_max), SDL_max(pitch_min, pitch_max));
+
+    float forward =
+        fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "forward")) -
+        fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "back"));
+    float side = fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "right")) -
+                 fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "left"));
+    float vertical = fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "up")) -
+                     fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "down"));
+    const float len_sq = forward * forward + side * side + vertical * vertical;
+    if (len_sq > 1.0f)
+    {
+        const float inv_len = 1.0f / SDL_sqrtf(len_sq);
+        forward *= inv_len;
+        side *= inv_len;
+        vertical *= inv_len;
+    }
+
+    const float fast =
+        fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "fast"));
+    const float speed = fast > 0.0f
+                            ? json_float(component, "fast_speed", json_float(component, "move_speed", 8.0f) * 2.5f)
+                            : json_float(component, "move_speed", 8.0f);
+    const float fwd_x = SDL_sinf(yaw);
+    const float fwd_z = -SDL_cosf(yaw);
+    const float right_x = SDL_cosf(yaw);
+    const float right_z = SDL_sinf(yaw);
+    const slayer3d_vec3 delta = slayer3d_vec3_make((fwd_x * forward + right_x * side) * speed * SDL_max(dt, 0.0f),
+                                                   vertical * speed * SDL_max(dt, 0.0f),
+                                                   (fwd_z * forward + right_z * side) * speed * SDL_max(dt, 0.0f));
+    if (slayer3d_vec3_length_squared(delta) > 0.0000001f)
+        actor_set_position(actor, slayer3d_vec3_add(actor->position, delta));
+
+    publish_editor_camera_actor_state(component, actor, yaw, pitch);
+}
+
 static bool initialize_fps_controller_runtime(slayer3d_game_data_runtime *runtime, fps_controller_runtime *controller,
                                               yyjson_val *component, slayer3d_registered_actor *actor)
 {

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -961,6 +961,8 @@ void update_fps_sector_controller(slayer3d_game_data_runtime *runtime, yyjson_va
                                   slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt);
 void update_fps_brush_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
                                  slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt);
+void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                     slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt);
 bool update_brush_velocity_motion(slayer3d_game_data_runtime *runtime, yyjson_val *component,
                                   slayer3d_registered_actor *actor, int actor_id, int pool_index, int actor_index,
                                   float dt);

--- a/src/game_data_motion_runtime.c
+++ b/src/game_data_motion_runtime.c
@@ -420,6 +420,10 @@ void update_control_components(slayer3d_game_data_runtime *runtime, yyjson_val *
             {
                 update_fps_brush_controller(runtime, component, actor, input, dt);
             }
+            else if (SDL_strcmp(type, "controller.editor_camera") == 0)
+            {
+                update_editor_camera_controller(runtime, component, actor, input, dt);
+            }
             else if (SDL_strcmp(type, "weapon.projectile") == 0 && input != NULL)
             {
                 const int action_id = slayer3d_game_data_find_action(runtime, json_string(component, "action", NULL));

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2866,6 +2866,7 @@ static bool is_supported_component_type(const char *type)
         "collision.circle",
         "combat.health",
         "control.axis_1d",
+        "controller.editor_camera",
         "controller.fps_brush",
         "controller.fps_sector",
         "lifecycle.ttl",
@@ -3175,6 +3176,61 @@ static bool validate_fps_brush_component(validation_context *ctx, yyjson_val *co
             return validation_error(ctx, path,
                                     "controller.fps_brush diagnostic property names must be non-empty strings");
     }
+    return true;
+}
+
+static bool validate_editor_camera_component(validation_context *ctx, yyjson_val *component, const char *path,
+                                             validation_names *names)
+{
+    yyjson_val *actions = obj_get(component, "actions");
+    if (!yyjson_is_obj(actions))
+        return validation_error(ctx, path, "controller.editor_camera requires an actions object");
+
+    const char *action_keys[] = {"forward", "back", "left", "right", "up", "down", "look", "fast"};
+    bool has_action = false;
+    for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
+    {
+        const char *action = json_string(actions, action_keys[i]);
+        if (action == NULL)
+            continue;
+        has_action = true;
+        if (!require_ref(ctx, &names->actions, "input action", action, path))
+            return false;
+    }
+    if (!has_action)
+        return validation_error(ctx, path, "controller.editor_camera actions must reference at least one input action");
+
+    const char *property_keys[] = {"yaw_property", "pitch_property", "forward_property"};
+    for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, property_keys[i]);
+        if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
+            return validation_error(ctx, path, "controller.editor_camera property names must be non-empty strings");
+    }
+
+    const char *numeric_keys[] = {"move_speed",  "fast_speed", "mouse_sensitivity", "spawn_yaw",
+                                  "spawn_pitch", "pitch_min",  "pitch_max"};
+    for (size_t i = 0; i < SDL_arraysize(numeric_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, numeric_keys[i]);
+        if (value != NULL && !yyjson_is_num(value))
+            return validation_error(ctx, path, "controller.editor_camera numeric tuning values must be numbers");
+    }
+    const char *non_negative[] = {"move_speed", "fast_speed", "mouse_sensitivity"};
+    for (size_t i = 0; i < SDL_arraysize(non_negative); ++i)
+    {
+        yyjson_val *value = obj_get(component, non_negative[i]);
+        if (value != NULL && yyjson_get_num(value) < 0.0)
+            return validation_error(ctx, path,
+                                    "controller.editor_camera speed and sensitivity values must be non-negative");
+    }
+    yyjson_val *pitch_min = obj_get(component, "pitch_min");
+    yyjson_val *pitch_max = obj_get(component, "pitch_max");
+    if (pitch_min != NULL && pitch_max != NULL && yyjson_get_num(pitch_min) >= yyjson_get_num(pitch_max))
+        return validation_error(ctx, path, "controller.editor_camera pitch_min must be less than pitch_max");
+    yyjson_val *mouse_look = obj_get(component, "mouse_look");
+    if (mouse_look != NULL && !yyjson_is_bool(mouse_look))
+        return validation_error(ctx, path, "controller.editor_camera mouse_look must be a boolean");
     return true;
 }
 
@@ -5706,6 +5762,11 @@ static bool validate_components(validation_context *ctx, yyjson_val *root, valid
                 if (!validate_fps_brush_component(ctx, component, path, names))
                     return false;
             }
+            else if (SDL_strcmp(type, "controller.editor_camera") == 0)
+            {
+                if (!validate_editor_camera_component(ctx, component, path, names))
+                    return false;
+            }
             else if (SDL_strcmp(type, "combat.health") == 0)
             {
                 if (!validate_combat_health_component(ctx, component, path))
@@ -6363,10 +6424,11 @@ static bool validate_actor_archetypes_and_pools(validation_context *ctx, yyjson_
             {
                 return false;
             }
-            if (SDL_strcmp(type, "controller.fps_sector") == 0 || SDL_strcmp(type, "controller.fps_brush") == 0)
+            if (SDL_strcmp(type, "controller.fps_sector") == 0 || SDL_strcmp(type, "controller.fps_brush") == 0 ||
+                SDL_strcmp(type, "controller.editor_camera") == 0)
             {
                 return validation_error(ctx, component_path,
-                                        "first-person controllers are only supported on static entities");
+                                        "camera and first-person controllers are only supported on static entities");
             }
             else if (SDL_strcmp(type, "combat.health") == 0)
             {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14388,6 +14388,61 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    slayer3d_registered_actor *camera_actor = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(camera_actor, nullptr);
+    const slayer3d_vec3 start_position = camera_actor->position;
+    const float start_yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", 0.0f);
+
+    slayer3d_camera3d before{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &before));
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.25f));
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, start_position)), 0.1f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    slayer3d_input_process_event(input, &key);
+
+    SDL_Event right_down{};
+    right_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    right_down.button.button = SDL_BUTTON_RIGHT;
+    slayer3d_input_process_event(input, &right_down);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.xrel = 60.0f;
+    motion.motion.yrel = -15.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+
+    const float yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);
+    EXPECT_GT(SDL_fabsf(yaw - start_yaw), 0.01f);
+    slayer3d_camera3d after{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &after));
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(after.target, before.target)), 0.01f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoDirectStartsPlayableSceneFromPlayerStart)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();


### PR DESCRIPTION
## Summary\n- add reusable controller.editor_camera for free-flight editor viewport movement\n- switch the editor shell dojo viewport to a data-authored camera actor with arrow/Q/E movement and RMB mouse-look\n- document the controller and cover camera movement/look with a focused game-data test\n\n## Verification\n- cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8\n- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*'\n- ./build/debug/tests/slayer3d_game_data_test\n\nNext slice: add viewport grid/prefab placement affordances that feel less like signal-only mock controls: visible placement cursor/ghost prefab follows the work plane before commit, with snap settings surfaced in scene state.