### PR TITLE
Add brush visibility occlusion culling

### DIFF
--- a/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
+++ b/demos/brush_geometry_dojo/data/fragments/input/fps_controls.json
@@ -14,6 +14,7 @@
           { "name": "action.camera.security.toggle", "bindings": [{ "device": "keyboard", "key": "V" }] },
           { "name": "action.render.depth_prepass.toggle", "bindings": [{ "device": "keyboard", "key": "N" }] },
           { "name": "action.render.light_selection.toggle", "bindings": [{ "device": "keyboard", "key": "B" }] },
+          { "name": "action.render.brush_visibility.toggle", "bindings": [{ "device": "keyboard", "key": "O" }] },
           { "name": "action.gun_tune.toggle", "bindings": [{ "device": "keyboard", "key": "G" }] },
           { "name": "action.smoke_tune.toggle", "bindings": [{ "device": "keyboard", "key": "H" }] },
           { "name": "action.muzzle_tune.toggle", "bindings": [{ "device": "keyboard", "key": "M" }] },

--- a/demos/brush_geometry_dojo/data/fragments/logic/movement_mechanics.json
+++ b/demos/brush_geometry_dojo/data/fragments/logic/movement_mechanics.json
@@ -3,7 +3,8 @@
   "signals": [
     "signal.brush_geometry.camera.toggle",
     "signal.brush_geometry.render.depth_prepass.toggle",
-    "signal.brush_geometry.render.light_selection.toggle"
+    "signal.brush_geometry.render.light_selection.toggle",
+    "signal.brush_geometry.render.brush_visibility.toggle"
   ],
   "logic": {
     "sensors": [
@@ -24,6 +25,12 @@
         "type": "sensor.input_pressed",
         "action": "action.render.light_selection.toggle",
         "on_pressed": "signal.brush_geometry.render.light_selection.toggle"
+      },
+      {
+        "name": "sensor.brush_geometry.brush_visibility_toggle",
+        "type": "sensor.input_pressed",
+        "action": "action.render.brush_visibility.toggle",
+        "on_pressed": "signal.brush_geometry.render.brush_visibility.toggle"
       },
       {
         "name": "sensor.brush_geometry.conveyor.stay",
@@ -101,6 +108,16 @@
             "type": "scene_state.toggle",
             "key": "debug.render.per_object_lights.enabled",
             "default": true
+          }
+        ]
+      },
+      {
+        "signal": "signal.brush_geometry.render.brush_visibility.toggle",
+        "actions": [
+          {
+            "type": "scene_state.toggle",
+            "key": "debug.render.brush_visibility.enabled",
+            "default": false
           }
         ]
       }

--- a/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
+++ b/demos/brush_geometry_dojo/data/scenes/showcase.scene.json
@@ -58,6 +58,7 @@
       "action.jump",
       "action.use",
       "action.camera.security.toggle",
+      "action.render.brush_visibility.toggle",
       "action.fire",
       "action.gun_tune.toggle",
       "action.smoke_tune.toggle",
@@ -173,7 +174,8 @@
         "position": [0.0, 0.0, 0.0],
         "acceleration": true,
         "lighting": true,
-        "debug_wireframe": false
+        "debug_wireframe": false,
+        "visibility_occlusion_key": "debug.render.brush_visibility.enabled"
       }
     ]
   },
@@ -416,6 +418,22 @@
         "scale": 0.48
       },
       {
+        "name": "ui.brush_geometry.brush_visibility_metrics",
+        "font": "font.brush_geometry.hud",
+        "format": "OCC %llu/%llu TRI %llu",
+        "bindings": [
+          { "type": "metric", "metric": "brush.visibility_brush_occluded" },
+          { "type": "metric", "metric": "brush.visibility_brush_candidates" },
+          { "type": "metric", "metric": "brush.visibility_triangles_culled" }
+        ],
+        "x": 0.985,
+        "y": 0.144,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
         "name": "ui.brush_geometry.light_selection_state",
         "font": "font.brush_geometry.hud",
         "format": "B LIGHT CULL %d",
@@ -423,7 +441,21 @@
           { "type": "scene_state", "key": "debug.render.per_object_lights.enabled", "default": true }
         ],
         "x": 0.985,
-        "y": 0.144,
+        "y": 0.172,
+        "normalized": true,
+        "align": "right",
+        "color": [175, 220, 255, 220],
+        "scale": 0.48
+      },
+      {
+        "name": "ui.brush_geometry.brush_visibility_state",
+        "font": "font.brush_geometry.hud",
+        "format": "O BRUSH OCC %d",
+        "bindings": [
+          { "type": "scene_state", "key": "debug.render.brush_visibility.enabled", "default": false }
+        ],
+        "x": 0.985,
+        "y": 0.200,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],
@@ -439,7 +471,7 @@
           { "type": "metric", "metric": "perf.render_cpu_ms" }
         ],
         "x": 0.985,
-        "y": 0.172,
+        "y": 0.228,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],
@@ -454,7 +486,7 @@
           { "type": "metric", "metric": "render.depth_prepass_triangles_per_frame" }
         ],
         "x": 0.985,
-        "y": 0.200,
+        "y": 0.256,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],
@@ -469,7 +501,7 @@
           { "type": "metric", "metric": "render.depth_prepass_samples_per_frame" }
         ],
         "x": 0.985,
-        "y": 0.228,
+        "y": 0.284,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],
@@ -485,7 +517,7 @@
           { "type": "metric", "metric": "render.light_selection_ratio" }
         ],
         "x": 0.985,
-        "y": 0.256,
+        "y": 0.312,
         "normalized": true,
         "align": "right",
         "color": [175, 220, 255, 220],

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -596,16 +596,22 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
         "position": [0.0, 0.0, 0.0],
         "acceleration": true,
         "lighting": true,
