### PR TITLE
Add authored GL depth pre-pass

### DIFF
--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -89,6 +89,7 @@
   },
   "render": {
     "lighting": true,
+    "depth_prepass": true,
     "bloom": false,
     "ssao": false,
     "clear_color": [0.035, 0.04, 0.05]

--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -91,6 +91,7 @@
     "lighting": true,
     "depth_prepass": true,
     "depth_prepass_key": "debug.render.depth_prepass.enabled",
+    "performance_queries": true,
     "bloom": false,
     "ssao": false,
     "clear_color": [0.035, 0.04, 0.05]

--- a/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
+++ b/demos/brush_geometry_dojo/data/brush_geometry_dojo.game.json
@@ -90,6 +90,7 @@
   "render": {
     "lighting": true,
     "depth_prepass": true,
+    "depth_prepass_key": "debug.render.depth_prepass.enabled",
     "bloom": false,
     "ssao": false,
     "clear_color": [0.035, 0.04, 0.05]

--- a/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
+++ b/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
@@ -12,6 +12,7 @@
           { "name": "action.jump", "bindings": [{ "device": "keyboard", "key": "SPACE" }] },
           { "name": "action.use", "bindings": [{ "device": "keyboard", "key": "E" }] },
           { "name": "action.camera.security.toggle", "bindings": [{ "device": "keyboard", "key": "V" }] },
+          { "name": "action.render.depth_prepass.toggle", "bindings": [{ "device": "keyboard", "key": "N" }] },
           { "name": "action.gun_tune.toggle", "bindings": [{ "device": "keyboard", "key": "G" }] },
           { "name": "action.smoke_tune.toggle", "bindings": [{ "device": "keyboard", "key": "H" }] },
           { "name": "action.muzzle_tune.toggle", "bindings": [{ "device": "keyboard", "key": "M" }] },

--- a/demos/brush_geometry_dojo/data/fragments/logic/movement_mechanics.json
+++ b/demos/brush_geometry_dojo/data/fragments/logic/movement_mechanics.json
@@ -1,6 +1,6 @@
 {
   "schema": "slayer3d.fragment.v0",
-  "signals": ["signal.brush_geometry.camera.toggle"],
+  "signals": ["signal.brush_geometry.camera.toggle", "signal.brush_geometry.render.depth_prepass.toggle"],
   "logic": {
     "sensors": [
       {
@@ -8,6 +8,12 @@
         "type": "sensor.input_pressed",
         "action": "action.camera.security.toggle",
         "on_pressed": "signal.brush_geometry.camera.toggle"
+      },
+      {
+        "name": "sensor.brush_geometry.depth_prepass_toggle",
+        "type": "sensor.input_pressed",
+        "action": "action.render.depth_prepass.toggle",
+        "on_pressed": "signal.brush_geometry.render.depth_prepass.toggle"
       },
       {
         "name": "sensor.brush_geometry.conveyor.stay",
@@ -65,6 +71,16 @@
             "type": "camera.toggle",
             "camera": "camera.brush_geometry.security",
             "fallback": "camera.brush_geometry.player"
+          }
+        ]
+      },
+      {
+        "signal": "signal.brush_geometry.render.depth_prepass.toggle",
+        "actions": [
+          {
+            "type": "scene_state.toggle",
+            "key": "debug.render.depth_prepass.enabled",
+            "default": true
           }
         ]
       }

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -447,6 +447,21 @@
         "scale": 0.48
       },
       {
+        "name": "ui.brush_geometry.sample_perf",
+        "font": "font.brush_geometry.hud",
+        "format": "SAMPLES GEO %.0f Z %.0f",
+        "bindings": [
+          { "type": "metric", "metric": "render.geometry_samples_per_frame" },
+          { "type": "metric", "metric": "render.depth_prepass_samples_per_frame" }
+        ],
+        "x": 0.985,
+        "y": 0.200,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
         "name": "ui.brush_geometry.trigger_state",
         "font": "font.brush_geometry.hud",
         "format": "TRIGGER %d",

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -404,12 +404,43 @@
       {
         "name": "ui.brush_geometry.depth_prepass_state",
         "font": "font.brush_geometry.hud",
-        "format": "Z PREPASS %d",
+        "format": "N Z PREPASS %d",
         "bindings": [
           { "type": "scene_state", "key": "debug.render.depth_prepass.enabled", "default": true }
         ],
         "x": 0.985,
         "y": 0.116,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.brush_geometry.frame_perf",
+        "font": "font.brush_geometry.hud",
+        "format": "FRAME %.2fms CPU %.2f/%.2fms",
+        "bindings": [
+          { "type": "metric", "metric": "perf.frame_ms" },
+          { "type": "metric", "metric": "perf.update_cpu_ms" },
+          { "type": "metric", "metric": "perf.render_cpu_ms" }
+        ],
+        "x": 0.985,
+        "y": 0.144,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.brush_geometry.depth_prepass_perf",
+        "font": "font.brush_geometry.hud",
+        "format": "Z AVG %.1f TRI %.0f",
+        "bindings": [
+          { "type": "metric", "metric": "render.depth_prepass_draws_per_frame" },
+          { "type": "metric", "metric": "render.depth_prepass_triangles_per_frame" }
+        ],
+        "x": 0.985,
+        "y": 0.172,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -402,21 +402,6 @@
         "scale": 0.48
       },
       {
-        "name": "ui.brush_geometry.depth_prepass_diagnostics",
-        "font": "font.brush_geometry.hud",
-        "format": "Z PREPASS %llu / TRI %llu",
-        "bindings": [
-          { "type": "metric", "metric": "brush.render_depth_prepass_draws" },
-          { "type": "metric", "metric": "brush.render_depth_prepass_triangles" }
-        ],
-        "x": 0.985,
-        "y": 0.116,
-        "normalized": true,
-        "align": "right",
-        "color": [175, 220, 255, 220],
-        "scale": 0.48
-      },
-      {
         "name": "ui.brush_geometry.trigger_state",
         "font": "font.brush_geometry.hud",
         "format": "TRIGGER %d",

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -402,6 +402,21 @@
         "scale": 0.48
       },
       {
+        "name": "ui.brush_geometry.depth_prepass_diagnostics",
+        "font": "font.brush_geometry.hud",
+        "format": "Z PREPASS %llu / TRI %llu",
+        "bindings": [
+          { "type": "metric", "metric": "brush.render_depth_prepass_draws" },
+          { "type": "metric", "metric": "brush.render_depth_prepass_triangles" }
+        ],
+        "x": 0.985,
+        "y": 0.116,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
         "name": "ui.brush_geometry.trigger_state",
         "font": "font.brush_geometry.hud",
         "format": "TRIGGER %d",

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -191,7 +191,7 @@
       },
       {
         "name": "ui.brush_geometry.help",
-        "text": "WASD move  Mouse look  Space jump  E use  V camera  F/Mouse fire  Esc quit",
+        "text": "WASD move  Mouse look  Space jump  E use  V camera  N z-prepass  F/Mouse fire  Esc quit",
         "font": "font.brush_geometry.hud",
         "x": 0.02,
         "y": 0.075,
@@ -396,6 +396,20 @@
         ],
         "x": 0.985,
         "y": 0.091,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.brush_geometry.depth_prepass_state",
+        "font": "font.brush_geometry.hud",
+        "format": "Z PREPASS %d",
+        "bindings": [
+          { "type": "scene_state", "key": "debug.render.depth_prepass.enabled", "default": true }
+        ],
+        "x": 0.985,
+        "y": 0.116,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -2502,8 +2502,19 @@ keeps HUD text renderable before the first action writes a transient value:
 ```
 
 UI text can also bind engine metrics. `fps`, `frame`, and `paused` are always
-available. Brush-world diagnostics are exposed with `brush.*` metric names so
-debug overlays can inspect collision and render cost without game-specific C:
+available. Frame-performance metrics are sampled over
+`presentation.metrics.fps_sample_seconds`, the same data-authored window used by
+the FPS counter. They are intended for human-facing diagnostics and quick A/B
+checks, not deterministic assertions. Available performance metrics are
+`perf.frame_ms`, `perf.update_cpu_ms`, and `perf.render_cpu_ms`. The render CPU
+time covers the managed data-game draw path and intentionally excludes backend
+present/swap time. Renderer submission metrics are exposed as per-frame sampled
+averages: `render.model_mesh_submissions_per_frame`,
+`render.model_mesh_draws_per_frame`, `render.model_triangles_per_frame`,
+`render.depth_prepass_draws_per_frame`, and
+`render.depth_prepass_triangles_per_frame`. Brush-world diagnostics are exposed
+with `brush.*` metric names so debug overlays can inspect collision and render
+cost without game-specific C:
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -115,11 +115,13 @@ are drawn after this presentation pass so menus and HUD text remain readable. If
 profile. Optional `*_key` fields read scene-state values at draw time and
 override the authored defaults. This lets games author debug/profile toggles
 through sensors and logic actions while keeping the runner game-agnostic.
-`depth_prepass` enables an OpenGL opaque depth pre-pass for lit triangle meshes.
-This can reduce expensive fragment shading in dense brush/model scenes with
-overdraw, especially when many dynamic lights are active. It adds an extra
-position-only replay of eligible opaque geometry, so leave it disabled for very
-simple or CPU-bound scenes unless profiling shows a benefit.
+`depth_prepass` enables an OpenGL opaque depth pre-pass for eligible static lit
+triangle meshes. The data-game runtime currently opts brush-world meshes into
+this pass and excludes actors, viewmodels, particles, billboards, and immediate
+debug primitives. This can reduce expensive fragment shading in dense brush
+scenes with overdraw, especially when many dynamic lights are active. It adds an
+extra position-only replay of eligible opaque geometry, so leave it disabled for
+very simple or CPU-bound scenes unless profiling shows a benefit.
 
 ## Structured Imports
 
@@ -2515,26 +2517,13 @@ debug overlays can inspect collision and render cost without game-specific C:
 }
 ```
 
-Use a second text entry for depth-prepass counters when needed:
-
-```json
-{
-  "format": "Z PREPASS %llu / TRI %llu",
-  "bindings": [
-    { "type": "metric", "metric": "brush.render_depth_prepass_draws" },
-    { "type": "metric", "metric": "brush.render_depth_prepass_triangles" }
-  ]
-}
-```
-
 Supported brush metrics are `brush.trace_count`,
 `brush.world_instance_count`, `brush.world_bounds_reject_count`,
 `brush.brush_count`, `brush.contents_reject_count`,
 `brush.bounds_reject_count`, `brush.collision_candidate_count`,
 `brush.hit_count`, `brush.render_mesh_submissions`,
 `brush.render_mesh_culled`, `brush.render_mesh_draws`, and
-`brush.render_triangles_submitted`, `brush.render_depth_prepass_draws`, and
-`brush.render_depth_prepass_triangles`.
+`brush.render_triangles_submitted`.
 
 For editor-like tools and diagnostics, `ui.panels` and `ui.inspectors` provide
 reusable higher-level overlay widgets while still rendering through the normal

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -94,6 +94,8 @@ The root `render` object configures frame-level presentation defaults:
     "ssao": true,
     "depth_prepass": false,
     "depth_prepass_key": "render_depth_prepass_enabled",
+    "performance_queries": false,
+    "performance_queries_key": "render_performance_queries_enabled",
     "profile": "modern",
     "profile_key": "render_profile"
   }
@@ -122,6 +124,11 @@ debug primitives. This can reduce expensive fragment shading in dense brush
 scenes with overdraw, especially when many dynamic lights are active. It adds an
 extra position-only replay of eligible opaque geometry, so leave it disabled for
 very simple or CPU-bound scenes unless profiling shows a benefit.
+`performance_queries` enables optional backend sample-count queries for
+diagnostic overlays. Capable OpenGL backends expose depth-passing sample counts
+for the depth pre-pass and main geometry pass through UI metrics. These queries
+can block while reading GPU results, so use them for profiling and do not leave
+them enabled in production scenes by default.
 
 ## Structured Imports
 
@@ -2512,9 +2519,14 @@ present/swap time. Renderer submission metrics are exposed as per-frame sampled
 averages: `render.model_mesh_submissions_per_frame`,
 `render.model_mesh_draws_per_frame`, `render.model_triangles_per_frame`,
 `render.depth_prepass_draws_per_frame`, and
-`render.depth_prepass_triangles_per_frame`. Brush-world diagnostics are exposed
-with `brush.*` metric names so debug overlays can inspect collision and render
-cost without game-specific C:
+`render.depth_prepass_triangles_per_frame`. When `render.performance_queries`
+is enabled, capable backends also expose `render.geometry_samples_per_frame` and
+`render.depth_prepass_samples_per_frame`. These two metrics are useful for
+depth-prepass A/B checks: in high-overdraw scenes, toggling pre-pass on should
+lower main geometry depth-passing samples while adding a cheaper position-only
+pre-pass sample count. Brush-world diagnostics are exposed with `brush.*` metric
+names so debug overlays can inspect collision and render cost without
+game-specific C:
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -92,6 +92,8 @@ The root `render` object configures frame-level presentation defaults:
     "bloom": true,
     "bloom_key": "render_bloom_enabled",
     "ssao": true,
+    "depth_prepass": false,
+    "depth_prepass_key": "render_depth_prepass_enabled",
     "profile": "modern",
     "profile_key": "render_profile"
   }
@@ -113,6 +115,11 @@ are drawn after this presentation pass so menus and HUD text remain readable. If
 profile. Optional `*_key` fields read scene-state values at draw time and
 override the authored defaults. This lets games author debug/profile toggles
 through sensors and logic actions while keeping the runner game-agnostic.
+`depth_prepass` enables an OpenGL opaque depth pre-pass for lit triangle meshes.
+This can reduce expensive fragment shading in dense brush/model scenes with
+overdraw, especially when many dynamic lights are active. It adds an extra
+position-only replay of eligible opaque geometry, so leave it disabled for very
+simple or CPU-bound scenes unless profiling shows a benefit.
 
 ## Structured Imports
 
@@ -2508,13 +2515,26 @@ debug overlays can inspect collision and render cost without game-specific C:
 }
 ```
 
+Use a second text entry for depth-prepass counters when needed:
+
+```json
+{
+  "format": "Z PREPASS %llu / TRI %llu",
+  "bindings": [
+    { "type": "metric", "metric": "brush.render_depth_prepass_draws" },
+    { "type": "metric", "metric": "brush.render_depth_prepass_triangles" }
+  ]
+}
+```
+
 Supported brush metrics are `brush.trace_count`,
 `brush.world_instance_count`, `brush.world_bounds_reject_count`,
 `brush.brush_count`, `brush.contents_reject_count`,
 `brush.bounds_reject_count`, `brush.collision_candidate_count`,
 `brush.hit_count`, `brush.render_mesh_submissions`,
 `brush.render_mesh_culled`, `brush.render_mesh_draws`, and
-`brush.render_triangles_submitted`.
+`brush.render_triangles_submitted`, `brush.render_depth_prepass_draws`, and
+`brush.render_depth_prepass_triangles`.
 
 For editor-like tools and diagnostics, `ui.panels` and `ui.inspectors` provide
 reusable higher-level overlay widgets while still rendering through the normal

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -949,6 +949,10 @@ extern "C"
         float render_depth_prepass_draws_per_frame;
         /** @brief Sampled depth-prepass triangles per frame. */
         float render_depth_prepass_triangles_per_frame;
+        /** @brief Sampled depth-prepass depth-passing samples per frame when performance queries are enabled. */
+        float render_depth_prepass_samples_per_frame;
+        /** @brief Sampled main-geometry depth-passing samples per frame when performance queries are enabled. */
+        float render_geometry_samples_per_frame;
     } slayer3d_game_data_ui_metrics;
 
     /** @brief Optional render evaluation inputs for dynamic visual effects. */
@@ -1157,6 +1161,8 @@ extern "C"
         bool ssao_enabled;
         /** @brief Whether the GL backend should run an opaque depth pre-pass before lit geometry. */
         bool depth_prepass_enabled;
+        /** @brief Whether capable backends should collect GPU sample-count diagnostics. */
+        bool performance_queries_enabled;
         /** @brief Tonemap operator for lit rendering. */
         slayer3d_tonemap_mode tonemap;
     } slayer3d_game_data_render_settings;

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -611,6 +611,10 @@ extern "C"
         Uint64 render_mesh_draws;
         /** @brief Approximate brush-world triangles submitted after renderer culling. */
         Uint64 render_triangles_submitted;
+        /** @brief Opaque brush-world draw calls replayed during the depth pre-pass. */
+        Uint64 render_depth_prepass_draws;
+        /** @brief Approximate brush-world triangles replayed during the depth pre-pass. */
+        Uint64 render_depth_prepass_triangles;
     } slayer3d_game_data_brush_diagnostics;
 
     /** @brief Runtime world model implementation kind. */
@@ -1139,6 +1143,8 @@ extern "C"
         bool bloom_enabled;
         /** @brief Whether SSAO post-processing should be enabled. */
         bool ssao_enabled;
+        /** @brief Whether the GL backend should run an opaque depth pre-pass before lit geometry. */
+        bool depth_prepass_enabled;
         /** @brief Tonemap operator for lit rendering. */
         slayer3d_tonemap_mode tonemap;
     } slayer3d_game_data_render_settings;

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -933,6 +933,22 @@ extern "C"
         float fps;
         /** @brief Number of rendered frames. */
         Uint64 frame;
+        /** @brief Sampled wall-clock frame time in milliseconds. */
+        float frame_ms;
+        /** @brief Sampled managed data-game update CPU time in milliseconds. */
+        float update_cpu_ms;
+        /** @brief Sampled managed data-game render CPU time in milliseconds, excluding GPU present. */
+        float render_cpu_ms;
+        /** @brief Sampled renderer model meshes submitted per frame. */
+        float render_model_mesh_submissions_per_frame;
+        /** @brief Sampled renderer model meshes accepted per frame. */
+        float render_model_mesh_draws_per_frame;
+        /** @brief Sampled renderer triangles submitted per frame. */
+        float render_model_triangles_per_frame;
+        /** @brief Sampled depth-prepass draw calls per frame. */
+        float render_depth_prepass_draws_per_frame;
+        /** @brief Sampled depth-prepass triangles per frame. */
+        float render_depth_prepass_triangles_per_frame;
     } slayer3d_game_data_ui_metrics;
 
     /** @brief Optional render evaluation inputs for dynamic visual effects. */

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -611,10 +611,6 @@ extern "C"
         Uint64 render_mesh_draws;
         /** @brief Approximate brush-world triangles submitted after renderer culling. */
         Uint64 render_triangles_submitted;
-        /** @brief Opaque brush-world draw calls replayed during the depth pre-pass. */
-        Uint64 render_depth_prepass_draws;
-        /** @brief Approximate brush-world triangles replayed during the depth pre-pass. */
-        Uint64 render_depth_prepass_triangles;
     } slayer3d_game_data_brush_diagnostics;
 
     /** @brief Runtime world model implementation kind. */

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -267,8 +267,18 @@ extern "C"
         float last_render_time;                     /**< Last sampled real render time. */
         float fps_sample_time;                      /**< Accumulated FPS sample time. */
         float displayed_fps;                        /**< Most recently sampled FPS. */
+        float frame_ms_sample_sum;                  /**< Accumulated wall-clock frame milliseconds. */
+        float update_cpu_ms_sample_sum;             /**< Accumulated managed update CPU milliseconds. */
+        float render_cpu_ms_sample_sum;             /**< Accumulated managed render CPU milliseconds. */
+        float render_mesh_submissions_sample_sum;   /**< Accumulated render mesh submission deltas. */
+        float render_mesh_draws_sample_sum;         /**< Accumulated render mesh draw deltas. */
+        float render_triangles_sample_sum;          /**< Accumulated render triangle deltas. */
+        float depth_prepass_draws_sample_sum;       /**< Accumulated depth-prepass draw deltas. */
+        float depth_prepass_triangles_sample_sum;   /**< Accumulated depth-prepass triangle deltas. */
+        slayer3d_render_stats last_render_stats;    /**< Previous cumulative render stats sample. */
         int fps_sample_frames;                      /**< Frames accumulated in current FPS sample. */
         Uint64 rendered_frames;                     /**< Number of rendered frames. */
+        bool have_last_render_stats;                /**< True once last_render_stats has been initialized. */
         bool was_paused;                            /**< Pause state from the previous update. */
     } slayer3d_game_data_frame_state;
 
@@ -558,6 +568,22 @@ extern "C"
      * @brief Initialize reusable frame/update state.
      */
     void slayer3d_game_data_frame_state_init(slayer3d_game_data_frame_state *state);
+
+    /**
+     * @brief Record CPU time spent updating managed data-game systems.
+     *
+     * The value is accumulated into the same authored metrics sample window as
+     * FPS and exposed through `perf.update_cpu_ms` UI metric bindings.
+     */
+    void slayer3d_game_data_frame_state_record_update_cpu_time(slayer3d_game_data_frame_state *state, float seconds);
+
+    /**
+     * @brief Record CPU time spent drawing managed data-game systems.
+     *
+     * This excludes the backend present/swap. The sampled value is exposed
+     * through `perf.render_cpu_ms` UI metric bindings.
+     */
+    void slayer3d_game_data_frame_state_record_render_cpu_time(slayer3d_game_data_frame_state *state, float seconds);
 
     /**
      * @brief Advance authored app flow, update phases, presentation clocks, and simulation.

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -275,6 +275,8 @@ extern "C"
         float render_triangles_sample_sum;          /**< Accumulated render triangle deltas. */
         float depth_prepass_draws_sample_sum;       /**< Accumulated depth-prepass draw deltas. */
         float depth_prepass_triangles_sample_sum;   /**< Accumulated depth-prepass triangle deltas. */
+        float depth_prepass_samples_sample_sum;     /**< Accumulated depth-prepass sample-query deltas. */
+        float geometry_samples_sample_sum;          /**< Accumulated main geometry sample-query deltas. */
         slayer3d_render_stats last_render_stats;    /**< Previous cumulative render stats sample. */
         int fps_sample_frames;                      /**< Frames accumulated in current FPS sample. */
         Uint64 rendered_frames;                     /**< Number of rendered frames. */

--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -52,6 +52,10 @@ extern "C"
         Uint64 model_mesh_draws;
         /** @brief Approximate triangles submitted by accepted model meshes. */
         Uint64 model_triangles_submitted;
+        /** @brief Opaque draw calls replayed during the depth pre-pass. */
+        Uint64 depth_prepass_draws;
+        /** @brief Approximate triangles replayed during the depth pre-pass. */
+        Uint64 depth_prepass_triangles;
     } slayer3d_render_stats;
 
     /**
@@ -185,6 +189,16 @@ extern "C"
     int slayer3d_get_render_context_height(const slayer3d_render_context *context);
     bool slayer3d_get_render_stats(const slayer3d_render_context *context, slayer3d_render_stats *out_stats);
     void slayer3d_reset_render_stats(slayer3d_render_context *context);
+    /**
+     * @brief Enable or disable the opaque depth pre-pass for capable backends.
+     *
+     * The OpenGL backend replays eligible opaque lit triangle meshes with a
+     * position-only shader before the main geometry pass. This can reduce
+     * expensive fragment shading in high-overdraw scenes.
+     */
+    bool slayer3d_set_depth_prepass_enabled(slayer3d_render_context *context, bool enabled);
+    /** @brief Return whether the opaque depth pre-pass is enabled on this context. */
+    bool slayer3d_is_depth_prepass_enabled(const slayer3d_render_context *context);
     bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color);
     bool slayer3d_clear_render_context_rect(slayer3d_render_context *context, const SDL_Rect *rect,
                                             slayer3d_color color);

--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -56,6 +56,10 @@ extern "C"
         Uint64 depth_prepass_draws;
         /** @brief Approximate triangles replayed during the depth pre-pass. */
         Uint64 depth_prepass_triangles;
+        /** @brief Optional depth-prepass samples that passed the depth test. */
+        Uint64 depth_prepass_samples_passed;
+        /** @brief Optional main geometry samples that passed the depth test. */
+        Uint64 geometry_samples_passed;
     } slayer3d_render_stats;
 
     /**
@@ -199,6 +203,16 @@ extern "C"
     bool slayer3d_set_depth_prepass_enabled(slayer3d_render_context *context, bool enabled);
     /** @brief Return whether the opaque depth pre-pass is enabled on this context. */
     bool slayer3d_is_depth_prepass_enabled(const slayer3d_render_context *context);
+    /**
+     * @brief Enable optional render sample queries for performance diagnostics.
+     *
+     * Capable OpenGL backends count depth-passing samples for the depth pre-pass
+     * and main geometry pass. This can block on GPU results, so keep it for
+     * profiling/debug overlays rather than shipping gameplay defaults.
+     */
+    bool slayer3d_set_render_sample_queries_enabled(slayer3d_render_context *context, bool enabled);
+    /** @brief Return whether render sample queries are requested. */
+    bool slayer3d_render_sample_queries_enabled(const slayer3d_render_context *context);
     bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color);
     bool slayer3d_clear_render_context_rect(slayer3d_render_context *context, const SDL_Rect *rect,
                                             slayer3d_color color);

--- a/src/backend.h
+++ b/src/backend.h
@@ -82,6 +82,7 @@ typedef struct slayer3d_draw_params_lit
     bool vertex_snap;
     int vertex_snap_precision;
     int texture_filter;
+    bool depth_prepass_eligible;
     const float *shadow_depth_data; /* 512*512 floats, or NULL */
     const float *shadow_vp;         /* 16 floats (mat4), or NULL */
     float shadow_bias;

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -87,6 +87,14 @@ static Uint32 data_game_input_tick(const slayer3d_data_game_runtime *runtime)
     return snapshot != NULL ? (Uint32)SDL_max(snapshot->tick, 0) : (Uint32)SDL_GetTicks();
 }
 
+static float data_game_elapsed_seconds(Uint64 start_counter, Uint64 end_counter)
+{
+    const Uint64 frequency = SDL_GetPerformanceFrequency();
+    if (frequency == 0 || end_counter < start_counter)
+        return 0.0f;
+    return (float)((double)(end_counter - start_counter) / (double)frequency);
+}
+
 static void data_game_release_mouse_capture(slayer3d_data_game_runtime *runtime, slayer3d_game_context *ctx)
 {
     if (runtime == NULL || ctx == NULL || ctx->window == NULL || !runtime->mouse_capture_applied ||
@@ -1370,6 +1378,7 @@ static bool refresh_active_input_profile_if_available(slayer3d_data_game_runtime
 
 bool slayer3d_data_game_runtime_update_frame(slayer3d_data_game_runtime *runtime, slayer3d_game_context *ctx, float dt)
 {
+    const Uint64 start_counter = SDL_GetPerformanceCounter();
     if (runtime == NULL || runtime->data == NULL)
     {
         return false;
@@ -1390,6 +1399,8 @@ bool slayer3d_data_game_runtime_update_frame(slayer3d_data_game_runtime *runtime
 
     managed_network_update_after_frame(runtime, ctx);
     data_game_apply_scene_mouse_capture(runtime, ctx);
+    slayer3d_game_data_frame_state_record_update_cpu_time(
+        &runtime->frame_state, data_game_elapsed_seconds(start_counter, SDL_GetPerformanceCounter()));
     return true;
 }
 
@@ -1416,5 +1427,8 @@ void slayer3d_data_game_runtime_render(slayer3d_data_game_runtime *runtime, slay
     frame.metrics = &runtime->frame_state.metrics;
     frame.render_eval = &runtime->frame_state.render_eval;
     frame.pulse_phase = runtime->frame_state.ui_pulse_phase;
+    const Uint64 start_counter = SDL_GetPerformanceCounter();
     slayer3d_game_data_draw_frame(&frame);
+    slayer3d_game_data_frame_state_record_render_cpu_time(
+        &runtime->frame_state, data_game_elapsed_seconds(start_counter, SDL_GetPerformanceCounter()));
 }

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -928,6 +928,7 @@ static bool slayer3d_draw_mesh_internal(slayer3d_render_context *context, const 
         lp.vertex_snap_precision = context->vertex_snap_precision;
         lp.texture_filter = (int)context->texture_filter;
         lp.static_geometry = static_geometry && !skinned && !mesh->dynamic_geometry;
+        lp.depth_prepass_eligible = context->depth_prepass_scope_enabled && lp.static_geometry;
 
         if (lighting->shadow_enabled[0] && lighting->shadow_depth[0] != NULL)
         {

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -621,8 +621,9 @@ float slayer3d_game_data_fps_sample_seconds(const slayer3d_game_data_runtime *ru
 {
     if (runtime == NULL)
         return fallback;
-    return json_float(obj_get(obj_get(runtime_root(runtime), "presentation"), "metrics"), "fps_sample_seconds",
-                      fallback);
+    const float sample_seconds =
+        json_float(obj_get(obj_get(runtime_root(runtime), "presentation"), "metrics"), "fps_sample_seconds", fallback);
+    return sample_seconds > 0.0f ? sample_seconds : fallback;
 }
 
 typedef enum ui_value_type
@@ -691,6 +692,35 @@ static bool read_brush_diagnostic_metric(const slayer3d_game_data_runtime *runti
     return true;
 }
 
+static bool read_performance_metric(const char *metric, const slayer3d_game_data_ui_metrics *metrics,
+                                    ui_value *out_value)
+{
+    if (metric == NULL || out_value == NULL)
+        return false;
+
+    if (SDL_strcmp(metric, "perf.frame_ms") == 0)
+        out_value->as_float = metrics != NULL ? metrics->frame_ms : 0.0f;
+    else if (SDL_strcmp(metric, "perf.update_cpu_ms") == 0)
+        out_value->as_float = metrics != NULL ? metrics->update_cpu_ms : 0.0f;
+    else if (SDL_strcmp(metric, "perf.render_cpu_ms") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_cpu_ms : 0.0f;
+    else if (SDL_strcmp(metric, "render.model_mesh_submissions_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_model_mesh_submissions_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.model_mesh_draws_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_model_mesh_draws_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.model_triangles_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_model_triangles_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.depth_prepass_draws_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_depth_prepass_draws_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.depth_prepass_triangles_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_depth_prepass_triangles_per_frame : 0.0f;
+    else
+        return false;
+
+    out_value->type = UI_VALUE_FLOAT;
+    return true;
+}
+
 static bool read_ui_binding_value(const slayer3d_game_data_runtime *runtime, yyjson_val *binding,
                                   const slayer3d_game_data_ui_metrics *metrics, ui_value *out_value)
 {
@@ -721,6 +751,8 @@ static bool read_ui_binding_value(const slayer3d_game_data_runtime *runtime, yyj
             out_value->as_bool = metrics != NULL && metrics->paused;
             return true;
         }
+        if (read_performance_metric(metric, metrics, out_value))
+            return true;
         if (read_brush_diagnostic_metric(runtime, metric, out_value))
             return true;
         return false;
@@ -826,6 +858,11 @@ static bool format_bound_ui_text(const char *format, const ui_value *values, int
         SDL_snprintf(buffer, buffer_size, format, values[0].as_float, (unsigned long long)values[1].as_uint64);
         return true;
     }
+    if (value_count == 2 && values[0].type == UI_VALUE_FLOAT && values[1].type == UI_VALUE_FLOAT)
+    {
+        SDL_snprintf(buffer, buffer_size, format, values[0].as_float, values[1].as_float);
+        return true;
+    }
     if (value_count == 2 && values[0].type == UI_VALUE_UINT64 && values[1].type == UI_VALUE_UINT64)
     {
         SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64,
@@ -839,12 +876,25 @@ static bool format_bound_ui_text(const char *format, const ui_value *values, int
                      (unsigned long long)values[1].as_uint64, (unsigned long long)values[2].as_uint64);
         return true;
     }
+    if (value_count == 3 && values[0].type == UI_VALUE_FLOAT && values[1].type == UI_VALUE_FLOAT &&
+        values[2].type == UI_VALUE_FLOAT)
+    {
+        SDL_snprintf(buffer, buffer_size, format, values[0].as_float, values[1].as_float, values[2].as_float);
+        return true;
+    }
     if (value_count == 4 && values[0].type == UI_VALUE_UINT64 && values[1].type == UI_VALUE_UINT64 &&
         values[2].type == UI_VALUE_UINT64 && values[3].type == UI_VALUE_UINT64)
     {
         SDL_snprintf(buffer, buffer_size, format, (unsigned long long)values[0].as_uint64,
                      (unsigned long long)values[1].as_uint64, (unsigned long long)values[2].as_uint64,
                      (unsigned long long)values[3].as_uint64);
+        return true;
+    }
+    if (value_count == 4 && values[0].type == UI_VALUE_FLOAT && values[1].type == UI_VALUE_FLOAT &&
+        values[2].type == UI_VALUE_FLOAT && values[3].type == UI_VALUE_FLOAT)
+    {
+        SDL_snprintf(buffer, buffer_size, format, values[0].as_float, values[1].as_float, values[2].as_float,
+                     values[3].as_float);
         return true;
     }
     return false;

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -714,6 +714,10 @@ static bool read_performance_metric(const char *metric, const slayer3d_game_data
         out_value->as_float = metrics != NULL ? metrics->render_depth_prepass_draws_per_frame : 0.0f;
     else if (SDL_strcmp(metric, "render.depth_prepass_triangles_per_frame") == 0)
         out_value->as_float = metrics != NULL ? metrics->render_depth_prepass_triangles_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.depth_prepass_samples_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_depth_prepass_samples_per_frame : 0.0f;
+    else if (SDL_strcmp(metric, "render.geometry_samples_per_frame") == 0)
+        out_value->as_float = metrics != NULL ? metrics->render_geometry_samples_per_frame : 0.0f;
     else
         return false;
 

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -683,10 +683,6 @@ static bool read_brush_diagnostic_metric(const slayer3d_game_data_runtime *runti
         value = diagnostics.render_mesh_draws;
     else if (SDL_strcmp(name, "render_triangles_submitted") == 0)
         value = diagnostics.render_triangles_submitted;
-    else if (SDL_strcmp(name, "render_depth_prepass_draws") == 0)
-        value = diagnostics.render_depth_prepass_draws;
-    else if (SDL_strcmp(name, "render_depth_prepass_triangles") == 0)
-        value = diagnostics.render_depth_prepass_triangles;
     else
         return false;
 

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -683,6 +683,10 @@ static bool read_brush_diagnostic_metric(const slayer3d_game_data_runtime *runti
         value = diagnostics.render_mesh_draws;
     else if (SDL_strcmp(name, "render_triangles_submitted") == 0)
         value = diagnostics.render_triangles_submitted;
+    else if (SDL_strcmp(name, "render_depth_prepass_draws") == 0)
+        value = diagnostics.render_depth_prepass_draws;
+    else if (SDL_strcmp(name, "render_depth_prepass_triangles") == 0)
+        value = diagnostics.render_depth_prepass_triangles;
     else
         return false;
 

--- a/src/game_data_menu_ui.c
+++ b/src/game_data_menu_ui.c
@@ -1414,6 +1414,10 @@ static bool ui_tool_metric_to_string(const slayer3d_game_data_ui_metrics *metric
         SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_depth_prepass_draws_per_frame);
     else if (SDL_strcmp(metric, "render.depth_prepass_triangles_per_frame") == 0)
         SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_depth_prepass_triangles_per_frame);
+    else if (SDL_strcmp(metric, "render.depth_prepass_samples_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_depth_prepass_samples_per_frame);
+    else if (SDL_strcmp(metric, "render.geometry_samples_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_geometry_samples_per_frame);
     else
         return false;
     return true;

--- a/src/game_data_menu_ui.c
+++ b/src/game_data_menu_ui.c
@@ -1398,6 +1398,22 @@ static bool ui_tool_metric_to_string(const slayer3d_game_data_ui_metrics *metric
         SDL_snprintf(buffer, buffer_size, "%llu", (unsigned long long)metrics->frame);
     else if (SDL_strcmp(metric, "paused") == 0)
         SDL_snprintf(buffer, buffer_size, "%s", metrics->paused ? "true" : "false");
+    else if (SDL_strcmp(metric, "perf.frame_ms") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->frame_ms);
+    else if (SDL_strcmp(metric, "perf.update_cpu_ms") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->update_cpu_ms);
+    else if (SDL_strcmp(metric, "perf.render_cpu_ms") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_cpu_ms);
+    else if (SDL_strcmp(metric, "render.model_mesh_submissions_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_model_mesh_submissions_per_frame);
+    else if (SDL_strcmp(metric, "render.model_mesh_draws_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_model_mesh_draws_per_frame);
+    else if (SDL_strcmp(metric, "render.model_triangles_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_model_triangles_per_frame);
+    else if (SDL_strcmp(metric, "render.depth_prepass_draws_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_depth_prepass_draws_per_frame);
+    else if (SDL_strcmp(metric, "render.depth_prepass_triangles_per_frame") == 0)
+        SDL_snprintf(buffer, buffer_size, "%.1f", metrics->render_depth_prepass_triangles_per_frame);
     else
         return false;
     return true;

--- a/src/game_data_render_runtime.c
+++ b/src/game_data_render_runtime.c
@@ -1780,6 +1780,7 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
         out_settings->lighting_enabled = true;
         out_settings->bloom_enabled = true;
         out_settings->ssao_enabled = true;
+        out_settings->depth_prepass_enabled = false;
         out_settings->tonemap = SLAYER3D_TONEMAP_ACES;
     }
     if (runtime == NULL || out_settings == NULL)
@@ -1796,6 +1797,9 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
                                                    json_bool(render, "bloom", out_settings->bloom_enabled));
     out_settings->ssao_enabled = scene_state_bool(runtime, json_string(render, "ssao_key", NULL),
                                                   json_bool(render, "ssao", out_settings->ssao_enabled));
+    out_settings->depth_prepass_enabled =
+        scene_state_bool(runtime, json_string(render, "depth_prepass_key", NULL),
+                         json_bool(render, "depth_prepass", out_settings->depth_prepass_enabled));
     const char *tonemap_name =
         scene_state_string(runtime, json_string(render, "tonemap_key", NULL), json_string(render, "tonemap", NULL));
     out_settings->tonemap = parse_tonemap(tonemap_name, out_settings->tonemap);

--- a/src/game_data_render_runtime.c
+++ b/src/game_data_render_runtime.c
@@ -1781,6 +1781,7 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
         out_settings->bloom_enabled = true;
         out_settings->ssao_enabled = true;
         out_settings->depth_prepass_enabled = false;
+        out_settings->performance_queries_enabled = false;
         out_settings->tonemap = SLAYER3D_TONEMAP_ACES;
     }
     if (runtime == NULL || out_settings == NULL)
@@ -1800,6 +1801,9 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
     out_settings->depth_prepass_enabled =
         scene_state_bool(runtime, json_string(render, "depth_prepass_key", NULL),
                          json_bool(render, "depth_prepass", out_settings->depth_prepass_enabled));
+    out_settings->performance_queries_enabled =
+        scene_state_bool(runtime, json_string(render, "performance_queries_key", NULL),
+                         json_bool(render, "performance_queries", out_settings->performance_queries_enabled));
     const char *tonemap_name =
         scene_state_string(runtime, json_string(render, "tonemap_key", NULL), json_string(render, "tonemap", NULL));
     out_settings->tonemap = parse_tonemap(tonemap_name, out_settings->tonemap);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10202,6 +10202,8 @@ static bool ui_metric_name_valid(const char *metric)
         "render.model_triangles_per_frame",
         "render.depth_prepass_draws_per_frame",
         "render.depth_prepass_triangles_per_frame",
+        "render.depth_prepass_samples_per_frame",
+        "render.geometry_samples_per_frame",
         "brush.trace_count",
         "brush.world_instance_count",
         "brush.world_bounds_reject_count",
@@ -12104,9 +12106,13 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
     yyjson_val *bloom = obj_get(render, "bloom");
     yyjson_val *ssao = obj_get(render, "ssao");
     yyjson_val *depth_prepass = obj_get(render, "depth_prepass");
+    yyjson_val *performance_queries = obj_get(render, "performance_queries");
     if ((lighting != NULL && !yyjson_is_bool(lighting)) || (bloom != NULL && !yyjson_is_bool(bloom)) ||
-        (ssao != NULL && !yyjson_is_bool(ssao)) || (depth_prepass != NULL && !yyjson_is_bool(depth_prepass)))
-        return validation_error(ctx, "$.render", "render lighting, bloom, ssao, and depth_prepass must be booleans");
+        (ssao != NULL && !yyjson_is_bool(ssao)) || (depth_prepass != NULL && !yyjson_is_bool(depth_prepass)) ||
+        (performance_queries != NULL && !yyjson_is_bool(performance_queries)))
+        return validation_error(ctx, "$.render",
+                                "render lighting, bloom, ssao, depth_prepass, and performance_queries must be "
+                                "booleans");
     if (obj_get(render, "clear_color") != NULL && !is_vec_array(obj_get(render, "clear_color"), 3))
         return validation_error(ctx, "$.render.clear_color", "render clear_color must be a vec3 or vec4 color");
     const char *tonemap = json_string(render, "tonemap");
@@ -12116,8 +12122,9 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
     if (profile != NULL && !valid_render_profile_name(profile))
         return validation_error(ctx, "$.render.profile", "render profile is unknown");
 
-    const char *key_fields[] = {"lighting_key",      "bloom_key",   "ssao_key",
-                                "depth_prepass_key", "tonemap_key", "profile_key"};
+    const char *key_fields[] = {"lighting_key",           "bloom_key",   "ssao_key",
+                                "depth_prepass_key",      "tonemap_key", "profile_key",
+                                "performance_queries_key"};
     for (size_t i = 0; i < SDL_arraysize(key_fields); ++i)
     {
         if (obj_get(render, key_fields[i]) != NULL && !is_non_empty_string(render, key_fields[i]))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10198,8 +10198,6 @@ static bool ui_metric_name_valid(const char *metric)
         "brush.render_mesh_culled",
         "brush.render_mesh_draws",
         "brush.render_triangles_submitted",
-        "brush.render_depth_prepass_draws",
-        "brush.render_depth_prepass_triangles",
     };
 
     for (size_t i = 0; i < SDL_arraysize(metrics); ++i)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10198,6 +10198,8 @@ static bool ui_metric_name_valid(const char *metric)
         "brush.render_mesh_culled",
         "brush.render_mesh_draws",
         "brush.render_triangles_submitted",
+        "brush.render_depth_prepass_draws",
+        "brush.render_depth_prepass_triangles",
     };
 
     for (size_t i = 0; i < SDL_arraysize(metrics); ++i)
@@ -12087,9 +12089,10 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
     yyjson_val *lighting = obj_get(render, "lighting");
     yyjson_val *bloom = obj_get(render, "bloom");
     yyjson_val *ssao = obj_get(render, "ssao");
+    yyjson_val *depth_prepass = obj_get(render, "depth_prepass");
     if ((lighting != NULL && !yyjson_is_bool(lighting)) || (bloom != NULL && !yyjson_is_bool(bloom)) ||
-        (ssao != NULL && !yyjson_is_bool(ssao)))
-        return validation_error(ctx, "$.render", "render lighting, bloom, and ssao must be booleans");
+        (ssao != NULL && !yyjson_is_bool(ssao)) || (depth_prepass != NULL && !yyjson_is_bool(depth_prepass)))
+        return validation_error(ctx, "$.render", "render lighting, bloom, ssao, and depth_prepass must be booleans");
     if (obj_get(render, "clear_color") != NULL && !is_vec_array(obj_get(render, "clear_color"), 3))
         return validation_error(ctx, "$.render.clear_color", "render clear_color must be a vec3 or vec4 color");
     const char *tonemap = json_string(render, "tonemap");
@@ -12099,7 +12102,8 @@ static bool validate_render_settings(validation_context *ctx, yyjson_val *root)
     if (profile != NULL && !valid_render_profile_name(profile))
         return validation_error(ctx, "$.render.profile", "render profile is unknown");
 
-    const char *key_fields[] = {"lighting_key", "bloom_key", "ssao_key", "tonemap_key", "profile_key"};
+    const char *key_fields[] = {"lighting_key",      "bloom_key",   "ssao_key",
+                                "depth_prepass_key", "tonemap_key", "profile_key"};
     for (size_t i = 0; i < SDL_arraysize(key_fields); ++i)
     {
         if (obj_get(render, key_fields[i]) != NULL && !is_non_empty_string(render, key_fields[i]))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -9983,6 +9983,14 @@ static bool validate_presentation(validation_context *ctx, yyjson_val *root, val
     if (!yyjson_is_obj(presentation))
         return validation_error(ctx, "$.presentation", "presentation must be an object");
 
+    yyjson_val *metrics = obj_get(presentation, "metrics");
+    if (metrics != NULL && !yyjson_is_obj(metrics))
+        return validation_error(ctx, "$.presentation.metrics", "presentation metrics must be an object");
+    yyjson_val *fps_sample_seconds = obj_get(metrics, "fps_sample_seconds");
+    if (fps_sample_seconds != NULL && (!yyjson_is_num(fps_sample_seconds) || yyjson_get_num(fps_sample_seconds) <= 0.0))
+        return validation_error(ctx, "$.presentation.metrics.fps_sample_seconds",
+                                "fps_sample_seconds must be positive");
+
     yyjson_val *clocks = obj_get(presentation, "clocks");
     if (clocks != NULL && !yyjson_is_arr(clocks))
         return validation_error(ctx, "$.presentation.clocks", "clocks must be an array");
@@ -10186,6 +10194,14 @@ static bool ui_metric_name_valid(const char *metric)
         "fps",
         "frame",
         "paused",
+        "perf.frame_ms",
+        "perf.update_cpu_ms",
+        "perf.render_cpu_ms",
+        "render.model_mesh_submissions_per_frame",
+        "render.model_mesh_draws_per_frame",
+        "render.model_triangles_per_frame",
+        "render.depth_prepass_draws_per_frame",
+        "render.depth_prepass_triangles_per_frame",
         "brush.trace_count",
         "brush.world_instance_count",
         "brush.world_bounds_reject_count",

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2044,6 +2044,14 @@ void slayer3d_game_data_accumulate_brush_render_diagnostics(slayer3d_game_data_r
         after->model_triangles_submitted >= before->model_triangles_submitted
             ? after->model_triangles_submitted - before->model_triangles_submitted
             : 0u;
+    runtime->brush_diagnostics.render_depth_prepass_draws +=
+        after->depth_prepass_draws >= before->depth_prepass_draws
+            ? after->depth_prepass_draws - before->depth_prepass_draws
+            : 0u;
+    runtime->brush_diagnostics.render_depth_prepass_triangles +=
+        after->depth_prepass_triangles >= before->depth_prepass_triangles
+            ? after->depth_prepass_triangles - before->depth_prepass_triangles
+            : 0u;
 }
 
 typedef struct brush_named_trace_context

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -2044,14 +2044,6 @@ void slayer3d_game_data_accumulate_brush_render_diagnostics(slayer3d_game_data_r
         after->model_triangles_submitted >= before->model_triangles_submitted
             ? after->model_triangles_submitted - before->model_triangles_submitted
             : 0u;
-    runtime->brush_diagnostics.render_depth_prepass_draws +=
-        after->depth_prepass_draws >= before->depth_prepass_draws
-            ? after->depth_prepass_draws - before->depth_prepass_draws
-            : 0u;
-    runtime->brush_diagnostics.render_depth_prepass_triangles +=
-        after->depth_prepass_triangles >= before->depth_prepass_triangles
-            ? after->depth_prepass_triangles - before->depth_prepass_triangles
-            : 0u;
 }
 
 typedef struct brush_named_trace_context

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -200,6 +200,7 @@ static bool apply_render_settings(const slayer3d_game_data_runtime *runtime, sla
     ok = slayer3d_set_bloom_enabled(renderer, settings.bloom_enabled) && ok;
     ok = slayer3d_set_ssao_enabled(renderer, settings.ssao_enabled) && ok;
     ok = slayer3d_set_depth_prepass_enabled(renderer, settings.depth_prepass_enabled) && ok;
+    ok = slayer3d_set_render_sample_queries_enabled(renderer, settings.performance_queries_enabled) && ok;
     ok = slayer3d_set_tonemap_mode(renderer, settings.tonemap) && ok;
     ok = slayer3d_clear_render_context(renderer, settings.clear_color) && ok;
     return ok;
@@ -3109,6 +3110,10 @@ void slayer3d_game_data_frame_state_record_render(slayer3d_game_data_frame_state
                             state->last_render_stats.depth_prepass_draws, stats.depth_prepass_draws);
                         state->depth_prepass_triangles_sample_sum += render_stat_delta_u64(
                             state->last_render_stats.depth_prepass_triangles, stats.depth_prepass_triangles);
+                        state->depth_prepass_samples_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.depth_prepass_samples_passed, stats.depth_prepass_samples_passed);
+                        state->geometry_samples_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.geometry_samples_passed, stats.geometry_samples_passed);
                     }
                     state->last_render_stats = stats;
                     state->have_last_render_stats = true;
@@ -3130,6 +3135,9 @@ void slayer3d_game_data_frame_state_record_render(slayer3d_game_data_frame_state
                     state->depth_prepass_draws_sample_sum / sample_frames;
                 state->metrics.render_depth_prepass_triangles_per_frame =
                     state->depth_prepass_triangles_sample_sum / sample_frames;
+                state->metrics.render_depth_prepass_samples_per_frame =
+                    state->depth_prepass_samples_sample_sum / sample_frames;
+                state->metrics.render_geometry_samples_per_frame = state->geometry_samples_sample_sum / sample_frames;
                 state->fps_sample_time = 0.0f;
                 state->frame_ms_sample_sum = 0.0f;
                 state->update_cpu_ms_sample_sum = 0.0f;
@@ -3139,6 +3147,8 @@ void slayer3d_game_data_frame_state_record_render(slayer3d_game_data_frame_state
                 state->render_triangles_sample_sum = 0.0f;
                 state->depth_prepass_draws_sample_sum = 0.0f;
                 state->depth_prepass_triangles_sample_sum = 0.0f;
+                state->depth_prepass_samples_sample_sum = 0.0f;
+                state->geometry_samples_sample_sum = 0.0f;
                 state->fps_sample_frames = 0;
             }
         }

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -3003,6 +3003,25 @@ void slayer3d_game_data_frame_state_init(slayer3d_game_data_frame_state *state)
     SDL_zero(*state);
 }
 
+void slayer3d_game_data_frame_state_record_update_cpu_time(slayer3d_game_data_frame_state *state, float seconds)
+{
+    if (state == NULL || seconds < 0.0f)
+        return;
+    state->update_cpu_ms_sample_sum += seconds * 1000.0f;
+}
+
+void slayer3d_game_data_frame_state_record_render_cpu_time(slayer3d_game_data_frame_state *state, float seconds)
+{
+    if (state == NULL || seconds < 0.0f)
+        return;
+    state->render_cpu_ms_sample_sum += seconds * 1000.0f;
+}
+
+static float render_stat_delta_u64(Uint64 before, Uint64 after)
+{
+    return (float)(after >= before ? after - before : 0u);
+}
+
 bool slayer3d_game_data_update_frame(slayer3d_game_data_frame_state *state,
                                      const slayer3d_game_data_update_frame_desc *desc)
 {
@@ -3071,12 +3090,55 @@ void slayer3d_game_data_frame_state_record_render(slayer3d_game_data_frame_state
         if (frame_dt > 0.0f)
         {
             state->fps_sample_time += frame_dt;
+            state->frame_ms_sample_sum += frame_dt * 1000.0f;
             ++state->fps_sample_frames;
+            if (ctx->renderer != NULL)
+            {
+                slayer3d_render_stats stats;
+                if (slayer3d_get_render_stats(ctx->renderer, &stats))
+                {
+                    if (state->have_last_render_stats)
+                    {
+                        state->render_mesh_submissions_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.model_mesh_submissions, stats.model_mesh_submissions);
+                        state->render_mesh_draws_sample_sum +=
+                            render_stat_delta_u64(state->last_render_stats.model_mesh_draws, stats.model_mesh_draws);
+                        state->render_triangles_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.model_triangles_submitted, stats.model_triangles_submitted);
+                        state->depth_prepass_draws_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.depth_prepass_draws, stats.depth_prepass_draws);
+                        state->depth_prepass_triangles_sample_sum += render_stat_delta_u64(
+                            state->last_render_stats.depth_prepass_triangles, stats.depth_prepass_triangles);
+                    }
+                    state->last_render_stats = stats;
+                    state->have_last_render_stats = true;
+                }
+            }
             const float sample_seconds = slayer3d_game_data_fps_sample_seconds(runtime, 0.25f);
             if (state->fps_sample_time >= sample_seconds)
             {
+                const float sample_frames = (float)SDL_max(state->fps_sample_frames, 1);
                 state->displayed_fps = (float)state->fps_sample_frames / state->fps_sample_time;
+                state->metrics.frame_ms = state->frame_ms_sample_sum / sample_frames;
+                state->metrics.update_cpu_ms = state->update_cpu_ms_sample_sum / sample_frames;
+                state->metrics.render_cpu_ms = state->render_cpu_ms_sample_sum / sample_frames;
+                state->metrics.render_model_mesh_submissions_per_frame =
+                    state->render_mesh_submissions_sample_sum / sample_frames;
+                state->metrics.render_model_mesh_draws_per_frame = state->render_mesh_draws_sample_sum / sample_frames;
+                state->metrics.render_model_triangles_per_frame = state->render_triangles_sample_sum / sample_frames;
+                state->metrics.render_depth_prepass_draws_per_frame =
+                    state->depth_prepass_draws_sample_sum / sample_frames;
+                state->metrics.render_depth_prepass_triangles_per_frame =
+                    state->depth_prepass_triangles_sample_sum / sample_frames;
                 state->fps_sample_time = 0.0f;
+                state->frame_ms_sample_sum = 0.0f;
+                state->update_cpu_ms_sample_sum = 0.0f;
+                state->render_cpu_ms_sample_sum = 0.0f;
+                state->render_mesh_submissions_sample_sum = 0.0f;
+                state->render_mesh_draws_sample_sum = 0.0f;
+                state->render_triangles_sample_sum = 0.0f;
+                state->depth_prepass_draws_sample_sum = 0.0f;
+                state->depth_prepass_triangles_sample_sum = 0.0f;
                 state->fps_sample_frames = 0;
             }
         }

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -197,6 +197,7 @@ static bool apply_render_settings(const slayer3d_game_data_runtime *runtime, sla
         ok = slayer3d_set_render_profile(renderer, &settings.profile) && ok;
     ok = slayer3d_set_bloom_enabled(renderer, settings.bloom_enabled) && ok;
     ok = slayer3d_set_ssao_enabled(renderer, settings.ssao_enabled) && ok;
+    ok = slayer3d_set_depth_prepass_enabled(renderer, settings.depth_prepass_enabled) && ok;
     ok = slayer3d_set_tonemap_mode(renderer, settings.tonemap) && ok;
     ok = slayer3d_clear_render_context(renderer, settings.clear_color) && ok;
     return ok;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -16,6 +16,8 @@
 #include "slayer3d/math.h"
 #include "slayer3d/shapes.h"
 
+#include "render_context_internal.h"
+
 typedef struct primitive_draw_context
 {
     const slayer3d_game_data_runtime *runtime;
@@ -2463,8 +2465,11 @@ bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_r
     context.renderer = renderer;
     context.assets = assets;
     context.ok = true;
+    const bool previous_depth_prepass_scope = renderer->depth_prepass_scope_enabled;
+    renderer->depth_prepass_scope_enabled = true;
     const bool iterated =
         slayer3d_game_data_for_each_brush_world_instance(runtime, draw_brush_world_instance, &context);
+    renderer->depth_prepass_scope_enabled = previous_depth_prepass_scope;
     slayer3d_render_stats after_stats;
     SDL_zero(after_stats);
     if (have_before_stats && slayer3d_get_render_stats(renderer, &after_stats))

--- a/src/gl_funcs.h
+++ b/src/gl_funcs.h
@@ -99,6 +99,8 @@ typedef void (*PFNGLCLEARCOLORPROC)(GLfloat, GLfloat, GLfloat, GLfloat);
 typedef void (*PFNGLENABLEPROC)(GLenum);
 typedef void (*PFNGLDISABLEPROC)(GLenum);
 typedef void (*PFNGLDEPTHFUNCPROC)(GLenum);
+typedef void (*PFNGLDEPTHMASKPROC)(GLboolean);
+typedef void (*PFNGLCOLORMASKPROC)(GLboolean, GLboolean, GLboolean, GLboolean);
 typedef void (*PFNGLCULLFACEPROC)(GLenum);
 typedef void (*PFNGLFRONTFACEPROC)(GLenum);
 typedef void (*PFNGLVIEWPORTPROC)(GLint, GLint, GLsizei, GLsizei);
@@ -178,6 +180,8 @@ typedef struct slayer3d_gl_funcs
     PFNGLENABLEPROC Enable;
     PFNGLDISABLEPROC Disable;
     PFNGLDEPTHFUNCPROC DepthFunc;
+    PFNGLDEPTHMASKPROC DepthMask;
+    PFNGLCOLORMASKPROC ColorMask;
     PFNGLCULLFACEPROC CullFace;
     PFNGLFRONTFACEPROC FrontFace;
     PFNGLVIEWPORTPROC Viewport;
@@ -267,6 +271,8 @@ static bool slayer3d_gl_load_funcs(slayer3d_gl_funcs *gl)
     LOAD(Enable);
     LOAD(Disable);
     LOAD(DepthFunc);
+    LOAD(DepthMask);
+    LOAD(ColorMask);
     LOAD(CullFace);
     LOAD(FrontFace);
     LOAD(Viewport);

--- a/src/gl_funcs.h
+++ b/src/gl_funcs.h
@@ -34,6 +34,8 @@ typedef unsigned int GLbitfield;
 #define GL_CCW 0x0901
 #define GL_LESS 0x0201
 #define GL_LEQUAL 0x0203
+#define GL_QUERY_RESULT 0x8866
+#define GL_SAMPLES_PASSED 0x8914
 #define GL_COLOR_BUFFER_BIT 0x00004000
 #define GL_DEPTH_BUFFER_BIT 0x00000100
 #define GL_VERTEX_SHADER 0x8B31
@@ -172,6 +174,11 @@ typedef void (*PFNGLDRAWBUFFERPROC)(GLenum);
 typedef void (*PFNGLREADBUFFERPROC)(GLenum);
 typedef void (*PFNGLUNIFORM1FVPROC)(GLint, GLsizei, const GLfloat *);
 typedef void (*PFNGLGENERATEMIPMAPPROC)(GLenum);
+typedef void (*PFNGLGENQUERIESPROC)(GLsizei, GLuint *);
+typedef void (*PFNGLDELETEQUERIESPROC)(GLsizei, const GLuint *);
+typedef void (*PFNGLBEGINQUERYPROC)(GLenum, GLuint);
+typedef void (*PFNGLENDQUERYPROC)(GLenum);
+typedef void (*PFNGLGETQUERYOBJECTUIVPROC)(GLuint, GLenum, GLuint *);
 /* Global function pointers. */
 typedef struct slayer3d_gl_funcs
 {
@@ -252,6 +259,11 @@ typedef struct slayer3d_gl_funcs
     PFNGLREADBUFFERPROC ReadBuffer;
     PFNGLUNIFORM1FVPROC Uniform1fv;
     PFNGLGENERATEMIPMAPPROC GenerateMipmap;
+    PFNGLGENQUERIESPROC GenQueries;
+    PFNGLDELETEQUERIESPROC DeleteQueries;
+    PFNGLBEGINQUERYPROC BeginQuery;
+    PFNGLENDQUERYPROC EndQuery;
+    PFNGLGETQUERYOBJECTUIVPROC GetQueryObjectuiv;
 } slayer3d_gl_funcs;
 
 static bool slayer3d_gl_load_funcs(slayer3d_gl_funcs *gl)
@@ -265,6 +277,17 @@ static bool slayer3d_gl_load_funcs(slayer3d_gl_funcs *gl)
             return false;                                                                                              \
         }                                                                                                              \
         SDL_memcpy(&gl->name, &fp, sizeof(fp));                                                                        \
+    } while (0)
+#define LOAD_OPTIONAL_ARB(name)                                                                                        \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        SDL_FunctionPointer fp = SDL_GL_GetProcAddress("gl" #name);                                                    \
+        if (fp == NULL)                                                                                                \
+            fp = SDL_GL_GetProcAddress("gl" #name "ARB");                                                              \
+        if (fp != NULL)                                                                                                \
+        {                                                                                                              \
+            SDL_memcpy(&gl->name, &fp, sizeof(fp));                                                                    \
+        }                                                                                                              \
     } while (0)
     LOAD(Clear);
     LOAD(ClearColor);
@@ -343,7 +366,13 @@ static bool slayer3d_gl_load_funcs(slayer3d_gl_funcs *gl)
     LOAD(ReadBuffer);
     LOAD(Uniform1fv);
     LOAD(GenerateMipmap);
+    LOAD_OPTIONAL_ARB(GenQueries);
+    LOAD_OPTIONAL_ARB(DeleteQueries);
+    LOAD_OPTIONAL_ARB(BeginQuery);
+    LOAD_OPTIONAL_ARB(EndQuery);
+    LOAD_OPTIONAL_ARB(GetQueryObjectuiv);
 #undef LOAD
+#undef LOAD_OPTIONAL_ARB
     return true;
 }
 

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -134,6 +134,7 @@ typedef struct slayer3d_draw_entry
     const char *shader_fragment_source;
     float mvp[16];
     bool owns_arrays;
+    bool depth_prepass_eligible;
     struct slayer3d_gl_mesh_cache_entry *mesh_cache;
 } slayer3d_draw_entry;
 
@@ -2337,8 +2338,8 @@ static void replay_draw_list_shadow(slayer3d_gl_context *ctx)
 
 static bool draw_entry_depth_prepass_eligible(const slayer3d_draw_entry *entry)
 {
-    return entry != NULL && entry->lit && entry->primitive_mode == GL_TRIANGLES && entry->vertex_count > 0 &&
-           entry->tint[3] >= 0.999f;
+    return entry != NULL && entry->depth_prepass_eligible && entry->lit && entry->primitive_mode == GL_TRIANGLES &&
+           entry->vertex_count > 0 && entry->mesh_cache != NULL && entry->tint[3] >= 0.999f;
 }
 
 static Uint64 draw_entry_triangle_count(const slayer3d_draw_entry *entry)
@@ -3817,6 +3818,7 @@ static bool gl_draw_mesh_lit(slayer3d_render_context *context, const slayer3d_dr
     e->baked_light_mode = params->baked_light_mode;
     e->has_lightmap = params->lightmap_uvs != NULL && params->lightmap != NULL;
     e->owns_arrays = !params->static_geometry;
+    e->depth_prepass_eligible = params->depth_prepass_eligible;
 
     if (params->static_geometry)
     {

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -221,6 +221,7 @@ struct slayer3d_gl_context
     SDL_GLContext gl_context;
     slayer3d_gl_funcs gl;
     bool is_es;
+    bool sample_queries_supported;
     Uint64 frame_index;
     bool ubo_dirty;
 
@@ -228,6 +229,8 @@ struct slayer3d_gl_context
     GLuint unlit_program;
     GLuint copy_program;
     slayer3d_custom_shader_cache_entry *custom_shader_cache;
+    GLuint depth_prepass_query;
+    GLuint geometry_query;
 
     /* PBR uniform locations */
     GLint pbr_model_loc;
@@ -2351,6 +2354,42 @@ static Uint64 draw_entry_triangle_count(const slayer3d_draw_entry *entry)
     return (Uint64)(entry->vertex_count / 3);
 }
 
+static bool gl_sample_queries_enabled(const slayer3d_gl_context *ctx)
+{
+    return ctx != NULL && ctx->sample_queries_supported && ctx->current_ctx != NULL &&
+           ctx->current_ctx->render_sample_queries_enabled;
+}
+
+static void replay_draw_list_geometry(slayer3d_gl_context *ctx);
+
+static Uint64 gl_query_samples_passed(slayer3d_gl_context *ctx, GLuint query)
+{
+    if (ctx == NULL || query == 0u || ctx->gl.GetQueryObjectuiv == NULL)
+        return 0u;
+    GLuint samples = 0u;
+    ctx->gl.GetQueryObjectuiv(query, GL_QUERY_RESULT, &samples);
+    return (Uint64)samples;
+}
+
+static void replay_draw_list_geometry_measured(slayer3d_gl_context *ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    slayer3d_gl_funcs *gl = &ctx->gl;
+    const bool sample_query = gl_sample_queries_enabled(ctx) && ctx->geometry_query != 0u;
+    if (sample_query)
+        gl->BeginQuery(GL_SAMPLES_PASSED, ctx->geometry_query);
+
+    replay_draw_list_geometry(ctx);
+
+    if (sample_query)
+    {
+        gl->EndQuery(GL_SAMPLES_PASSED);
+        ctx->current_ctx->stats.geometry_samples_passed += gl_query_samples_passed(ctx, ctx->geometry_query);
+    }
+}
+
 static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
 {
     if (ctx == NULL || ctx->current_ctx == NULL || !ctx->current_ctx->depth_prepass_enabled || !ctx->shadow_program)
@@ -2364,6 +2403,9 @@ static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
     gl->DepthFunc(GL_LESS);
     gl->ColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
     gl->UseProgram(ctx->shadow_program);
+    const bool sample_query = gl_sample_queries_enabled(ctx) && ctx->depth_prepass_query != 0u;
+    if (sample_query)
+        gl->BeginQuery(GL_SAMPLES_PASSED, ctx->depth_prepass_query);
 
     for (int i = 0; i < ctx->draw_count; i++)
     {
@@ -2399,6 +2441,12 @@ static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
 
         ctx->current_ctx->stats.depth_prepass_draws += 1u;
         ctx->current_ctx->stats.depth_prepass_triangles += draw_entry_triangle_count(e);
+    }
+
+    if (sample_query)
+    {
+        gl->EndQuery(GL_SAMPLES_PASSED);
+        ctx->current_ctx->stats.depth_prepass_samples_passed += gl_query_samples_passed(ctx, ctx->depth_prepass_query);
     }
 
     gl->BindVertexArray(0);
@@ -3209,6 +3257,14 @@ slayer3d_gl_context *slayer3d_gl_create(SDL_Window *window, int width, int heigh
 
     /* Detect ES. */
     ctx->is_es = false;
+    ctx->sample_queries_supported = !ctx->is_es && gl->GenQueries != NULL && gl->DeleteQueries != NULL &&
+                                    gl->BeginQuery != NULL && gl->EndQuery != NULL && gl->GetQueryObjectuiv != NULL;
+    if (ctx->sample_queries_supported)
+    {
+        gl->GenQueries(1, &ctx->depth_prepass_query);
+        gl->GenQueries(1, &ctx->geometry_query);
+        ctx->sample_queries_supported = ctx->depth_prepass_query != 0u && ctx->geometry_query != 0u;
+    }
 
     const char *version_prefix = ctx->is_es ? "#version 300 es\nprecision highp float;\n" : "#version 330\n";
 
@@ -3635,6 +3691,13 @@ void slayer3d_gl_destroy(slayer3d_gl_context *ctx)
 
     if (ctx->scene_ubo)
         gl->DeleteBuffers(1, &ctx->scene_ubo);
+    if (gl->DeleteQueries != NULL)
+    {
+        if (ctx->depth_prepass_query)
+            gl->DeleteQueries(1, &ctx->depth_prepass_query);
+        if (ctx->geometry_query)
+            gl->DeleteQueries(1, &ctx->geometry_query);
+    }
 
     GLuint lit_bufs[] = {ctx->lit_position_vbo,    ctx->lit_normal_vbo, ctx->lit_uv_vbo,
                          ctx->lit_lightmap_uv_vbo, ctx->lit_color_vbo,  ctx->lit_ebo};
@@ -4170,7 +4233,7 @@ static bool gl_present(slayer3d_render_context *context)
      * so this must be restored explicitly every frame. */
     replay_draw_list_depth_prepass(ctx);
     apply_geometry_cull_state(ctx);
-    replay_draw_list_geometry(ctx);
+    replay_draw_list_geometry_measured(ctx);
 
     /* ---- Post-process pipeline ---- */
     gl->Disable(GL_DEPTH_TEST);
@@ -4455,7 +4518,7 @@ void slayer3d_gl_read_pixel(slayer3d_gl_context *ctx, int x, int y, unsigned cha
         }
         replay_draw_list_depth_prepass(ctx);
         apply_geometry_cull_state(ctx);
-        replay_draw_list_geometry(ctx);
+        replay_draw_list_geometry_measured(ctx);
     }
     rgba[0] = rgba[1] = rgba[2] = rgba[3] = 0;
     SDL_GL_MakeCurrent(ctx->window, ctx->gl_context);

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -2335,6 +2335,76 @@ static void replay_draw_list_shadow(slayer3d_gl_context *ctx)
     gl->BindVertexArray(0);
 }
 
+static bool draw_entry_depth_prepass_eligible(const slayer3d_draw_entry *entry)
+{
+    return entry != NULL && entry->lit && entry->primitive_mode == GL_TRIANGLES && entry->vertex_count > 0 &&
+           entry->tint[3] >= 0.999f;
+}
+
+static Uint64 draw_entry_triangle_count(const slayer3d_draw_entry *entry)
+{
+    if (entry == NULL)
+        return 0u;
+    if (entry->indices != NULL && entry->index_count > 0)
+        return (Uint64)(entry->index_count / 3);
+    return (Uint64)(entry->vertex_count / 3);
+}
+
+static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
+{
+    if (ctx == NULL || ctx->current_ctx == NULL || !ctx->current_ctx->depth_prepass_enabled || !ctx->shadow_program)
+        return;
+
+    slayer3d_gl_funcs *gl = &ctx->gl;
+    gl->BindFramebuffer(GL_FRAMEBUFFER, ctx->fbo);
+    gl->Viewport(0, 0, ctx->logical_w, ctx->logical_h);
+    gl->Enable(GL_DEPTH_TEST);
+    gl->DepthMask(GL_TRUE);
+    gl->DepthFunc(GL_LESS);
+    gl->ColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    gl->UseProgram(ctx->shadow_program);
+
+    for (int i = 0; i < ctx->draw_count; i++)
+    {
+        slayer3d_draw_entry *e = &ctx->draw_list[i];
+        if (!draw_entry_depth_prepass_eligible(e))
+            continue;
+
+        gl->UniformMatrix4fv(ctx->shadow_light_vp_loc, 1, GL_FALSE, e->view_projection);
+        gl->UniformMatrix4fv(ctx->shadow_model_loc, 1, GL_FALSE, e->model_matrix);
+
+        gl->BindVertexArray(e->mesh_cache ? e->mesh_cache->shadow_vao : ctx->shadow_vao);
+        if (e->mesh_cache == NULL)
+        {
+            gl->BindBuffer(GL_ARRAY_BUFFER, ctx->shadow_position_vbo);
+            gl->BufferData(GL_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->vertex_count * 3 * sizeof(float)), e->positions,
+                           GL_DYNAMIC_DRAW);
+        }
+
+        if (e->indices && e->index_count > 0)
+        {
+            if (e->mesh_cache == NULL)
+            {
+                gl->BindBuffer(GL_ELEMENT_ARRAY_BUFFER, ctx->shadow_ebo);
+                gl->BufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)((size_t)e->index_count * sizeof(unsigned int)),
+                               e->indices, GL_DYNAMIC_DRAW);
+            }
+            gl->DrawElements(GL_TRIANGLES, e->index_count, GL_UNSIGNED_INT, NULL);
+        }
+        else
+        {
+            gl->DrawArrays(GL_TRIANGLES, 0, e->vertex_count);
+        }
+
+        ctx->current_ctx->stats.depth_prepass_draws += 1u;
+        ctx->current_ctx->stats.depth_prepass_triangles += draw_entry_triangle_count(e);
+    }
+
+    gl->BindVertexArray(0);
+    gl->ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    gl->DepthFunc(GL_LEQUAL);
+}
+
 static void camera_position_from_view_matrix(const slayer3d_mat4 *view, float out_position[3])
 {
     if (view == NULL || out_position == NULL)
@@ -4096,6 +4166,7 @@ static bool gl_present(slayer3d_render_context *context)
     /* Geometry pass: replay all entries into main FBO using the caller's
      * configured backface-culling state. Post-process passes disable culling,
      * so this must be restored explicitly every frame. */
+    replay_draw_list_depth_prepass(ctx);
     apply_geometry_cull_state(ctx);
     replay_draw_list_geometry(ctx);
 
@@ -4380,6 +4451,7 @@ void slayer3d_gl_read_pixel(slayer3d_gl_context *ctx, int x, int y, unsigned cha
             gl->Disable(GL_CULL_FACE);
             gl->CullFace(GL_BACK);
         }
+        replay_draw_list_depth_prepass(ctx);
         apply_geometry_cull_state(ctx);
         replay_draw_list_geometry(ctx);
     }

--- a/src/network.c
+++ b/src/network.c
@@ -137,9 +137,9 @@ struct slayer3d_network_discovery_session
 static int slayer3d_network_library_refs = 0;
 #endif
 
+#if SLAYER3D_NETWORKING_ENABLED
 static NET_DatagramSocket *slayer3d_network_create_datagram_socket(Uint16 port, bool allow_broadcast)
 {
-#if SLAYER3D_NETWORKING_ENABLED
     SDL_PropertiesID props = 0;
     NET_DatagramSocket *socket = NULL;
     if (allow_broadcast)
@@ -159,12 +159,8 @@ static NET_DatagramSocket *slayer3d_network_create_datagram_socket(Uint16 port, 
     }
 
     return socket != NULL ? socket : NET_CreateDatagramSocket(NULL, port, 0);
-#else
-    (void)port;
-    (void)allow_broadcast;
-    return NULL;
-#endif
 }
+#endif
 
 #if SLAYER3D_NETWORKING_ENABLED
 static void slayer3d_network_set_status(slayer3d_network_session *session, slayer3d_network_state state,

--- a/src/network.c
+++ b/src/network.c
@@ -3,6 +3,7 @@
 #include <SDL3/SDL_endian.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_log.h>
+#include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_stdinc.h>
 
 #if SLAYER3D_NETWORKING_ENABLED
@@ -45,7 +46,7 @@ typedef int NET_Status;
     do                                                                                                                 \
     {                                                                                                                  \
     } while (0)
-#define NET_CreateDatagramSocket(interface, port) ((NET_DatagramSocket *)NULL)
+#define NET_CreateDatagramSocket(interface, port, props) ((NET_DatagramSocket *)NULL)
 #define NET_DestroyDatagramSocket(socket)                                                                              \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -135,6 +136,35 @@ struct slayer3d_network_discovery_session
 #if SLAYER3D_NETWORKING_ENABLED
 static int slayer3d_network_library_refs = 0;
 #endif
+
+static NET_DatagramSocket *slayer3d_network_create_datagram_socket(Uint16 port, bool allow_broadcast)
+{
+#if SLAYER3D_NETWORKING_ENABLED
+    SDL_PropertiesID props = 0;
+    NET_DatagramSocket *socket = NULL;
+    if (allow_broadcast)
+    {
+        props = SDL_CreateProperties();
+        if (props != 0 && SDL_SetBooleanProperty(props, NET_PROP_DATAGRAM_SOCKET_ALLOW_BROADCAST_BOOLEAN, true))
+        {
+            socket = NET_CreateDatagramSocket(NULL, port, props);
+            if (socket == NULL)
+            {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "SLAYER3D broadcast socket create failed, retrying without broadcast: %s", SDL_GetError());
+            }
+        }
+        if (props != 0)
+            SDL_DestroyProperties(props);
+    }
+
+    return socket != NULL ? socket : NET_CreateDatagramSocket(NULL, port, 0);
+#else
+    (void)port;
+    (void)allow_broadcast;
+    return NULL;
+#endif
+}
 
 #if SLAYER3D_NETWORKING_ENABLED
 static void slayer3d_network_set_status(slayer3d_network_session *session, slayer3d_network_state state,
@@ -1105,7 +1135,7 @@ bool slayer3d_network_session_create(const slayer3d_network_session_desc *desc, 
     const Uint16 bound_port = effective->role == SLAYER3D_NETWORK_ROLE_HOST
                                   ? effective->port
                                   : (effective->local_port != 0 ? effective->local_port : 0);
-    session->socket = NET_CreateDatagramSocket(NULL, bound_port);
+    session->socket = slayer3d_network_create_datagram_socket(bound_port, false);
     if (session->socket == NULL)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D network socket create failed: %s", SDL_GetError());
@@ -1444,7 +1474,9 @@ bool slayer3d_network_discovery_session_create(const slayer3d_network_discovery_
     }
 
 #if SLAYER3D_NETWORKING_ENABLED
-    session->socket = NET_CreateDatagramSocket(NULL, effective->local_port != 0 ? effective->local_port : 0);
+    const bool allow_broadcast = effective->host == NULL || effective->host[0] == '\0';
+    session->socket = slayer3d_network_create_datagram_socket(effective->local_port != 0 ? effective->local_port : 0,
+                                                              allow_broadcast);
     if (session->socket == NULL)
     {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D discovery socket create failed: %s", SDL_GetError());

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -332,6 +332,7 @@ bool slayer3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer,
     context->bloom_enabled = true;
     context->ssao_enabled = true;
     context->point_shadows_enabled = true;
+    context->depth_prepass_enabled = false;
     context->fog.mode = SLAYER3D_FOG_NONE;
     context->tonemap_mode = SLAYER3D_TONEMAP_NONE;
     SDL_memset(context->shadow_depth, 0, sizeof(context->shadow_depth));
@@ -434,6 +435,21 @@ void slayer3d_reset_render_stats(slayer3d_render_context *context)
         return;
     }
     SDL_zero(context->stats);
+}
+
+bool slayer3d_set_depth_prepass_enabled(slayer3d_render_context *context, bool enabled)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    context->depth_prepass_enabled = enabled;
+    return true;
+}
+
+bool slayer3d_is_depth_prepass_enabled(const slayer3d_render_context *context)
+{
+    return context != NULL && context->depth_prepass_enabled;
 }
 
 bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color)

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -333,6 +333,7 @@ bool slayer3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer,
     context->ssao_enabled = true;
     context->point_shadows_enabled = true;
     context->depth_prepass_enabled = false;
+    context->render_sample_queries_enabled = false;
     context->fog.mode = SLAYER3D_FOG_NONE;
     context->tonemap_mode = SLAYER3D_TONEMAP_NONE;
     SDL_memset(context->shadow_depth, 0, sizeof(context->shadow_depth));
@@ -450,6 +451,21 @@ bool slayer3d_set_depth_prepass_enabled(slayer3d_render_context *context, bool e
 bool slayer3d_is_depth_prepass_enabled(const slayer3d_render_context *context)
 {
     return context != NULL && context->depth_prepass_enabled;
+}
+
+bool slayer3d_set_render_sample_queries_enabled(slayer3d_render_context *context, bool enabled)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    context->render_sample_queries_enabled = enabled;
+    return true;
+}
+
+bool slayer3d_render_sample_queries_enabled(const slayer3d_render_context *context)
+{
+    return context != NULL && context->render_sample_queries_enabled;
 }
 
 bool slayer3d_clear_render_context(slayer3d_render_context *context, slayer3d_color color)

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -63,6 +63,7 @@ struct slayer3d_render_context
     bool ssao_enabled;
     bool point_shadows_enabled;
     bool depth_prepass_enabled;
+    bool render_sample_queries_enabled;
     bool depth_prepass_scope_enabled;
 
     /* Z-fighting detection callback. */

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -63,6 +63,7 @@ struct slayer3d_render_context
     bool ssao_enabled;
     bool point_shadows_enabled;
     bool depth_prepass_enabled;
+    bool depth_prepass_scope_enabled;
 
     /* Z-fighting detection callback. */
     void (*zfight_callback)(const char *message, void *userdata);

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -62,6 +62,7 @@ struct slayer3d_render_context
     bool bloom_enabled;
     bool ssao_enabled;
     bool point_shadows_enabled;
+    bool depth_prepass_enabled;
 
     /* Z-fighting detection callback. */
     void (*zfight_callback)(const char *message, void *userdata);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -4996,6 +4996,14 @@ TEST(GameDataRuntime, UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives)
           {
             "label": "FPS",
             "binding": { "type": "metric", "metric": "fps", "default": 0 }
+          },
+          {
+            "label": "Frame ms",
+            "binding": { "type": "metric", "metric": "perf.frame_ms" }
+          },
+          {
+            "label": "Z prepass",
+            "binding": { "type": "metric", "metric": "render.depth_prepass_draws_per_frame" }
           }
         ]
       }
@@ -5029,10 +5037,12 @@ TEST(GameDataRuntime, UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives)
     };
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_tool_rects, &rects));
     EXPECT_EQ(rects.sidebar_rects, 5);
-    EXPECT_EQ(rects.inspector_rects, 4);
+    EXPECT_EQ(rects.inspector_rects, 6);
 
     slayer3d_game_data_ui_metrics metrics{};
     metrics.fps = 59.75f;
+    metrics.frame_ms = 8.33f;
+    metrics.render_depth_prepass_draws_per_frame = 14.25f;
     struct Texts
     {
         std::vector<std::string> values;
@@ -5044,7 +5054,7 @@ TEST(GameDataRuntime, UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives)
         return true;
     };
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture_tool_texts, &texts));
-    ASSERT_EQ(texts.values.size(), 7U);
+    ASSERT_EQ(texts.values.size(), 11U);
     EXPECT_EQ(texts.values[0], "Selection");
     EXPECT_EQ(texts.values[1], "World");
     EXPECT_EQ(texts.values[2], "brush.dojo");
@@ -5052,10 +5062,34 @@ TEST(GameDataRuntime, UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives)
     EXPECT_EQ(texts.values[4], "100");
     EXPECT_EQ(texts.values[5], "FPS");
     EXPECT_EQ(texts.values[6], "59.8");
+    EXPECT_EQ(texts.values[7], "Frame ms");
+    EXPECT_EQ(texts.values[8], "8.3");
+    EXPECT_EQ(texts.values[9], "Z prepass");
+    EXPECT_EQ(texts.values[10], "14.2");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, FrameStateSamplesDataDrivenPerformanceMetrics)
+{
+    slayer3d_game_data_frame_state state{};
+    slayer3d_game_data_frame_state_init(&state);
+
+    slayer3d_game_context ctx{};
+    ctx.real_time = 0.0f;
+    slayer3d_game_data_frame_state_record_render(&state, &ctx, nullptr);
+
+    slayer3d_game_data_frame_state_record_update_cpu_time(&state, 0.002f);
+    slayer3d_game_data_frame_state_record_render_cpu_time(&state, 0.004f);
+    ctx.real_time = 0.25f;
+    slayer3d_game_data_frame_state_record_render(&state, &ctx, nullptr);
+
+    EXPECT_NEAR(state.metrics.fps, 4.0f, 0.0001f);
+    EXPECT_NEAR(state.metrics.frame_ms, 250.0f, 0.0001f);
+    EXPECT_NEAR(state.metrics.update_cpu_ms, 2.0f, 0.0001f);
+    EXPECT_NEAR(state.metrics.render_cpu_ms, 4.0f, 0.0001f);
 }
 
 TEST(GameDataValidation, RejectsInvalidUiTooling)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8401,7 +8401,6 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     after_stats.model_mesh_culled = 2;
     after_stats.model_mesh_draws = 5;
     after_stats.model_triangles_submitted = 128;
-    after_stats.depth_prepass_draws = 5;
     slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
     bool saw_render_diagnostics = false;
     char render_diagnostics[128]{};
@@ -8419,23 +8418,6 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_text(runtime, find_render_diagnostics, &render_diagnostics_args));
     EXPECT_TRUE(saw_render_diagnostics);
     EXPECT_STREQ(render_diagnostics, "RENDER 5/7 CULL 2 TRI 128");
-    bool saw_depth_prepass_diagnostics = false;
-    char depth_prepass_diagnostics[128]{};
-    auto find_depth_prepass_diagnostics = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
-        if (std::string(text->name) != "ui.brush_geometry.depth_prepass_diagnostics")
-            return true;
-        auto *args = static_cast<std::tuple<slayer3d_game_data_runtime *, bool *, char *> *>(userdata);
-        *std::get<1>(*args) = true;
-        slayer3d_game_data_ui_metrics metrics{};
-        EXPECT_TRUE(slayer3d_game_data_format_ui_text(std::get<0>(*args), text, &metrics, std::get<2>(*args), 128));
-        return false;
-    };
-    std::tuple<slayer3d_game_data_runtime *, bool *, char *> depth_prepass_diagnostics_args{
-        runtime, &saw_depth_prepass_diagnostics, depth_prepass_diagnostics};
-    ASSERT_TRUE(
-        slayer3d_game_data_for_each_ui_text(runtime, find_depth_prepass_diagnostics, &depth_prepass_diagnostics_args));
-    EXPECT_TRUE(saw_depth_prepass_diagnostics);
-    EXPECT_STREQ(depth_prepass_diagnostics, "Z PREPASS 5 / TRI 0");
 
     const int forward = slayer3d_game_data_find_action(runtime, "action.move.forward");
     ASSERT_GE(forward, 0);
@@ -12981,22 +12963,16 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     before_stats.model_mesh_culled = 1;
     before_stats.model_mesh_draws = 3;
     before_stats.model_triangles_submitted = 48;
-    before_stats.depth_prepass_draws = 2;
-    before_stats.depth_prepass_triangles = 36;
     after_stats.model_mesh_submissions = 7;
     after_stats.model_mesh_culled = 2;
     after_stats.model_mesh_draws = 5;
     after_stats.model_triangles_submitted = 96;
-    after_stats.depth_prepass_draws = 6;
-    after_stats.depth_prepass_triangles = 84;
     slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
     ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
     EXPECT_EQ(diagnostics.render_mesh_submissions, 3u);
     EXPECT_EQ(diagnostics.render_mesh_culled, 1u);
     EXPECT_EQ(diagnostics.render_mesh_draws, 2u);
     EXPECT_EQ(diagnostics.render_triangles_submitted, 48u);
-    EXPECT_EQ(diagnostics.render_depth_prepass_draws, 4u);
-    EXPECT_EQ(diagnostics.render_depth_prepass_triangles, 48u);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -3107,6 +3107,7 @@ TEST(GameDataRuntime, ExposesAuthoredPongPresentationData)
     EXPECT_TRUE(render.lighting_enabled);
     EXPECT_TRUE(render.bloom_enabled);
     EXPECT_TRUE(render.ssao_enabled);
+    EXPECT_FALSE(render.depth_prepass_enabled);
     EXPECT_EQ(render.tonemap, SLAYER3D_TONEMAP_ACES);
 
     slayer3d_game_data_transition_desc transition{};
@@ -7813,6 +7814,10 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
 
+    slayer3d_game_data_render_settings render_settings{};
+    ASSERT_TRUE(slayer3d_game_data_get_render_settings(runtime, &render_settings));
+    EXPECT_TRUE(render_settings.depth_prepass_enabled);
+
     ASSERT_TRUE(slayer3d_game_data_set_active_scene(runtime, "scene.brush_geometry.showcase"));
     slayer3d_game_data_scene_skybox skybox{};
     ASSERT_TRUE(slayer3d_game_data_get_active_scene_skybox(runtime, &skybox));
@@ -8396,6 +8401,7 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     after_stats.model_mesh_culled = 2;
     after_stats.model_mesh_draws = 5;
     after_stats.model_triangles_submitted = 128;
+    after_stats.depth_prepass_draws = 5;
     slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
     bool saw_render_diagnostics = false;
     char render_diagnostics[128]{};
@@ -8413,6 +8419,23 @@ TEST(GameDataRuntime, BrushGeometryDojoLoadsCompiledBrushShowcase)
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_text(runtime, find_render_diagnostics, &render_diagnostics_args));
     EXPECT_TRUE(saw_render_diagnostics);
     EXPECT_STREQ(render_diagnostics, "RENDER 5/7 CULL 2 TRI 128");
+    bool saw_depth_prepass_diagnostics = false;
+    char depth_prepass_diagnostics[128]{};
+    auto find_depth_prepass_diagnostics = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+        if (std::string(text->name) != "ui.brush_geometry.depth_prepass_diagnostics")
+            return true;
+        auto *args = static_cast<std::tuple<slayer3d_game_data_runtime *, bool *, char *> *>(userdata);
+        *std::get<1>(*args) = true;
+        slayer3d_game_data_ui_metrics metrics{};
+        EXPECT_TRUE(slayer3d_game_data_format_ui_text(std::get<0>(*args), text, &metrics, std::get<2>(*args), 128));
+        return false;
+    };
+    std::tuple<slayer3d_game_data_runtime *, bool *, char *> depth_prepass_diagnostics_args{
+        runtime, &saw_depth_prepass_diagnostics, depth_prepass_diagnostics};
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_ui_text(runtime, find_depth_prepass_diagnostics, &depth_prepass_diagnostics_args));
+    EXPECT_TRUE(saw_depth_prepass_diagnostics);
+    EXPECT_STREQ(depth_prepass_diagnostics, "Z PREPASS 5 / TRI 0");
 
     const int forward = slayer3d_game_data_find_action(runtime, "action.move.forward");
     ASSERT_GE(forward, 0);
@@ -12958,16 +12981,22 @@ TEST(GameDataRuntime, TracesAuthoredBrushWorldsWithContentsAndSweptHulls)
     before_stats.model_mesh_culled = 1;
     before_stats.model_mesh_draws = 3;
     before_stats.model_triangles_submitted = 48;
+    before_stats.depth_prepass_draws = 2;
+    before_stats.depth_prepass_triangles = 36;
     after_stats.model_mesh_submissions = 7;
     after_stats.model_mesh_culled = 2;
     after_stats.model_mesh_draws = 5;
     after_stats.model_triangles_submitted = 96;
+    after_stats.depth_prepass_draws = 6;
+    after_stats.depth_prepass_triangles = 84;
     slayer3d_game_data_accumulate_brush_render_diagnostics(runtime, &before_stats, &after_stats);
     ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
     EXPECT_EQ(diagnostics.render_mesh_submissions, 3u);
     EXPECT_EQ(diagnostics.render_mesh_culled, 1u);
     EXPECT_EQ(diagnostics.render_mesh_draws, 2u);
     EXPECT_EQ(diagnostics.render_triangles_submitted, 48u);
+    EXPECT_EQ(diagnostics.render_depth_prepass_draws, 4u);
+    EXPECT_EQ(diagnostics.render_depth_prepass_triangles, 48u);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -176,6 +176,26 @@ TEST_F(GLRendererTest, DepthPrepassReplaysOpaqueLitTriangles)
     ASSERT_TRUE(slayer3d_set_depth_prepass_enabled(ctx, true));
     ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
     ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.2f, 0.2f, 0.2f));
+    ctx->depth_prepass_scope_enabled = true;
+
+    float positions[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 1.0f, 1.0f, 0.0f, -1.0f, 1.0f, 0.0f,
+    };
+    float normals[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    };
+    unsigned int indices[] = {0, 1, 2, 0, 2, 3};
+    slayer3d_mesh mesh = {};
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.vertex_count = 4;
+    mesh.indices = indices;
+    mesh.index_count = 6;
+    mesh.material_index = -1;
+
+    slayer3d_model model = {};
+    model.meshes = &mesh;
+    model.mesh_count = 1;
 
     slayer3d_camera3d cam;
     cam.position = slayer3d_vec3_make(0, 0, 5);
@@ -186,8 +206,8 @@ TEST_F(GLRendererTest, DepthPrepassReplaysOpaqueLitTriangles)
 
     ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
-    ASSERT_TRUE(slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
-                                   (slayer3d_color){255, 255, 255, 255}));
+    ASSERT_TRUE(
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -220,6 +220,55 @@ TEST_F(GLRendererTest, DepthPrepassReplaysOpaqueLitTriangles)
     EXPECT_GT(px[0] + px[1] + px[2], 20);
 }
 
+TEST_F(GLRendererTest, DepthPrepassDisabledDoesNotReplayEligibleMeshes)
+{
+    ASSERT_TRUE(slayer3d_set_depth_prepass_enabled(ctx, false));
+    ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
+    ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.2f, 0.2f, 0.2f));
+    ctx->depth_prepass_scope_enabled = true;
+
+    float positions[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 1.0f, 1.0f, 0.0f, -1.0f, 1.0f, 0.0f,
+    };
+    float normals[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    };
+    unsigned int indices[] = {0, 1, 2, 0, 2, 3};
+    slayer3d_mesh mesh = {};
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.vertex_count = 4;
+    mesh.indices = indices;
+    mesh.index_count = 6;
+    mesh.material_index = -1;
+
+    slayer3d_model model = {};
+    model.meshes = &mesh;
+    model.mesh_count = 1;
+
+    slayer3d_camera3d cam;
+    cam.position = slayer3d_vec3_make(0, 0, 5);
+    cam.target = slayer3d_vec3_make(0, 0, 0);
+    cam.up = slayer3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    unsigned char px[4];
+    readPixel(160, 120, px);
+
+    slayer3d_render_stats stats{};
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.depth_prepass_draws, 0u);
+    EXPECT_EQ(stats.depth_prepass_triangles, 0u);
+    EXPECT_GT(px[0] + px[1] + px[2], 20);
+}
+
 TEST_F(GLRendererTest, PhongCubeVisibleWithoutIBL)
 {
     ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -269,6 +269,79 @@ TEST_F(GLRendererTest, DepthPrepassDisabledDoesNotReplayEligibleMeshes)
     EXPECT_GT(px[0] + px[1] + px[2], 20);
 }
 
+TEST_F(GLRendererTest, DepthPrepassReducesMainGeometrySamplesInOverdrawCase)
+{
+    ASSERT_TRUE(slayer3d_set_render_sample_queries_enabled(ctx, true));
+    ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
+    ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.35f, 0.35f, 0.35f));
+    ctx->depth_prepass_scope_enabled = true;
+
+    float positions[] = {
+        -1.4f, -1.4f, 0.0f, 1.4f, -1.4f, 0.0f, 1.4f, 1.4f, 0.0f, -1.4f, 1.4f, 0.0f,
+    };
+    float normals[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    };
+    unsigned int indices[] = {0, 1, 2, 0, 2, 3};
+    slayer3d_mesh mesh = {};
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.vertex_count = 4;
+    mesh.indices = indices;
+    mesh.index_count = 6;
+    mesh.material_index = -1;
+
+    slayer3d_model model = {};
+    model.meshes = &mesh;
+    model.mesh_count = 1;
+
+    slayer3d_camera3d cam;
+    cam.position = slayer3d_vec3_make(0, 0, 5);
+    cam.target = slayer3d_vec3_make(0, 0, 0);
+    cam.up = slayer3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    auto draw_overdraw_stack = [&](int layer_count) {
+        ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+        ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+        for (int i = 0; i < layer_count; ++i)
+        {
+            const float z = -0.14f + (float)i * 0.02f;
+            ASSERT_TRUE(slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, z), 1.0f,
+                                            (slayer3d_color){255, 255, 255, 255}));
+        }
+        ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+        unsigned char px[4];
+        readPixel(160, 120, px);
+        EXPECT_GT(px[0] + px[1] + px[2], 20);
+    };
+
+    auto measure = [&](int layer_count, bool depth_prepass) {
+        EXPECT_TRUE(slayer3d_set_depth_prepass_enabled(ctx, depth_prepass));
+        slayer3d_reset_render_stats(ctx);
+        draw_overdraw_stack(layer_count);
+        slayer3d_render_stats stats{};
+        EXPECT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+        return stats;
+    };
+
+    const slayer3d_render_stats one_layer = measure(1, false);
+    if (one_layer.geometry_samples_passed == 0u)
+    {
+        GTEST_SKIP() << "OpenGL sample queries are unavailable on this backend";
+    }
+    const slayer3d_render_stats four_layers = measure(4, false);
+    const slayer3d_render_stats eight_layers = measure(8, false);
+    const slayer3d_render_stats eight_layers_with_prepass = measure(8, true);
+
+    EXPECT_GT(four_layers.geometry_samples_passed, one_layer.geometry_samples_passed * 3u);
+    EXPECT_GT(eight_layers.geometry_samples_passed, one_layer.geometry_samples_passed * 6u);
+    EXPECT_GT(eight_layers_with_prepass.depth_prepass_samples_passed, 0u);
+    EXPECT_LE(eight_layers_with_prepass.geometry_samples_passed, one_layer.geometry_samples_passed * 2u);
+    EXPECT_LT(eight_layers_with_prepass.geometry_samples_passed, eight_layers.geometry_samples_passed / 2u);
+}
+
 TEST_F(GLRendererTest, PhongCubeVisibleWithoutIBL)
 {
     ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -171,6 +171,35 @@ TEST_F(GLRendererTest, LitCubeProducesNonClearPixels)
     EXPECT_GT(brightness, 30);
 }
 
+TEST_F(GLRendererTest, DepthPrepassReplaysOpaqueLitTriangles)
+{
+    ASSERT_TRUE(slayer3d_set_depth_prepass_enabled(ctx, true));
+    ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
+    ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.2f, 0.2f, 0.2f));
+
+    slayer3d_camera3d cam;
+    cam.position = slayer3d_vec3_make(0, 0, 5);
+    cam.target = slayer3d_vec3_make(0, 0, 0);
+    cam.up = slayer3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
+                                   (slayer3d_color){255, 255, 255, 255}));
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    unsigned char px[4];
+    readPixel(160, 120, px);
+
+    slayer3d_render_stats stats{};
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_GT(stats.depth_prepass_draws, 0u);
+    EXPECT_GT(stats.depth_prepass_triangles, 0u);
+    EXPECT_GT(px[0] + px[1] + px[2], 20);
+}
+
 TEST_F(GLRendererTest, PhongCubeVisibleWithoutIBL)
 {
     ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));


### PR DESCRIPTION
## Summary
- Adds an authored `render.depth_prepass` / `depth_prepass_key` setting that toggles an OpenGL opaque depth pre-pass without game-specific host code.
- Replays eligible static opaque lit brush-world meshes through the existing position-only GL path before the main geometry pass, with renderer-level depth-prepass draw and triangle stats.
- Intentionally excludes actors, viewmodels, particles, billboards, and dynamic/immediate primitives from the first pre-pass slice to avoid corrupting animated or effect-heavy rendering.
- Enables the pre-pass in the brush geometry dojo and adds an `N` key toggle plus HUD state (`Z PREPASS 1/0`) so the scene can be compared at runtime without editing JSON.
- Adds data-driven performance measurement primitives exposed through UI metric bindings: `perf.frame_ms`, `perf.update_cpu_ms`, `perf.render_cpu_ms`, sampled renderer counters, and optional backend sample-query metrics via `render.performance_queries`.
- Adds OpenGL sample-query diagnostics for main geometry and depth-prepass samples, plus a high-overdraw renderer test proving that geometry-pass samples scale with overlapping layers without the pre-pass and collapse near one visible layer with the pre-pass.
- Updates validation, docs, and tests.
- Updates SDL_net datagram socket creation for the current three-argument API used by fresh builds, while preserving directed discovery behavior.

Closes first slice of #382.

## Verification
- `make`
- `cmake --build build/debug -j8`
- `./build/debug/tests/slayer3d_network_test`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.UiToolPanelsAndInspectorsEmitReusableOverlayPrimitives:GameDataRuntime.FrameStateSamplesDataDrivenPerformanceMetrics:GameDataRuntime.BrushGeometryDojoLoadsCompiledBrushShowcase'`
- `./build/debug/tests/slayer3d_gl_renderer_test --gtest_filter='GLRendererTest.DepthPrepass*'`
- `ctest --test-dir build/debug -R 'DepthPrepass|FrameStateSamples|BrushGeometryDojoLoads' --output-on-failure`
- Smoke launched: `./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json`