### PR TITLE
Cache model animation poses per frame

### DIFF
--- a/include/slayer3d/game_presentation.h
+++ b/include/slayer3d/game_presentation.h
@@ -145,18 +145,34 @@ extern "C"
         bool loaded;          /**< True once the model owns loaded meshes/materials. */
     } slayer3d_game_data_model_cache_entry;
 
+    /** @brief One frame-local cached skeletal pose for an authored render.model draw. */
+    typedef struct slayer3d_game_data_model_pose_cache_entry
+    {
+        const slayer3d_model *model;   /**< Model that owns the skeleton/clip. */
+        int animation_clip;            /**< Animation clip index on model. */
+        float animation_time;          /**< Normalized animation time used for evaluation. */
+        slayer3d_mat4 *joint_matrices; /**< Owned matrix palette reused across frames. */
+        int joint_count;               /**< Number of valid joint matrices. */
+        int joint_capacity;            /**< Allocated matrix capacity. */
+    } slayer3d_game_data_model_pose_cache_entry;
+
     /**
      * @brief Runtime cache for model assets referenced by authored world models.
      *
      * The cache owns loaded model data. Current model loaders require a
      * filesystem path, so model assets must resolve through a directory mount.
+     * It also owns a frame-local skeletal pose cache used by presentation
+     * helpers to avoid re-evaluating identical model/clip/time poses.
      */
     typedef struct slayer3d_game_data_model_cache
     {
-        slayer3d_game_data_model_cache_entry *entries; /**< Cached model entries. */
-        int count;                                     /**< Number of cached models. */
-        int capacity;                                  /**< Allocated cache slots. */
-        slayer3d_asset_resolver *assets;               /**< Resolver used for lazy loads; not owned. */
+        slayer3d_game_data_model_cache_entry *entries;           /**< Cached model entries. */
+        int count;                                               /**< Number of cached models. */
+        int capacity;                                            /**< Allocated cache slots. */
+        slayer3d_asset_resolver *assets;                         /**< Resolver used for lazy loads; not owned. */
+        slayer3d_game_data_model_pose_cache_entry *pose_entries; /**< Frame-local cached skeletal poses. */
+        int pose_count;                                          /**< Number of poses used this frame. */
+        int pose_capacity;                                       /**< Allocated pose cache slots. */
     } slayer3d_game_data_model_cache;
 
     /** @brief One cached procedural mesh generated from an authored render.mesh_primitive descriptor. */
@@ -435,6 +451,29 @@ extern "C"
      * @param assets Asset resolver used to resolve authored model paths; not owned.
      */
     void slayer3d_game_data_model_cache_init(slayer3d_game_data_model_cache *cache, slayer3d_asset_resolver *assets);
+
+    /**
+     * @brief Clear frame-local skeletal poses while keeping allocated matrix storage.
+     *
+     * Call once at the beginning of a presented frame before evaluating
+     * render.model animation poses. slayer3d_game_data_draw_frame() does this
+     * automatically for its model cache.
+     */
+    void slayer3d_game_data_model_cache_begin_pose_frame(slayer3d_game_data_model_cache *cache);
+
+    /**
+     * @brief Evaluate or reuse a cached model animation pose.
+     *
+     * The returned matrix palette is owned by @p cache and remains valid until
+     * the next slayer3d_game_data_model_cache_begin_pose_frame() or
+     * slayer3d_game_data_model_cache_free(). @p animation_time is wrapped by
+     * clip duration when @p loop is true.
+     */
+    const slayer3d_mat4 *slayer3d_game_data_model_cache_evaluate_pose(slayer3d_game_data_model_cache *cache,
+                                                                      slayer3d_render_context *renderer,
+                                                                      const slayer3d_model *model, int animation_clip,
+                                                                      float animation_time, bool loop,
+                                                                      int *out_joint_count);
 
     /**
      * @brief Free all models owned by a world model cache.

--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -80,6 +80,10 @@ extern "C"
         Uint64 gpu_skinned_vertices;
         /** @brief Vertices skinned on the CPU fallback path. */
         Uint64 cpu_skinned_vertices;
