### PR TITLE
Batch shared-pose skinned model instances

### DIFF
--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -78,6 +78,10 @@ extern "C"
         Uint64 gpu_skinned_draws;
         /** @brief Vertices skinned on the GPU by capable renderers. */
         Uint64 gpu_skinned_vertices;
+        /** @brief GPU skinning joint palette uniform uploads issued by capable renderers. */
+        Uint64 gpu_skinning_palette_uploads;
+        /** @brief Joint matrices uploaded for GPU skinning palettes. */
+        Uint64 gpu_skinning_palette_matrices_uploaded;
         /** @brief Vertices skinned on the CPU fallback path. */
         Uint64 cpu_skinned_vertices;
         /** @brief Authored model animation poses evaluated by the presentation layer. */

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -2438,6 +2438,7 @@ static void replay_draw_list_geometry(slayer3d_gl_context *ctx);
 static bool draw_entries_can_instance(const slayer3d_gl_context *ctx, const slayer3d_draw_entry *a,
                                       const slayer3d_draw_entry *b);
 static bool upload_instance_model_attributes(slayer3d_gl_context *ctx, const slayer3d_draw_entry *entries, int count);
+static void upload_joint_palette_uniform(slayer3d_gl_context *ctx, GLint location, const slayer3d_draw_entry *entry);
 
 static void replay_draw_list_shadow(slayer3d_gl_context *ctx)
 {
@@ -2458,8 +2459,7 @@ static void replay_draw_list_shadow(slayer3d_gl_context *ctx)
         gl->UniformMatrix4fv(ctx->shadow_model_loc, 1, GL_FALSE, e->model_matrix);
         if (ctx->shadow_use_skinning_loc >= 0)
             gl->Uniform1i(ctx->shadow_use_skinning_loc, e->gpu_skinned ? 1 : 0);
-        if (e->gpu_skinned && ctx->shadow_joint_matrices_loc >= 0)
-            gl->UniformMatrix4fv(ctx->shadow_joint_matrices_loc, e->joint_count, GL_FALSE, e->joint_matrices);
+        upload_joint_palette_uniform(ctx, ctx->shadow_joint_matrices_loc, e);
 
         gl->BindVertexArray(e->mesh_cache ? e->mesh_cache->shadow_vao : ctx->shadow_vao);
         if (e->mesh_cache == NULL)
@@ -2517,6 +2517,20 @@ static Uint64 draw_entry_triangle_count(const slayer3d_draw_entry *entry)
     if (entry->indices != NULL && entry->index_count > 0)
         return (Uint64)(entry->index_count / 3);
     return (Uint64)(entry->vertex_count / 3);
+}
+
+static void upload_joint_palette_uniform(slayer3d_gl_context *ctx, GLint location, const slayer3d_draw_entry *entry)
+{
+    if (ctx == NULL || entry == NULL || location < 0 || !entry->gpu_skinned || entry->joint_count <= 0 ||
+        entry->joint_matrices == NULL)
+        return;
+
+    ctx->gl.UniformMatrix4fv(location, entry->joint_count, GL_FALSE, entry->joint_matrices);
+    if (ctx->current_ctx != NULL)
+    {
+        ctx->current_ctx->stats.gpu_skinning_palette_uploads += 1u;
+        ctx->current_ctx->stats.gpu_skinning_palette_matrices_uploaded += (Uint64)entry->joint_count;
+    }
 }
 
 static bool gl_sample_queries_enabled(const slayer3d_gl_context *ctx)
@@ -2584,7 +2598,8 @@ static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
             if (ctx->shadow_use_instancing_loc >= 0)
                 gl->Uniform1i(ctx->shadow_use_instancing_loc, 1);
             if (ctx->shadow_use_skinning_loc >= 0)
