### PR TITLE
Batch equivalent brush render materials

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -610,7 +610,12 @@ code should use
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are
 drawn by the generic data-game frame path. During load, brush worlds also
-precompute local AABBs for each brush and for the whole world. When
+batch render-equivalent authored materials into shared static meshes. Materials
+remain distinct for editor picking, exports, and face metadata, but materials
+with the same texture, color, metallic/roughness, and emissive response can be
+submitted as one mesh; per-face UVs still honor each material's `tex_scale` and
+face UV overrides. During load, brush worlds also precompute local AABBs for
+each brush and for the whole world. When
 `acceleration` is enabled on a scene instance, active-scene trace queries use
 those bounds as a broad phase before exact plane clipping.
 

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -255,6 +255,60 @@ static void brush_mesh_bounds_add(slayer3d_mesh *mesh, slayer3d_vec3 p)
     mesh->local_bounds.max.z = SDL_max(mesh->local_bounds.max.z, p.z);
 }
 
+static bool brush_float_equal(float a, float b)
+{
+    return SDL_fabsf(a - b) <= 0.000001f;
+}
+
+static bool brush_string_equal(const char *a, const char *b)
+{
+    if (a == NULL || a[0] == '\0')
+        a = "";
+    if (b == NULL || b[0] == '\0')
+        b = "";
+    return SDL_strcmp(a, b) == 0;
+}
+
+static bool brush_materials_render_equivalent(const slayer3d_game_data_brush_material *a,
+                                              const slayer3d_game_data_brush_material *b)
+{
+    if (a == NULL || b == NULL)
+        return false;
+    return brush_string_equal(a->texture, b->texture) && brush_float_equal(a->albedo.x, b->albedo.x) &&
+           brush_float_equal(a->albedo.y, b->albedo.y) && brush_float_equal(a->albedo.z, b->albedo.z) &&
+           brush_float_equal(a->albedo.w, b->albedo.w) && brush_float_equal(a->metallic, b->metallic) &&
+           brush_float_equal(a->roughness, b->roughness) && brush_float_equal(a->emissive.x, b->emissive.x) &&
+           brush_float_equal(a->emissive.y, b->emissive.y) && brush_float_equal(a->emissive.z, b->emissive.z);
+}
+
+static int brush_model_build_material_batches(const slayer3d_game_data_brush_world *world, int *material_to_batch,
+                                              int *batch_material_indices)
+{
+    if (world == NULL || material_to_batch == NULL || batch_material_indices == NULL)
+        return 0;
+
+    int batch_count = 0;
+    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    {
+        material_to_batch[material_index] = -1;
+        for (int batch_index = 0; batch_index < batch_count; ++batch_index)
+        {
+            const int representative = batch_material_indices[batch_index];
+            if (brush_materials_render_equivalent(&world->materials[material_index], &world->materials[representative]))
+            {
+                material_to_batch[material_index] = batch_index;
+                break;
+            }
+        }
+        if (material_to_batch[material_index] < 0)
+        {
+            material_to_batch[material_index] = batch_count;
+            batch_material_indices[batch_count++] = material_index;
+        }
+    }
+    return batch_count;
+}
+
 bool slayer3d_game_data_brush_world_build_acceleration(slayer3d_game_data_brush_world *world)
 {
     if (world == NULL)
@@ -337,9 +391,22 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
     if (!brush_model_copy_materials(world, model))
         return false;
 
-    int *triangle_counts = (int *)SDL_calloc((size_t)world->material_count, sizeof(*triangle_counts));
-    if (triangle_counts == NULL)
+    int *material_to_batch = (int *)SDL_malloc((size_t)world->material_count * sizeof(*material_to_batch));
+    int *batch_material_indices = (int *)SDL_malloc((size_t)world->material_count * sizeof(*batch_material_indices));
+    if (material_to_batch == NULL || batch_material_indices == NULL)
+    {
+        SDL_free(material_to_batch);
+        SDL_free(batch_material_indices);
         return false;
+    }
+    const int batch_count = brush_model_build_material_batches(world, material_to_batch, batch_material_indices);
+    int *triangle_counts = (int *)SDL_calloc((size_t)batch_count, sizeof(*triangle_counts));
+    if (triangle_counts == NULL)
+    {
+        SDL_free(material_to_batch);
+        SDL_free(batch_material_indices);
+        return false;
+    }
 
     int max_face_count = 0;
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
@@ -348,6 +415,8 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
     slayer3d_vec3 *polygon = (slayer3d_vec3 *)SDL_malloc((size_t)polygon_capacity * sizeof(*polygon));
     if (polygon == NULL)
     {
+        SDL_free(material_to_batch);
+        SDL_free(batch_material_indices);
         SDL_free(triangle_counts);
         return false;
     }
@@ -364,19 +433,21 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
                 continue;
             const int count = brush_build_face_polygon(brush, face_index, polygon, polygon_capacity, NULL, NULL, NULL);
             if (count >= 3)
-                triangle_counts[material_index] += count - 2;
+                triangle_counts[material_to_batch[material_index]] += count - 2;
         }
     }
 
     int mesh_count = 0;