+        /** @brief Authored model animation poses evaluated by the presentation layer. */
+        Uint64 animation_pose_evaluations;
+        /** @brief Authored model animation pose cache hits in the presentation layer. */
+        Uint64 animation_pose_cache_hits;
     } slayer3d_render_stats;
 
     /**

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -421,6 +421,26 @@ static bool ensure_model_cache_capacity(slayer3d_game_data_model_cache *cache, i
     return true;
 }
 
+static bool ensure_model_pose_cache_capacity(slayer3d_game_data_model_cache *cache, int required)
+{
+    if (cache == NULL || required <= cache->pose_capacity)
+        return cache != NULL;
+
+    int next_capacity = cache->pose_capacity < 16 ? 16 : cache->pose_capacity * 2;
+    while (next_capacity < required)
+        next_capacity *= 2;
+
+    slayer3d_game_data_model_pose_cache_entry *entries = (slayer3d_game_data_model_pose_cache_entry *)SDL_realloc(
+        cache->pose_entries, (size_t)next_capacity * sizeof(*entries));
+    if (entries == NULL)
+        return false;
+
+    SDL_memset(entries + cache->pose_capacity, 0, (size_t)(next_capacity - cache->pose_capacity) * sizeof(*entries));
+    cache->pose_entries = entries;
+    cache->pose_capacity = next_capacity;
+    return true;
+}
+
 static bool ensure_mesh_primitive_cache_capacity(slayer3d_game_data_mesh_primitive_cache *cache, int required)
 {
     if (cache == NULL || required <= cache->capacity)
@@ -715,6 +735,94 @@ static slayer3d_game_data_model_cache_entry *find_or_load_model_entry(const slay
 
     ++cache->count;
     return entry;
+}
+
+void slayer3d_game_data_model_cache_begin_pose_frame(slayer3d_game_data_model_cache *cache)
+{
+    if (cache != NULL)
+        cache->pose_count = 0;
+}
+
+static const slayer3d_mat4 *model_pose_cache_evaluate_clip(slayer3d_game_data_model_cache *cache,
+                                                           slayer3d_render_context *renderer,
+                                                           const slayer3d_model *model,
+                                                           const slayer3d_animation_clip *clip, int animation_clip,
+                                                           float animation_time, int *out_joint_count)
+{
+    if (out_joint_count != NULL)
+        *out_joint_count = 0;
+    if (cache == NULL || model == NULL || model->skeleton == NULL || clip == NULL || out_joint_count == NULL)
+        return NULL;
+
+    const int joint_count = model->skeleton->joint_count;
+    if (joint_count <= 0)
+        return NULL;
+
+    for (int i = 0; i < cache->pose_count; ++i)
+    {
+        slayer3d_game_data_model_pose_cache_entry *entry = &cache->pose_entries[i];
+        if (entry->model == model && entry->animation_clip == animation_clip &&
+            entry->animation_time == animation_time && entry->joint_count == joint_count)
+        {
+            *out_joint_count = joint_count;
+            if (renderer != NULL)
+                renderer->stats.animation_pose_cache_hits += 1u;
+            return entry->joint_matrices;
+        }
+    }
+
+    if (!ensure_model_pose_cache_capacity(cache, cache->pose_count + 1))
+        return NULL;
+
+    slayer3d_game_data_model_pose_cache_entry *entry = &cache->pose_entries[cache->pose_count];
+    if (entry->joint_capacity < joint_count)
+    {
+        slayer3d_mat4 *matrices =
+            (slayer3d_mat4 *)SDL_realloc(entry->joint_matrices, (size_t)joint_count * sizeof(*matrices));
+        if (matrices == NULL)
+            return NULL;
+        entry->joint_matrices = matrices;
+        entry->joint_capacity = joint_count;
+    }
+
+    if (!slayer3d_evaluate_animation(model->skeleton, clip, animation_time, entry->joint_matrices))
+        return NULL;
+
+    entry->model = model;
+    entry->animation_clip = animation_clip;
+    entry->animation_time = animation_time;
+    entry->joint_count = joint_count;
+    ++cache->pose_count;
+    *out_joint_count = joint_count;
+    if (renderer != NULL)
+        renderer->stats.animation_pose_evaluations += 1u;
+    return entry->joint_matrices;
+}
+
+const slayer3d_mat4 *slayer3d_game_data_model_cache_evaluate_pose(slayer3d_game_data_model_cache *cache,
+                                                                  slayer3d_render_context *renderer,
+                                                                  const slayer3d_model *model, int animation_clip,
+                                                                  float animation_time, bool loop, int *out_joint_count)
+{
+    if (out_joint_count != NULL)
+        *out_joint_count = 0;
+    if (cache == NULL || model == NULL || model->skeleton == NULL || model->animations == NULL ||
+        model->animation_count <= 0 || animation_clip < 0 || out_joint_count == NULL)
+    {
+        return NULL;
+    }
+
+    int clip_index = animation_clip;
+    if (clip_index >= model->animation_count)
+        clip_index = 0;
+    const slayer3d_animation_clip *clip = &model->animations[clip_index];
+    if (loop && clip->duration > 0.0f)
+    {
+        animation_time = SDL_fmodf(animation_time, clip->duration);
+        if (animation_time < 0.0f)
+            animation_time += clip->duration;
+    }
+    return model_pose_cache_evaluate_clip(cache, renderer, model, clip, clip_index, animation_time, out_joint_count);
 }
 
 static bool draw_sphere_batch(slayer3d_render_context *renderer, const slayer3d_game_data_render_primitive *primitive)
@@ -2062,33 +2170,20 @@ static bool draw_primitive(void *userdata, const slayer3d_game_data_render_primi
         }
         if (primitive->animation_clip >= 0 && entry->model.skeleton != NULL && entry->model.animation_count > 0)
         {
-            int clip_index = primitive->animation_clip;
-            if (clip_index >= entry->model.animation_count)
-                clip_index = 0;
-            const slayer3d_animation_clip *clip = &entry->model.animations[clip_index];
-            float animation_time = primitive->animation_time;
-            if (primitive->animation_loop && clip->duration > 0.0f)
-            {
-                animation_time = SDL_fmodf(animation_time, clip->duration);
-                if (animation_time < 0.0f)
-                    animation_time += clip->duration;
-            }
-            const int joint_count = entry->model.skeleton->joint_count;
-            slayer3d_mat4 *joint_matrices = (slayer3d_mat4 *)SDL_calloc((size_t)joint_count, sizeof(*joint_matrices));
-            if (joint_matrices == NULL)
+            int joint_count = 0;
+            const slayer3d_mat4 *joint_matrices = slayer3d_game_data_model_cache_evaluate_pose(
+                context->model_cache, context->renderer, &entry->model, primitive->animation_clip,
+                primitive->animation_time, primitive->animation_loop, &joint_count);
+            if (joint_matrices == NULL || joint_count <= 0)
                 return false;
-            const bool evaluated =
-                slayer3d_evaluate_animation(entry->model.skeleton, clip, animation_time, joint_matrices);
             const bool drawn =
-                evaluated &&
-                (use_model_matrix
-                     ? draw_skinned_model_with_matrix(context->renderer, context->model_cache->assets, &entry->model,
-                                                      model_matrix, primitive->color, joint_matrices)
-                     : slayer3d_draw_model_skinned_with_assets(context->renderer, context->model_cache->assets,
-                                                               &entry->model, model_position, primitive->rotation_axis,
-                                                               primitive->rotation_angle, primitive->model_scale,
-                                                               primitive->color, joint_matrices));
-            SDL_free(joint_matrices);
+                use_model_matrix
+                    ? draw_skinned_model_with_matrix(context->renderer, context->model_cache->assets, &entry->model,
+                                                     model_matrix, primitive->color, joint_matrices)
+                    : slayer3d_draw_model_skinned_with_assets(context->renderer, context->model_cache->assets,
+                                                              &entry->model, model_position, primitive->rotation_axis,
+                                                              primitive->rotation_angle, primitive->model_scale,
+                                                              primitive->color, joint_matrices);
             if (!drawn)
                 return false;
         }
@@ -2453,6 +2548,9 @@ void slayer3d_game_data_model_cache_free(slayer3d_game_data_model_cache *cache)
         if (cache->entries[i].loaded)
             slayer3d_free_model(&cache->entries[i].model);
     }
+    for (int i = 0; i < cache->pose_capacity; ++i)
+        SDL_free(cache->pose_entries[i].joint_matrices);
+    SDL_free(cache->pose_entries);
     SDL_free(cache->entries);
     SDL_zero(*cache);
 }
@@ -4437,6 +4535,7 @@ bool slayer3d_game_data_draw_frame(const slayer3d_game_data_frame_desc *frame)
     bool ok = true;
     ok = apply_render_settings(frame->runtime, frame->renderer) && ok;
     ok = apply_world_lights(frame->runtime, frame->renderer, frame->render_eval) && ok;
+    slayer3d_game_data_model_cache_begin_pose_frame(frame->model_cache);
 
     if (slayer3d_game_data_active_scene_renders_world(frame->runtime))
     {

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -10,6 +10,7 @@
 extern "C"
 {
 #include "slayer3d/animation.h"
+#include "slayer3d/game_presentation.h"
 #include "slayer3d/math.h"
 #include "slayer3d/scene.h"
 }
@@ -133,6 +134,65 @@ TEST(SLAYER3DAnimation, TranslationKeyframes)
     /* At t=1.0: translation = (10,0,0). */
     ASSERT_TRUE(slayer3d_evaluate_animation(&skel, &clip, 1.0f, matrices));
     EXPECT_NEAR(matrices[0].m[12], 10.0f, 1e-5f);