-                gl->Uniform1i(ctx->shadow_use_skinning_loc, 0);
+                gl->Uniform1i(ctx->shadow_use_skinning_loc, e->gpu_skinned ? 1 : 0);
+            upload_joint_palette_uniform(ctx, ctx->shadow_joint_matrices_loc, e);
             gl->BindVertexArray(e->mesh_cache->shadow_vao);
             if (upload_instance_model_attributes(ctx, e, instance_batch_count))
             {
@@ -2606,8 +2621,7 @@ static void replay_draw_list_depth_prepass(slayer3d_gl_context *ctx)
             gl->Uniform1i(ctx->shadow_use_instancing_loc, 0);
         if (ctx->shadow_use_skinning_loc >= 0)
             gl->Uniform1i(ctx->shadow_use_skinning_loc, e->gpu_skinned ? 1 : 0);
-        if (e->gpu_skinned && ctx->shadow_joint_matrices_loc >= 0)
-            gl->UniformMatrix4fv(ctx->shadow_joint_matrices_loc, e->joint_count, GL_FALSE, e->joint_matrices);
+        upload_joint_palette_uniform(ctx, ctx->shadow_joint_matrices_loc, e);
         gl->UniformMatrix4fv(ctx->shadow_light_vp_loc, 1, GL_FALSE, e->view_projection);
         gl->UniformMatrix4fv(ctx->shadow_model_loc, 1, GL_FALSE, e->model_matrix);
 
@@ -2836,9 +2850,8 @@ static void bind_builtin_pbr_entry(slayer3d_gl_context *ctx, const slayer3d_draw
     if (ctx->pbr_use_instancing_loc >= 0)
         gl->Uniform1i(ctx->pbr_use_instancing_loc, use_instancing ? 1 : 0);
     if (ctx->pbr_use_skinning_loc >= 0)
-        gl->Uniform1i(ctx->pbr_use_skinning_loc, (!use_instancing && e->gpu_skinned) ? 1 : 0);
-    if (!use_instancing && e->gpu_skinned && ctx->pbr_joint_matrices_loc >= 0)
-        gl->UniformMatrix4fv(ctx->pbr_joint_matrices_loc, e->joint_count, GL_FALSE, e->joint_matrices);
+        gl->Uniform1i(ctx->pbr_use_skinning_loc, e->gpu_skinned ? 1 : 0);
+    upload_joint_palette_uniform(ctx, ctx->pbr_joint_matrices_loc, e);
     gl->Uniform4f(ctx->pbr_tint_loc, e->tint[0], e->tint[1], e->tint[2], e->tint[3]);
     gl->Uniform1f(ctx->pbr_metallic_loc, e->metallic);
     gl->Uniform1f(ctx->pbr_roughness_loc, e->roughness);
@@ -2962,6 +2975,17 @@ static bool draw_entry_matrix_equal(const float *a, const float *b, int count)
     return true;
 }
 
+static bool draw_entry_skinning_equal(const slayer3d_draw_entry *a, const slayer3d_draw_entry *b)
+{
+    if (a->gpu_skinned != b->gpu_skinned)
+        return false;
+    if (!a->gpu_skinned)
+        return true;
+    return a->joint_count == b->joint_count && a->joint_count > 0 && a->joint_matrices != NULL &&
+           b->joint_matrices != NULL &&
+           draw_entry_matrix_equal(a->joint_matrices, b->joint_matrices, a->joint_count * 16);
+}
+
 static bool draw_entry_instancing_light_safe(const slayer3d_gl_context *ctx)
 {
     const slayer3d_render_context *rc = ctx != NULL ? ctx->current_ctx : NULL;
@@ -2979,10 +3003,10 @@ static bool draw_entries_can_instance(const slayer3d_gl_context *ctx, const slay
         return false;
     if (!draw_entry_instancing_light_safe(ctx))
         return false;
-    if (!a->lit || !b->lit || a->gpu_skinned || b->gpu_skinned || a->mesh_cache == NULL ||
-        a->mesh_cache != b->mesh_cache || a->primitive_mode != GL_TRIANGLES || b->primitive_mode != GL_TRIANGLES ||
-        a->tint[3] < 0.999f || b->tint[3] < 0.999f || a->shader_vertex_source != NULL ||
-        a->shader_fragment_source != NULL || b->shader_vertex_source != NULL || b->shader_fragment_source != NULL)
+    if (!a->lit || !b->lit || a->mesh_cache == NULL || a->mesh_cache != b->mesh_cache ||
+        a->primitive_mode != GL_TRIANGLES || b->primitive_mode != GL_TRIANGLES || a->tint[3] < 0.999f ||
+        b->tint[3] < 0.999f || a->shader_vertex_source != NULL || a->shader_fragment_source != NULL ||
+        b->shader_vertex_source != NULL || b->shader_fragment_source != NULL)
         return false;
     return a->texture == b->texture && a->lightmap_texture == b->lightmap_texture &&
            a->has_lightmap == b->has_lightmap && a->baked_light_mode == b->baked_light_mode &&
@@ -2992,7 +3016,7 @@ static bool draw_entries_can_instance(const slayer3d_gl_context *ctx, const slay
            SDL_fabsf(a->metallic - b->metallic) <= 0.000001f && SDL_fabsf(a->roughness - b->roughness) <= 0.000001f &&
            draw_entry_float3_equal(a->emissive, b->emissive) &&
            draw_entry_matrix_equal(a->view_projection, b->view_projection, 16) &&
-           draw_entry_float3_equal(a->camera_pos, b->camera_pos);
+           draw_entry_float3_equal(a->camera_pos, b->camera_pos) && draw_entry_skinning_equal(a, b);
 }
 
 static int draw_entry_instance_batch_count(const slayer3d_gl_context *ctx, int start)
@@ -3253,8 +3277,7 @@ static void replay_draw_list_geometry(slayer3d_gl_context *ctx)
                     gl->Uniform1i(ctx->pbr_use_instancing_loc, 0);
                 if (ctx->pbr_use_skinning_loc >= 0)
                     gl->Uniform1i(ctx->pbr_use_skinning_loc, e->gpu_skinned ? 1 : 0);
-                if (e->gpu_skinned && ctx->pbr_joint_matrices_loc >= 0)
-                    gl->UniformMatrix4fv(ctx->pbr_joint_matrices_loc, e->joint_count, GL_FALSE, e->joint_matrices);
+                upload_joint_palette_uniform(ctx, ctx->pbr_joint_matrices_loc, e);
                 gl->Uniform4f(ctx->pbr_tint_loc, e->tint[0], e->tint[1], e->tint[2], e->tint[3]);
                 gl->Uniform1f(ctx->pbr_metallic_loc, e->metallic);
                 gl->Uniform1f(ctx->pbr_roughness_loc, e->roughness);
@@ -4826,9 +4849,7 @@ static bool gl_present(slayer3d_render_context *context)
                     gl->UniformMatrix4fv(ctx->point_shadow_model_loc, 1, GL_FALSE, e->model_matrix);
                     if (ctx->point_shadow_use_skinning_loc >= 0)
                         gl->Uniform1i(ctx->point_shadow_use_skinning_loc, e->gpu_skinned ? 1 : 0);
-                    if (e->gpu_skinned && ctx->point_shadow_joint_matrices_loc >= 0)
-                        gl->UniformMatrix4fv(ctx->point_shadow_joint_matrices_loc, e->joint_count, GL_FALSE,
-                                             e->joint_matrices);
+                    upload_joint_palette_uniform(ctx, ctx->point_shadow_joint_matrices_loc, e);
                     gl->BindVertexArray(e->mesh_cache ? e->mesh_cache->shadow_vao : ctx->shadow_vao);
                     if (e->mesh_cache == NULL)
                     {
@@ -5120,9 +5141,7 @@ void slayer3d_gl_read_pixel(slayer3d_gl_context *ctx, int x, int y, unsigned cha
                         gl->UniformMatrix4fv(ctx->point_shadow_model_loc, 1, GL_FALSE, e->model_matrix);
                         if (ctx->point_shadow_use_skinning_loc >= 0)
                             gl->Uniform1i(ctx->point_shadow_use_skinning_loc, e->gpu_skinned ? 1 : 0);
-                        if (e->gpu_skinned && ctx->point_shadow_joint_matrices_loc >= 0)
-                            gl->UniformMatrix4fv(ctx->point_shadow_joint_matrices_loc, e->joint_count, GL_FALSE,
-                                                 e->joint_matrices);
+                        upload_joint_palette_uniform(ctx, ctx->point_shadow_joint_matrices_loc, e);
                         gl->BindVertexArray(e->mesh_cache ? e->mesh_cache->shadow_vao : ctx->shadow_vao);
                         if (e->mesh_cache == NULL)
                         {

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -422,6 +422,94 @@ TEST_F(GLRendererTest, SkinnedLitModelsUseGpuSkinningWhenJointBudgetAllows)
     EXPECT_EQ(stats.depth_prepass_draws, 1u);
 }
 
+TEST_F(GLRendererTest, SkinnedLitModelsWithSharedPoseUseInstancedBackendDraw)
+{
+    ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));
+    ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.8f, 0.8f, 0.8f));
+    ASSERT_TRUE(slayer3d_set_per_object_light_selection_enabled(ctx, false));
+    ASSERT_TRUE(slayer3d_set_depth_prepass_enabled(ctx, true));
+    ctx->depth_prepass_scope_enabled = true;
+
+    float positions[] = {
+        -0.25f, -0.25f, 0.0f, 0.25f, -0.25f, 0.0f, 0.0f, 0.25f, 0.0f,
+    };
+    float normals[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+    };
+    float uvs[] = {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.5f, 1.0f,
+    };
+    float colors[] = {
+        1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+    };
+    unsigned short joint_indices[] = {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+    float joint_weights[] = {
+        1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+    };
+    unsigned int indices[] = {0, 1, 2};
+    slayer3d_mesh mesh = {};
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.uvs = uvs;
+    mesh.colors = colors;
+    mesh.joint_indices = joint_indices;
+    mesh.joint_weights = joint_weights;
+    mesh.vertex_count = 3;
+    mesh.indices = indices;
+    mesh.index_count = 3;
+    mesh.material_index = -1;
+    mesh.has_local_bounds = true;
+    mesh.local_bounds.min = slayer3d_vec3_make(-0.25f, -0.25f, 0.0f);
+    mesh.local_bounds.max = slayer3d_vec3_make(0.25f, 0.25f, 0.0f);
+
+    slayer3d_skeleton skeleton = {};
+    skeleton.joint_count = 1;
+    slayer3d_model model = {};
+    model.meshes = &mesh;
+    model.mesh_count = 1;
+    model.skeleton = &skeleton;
+    slayer3d_mat4 joints[1] = {slayer3d_mat4_identity()};
+
+    slayer3d_camera3d cam;
+    cam.position = slayer3d_vec3_make(0, 0, 5);
+    cam.target = slayer3d_vec3_make(0, 0, 0);
+    cam.up = slayer3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    constexpr int instance_count = 5;
+    slayer3d_reset_render_stats(ctx);
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
+    for (int i = 0; i < instance_count; ++i)
+    {
+        ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(-1.0f + 0.5f * (float)i, 0, 0),
+                                                slayer3d_vec3_make(0, 1, 0), 0.0f, slayer3d_vec3_make(1, 1, 1),
+                                                (slayer3d_color){255, 255, 255, 255}, joints));
+    }
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
+
+    unsigned char px[4];
+    readPixel(160, 120, px);
+    EXPECT_GT(px[0] + px[1] + px[2], 20);
+
+    slayer3d_render_stats stats{};
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.gpu_skinned_draws, (Uint64)instance_count);
+    EXPECT_EQ(stats.gpu_skinned_vertices, (Uint64)instance_count * 3u);
+    EXPECT_EQ(stats.cpu_skinned_vertices, 0u);
+    EXPECT_EQ(stats.depth_prepass_draws, 1u);
+    EXPECT_EQ(stats.depth_prepass_triangles, (Uint64)instance_count);
+    EXPECT_EQ(stats.geometry_draw_calls, 1u);
+    EXPECT_EQ(stats.static_mesh_instanced_draw_calls, 1u);
+    EXPECT_EQ(stats.static_mesh_instances_batched, (Uint64)instance_count);
+    EXPECT_EQ(stats.static_mesh_draw_calls_saved, (Uint64)(instance_count - 1));
+    EXPECT_EQ(stats.gpu_skinning_palette_uploads, 2u);
+    EXPECT_EQ(stats.gpu_skinning_palette_matrices_uploaded, 2u);
+}
+
 TEST_F(GLRendererTest, SkinnedLitModelsFallBackToCpuWhenJointBudgetIsExceeded)
 {
     ASSERT_TRUE(slayer3d_set_shading_mode(ctx, SLAYER3D_SHADING_PHONG));


### PR DESCRIPTION
## Summary\n- allow static GPU-skinned mesh draws with identical joint palettes to use the existing instanced backend path\n- upload the shared joint palette once per instanced depth/lit pass instead of once per instance\n- add render stats for GPU skinning palette uploads and a GL regression test proving five shared-pose skinned instances render as one geometry draw\n\n## Tests\n- ./build/debug/tests/slayer3d_gl_renderer_test --gtest_filter='GLRendererTest.SkinnedLitModels*'\n- ./build/debug/tests/slayer3d_gl_renderer_test\n- cmake --build build/debug -j 8\n\nStacked on PR #393.