-        "debug_wireframe": false
+        "debug_wireframe": false,
+        "visibility_occlusion": false
       }
     ]
   }
 }
 ```
 
-`acceleration_key`, `lighting_key`, and `debug_wireframe_key` may name
-scene-state booleans that override the authored defaults. Runtime and editor
-code should use
+`visibility_occlusion` is an opt-in CPU-side brush visibility pass. When a
+camera is available, the generic frame path tests each renderable brush against
+solid brush blockers and skips brush submodels that are fully hidden. The test
+is conservative: ambiguous brushes remain visible. Use it for indoor/high
+occlusion brush worlds where skipped triangles and material meshes outweigh the
+extra per-brush visibility checks. `acceleration_key`, `lighting_key`,
+`debug_wireframe_key`, and `visibility_occlusion_key` may name scene-state
+booleans that override the authored defaults. Runtime and editor code should use
 `slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are
@@ -2591,7 +2597,9 @@ Supported brush metrics are `brush.trace_count`,
 `brush.bounds_reject_count`, `brush.collision_candidate_count`,
 `brush.hit_count`, `brush.render_mesh_submissions`,
 `brush.render_mesh_culled`, `brush.render_mesh_draws`, and
-`brush.render_triangles_submitted`.
+`brush.render_triangles_submitted`, plus visibility counters
+`brush.visibility_brush_candidates`, `brush.visibility_brush_visible`,
+`brush.visibility_brush_occluded`, and `brush.visibility_triangles_culled`.
 
 For editor-like tools and diagnostics, `ui.panels` and `ui.inspectors` provide
 reusable higher-level overlay widgets while still rendering through the normal

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -528,6 +528,7 @@ in later slices.
           "name": "brush.start_room",
           "tags": ["room", "solid"],
           "contents": ["solid", "player_clip"],
+          "visibility_cullable": false,
           "editor": {
             "stable_id": "brush.keep_01.start_room.v1",
             "display_name": "Start Room",
@@ -573,6 +574,9 @@ Validation requires:
 - optional `contents` as one value or an array of unique values: `solid`,
   `player_clip`, `projectile_clip`, `trigger`, `water`, `lava`, or `sky`;
   omitted contents default to `solid`
+- optional `visibility_cullable` boolean, default `false`; enable this only on
+  discrete/detail brushes that are safe to skip when hidden by other solid
+  brushes
 - each brush to contain at least four `faces`
 - each face to declare `plane.normal` as a non-zero vec3 and
   `plane.distance` as a number
@@ -605,14 +609,17 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
 ```
 
 `visibility_occlusion` is an opt-in CPU-side brush visibility pass. When a
-camera is available, the generic frame path tests each renderable brush against
-solid brush blockers and skips brush submodels that are fully hidden. The test
-is conservative: ambiguous brushes remain visible. Use it for indoor/high
-occlusion brush worlds where skipped triangles and material meshes outweigh the
-extra per-brush visibility checks. `acceleration_key`, `lighting_key`,
-`debug_wireframe_key`, and `visibility_occlusion_key` may name scene-state
-booleans that override the authored defaults. Runtime and editor code should use
-`slayer3d_game_data_get_brush_world()` and
+camera is available, the generic frame path tests brushes authored with
+`visibility_cullable: true` against solid brush blockers and skips cullable
+brush submodels that are fully hidden. Structural floors, walls, ceilings, and
+large world-shell brushes should normally leave `visibility_cullable` unset so
+they cannot disappear from conservative trace ambiguity around shared edges,
+thin openings, or connected-room geometry. Use cullable brushes for discrete
+detail/prop-style brush geometry where skipped triangles and material meshes
+outweigh the extra per-brush visibility checks. `acceleration_key`,
+`lighting_key`, `debug_wireframe_key`, and `visibility_occlusion_key` may name
+scene-state booleans that override the authored defaults. Runtime and editor
+code should use `slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are
 drawn by the generic data-game frame path. During load, brush worlds also

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -521,6 +521,8 @@ extern "C"
         bool lighting_enabled;
         /** @brief Whether debug wireframe should be requested for this instance. */
         bool debug_wireframe;
+        /** @brief Whether camera-based brush visibility/occlusion should be evaluated before drawing. */
+        bool visibility_occlusion_enabled;
     } slayer3d_game_data_brush_world_instance;
 
     /** @brief Collision shape used by a brush-world trace. */
@@ -611,6 +613,14 @@ extern "C"
         Uint64 render_mesh_draws;
         /** @brief Approximate brush-world triangles submitted after renderer culling. */
         Uint64 render_triangles_submitted;
+        /** @brief Renderable brushes tested by brush-world visibility culling. */
+        Uint64 visibility_brush_candidates;
+        /** @brief Renderable brushes accepted by brush-world visibility culling. */
+        Uint64 visibility_brush_visible;
+        /** @brief Renderable brushes rejected by brush-world visibility culling. */
+        Uint64 visibility_brush_occluded;
+        /** @brief Approximate triangles skipped by brush-world visibility culling. */
+        Uint64 visibility_triangles_culled;
     } slayer3d_game_data_brush_diagnostics;
 
     /** @brief Runtime world model implementation kind. */

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -463,6 +463,8 @@ extern "C"
         const char *name;
         /** @brief Bitmask of SLAYER3D_GAME_DATA_BRUSH_CONTENT_* flags. */
         unsigned int contents;
