### PR TITLE
Improve editor placement ergonomics

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -14,7 +14,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
   `4` player start, then click a brush face or the ground work plane and press
   `Enter` to place the selected prefab at that point
 - live snapped placement previews for floor, wall, ceiling, and player-start
-  tools using the same renderer-agnostic editor debug primitive path
+  tools using the same renderer-agnostic editor debug primitive path; `[`/`]`
+  change snap size and `R` toggles wall orientation between grid axes
 - unified editable-level save/export: `S` saves and publishes one fragment
   containing the brush world and player starts
 - test-run handoff manifest: `T` publishes and saves runner arguments for the

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -77,6 +77,18 @@
             "bindings": [{ "device": "keyboard", "key": "4" }]
           },
           {
+            "name": "action.editor.snap.finer",
+            "bindings": [{ "device": "keyboard", "key": "LEFTBRACKET" }]
+          },
+          {
+            "name": "action.editor.snap.coarser",
+            "bindings": [{ "device": "keyboard", "key": "RIGHTBRACKET" }]
+          },
+          {
+            "name": "action.editor.wall_axis.toggle",
+            "bindings": [{ "device": "keyboard", "key": "R" }]
+          },
+          {
             "name": "action.editor.camera.forward",
             "bindings": [{ "device": "keyboard", "key": "UP" }]
           },
@@ -144,6 +156,9 @@
     "signal.editor.tool.wall",
     "signal.editor.tool.ceiling",
     "signal.editor.tool.player_start",
+    "signal.editor.snap.finer",
+    "signal.editor.snap.coarser",
+    "signal.editor.wall_axis.toggle",
     "signal.editor.export",
     "signal.editor.test_run.prepare"
   ],
@@ -213,6 +228,21 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.tool.player_start",
         "on_pressed": "signal.editor.tool.player_start"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.snap.finer",
