### PR TITLE
Add editor placement previews

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -13,6 +13,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
   `4` player start, then click a brush face or the ground work plane and press
   `Enter` to place the selected prefab at that point
+- live snapped placement previews for floor, wall, ceiling, and player-start
+  tools using the same renderer-agnostic editor debug primitive path
 - unified editable-level save/export: `S` saves and publishes one fragment
   containing the brush world and player starts
 - test-run handoff manifest: `T` publishes and saves runner arguments for the

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -85,6 +85,63 @@
         "face_stable_id_key": "editor.hover.face_stable_id"
       }
     },
+    "placement": {
+      "tool_key": "editor.tool.mode",
+      "snap_key": "editor.placement.snap",
+      "default_snap": 0.5,
+      "outputs": {
+        "active_key": "editor.placement_preview.active",
+        "valid_key": "editor.placement_preview.valid",
+        "mode_key": "editor.placement_preview.mode",
+        "kind_key": "editor.placement_preview.kind",
+        "world_key": "editor.placement_preview.world",
+        "material_key": "editor.placement_preview.material",
+        "message_key": "editor.placement_preview.message",
+        "anchor_key": "editor.placement_preview.anchor",
+        "snap_key": "editor.placement_preview.snap",
+        "bounds_min_key": "editor.placement_preview.bounds_min",
+        "bounds_max_key": "editor.placement_preview.bounds_max"
+      },
+      "previews": [
+        {
+          "mode": "floor",
+          "kind": "box",
+          "world": "brush.editor_shell.target",
+          "material": "mat.editor.floor",
+          "snap": 0.5,
+          "min": [-3.0, -0.2, -3.0],
+          "max": [3.0, 0.0, 3.0],
+          "message": "floor prefab preview"
+        },
+        {
+          "mode": "wall",
+          "kind": "box",
+          "world": "brush.editor_shell.target",
+          "material": "mat.editor.wall",
+          "snap": 0.5,
+          "min": [-0.125, 0.0, -3.0],
+          "max": [0.125, 2.5, 3.0],
+          "message": "wall prefab preview"
+        },
+        {
+          "mode": "ceiling",
+          "kind": "box",
+          "world": "brush.editor_shell.target",
+          "material": "mat.editor.ceiling",
+          "snap": 0.5,
+          "min": [-3.0, 2.5, -3.0],
+          "max": [3.0, 2.7, 3.0],
+          "message": "ceiling prefab preview"
+        },
+        {
+          "mode": "player_start",
+          "kind": "player_start",
+          "snap": 0.5,
+          "size": [0.5, 1.8, 0.5],
+          "message": "player start preview"
+        }
+      ]
+    },
     "debug_overlay": {
       "enabled": true,
       "flags": [
@@ -189,6 +246,14 @@
           {
             "label": "Preview",
             "binding": { "type": "scene_state", "key": "editor.command_preview.message", "default": "none" }
+          },
+          {
+            "label": "Place",
+            "binding": { "type": "scene_state", "key": "editor.placement_preview.message", "default": "none" }
+          },
+          {
+            "label": "Snap",
+            "binding": { "type": "scene_state", "key": "editor.placement_preview.snap", "default": 0.5 }
           },
           {
             "label": "Txn",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -809,6 +809,47 @@ rounds the anchor to a grid size in world units before applying the offsets.
 }
 ```
 
+Scenes can also author `editor.placement` to show a live placement preview while
+the mouse hovers over a brush or work plane. `tool_key` names the scene-state
+property that selects the active tool. Each preview entry maps a tool `mode` to
+either a `box` ghost or a `player_start` marker. The preview reuses the editor
+debug overlay's `command_preview` flag and color, so editor hosts do not need a
+second rendering path.
+
+```json
+{
+  "editor": {
+    "placement": {
+      "tool_key": "editor.tool.mode",
+      "snap_key": "editor.placement.snap",
+      "default_snap": 0.5,
+      "outputs": {
+        "active_key": "editor.placement_preview.active",
+        "mode_key": "editor.placement_preview.mode",
+        "bounds_min_key": "editor.placement_preview.bounds_min",
+        "bounds_max_key": "editor.placement_preview.bounds_max"
+      },
+      "previews": [
+        {
+          "mode": "floor",
+          "kind": "box",
+          "world": "brush.level.blockout",
+          "material": "mat.stone_floor",
+          "min": [-4.0, -0.25, -4.0],
+          "max": [4.0, 0.0, 4.0],
+          "snap": 0.5
+        },
+        {
+          "mode": "player_start",
+          "kind": "player_start",
+          "size": [0.5, 1.8, 0.5]
+        }
+      ]
+    }
+  }
+}
+```
+
 Use `editor.player_start.place` to create or update one runtime player start.
 The action can be bound to editor tools that place a marker at a clicked point,
 or to direct UI controls that place a known target actor at an explicit

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -164,6 +164,20 @@ typedef struct editor_command_preview_state
     slayer3d_bounding_box bounds;
 } editor_command_preview_state;
 
+typedef struct editor_placement_preview_state
+{
+    bool active;
+    const char *scene;
+    const char *mode;
+    const char *kind;
+    const char *world_name;
+    const char *material_name;
+    slayer3d_vec3 anchor;
+    float snap;
+    bool has_bounds;
+    slayer3d_bounding_box bounds;
+} editor_placement_preview_state;
+
 #define SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY 32
 
 typedef struct editor_command_transaction_entry
@@ -697,6 +711,7 @@ typedef struct slayer3d_game_data_runtime
     slayer3d_game_data_editor_selection editor_active_selection;
     const char *editor_selection_scene;
     editor_command_preview_state editor_command_preview;
+    editor_placement_preview_state editor_placement_preview;
     editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -11417,6 +11417,95 @@ static bool validate_scene_editor_selection_options(validation_context *ctx, yyj
     return true;
 }
 
+static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val *placement, const char *placement_path,
+                                            validation_names *names)
+{
+    if (placement == NULL)
+        return true;
+    if (!yyjson_is_obj(placement))
+        return validation_error(ctx, placement_path, "scene editor placement must be an object");
+
+    const char *string_fields[] = {"tool_key", "snap_key", "default_tool"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        char field_path[PATH_BUFFER_SIZE];
+        format_path(field_path, sizeof(field_path), "%s.%s", placement_path, string_fields[i]);
+        if (!validate_optional_non_empty_string(ctx, obj_get(placement, string_fields[i]), field_path,
+                                                "scene editor placement field"))
+            return false;
+    }
+    yyjson_val *default_snap = obj_get(placement, "default_snap");
+    if (default_snap != NULL && (!yyjson_is_num(default_snap) || yyjson_get_num(default_snap) <= 0.0))
+        return validation_error(ctx, placement_path, "scene editor placement default_snap must be positive");
+
+    yyjson_val *outputs = obj_get(placement, "outputs");
+    if (outputs != NULL && !yyjson_is_obj(outputs))
+        return validation_error(ctx, placement_path, "scene editor placement outputs must be an object");
+    static const char *const output_keys[] = {"active_key", "valid_key",      "mode_key",      "kind_key",
+                                              "world_key",  "material_key",   "message_key",   "anchor_key",
+                                              "snap_key",   "bounds_min_key", "bounds_max_key"};
+    for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+    {
+        yyjson_val *output = obj_get(outputs, output_keys[i]);
+        if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+            return validation_error(ctx, placement_path,
+                                    "scene editor placement output keys must be non-empty strings");
+    }
+
+    yyjson_val *previews = obj_get(placement, "previews");
+    if (!yyjson_is_arr(previews) || yyjson_arr_size(previews) == 0)
+        return validation_error(ctx, placement_path, "scene editor placement previews must be a non-empty array");
+    for (size_t i = 0; i < yyjson_arr_size(previews); ++i)
+    {
+        char preview_path[PATH_BUFFER_SIZE];
+        format_path(preview_path, sizeof(preview_path), "%s.previews[%zu]", placement_path, i);
+        yyjson_val *preview = yyjson_arr_get(previews, i);
+        if (!yyjson_is_obj(preview))
+            return validation_error(ctx, preview_path, "scene editor placement preview must be an object");
+        if (!is_non_empty_string(preview, "mode"))
+            return validation_error(ctx, preview_path, "scene editor placement preview requires a non-empty mode");
+        const char *kind = json_string(preview, "kind");
+        if (kind == NULL)
+            kind = "box";
+        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0)
+            return validation_error(ctx, preview_path,
+                                    "scene editor placement preview kind must be box or player_start");
+        yyjson_val *offset = obj_get(preview, "position_offset");
+        if (offset != NULL && !is_exact_vec_array(offset, 3))
+            return validation_error(ctx, preview_path, "scene editor placement preview position_offset must be a vec3");
+        yyjson_val *snap = obj_get(preview, "snap");
+        if (snap != NULL && (!yyjson_is_num(snap) || yyjson_get_num(snap) <= 0.0))
+            return validation_error(ctx, preview_path, "scene editor placement preview snap must be positive");
+        if (SDL_strcmp(kind, "player_start") == 0)
+        {
+            yyjson_val *size = obj_get(preview, "size");
+            if (size != NULL &&
+                (!is_exact_vec_array(size, 3) || yyjson_get_num(yyjson_arr_get(size, 0)) <= 0.0 ||
+                 yyjson_get_num(yyjson_arr_get(size, 1)) <= 0.0 || yyjson_get_num(yyjson_arr_get(size, 2)) <= 0.0))
+            {
+                return validation_error(ctx, preview_path,
+                                        "scene editor placement player_start size must be a positive vec3");
+            }
+            continue;
+        }
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(preview, "world"), preview_path))
+            return false;
+        if (!is_non_empty_string(preview, "material"))
+            return validation_error(ctx, preview_path, "scene editor placement box preview requires a material");
+        yyjson_val *min = obj_get(preview, "min");
+        yyjson_val *max = obj_get(preview, "max");
+        if (!is_exact_vec_array(min, 3) || !is_exact_vec_array(max, 3))
+            return validation_error(ctx, preview_path, "scene editor placement box preview requires min and max vec3");
+        if (!(yyjson_get_num(yyjson_arr_get(min, 0)) < yyjson_get_num(yyjson_arr_get(max, 0)) &&
+              yyjson_get_num(yyjson_arr_get(min, 1)) < yyjson_get_num(yyjson_arr_get(max, 1)) &&
+              yyjson_get_num(yyjson_arr_get(min, 2)) < yyjson_get_num(yyjson_arr_get(max, 2))))
+        {
+            return validation_error(ctx, preview_path, "scene editor placement box preview bounds require min < max");
+        }
+    }
+    return true;
+}
+
 static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
                                           validation_names *names)
 {
@@ -11451,6 +11540,11 @@ static bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *s
         if (!validate_scene_editor_outputs(ctx, obj_get(selection, "hover_outputs"), hover_outputs_path))
             return false;
     }
+
+    char placement_path[PATH_BUFFER_SIZE];
+    format_path(placement_path, sizeof(placement_path), "%s.editor.placement", json_path);
+    if (!validate_scene_editor_placement(ctx, obj_get(editor, "placement"), placement_path, names))
+        return false;
 
     yyjson_val *overlay = obj_get(editor, "debug_overlay");
     if (overlay != NULL)

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2755,6 +2755,7 @@ typedef struct editor_world_bounds_context
 } editor_world_bounds_context;
 
 static bool editor_command_preview_active_for_scene(const slayer3d_game_data_runtime *runtime);
+static bool editor_placement_preview_active_for_scene(const slayer3d_game_data_runtime *runtime);
 
 static bool emit_editor_debug_world_bounds(void *userdata, const slayer3d_game_data_world_model_instance *instance)
 {
@@ -2903,6 +2904,23 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
         context.world_name = preview->world_name;
         context.element_name = preview->element_name;
         context.face_index = preview->face_index;
+        if (!emit_editor_debug_bounds(&context, preview->bounds))
+            return true;
+    }
+
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW) != 0u &&
+        editor_placement_preview_active_for_scene(runtime) && runtime->editor_placement_preview.has_bounds)
+    {
+        const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+        editor_debug_iteration_context context;
+        SDL_zero(context);
+        context.callback = callback;
+        context.userdata = userdata;
+        context.color = editor_debug_color_or_default(desc->command_preview_color, (slayer3d_color){80, 255, 255, 220});
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE;
+        context.world_name = preview->world_name;
+        context.element_name = preview->mode;
+        context.face_index = -1;
         if (!emit_editor_debug_bounds(&context, preview->bounds))
             return true;
     }
@@ -3197,6 +3215,13 @@ static void clear_editor_command_preview(slayer3d_game_data_runtime *runtime)
     runtime->editor_command_preview.face_index = -1;
 }
 
+static void clear_editor_placement_preview(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    SDL_zero(runtime->editor_placement_preview);
+}
+
 static void clear_editor_active_selection(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
@@ -3204,6 +3229,7 @@ static void clear_editor_active_selection(slayer3d_game_data_runtime *runtime)
     init_editor_selection(&runtime->editor_active_selection);
     runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
     clear_editor_command_preview(runtime);
+    clear_editor_placement_preview(runtime);
 }
 
 static bool editor_selection_select_requested(const slayer3d_game_data_runtime *runtime, yyjson_val *selection)
@@ -3223,6 +3249,15 @@ static bool editor_command_preview_active_for_scene(const slayer3d_game_data_run
     const char *active_scene = slayer3d_game_data_active_scene(runtime);
     return active_scene != NULL && runtime->editor_command_preview.scene != NULL &&
            SDL_strcmp(runtime->editor_command_preview.scene, active_scene) == 0;
+}
+
+static bool editor_placement_preview_active_for_scene(const slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || !runtime->editor_placement_preview.active)
+        return false;
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    return active_scene != NULL && runtime->editor_placement_preview.scene != NULL &&
+           SDL_strcmp(runtime->editor_placement_preview.scene, active_scene) == 0;
 }
 
 static bool editor_command_name_valid(const char *command)
@@ -3741,6 +3776,126 @@ static void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson
                            selection->hit ? selection->normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
 }
 
+static yyjson_val *find_editor_placement_preview_json(yyjson_val *placement, const char *mode)
+{
+    yyjson_val *previews = obj_get(placement, "previews");
+    for (size_t i = 0; yyjson_is_arr(previews) && i < yyjson_arr_size(previews); ++i)
+    {
+        yyjson_val *preview = yyjson_arr_get(previews, i);
+        if (SDL_strcmp(json_string(preview, "mode", ""), mode != NULL ? mode : "") == 0)
+            return preview;
+    }
+    return NULL;
+}
+
+static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,
+                                             yyjson_val *preview_json, const editor_placement_preview_state *preview,
+                                             const char *message)
+{
+    if (runtime == NULL || outputs == NULL)
+        return;
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "active_key", valid);
+    editor_set_bool_output(scene_state, outputs, "valid_key", valid);
+    editor_set_string_output(scene_state, outputs, "mode_key", valid && preview != NULL ? preview->mode : "");
+    editor_set_string_output(scene_state, outputs, "kind_key", valid && preview != NULL ? preview->kind : "");
+    editor_set_string_output(scene_state, outputs, "world_key", valid && preview != NULL ? preview->world_name : "");
+    editor_set_string_output(scene_state, outputs, "material_key",
+                             valid && preview != NULL ? preview->material_name : "");
+    editor_set_string_output(scene_state, outputs, "message_key", message != NULL ? message : "");
+    editor_set_vec3_output(scene_state, outputs, "anchor_key",
+                           valid && preview != NULL ? preview->anchor : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_float_output(scene_state, outputs, "snap_key", valid && preview != NULL ? preview->snap : 0.0f);
+    editor_set_vec3_output(scene_state, outputs, "bounds_min_key",
+                           valid && preview != NULL && preview->has_bounds ? preview->bounds.min
+                                                                           : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    editor_set_vec3_output(scene_state, outputs, "bounds_max_key",
+                           valid && preview != NULL && preview->has_bounds ? preview->bounds.max
+                                                                           : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const char *last_action_key = json_string(preview_json, "last_action_key", NULL);
+    if (last_action_key != NULL && last_action_key[0] != '\0')
+        slayer3d_properties_set_string(scene_state, last_action_key, message != NULL ? message : "");
+}
+
+static float editor_placement_snap(slayer3d_game_data_runtime *runtime, yyjson_val *placement, yyjson_val *preview)
+{
+    const float authored_snap = json_float(preview, "snap", json_float(placement, "default_snap", 0.0f));
+    const char *snap_key = json_string(placement, "snap_key", NULL);
+    if (runtime != NULL && snap_key != NULL && snap_key[0] != '\0')
+        return slayer3d_properties_get_float(slayer3d_game_data_scene_state(runtime), snap_key, authored_snap);
+    return authored_snap;
+}
+
+static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                             yyjson_val *preview, const slayer3d_game_data_editor_selection *selection,
+                                             float snap)
+{
+    (void)runtime;
+    (void)placement;
+    slayer3d_vec3 anchor = selection != NULL ? selection->point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    anchor = slayer3d_vec3_add(anchor, json_vec3(preview, "position_offset", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    if (snap > 0.0f)
+    {
+        anchor.x = SDL_roundf(anchor.x / snap) * snap;
+        anchor.y = SDL_roundf(anchor.y / snap) * snap;
+        anchor.z = SDL_roundf(anchor.z / snap) * snap;
+    }
+    return anchor;
+}
+
+static void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                                            const slayer3d_game_data_editor_selection *hover_selection)
+{
+    yyjson_val *placement = obj_get(editor, "placement");
+    if (runtime == NULL || !yyjson_is_obj(placement))
+    {
+        clear_editor_placement_preview(runtime);
+        return;
+    }
+
+    const char *tool_key = json_string(placement, "tool_key", "editor.tool.mode");
+    const char *mode = slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), tool_key,
+                                                      json_string(placement, "default_tool", "select"));
+    yyjson_val *preview_json = find_editor_placement_preview_json(placement, mode);
+    yyjson_val *outputs = obj_get(placement, "outputs");
+    if (preview_json == NULL || hover_selection == NULL || !hover_selection->hit)
+    {
+        clear_editor_placement_preview(runtime);
+        publish_editor_placement_preview(runtime, outputs, false, preview_json, NULL,
+                                         preview_json == NULL ? "" : "placement requires a hovered point");
+        return;
+    }
+
+    const float snap = editor_placement_snap(runtime, placement, preview_json);
+    const slayer3d_vec3 anchor = editor_placement_anchor(runtime, placement, preview_json, hover_selection, snap);
+    editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+    SDL_zero(*preview);
+    preview->active = true;
+    preview->scene = slayer3d_game_data_active_scene(runtime);
+    preview->mode = json_string(preview_json, "mode", mode);
+    preview->kind = json_string(preview_json, "kind", "box");
+    preview->world_name = json_string(preview_json, "world", hover_selection->world_name);
+    preview->material_name = json_string(preview_json, "material", hover_selection->material_name);
+    preview->anchor = anchor;
+    preview->snap = snap;
+    preview->has_bounds = true;
+    if (SDL_strcmp(preview->kind, "player_start") == 0)
+    {
+        const slayer3d_vec3 size = json_vec3(preview_json, "size", slayer3d_vec3_make(0.5f, 1.8f, 0.5f));
+        preview->bounds.min = slayer3d_vec3_make(anchor.x - size.x * 0.5f, anchor.y, anchor.z - size.z * 0.5f);
+        preview->bounds.max = slayer3d_vec3_make(anchor.x + size.x * 0.5f, anchor.y + size.y, anchor.z + size.z * 0.5f);
+    }
+    else
+    {
+        preview->bounds.min =
+            slayer3d_vec3_add(anchor, json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
+        preview->bounds.max =
+            slayer3d_vec3_add(anchor, json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
+    }
+    publish_editor_placement_preview(runtime, outputs, true, preview_json, preview,
+                                     json_string(preview_json, "message", "placement preview"));
+}
+
 bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
@@ -3769,11 +3924,13 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     {
         runtime->editor_active_selection = hover_selection;
         runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+        update_editor_placement_preview(runtime, editor, &hover_selection);
         publish_editor_selection(runtime, outputs, &hover_selection);
         return true;
     }
 
     publish_editor_selection(runtime, obj_get(selection_json, "hover_outputs"), &hover_selection);
+    update_editor_placement_preview(runtime, editor, &hover_selection);
     if (editor_selection_select_requested(runtime, selection_json))
     {
         if (hover_selection.hit)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8771,6 +8771,40 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
                                                   grid_error, sizeof(grid_error)));
     EXPECT_NE(std::string(grid_error).find("work_plane_grid_spacing must be positive"), std::string::npos)
         << grid_error;
+
+    write_text(dir / "bad_placement.game.json", R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Scene Editor Placement" },
+  "world": {
+    "name": "world.bad_scene_editor_placement",
+    "kind": "3d",
+    "cameras": [
+      { "name": "camera.valid", "type": "perspective", "position": [0, 0, 5], "target": [0, 0, 0], "up": [0, 1, 0] }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json", R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.valid",
+  "editor": {
+    "selection": {
+      "trace": { "source": "camera_screen", "camera": "camera.valid" },
+      "outputs": { "hit_key": "editor.hit" }
+    },
+    "placement": {
+      "previews": [
+        { "mode": "floor", "kind": "capsule" }
+      ]
+    }
+  }
+})json");
+    char placement_error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_placement.game.json").string().c_str(), nullptr,
+                                                  placement_error, sizeof(placement_error)));
+    EXPECT_NE(std::string(placement_error).find("preview kind must be box or player_start"), std::string::npos)
+        << placement_error;
     remove_test_dir(dir);
 }
 
@@ -14195,6 +14229,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_input_process_event(input, &click);
     slayer3d_input_update(input, 1);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    SDL_Event release{};
+    release.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    release.button.button = SDL_BUTTON_LEFT;
+    release.button.x = click.button.x;
+    release.button.y = click.button.y;
+    slayer3d_input_process_event(input, &release);
+    slayer3d_input_update(input, 2);
     slayer3d_game_data_editor_selection placement_selection{};
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &placement_selection));
     ASSERT_TRUE(placement_selection.hit);
@@ -14212,6 +14253,39 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, floor_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "floor prefab selected");
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
+                 "mat.editor.floor");
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
+    const slayer3d_value *placement_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *placement_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(placement_min, nullptr);
+    ASSERT_NE(placement_max, nullptr);
+    ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(placement_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 3.0f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y - 0.2f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 3.0f, 0.001f);
+    struct PlacementPreviewDebug
+    {
+        int edges = 0;
+    } placement_debug;
+    auto count_placement_preview = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) {
+        auto *debug = static_cast<PlacementPreviewDebug *>(userdata);
+        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE &&
+            primitive->element_name != nullptr && std::string(primitive->element_name) == "floor")
+        {
+            debug->edges++;
+        }
+        return true;
+    };
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_placement_preview, &placement_debug));
+    EXPECT_EQ(placement_debug.edges, 12);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
@@ -14260,6 +14334,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
 
     slayer3d_signal_emit(bus, player_start_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "player_start");
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.kind", ""), "player_start");
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.name", ""),


### PR DESCRIPTION
## Summary
- add data-authored editor placement previews for floor, wall, ceiling, and player-start tools
- render placement previews through the existing editor command-preview debug overlay
- publish preview state to scene state and document the new editor.placement schema

## Verification
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RejectsInvalidSceneEditorTooling:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools'
- ./build/debug/tests/slayer3d_game_data_test