### PR TITLE
Add automated brush visibility grid culling

### DIFF
--- a/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
+++ b/demos/brush_geometry_dojo/data/fragments/world/showcase.brushes.json
@@ -5,6 +5,7 @@
       "name": "brush.brush_geometry.showcase",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "visibility_cell_size": 2.0,
       "editor": {
         "stable_id": "brush_world.showcase.v1",
         "display_name": "Brush Geometry Showcase",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -529,7 +529,7 @@ in later slices.
           "name": "brush.start_room",
           "tags": ["room", "solid"],
           "contents": ["solid", "player_clip"],
-          "visibility_cullable": false,
+          "visibility": "auto",
           "editor": {
             "stable_id": "brush.keep_01.start_room.v1",
             "display_name": "Start Room",
@@ -577,9 +577,12 @@ Validation requires:
 - optional `contents` as one value or an array of unique values: `solid`,
   `player_clip`, `projectile_clip`, `trigger`, `water`, `lava`, or `sky`;
   omitted contents default to `solid`
-- optional `visibility_cullable` boolean, default `false`; enable this only on
-  discrete/detail brushes that are safe to skip when hidden by other solid
-  brushes
+- optional `visibility` override: `auto` (default), `always`, or `trace`;
+  `auto` lets the compiled visibility grid decide, `always` keeps rare
+  exception brushes visible, and `trace` enables the older camera-to-brush
+  trace fallback when the automatic grid is unavailable
+- optional legacy `visibility_cullable` boolean, default `false`; when no
+  `visibility` override is authored, `true` is treated as `visibility: "trace"`
 - each brush to contain at least four `faces`
 - each face to declare `plane.normal` as a non-zero vec3 and
   `plane.distance` as a number
@@ -614,17 +617,22 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
 `visibility_occlusion` is an opt-in CPU-side brush visibility pass. At load
 time, the engine automatically compiles a conservative empty-space visibility
 grid from the brush world's solid/player-clip contents. When a camera is
-available, the generic frame path flood-fills visible empty cells from the
-camera and skips brush submodels that have no neighboring visible cell. This is
-intentionally fail-open: if the grid is missing, the camera is outside the grid,
-or a brush is ambiguous, the brush remains visible. Smaller
+available, the generic frame path marks empty cells that have unobstructed
+grid line-of-sight from the camera and skips brush submodels that have no
+neighboring visible cell. This catches common room/corner occlusion without
+requiring authors to place portals by hand. It is intentionally fail-open: if
+the grid is missing, too large for the current CPU pass, the camera is outside
+the grid, or a brush is ambiguous, the brush remains visible. Use
+`visibility: "always"` for rare sky, vista, or effect brushes that must never
+be culled. Smaller
 `visibility_cell_size` values improve blocker precision and doorway behavior at
 higher memory/compile cost; larger values are cheaper but more conservative.
-Brushes authored with `visibility_cullable: true` still participate in the
-older trace-based fallback when no visibility grid is available. `acceleration_key`,
-`lighting_key`, `debug_wireframe_key`, and `visibility_occlusion_key` may name
-scene-state booleans that override the authored defaults. Runtime and editor
-code should use `slayer3d_game_data_get_brush_world()` and
+Brushes authored with `visibility: "trace"` or legacy
+`visibility_cullable: true` still participate in the older trace-based fallback
+when no visibility grid is available. `acceleration_key`, `lighting_key`,
+`debug_wireframe_key`, and `visibility_occlusion_key` may name scene-state
+booleans that override the authored defaults. Runtime and editor code should
+use `slayer3d_game_data_get_brush_world()` and
 `slayer3d_game_data_for_each_brush_world_instance()` rather than reparsing JSON.
 Brush render meshes are available through `brush_world.render_model` and are
 drawn by the generic data-game frame path. During load, brush worlds also

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -502,6 +502,7 @@ in later slices.
       "name": "brush.keep_01",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "visibility_cell_size": 2.0,
       "editor": {
         "stable_id": "brush_world.keep_01.v1",
         "display_name": "Keep 01",
@@ -561,6 +562,8 @@ Validation requires:
 
 - unique brush world names
 - `units` omitted or `"meters"`, with positive `meters_per_unit`
+- optional positive `visibility_cell_size`, default `2.0`; this controls the
+  coarse empty-space grid used by automatic brush visibility culling
 - optional `editor` metadata on brush worlds, materials, brushes, and faces;
   `editor.stable_id` values must be unique inside each brush world
 - non-empty `materials` with unique names
@@ -608,15 +611,17 @@ Scenes instantiate brush worlds through `world.brush_worlds`:
 }
 ```
 
-`visibility_occlusion` is an opt-in CPU-side brush visibility pass. When a
-camera is available, the generic frame path tests brushes authored with
-`visibility_cullable: true` against solid brush blockers and skips cullable
-brush submodels that are fully hidden. Structural floors, walls, ceilings, and
-large world-shell brushes should normally leave `visibility_cullable` unset so
-they cannot disappear from conservative trace ambiguity around shared edges,
-thin openings, or connected-room geometry. Use cullable brushes for discrete
-detail/prop-style brush geometry where skipped triangles and material meshes
-outweigh the extra per-brush visibility checks. `acceleration_key`,
+`visibility_occlusion` is an opt-in CPU-side brush visibility pass. At load
+time, the engine automatically compiles a conservative empty-space visibility
+grid from the brush world's solid/player-clip contents. When a camera is
+available, the generic frame path flood-fills visible empty cells from the
+camera and skips brush submodels that have no neighboring visible cell. This is
+intentionally fail-open: if the grid is missing, the camera is outside the grid,
+or a brush is ambiguous, the brush remains visible. Smaller
+`visibility_cell_size` values improve blocker precision and doorway behavior at
+higher memory/compile cost; larger values are cheaper but more conservative.
+Brushes authored with `visibility_cullable: true` still participate in the
+older trace-based fallback when no visibility grid is available. `acceleration_key`,
 `lighting_key`, `debug_wireframe_key`, and `visibility_occlusion_key` may name
 scene-state booleans that override the authored defaults. Runtime and editor
 code should use `slayer3d_game_data_get_brush_world()` and

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -456,6 +456,17 @@ extern "C"
         slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush_face;
 
+    /** @brief Authored per-brush visibility override for automatic occlusion. */
+    typedef enum slayer3d_game_data_brush_visibility
+    {
+        /** @brief Let the renderer decide visibility from the brush world visibility grid. */
+        SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_AUTO = 0,
+        /** @brief Never hide this brush through visibility occlusion. */
+        SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_ALWAYS = 1,
+        /** @brief Use explicit camera-to-brush trace fallback if the automatic grid is unavailable. */
+        SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_TRACE = 2,
+    } slayer3d_game_data_brush_visibility;
+
     /** @brief Authored convex brush loaded into runtime-owned data. */
     typedef struct slayer3d_game_data_brush
     {
@@ -465,6 +476,8 @@ extern "C"
         unsigned int contents;
         /** @brief True when runtime visibility occlusion may cull this brush. */
         bool visibility_cullable;
+        /** @brief Authored visibility override, normally automatic. */
+        slayer3d_game_data_brush_visibility visibility;
         /** @brief Optional authored tags for editor/runtime queries. */
         const char *const *tags;
         /** @brief Number of entries in @p tags. */

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -490,6 +490,8 @@ extern "C"
         const char *units;
         /** @brief Conversion factor from authored units to meters. */
         float meters_per_unit;
+        /** @brief Positive cell size for automatic visibility culling, in local world units. */
+        float visibility_cell_size;
         /** @brief Runtime material palette for brush faces. */
         const slayer3d_game_data_brush_material *materials;
         /** @brief Number of entries in @p materials. */

--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -494,8 +494,9 @@ extern "C"
      *
      * Passing NULL for @p camera preserves the baseline whole-world static mesh
      * path. Scene instances that opt into `visibility_occlusion` use @p camera
-     * to conservatively skip fully occluded brush submodels before renderer
-     * submission.
+     * to flood-fill the brush world's compiled empty-space visibility grid and
+     * conservatively skip brush submodels with no neighboring visible cell
+     * before renderer submission.
      */
     bool slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(const slayer3d_game_data_runtime *runtime,
                                                                      slayer3d_render_context *renderer,

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -306,6 +306,7 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
             slayer3d_free_model(&runtime->brush_worlds[i].brush_render_models[brush_model_index]);
         }
         SDL_free(runtime->brush_worlds[i].brush_render_models);
+        free_brush_world_visibility_grid(&runtime->brush_worlds[i]);
         SDL_free(runtime->brush_worlds[i].editor_source_path);
         free_editor_metadata(&world->editor);
         SDL_free((void *)world->name);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -447,6 +447,13 @@ typedef struct brush_world_runtime
     slayer3d_model render_model;
     slayer3d_model *brush_render_models;
     int brush_render_model_count;
+    slayer3d_bounding_box visibility_grid_bounds;
+    float visibility_cell_size;
+    int visibility_grid_dim_x;
+    int visibility_grid_dim_y;
+    int visibility_grid_dim_z;
+    int visibility_grid_cell_count;
+    Uint8 *visibility_grid_solid;
     char *editor_source_path;
     Uint64 editor_revision;
     Uint64 editor_saved_revision;
@@ -1020,6 +1027,8 @@ sector_level_runtime *find_sector_level_runtime_mutable(slayer3d_game_data_runti
 const sector_level_runtime *find_sector_level_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
 int sector_level_find_sector_name(const sector_level_runtime *level, const char *sector_name);
 const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
+bool compile_brush_world_visibility_grid(brush_world_runtime *world_runtime);
+void free_brush_world_visibility_grid(brush_world_runtime *world_runtime);
 bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_grid_pickup_layers(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                              int error_buffer_size);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5554,6 +5554,15 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, val
                 ok = validation_error(ctx, brush_path, "brush visibility_cullable must be a boolean");
                 break;
             }
+            yyjson_val *visibility = obj_get(brush, "visibility");
+            if (visibility != NULL &&
+                (!yyjson_is_str(visibility) || (SDL_strcmp(yyjson_get_str(visibility), "auto") != 0 &&
+                                                SDL_strcmp(yyjson_get_str(visibility), "always") != 0 &&
+                                                SDL_strcmp(yyjson_get_str(visibility), "trace") != 0)))
+            {
+                ok = validation_error(ctx, brush_path, "brush visibility must be 'auto', 'always', or 'trace'");
+                break;
+            }
             if (!yyjson_is_arr(faces) || yyjson_arr_size(faces) < 4)
             {
                 ok = validation_error(ctx, brush_path, "brush faces must contain at least 4 entries");

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5389,6 +5389,13 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, val
             ok = validation_error(ctx, world_path, "brush world meters_per_unit must be positive");
             goto done;
         }
+        yyjson_val *visibility_cell_size = obj_get(world, "visibility_cell_size");
+        if (visibility_cell_size != NULL &&
+            (!yyjson_is_num(visibility_cell_size) || yyjson_get_num(visibility_cell_size) <= 0.0))
+        {
+            ok = validation_error(ctx, world_path, "brush world visibility_cell_size must be positive");
+            goto done;
+        }
         {
             char editor_path[PATH_BUFFER_SIZE];
             format_path(editor_path, sizeof(editor_path), "%s.editor", world_path);

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -556,6 +556,17 @@ static unsigned int brush_surface_flag_from_string(const char *name)
     return 0u;
 }
 
+static slayer3d_game_data_brush_visibility brush_visibility_from_string(const char *name)
+{
+    if (name == NULL || name[0] == '\0' || SDL_strcmp(name, "auto") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_AUTO;
+    if (SDL_strcmp(name, "always") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_ALWAYS;
+    if (SDL_strcmp(name, "trace") == 0)
+        return SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_TRACE;
+    return SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_AUTO;
+}
+
 unsigned int brush_flags_from_json(yyjson_val *value, unsigned int (*flag_from_string)(const char *name),
                                    unsigned int fallback)
 {
@@ -684,6 +695,9 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
             brush->contents = brush_flags_from_json(obj_get(brush_json, "contents"), brush_content_flag_from_string,
                                                     SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
             brush->visibility_cullable = json_bool(brush_json, "visibility_cullable", false);
+            brush->visibility = brush_visibility_from_string(json_string(brush_json, "visibility", NULL));
+            if (brush->visibility_cullable && obj_get(brush_json, "visibility") == NULL)
+                brush->visibility = SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_TRACE;
             brush->tag_count = yyjson_is_arr(tags_json) ? (int)yyjson_arr_size(tags_json) : 0;
             brush->face_count = (int)yyjson_arr_size(faces_json);
             if (brush->name == NULL)

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -627,6 +627,7 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
         world->name = SDL_strdup(json_string(world_json, "name", ""));
         world->units = SDL_strdup(json_string(world_json, "units", "meters"));
         world->meters_per_unit = json_float(world_json, "meters_per_unit", 1.0f);
+        world->visibility_cell_size = json_float(world_json, "visibility_cell_size", 2.0f);
         world->material_count = (int)yyjson_arr_size(materials_json);
         world->brush_count = (int)yyjson_arr_size(brushes_json);
         if (world->name == NULL || world->units == NULL)
@@ -768,6 +769,12 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
                            world->name != NULL ? world->name : "<unnamed>");
                 return false;
             }
+        }
+        if (!compile_brush_world_visibility_grid(&runtime->brush_worlds[world_index]))
+        {
+            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility grid",
+                       world->name != NULL ? world->name : "<unnamed>");
+            return false;
         }
     }
     return true;

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1485,6 +1485,20 @@ static bool export_add_brush_face(yyjson_mut_doc *doc, yyjson_mut_val *faces,
            export_add_editor_metadata(doc, obj, &face->editor);
 }
 
+static const char *brush_visibility_name(slayer3d_game_data_brush_visibility visibility)
+{
+    switch (visibility)
+    {
+    case SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_ALWAYS:
+        return "always";
+    case SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_TRACE:
+        return "trace";
+    case SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_AUTO:
+    default:
+        return "auto";
+    }
+}
+
 static bool export_add_brush(yyjson_mut_doc *doc, yyjson_mut_val *brushes, const slayer3d_game_data_brush_world *world,
                              const slayer3d_game_data_brush *brush)
 {
@@ -1494,6 +1508,8 @@ static bool export_add_brush(yyjson_mut_doc *doc, yyjson_mut_val *brushes, const
         !yyjson_mut_obj_add_strcpy(doc, obj, "name", brush->name != NULL ? brush->name : "") ||
         !export_add_brush_contents(doc, obj, brush->contents) ||
         !export_add_string_array(doc, obj, "tags", brush->tags, brush->tag_count) ||
+        (brush->visibility != SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_AUTO &&
+         !yyjson_mut_obj_add_strcpy(doc, obj, "visibility", brush_visibility_name(brush->visibility))) ||
         (brush->visibility_cullable && !yyjson_mut_obj_add_bool(doc, obj, "visibility_cullable", true)) ||
         !export_add_editor_metadata(doc, obj, &brush->editor) || !yyjson_mut_obj_add_val(doc, obj, "faces", faces))
     {

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -662,6 +662,129 @@ static void free_brush_world_visibility_models(brush_world_runtime *world_runtim
     world_runtime->brush_render_model_count = 0;
 }
 
+void free_brush_world_visibility_grid(brush_world_runtime *world_runtime)
+{
+    if (world_runtime == NULL)
+        return;
+    SDL_free(world_runtime->visibility_grid_solid);
+    world_runtime->visibility_grid_solid = NULL;
+    world_runtime->visibility_cell_size = 0.0f;
+    world_runtime->visibility_grid_dim_x = 0;
+    world_runtime->visibility_grid_dim_y = 0;
+    world_runtime->visibility_grid_dim_z = 0;
+    world_runtime->visibility_grid_cell_count = 0;
+    SDL_zero(world_runtime->visibility_grid_bounds);
+}
+
+static bool brush_point_inside_contents(const slayer3d_game_data_brush *brush, slayer3d_vec3 point,
+                                        unsigned int contents_mask)
+{
+    if (brush == NULL || (brush->contents & contents_mask) == 0u)
+        return false;
+    const float epsilon = 0.0005f;
+    for (int face_index = 0; face_index < brush->face_count; ++face_index)
+    {
+        const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+        if ((face->surface_flags & SLAYER3D_GAME_DATA_BRUSH_SURFACE_NO_COLLIDE) != 0u)
+            continue;
+        const float len = slayer3d_vec3_length(face->normal);
+        if (len <= 0.000001f)
+            continue;
+        const slayer3d_vec3 normal = slayer3d_vec3_scale(face->normal, 1.0f / len);
+        const float distance = face->distance / len;
+        if (slayer3d_vec3_dot(normal, point) - distance > epsilon)
+            return false;
+    }
+    return true;
+}
+
+static bool brush_world_point_inside_contents(const slayer3d_game_data_brush_world *world, slayer3d_vec3 point,
+                                              unsigned int contents_mask)
+{
+    if (world == NULL)
+        return false;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        if (brush->has_bounds &&
+            (point.x < brush->bounds.min.x || point.x > brush->bounds.max.x || point.y < brush->bounds.min.y ||
+             point.y > brush->bounds.max.y || point.z < brush->bounds.min.z || point.z > brush->bounds.max.z))
+        {
+            continue;
+        }
+        if (brush_point_inside_contents(brush, point, contents_mask))
+            return true;
+    }
+    return false;
+}
+
+static int visibility_grid_index(int x, int y, int z, int dim_x, int dim_y)
+{
+    return x + y * dim_x + z * dim_x * dim_y;
+}
+
+bool compile_brush_world_visibility_grid(brush_world_runtime *world_runtime)
+{
+    static const int max_cells = 524288;
+    static const float min_cell_size = 0.25f;
+    static const float max_cell_size = 64.0f;
+    free_brush_world_visibility_grid(world_runtime);
+    if (world_runtime == NULL)
+        return false;
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    if (world == NULL || !world->has_bounds || world->brush_count <= 0)
+        return true;
+    const float cell_size = SDL_clamp(world->visibility_cell_size > 0.0f ? world->visibility_cell_size : 2.0f,
+                                      min_cell_size, max_cell_size);
+    slayer3d_bounding_box bounds = world->bounds;
+    bounds.min.x -= cell_size;
+    bounds.min.y -= cell_size;
+    bounds.min.z -= cell_size;
+    bounds.max.x += cell_size;
+    bounds.max.y += cell_size;
+    bounds.max.z += cell_size;
+
+    const int dim_x = SDL_max(1, (int)SDL_ceilf((bounds.max.x - bounds.min.x) / cell_size));
+    const int dim_y = SDL_max(1, (int)SDL_ceilf((bounds.max.y - bounds.min.y) / cell_size));
+    const int dim_z = SDL_max(1, (int)SDL_ceilf((bounds.max.z - bounds.min.z) / cell_size));
+    if (dim_x <= 0 || dim_y <= 0 || dim_z <= 0 || dim_x > max_cells / SDL_max(dim_y, 1) / SDL_max(dim_z, 1))
+        return true;
+    const int cell_count = dim_x * dim_y * dim_z;
+    if (cell_count <= 0 || cell_count > max_cells)
+        return true;
+
+    Uint8 *solid = (Uint8 *)SDL_calloc((size_t)cell_count, sizeof(*solid));
+    if (solid == NULL)
+        return false;
+
+    const unsigned int blocker_mask =
+        SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP;
+    for (int z = 0; z < dim_z; ++z)
+    {
+        for (int y = 0; y < dim_y; ++y)
+        {
+            for (int x = 0; x < dim_x; ++x)
+            {
+                const slayer3d_vec3 point = slayer3d_vec3_make(bounds.min.x + ((float)x + 0.5f) * cell_size,
+                                                               bounds.min.y + ((float)y + 0.5f) * cell_size,
+                                                               bounds.min.z + ((float)z + 0.5f) * cell_size);
+                if (brush_world_point_inside_contents(world, point, blocker_mask))
+                    solid[visibility_grid_index(x, y, z, dim_x, dim_y)] = 1u;
+            }
+        }
+    }
+
+    world_runtime->visibility_grid_bounds = bounds;
+    world_runtime->visibility_cell_size = cell_size;
+    world_runtime->visibility_grid_dim_x = dim_x;
+    world_runtime->visibility_grid_dim_y = dim_y;
+    world_runtime->visibility_grid_dim_z = dim_z;
+    world_runtime->visibility_grid_cell_count = cell_count;
+    world_runtime->visibility_grid_solid = solid;
+    return true;
+}
+
 static bool compile_brush_world_visibility_models(brush_world_runtime *world_runtime, slayer3d_model **out_models,
                                                   int *out_model_count)
 {
@@ -864,7 +987,8 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     const bool rebuilt =
         slayer3d_game_data_brush_world_build_acceleration(world) &&
         slayer3d_game_data_brush_world_compile_render_model(world, &render_model) &&
-        compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count);
+        compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count) &&
+        compile_brush_world_visibility_grid(world_runtime);
     if (!rebuilt)
     {
         slayer3d_free_model(&render_model);
@@ -1393,6 +1517,7 @@ static bool export_add_brush_world(yyjson_mut_doc *doc, yyjson_mut_val *worlds,
         !yyjson_mut_obj_add_strcpy(doc, obj, "name", world->name != NULL ? world->name : "") ||
         !yyjson_mut_obj_add_strcpy(doc, obj, "units", world->units != NULL ? world->units : "meters") ||
         !yyjson_mut_obj_add_real(doc, obj, "meters_per_unit", world->meters_per_unit) ||
+        !yyjson_mut_obj_add_real(doc, obj, "visibility_cell_size", world->visibility_cell_size) ||
         !export_add_editor_metadata(doc, obj, &world->editor) ||
         !yyjson_mut_obj_add_val(doc, obj, "materials", materials) ||
         !yyjson_mut_obj_add_val(doc, obj, "brushes", brushes))
@@ -4562,7 +4687,8 @@ static bool rebuild_editor_brush_world(brush_world_runtime *world_runtime)
     int brush_render_model_count = 0;
     SDL_zero(render_model);
     if (!slayer3d_game_data_brush_world_compile_render_model(world, &render_model) ||
-        !compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count))
+        !compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count) ||
+        !compile_brush_world_visibility_grid(world_runtime))
     {
         slayer3d_free_model(&render_model);
         for (int i = 0; i < brush_render_model_count; ++i)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2560,8 +2560,89 @@ static bool brush_visibility_grid_cell(const brush_world_runtime *world_runtime,
     return true;
 }
 
-static bool brush_visibility_grid_mark_visible(const brush_world_runtime *world_runtime, slayer3d_vec3 local_camera,
-                                               Uint8 *visible_cells)
+static void brush_visibility_grid_cell_coords(const brush_world_runtime *world_runtime, int index, int *out_x,
+                                              int *out_y, int *out_z)
+{
+    const int dim_x = world_runtime != NULL ? world_runtime->visibility_grid_dim_x : 1;
+    const int dim_y = world_runtime != NULL ? world_runtime->visibility_grid_dim_y : 1;
+    const int z = index / (dim_x * dim_y);
+    const int rem = index - z * dim_x * dim_y;
+    const int y = rem / dim_x;
+    const int x = rem - y * dim_x;
+    if (out_x != NULL)
+        *out_x = x;
+    if (out_y != NULL)
+        *out_y = y;
+    if (out_z != NULL)
+        *out_z = z;
+}
+
+static slayer3d_vec3 brush_visibility_grid_cell_center(const brush_world_runtime *world_runtime, int x, int y, int z)
+{
+    const float cell_size = world_runtime->visibility_cell_size;
+    return slayer3d_vec3_make(world_runtime->visibility_grid_bounds.min.x + ((float)x + 0.5f) * cell_size,
+                              world_runtime->visibility_grid_bounds.min.y + ((float)y + 0.5f) * cell_size,
+                              world_runtime->visibility_grid_bounds.min.z + ((float)z + 0.5f) * cell_size);
+}
+
+static bool brush_visibility_grid_ray_clear(const brush_world_runtime *world_runtime, int start_index,
+                                            slayer3d_vec3 local_camera, slayer3d_vec3 target)
+{
+    if (world_runtime == NULL || world_runtime->visibility_grid_solid == NULL)
+        return false;
+    const slayer3d_vec3 delta = slayer3d_vec3_sub(target, local_camera);
+    const float distance = slayer3d_vec3_length(delta);
+    if (distance <= 0.0001f)
+        return true;
+    const float cell_size = world_runtime->visibility_cell_size;
+    const int steps = SDL_max(1, SDL_min(4096, (int)SDL_ceilf(distance / SDL_max(cell_size * 0.35f, 0.05f))));
+    for (int step = 1; step <= steps; ++step)
+    {
+        const float t = (float)step / (float)steps;
+        const slayer3d_vec3 point = slayer3d_vec3_add(local_camera, slayer3d_vec3_scale(delta, t));
+        int index = -1;
+        if (!brush_visibility_grid_cell(world_runtime, point, &index))
+            return false;
+        if (index == start_index)
+            continue;
+        if (world_runtime->visibility_grid_solid[index])
+            return false;
+    }
+    return true;
+}
+
+static void brush_visibility_grid_mark_neighborhood_visible(const brush_world_runtime *world_runtime, int start,
+                                                            Uint8 *visible_cells)
+{
+    int sx = 0;
+    int sy = 0;
+    int sz = 0;
+    brush_visibility_grid_cell_coords(world_runtime, start, &sx, &sy, &sz);
+    for (int z = sz - 1; z <= sz + 1; ++z)
+    {
+        for (int y = sy - 1; y <= sy + 1; ++y)
+        {
+            for (int x = sx - 1; x <= sx + 1; ++x)
+            {
+                if (x < 0 || y < 0 || z < 0 || x >= world_runtime->visibility_grid_dim_x ||
+                    y >= world_runtime->visibility_grid_dim_y || z >= world_runtime->visibility_grid_dim_z)
+                {
+                    continue;
+                }
+                const int index = x + y * world_runtime->visibility_grid_dim_x +
+                                  z * world_runtime->visibility_grid_dim_x * world_runtime->visibility_grid_dim_y;
+                if (index >= 0 && index < world_runtime->visibility_grid_cell_count &&
+                    !world_runtime->visibility_grid_solid[index])
+                {
+                    visible_cells[index] = 1u;
+                }
+            }
+        }
+    }
+}
+
+static bool brush_visibility_grid_mark_visible_los(const brush_world_runtime *world_runtime, slayer3d_vec3 local_camera,
+                                                   Uint8 *visible_cells)
 {
     int start = -1;
     if (world_runtime == NULL || visible_cells == NULL ||
@@ -2571,43 +2652,48 @@ static bool brush_visibility_grid_mark_visible(const brush_world_runtime *world_
         return false;
     }
 
-    int *queue = (int *)SDL_malloc(sizeof(*queue) * (size_t)world_runtime->visibility_grid_cell_count);
-    if (queue == NULL)
+    static const int max_los_cells = 131072;
+    if (world_runtime->visibility_grid_cell_count > max_los_cells)
         return false;
 
-    int head = 0;
-    int tail = 0;
     visible_cells[start] = 1u;
-    queue[tail++] = start;
+    brush_visibility_grid_mark_neighborhood_visible(world_runtime, start, visible_cells);
     const int dim_x = world_runtime->visibility_grid_dim_x;
     const int dim_y = world_runtime->visibility_grid_dim_y;
     const int dim_z = world_runtime->visibility_grid_dim_z;
-    while (head < tail)
+    for (int z = 0; z < dim_z; ++z)
     {
-        const int index = queue[head++];
-        const int z = index / (dim_x * dim_y);
-        const int rem = index - z * dim_x * dim_y;
-        const int y = rem / dim_x;
-        const int x = rem - y * dim_x;
-        const int neighbors[6][3] = {
-            {x - 1, y, z}, {x + 1, y, z}, {x, y - 1, z}, {x, y + 1, z}, {x, y, z - 1}, {x, y, z + 1},
-        };
-        for (int i = 0; i < 6; ++i)
+        for (int y = 0; y < dim_y; ++y)
         {
-            const int nx = neighbors[i][0];
-            const int ny = neighbors[i][1];
-            const int nz = neighbors[i][2];
-            if (nx < 0 || ny < 0 || nz < 0 || nx >= dim_x || ny >= dim_y || nz >= dim_z)
-                continue;
-            const int neighbor = nx + ny * dim_x + nz * dim_x * dim_y;
-            if (visible_cells[neighbor] || world_runtime->visibility_grid_solid[neighbor])
-                continue;
-            visible_cells[neighbor] = 1u;
-            queue[tail++] = neighbor;
+            for (int x = 0; x < dim_x; ++x)
+            {
+                const int index = x + y * dim_x + z * dim_x * dim_y;
+                if (visible_cells[index] || world_runtime->visibility_grid_solid[index])
+                    continue;
+                const slayer3d_vec3 target = brush_visibility_grid_cell_center(world_runtime, x, y, z);
+                if (brush_visibility_grid_ray_clear(world_runtime, start, local_camera, target))
+                    visible_cells[index] = 1u;
+            }
         }
     }
-    SDL_free(queue);
     return true;
+}
+
+static bool brush_visibility_grid_mark_visible(const brush_world_runtime *world_runtime, slayer3d_vec3 local_camera,
+                                               Uint8 *visible_cells)
+{
+    return brush_visibility_grid_mark_visible_los(world_runtime, local_camera, visible_cells);
+}
+
+static bool brush_visibility_forced_visible(const slayer3d_game_data_brush *brush)
+{
+    return brush != NULL && brush->visibility == SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_ALWAYS;
+}
+
+static bool brush_visibility_trace_fallback_enabled(const slayer3d_game_data_brush *brush)
+{
+    return brush != NULL &&
+           (brush->visibility == SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_TRACE || brush->visibility_cullable);
 }
 
 static bool brush_visible_from_visibility_grid(const brush_world_runtime *world_runtime,
@@ -2688,9 +2774,12 @@ static bool apply_brush_visibility_grid(const brush_world_runtime *world_runtime
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
             continue;
+        if (brush_visibility_forced_visible(brush))
+            continue;
 
         ++mutable_runtime->brush_diagnostics.visibility_brush_candidates;
-        if (brush_visible_from_visibility_grid(world_runtime, brush, visible_cells))
+        if (brush_visible_from_visibility_grid(world_runtime, brush, visible_cells) ||
+            !brush_occluded_from_camera(instance, brush, camera))
         {
             ++mutable_runtime->brush_diagnostics.visibility_brush_visible;
         }
@@ -2744,7 +2833,7 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
             continue;
-        if (!brush->visibility_cullable)
+        if (!brush_visibility_trace_fallback_enabled(brush))
             continue;
 
         ++mutable_runtime->brush_diagnostics.visibility_brush_candidates;

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -2533,6 +2533,181 @@ static bool brush_occluded_from_camera(const slayer3d_game_data_brush_world_inst
     return true;
 }
 
+static bool brush_visibility_grid_cell(const brush_world_runtime *world_runtime, slayer3d_vec3 point, int *out_index)
+{
+    if (out_index != NULL)
+        *out_index = -1;
+    if (world_runtime == NULL || world_runtime->visibility_grid_solid == NULL ||
+        world_runtime->visibility_grid_cell_count <= 0 || world_runtime->visibility_cell_size <= 0.0f)
+    {
+        return false;
+    }
+    const float cell_size = world_runtime->visibility_cell_size;
+    const int x = (int)SDL_floorf((point.x - world_runtime->visibility_grid_bounds.min.x) / cell_size);
+    const int y = (int)SDL_floorf((point.y - world_runtime->visibility_grid_bounds.min.y) / cell_size);
+    const int z = (int)SDL_floorf((point.z - world_runtime->visibility_grid_bounds.min.z) / cell_size);
+    if (x < 0 || y < 0 || z < 0 || x >= world_runtime->visibility_grid_dim_x ||
+        y >= world_runtime->visibility_grid_dim_y || z >= world_runtime->visibility_grid_dim_z)
+    {
+        return false;
+    }
+    const int index = x + y * world_runtime->visibility_grid_dim_x +
+                      z * world_runtime->visibility_grid_dim_x * world_runtime->visibility_grid_dim_y;
+    if (index < 0 || index >= world_runtime->visibility_grid_cell_count)
+        return false;
+    if (out_index != NULL)
+        *out_index = index;
+    return true;
+}
+
+static bool brush_visibility_grid_mark_visible(const brush_world_runtime *world_runtime, slayer3d_vec3 local_camera,
+                                               Uint8 *visible_cells)
+{
+    int start = -1;
+    if (world_runtime == NULL || visible_cells == NULL ||
+        !brush_visibility_grid_cell(world_runtime, local_camera, &start) || start < 0 ||
+        world_runtime->visibility_grid_solid[start])
+    {
+        return false;
+    }
+
+    int *queue = (int *)SDL_malloc(sizeof(*queue) * (size_t)world_runtime->visibility_grid_cell_count);
+    if (queue == NULL)
+        return false;
+
+    int head = 0;
+    int tail = 0;
+    visible_cells[start] = 1u;
+    queue[tail++] = start;
+    const int dim_x = world_runtime->visibility_grid_dim_x;
+    const int dim_y = world_runtime->visibility_grid_dim_y;
+    const int dim_z = world_runtime->visibility_grid_dim_z;
+    while (head < tail)
+    {
+        const int index = queue[head++];
+        const int z = index / (dim_x * dim_y);
+        const int rem = index - z * dim_x * dim_y;
+        const int y = rem / dim_x;
+        const int x = rem - y * dim_x;
+        const int neighbors[6][3] = {
+            {x - 1, y, z}, {x + 1, y, z}, {x, y - 1, z}, {x, y + 1, z}, {x, y, z - 1}, {x, y, z + 1},
+        };
+        for (int i = 0; i < 6; ++i)
+        {
+            const int nx = neighbors[i][0];
+            const int ny = neighbors[i][1];
+            const int nz = neighbors[i][2];
+            if (nx < 0 || ny < 0 || nz < 0 || nx >= dim_x || ny >= dim_y || nz >= dim_z)
+                continue;
+            const int neighbor = nx + ny * dim_x + nz * dim_x * dim_y;
+            if (visible_cells[neighbor] || world_runtime->visibility_grid_solid[neighbor])
+                continue;
+            visible_cells[neighbor] = 1u;
+            queue[tail++] = neighbor;
+        }
+    }
+    SDL_free(queue);
+    return true;
+}
+
+static bool brush_visible_from_visibility_grid(const brush_world_runtime *world_runtime,
+                                               const slayer3d_game_data_brush *brush, const Uint8 *visible_cells)
+{
+    if (world_runtime == NULL || brush == NULL || visible_cells == NULL || !brush->has_bounds ||
+        world_runtime->visibility_cell_size <= 0.0f)
+    {
+        return true;
+    }
+    const float cell_size = world_runtime->visibility_cell_size;
+    const float expand = cell_size * 0.5f;
+    const int min_x = SDL_max(
+        0, (int)SDL_floorf((brush->bounds.min.x - expand - world_runtime->visibility_grid_bounds.min.x) / cell_size));
+    const int min_y = SDL_max(
+        0, (int)SDL_floorf((brush->bounds.min.y - expand - world_runtime->visibility_grid_bounds.min.y) / cell_size));
+    const int min_z = SDL_max(
+        0, (int)SDL_floorf((brush->bounds.min.z - expand - world_runtime->visibility_grid_bounds.min.z) / cell_size));
+    const int max_x = SDL_min(
+        world_runtime->visibility_grid_dim_x - 1,
+        (int)SDL_floorf((brush->bounds.max.x + expand - world_runtime->visibility_grid_bounds.min.x) / cell_size));
+    const int max_y = SDL_min(
+        world_runtime->visibility_grid_dim_y - 1,
+        (int)SDL_floorf((brush->bounds.max.y + expand - world_runtime->visibility_grid_bounds.min.y) / cell_size));
+    const int max_z = SDL_min(
+        world_runtime->visibility_grid_dim_z - 1,
+        (int)SDL_floorf((brush->bounds.max.z + expand - world_runtime->visibility_grid_bounds.min.z) / cell_size));
+    if (min_x > max_x || min_y > max_y || min_z > max_z)
+        return true;
+
+    const int dim_x = world_runtime->visibility_grid_dim_x;
+    const int dim_y = world_runtime->visibility_grid_dim_y;
+    for (int z = min_z; z <= max_z; ++z)
+    {
+        for (int y = min_y; y <= max_y; ++y)
+        {
+            for (int x = min_x; x <= max_x; ++x)
+            {
+                const int index = x + y * dim_x + z * dim_x * dim_y;
+                if (index >= 0 && index < world_runtime->visibility_grid_cell_count && visible_cells[index])
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool apply_brush_visibility_grid(const brush_world_runtime *world_runtime,
+                                        const slayer3d_game_data_brush_world_instance *instance,
+                                        const slayer3d_camera3d *camera, bool *brush_visible, int brush_count,
+                                        int *out_occluded_count, slayer3d_game_data_runtime *mutable_runtime)
+{
+    if (out_occluded_count != NULL)
+        *out_occluded_count = 0;
+    if (world_runtime == NULL || instance == NULL || camera == NULL || brush_visible == NULL ||
+        mutable_runtime == NULL || world_runtime->visibility_grid_solid == NULL ||
+        world_runtime->visibility_grid_cell_count <= 0)
+    {
+        return false;
+    }
+    Uint8 *visible_cells =
+        (Uint8 *)SDL_calloc((size_t)world_runtime->visibility_grid_cell_count, sizeof(*visible_cells));
+    if (visible_cells == NULL)
+        return false;
+
+    const slayer3d_vec3 local_camera = slayer3d_vec3_sub(camera->position, instance->position);
+    if (!brush_visibility_grid_mark_visible(world_runtime, local_camera, visible_cells))
+    {
+        SDL_free(visible_cells);
+        return false;
+    }
+
+    int occluded_count = 0;
+    for (int brush_index = 0; brush_index < brush_count; ++brush_index)
+    {
+        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];
+        const Uint64 triangles = brush_model_triangle_count(brush_model);
+        if (triangles == 0u)
+            continue;
+
+        ++mutable_runtime->brush_diagnostics.visibility_brush_candidates;
+        if (brush_visible_from_visibility_grid(world_runtime, brush, visible_cells))
+        {
+            ++mutable_runtime->brush_diagnostics.visibility_brush_visible;
+        }
+        else
+        {
+            ++mutable_runtime->brush_diagnostics.visibility_brush_occluded;
+            mutable_runtime->brush_diagnostics.visibility_triangles_culled += triangles;
+            brush_visible[brush_index] = false;
+            ++occluded_count;
+        }
+    }
+    SDL_free(visible_cells);
+    if (out_occluded_count != NULL)
+        *out_occluded_count = occluded_count;
+    return true;
+}
+
 static bool draw_brush_world_instance_with_visibility(void *userdata,
                                                       const slayer3d_game_data_brush_world_instance *instance)
 {
@@ -2560,7 +2735,9 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
 
     slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
     int occluded_count = 0;
-    for (int brush_index = 0; brush_index < brush_count; ++brush_index)
+    const bool used_visibility_grid = apply_brush_visibility_grid(
+        world_runtime, instance, context->camera, brush_visible, brush_count, &occluded_count, mutable_runtime);
+    for (int brush_index = 0; !used_visibility_grid && brush_index < brush_count; ++brush_index)
     {
         const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
         const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12444,6 +12444,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
           "name": "brush.room",
           "tags": ["solid", "room"],
           "contents": ["solid", "player_clip"],
+          "visibility": "always",
           "editor": {
             "stable_id": "brush.test.room.v1",
             "display_name": "Runtime Test Room",
@@ -12518,6 +12519,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(world.brushes[0].editor.prefab, "prefab.test.room");
     EXPECT_EQ(world.brushes[0].contents,
               SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP);
+    EXPECT_EQ(world.brushes[0].visibility, SLAYER3D_GAME_DATA_BRUSH_VISIBILITY_ALWAYS);
     ASSERT_EQ(world.brushes[0].tag_count, 2);
     EXPECT_STREQ(world.brushes[0].tags[1], "room");
     ASSERT_EQ(world.brushes[0].face_count, 6);
@@ -12676,6 +12678,31 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
 })json",
             nullptr,
             "brush world visibility_cell_size must be positive",
+        },
+        {
+            "bad_visibility",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "visibility": "maybe",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush visibility must be 'auto', 'always', or 'trace'",
         },
         {
             "bad_emissive",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12409,6 +12409,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
       "name": "brush.test",
       "units": "meters",
       "meters_per_unit": 1.0,
+      "visibility_cell_size": 1.5,
       "editor": {
         "stable_id": "brush_world.test.v1",
         "display_name": "Brush Test World",
@@ -12488,6 +12489,7 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(world.name, "brush.test");
     EXPECT_STREQ(world.units, "meters");
     EXPECT_FLOAT_EQ(world.meters_per_unit, 1.0f);
+    EXPECT_FLOAT_EQ(world.visibility_cell_size, 1.5f);
     EXPECT_STREQ(world.editor.stable_id, "brush_world.test.v1");
     EXPECT_STREQ(world.editor.display_name, "Brush Test World");
     EXPECT_STREQ(world.editor.category, "tests/brush");
@@ -12649,6 +12651,31 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
 })json",
             nullptr,
             "brush content value is unknown",
+        },
+        {
+            "bad_visibility_cell_size",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "visibility_cell_size": 0.0,
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush world visibility_cell_size must be positive",
         },
         {
             "bad_emissive",

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -59,6 +59,36 @@ void WriteText(const std::filesystem::path &path, const std::string &text)
     out << text;
 }
 
+std::string BrushVisibilityBoxJson(const char *name, const char *material, float min_x, float max_x, float min_y,
+                                   float max_y, float min_z, float max_z, const char *visibility = nullptr)
+{
+    std::ostringstream json;
+    json << R"json({
+          "name": ")json"
+         << name << R"json(",
+          "contents": "solid",
+)json";
+    if (visibility != nullptr)
+        json << R"json(          "visibility": ")json" << visibility << R"json(",
+)json";
+    json << R"json(          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance": )json"
+         << max_x << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [-1,  0,  0], "distance": )json"
+         << -min_x << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  1,  0], "distance": )json"
+         << max_y << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0, -1,  0], "distance": )json"
+         << -min_y << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  0,  1], "distance": )json"
+         << max_z << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  0, -1], "distance": )json"
+         << -min_z << R"json( }, "material": ")json" << material << R"json(" }
+          ]
+        })json";
+    return json.str();
+}
+
 } // namespace
 
 class GLRendererTest : public ::testing::Test
@@ -316,30 +346,6 @@ TEST_F(GLRendererTest, StaticModelMeshesUseInstancedBackendDraws)
 TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
 {
     const std::filesystem::path dir = UniqueTempDir("brush_visibility_occlusion");
-    auto box = [](const char *name, const char *material, float min_x, float max_x, float min_y, float max_y,
-                  float min_z, float max_z) {
-        std::ostringstream json;
-        json << R"json({
-          "name": ")json"
-             << name << R"json(",
-          "contents": "solid",
-          "faces": [
-            { "plane": { "normal": [ 1,  0,  0], "distance": )json"
-             << max_x << R"json( }, "material": ")json" << material << R"json(" },
-            { "plane": { "normal": [-1,  0,  0], "distance": )json"
-             << -min_x << R"json( }, "material": ")json" << material << R"json(" },
-            { "plane": { "normal": [ 0,  1,  0], "distance": )json"
-             << max_y << R"json( }, "material": ")json" << material << R"json(" },
-            { "plane": { "normal": [ 0, -1,  0], "distance": )json"
-             << -min_y << R"json( }, "material": ")json" << material << R"json(" },
-            { "plane": { "normal": [ 0,  0,  1], "distance": )json"
-             << max_z << R"json( }, "material": ")json" << material << R"json(" },
-            { "plane": { "normal": [ 0,  0, -1], "distance": )json"
-             << -min_z << R"json( }, "material": ")json" << material << R"json(" }
-          ]
-        })json";
-        return json.str();
-    };
     WriteText(dir / "scenes" / "play.scene.json",
               R"json({
   "schema": "slayer3d.scene.v0",
@@ -365,9 +371,10 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
         { "name": "mat.hidden", "albedo": [0.2, 0.2, 0.8, 1.0] }
       ],
       "brushes": [
-)json" << box("brush.front_marker", "mat.front", -0.75f, 0.75f, 0.5f, 1.5f, -2.5f, -2.0f)
-              << "," << box("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f) << ","
-              << box("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f) << R"json(
+)json" << BrushVisibilityBoxJson("brush.front_marker", "mat.front", 2.4f, 3.0f, 0.5f, 1.5f, -2.5f, -2.0f)
+              << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f)
+              << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f)
+              << R"json(
       ]
     }
   ],
@@ -418,7 +425,54 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     EXPECT_GE(diagnostics.visibility_brush_occluded, 1u);
     EXPECT_GE(diagnostics.visibility_triangles_culled, 12u);
     EXPECT_EQ(diagnostics.render_mesh_submissions, 2u);
-    EXPECT_EQ(diagnostics.render_triangles_submitted, 24u);
+    EXPECT_LT(diagnostics.render_triangles_submitted, 36u);
+
+    slayer3d_game_data_destroy(runtime);
+    runtime = nullptr;
+
+    std::ostringstream override_game_json;
+    override_game_json << R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Visibility Override Test" },
+  "world": { "name": "world.visibility", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.visibility",
+      "visibility_cell_size": 0.5,
+      "materials": [
+        { "name": "mat.front", "albedo": [0.2, 0.8, 0.2, 1.0] },
+        { "name": "mat.blocker", "albedo": [0.8, 0.2, 0.2, 1.0] },
+        { "name": "mat.hidden", "albedo": [0.2, 0.2, 0.8, 1.0] }
+      ],
+      "brushes": [
+)json" << BrushVisibilityBoxJson("brush.front_marker", "mat.front", 2.4f, 3.0f, 0.5f, 1.5f, -2.5f, -2.0f)
+                       << ","
+                       << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f)
+                       << ","
+                       << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f,
+                                                 "always")
+                       << R"json(
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+    WriteText(dir / "visibility_override.game.json", override_game_json.str());
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "visibility_override.game.json").string().c_str(), session,
+                                             &runtime, error, sizeof(error)))
+        << error;
+    slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "brush.visibility.enabled", true);
+    slayer3d_reset_render_stats(ctx);
+    slayer3d_game_data_reset_brush_diagnostics(runtime);
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
+    EXPECT_EQ(diagnostics.visibility_brush_candidates, 2u);
+    EXPECT_EQ(diagnostics.visibility_brush_occluded, 0u);
+    EXPECT_EQ(diagnostics.render_mesh_submissions, 3u);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 
 extern "C"
@@ -315,6 +316,30 @@ TEST_F(GLRendererTest, StaticModelMeshesUseInstancedBackendDraws)
 TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
 {
     const std::filesystem::path dir = UniqueTempDir("brush_visibility_occlusion");
+    auto box = [](const char *name, const char *material, float min_x, float max_x, float min_y, float max_y,
+                  float min_z, float max_z) {
+        std::ostringstream json;
+        json << R"json({
+          "name": ")json"
+             << name << R"json(",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance": )json"
+             << max_x << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [-1,  0,  0], "distance": )json"
+             << -min_x << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  1,  0], "distance": )json"
+             << max_y << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0, -1,  0], "distance": )json"
+             << -min_y << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  0,  1], "distance": )json"
+             << max_z << R"json( }, "material": ")json" << material << R"json(" },
+            { "plane": { "normal": [ 0,  0, -1], "distance": )json"
+             << -min_z << R"json( }, "material": ")json" << material << R"json(" }
+          ]
+        })json";
+        return json.str();
+    };
     WriteText(dir / "scenes" / "play.scene.json",
               R"json({
   "schema": "slayer3d.scene.v0",
@@ -325,62 +350,30 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     ]
   }
 })json");
-    WriteText(dir / "visibility.game.json",
-              R"json({
+    std::ostringstream game_json;
+    game_json << R"json({
   "schema": "slayer3d.game.v0",
   "metadata": { "name": "Brush Visibility Occlusion Test" },
   "world": { "name": "world.visibility", "kind": "brush" },
   "brush_worlds": [
     {
       "name": "brush.visibility",
+      "visibility_cell_size": 0.5,
       "materials": [
         { "name": "mat.front", "albedo": [0.2, 0.8, 0.2, 1.0] },
         { "name": "mat.blocker", "albedo": [0.8, 0.2, 0.2, 1.0] },
         { "name": "mat.hidden", "albedo": [0.2, 0.2, 0.8, 1.0] }
       ],
       "brushes": [
-        {
-          "name": "brush.front",
-          "contents": "solid",
-          "faces": [
-            { "plane": { "normal": [ 1,  0,  0], "distance": -0.5 }, "material": "mat.front" },
-            { "plane": { "normal": [-1,  0,  0], "distance":  1.5 }, "material": "mat.front" },
-            { "plane": { "normal": [ 0,  1,  0], "distance":  2.0 }, "material": "mat.front" },
-            { "plane": { "normal": [ 0, -1,  0], "distance":  0.0 }, "material": "mat.front" },
-            { "plane": { "normal": [ 0,  0,  1], "distance": -1.0 }, "material": "mat.front" },
-            { "plane": { "normal": [ 0,  0, -1], "distance":  1.5 }, "material": "mat.front" }
-          ]
-        },
-        {
-          "name": "brush.blocker",
-          "contents": "solid",
-          "faces": [
-            { "plane": { "normal": [ 1,  0,  0], "distance":  3.0 }, "material": "mat.blocker" },
-            { "plane": { "normal": [-1,  0,  0], "distance":  3.0 }, "material": "mat.blocker" },
-            { "plane": { "normal": [ 0,  1,  0], "distance":  4.0 }, "material": "mat.blocker" },
-            { "plane": { "normal": [ 0, -1,  0], "distance":  1.0 }, "material": "mat.blocker" },
-            { "plane": { "normal": [ 0,  0,  1], "distance":  0.2 }, "material": "mat.blocker" },
-            { "plane": { "normal": [ 0,  0, -1], "distance":  0.0 }, "material": "mat.blocker" }
-          ]
-        },
-        {
-          "name": "brush.hidden",
-          "contents": "solid",
-          "visibility_cullable": true,
-          "faces": [
-            { "plane": { "normal": [ 1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
-            { "plane": { "normal": [-1,  0,  0], "distance":  1.0 }, "material": "mat.hidden" },
-            { "plane": { "normal": [ 0,  1,  0], "distance":  2.0 }, "material": "mat.hidden" },
-            { "plane": { "normal": [ 0, -1,  0], "distance":  0.0 }, "material": "mat.hidden" },
-            { "plane": { "normal": [ 0,  0,  1], "distance":  3.0 }, "material": "mat.hidden" },
-            { "plane": { "normal": [ 0,  0, -1], "distance": -2.0 }, "material": "mat.hidden" }
-          ]
-        }
+)json" << box("brush.front_marker", "mat.front", -0.75f, 0.75f, 0.5f, 1.5f, -2.5f, -2.0f)
+              << "," << box("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f) << ","
+              << box("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f) << R"json(
       ]
     }
   ],
   "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
-})json");
+})json";
+    WriteText(dir / "visibility.game.json", game_json.str());
 
     slayer3d_game_session *session = nullptr;
     ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
@@ -391,7 +384,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
         << error;
 
     slayer3d_camera3d cam{};
-    cam.position = slayer3d_vec3_make(0.0f, 1.0f, -3.0f);
+    cam.position = slayer3d_vec3_make(0.0f, 1.0f, -2.75f);
     cam.target = slayer3d_vec3_make(0.0f, 1.0f, 4.0f);
     cam.up = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
     cam.fovy = 70.0f;
@@ -420,10 +413,10 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     ASSERT_TRUE(slayer3d_game_data_get_brush_diagnostics(runtime, &diagnostics));
-    EXPECT_EQ(diagnostics.visibility_brush_candidates, 1u);
-    EXPECT_EQ(diagnostics.visibility_brush_visible, 0u);
-    EXPECT_EQ(diagnostics.visibility_brush_occluded, 1u);
-    EXPECT_EQ(diagnostics.visibility_triangles_culled, 12u);
+    EXPECT_EQ(diagnostics.visibility_brush_candidates, 3u);
+    EXPECT_LT(diagnostics.visibility_brush_visible, diagnostics.visibility_brush_candidates);
+    EXPECT_GE(diagnostics.visibility_brush_occluded, 1u);
+    EXPECT_GE(diagnostics.visibility_triangles_culled, 12u);
     EXPECT_EQ(diagnostics.render_mesh_submissions, 2u);
     EXPECT_EQ(diagnostics.render_triangles_submitted, 24u);
 


### PR DESCRIPTION
## Summary
- compile an automatic empty-space visibility grid for each brush world from solid/player-clip brush contents
- mark visible cells using conservative grid line-of-sight from the active camera instead of whole-room flood fill
- cull brush submodels with no neighboring visible cell, then verify with exact camera-to-brush traces before hiding anything
- add authored per-brush visibility overrides: `auto`, `always`, and `trace`; legacy `visibility_cullable` remains a trace fallback alias
- enable the brush geometry dojo's brush visibility path by default with an explicit 2m visibility grid
- update validation, export, docs, and renderer/game-data tests

## Tests
- `cmake --build build/debug --target slayer3d_gl_renderer_test slayer3d_game_data_test game_data_json_test -j8`
- `ctest --test-dir build/debug -R '^GLRendererTest\\.BrushVisibilityOcclusionCullsHiddenBrushSubmodels$|GameDataRuntime\\.LoadsAuthoredBrushWorlds|GameDataRuntime\\.RejectsInvalidBrushWorlds|GameDataRuntime\\.BrushGeometryDojoLoadsCompiledBrushShowcase|GameDataJson' --output-on-failure`

## Notes
The path is still fail-open: missing grids, oversized grids, camera-outside-grid cases, and ambiguous visible blockers render normally. `visibility: "always"` is the rare manual escape hatch for sky/vista/effect brushes that should never be culled.