+        "on_pressed": "signal.editor.snap.finer"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.snap.coarser",
+        "on_pressed": "signal.editor.snap.coarser"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.wall_axis.toggle",
+        "on_pressed": "signal.editor.wall_axis.toggle"
       }
     ],
     "bindings": [
@@ -253,6 +283,44 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.tool.mode", "value": "player_start" },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start tool selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.snap.finer",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "editor.placement.snap",
+            "default": 0.5,
+            "direction": -1,
+            "values": [0.25, 0.5, 1.0, 2.0]
+          },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "placement snap decreased" }
+        ]
+      },
+      {
+        "signal": "signal.editor.snap.coarser",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "editor.placement.snap",
+            "default": 0.5,
+            "direction": 1,
+            "values": [0.25, 0.5, 1.0, 2.0]
+          },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "placement snap increased" }
+        ]
+      },
+      {
+        "signal": "signal.editor.wall_axis.toggle",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "editor.placement.wall_axis",
+            "default": "z",
+            "values": ["z", "x"]
+          },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "wall axis toggled" }
         ]
       },
       {
@@ -349,13 +417,8 @@
             "then": [
               {
                 "type": "editor.brush_world.create_box",
-                "world": "brush.editor_shell.target",
-                "material": "mat.editor.floor",
-                "position_from": "selection_point",
-                "position_offset": [0.0, 0.0, 0.0],
-                "snap": 0.5,
-                "min": [-3.0, -0.2, -3.0],
-                "max": [3.0, 0.0, 3.0],
+                "position_from": "placement_preview",
+                "preview_mode": "floor",
                 "message": "floor prefab created",
                 "outputs": {
                   "valid_key": "editor.create.valid",
@@ -379,13 +442,8 @@
                 "then": [
                   {
                     "type": "editor.brush_world.create_box",
-                    "world": "brush.editor_shell.target",
-                    "material": "mat.editor.wall",
-                    "position_from": "selection_point",
-                    "position_offset": [0.0, 0.0, 0.0],
-                    "snap": 0.5,
-                    "min": [-0.125, 0.0, -3.0],
-                    "max": [0.125, 2.5, 3.0],
+                    "position_from": "placement_preview",
+                    "preview_mode": "wall",
                     "message": "wall prefab created",
                     "outputs": {
                       "valid_key": "editor.create.valid",
@@ -409,13 +467,8 @@
                     "then": [
                       {
                         "type": "editor.brush_world.create_box",
-                        "world": "brush.editor_shell.target",
-                        "material": "mat.editor.ceiling",
-                        "position_from": "selection_point",
-                        "position_offset": [0.0, 0.0, 0.0],
-                        "snap": 0.5,
-                        "min": [-3.0, 2.5, -3.0],
-                        "max": [3.0, 2.7, 3.0],
+                        "position_from": "placement_preview",
+                        "preview_mode": "ceiling",
                         "message": "ceiling prefab created",
                         "outputs": {
                           "valid_key": "editor.create.valid",
@@ -451,7 +504,8 @@
                             "name": "player_start.editor_shell",
                             "scene": "scene.editor_shell.test_run",
                             "target": "entity.editor_shell.player",
-                            "position_from": "selection_point",
+                            "position_from": "placement_preview",
+                            "preview_mode": "player_start",
                             "yaw": 3.14159,
                             "pitch": 0.0,
                             "outputs": {

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -10,7 +10,9 @@
       "key": "editor.save.path",
       "value": "demos/editor_shell_dojo/data/generated/editable_level.fragment.json"
     },
-    { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" }
+    { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" },
+    { "type": "scene_state.set", "key": "editor.placement.snap", "value": 0.5 },
+    { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
   ],
   "input": {
     "actions": [
@@ -28,6 +30,9 @@
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
       "action.editor.tool.player_start",
+      "action.editor.snap.finer",
+      "action.editor.snap.coarser",
+      "action.editor.wall_axis.toggle",
       "action.editor.camera.forward",
       "action.editor.camera.back",
       "action.editor.camera.left",
@@ -94,6 +99,7 @@
         "valid_key": "editor.placement_preview.valid",
         "mode_key": "editor.placement_preview.mode",
         "kind_key": "editor.placement_preview.kind",
+        "axis_key": "editor.placement_preview.axis",
         "world_key": "editor.placement_preview.world",
         "material_key": "editor.placement_preview.material",
         "message_key": "editor.placement_preview.message",
@@ -118,6 +124,8 @@
           "kind": "box",
           "world": "brush.editor_shell.target",
           "material": "mat.editor.wall",
+          "axis_key": "editor.placement.wall_axis",
+          "axis": "z",
           "snap": 0.5,
           "min": [-0.125, 0.0, -3.0],
           "max": [0.125, 2.5, 3.0],
@@ -256,6 +264,10 @@
             "binding": { "type": "scene_state", "key": "editor.placement_preview.snap", "default": 0.5 }
           },
           {
+            "label": "Axis",
+            "binding": { "type": "scene_state", "key": "editor.placement_preview.axis", "default": "none" }
+          },
+          {
             "label": "Txn",
             "binding": { "type": "scene_state", "key": "editor.transaction.message", "default": "none" }
           }
@@ -276,7 +288,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. Enter commit. S save.",
+        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. [/] snap, R axis. Enter commit. S save.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -811,10 +811,13 @@ rounds the anchor to a grid size in world units before applying the offsets.
 
 Scenes can also author `editor.placement` to show a live placement preview while
 the mouse hovers over a brush or work plane. `tool_key` names the scene-state
-property that selects the active tool. Each preview entry maps a tool `mode` to
-either a `box` ghost or a `player_start` marker. The preview reuses the editor
-debug overlay's `command_preview` flag and color, so editor hosts do not need a
-second rendering path.
+property that selects the active tool. `snap_key` can point at a runtime
+scene-state float so UI or keyboard shortcuts can change grid size without
+reloading data. Each preview entry maps a tool `mode` to either a `box` ghost or
+a `player_start` marker. Box previews can use `axis_key` with `axis` `x` or `z`
+to rotate wall-like prefabs between horizontal grid axes. The preview reuses
+the editor debug overlay's `command_preview` flag and color, so editor hosts do
+not need a second rendering path.
 
 ```json
 {
@@ -840,6 +843,16 @@ second rendering path.
           "snap": 0.5
         },
         {
+          "mode": "wall",
+          "kind": "box",
+          "world": "brush.level.blockout",
+          "material": "mat.stone_wall",
+          "axis_key": "editor.wall_axis",
+          "axis": "z",
+          "min": [-0.125, 0.0, -3.0],
+          "max": [0.125, 2.5, 3.0]
+        },
+        {
           "mode": "player_start",
           "kind": "player_start",
           "size": [0.5, 1.8, 0.5]
@@ -849,6 +862,12 @@ second rendering path.
   }
 }
 ```
+
+`editor.brush_world.create_box` and `editor.player_start.place` may use
+`"position_from": "placement_preview"` to commit exactly the active preview.
+Set `preview_mode` on the action to fail closed if the active preview belongs
+to a different tool. This keeps authored preview geometry and committed
+geometry in one place.
 
 Use `editor.player_start.place` to create or update one runtime player start.
 The action can be bound to editor tools that place a marker at a clicked point,
@@ -2480,7 +2499,8 @@ instances, and conditions can read:
 ```
 
 Use `set` for fixed values, `toggle` for booleans, and `cycle` for small
-ordered sets such as render profiles or debug variants.
+ordered sets such as render profiles or debug variants. `cycle` accepts an
+optional non-zero integer `direction`; use `-1` for previous-value shortcuts.
 
 UI text bindings can read scene state with an optional scalar `default`, which
 keeps HUD text renderable before the first action writes a transient value:

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -350,13 +350,18 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         slayer3d_value fallback;
         if (current == NULL && json_scalar_to_value(obj_get(action, "default"), &fallback))
             current = &fallback;
+        const int direction = json_int(action, "direction", 1);
         size_t next = 0U;
         for (size_t i = 0; i < count; ++i)
         {
             yyjson_val *value = yyjson_arr_get(values, i);
             if (json_value_matches_property(value, current))
             {
-                next = (i + 1U) % count;
+                const int signed_count = (int)count;
+                int signed_next = ((int)i + direction) % signed_count;
+                if (signed_next < 0)
+                    signed_next += signed_count;
+                next = (size_t)signed_next;
                 break;
             }
         }

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -170,6 +170,7 @@ typedef struct editor_placement_preview_state
     const char *scene;
     const char *mode;
     const char *kind;
+    const char *axis;
     const char *world_name;
     const char *material_name;
     slayer3d_vec3 anchor;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8517,6 +8517,9 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (default_value != NULL &&
             !(yyjson_is_bool(default_value) || yyjson_is_num(default_value) || yyjson_is_str(default_value)))
             return validation_error(ctx, json_path, "scene_state.cycle default must be scalar");
+        yyjson_val *direction = obj_get(action, "direction");
+        if (direction != NULL && (!yyjson_is_int(direction) || yyjson_get_int(direction) == 0))
+            return validation_error(ctx, json_path, "scene_state.cycle direction must be a non-zero integer");
         return true;
     }
     if (SDL_strcmp(type, "editor.selection.clear") == 0)
@@ -8819,36 +8822,46 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     }
     if (SDL_strcmp(type, "editor.brush_world.create_box") == 0)
     {
-        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+        const char *position_from = json_string(action, "position_from");
+        const bool from_preview = position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0;
+        if (!from_preview &&
+            !require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
             return false;
-        if (!is_non_empty_string(action, "material"))
+        if (!from_preview && !is_non_empty_string(action, "material"))
             return validation_error(ctx, json_path, "editor.brush_world.create_box requires a non-empty material");
         yyjson_val *name = obj_get(action, "name");
         if (name != NULL && (!yyjson_is_str(name) || yyjson_get_str(name)[0] == '\0'))
             return validation_error(ctx, json_path,
                                     "editor.brush_world.create_box name must be non-empty when present");
+        yyjson_val *preview_mode = obj_get(action, "preview_mode");
+        if (preview_mode != NULL && (!yyjson_is_str(preview_mode) || yyjson_get_str(preview_mode)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.brush_world.create_box preview_mode must be non-empty");
         yyjson_val *min = obj_get(action, "min");
         yyjson_val *max = obj_get(action, "max");
-        if (!is_exact_vec_array(min, 3) || !is_exact_vec_array(max, 3))
+        if (!from_preview && (!is_exact_vec_array(min, 3) || !is_exact_vec_array(max, 3)))
             return validation_error(ctx, json_path, "editor.brush_world.create_box requires min and max vec3 values");
-        const char *position_from = json_string(action, "position_from");
-        if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0)
+        if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0 &&
+            SDL_strcmp(position_from, "placement_preview") != 0)
             return validation_error(ctx, json_path,
-                                    "editor.brush_world.create_box position_from must be selection_point");
+                                    "editor.brush_world.create_box position_from must be selection_point or "
+                                    "placement_preview");
         yyjson_val *position_offset = obj_get(action, "position_offset");
         if (position_offset != NULL && !is_exact_vec_array(position_offset, 3))
             return validation_error(ctx, json_path, "editor.brush_world.create_box position_offset must be a vec3");
         yyjson_val *snap = obj_get(action, "snap");
         if (snap != NULL && (!yyjson_is_num(snap) || yyjson_get_num(snap) <= 0.0))
             return validation_error(ctx, json_path, "editor.brush_world.create_box snap must be a positive number");
-        const double min_x = yyjson_get_num(yyjson_arr_get(min, 0));
-        const double min_y = yyjson_get_num(yyjson_arr_get(min, 1));
-        const double min_z = yyjson_get_num(yyjson_arr_get(min, 2));
-        const double max_x = yyjson_get_num(yyjson_arr_get(max, 0));
-        const double max_y = yyjson_get_num(yyjson_arr_get(max, 1));
-        const double max_z = yyjson_get_num(yyjson_arr_get(max, 2));
-        if (!(min_x < max_x && min_y < max_y && min_z < max_z))
-            return validation_error(ctx, json_path, "editor.brush_world.create_box bounds require min < max");
+        if (!from_preview)
+        {
+            const double min_x = yyjson_get_num(yyjson_arr_get(min, 0));
+            const double min_y = yyjson_get_num(yyjson_arr_get(min, 1));
+            const double min_z = yyjson_get_num(yyjson_arr_get(min, 2));
+            const double max_x = yyjson_get_num(yyjson_arr_get(max, 0));
+            const double max_y = yyjson_get_num(yyjson_arr_get(max, 1));
+            const double max_z = yyjson_get_num(yyjson_arr_get(max, 2));
+            if (!(min_x < max_x && min_y < max_y && min_z < max_z))
+                return validation_error(ctx, json_path, "editor.brush_world.create_box bounds require min < max");
+        }
         yyjson_val *outputs = obj_get(action, "outputs");
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "editor.brush_world.create_box outputs must be an object");
@@ -8881,8 +8894,14 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (position != NULL && position_from != NULL)
             return validation_error(ctx, json_path,
                                     "editor.player_start.place requires position or position_from, not both");
-        if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0)
-            return validation_error(ctx, json_path, "editor.player_start.place position_from must be selection_point");
+        yyjson_val *preview_mode = obj_get(action, "preview_mode");
+        if (preview_mode != NULL && (!yyjson_is_str(preview_mode) || yyjson_get_str(preview_mode)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.player_start.place preview_mode must be non-empty");
+        if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0 &&
+            SDL_strcmp(position_from, "placement_preview") != 0)
+            return validation_error(ctx, json_path,
+                                    "editor.player_start.place position_from must be selection_point or "
+                                    "placement_preview");
         yyjson_val *yaw = obj_get(action, "yaw");
         yyjson_val *pitch = obj_get(action, "pitch");
         yyjson_val *apply_to_target = obj_get(action, "apply_to_target");
@@ -11441,9 +11460,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     yyjson_val *outputs = obj_get(placement, "outputs");
     if (outputs != NULL && !yyjson_is_obj(outputs))
         return validation_error(ctx, placement_path, "scene editor placement outputs must be an object");
-    static const char *const output_keys[] = {"active_key", "valid_key",      "mode_key",      "kind_key",
-                                              "world_key",  "material_key",   "message_key",   "anchor_key",
-                                              "snap_key",   "bounds_min_key", "bounds_max_key"};
+    static const char *const output_keys[] = {"active_key", "valid_key", "mode_key",       "kind_key",
+                                              "axis_key",   "world_key", "material_key",   "message_key",
+                                              "anchor_key", "snap_key",  "bounds_min_key", "bounds_max_key"};
     for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
     {
         yyjson_val *output = obj_get(outputs, output_keys[i]);
@@ -11470,6 +11489,12 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0)
             return validation_error(ctx, preview_path,
                                     "scene editor placement preview kind must be box or player_start");
+        yyjson_val *axis_key = obj_get(preview, "axis_key");
+        if (axis_key != NULL && (!yyjson_is_str(axis_key) || yyjson_get_str(axis_key)[0] == '\0'))
+            return validation_error(ctx, preview_path, "scene editor placement preview axis_key must be non-empty");
+        const char *axis = json_string(preview, "axis");
+        if (axis != NULL && SDL_strcmp(axis, "x") != 0 && SDL_strcmp(axis, "z") != 0)
+            return validation_error(ctx, preview_path, "scene editor placement preview axis must be x or z");
         yyjson_val *offset = obj_get(preview, "position_offset");
         if (offset != NULL && !is_exact_vec_array(offset, 3))
             return validation_error(ctx, preview_path, "scene editor placement preview position_offset must be a vec3");

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -3672,7 +3672,30 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
     char error[256];
     error[0] = '\0';
     const char *position_from = json_string(action, "position_from", NULL);
-    if (position_from != NULL && SDL_strcmp(position_from, "selection_point") == 0)
+    if (position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0)
+    {
+        if (!editor_placement_preview_active_for_scene(runtime) || !runtime->editor_placement_preview.has_bounds)
+        {
+            set_error(error, (int)sizeof(error), "box brush placement requires an active placement preview");
+        }
+        else
+        {
+            const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+            const char *preview_mode = json_string(action, "preview_mode", NULL);
+            if (preview_mode != NULL && preview->mode != NULL && SDL_strcmp(preview_mode, preview->mode) != 0)
+            {
+                set_error(error, (int)sizeof(error), "box brush placement preview mode does not match action");
+            }
+            else
+            {
+                desc.world_name = json_string(action, "world", preview->world_name);
+                desc.material_name = json_string(action, "material", preview->material_name);
+                desc.min = preview->bounds.min;
+                desc.max = preview->bounds.max;
+            }
+        }
+    }
+    else if (position_from != NULL && SDL_strcmp(position_from, "selection_point") == 0)
     {
         slayer3d_game_data_editor_selection selection;
         SDL_zero(selection);
@@ -3727,6 +3750,27 @@ bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runt
     const char *position_from = json_string(action, "position_from", NULL);
     desc.has_position = position != NULL && position_from == NULL;
     desc.position = json_vec3(action, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    char error[256];
+    error[0] = '\0';
+    if (position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0)
+    {
+        if (!editor_placement_preview_active_for_scene(runtime))
+        {
+            set_error(error, (int)sizeof(error), "player start placement requires an active placement preview");
+        }
+        else
+        {
+            const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+            const char *preview_mode = json_string(action, "preview_mode", NULL);
+            if (preview_mode != NULL && preview->mode != NULL && SDL_strcmp(preview_mode, preview->mode) != 0)
+                set_error(error, (int)sizeof(error), "player start placement preview mode does not match action");
+            else
+            {
+                desc.has_position = true;
+                desc.position = preview->anchor;
+            }
+        }
+    }
     yyjson_val *yaw = obj_get(action, "yaw");
     yyjson_val *pitch = obj_get(action, "pitch");
     desc.has_yaw = yaw != NULL;
@@ -3735,9 +3779,8 @@ bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runt
     desc.pitch = json_float(action, "pitch", 0.0f);
     desc.apply_to_target = json_bool(action, "apply_to_target", true);
 
-    char error[256];
-    error[0] = '\0';
-    const bool ok = slayer3d_game_data_place_editor_player_start(runtime, &desc, error, (int)sizeof(error));
+    const bool ok =
+        error[0] == '\0' && slayer3d_game_data_place_editor_player_start(runtime, &desc, error, (int)sizeof(error));
     slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     editor_set_bool_output(scene_state, outputs, "valid_key", ok);
     editor_set_string_output(scene_state, outputs, "message_key",
@@ -3799,6 +3842,7 @@ static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime
     editor_set_bool_output(scene_state, outputs, "valid_key", valid);
     editor_set_string_output(scene_state, outputs, "mode_key", valid && preview != NULL ? preview->mode : "");
     editor_set_string_output(scene_state, outputs, "kind_key", valid && preview != NULL ? preview->kind : "");
+    editor_set_string_output(scene_state, outputs, "axis_key", valid && preview != NULL ? preview->axis : "");
     editor_set_string_output(scene_state, outputs, "world_key", valid && preview != NULL ? preview->world_name : "");
     editor_set_string_output(scene_state, outputs, "material_key",
                              valid && preview != NULL ? preview->material_name : "");
@@ -3824,6 +3868,34 @@ static float editor_placement_snap(slayer3d_game_data_runtime *runtime, yyjson_v
     if (runtime != NULL && snap_key != NULL && snap_key[0] != '\0')
         return slayer3d_properties_get_float(slayer3d_game_data_scene_state(runtime), snap_key, authored_snap);
     return authored_snap;
+}
+
+static const char *editor_placement_axis(slayer3d_game_data_runtime *runtime, yyjson_val *preview)
+{
+    const char *authored_axis = json_string(preview, "axis", "z");
+    const char *axis_key = json_string(preview, "axis_key", NULL);
+    if (runtime != NULL && axis_key != NULL && axis_key[0] != '\0')
+        return slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), axis_key, authored_axis);
+    return authored_axis;
+}
+
+static slayer3d_bounding_box editor_placement_oriented_box_bounds(yyjson_val *preview_json, slayer3d_vec3 anchor,
+                                                                  const char *axis)
+{
+    const slayer3d_vec3 source_min = json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const slayer3d_vec3 source_max = json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_bounding_box bounds;
+    if (axis != NULL && SDL_strcmp(axis, "x") == 0)
+    {
+        bounds.min = slayer3d_vec3_make(anchor.x + source_min.z, anchor.y + source_min.y, anchor.z + source_min.x);
+        bounds.max = slayer3d_vec3_make(anchor.x + source_max.z, anchor.y + source_max.y, anchor.z + source_max.x);
+    }
+    else
+    {
+        bounds.min = slayer3d_vec3_add(anchor, source_min);
+        bounds.max = slayer3d_vec3_add(anchor, source_max);
+    }
+    return bounds;
 }
 
 static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
@@ -3874,6 +3946,7 @@ static void update_editor_placement_preview(slayer3d_game_data_runtime *runtime,
     preview->scene = slayer3d_game_data_active_scene(runtime);
     preview->mode = json_string(preview_json, "mode", mode);
     preview->kind = json_string(preview_json, "kind", "box");
+    preview->axis = editor_placement_axis(runtime, preview_json);
     preview->world_name = json_string(preview_json, "world", hover_selection->world_name);
     preview->material_name = json_string(preview_json, "material", hover_selection->material_name);
     preview->anchor = anchor;
@@ -3887,10 +3960,7 @@ static void update_editor_placement_preview(slayer3d_game_data_runtime *runtime,
     }
     else
     {
-        preview->bounds.min =
-            slayer3d_vec3_add(anchor, json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
-        preview->bounds.max =
-            slayer3d_vec3_add(anchor, json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
+        preview->bounds = editor_placement_oriented_box_bounds(preview_json, anchor, preview->axis);
     }
     publish_editor_placement_preview(runtime, outputs, true, preview_json, preview,
                                      json_string(preview_json, "message", "placement preview"));

--- a/src/network.c
+++ b/src/network.c
@@ -3,6 +3,7 @@
 #include <SDL3/SDL_endian.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_log.h>
+#include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_stdinc.h>
 
 #if SLAYER3D_NETWORKING_ENABLED
@@ -45,7 +46,7 @@ typedef int NET_Status;
     do                                                                                                                 \
     {                                                                                                                  \
     } while (0)
-#define NET_CreateDatagramSocket(interface, port) ((NET_DatagramSocket *)NULL)
+#define NET_CreateDatagramSocket(interface, port, props) ((NET_DatagramSocket *)NULL)
 #define NET_DestroyDatagramSocket(socket)                                                                              \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -134,6 +135,29 @@ struct slayer3d_network_discovery_session
 
 #if SLAYER3D_NETWORKING_ENABLED
 static int slayer3d_network_library_refs = 0;
+
+static NET_DatagramSocket *slayer3d_network_create_datagram_socket(Uint16 port, bool allow_broadcast)
+{
+    SDL_PropertiesID props = 0;
+    NET_DatagramSocket *socket = NULL;
+    if (allow_broadcast)
+    {
+        props = SDL_CreateProperties();
+        if (props != 0 && SDL_SetBooleanProperty(props, NET_PROP_DATAGRAM_SOCKET_ALLOW_BROADCAST_BOOLEAN, true))
+        {
+            socket = NET_CreateDatagramSocket(NULL, port, props);
+            if (socket == NULL)
+            {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "SLAYER3D broadcast socket create failed, retrying without broadcast: %s", SDL_GetError());
+            }
+        }
+        if (props != 0)
+            SDL_DestroyProperties(props);
+    }
+
+    return socket != NULL ? socket : NET_CreateDatagramSocket(NULL, port, 0);
+}
 #endif
 
 #if SLAYER3D_NETWORKING_ENABLED
@@ -1105,7 +1129,7 @@ bool slayer3d_network_session_create(const slayer3d_network_session_desc *desc, 
     const Uint16 bound_port = effective->role == SLAYER3D_NETWORK_ROLE_HOST
                                   ? effective->port
                                   : (effective->local_port != 0 ? effective->local_port : 0);
-    session->socket = NET_CreateDatagramSocket(NULL, bound_port);
+    session->socket = slayer3d_network_create_datagram_socket(bound_port, false);
     if (session->socket == NULL)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D network socket create failed: %s", SDL_GetError());
@@ -1444,7 +1468,9 @@ bool slayer3d_network_discovery_session_create(const slayer3d_network_discovery_
     }
 
 #if SLAYER3D_NETWORKING_ENABLED
-    session->socket = NET_CreateDatagramSocket(NULL, effective->local_port != 0 ? effective->local_port : 0);
+    const bool allow_broadcast = effective->host == NULL || effective->host[0] == '\0';
+    session->socket = slayer3d_network_create_datagram_socket(effective->local_port != 0 ? effective->local_port : 0,
+                                                              allow_broadcast);
     if (session->socket == NULL)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D discovery socket create failed: %s", SDL_GetError());

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14194,6 +14194,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int wall_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.wall");
     const int ceiling_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.ceiling");
     const int player_start_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start");
+    const int snap_finer_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.snap.finer");
+    const int snap_coarser_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.snap.coarser");
+    const int wall_axis_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.wall_axis.toggle");
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
     const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
     const int test_run_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.test_run.prepare");
@@ -14201,6 +14204,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GE(wall_signal, 0);
     ASSERT_GE(ceiling_signal, 0);
     ASSERT_GE(player_start_signal, 0);
+    ASSERT_GE(snap_finer_signal, 0);
+    ASSERT_GE(snap_coarser_signal, 0);
+    ASSERT_GE(wall_axis_signal, 0);
     ASSERT_GE(commit_signal, 0);
     ASSERT_GE(export_signal, 0);
     ASSERT_GE(test_run_signal, 0);
@@ -14259,6 +14265,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
                  "mat.editor.floor");
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
+    slayer3d_signal_emit(bus, snap_coarser_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
+    slayer3d_signal_emit(bus, snap_finer_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
     const slayer3d_value *placement_min =
         slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
     const slayer3d_value *placement_max =
@@ -14302,6 +14314,19 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
+    slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "x");
+    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(placement_min, nullptr);
+    ASSERT_NE(placement_max, nullptr);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 3.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 3.0f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.125f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.125f, 0.001f);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
@@ -14311,12 +14336,15 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
     EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.wall");
-    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 0.125f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 0.125f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 3.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 3.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.z, placement_origin.z - 0.125f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 0.125f, 0.001f);
     EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 2.5f, 0.001f);
 
     slayer3d_signal_emit(bus, ceiling_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "ceiling");
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "ceiling prefab created");
@@ -14348,9 +14376,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_data_editor_player_start start{};
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
     EXPECT_STREQ(start.target, "entity.editor_shell.player");
-    EXPECT_NEAR(start.position.x, placement_selection.point.x, 0.001f);
-    EXPECT_NEAR(start.position.y, placement_selection.point.y, 0.001f);
-    EXPECT_NEAR(start.position.z, placement_selection.point.z, 0.001f);
+    EXPECT_NEAR(start.position.x, placement_origin.x, 0.001f);
+    EXPECT_NEAR(start.position.y, placement_origin.y, 0.001f);
+    EXPECT_NEAR(start.position.z, placement_origin.z, 0.001f);
     EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.dirty", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
@@ -14452,9 +14480,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(roundtrip_runtime, "player_start.editor_shell", &start));
     EXPECT_STREQ(start.scene, "scene.editor_shell.test_run");
     EXPECT_STREQ(start.target, "entity.editor_shell.player");
-    EXPECT_NEAR(start.position.x, placement_selection.point.x, 0.001f);
-    EXPECT_NEAR(start.position.y, placement_selection.point.y, 0.001f);
-    EXPECT_NEAR(start.position.z, placement_selection.point.z, 0.001f);
+    EXPECT_NEAR(start.position.x, placement_origin.x, 0.001f);
+    EXPECT_NEAR(start.position.y, placement_origin.y, 0.001f);
+    EXPECT_NEAR(start.position.z, placement_origin.z, 0.001f);
     EXPECT_NEAR(start.yaw, 3.14159f, 0.001f);
 
     slayer3d_game_data_destroy(roundtrip_runtime);


### PR DESCRIPTION
## Summary
- add authored snap-size and wall-axis controls to the editor shell dojo
- let box/player-start placement actions commit from the active placement preview, with preview-mode guards to avoid stale commits
- support placement preview axis output and x/z wall orientation, and document the new behavior

## Verification
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.RejectsInvalidSceneEditorTooling:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools'
- ./build/debug/tests/slayer3d_game_data_test