+}
+
+TEST(SLAYER3DAnimation, ModelPoseCacheReusesIdenticalFramePoses)
+{
+    slayer3d_joint joints[1] = {make_joint("root", -1, 0, 0, 0)};
+    slayer3d_skeleton skel{};
+    skel.joints = joints;
+    skel.joint_count = 1;
+
+    slayer3d_keyframe keyframes[2] = {kf(0.0f, 0, 0, 0, 0), kf(1.0f, 10, 0, 0, 0)};
+    slayer3d_anim_channel ch{};
+    ch.joint_index = 0;
+    ch.path = SLAYER3D_ANIM_TRANSLATION;
+    ch.keyframes = keyframes;
+    ch.keyframe_count = 2;
+
+    slayer3d_animation_clip clip{};
+    clip.duration = 1.0f;
+    clip.channels = &ch;
+    clip.channel_count = 1;
+
+    slayer3d_model model{};
+    model.skeleton = &skel;
+    model.animations = &clip;
+    model.animation_count = 1;
+
+    slayer3d_game_data_model_cache cache{};
+    slayer3d_game_data_model_cache_init(&cache, nullptr);
+    slayer3d_game_data_model_cache_begin_pose_frame(&cache);
+
+    int joint_count = 0;
+    const slayer3d_mat4 *first =
+        slayer3d_game_data_model_cache_evaluate_pose(&cache, nullptr, &model, 0, 1.25f, true, &joint_count);
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(joint_count, 1);
+    EXPECT_EQ(cache.pose_count, 1);
+    EXPECT_NEAR(first[0].m[12], 2.5f, 1e-5f);
+
+    const slayer3d_mat4 *second =
+        slayer3d_game_data_model_cache_evaluate_pose(&cache, nullptr, &model, 0, 1.25f, true, &joint_count);
+    EXPECT_EQ(second, first);
+    EXPECT_EQ(cache.pose_count, 1);
+
+    const slayer3d_mat4 *different_time =
+        slayer3d_game_data_model_cache_evaluate_pose(&cache, nullptr, &model, 0, 0.5f, true, &joint_count);
+    ASSERT_NE(different_time, nullptr);
+    EXPECT_NE(different_time, first);
+    EXPECT_EQ(cache.pose_count, 2);
+    EXPECT_NEAR(different_time[0].m[12], 5.0f, 1e-5f);
+
+    slayer3d_game_data_model_cache_begin_pose_frame(&cache);
+    EXPECT_EQ(cache.pose_count, 0);
+    const slayer3d_mat4 *next_frame =
+        slayer3d_game_data_model_cache_evaluate_pose(&cache, nullptr, &model, 0, 1.25f, true, &joint_count);
+    ASSERT_NE(next_frame, nullptr);
+    EXPECT_EQ(cache.pose_count, 1);
+    EXPECT_NEAR(next_frame[0].m[12], 2.5f, 1e-5f);
+
+    slayer3d_game_data_model_cache_free(&cache);
 }
 
 TEST(SLAYER3DAnimation, RotationKeyframesSlerp)


### PR DESCRIPTION
## Summary\n- add a frame-local skeletal pose cache to the authored model presentation cache\n- reuse identical model/clip/time joint palettes within a frame instead of reallocating and re-evaluating them per draw\n- reuse matrix storage across frames to remove per-draw allocation churn\n- expose render stats for pose evaluations and cache hits\n\n## Tests\n- ./build/debug/tests/slayer3d_animation_test --gtest_filter='SLAYER3DAnimation.ModelPoseCacheReusesIdenticalFramePoses'\n- ./build/debug/tests/slayer3d_animation_test\n- ./build/debug/tests/slayer3d_gl_renderer_test\n- cmake --build build/debug -j 8