-    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    for (int batch_index = 0; batch_index < batch_count; ++batch_index)
     {
-        if (triangle_counts[material_index] > 0)
+        if (triangle_counts[batch_index] > 0)
             ++mesh_count;
     }
     if (mesh_count <= 0)
     {
         SDL_free(polygon);
+        SDL_free(material_to_batch);
+        SDL_free(batch_material_indices);
         SDL_free(triangle_counts);
         world->render_model = NULL;
         return true;
@@ -392,22 +463,25 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
     model->mesh_count = mesh_count;
 
     int mesh_index = 0;
-    int *material_to_mesh = (int *)SDL_malloc((size_t)world->material_count * sizeof(*material_to_mesh));
-    int *vertex_offsets = (int *)SDL_calloc((size_t)world->material_count, sizeof(*vertex_offsets));
-    if (material_to_mesh == NULL || vertex_offsets == NULL)
+    int *batch_to_mesh = (int *)SDL_malloc((size_t)batch_count * sizeof(*batch_to_mesh));
+    int *vertex_offsets = (int *)SDL_calloc((size_t)batch_count, sizeof(*vertex_offsets));
+    if (batch_to_mesh == NULL || vertex_offsets == NULL)
     {
-        SDL_free(material_to_mesh);
+        SDL_free(batch_to_mesh);
         SDL_free(vertex_offsets);
         SDL_free(polygon);
+        SDL_free(material_to_batch);
+        SDL_free(batch_material_indices);
         SDL_free(triangle_counts);
         return false;
     }
-    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    for (int batch_index = 0; batch_index < batch_count; ++batch_index)
     {
-        material_to_mesh[material_index] = -1;
-        const int triangles = triangle_counts[material_index];
+        batch_to_mesh[batch_index] = -1;
+        const int triangles = triangle_counts[batch_index];
         if (triangles <= 0)
             continue;
+        const int material_index = batch_material_indices[batch_index];
         slayer3d_mesh *mesh = &model->meshes[mesh_index];
         const int vertex_count = triangles * 3;
         mesh->name =
@@ -423,15 +497,17 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
         if (mesh->name == NULL || mesh->positions == NULL || mesh->normals == NULL || mesh->uvs == NULL ||
             mesh->colors == NULL || mesh->indices == NULL)
         {
-            SDL_free(material_to_mesh);
+            SDL_free(batch_to_mesh);
             SDL_free(vertex_offsets);
             SDL_free(polygon);
+            SDL_free(material_to_batch);
+            SDL_free(batch_material_indices);
             SDL_free(triangle_counts);
             return false;
         }
         for (int i = 0; i < vertex_count; ++i)
             mesh->indices[i] = (unsigned int)i;
-        material_to_mesh[material_index] = mesh_index++;
+        batch_to_mesh[batch_index] = mesh_index++;
     }
 
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
@@ -442,9 +518,11 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
         for (int face_index = 0; face_index < brush->face_count; ++face_index)
         {
             const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
-            const int mesh_for_material = face->material_index >= 0 && face->material_index < world->material_count
-                                              ? material_to_mesh[face->material_index]
-                                              : -1;
+            const int batch_for_material = face->material_index >= 0 && face->material_index < world->material_count
+                                               ? material_to_batch[face->material_index]
+                                               : -1;
+            const int mesh_for_material =
+                batch_for_material >= 0 && batch_for_material < batch_count ? batch_to_mesh[batch_for_material] : -1;
             slayer3d_vec3 normal;
             slayer3d_vec3 u;
             slayer3d_vec3 v;
@@ -471,7 +549,7 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
                 const slayer3d_vec3 verts[3] = {polygon[0], polygon[tri], polygon[tri + 1]};
                 for (int corner = 0; corner < 3; ++corner)
                 {
-                    const int vertex = vertex_offsets[face->material_index]++;
+                    const int vertex = vertex_offsets[batch_for_material]++;
                     if (vertex >= mesh->vertex_count)
                         continue;
                     mesh->positions[vertex * 3 + 0] = verts[corner].x;
@@ -495,9 +573,11 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
     }
 
     world->render_model = model;
-    SDL_free(material_to_mesh);
+    SDL_free(batch_to_mesh);
     SDL_free(vertex_offsets);
     SDL_free(polygon);
+    SDL_free(material_to_batch);
+    SDL_free(batch_material_indices);
     SDL_free(triangle_counts);
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13352,6 +13352,103 @@ TEST(GameDataRuntime, EditorPickingPreservesRepeatedBrushWorldInstancePlacement)
     remove_test_dir(dir);
 }
 
+TEST(GameDataRuntime, BrushRenderModelBatchesEquivalentMaterialsAndPreservesEditorSelection)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_equivalent_material_batching");
+    write_text(dir / "textures" / "wall_metal.jpg", "placeholder");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "brush_worlds": [{ "world": "brush.batched", "position": [0.0, 0.0, 0.0] }]
+  }
+})json");
+    write_text(dir / "equivalent_material_batching.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Equivalent Brush Material Batching Test" },
+  "world": { "name": "world.batch", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.batched",
+      "materials": [
+        {
+          "name": "mat.semantic.wall",
+          "texture": "asset://textures/wall_metal.jpg",
+          "albedo": [0.75, 0.75, 0.75, 1.0],
+          "roughness": 0.8,
+          "tex_scale": 1.0,
+          "editor": { "stable_id": "editor.material.semantic.wall" }
+        },
+        {
+          "name": "mat.semantic.trim",
+          "texture": "asset://textures/wall_metal.jpg",
+          "albedo": [0.75, 0.75, 0.75, 1.0],
+          "roughness": 0.8,
+          "tex_scale": 4.0,
+          "editor": { "stable_id": "editor.material.semantic.trim" }
+        }
+      ],
+      "brushes": [
+        {
+          "name": "brush.room",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  2 }, "material": "mat.semantic.trim" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.semantic.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2 }, "material": "mat.semantic.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.semantic.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  2 }, "material": "mat.semantic.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.semantic.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "equivalent_material_batching.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.batched", &world));
+    ASSERT_EQ(world.material_count, 2);
+    ASSERT_NE(world.render_model, nullptr);
+    EXPECT_EQ(world.render_model->material_count, 2);
+    EXPECT_EQ(world.render_model->mesh_count, 1)
+        << "render-equivalent authored materials should submit as one static brush mesh";
+    EXPECT_EQ(world.render_model->meshes[0].material_index, 0);
+    EXPECT_EQ(world.render_model->meshes[0].vertex_count, 36);
+
+    slayer3d_game_data_world_trace_desc trace{};
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.model_filter = SLAYER3D_GAME_DATA_WORLD_MODEL_FILTER_BRUSH_WORLDS;
+    trace.start = slayer3d_vec3_make(4.0f, 1.0f, 1.0f);
+    trace.end = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+
+    slayer3d_game_data_editor_selection selection{};
+    ASSERT_TRUE(slayer3d_game_data_pick_editor_world_model(runtime, &trace, &selection));
+    EXPECT_TRUE(selection.hit);
+    EXPECT_STREQ(selection.world_name, "brush.batched");
+    EXPECT_STREQ(selection.element_name, "brush.room");
+    EXPECT_STREQ(selection.material_name, "mat.semantic.trim");
+    ASSERT_NE(selection.material_editor, nullptr);
+    EXPECT_STREQ(selection.material_editor->stable_id, "editor.material.semantic.trim");
+    EXPECT_EQ(selection.face_index, 0);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
 TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
 {
     const std::filesystem::path dir = unique_test_dir("editor_create_box_brush");


### PR DESCRIPTION
## Summary
- batch render-equivalent authored brush materials into shared static render meshes while preserving authored material metadata
- keep per-face UV scale/offset/rotation baked into vertex data so semantic material variants can still render correctly
- document the brush render batching behavior

## Quantitative proof
- adds a focused runtime test where 2 authored brush materials with identical render state compile to 1 render mesh
- the same test verifies editor picking still reports the second authored material and editor metadata, proving selection/export correctness is preserved

## Validation
- cmake --build build/debug --target slayer3d_game_data_test -j8
- ctest --test-dir build/debug -R 'GameDataRuntime' --output-on-failure