+        /** @brief True when runtime visibility occlusion may cull this brush. */
+        bool visibility_cullable;
         /** @brief Optional authored tags for editor/runtime queries. */
         const char *const *tags;
         /** @brief Number of entries in @p tags. */

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -490,6 +490,19 @@ extern "C"
                                                           const slayer3d_asset_resolver *assets);
 
     /**
+     * @brief Draw active-scene brush worlds with optional camera visibility culling.
+     *
+     * Passing NULL for @p camera preserves the baseline whole-world static mesh
+     * path. Scene instances that opt into `visibility_occlusion` use @p camera
+     * to conservatively skip fully occluded brush submodels before renderer
+     * submission.
+     */
+    bool slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(const slayer3d_game_data_runtime *runtime,
+                                                                     slayer3d_render_context *renderer,
+                                                                     const slayer3d_asset_resolver *assets,
+                                                                     const slayer3d_camera3d *camera);
+
+    /**
      * @brief Draw authored UI text for the active scene.
      *
      * Built-in font assets are loaded on demand through @p font_cache. Text is

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -300,6 +300,12 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     {
         slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
         slayer3d_free_model(&runtime->brush_worlds[i].render_model);
+        for (int brush_model_index = 0; brush_model_index < runtime->brush_worlds[i].brush_render_model_count;
+             ++brush_model_index)
+        {
+            slayer3d_free_model(&runtime->brush_worlds[i].brush_render_models[brush_model_index]);
+        }
+        SDL_free(runtime->brush_worlds[i].brush_render_models);
         SDL_free(runtime->brush_worlds[i].editor_source_path);
         free_editor_metadata(&world->editor);
         SDL_free((void *)world->name);

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -383,7 +383,13 @@ static bool brush_model_copy_materials(const slayer3d_game_data_brush_world *wor
     return true;
 }
 
-bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brush_world *world, slayer3d_model *model)
+static bool brush_index_in_render_filter(int brush_index, int only_brush_index)
+{
+    return only_brush_index < 0 || brush_index == only_brush_index;
+}
+
+static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_world *world, slayer3d_model *model,
+                                                      int only_brush_index)
 {
     if (world == NULL || model == NULL)
         return false;
@@ -423,6 +429,8 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
 
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
     {
+        if (!brush_index_in_render_filter(brush_index, only_brush_index))
+            continue;
         const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
         if (!brush_is_renderable(brush))
             continue;
@@ -449,7 +457,6 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
         SDL_free(material_to_batch);
         SDL_free(batch_material_indices);
         SDL_free(triangle_counts);
-        world->render_model = NULL;
         return true;
     }
 
@@ -512,6 +519,8 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
 
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
     {
+        if (!brush_index_in_render_filter(brush_index, only_brush_index))
+            continue;
         const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
         if (!brush_is_renderable(brush))
             continue;
@@ -572,13 +581,38 @@ bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brus
         }
     }
 
-    world->render_model = model;
     SDL_free(batch_to_mesh);
     SDL_free(vertex_offsets);
     SDL_free(polygon);
     SDL_free(material_to_batch);
     SDL_free(batch_material_indices);
     SDL_free(triangle_counts);
+    return true;
+}
+
+bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brush_world *world, slayer3d_model *model)
+{
+    if (!brush_world_compile_render_model_filtered(world, model, -1))
+        return false;
+    world->render_model = model->mesh_count > 0 ? model : NULL;
+    return true;
+}
+
+bool slayer3d_game_data_brush_world_compile_brush_render_models(slayer3d_game_data_brush_world *world,
+                                                                slayer3d_model *models, int model_count)
+{
+    if (world == NULL || models == NULL || model_count < world->brush_count)
+        return false;
+
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        if (!brush_world_compile_render_model_filtered(world, &models[brush_index], brush_index))
+        {
+            for (int cleanup = 0; cleanup <= brush_index; ++cleanup)
+                slayer3d_free_model(&models[cleanup]);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/src/game_data_brush_internal.h
+++ b/src/game_data_brush_internal.h
@@ -29,6 +29,9 @@ bool slayer3d_game_data_brush_world_build_acceleration(slayer3d_game_data_brush_
 
 bool slayer3d_game_data_brush_world_compile_render_model(slayer3d_game_data_brush_world *world, slayer3d_model *model);
 
+bool slayer3d_game_data_brush_world_compile_brush_render_models(slayer3d_game_data_brush_world *world,
+                                                                slayer3d_model *models, int model_count);
+
 bool slayer3d_game_data_brush_slide_with_trace(slayer3d_game_data_brush_trace_fn trace_fn, void *trace_userdata,
                                                const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
                                                slayer3d_game_data_brush_trace_result *out_result);

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -684,6 +684,14 @@ static bool read_brush_diagnostic_metric(const slayer3d_game_data_runtime *runti
         value = diagnostics.render_mesh_draws;
     else if (SDL_strcmp(name, "render_triangles_submitted") == 0)
         value = diagnostics.render_triangles_submitted;
+    else if (SDL_strcmp(name, "visibility_brush_candidates") == 0)
+        value = diagnostics.visibility_brush_candidates;
+    else if (SDL_strcmp(name, "visibility_brush_visible") == 0)
+        value = diagnostics.visibility_brush_visible;
+    else if (SDL_strcmp(name, "visibility_brush_occluded") == 0)
+        value = diagnostics.visibility_brush_occluded;
+    else if (SDL_strcmp(name, "visibility_triangles_culled") == 0)
+        value = diagnostics.visibility_triangles_culled;
     else
         return false;
 

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -445,6 +445,8 @@ typedef struct brush_world_runtime
 {
     slayer3d_game_data_brush_world desc;
     slayer3d_model render_model;
+    slayer3d_model *brush_render_models;
+    int brush_render_model_count;
     char *editor_source_path;
     Uint64 editor_revision;
     Uint64 editor_saved_revision;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5541,6 +5541,12 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, val
                 ok = false;
                 break;
             }
+            yyjson_val *visibility_cullable = obj_get(brush, "visibility_cullable");
+            if (visibility_cullable != NULL && !yyjson_is_bool(visibility_cullable))
+            {
+                ok = validation_error(ctx, brush_path, "brush visibility_cullable must be a boolean");
+                break;
+            }
             if (!yyjson_is_arr(faces) || yyjson_arr_size(faces) < 4)
             {
                 ok = validation_error(ctx, brush_path, "brush faces must contain at least 4 entries");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -10244,6 +10244,10 @@ static bool ui_metric_name_valid(const char *metric)
         "brush.render_mesh_culled",
         "brush.render_mesh_draws",
         "brush.render_triangles_submitted",
+        "brush.visibility_brush_candidates",
+        "brush.visibility_brush_visible",
+        "brush.visibility_brush_occluded",
+        "brush.visibility_triangles_culled",
     };
 
     for (size_t i = 0; i < SDL_arraysize(metrics); ++i)
@@ -11145,6 +11149,9 @@ static bool validate_scene_brush_worlds(validation_context *ctx, yyjson_val *sce
         yyjson_val *debug_wireframe = obj_get(entry, "debug_wireframe");
         if (debug_wireframe != NULL && !yyjson_is_bool(debug_wireframe))
             return validation_error(ctx, entry_path, "scene brush world debug_wireframe must be a boolean");
+        yyjson_val *visibility_occlusion = obj_get(entry, "visibility_occlusion");
+        if (visibility_occlusion != NULL && !yyjson_is_bool(visibility_occlusion))
+            return validation_error(ctx, entry_path, "scene brush world visibility_occlusion must be a boolean");
         yyjson_val *acceleration_key = obj_get(entry, "acceleration_key");
         if (acceleration_key != NULL && !is_non_empty_string(entry, "acceleration_key"))
             return validation_error(ctx, entry_path, "scene brush world acceleration_key must be non-empty");
@@ -11154,6 +11161,9 @@ static bool validate_scene_brush_worlds(validation_context *ctx, yyjson_val *sce
         yyjson_val *debug_wireframe_key = obj_get(entry, "debug_wireframe_key");
         if (debug_wireframe_key != NULL && !is_non_empty_string(entry, "debug_wireframe_key"))
             return validation_error(ctx, entry_path, "scene brush world debug_wireframe_key must be non-empty");
+        yyjson_val *visibility_occlusion_key = obj_get(entry, "visibility_occlusion_key");
+        if (visibility_occlusion_key != NULL && !is_non_empty_string(entry, "visibility_occlusion_key"))
+            return validation_error(ctx, entry_path, "scene brush world visibility_occlusion_key must be non-empty");
     }
     return true;
 }

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -751,6 +751,23 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
                        world->name != NULL ? world->name : "<unnamed>");
             return false;
         }
+        if (world->brush_count > 0)
+        {
+            runtime->brush_worlds[world_index].brush_render_models =
+                (slayer3d_model *)SDL_calloc((size_t)world->brush_count, sizeof(slayer3d_model));
+            runtime->brush_worlds[world_index].brush_render_model_count = world->brush_count;
+            if (runtime->brush_worlds[world_index].brush_render_models == NULL ||
+                !slayer3d_game_data_brush_world_compile_brush_render_models(
+                    world, runtime->brush_worlds[world_index].brush_render_models, world->brush_count))
+            {
+                SDL_free(runtime->brush_worlds[world_index].brush_render_models);
+                runtime->brush_worlds[world_index].brush_render_models = NULL;
+                runtime->brush_worlds[world_index].brush_render_model_count = 0;
+                set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility meshes",
+                           world->name != NULL ? world->name : "<unnamed>");
+                return false;
+            }
+        }
     }
     return true;
 }

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -682,6 +682,7 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
             brush->name = SDL_strdup(json_string(brush_json, "name", ""));
             brush->contents = brush_flags_from_json(obj_get(brush_json, "contents"), brush_content_flag_from_string,
                                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
+            brush->visibility_cullable = json_bool(brush_json, "visibility_cullable", false);
             brush->tag_count = yyjson_is_arr(tags_json) ? (int)yyjson_arr_size(tags_json) : 0;
             brush->face_count = (int)yyjson_arr_size(faces_json);
             if (brush->name == NULL)

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -651,6 +651,43 @@ static bool editor_brush_world_mark_saved(brush_world_runtime *world_runtime, co
     return true;
 }
 
+static void free_brush_world_visibility_models(brush_world_runtime *world_runtime)
+{
+    if (world_runtime == NULL)
+        return;
+    for (int i = 0; i < world_runtime->brush_render_model_count; ++i)
+        slayer3d_free_model(&world_runtime->brush_render_models[i]);
+    SDL_free(world_runtime->brush_render_models);
+    world_runtime->brush_render_models = NULL;
+    world_runtime->brush_render_model_count = 0;
+}
+
+static bool compile_brush_world_visibility_models(brush_world_runtime *world_runtime, slayer3d_model **out_models,
+                                                  int *out_model_count)
+{
+    if (out_models != NULL)
+        *out_models = NULL;
+    if (out_model_count != NULL)
+        *out_model_count = 0;
+    if (world_runtime == NULL || out_models == NULL || out_model_count == NULL)
+        return false;
+
+    slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    if (world->brush_count <= 0)
+        return true;
+    slayer3d_model *models = (slayer3d_model *)SDL_calloc((size_t)world->brush_count, sizeof(*models));
+    if (models == NULL)
+        return false;
+    if (!slayer3d_game_data_brush_world_compile_brush_render_models(world, models, world->brush_count))
+    {
+        SDL_free(models);
+        return false;
+    }
+    *out_models = models;
+    *out_model_count = world->brush_count;
+    return true;
+}
+
 static bool editor_brush_world_name_exists(const brush_world_runtime *world_runtime, const char *brush_name)
 {
     if (world_runtime == NULL || brush_name == NULL || brush_name[0] == '\0')
@@ -821,12 +858,19 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     world->brush_count = old_count + 1;
 
     slayer3d_model render_model;
+    slayer3d_model *brush_render_models = NULL;
+    int brush_render_model_count = 0;
     SDL_zero(render_model);
-    const bool rebuilt = slayer3d_game_data_brush_world_build_acceleration(world) &&
-                         slayer3d_game_data_brush_world_compile_render_model(world, &render_model);
+    const bool rebuilt =
+        slayer3d_game_data_brush_world_build_acceleration(world) &&
+        slayer3d_game_data_brush_world_compile_render_model(world, &render_model) &&
+        compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count);
     if (!rebuilt)
     {
         slayer3d_free_model(&render_model);
+        for (int i = 0; i < brush_render_model_count; ++i)
+            slayer3d_free_model(&brush_render_models[i]);
+        SDL_free(brush_render_models);
         world->brushes = old_brushes;
         world->brush_count = old_count;
         free_editor_runtime_brush(&brushes[old_count]);
@@ -838,7 +882,10 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
 
     SDL_free(old_brushes);
     slayer3d_free_model(&world_runtime->render_model);
+    free_brush_world_visibility_models(world_runtime);
     world_runtime->render_model = render_model;
+    world_runtime->brush_render_models = brush_render_models;
+    world_runtime->brush_render_model_count = brush_render_model_count;
     world->render_model = &world_runtime->render_model;
     editor_brush_world_mark_dirty(world_runtime);
     if (out_brush_name != NULL && out_brush_name_size > 0u)
@@ -2298,6 +2345,9 @@ bool slayer3d_game_data_for_each_brush_world_instance(const slayer3d_game_data_r
             scene_state_bool(runtime, json_string(entry, "lighting_key", NULL), json_bool(entry, "lighting", true));
         instance.debug_wireframe = scene_state_bool(runtime, json_string(entry, "debug_wireframe_key", NULL),
                                                     json_bool(entry, "debug_wireframe", false));
+        instance.visibility_occlusion_enabled =
+            scene_state_bool(runtime, json_string(entry, "visibility_occlusion_key", NULL),
+                             json_bool(entry, "visibility_occlusion", false));
         if (!callback(userdata, &instance))
             return true;
     }
@@ -4507,15 +4557,24 @@ static bool rebuild_editor_brush_world(brush_world_runtime *world_runtime)
         return false;
 
     slayer3d_model render_model;
+    slayer3d_model *brush_render_models = NULL;
+    int brush_render_model_count = 0;
     SDL_zero(render_model);
-    if (!slayer3d_game_data_brush_world_compile_render_model(world, &render_model))
+    if (!slayer3d_game_data_brush_world_compile_render_model(world, &render_model) ||
+        !compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count))
     {
         slayer3d_free_model(&render_model);
+        for (int i = 0; i < brush_render_model_count; ++i)
+            slayer3d_free_model(&brush_render_models[i]);
+        SDL_free(brush_render_models);
         return false;
     }
 
     slayer3d_free_model(&world_runtime->render_model);
+    free_brush_world_visibility_models(world_runtime);
     world_runtime->render_model = render_model;
+    world_runtime->brush_render_models = brush_render_models;
+    world_runtime->brush_render_model_count = brush_render_model_count;
     world->render_model = &world_runtime->render_model;
     return true;
 }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1370,6 +1370,7 @@ static bool export_add_brush(yyjson_mut_doc *doc, yyjson_mut_val *brushes, const
         !yyjson_mut_obj_add_strcpy(doc, obj, "name", brush->name != NULL ? brush->name : "") ||
         !export_add_brush_contents(doc, obj, brush->contents) ||
         !export_add_string_array(doc, obj, "tags", brush->tags, brush->tag_count) ||
+        (brush->visibility_cullable && !yyjson_mut_obj_add_bool(doc, obj, "visibility_cullable", true)) ||
         !export_add_editor_metadata(doc, obj, &brush->editor) || !yyjson_mut_obj_add_val(doc, obj, "faces", faces))
     {
         return false;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2555,6 +2555,9 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
         context->ok = false;
         return false;
     }
+    for (int brush_index = 0; brush_index < brush_count; ++brush_index)
+        brush_visible[brush_index] = true;
+
     slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
     int occluded_count = 0;
     for (int brush_index = 0; brush_index < brush_count; ++brush_index)
@@ -2564,18 +2567,20 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
             continue;
+        if (!brush->visibility_cullable)
+            continue;
 
         ++mutable_runtime->brush_diagnostics.visibility_brush_candidates;
         if (brush_occluded_from_camera(instance, brush, context->camera))
         {
             ++mutable_runtime->brush_diagnostics.visibility_brush_occluded;
             mutable_runtime->brush_diagnostics.visibility_triangles_culled += triangles;
+            brush_visible[brush_index] = false;
             ++occluded_count;
         }
         else
         {
             ++mutable_runtime->brush_diagnostics.visibility_brush_visible;
-            brush_visible[brush_index] = true;
         }
     }
     if (occluded_count <= 0)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -16,6 +16,7 @@
 #include "slayer3d/math.h"
 #include "slayer3d/shapes.h"
 
+#include "game_data_internal.h"
 #include "render_context_internal.h"
 
 typedef struct primitive_draw_context
@@ -51,8 +52,10 @@ typedef struct sector_level_draw_context
 
 typedef struct brush_world_draw_context
 {
+    const slayer3d_game_data_runtime *runtime;
     slayer3d_render_context *renderer;
     const slayer3d_asset_resolver *assets;
+    const slayer3d_camera3d *camera;
     bool ok;
 } brush_world_draw_context;
 
@@ -2448,6 +2451,181 @@ static bool draw_brush_world_instance(void *userdata, const slayer3d_game_data_b
     return context->ok;
 }
 
+static Uint64 brush_model_triangle_count(const slayer3d_model *model)
+{
+    if (model == NULL || model->meshes == NULL || model->mesh_count <= 0)
+        return 0u;
+    Uint64 triangles = 0u;
+    for (int mesh_index = 0; mesh_index < model->mesh_count; ++mesh_index)
+    {
+        const slayer3d_mesh *mesh = &model->meshes[mesh_index];
+        triangles += (Uint64)((mesh->index_count > 0 ? mesh->index_count : mesh->vertex_count) / 3);
+    }
+    return triangles;
+}
+
+static slayer3d_vec3 brush_bounds_sample(const slayer3d_bounding_box *bounds, int sample_index)
+{
+    if (bounds == NULL)
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (sample_index <= 0)
+    {
+        return slayer3d_vec3_scale(slayer3d_vec3_add(bounds->min, bounds->max), 0.5f);
+    }
+    const int corner = sample_index - 1;
+    return slayer3d_vec3_make((corner & 1) != 0 ? bounds->max.x : bounds->min.x,
+                              (corner & 2) != 0 ? bounds->max.y : bounds->min.y,
+                              (corner & 4) != 0 ? bounds->max.z : bounds->min.z);
+}
+
+static bool point_inside_bounds(slayer3d_vec3 point, const slayer3d_bounding_box *bounds)
+{
+    if (bounds == NULL)
+        return false;
+    return point.x >= bounds->min.x && point.x <= bounds->max.x && point.y >= bounds->min.y &&
+           point.y <= bounds->max.y && point.z >= bounds->min.z && point.z <= bounds->max.z;
+}
+
+static bool brush_visibility_sample_occluded(const slayer3d_game_data_brush_world_instance *instance,
+                                             const slayer3d_game_data_brush *brush, slayer3d_vec3 local_camera,
+                                             slayer3d_vec3 sample)
+{
+    if (instance == NULL || instance->world == NULL || brush == NULL)
+        return false;
+    if (slayer3d_vec3_length_squared(slayer3d_vec3_sub(sample, local_camera)) <= 0.0001f)
+        return false;
+
+    slayer3d_game_data_brush_trace_desc trace;
+    SDL_zero(trace);
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_WATER |
+                          SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY;
+    trace.start = local_camera;
+    trace.end = sample;
+
+    slayer3d_game_data_brush_trace_result result;
+    if (!slayer3d_game_data_brush_world_trace_local_with_diagnostics(instance->world, &trace,
+                                                                     instance->acceleration_enabled, &result, NULL) ||
+        !result.hit)
+    {
+        return false;
+    }
+    if (brush->name != NULL && result.brush_name != NULL && SDL_strcmp(brush->name, result.brush_name) == 0)
+        return false;
+    return result.fraction < 0.995f;
+}
+
+static bool brush_occluded_from_camera(const slayer3d_game_data_brush_world_instance *instance,
+                                       const slayer3d_game_data_brush *brush, const slayer3d_camera3d *camera)
+{
+    if (instance == NULL || brush == NULL || camera == NULL || !brush->has_bounds)
+        return false;
+    const slayer3d_vec3 local_camera = slayer3d_vec3_sub(camera->position, instance->position);
+    if (point_inside_bounds(local_camera, &brush->bounds))
+        return false;
+
+    for (int sample_index = 0; sample_index < 9; ++sample_index)
+    {
+        const slayer3d_vec3 sample = brush_bounds_sample(&brush->bounds, sample_index);
+        if (!brush_visibility_sample_occluded(instance, brush, local_camera, sample))
+            return false;
+    }
+    return true;
+}
+
+static bool draw_brush_world_instance_with_visibility(void *userdata,
+                                                      const slayer3d_game_data_brush_world_instance *instance)
+{
+    brush_world_draw_context *context = (brush_world_draw_context *)userdata;
+    if (context == NULL || context->renderer == NULL || context->runtime == NULL || instance == NULL ||
+        instance->world == NULL)
+        return false;
+    if (!instance->visibility_occlusion_enabled || context->camera == NULL)
+        return draw_brush_world_instance(userdata, instance);
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(context->runtime, instance->world_name);
+    if (world_runtime == NULL || world_runtime->brush_render_models == NULL || instance->world->brushes == NULL ||
+        instance->world->brush_count <= 0)
+    {
+        return draw_brush_world_instance(userdata, instance);
+    }
+    const int brush_count = SDL_min(instance->world->brush_count, world_runtime->brush_render_model_count);
+    bool *brush_visible = (bool *)SDL_calloc((size_t)brush_count, sizeof(*brush_visible));
+    if (brush_visible == NULL)
+    {
+        context->ok = false;
+        return false;
+    }
+    slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
+    int occluded_count = 0;
+    for (int brush_index = 0; brush_index < brush_count; ++brush_index)
+    {
+        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];
+        const Uint64 triangles = brush_model_triangle_count(brush_model);
+        if (triangles == 0u)
+            continue;
+
+        ++mutable_runtime->brush_diagnostics.visibility_brush_candidates;
+        if (brush_occluded_from_camera(instance, brush, context->camera))
+        {
+            ++mutable_runtime->brush_diagnostics.visibility_brush_occluded;
+            mutable_runtime->brush_diagnostics.visibility_triangles_culled += triangles;
+            ++occluded_count;
+        }
+        else
+        {
+            ++mutable_runtime->brush_diagnostics.visibility_brush_visible;
+            brush_visible[brush_index] = true;
+        }
+    }
+    if (occluded_count <= 0)
+    {
+        SDL_free(brush_visible);
+        return draw_brush_world_instance(userdata, instance);
+    }
+
+    bool pushed = false;
+    bool ok = true;
+    if (instance->position.x != 0.0f || instance->position.y != 0.0f || instance->position.z != 0.0f)
+    {
+        if (!slayer3d_push_matrix(context->renderer))
+        {
+            context->ok = false;
+            return false;
+        }
+        pushed = true;
+        ok = slayer3d_translate(context->renderer, instance->position.x, instance->position.y, instance->position.z);
+    }
+
+    const bool restore_lighting = slayer3d_is_lighting_enabled(context->renderer);
+    if (!instance->lighting_enabled)
+        slayer3d_set_lighting_enabled(context->renderer, false);
+
+    for (int brush_index = 0; ok && brush_index < brush_count; ++brush_index)
+    {
+        if (!brush_visible[brush_index])
+            continue;
+        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const Uint64 triangles = brush_model_triangle_count(brush_model);
+        if (triangles == 0u)
+            continue;
+
+        ok = slayer3d_draw_model_ex_with_assets(
+            context->renderer, context->assets, brush_model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+            slayer3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, slayer3d_vec3_make(1.0f, 1.0f, 1.0f),
+            (slayer3d_color){255, 255, 255, 255});
+    }
+
+    if (!instance->lighting_enabled)
+        slayer3d_set_lighting_enabled(context->renderer, restore_lighting);
+    if (pushed && !slayer3d_pop_matrix(context->renderer))
+        ok = false;
+    SDL_free(brush_visible);
+    if (!ok)
+        context->ok = false;
+    return context->ok;
+}
+
 bool slayer3d_game_data_draw_brush_worlds(const slayer3d_game_data_runtime *runtime, slayer3d_render_context *renderer)
 {
     return slayer3d_game_data_draw_brush_worlds_with_assets(runtime, renderer, NULL);
@@ -2457,6 +2635,14 @@ bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_r
                                                       slayer3d_render_context *renderer,
                                                       const slayer3d_asset_resolver *assets)
 {
+    return slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, renderer, assets, NULL);
+}
+
+bool slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(const slayer3d_game_data_runtime *runtime,
+                                                                 slayer3d_render_context *renderer,
+                                                                 const slayer3d_asset_resolver *assets,
+                                                                 const slayer3d_camera3d *camera)
+{
     if (runtime == NULL || renderer == NULL)
         return false;
 
@@ -2465,13 +2651,15 @@ bool slayer3d_game_data_draw_brush_worlds_with_assets(const slayer3d_game_data_r
     const bool have_before_stats = slayer3d_get_render_stats(renderer, &before_stats);
     brush_world_draw_context context;
     SDL_zero(context);
+    context.runtime = runtime;
     context.renderer = renderer;
     context.assets = assets;
+    context.camera = camera;
     context.ok = true;
     const bool previous_depth_prepass_scope = renderer->depth_prepass_scope_enabled;
     renderer->depth_prepass_scope_enabled = true;
-    const bool iterated =
-        slayer3d_game_data_for_each_brush_world_instance(runtime, draw_brush_world_instance, &context);
+    const bool iterated = slayer3d_game_data_for_each_brush_world_instance(
+        runtime, camera != NULL ? draw_brush_world_instance_with_visibility : draw_brush_world_instance, &context);
     renderer->depth_prepass_scope_enabled = previous_depth_prepass_scope;
     slayer3d_render_stats after_stats;
     SDL_zero(after_stats);
@@ -3758,8 +3946,9 @@ bool slayer3d_game_data_draw_frame(const slayer3d_game_data_frame_desc *frame)
                      frame->runtime, frame->renderer, frame->image_cache != NULL ? frame->image_cache->assets : NULL,
                      &camera) &&
                  ok;
-            ok = slayer3d_game_data_draw_brush_worlds_with_assets(
-                     frame->runtime, frame->renderer, frame->image_cache != NULL ? frame->image_cache->assets : NULL) &&
+            ok = slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(
+                     frame->runtime, frame->renderer, frame->image_cache != NULL ? frame->image_cache->assets : NULL,
+                     &camera) &&
                  ok;
             if (frame->particle_cache != NULL)
                 ok = draw_particles_filtered(frame->runtime, frame->renderer, frame->particle_cache, true, false) && ok;

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -366,6 +366,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
         {
           "name": "brush.hidden",
           "contents": "solid",
+          "visibility_cullable": true,
           "faces": [
             { "plane": { "normal": [ 1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
             { "plane": { "normal": [-1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
@@ -419,8 +420,8 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
-    EXPECT_EQ(diagnostics.visibility_brush_candidates, 3u);
-    EXPECT_EQ(diagnostics.visibility_brush_visible, 2u);
+    EXPECT_EQ(diagnostics.visibility_brush_candidates, 1u);
+    EXPECT_EQ(diagnostics.visibility_brush_visible, 0u);
     EXPECT_EQ(diagnostics.visibility_brush_occluded, 1u);
     EXPECT_EQ(diagnostics.visibility_triangles_culled, 12u);
     EXPECT_EQ(diagnostics.render_mesh_submissions, 2u);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -8,11 +8,19 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
 extern "C"
 {
 #include "gl_renderer.h"
 #include "render_context_internal.h"
 #include "slayer3d/effects.h"
+#include "slayer3d/game.h"
+#include "slayer3d/game_data.h"
+#include "slayer3d/game_presentation.h"
 #include "slayer3d/level.h"
 #include "slayer3d/slayer3d.h"
 }
@@ -31,6 +39,23 @@ slayer3d_texture2d MakeTextureFromPixels(const Uint8 *pixels, int width, int hei
     EXPECT_TRUE(slayer3d_create_texture_from_image(&image, &texture));
     EXPECT_TRUE(slayer3d_set_texture_filter(&texture, SLAYER3D_TEXTURE_FILTER_NEAREST));
     return texture;
+}
+
+std::filesystem::path UniqueTempDir(const char *name)
+{
+    const auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    std::filesystem::path dir =
+        std::filesystem::temp_directory_path() / (std::string("slayer3d_") + name + "_" + std::to_string(now));
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+void WriteText(const std::filesystem::path &path, const std::string &text)
+{
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path);
+    ASSERT_TRUE(out.good()) << "failed to open " << path;
+    out << text;
 }
 
 } // namespace
@@ -285,6 +310,125 @@ TEST_F(GLRendererTest, StaticModelMeshesUseInstancedBackendDraws)
     EXPECT_EQ(stats.static_mesh_instanced_draw_calls, 1u);
     EXPECT_EQ(stats.static_mesh_instances_batched, 5u);
     EXPECT_EQ(stats.static_mesh_draw_calls_saved, 4u);
+}
+
+TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
+{
+    const std::filesystem::path dir = UniqueTempDir("brush_visibility_occlusion");
+    WriteText(dir / "scenes" / "play.scene.json",
+              R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": {
+    "brush_worlds": [
+      { "world": "brush.visibility", "visibility_occlusion_key": "brush.visibility.enabled" }
+    ]
+  }
+})json");
+    WriteText(dir / "visibility.game.json",
+              R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Visibility Occlusion Test" },
+  "world": { "name": "world.visibility", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.visibility",
+      "materials": [
+        { "name": "mat.front", "albedo": [0.2, 0.8, 0.2, 1.0] },
+        { "name": "mat.blocker", "albedo": [0.8, 0.2, 0.2, 1.0] },
+        { "name": "mat.hidden", "albedo": [0.2, 0.2, 0.8, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.front",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance": -0.5 }, "material": "mat.front" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  1.5 }, "material": "mat.front" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2.0 }, "material": "mat.front" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0.0 }, "material": "mat.front" },
+            { "plane": { "normal": [ 0,  0,  1], "distance": -1.0 }, "material": "mat.front" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  1.5 }, "material": "mat.front" }
+          ]
+        },
+        {
+          "name": "brush.blocker",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  3.0 }, "material": "mat.blocker" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  3.0 }, "material": "mat.blocker" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  4.0 }, "material": "mat.blocker" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  1.0 }, "material": "mat.blocker" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  0.2 }, "material": "mat.blocker" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0.0 }, "material": "mat.blocker" }
+          ]
+        },
+        {
+          "name": "brush.hidden",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  2.0 }, "material": "mat.hidden" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0.0 }, "material": "mat.hidden" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  3.0 }, "material": "mat.hidden" },
+            { "plane": { "normal": [ 0,  0, -1], "distance": -2.0 }, "material": "mat.hidden" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    char error[512]{};
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "visibility.game.json").string().c_str(), session, &runtime, error,
+                                             sizeof(error)))
+        << error;
+
+    slayer3d_camera3d cam{};
+    cam.position = slayer3d_vec3_make(0.0f, 1.0f, -3.0f);
+    cam.target = slayer3d_vec3_make(0.0f, 1.0f, 4.0f);
+    cam.up = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    cam.fovy = 70.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
+    ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.45f, 0.45f, 0.45f));
+    slayer3d_reset_render_stats(ctx);
+    slayer3d_game_data_reset_brush_diagnostics(runtime);
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    slayer3d_game_data_brush_diagnostics diagnostics{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.render_mesh_submissions, 3u);
+    EXPECT_EQ(diagnostics.visibility_brush_candidates, 0u);
+
+    slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "brush.visibility.enabled", true);
+    slayer3d_reset_render_stats(ctx);
+    slayer3d_game_data_reset_brush_diagnostics(runtime);
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.visibility_brush_candidates, 3u);
+    EXPECT_EQ(diagnostics.visibility_brush_visible, 2u);
+    EXPECT_EQ(diagnostics.visibility_brush_occluded, 1u);
+    EXPECT_EQ(diagnostics.visibility_triangles_culled, 12u);
+    EXPECT_EQ(diagnostics.render_mesh_submissions, 2u);
+    EXPECT_EQ(diagnostics.render_triangles_submitted, 24u);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    std::filesystem::remove_all(dir);
 }
 
 TEST_F(GLRendererTest, DepthPrepassDisabledDoesNotReplayEligibleMeshes)


### PR DESCRIPTION
## Summary
- Add opt-in brush-world visibility occlusion with data-authored visibility_occlusion / visibility_occlusion_key controls.
- Make actual brush removal explicitly per-brush via visibility_cullable so structural floors/walls/ceilings never disappear from conservative trace ambiguity by default.
- Cull fully hidden cullable brush submodels from the forward brush render path while preserving the existing full batched model when nothing is occluded.
- Expose brush visibility diagnostics in render metrics and the brush geometry dojo overlay; press O to toggle the world-level pass.
- Document the authored controls and add a GL renderer regression test proving submission and triangle reduction for an explicitly cullable hidden brush.

## Tests
- cmake --build build/debug --target slayer3d_gl_renderer_test slayer3d_game_data_test game_data_json_test -j8
- ctest --test-dir build/debug -R ^GLRendererTest\\.BrushVisibilityOcclusionCullsHiddenBrushSubmodels$ --output-on-failure
- ctest --test-dir build/debug -R ^GLRendererTest\\.|GameDataRuntime\\.Brush|GameDataJson --output-on-failure

## Manual verification
Run: ./build/debug/slayer3d_runner --root demos/brush_geometry_dojo/data --data asset://brush_geometry_dojo.game.json

Press O to toggle brush occlusion. Structural dojo walls should no longer disappear; only brushes authored with visibility_cullable can be skipped.