### PR TITLE
Add authored brush compile artifacts

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -740,6 +740,16 @@ compile policy, render mesh totals, spatial chunk summaries, and visibility-grid
 metadata. It is intentionally a descriptor rather than a binary cache payload:
 use the source hash, policy, and compile artifact hash together to inspect,
 compare, and invalidate compiled artifacts before adding cache storage/loading.
+Native editor/offline compiler hosts can call
+`slayer3d_game_data_save_brush_world_compile_artifact_file()` to atomically save
+that manifest beside authored brush fragments, then use
+`slayer3d_game_data_verify_brush_world_compile_artifact_json()` or
+`slayer3d_game_data_verify_brush_world_compile_artifact_file()` to decide whether
+a descriptor still matches the current authored source and compile policy. A
+valid-but-stale descriptor is not a load failure: verification returns status
+flags so tooling can ignore stale artifacts and let the runtime rebuild from
+source. When binary cache payloads are added later, this status check should be
+the gate before any cached mesh/collision data is trusted.
 When visibility culling leaves every brush in a compile chunk visible, the
 renderer can draw that chunk as one optimized model instead of submitting each
 brush model separately; partially visible chunks still fall back to per-brush

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -750,6 +750,26 @@ valid-but-stale descriptor is not a load failure: verification returns status
 flags so tooling can ignore stale artifacts and let the runtime rebuild from
 source. When binary cache payloads are added later, this status check should be
 the gate before any cached mesh/collision data is trusted.
+Tools that need a stable cache location can call
+`slayer3d_game_data_get_brush_world_compile_artifact_layout()` or
+`slayer3d_game_data_save_brush_world_compile_artifact_layout()`. The canonical
+layout is:
+
+```text
+<artifact-root>/brush/v0/<world-key>/<source-hash>/<compile-artifact-hash>/
+  manifest.json
+  render.payload.bin       (reserved)
+  collision.payload.bin    (reserved)
+  visibility.payload.bin   (reserved)
+```
+
+`<world-key>` is a filesystem-safe key derived from the brush world name with a
+hash suffix to avoid collisions. `<source-hash>` changes when authored brush
+source changes; `<compile-artifact-hash>` changes when the compile policy or the
+compiled artifact metadata changes. The reserved payload names are intentional
+contract boundaries for future binary mesh, collision, and visibility cache
+files. Current runtime loading remains source-first and does not trust or load
+those payload files.
 When visibility culling leaves every brush in a compile chunk visible, the
 renderer can draw that chunk as one optimized model instead of submitting each
 brush model separately; partially visible chunks still fall back to per-brush

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -732,10 +732,18 @@ while grouping them into optimized runtime broad-phase artifacts for collision
 traces, editor diagnostics, and future render/collision chunk generation. The
 runtime descriptor's `compile_artifact_hash` is a deterministic hash of the
 compiled mesh/chunk metadata and can be used by tests, tools, and future offline
-cache invalidation. When visibility culling leaves every brush in a compile chunk
-visible, the renderer can draw that chunk as one optimized model instead of
-submitting each brush model separately; partially visible chunks still fall back
-to per-brush models so occlusion correctness is preserved. When
+cache invalidation. Tools can also call
+`slayer3d_game_data_export_brush_world_compile_artifact_json()` to write an
+inspection manifest using `schema: "slayer3d.brush_compile_artifact.v0"`. The
+manifest records a deterministic source hash for authored brush inputs, the
+compile policy, render mesh totals, spatial chunk summaries, and visibility-grid
+metadata. It is intentionally a descriptor rather than a binary cache payload:
+use the source hash, policy, and compile artifact hash together to inspect,
+compare, and invalidate compiled artifacts before adding cache storage/loading.
+When visibility culling leaves every brush in a compile chunk visible, the
+renderer can draw that chunk as one optimized model instead of submitting each
+brush model separately; partially visible chunks still fall back to per-brush
+models so occlusion correctness is preserved. When
 `acceleration` is enabled on a scene instance, active-scene trace queries use
 those chunks and bounds as a broad phase before exact plane clipping.
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -562,6 +562,10 @@ in later slices.
       "units": "meters",
       "meters_per_unit": 1.0,
       "visibility_cell_size": 2.0,
+      "compile": {
+        "hidden_face_culling": true,
+        "chunk_cell_size": 8.0
+      },
       "editor": {
         "stable_id": "brush_world.keep_01.v1",
         "display_name": "Keep 01",
@@ -623,6 +627,12 @@ Validation requires:
 - `units` omitted or `"meters"`, with positive `meters_per_unit`
 - optional positive `visibility_cell_size`, default `2.0`; this controls the
   coarse empty-space grid used by automatic brush visibility culling
+- optional `compile` object for runtime/offline compile policy
+- optional `compile.hidden_face_culling` boolean, default `true`; when enabled,
+  fully covered adjacent opaque solid faces are removed from compiled render
+  meshes
+- optional positive `compile.chunk_cell_size`; when omitted, the engine derives
+  a deterministic chunk size from the world bounds and visibility cell size
 - optional `editor` metadata on brush worlds, materials, brushes, and faces;
   `editor.stable_id` values must be unique inside each brush world
 - non-empty `materials` with unique names
@@ -711,12 +721,18 @@ ambiguous cases fail open. Runtime descriptors expose
 `compile_invalid_brush_count`, and `compile_degenerate_face_count` for tests,
 editor diagnostics, and performance audits. Brush worlds fail to load when an
 authored brush cannot produce bounded geometry; degenerate faces are counted so
-tooling can surface geometry-health issues. During load, brush worlds also precompute
+tooling can surface geometry-health issues. `compile.hidden_face_culling` can be
+disabled by editor/debug content when authors need to compare the source faces
+against the optimized render artifact. During load, brush worlds also precompute
 local AABBs for each brush and for the whole world, then build spatial compile
-chunks from those bounds. Compile chunks preserve authored brushes as the source
-of truth while grouping them into optimized runtime broad-phase artifacts for
-collision traces, editor diagnostics, and future render/collision chunk
-generation. When visibility culling leaves every brush in a compile chunk
+chunks from those bounds. `compile.chunk_cell_size` gives editor/offline compile
+tools a stable chunking knob; otherwise the runtime computes a conservative
+automatic size. Compile chunks preserve authored brushes as the source of truth
+while grouping them into optimized runtime broad-phase artifacts for collision
+traces, editor diagnostics, and future render/collision chunk generation. The
+runtime descriptor's `compile_artifact_hash` is a deterministic hash of the
+compiled mesh/chunk metadata and can be used by tests, tools, and future offline
+cache invalidation. When visibility culling leaves every brush in a compile chunk
 visible, the renderer can draw that chunk as one optimized model instead of
 submitting each brush model separately; partially visible chunks still fall back
 to per-brush models so occlusion correctness is preserved. When

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2335,6 +2335,23 @@ extern "C"
                                                              char *error_buffer, int error_buffer_size);
 
     /**
+     * @brief Export a JSON manifest describing one compiled brush-world artifact.
+     *
+     * The exported document uses `schema:
+     * "slayer3d.brush_compile_artifact.v0"` and records a deterministic source
+     * hash for authored brush inputs, the compile policy, the compiled-artifact
+     * hash, render mesh totals, spatial chunk metadata, and visibility-grid
+     * metadata. This is an inspection and cache-invalidation descriptor; it does
+     * not contain the binary mesh or collision payloads needed to load a compiled
+     * artifact directly. The returned string is allocated with SDL_malloc and
+     * must be released with SDL_free().
+     */
+    bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_game_data_runtime *runtime,
+                                                                     const char *world_name, char **out_json,
+                                                                     size_t *out_size, char *error_buffer,
+                                                                     int error_buffer_size);
+
+    /**
      * @brief Atomically save one runtime brush world as a JSON fragment file.
      *
      * This is the filesystem-facing companion to

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -591,6 +591,30 @@ extern "C"
         Uint64 artifact_compile_artifact_hash;
     } slayer3d_game_data_brush_compile_artifact_status;
 
+    /** @brief Maximum bytes, including the NUL terminator, for brush compile artifact layout paths. */
+#define SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX 1024
+
+    /** @brief Canonical filesystem layout for one offline brush compile artifact. */
+    typedef struct slayer3d_game_data_brush_compile_artifact_layout
+    {
+        /** @brief Stable filesystem-safe key derived from the brush world name. */
+        char world_key[128];
+        /** @brief Directory containing this exact source/policy artifact. */
+        char directory[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+        /** @brief JSON descriptor path produced by the current manifest exporter. */
+        char manifest_path[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+        /** @brief Reserved path for future compiled render-mesh payload data. */
+        char render_payload_path[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+        /** @brief Reserved path for future compiled collision payload data. */
+        char collision_payload_path[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+        /** @brief Reserved path for future compiled visibility-grid payload data. */
+        char visibility_payload_path[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+        /** @brief Current runtime source hash for authored brush inputs. */
+        Uint64 source_hash;
+        /** @brief Current runtime compiled artifact hash for source plus compile policy. */
+        Uint64 compile_artifact_hash;
+    } slayer3d_game_data_brush_compile_artifact_layout;
+
     /** @brief Active-scene instance of an authored brush world. */
     typedef struct slayer3d_game_data_brush_world_instance
     {
@@ -2415,6 +2439,34 @@ extern "C"
                                                                    const char *world_name, const char *path,
                                                                    size_t *out_size, char *error_buffer,
                                                                    int error_buffer_size);
+
+    /**
+     * @brief Resolve the canonical offline artifact layout for one brush world.
+     *
+     * @p artifact_root must be a native filesystem directory path, not an
+     * `asset://` or other virtual URI. The resolved layout is versioned as
+     * `brush/v0/<world-key>/<source-hash>/<compile-artifact-hash>/...`.
+     * The manifest path is usable with
+     * @ref slayer3d_game_data_save_brush_world_compile_artifact_file. Binary
+     * payload paths are reserved for future offline mesh/collision cache data;
+     * the runtime still rebuilds brush artifacts from authored source.
+     */
+    bool slayer3d_game_data_get_brush_world_compile_artifact_layout(
+        const slayer3d_game_data_runtime *runtime, const char *world_name, const char *artifact_root,
+        slayer3d_game_data_brush_compile_artifact_layout *out_layout, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Atomically save one brush compile artifact manifest using the canonical layout.
+     *
+     * This resolves the layout with
+     * @ref slayer3d_game_data_get_brush_world_compile_artifact_layout and writes
+     * the JSON manifest to `out_layout->manifest_path`. Parent directories are
+     * created automatically. Passing NULL for @p out_layout is allowed.
+     */
+    bool slayer3d_game_data_save_brush_world_compile_artifact_layout(
+        const slayer3d_game_data_runtime *runtime, const char *world_name, const char *artifact_root,
+        slayer3d_game_data_brush_compile_artifact_layout *out_layout, size_t *out_size, char *error_buffer,
+        int error_buffer_size);
 
     /**
      * @brief Atomically save one runtime brush world as a JSON fragment file.

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -566,6 +566,31 @@ extern "C"
         slayer3d_game_data_editor_metadata editor;
     } slayer3d_game_data_brush_world;
 
+    /** @brief Result of comparing a brush compile artifact manifest to a runtime brush world. */
+    typedef struct slayer3d_game_data_brush_compile_artifact_status
+    {
+        /** @brief True when the JSON document has the expected artifact schema. */
+        bool schema_matches;
+        /** @brief True when the manifest names the requested brush world. */
+        bool world_matches;
+        /** @brief True when the manifest source hash matches the current authored brush source. */
+        bool source_hash_matches;
+        /** @brief True when the manifest compile policy matches the current authored compile policy. */
+        bool policy_matches;
+        /** @brief True when the manifest compiled artifact hash matches the current runtime artifact. */
+        bool compile_artifact_hash_matches;
+        /** @brief True when all fields required for artifact reuse match. */
+        bool fresh;
+        /** @brief Current runtime source hash for authored brush inputs. */
+        Uint64 expected_source_hash;
+        /** @brief Source hash stored in the manifest. */
+        Uint64 artifact_source_hash;
+        /** @brief Current runtime compiled artifact hash. */
+        Uint64 expected_compile_artifact_hash;
+        /** @brief Compiled artifact hash stored in the manifest. */
+        Uint64 artifact_compile_artifact_hash;
+    } slayer3d_game_data_brush_compile_artifact_status;
+
     /** @brief Active-scene instance of an authored brush world. */
     typedef struct slayer3d_game_data_brush_world_instance
     {
@@ -2350,6 +2375,46 @@ extern "C"
                                                                      const char *world_name, char **out_json,
                                                                      size_t *out_size, char *error_buffer,
                                                                      int error_buffer_size);
+
+    /**
+     * @brief Verify one brush compile artifact manifest against the current runtime world.
+     *
+     * This helper checks the descriptor JSON produced by
+     * @ref slayer3d_game_data_export_brush_world_compile_artifact_json without
+     * loading any binary cache payload. A return value of true means the manifest
+     * was parsed and compared; inspect @p out_status->fresh to decide whether an
+     * offline artifact is reusable. Stale manifests are reported through
+     * @p out_status rather than treated as API errors.
+     */
+    bool slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        const slayer3d_game_data_runtime *runtime, const char *world_name, const char *json, size_t json_size,
+        slayer3d_game_data_brush_compile_artifact_status *out_status, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Verify a brush compile artifact manifest file against the current runtime world.
+     *
+     * The file is read as JSON and compared using
+     * @ref slayer3d_game_data_verify_brush_world_compile_artifact_json. Missing,
+     * unreadable, or malformed files return false; valid-but-stale manifests
+     * return true with @p out_status->fresh set to false.
+     */
+    bool slayer3d_game_data_verify_brush_world_compile_artifact_file(
+        const slayer3d_game_data_runtime *runtime, const char *world_name, const char *path,
+        slayer3d_game_data_brush_compile_artifact_status *out_status, char *error_buffer, int error_buffer_size);
+
+    /**
+     * @brief Atomically save one brush compile artifact manifest file.
+     *
+     * This writes the same descriptor JSON produced by
+     * @ref slayer3d_game_data_export_brush_world_compile_artifact_json. Parent
+     * directories are created automatically. The manifest is intended for
+     * editor/offline compiler inspection and future cache invalidation, not as a
+     * binary artifact payload.
+     */
+    bool slayer3d_game_data_save_brush_world_compile_artifact_file(const slayer3d_game_data_runtime *runtime,
+                                                                   const char *world_name, const char *path,
+                                                                   size_t *out_size, char *error_buffer,
+                                                                   int error_buffer_size);
 
     /**
      * @brief Atomically save one runtime brush world as a JSON fragment file.

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -520,6 +520,10 @@ extern "C"
         float meters_per_unit;
         /** @brief Positive cell size for automatic visibility culling, in local world units. */
         float visibility_cell_size;
+        /** @brief True when fully hidden adjacent solid faces are removed from compiled render meshes. */
+        bool compile_hidden_face_culling;
+        /** @brief Optional authored spatial compile chunk cell size, or <= 0 for automatic sizing. */
+        float compile_chunk_cell_size_hint;
         /** @brief Runtime material palette for brush faces. */
         const slayer3d_game_data_brush_material *materials;
         /** @brief Number of entries in @p materials. */
@@ -552,6 +556,8 @@ extern "C"
         int compile_chunk_brush_index_count;
         /** @brief Local-space cell size used to build the compile chunks. */
         float compile_chunk_cell_size;
+        /** @brief Deterministic hash of the compiled render/chunk artifact metadata. */
+        Uint64 compile_artifact_hash;
         /** @brief Precomputed local-space bounds spanning all bounded brushes. */
         slayer3d_bounding_box bounds;
         /** @brief True when @p bounds is valid. */

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -299,19 +299,19 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     for (int i = 0; i < runtime->brush_world_count; ++i)
     {
         slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
-        slayer3d_free_model(&runtime->brush_worlds[i].render_model);
-        for (int brush_model_index = 0; brush_model_index < runtime->brush_worlds[i].brush_render_model_count;
+        slayer3d_free_model(&runtime->brush_worlds[i].artifacts.render_model);
+        for (int brush_model_index = 0; brush_model_index < runtime->brush_worlds[i].artifacts.brush_render_model_count;
              ++brush_model_index)
         {
-            slayer3d_free_model(&runtime->brush_worlds[i].brush_render_models[brush_model_index]);
+            slayer3d_free_model(&runtime->brush_worlds[i].artifacts.brush_render_models[brush_model_index]);
         }
-        for (int chunk_model_index = 0; chunk_model_index < runtime->brush_worlds[i].chunk_render_model_count;
+        for (int chunk_model_index = 0; chunk_model_index < runtime->brush_worlds[i].artifacts.chunk_render_model_count;
              ++chunk_model_index)
         {
-            slayer3d_free_model(&runtime->brush_worlds[i].chunk_render_models[chunk_model_index]);
+            slayer3d_free_model(&runtime->brush_worlds[i].artifacts.chunk_render_models[chunk_model_index]);
         }
-        SDL_free(runtime->brush_worlds[i].brush_render_models);
-        SDL_free(runtime->brush_worlds[i].chunk_render_models);
+        SDL_free(runtime->brush_worlds[i].artifacts.brush_render_models);
+        SDL_free(runtime->brush_worlds[i].artifacts.chunk_render_models);
         free_brush_world_visibility_grid(&runtime->brush_worlds[i]);
         slayer3d_game_data_brush_world_free_compile_chunks(world);
         SDL_free(runtime->brush_worlds[i].editor_source_path);

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -10,6 +10,54 @@
 #include "slayer3d/collision.h"
 #include "slayer3d/math.h"
 
+static void brush_compile_hash_bytes(Uint64 *hash, const void *data, size_t size)
+{
+    if (hash == NULL || (data == NULL && size > 0u))
+        return;
+    const Uint8 *bytes = (const Uint8 *)data;
+    for (size_t i = 0; i < size; ++i)
+    {
+        *hash ^= (Uint64)bytes[i];
+        *hash *= 1099511628211ull;
+    }
+}
+
+static void brush_compile_hash_int(Uint64 *hash, int value)
+{
+    brush_compile_hash_bytes(hash, &value, sizeof(value));
+}
+
+static void brush_compile_hash_uint(Uint64 *hash, unsigned int value)
+{
+    brush_compile_hash_bytes(hash, &value, sizeof(value));
+}
+
+static void brush_compile_hash_bool(Uint64 *hash, bool value)
+{
+    const Uint8 byte = value ? 1u : 0u;
+    brush_compile_hash_bytes(hash, &byte, sizeof(byte));
+}
+
+static void brush_compile_hash_float(Uint64 *hash, float value)
+{
+    Uint32 bits = 0u;
+    SDL_memcpy(&bits, &value, sizeof(bits));
+    brush_compile_hash_bytes(hash, &bits, sizeof(bits));
+}
+
+static void brush_compile_hash_string(Uint64 *hash, const char *value)
+{
+    if (value == NULL)
+    {
+        const Uint8 null_marker = 0xffu;
+        brush_compile_hash_bytes(hash, &null_marker, sizeof(null_marker));
+        return;
+    }
+    brush_compile_hash_bytes(hash, value, SDL_strlen(value));
+    const Uint8 terminator = 0u;
+    brush_compile_hash_bytes(hash, &terminator, sizeof(terminator));
+}
+
 static void brush_bounds_add_point(slayer3d_bounding_box *bounds, bool *has_bounds, slayer3d_vec3 point)
 {
     if (bounds == NULL || has_bounds == NULL)
@@ -460,7 +508,10 @@ bool slayer3d_game_data_brush_world_build_compile_chunks(slayer3d_game_data_brus
     const float largest_extent =
         SDL_max(world->bounds.max.x - world->bounds.min.x,
                 SDL_max(world->bounds.max.y - world->bounds.min.y, world->bounds.max.z - world->bounds.min.z));
-    float cell_size = SDL_max(min_chunk_cell_size, SDL_max(world->visibility_cell_size * 4.0f, largest_extent / 16.0f));
+    float cell_size =
+        world->compile_chunk_cell_size_hint > 0.0f
+            ? SDL_max(min_chunk_cell_size, world->compile_chunk_cell_size_hint)
+            : SDL_max(min_chunk_cell_size, SDL_max(world->visibility_cell_size * 4.0f, largest_extent / 16.0f));
     int dim_x = 1;
     int dim_y = 1;
     int dim_z = 1;
@@ -747,6 +798,7 @@ static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_w
         world->compile_culled_face_count = 0;
         world->compile_triangle_count = 0;
     }
+    const bool cull_hidden_faces = world->compile_hidden_face_culling;
     if (!brush_model_copy_materials(world, model))
         return false;
 
@@ -806,7 +858,8 @@ static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_w
             {
                 if (update_compile_counters)
                     ++world->compile_face_count;
-                if (brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
+                if (cull_hidden_faces &&
+                    brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
                                                   distance, neighbor_polygon, polygon_capacity))
                 {
                     if (update_compile_counters)
@@ -925,8 +978,9 @@ static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_w
                 continue;
             float distance = 0.0f;
             if (!brush_plane_normalized(face, &normal, &distance) ||
-                brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v, distance,
-                                              neighbor_polygon, polygon_capacity))
+                (cull_hidden_faces &&
+                 brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v, distance,
+                                               neighbor_polygon, polygon_capacity)))
             {
                 continue;
             }
@@ -1027,6 +1081,89 @@ bool slayer3d_game_data_brush_world_compile_chunk_render_models(slayer3d_game_da
         }
     }
     return true;
+}
+
+static void brush_compile_hash_model(Uint64 *hash, const slayer3d_model *model)
+{
+    brush_compile_hash_int(hash, model != NULL ? model->material_count : 0);
+    if (model != NULL)
+    {
+        for (int material_index = 0; material_index < model->material_count; ++material_index)
+        {
+            const slayer3d_material *material = &model->materials[material_index];
+            brush_compile_hash_string(hash, material->name);
+            brush_compile_hash_bytes(hash, material->albedo, sizeof(material->albedo));
+            brush_compile_hash_float(hash, material->metallic);
+            brush_compile_hash_float(hash, material->roughness);
+            brush_compile_hash_bytes(hash, material->emissive, sizeof(material->emissive));
+            brush_compile_hash_string(hash, material->albedo_map);
+            brush_compile_hash_string(hash, material->normal_map);
+            brush_compile_hash_string(hash, material->metallic_roughness_map);
+            brush_compile_hash_string(hash, material->emissive_map);
+        }
+    }
+
+    brush_compile_hash_int(hash, model != NULL ? model->mesh_count : 0);
+    if (model == NULL)
+        return;
+    for (int mesh_index = 0; mesh_index < model->mesh_count; ++mesh_index)
+    {
+        const slayer3d_mesh *mesh = &model->meshes[mesh_index];
+        brush_compile_hash_string(hash, mesh->name);
+        brush_compile_hash_int(hash, mesh->material_index);
+        brush_compile_hash_int(hash, mesh->vertex_count);
+        brush_compile_hash_int(hash, mesh->index_count);
+        brush_compile_hash_bool(hash, mesh->has_local_bounds);
+        if (mesh->has_local_bounds)
+        {
+            brush_compile_hash_bytes(hash, &mesh->local_bounds, sizeof(mesh->local_bounds));
+        }
+        if (mesh->vertex_count > 0)
+        {
+            brush_compile_hash_bytes(hash, mesh->positions, (size_t)mesh->vertex_count * 3u * sizeof(float));
+            brush_compile_hash_bytes(hash, mesh->normals, (size_t)mesh->vertex_count * 3u * sizeof(float));
+            brush_compile_hash_bytes(hash, mesh->uvs, (size_t)mesh->vertex_count * 2u * sizeof(float));
+            brush_compile_hash_bytes(hash, mesh->colors, (size_t)mesh->vertex_count * 4u * sizeof(float));
+        }
+        if (mesh->index_count > 0)
+            brush_compile_hash_bytes(hash, mesh->indices, (size_t)mesh->index_count * sizeof(unsigned int));
+    }
+}
+
+Uint64 slayer3d_game_data_brush_world_compute_compile_artifact_hash(const slayer3d_game_data_brush_world *world)
+{
+    Uint64 hash = 1469598103934665603ull;
+    brush_compile_hash_string(&hash, "slayer3d.brush_compile.v1");
+    if (world == NULL)
+        return hash;
+
+    brush_compile_hash_string(&hash, world->name);
+    brush_compile_hash_bool(&hash, world->compile_hidden_face_culling);
+    brush_compile_hash_float(&hash, world->compile_chunk_cell_size_hint);
+    brush_compile_hash_float(&hash, world->compile_chunk_cell_size);
+    brush_compile_hash_int(&hash, world->compile_face_count);
+    brush_compile_hash_int(&hash, world->compile_rendered_face_count);
+    brush_compile_hash_int(&hash, world->compile_culled_face_count);
+    brush_compile_hash_int(&hash, world->compile_triangle_count);
+    brush_compile_hash_int(&hash, world->compile_invalid_brush_count);
+    brush_compile_hash_int(&hash, world->compile_degenerate_face_count);
+    brush_compile_hash_bool(&hash, world->has_bounds);
+    if (world->has_bounds)
+        brush_compile_hash_bytes(&hash, &world->bounds, sizeof(world->bounds));
+    brush_compile_hash_int(&hash, world->compile_chunk_count);
+    for (int chunk_index = 0; chunk_index < world->compile_chunk_count; ++chunk_index)
+    {
+        const slayer3d_game_data_brush_compile_chunk *chunk = &world->compile_chunks[chunk_index];
+        brush_compile_hash_bool(&hash, chunk->has_bounds);
+        if (chunk->has_bounds)
+            brush_compile_hash_bytes(&hash, &chunk->bounds, sizeof(chunk->bounds));
+        brush_compile_hash_uint(&hash, chunk->contents_mask);
+        brush_compile_hash_int(&hash, chunk->brush_count);
+        for (int i = 0; i < chunk->brush_count; ++i)
+            brush_compile_hash_int(&hash, chunk->brush_indices[i]);
+    }
+    brush_compile_hash_model(&hash, world->render_model);
+    return hash;
 }
 
 slayer3d_game_data_brush_trace_result slayer3d_game_data_brush_trace_default_result(

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -1166,6 +1166,58 @@ Uint64 slayer3d_game_data_brush_world_compute_compile_artifact_hash(const slayer
     return hash;
 }
 
+Uint64 slayer3d_game_data_brush_world_compute_source_hash(const slayer3d_game_data_brush_world *world)
+{
+    Uint64 hash = 1469598103934665603ull;
+    brush_compile_hash_string(&hash, "slayer3d.brush_source.v1");
+    if (world == NULL)
+        return hash;
+
+    brush_compile_hash_string(&hash, world->name);
+    brush_compile_hash_string(&hash, world->units);
+    brush_compile_hash_float(&hash, world->meters_per_unit);
+    brush_compile_hash_float(&hash, world->visibility_cell_size);
+
+    brush_compile_hash_int(&hash, world->material_count);
+    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    {
+        const slayer3d_game_data_brush_material *material = &world->materials[material_index];
+        brush_compile_hash_string(&hash, material->name);
+        brush_compile_hash_string(&hash, material->texture);
+        brush_compile_hash_bytes(&hash, &material->albedo, sizeof(material->albedo));
+        brush_compile_hash_float(&hash, material->metallic);
+        brush_compile_hash_float(&hash, material->roughness);
+        brush_compile_hash_bytes(&hash, &material->emissive, sizeof(material->emissive));
+        brush_compile_hash_float(&hash, material->tex_scale);
+    }
+
+    brush_compile_hash_int(&hash, world->brush_count);
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        brush_compile_hash_string(&hash, brush->name);
+        brush_compile_hash_uint(&hash, brush->contents);
+        brush_compile_hash_int(&hash, (int)brush->visibility);
+        brush_compile_hash_int(&hash, brush->tag_count);
+        for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
+            brush_compile_hash_string(&hash, brush->tags[tag_index]);
+        brush_compile_hash_int(&hash, brush->face_count);
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+            brush_compile_hash_bytes(&hash, &face->normal, sizeof(face->normal));
+            brush_compile_hash_float(&hash, face->distance);
+            brush_compile_hash_int(&hash, face->material_index);
+            brush_compile_hash_string(&hash, face->material_name);
+            brush_compile_hash_bytes(&hash, face->uv_scale, sizeof(face->uv_scale));
+            brush_compile_hash_bytes(&hash, face->uv_offset, sizeof(face->uv_offset));
+            brush_compile_hash_float(&hash, face->uv_rotation_degrees);
+            brush_compile_hash_uint(&hash, face->surface_flags);
+        }
+    }
+    return hash;
+}
+
 slayer3d_game_data_brush_trace_result slayer3d_game_data_brush_trace_default_result(
     const slayer3d_game_data_brush_trace_desc *desc)
 {

--- a/src/game_data_brush_internal.h
+++ b/src/game_data_brush_internal.h
@@ -42,6 +42,8 @@ bool slayer3d_game_data_brush_world_compile_brush_render_models(slayer3d_game_da
 bool slayer3d_game_data_brush_world_compile_chunk_render_models(slayer3d_game_data_brush_world *world,
                                                                 slayer3d_model *models, int model_count);
 
+Uint64 slayer3d_game_data_brush_world_compute_compile_artifact_hash(const slayer3d_game_data_brush_world *world);
+
 bool slayer3d_game_data_brush_slide_with_trace(slayer3d_game_data_brush_trace_fn trace_fn, void *trace_userdata,
                                                const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
                                                slayer3d_game_data_brush_trace_result *out_result);

--- a/src/game_data_brush_internal.h
+++ b/src/game_data_brush_internal.h
@@ -44,6 +44,8 @@ bool slayer3d_game_data_brush_world_compile_chunk_render_models(slayer3d_game_da
 
 Uint64 slayer3d_game_data_brush_world_compute_compile_artifact_hash(const slayer3d_game_data_brush_world *world);
 
+Uint64 slayer3d_game_data_brush_world_compute_source_hash(const slayer3d_game_data_brush_world *world);
+
 bool slayer3d_game_data_brush_slide_with_trace(slayer3d_game_data_brush_trace_fn trace_fn, void *trace_userdata,
                                                const slayer3d_game_data_brush_trace_desc *desc, int max_bumps,
                                                slayer3d_game_data_brush_trace_result *out_result);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -442,9 +442,8 @@ typedef struct sector_level_runtime
     slayer3d_level unlit_without_sector_lighting;
 } sector_level_runtime;
 
-typedef struct brush_world_runtime
+typedef struct brush_world_compile_artifacts
 {
-    slayer3d_game_data_brush_world desc;
     slayer3d_model render_model;
     slayer3d_model *brush_render_models;
     int brush_render_model_count;
@@ -461,6 +460,12 @@ typedef struct brush_world_runtime
     int visibility_grid_visible_cache_start[SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS];
     Uint64 visibility_grid_visible_cache_tick[SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS];
     Uint64 visibility_grid_visible_cache_clock;
+} brush_world_compile_artifacts;
+
+typedef struct brush_world_runtime
+{
+    slayer3d_game_data_brush_world desc;
+    brush_world_compile_artifacts artifacts;
     char *editor_source_path;
     Uint64 editor_revision;
     Uint64 editor_saved_revision;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -1036,6 +1036,8 @@ int sector_level_find_sector_name(const sector_level_runtime *level, const char 
 const brush_world_runtime *find_brush_world_runtime(const slayer3d_game_data_runtime *runtime, const char *name);
 bool compile_brush_world_visibility_grid(brush_world_runtime *world_runtime);
 void free_brush_world_visibility_grid(brush_world_runtime *world_runtime);
+bool rebuild_brush_world_runtime_artifacts(brush_world_runtime *world_runtime, char *error_buffer,
+                                           int error_buffer_size);
 bool load_grid_maps(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_grid_pickup_layers(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                              int error_buffer_size);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -5402,6 +5402,29 @@ static bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, val
             ok = validation_error(ctx, world_path, "brush world visibility_cell_size must be positive");
             goto done;
         }
+        yyjson_val *compile = obj_get(world, "compile");
+        if (compile != NULL)
+        {
+            char compile_path[PATH_BUFFER_SIZE];
+            format_path(compile_path, sizeof(compile_path), "%s.compile", world_path);
+            if (!yyjson_is_obj(compile))
+            {
+                ok = validation_error(ctx, compile_path, "brush world compile must be an object");
+                goto done;
+            }
+            yyjson_val *hidden_face_culling = obj_get(compile, "hidden_face_culling");
+            if (hidden_face_culling != NULL && !yyjson_is_bool(hidden_face_culling))
+            {
+                ok = validation_error(ctx, compile_path, "brush world compile hidden_face_culling must be a boolean");
+                goto done;
+            }
+            yyjson_val *chunk_cell_size = obj_get(compile, "chunk_cell_size");
+            if (chunk_cell_size != NULL && (!yyjson_is_num(chunk_cell_size) || yyjson_get_num(chunk_cell_size) <= 0.0))
+            {
+                ok = validation_error(ctx, compile_path, "brush world compile chunk_cell_size must be positive");
+                goto done;
+            }
+        }
         {
             char editor_path[PATH_BUFFER_SIZE];
             format_path(editor_path, sizeof(editor_path), "%s.editor", world_path);

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -639,6 +639,9 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
         world->units = SDL_strdup(json_string(world_json, "units", "meters"));
         world->meters_per_unit = json_float(world_json, "meters_per_unit", 1.0f);
         world->visibility_cell_size = json_float(world_json, "visibility_cell_size", 2.0f);
+        yyjson_val *compile_json = obj_get(world_json, "compile");
+        world->compile_hidden_face_culling = json_bool(compile_json, "hidden_face_culling", true);
+        world->compile_chunk_cell_size_hint = json_float(compile_json, "chunk_cell_size", 0.0f);
         world->material_count = (int)yyjson_arr_size(materials_json);
         world->brush_count = (int)yyjson_arr_size(brushes_json);
         if (world->name == NULL || world->units == NULL)
@@ -815,6 +818,7 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
                 return false;
             }
         }
+        world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     }
     return true;
 }

--- a/src/game_data_world_loaders.c
+++ b/src/game_data_world_loaders.c
@@ -756,69 +756,9 @@ bool load_brush_worlds(slayer3d_game_data_runtime *runtime, yyjson_val *root, ch
             }
         }
 
-        char compile_error[256] = {0};
-        if (!slayer3d_game_data_brush_world_build_acceleration_checked(world, compile_error, sizeof(compile_error)))
-        {
-            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' acceleration data: %s",
-                       world->name != NULL ? world->name : "<unnamed>",
-                       compile_error[0] != '\0' ? compile_error : "unknown compile error");
+        if (!rebuild_brush_world_runtime_artifacts(&runtime->brush_worlds[world_index], error_buffer,
+                                                   error_buffer_size))
             return false;
-        }
-
-        if (!slayer3d_game_data_brush_world_compile_render_model(world,
-                                                                 &runtime->brush_worlds[world_index].render_model))
-        {
-            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' render mesh",
-                       world->name != NULL ? world->name : "<unnamed>");
-            return false;
-        }
-        if (world->brush_count > 0)
-        {
-            runtime->brush_worlds[world_index].brush_render_models =
-                (slayer3d_model *)SDL_calloc((size_t)world->brush_count, sizeof(slayer3d_model));
-            runtime->brush_worlds[world_index].brush_render_model_count = world->brush_count;
-            if (runtime->brush_worlds[world_index].brush_render_models == NULL ||
-                !slayer3d_game_data_brush_world_compile_brush_render_models(
-                    world, runtime->brush_worlds[world_index].brush_render_models, world->brush_count))
-            {
-                SDL_free(runtime->brush_worlds[world_index].brush_render_models);
-                runtime->brush_worlds[world_index].brush_render_models = NULL;
-                runtime->brush_worlds[world_index].brush_render_model_count = 0;
-                set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility meshes",
-                           world->name != NULL ? world->name : "<unnamed>");
-                return false;
-            }
-        }
-        if (!compile_brush_world_visibility_grid(&runtime->brush_worlds[world_index]))
-        {
-            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility grid",
-                       world->name != NULL ? world->name : "<unnamed>");
-            return false;
-        }
-        if (!slayer3d_game_data_brush_world_build_compile_chunks(world))
-        {
-            set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' spatial chunks",
-                       world->name != NULL ? world->name : "<unnamed>");
-            return false;
-        }
-        if (world->compile_chunk_count > 0)
-        {
-            runtime->brush_worlds[world_index].chunk_render_models =
-                (slayer3d_model *)SDL_calloc((size_t)world->compile_chunk_count, sizeof(slayer3d_model));
-            runtime->brush_worlds[world_index].chunk_render_model_count = world->compile_chunk_count;
-            if (runtime->brush_worlds[world_index].chunk_render_models == NULL ||
-                !slayer3d_game_data_brush_world_compile_chunk_render_models(
-                    world, runtime->brush_worlds[world_index].chunk_render_models, world->compile_chunk_count))
-            {
-                SDL_free(runtime->brush_worlds[world_index].chunk_render_models);
-                runtime->brush_worlds[world_index].chunk_render_models = NULL;
-                runtime->brush_worlds[world_index].chunk_render_model_count = 0;
-                set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' chunk meshes",
-                           world->name != NULL ? world->name : "<unnamed>");
-                return false;
-            }
-        }
-        world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     }
     return true;
 }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -17,6 +17,9 @@
 #include <SDL3/SDL_timer.h>
 #include <stdlib.h>
 
+static bool editor_save_bytes_atomic(const char *path, const void *data, size_t size, const char *kind,
+                                     char *error_buffer, int error_buffer_size);
+
 const char *slayer3d_game_data_active_scene(const slayer3d_game_data_runtime *runtime)
 {
     const scene_entry *scene = active_scene_entry_const(runtime);
@@ -1935,6 +1938,123 @@ bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_
     return true;
 }
 
+static bool artifact_json_real_matches(yyjson_val *obj, const char *key, float expected)
+{
+    yyjson_val *value = yyjson_obj_get(obj, key);
+    return yyjson_is_num(value) && SDL_fabsf((float)yyjson_get_num(value) - expected) <= 0.0001f;
+}
+
+bool slayer3d_game_data_verify_brush_world_compile_artifact_json(
+    const slayer3d_game_data_runtime *runtime, const char *world_name, const char *json, size_t json_size,
+    slayer3d_game_data_brush_compile_artifact_status *out_status, char *error_buffer, int error_buffer_size)
+{
+    if (out_status != NULL)
+        SDL_zero(*out_status);
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || json == NULL || out_status == NULL)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "brush compile artifact verification requires runtime, world name, JSON, and status output");
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "brush world '%s' not found", world_name);
+        return false;
+    }
+
+    const size_t parse_size = json_size > 0u ? json_size : SDL_strlen(json);
+    yyjson_doc *doc = yyjson_read(json, parse_size, YYJSON_READ_NOFLAG);
+    yyjson_val *root = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    if (doc == NULL || !yyjson_is_obj(root))
+    {
+        yyjson_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to parse brush compile artifact JSON");
+        return false;
+    }
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    out_status->expected_source_hash = slayer3d_game_data_brush_world_compute_source_hash(world);
+    out_status->expected_compile_artifact_hash = world->compile_artifact_hash;
+    out_status->artifact_source_hash = yyjson_get_uint(yyjson_obj_get(root, "source_hash"));
+    out_status->artifact_compile_artifact_hash = yyjson_get_uint(yyjson_obj_get(root, "compile_artifact_hash"));
+    const char *schema = yyjson_get_str(yyjson_obj_get(root, "schema"));
+    const char *artifact_world = yyjson_get_str(yyjson_obj_get(root, "world"));
+    out_status->schema_matches = schema != NULL && SDL_strcmp(schema, "slayer3d.brush_compile_artifact.v0") == 0;
+    out_status->world_matches = artifact_world != NULL && SDL_strcmp(artifact_world, world_name) == 0;
+    out_status->source_hash_matches = out_status->artifact_source_hash == out_status->expected_source_hash;
+    out_status->compile_artifact_hash_matches =
+        out_status->artifact_compile_artifact_hash == out_status->expected_compile_artifact_hash;
+
+    yyjson_val *policy = yyjson_obj_get(root, "policy");
+    yyjson_val *hidden_face_culling = yyjson_is_obj(policy) ? yyjson_obj_get(policy, "hidden_face_culling") : NULL;
+    out_status->policy_matches =
+        yyjson_is_obj(policy) && yyjson_is_bool(hidden_face_culling) &&
+        yyjson_get_bool(hidden_face_culling) == world->compile_hidden_face_culling &&
+        artifact_json_real_matches(policy, "chunk_cell_size_hint", world->compile_chunk_cell_size_hint) &&
+        artifact_json_real_matches(policy, "chunk_cell_size", world->compile_chunk_cell_size) &&
+        artifact_json_real_matches(policy, "visibility_cell_size", world->visibility_cell_size);
+
+    out_status->fresh = out_status->schema_matches && out_status->world_matches && out_status->source_hash_matches &&
+                        out_status->policy_matches && out_status->compile_artifact_hash_matches;
+    yyjson_doc_free(doc);
+    return true;
+}
+
+bool slayer3d_game_data_verify_brush_world_compile_artifact_file(
+    const slayer3d_game_data_runtime *runtime, const char *world_name, const char *path,
+    slayer3d_game_data_brush_compile_artifact_status *out_status, char *error_buffer, int error_buffer_size)
+{
+    if (out_status != NULL)
+        SDL_zero(*out_status);
+    if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush compile artifact verification requires a filesystem path");
+        return false;
+    }
+
+    size_t size = 0u;
+    char *json = (char *)SDL_LoadFile(path, &size);
+    if (json == NULL || size == 0u)
+    {
+        SDL_free(json);
+        set_errorf(error_buffer, error_buffer_size, "failed to read brush compile artifact file '%s'", path);
+        return false;
+    }
+
+    const bool ok = slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        runtime, world_name, json, size, out_status, error_buffer, error_buffer_size);
+    SDL_free(json);
+    return ok;
+}
+
+bool slayer3d_game_data_save_brush_world_compile_artifact_file(const slayer3d_game_data_runtime *runtime,
+                                                               const char *world_name, const char *path,
+                                                               size_t *out_size, char *error_buffer,
+                                                               int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0u;
+
+    char *json = NULL;
+    size_t size = 0u;
+    if (!slayer3d_game_data_export_brush_world_compile_artifact_json(runtime, world_name, &json, &size, error_buffer,
+                                                                     error_buffer_size))
+    {
+        return false;
+    }
+
+    const bool ok =
+        editor_save_bytes_atomic(path, json, size, "brush compile artifact manifest", error_buffer, error_buffer_size);
+    SDL_free(json);
+    if (!ok)
+        return false;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
 static bool export_add_player_start(yyjson_mut_doc *doc, yyjson_mut_val *starts,
                                     const editor_player_start_runtime *start)
 {
@@ -2153,23 +2273,12 @@ static char *editor_save_parent_directory(const char *path)
     return parent;
 }
 
-bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
-                                                       const char *path, size_t *out_size, char *error_buffer,
-                                                       int error_buffer_size)
+static bool editor_save_bytes_atomic(const char *path, const void *data, size_t size, const char *kind,
+                                     char *error_buffer, int error_buffer_size)
 {
-    if (out_size != NULL)
-        *out_size = 0u;
     if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
     {
-        set_error(error_buffer, error_buffer_size, "brush world save requires a filesystem path");
-        return false;
-    }
-
-    char *json = NULL;
-    size_t size = 0u;
-    if (!slayer3d_game_data_export_brush_world_fragment_json(runtime, world_name, &json, &size, error_buffer,
-                                                             error_buffer_size))
-    {
+        set_errorf(error_buffer, error_buffer_size, "%s save requires a filesystem path", kind != NULL ? kind : "file");
         return false;
     }
 
@@ -2177,8 +2286,7 @@ bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtim
     if (parent == NULL || !editor_save_make_directory_recursive(parent))
     {
         SDL_free(parent);
-        SDL_free(json);
-        set_error(error_buffer, error_buffer_size, "failed to create brush world save directory");
+        set_errorf(error_buffer, error_buffer_size, "failed to create %s save directory", kind != NULL ? kind : "file");
         return false;
     }
     SDL_free(parent);
@@ -2192,7 +2300,7 @@ bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtim
         SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
         if (stream == NULL)
             continue;
-        ok = editor_save_write_all(stream, json, size) && SDL_FlushIO(stream);
+        ok = editor_save_write_all(stream, data, size) && SDL_FlushIO(stream);
         ok = SDL_CloseIO(stream) && ok;
         if (!ok)
         {
@@ -2208,12 +2316,30 @@ bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtim
             SDL_RemovePath(temp_path);
     }
 
-    SDL_free(json);
     if (!ok)
+        set_errorf(error_buffer, error_buffer_size, "failed to save %s", kind != NULL ? kind : "file");
+    return ok;
+}
+
+bool slayer3d_game_data_save_brush_world_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                       const char *path, size_t *out_size, char *error_buffer,
+                                                       int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0u;
+
+    char *json = NULL;
+    size_t size = 0u;
+    if (!slayer3d_game_data_export_brush_world_fragment_json(runtime, world_name, &json, &size, error_buffer,
+                                                             error_buffer_size))
     {
-        set_error(error_buffer, error_buffer_size, "failed to save brush world fragment");
         return false;
     }
+
+    const bool ok = editor_save_bytes_atomic(path, json, size, "brush world fragment", error_buffer, error_buffer_size);
+    SDL_free(json);
+    if (!ok)
+        return false;
     if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size))
         return false;
     if (out_size != NULL)
@@ -2227,11 +2353,6 @@ bool slayer3d_game_data_save_editable_level_fragment_file(slayer3d_game_data_run
 {
     if (out_size != NULL)
         *out_size = 0u;
-    if (path == NULL || path[0] == '\0' || SDL_strstr(path, "://") != NULL)
-    {
-        set_error(error_buffer, error_buffer_size, "editable level save requires a filesystem path");
-        return false;
-    }
 
     char *json = NULL;
     size_t size = 0u;
@@ -2241,47 +2362,11 @@ bool slayer3d_game_data_save_editable_level_fragment_file(slayer3d_game_data_run
         return false;
     }
 
-    char *parent = editor_save_parent_directory(path);
-    if (parent == NULL || !editor_save_make_directory_recursive(parent))
-    {
-        SDL_free(parent);
-        SDL_free(json);
-        set_error(error_buffer, error_buffer_size, "failed to create editable level save directory");
-        return false;
-    }
-    SDL_free(parent);
-
-    bool ok = false;
-    char temp_path[4096];
-    for (int attempt = 0; attempt < 16 && !ok; ++attempt)
-    {
-        SDL_snprintf(temp_path, sizeof(temp_path), "%s.tmp.%llu.%d", path, (unsigned long long)SDL_GetTicksNS(),
-                     attempt);
-        SDL_IOStream *stream = SDL_IOFromFile(temp_path, "wb");
-        if (stream == NULL)
-            continue;
-        ok = editor_save_write_all(stream, json, size) && SDL_FlushIO(stream);
-        ok = SDL_CloseIO(stream) && ok;
-        if (!ok)
-        {
-            SDL_RemovePath(temp_path);
-            continue;
-        }
-        if (!SDL_RenamePath(temp_path, path))
-        {
-            SDL_RemovePath(path);
-            ok = SDL_RenamePath(temp_path, path);
-        }
-        if (!ok)
-            SDL_RemovePath(temp_path);
-    }
-
+    const bool ok =
+        editor_save_bytes_atomic(path, json, size, "editable level fragment", error_buffer, error_buffer_size);
     SDL_free(json);
     if (!ok)
-    {
-        set_error(error_buffer, error_buffer_size, "failed to save editable level fragment");
         return false;
-    }
     if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size))
         return false;
     if (!slayer3d_game_data_mark_player_starts_saved(runtime, path, error_buffer, error_buffer_size))

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -655,38 +655,38 @@ static void free_brush_world_visibility_models(brush_world_runtime *world_runtim
 {
     if (world_runtime == NULL)
         return;
-    for (int i = 0; i < world_runtime->brush_render_model_count; ++i)
-        slayer3d_free_model(&world_runtime->brush_render_models[i]);
-    SDL_free(world_runtime->brush_render_models);
-    world_runtime->brush_render_models = NULL;
-    world_runtime->brush_render_model_count = 0;
-    for (int i = 0; i < world_runtime->chunk_render_model_count; ++i)
-        slayer3d_free_model(&world_runtime->chunk_render_models[i]);
-    SDL_free(world_runtime->chunk_render_models);
-    world_runtime->chunk_render_models = NULL;
-    world_runtime->chunk_render_model_count = 0;
+    for (int i = 0; i < world_runtime->artifacts.brush_render_model_count; ++i)
+        slayer3d_free_model(&world_runtime->artifacts.brush_render_models[i]);
+    SDL_free(world_runtime->artifacts.brush_render_models);
+    world_runtime->artifacts.brush_render_models = NULL;
+    world_runtime->artifacts.brush_render_model_count = 0;
+    for (int i = 0; i < world_runtime->artifacts.chunk_render_model_count; ++i)
+        slayer3d_free_model(&world_runtime->artifacts.chunk_render_models[i]);
+    SDL_free(world_runtime->artifacts.chunk_render_models);
+    world_runtime->artifacts.chunk_render_models = NULL;
+    world_runtime->artifacts.chunk_render_model_count = 0;
 }
 
 void free_brush_world_visibility_grid(brush_world_runtime *world_runtime)
 {
     if (world_runtime == NULL)
         return;
-    SDL_free(world_runtime->visibility_grid_solid);
+    SDL_free(world_runtime->artifacts.visibility_grid_solid);
     for (int i = 0; i < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++i)
     {
-        SDL_free(world_runtime->visibility_grid_visible_cache[i]);
-        world_runtime->visibility_grid_visible_cache[i] = NULL;
-        world_runtime->visibility_grid_visible_cache_start[i] = -1;
-        world_runtime->visibility_grid_visible_cache_tick[i] = 0u;
+        SDL_free(world_runtime->artifacts.visibility_grid_visible_cache[i]);
+        world_runtime->artifacts.visibility_grid_visible_cache[i] = NULL;
+        world_runtime->artifacts.visibility_grid_visible_cache_start[i] = -1;
+        world_runtime->artifacts.visibility_grid_visible_cache_tick[i] = 0u;
     }
-    world_runtime->visibility_grid_solid = NULL;
-    world_runtime->visibility_grid_visible_cache_clock = 0u;
-    world_runtime->visibility_cell_size = 0.0f;
-    world_runtime->visibility_grid_dim_x = 0;
-    world_runtime->visibility_grid_dim_y = 0;
-    world_runtime->visibility_grid_dim_z = 0;
-    world_runtime->visibility_grid_cell_count = 0;
-    SDL_zero(world_runtime->visibility_grid_bounds);
+    world_runtime->artifacts.visibility_grid_solid = NULL;
+    world_runtime->artifacts.visibility_grid_visible_cache_clock = 0u;
+    world_runtime->artifacts.visibility_cell_size = 0.0f;
+    world_runtime->artifacts.visibility_grid_dim_x = 0;
+    world_runtime->artifacts.visibility_grid_dim_y = 0;
+    world_runtime->artifacts.visibility_grid_dim_z = 0;
+    world_runtime->artifacts.visibility_grid_cell_count = 0;
+    SDL_zero(world_runtime->artifacts.visibility_grid_bounds);
 }
 
 static bool brush_point_inside_contents(const slayer3d_game_data_brush *brush, slayer3d_vec3 point,
@@ -788,15 +788,15 @@ bool compile_brush_world_visibility_grid(brush_world_runtime *world_runtime)
         }
     }
 
-    world_runtime->visibility_grid_bounds = bounds;
-    world_runtime->visibility_cell_size = cell_size;
-    world_runtime->visibility_grid_dim_x = dim_x;
-    world_runtime->visibility_grid_dim_y = dim_y;
-    world_runtime->visibility_grid_dim_z = dim_z;
-    world_runtime->visibility_grid_cell_count = cell_count;
-    world_runtime->visibility_grid_solid = solid;
+    world_runtime->artifacts.visibility_grid_bounds = bounds;
+    world_runtime->artifacts.visibility_cell_size = cell_size;
+    world_runtime->artifacts.visibility_grid_dim_x = dim_x;
+    world_runtime->artifacts.visibility_grid_dim_y = dim_y;
+    world_runtime->artifacts.visibility_grid_dim_z = dim_z;
+    world_runtime->artifacts.visibility_grid_cell_count = cell_count;
+    world_runtime->artifacts.visibility_grid_solid = solid;
     for (int i = 0; i < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++i)
-        world_runtime->visibility_grid_visible_cache_start[i] = -1;
+        world_runtime->artifacts.visibility_grid_visible_cache_start[i] = -1;
     return true;
 }
 
@@ -871,6 +871,7 @@ bool rebuild_brush_world_runtime_artifacts(brush_world_runtime *world_runtime, c
     }
 
     slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    const slayer3d_model *old_render_model = world->render_model;
     char compile_error[256] = {0};
     if (!slayer3d_game_data_brush_world_build_acceleration_checked(world, compile_error, sizeof(compile_error)))
     {
@@ -926,29 +927,30 @@ bool rebuild_brush_world_runtime_artifacts(brush_world_runtime *world_runtime, c
         free_brush_world_model_array(brush_render_models, brush_render_model_count);
         free_brush_world_model_array(chunk_render_models, chunk_render_model_count);
         free_brush_world_visibility_grid(&staged_grid);
+        world->render_model = old_render_model;
         return false;
     }
 
-    slayer3d_free_model(&world_runtime->render_model);
+    slayer3d_free_model(&world_runtime->artifacts.render_model);
     free_brush_world_visibility_models(world_runtime);
     free_brush_world_visibility_grid(world_runtime);
 
-    world_runtime->render_model = render_model;
-    world_runtime->brush_render_models = brush_render_models;
-    world_runtime->brush_render_model_count = brush_render_model_count;
-    world_runtime->chunk_render_models = chunk_render_models;
-    world_runtime->chunk_render_model_count = chunk_render_model_count;
-    world_runtime->visibility_grid_bounds = staged_grid.visibility_grid_bounds;
-    world_runtime->visibility_cell_size = staged_grid.visibility_cell_size;
-    world_runtime->visibility_grid_dim_x = staged_grid.visibility_grid_dim_x;
-    world_runtime->visibility_grid_dim_y = staged_grid.visibility_grid_dim_y;
-    world_runtime->visibility_grid_dim_z = staged_grid.visibility_grid_dim_z;
-    world_runtime->visibility_grid_cell_count = staged_grid.visibility_grid_cell_count;
-    world_runtime->visibility_grid_solid = staged_grid.visibility_grid_solid;
+    world_runtime->artifacts.render_model = render_model;
+    world_runtime->artifacts.brush_render_models = brush_render_models;
+    world_runtime->artifacts.brush_render_model_count = brush_render_model_count;
+    world_runtime->artifacts.chunk_render_models = chunk_render_models;
+    world_runtime->artifacts.chunk_render_model_count = chunk_render_model_count;
+    world_runtime->artifacts.visibility_grid_bounds = staged_grid.artifacts.visibility_grid_bounds;
+    world_runtime->artifacts.visibility_cell_size = staged_grid.artifacts.visibility_cell_size;
+    world_runtime->artifacts.visibility_grid_dim_x = staged_grid.artifacts.visibility_grid_dim_x;
+    world_runtime->artifacts.visibility_grid_dim_y = staged_grid.artifacts.visibility_grid_dim_y;
+    world_runtime->artifacts.visibility_grid_dim_z = staged_grid.artifacts.visibility_grid_dim_z;
+    world_runtime->artifacts.visibility_grid_cell_count = staged_grid.artifacts.visibility_grid_cell_count;
+    world_runtime->artifacts.visibility_grid_solid = staged_grid.artifacts.visibility_grid_solid;
     for (int i = 0; i < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++i)
-        world_runtime->visibility_grid_visible_cache_start[i] = -1;
+        world_runtime->artifacts.visibility_grid_visible_cache_start[i] = -1;
 
-    world->render_model = &world_runtime->render_model;
+    world->render_model = &world_runtime->artifacts.render_model;
     world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     return true;
 }

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1064,6 +1064,7 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     world_runtime->chunk_render_models = chunk_render_models;
     world_runtime->chunk_render_model_count = chunk_render_model_count;
     world->render_model = &world_runtime->render_model;
+    world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     editor_brush_world_mark_dirty(world_runtime);
     if (out_brush_name != NULL && out_brush_name_size > 0u)
         SDL_strlcpy(out_brush_name, brushes[old_count].name != NULL ? brushes[old_count].name : "",
@@ -1582,6 +1583,7 @@ static bool export_add_brush_world(yyjson_mut_doc *doc, yyjson_mut_val *worlds,
     yyjson_mut_val *obj = yyjson_mut_obj(doc);
     yyjson_mut_val *materials = yyjson_mut_arr(doc);
     yyjson_mut_val *brushes = yyjson_mut_arr(doc);
+    yyjson_mut_val *compile = yyjson_mut_obj(doc);
     if (obj == NULL || materials == NULL || brushes == NULL || !yyjson_mut_arr_add_val(worlds, obj) ||
         !yyjson_mut_obj_add_strcpy(doc, obj, "name", world->name != NULL ? world->name : "") ||
         !yyjson_mut_obj_add_strcpy(doc, obj, "units", world->units != NULL ? world->units : "meters") ||
@@ -1592,6 +1594,17 @@ static bool export_add_brush_world(yyjson_mut_doc *doc, yyjson_mut_val *worlds,
         !yyjson_mut_obj_add_val(doc, obj, "brushes", brushes))
     {
         return false;
+    }
+    if (world->compile_hidden_face_culling == false || world->compile_chunk_cell_size_hint > 0.0f)
+    {
+        if (compile == NULL ||
+            !yyjson_mut_obj_add_bool(doc, compile, "hidden_face_culling", world->compile_hidden_face_culling) ||
+            (world->compile_chunk_cell_size_hint > 0.0f &&
+             !yyjson_mut_obj_add_real(doc, compile, "chunk_cell_size", world->compile_chunk_cell_size_hint)) ||
+            !yyjson_mut_obj_add_val(doc, obj, "compile", compile))
+        {
+            return false;
+        }
     }
     for (int i = 0; i < world->material_count; ++i)
     {
@@ -4792,6 +4805,7 @@ static bool rebuild_editor_brush_world(brush_world_runtime *world_runtime)
     world_runtime->chunk_render_models = chunk_render_models;
     world_runtime->chunk_render_model_count = chunk_render_model_count;
     world->render_model = &world_runtime->render_model;
+    world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     return true;
 }
 

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -1441,6 +1441,20 @@ static bool export_add_vec3(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char
            yyjson_mut_arr_add_real(doc, arr, value.z) && yyjson_mut_obj_add_val(doc, obj, key, arr);
 }
 
+static bool export_add_int3_values(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, int x, int y, int z)
+{
+    yyjson_mut_val *arr = yyjson_mut_arr(doc);
+    return arr != NULL && yyjson_mut_arr_add_int(doc, arr, x) && yyjson_mut_arr_add_int(doc, arr, y) &&
+           yyjson_mut_arr_add_int(doc, arr, z) && yyjson_mut_obj_add_val(doc, obj, key, arr);
+}
+
+static bool export_add_bounds(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_bounding_box bounds)
+{
+    yyjson_mut_val *bounds_obj = yyjson_mut_obj(doc);
+    return bounds_obj != NULL && yyjson_mut_obj_add_val(doc, obj, key, bounds_obj) &&
+           export_add_vec3(doc, bounds_obj, "min", bounds.min) && export_add_vec3(doc, bounds_obj, "max", bounds.max);
+}
+
 static bool export_add_vec4(yyjson_mut_doc *doc, yyjson_mut_val *obj, const char *key, slayer3d_vec4 value)
 {
     yyjson_mut_val *arr = yyjson_mut_arr(doc);
@@ -1692,6 +1706,108 @@ static bool export_add_brush_world(yyjson_mut_doc *doc, yyjson_mut_val *worlds,
     return true;
 }
 
+static bool export_add_brush_compile_policy(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                            const slayer3d_game_data_brush_world *world)
+{
+    yyjson_mut_val *policy = yyjson_mut_obj(doc);
+    return policy != NULL && yyjson_mut_obj_add_val(doc, root, "policy", policy) &&
+           yyjson_mut_obj_add_bool(doc, policy, "hidden_face_culling", world->compile_hidden_face_culling) &&
+           yyjson_mut_obj_add_real(doc, policy, "chunk_cell_size_hint", world->compile_chunk_cell_size_hint) &&
+           yyjson_mut_obj_add_real(doc, policy, "chunk_cell_size", world->compile_chunk_cell_size) &&
+           yyjson_mut_obj_add_real(doc, policy, "visibility_cell_size", world->visibility_cell_size);
+}
+
+static bool export_add_brush_compile_source_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                                    const slayer3d_game_data_brush_world *world)
+{
+    yyjson_mut_val *source = yyjson_mut_obj(doc);
+    const char *units = world->units != NULL ? world->units : "meters";
+    return source != NULL && yyjson_mut_obj_add_val(doc, root, "source", source) &&
+           yyjson_mut_obj_add_strcpy(doc, source, "units", units) &&
+           yyjson_mut_obj_add_real(doc, source, "meters_per_unit", world->meters_per_unit) &&
+           yyjson_mut_obj_add_int(doc, source, "material_count", world->material_count) &&
+           yyjson_mut_obj_add_int(doc, source, "brush_count", world->brush_count) &&
+           yyjson_mut_obj_add_bool(doc, source, "has_bounds", world->has_bounds) &&
+           (!world->has_bounds || export_add_bounds(doc, source, "bounds", world->bounds));
+}
+
+static bool export_add_brush_compile_render_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                                    const slayer3d_game_data_brush_world *world)
+{
+    yyjson_mut_val *render = yyjson_mut_obj(doc);
+    if (render == NULL || !yyjson_mut_obj_add_val(doc, root, "render", render) ||
+        !yyjson_mut_obj_add_int(doc, render, "face_count", world->compile_face_count) ||
+        !yyjson_mut_obj_add_int(doc, render, "rendered_face_count", world->compile_rendered_face_count) ||
+        !yyjson_mut_obj_add_int(doc, render, "culled_face_count", world->compile_culled_face_count) ||
+        !yyjson_mut_obj_add_int(doc, render, "triangle_count", world->compile_triangle_count) ||
+        !yyjson_mut_obj_add_int(doc, render, "invalid_brush_count", world->compile_invalid_brush_count) ||
+        !yyjson_mut_obj_add_int(doc, render, "degenerate_face_count", world->compile_degenerate_face_count))
+    {
+        return false;
+    }
+
+    const slayer3d_model *model = world->render_model;
+    int vertex_count = 0;
+    int index_count = 0;
+    for (int mesh_index = 0; model != NULL && mesh_index < model->mesh_count; ++mesh_index)
+    {
+        vertex_count += model->meshes[mesh_index].vertex_count;
+        index_count += model->meshes[mesh_index].index_count;
+    }
+
+    return yyjson_mut_obj_add_int(doc, render, "material_count", model != NULL ? model->material_count : 0) &&
+           yyjson_mut_obj_add_int(doc, render, "mesh_count", model != NULL ? model->mesh_count : 0) &&
+           yyjson_mut_obj_add_int(doc, render, "vertex_count", vertex_count) &&
+           yyjson_mut_obj_add_int(doc, render, "index_count", index_count);
+}
+
+static bool export_add_brush_compile_chunks(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                            const slayer3d_game_data_brush_world *world)
+{
+    yyjson_mut_val *chunks = yyjson_mut_obj(doc);
+    yyjson_mut_val *items = yyjson_mut_arr(doc);
+    if (chunks == NULL || items == NULL || !yyjson_mut_obj_add_val(doc, root, "chunks", chunks) ||
+        !yyjson_mut_obj_add_real(doc, chunks, "cell_size", world->compile_chunk_cell_size) ||
+        !yyjson_mut_obj_add_int(doc, chunks, "count", world->compile_chunk_count) ||
+        !yyjson_mut_obj_add_int(doc, chunks, "brush_index_count", world->compile_chunk_brush_index_count) ||
+        !yyjson_mut_obj_add_val(doc, chunks, "items", items))
+    {
+        return false;
+    }
+
+    for (int chunk_index = 0; chunk_index < world->compile_chunk_count; ++chunk_index)
+    {
+        const slayer3d_game_data_brush_compile_chunk *chunk = &world->compile_chunks[chunk_index];
+        yyjson_mut_val *item = yyjson_mut_obj(doc);
+        if (item == NULL || !yyjson_mut_arr_add_val(items, item) ||
+            !yyjson_mut_obj_add_int(doc, item, "index", chunk_index) ||
+            !yyjson_mut_obj_add_int(doc, item, "brush_count", chunk->brush_count) ||
+            !yyjson_mut_obj_add_uint(doc, item, "contents_mask", chunk->contents_mask) ||
+            !yyjson_mut_obj_add_bool(doc, item, "has_bounds", chunk->has_bounds) ||
+            (chunk->has_bounds && !export_add_bounds(doc, item, "bounds", chunk->bounds)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool export_add_brush_compile_visibility_grid(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                                     const brush_world_compile_artifacts *artifacts)
+{
+    yyjson_mut_val *grid = yyjson_mut_obj(doc);
+    const bool has_grid = artifacts != NULL && artifacts->visibility_grid_solid != NULL &&
+                          artifacts->visibility_grid_cell_count > 0 && artifacts->visibility_cell_size > 0.0f;
+    return grid != NULL && yyjson_mut_obj_add_val(doc, root, "visibility_grid", grid) &&
+           yyjson_mut_obj_add_bool(doc, grid, "present", has_grid) &&
+           yyjson_mut_obj_add_real(doc, grid, "cell_size", has_grid ? artifacts->visibility_cell_size : 0.0f) &&
+           export_add_int3_values(doc, grid, "dimensions", has_grid ? artifacts->visibility_grid_dim_x : 0,
+                                  has_grid ? artifacts->visibility_grid_dim_y : 0,
+                                  has_grid ? artifacts->visibility_grid_dim_z : 0) &&
+           yyjson_mut_obj_add_int(doc, grid, "cell_count", has_grid ? artifacts->visibility_grid_cell_count : 0) &&
+           (!has_grid || export_add_bounds(doc, grid, "bounds", artifacts->visibility_grid_bounds));
+}
+
 bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_data_runtime *runtime,
                                                          const char *world_name, char **out_json, size_t *out_size,
                                                          char *error_buffer, int error_buffer_size)
@@ -1741,6 +1857,74 @@ bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_dat
     {
         free(json);
         set_error(error_buffer, error_buffer_size, "failed to allocate brush world export JSON");
+        return false;
+    }
+    SDL_memcpy(copy, json, size + 1u);
+    free(json);
+    *out_json = copy;
+    if (out_size != NULL)
+        *out_size = size;
+    return true;
+}
+
+bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_game_data_runtime *runtime,
+                                                                 const char *world_name, char **out_json,
+                                                                 size_t *out_size, char *error_buffer,
+                                                                 int error_buffer_size)
+{
+    if (out_json != NULL)
+        *out_json = NULL;
+    if (out_size != NULL)
+        *out_size = 0u;
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || out_json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "brush compile artifact export requires runtime, world name, and output");
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "brush world '%s' not found", world_name);
+        return false;
+    }
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = doc != NULL ? yyjson_mut_obj(doc) : NULL;
+    if (doc == NULL || root == NULL)
+    {
+        yyjson_mut_doc_free(doc);
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush compile artifact document");
+        return false;
+    }
+
+    yyjson_mut_doc_set_root(doc, root);
+    const Uint64 source_hash = slayer3d_game_data_brush_world_compute_source_hash(world);
+    bool ok = yyjson_mut_obj_add_strcpy(doc, root, "schema", "slayer3d.brush_compile_artifact.v0") &&
+              yyjson_mut_obj_add_strcpy(doc, root, "world", world->name != NULL ? world->name : "") &&
+              yyjson_mut_obj_add_uint(doc, root, "source_hash", source_hash) &&
+              yyjson_mut_obj_add_uint(doc, root, "compile_artifact_hash", world->compile_artifact_hash) &&
+              export_add_brush_compile_policy(doc, root, world) &&
+              export_add_brush_compile_source_summary(doc, root, world) &&
+              export_add_brush_compile_render_summary(doc, root, world) &&
+              export_add_brush_compile_chunks(doc, root, world) &&
+              export_add_brush_compile_visibility_grid(doc, root, &world_runtime->artifacts);
+    size_t size = 0u;
+    char *json = ok ? yyjson_mut_write(doc, YYJSON_WRITE_PRETTY_TWO_SPACES | YYJSON_WRITE_NEWLINE_AT_END, &size) : NULL;
+    yyjson_mut_doc_free(doc);
+    if (json == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to write brush compile artifact JSON");
+        return false;
+    }
+
+    char *copy = (char *)SDL_malloc(size + 1u);
+    if (copy == NULL)
+    {
+        free(json);
+        set_error(error_buffer, error_buffer_size, "failed to allocate brush compile artifact JSON");
         return false;
     }
     SDL_memcpy(copy, json, size + 1u);

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -15,6 +15,7 @@
 #include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_iostream.h>
 #include <SDL3/SDL_timer.h>
+#include <stdarg.h>
 #include <stdlib.h>
 
 static bool editor_save_bytes_atomic(const char *path, const void *data, size_t size, const char *kind,
@@ -1870,6 +1871,149 @@ bool slayer3d_game_data_export_brush_world_fragment_json(const slayer3d_game_dat
     return true;
 }
 
+static Uint64 brush_artifact_hash_string(const char *value)
+{
+    Uint64 hash = 1469598103934665603ull;
+    if (value == NULL)
+        return hash;
+    while (*value != '\0')
+    {
+        hash ^= (Uint8)*value;
+        hash *= 1099511628211ull;
+        ++value;
+    }
+    return hash;
+}
+
+static bool brush_artifact_safe_char(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+           c == '.';
+}
+
+static bool brush_artifact_make_world_key(const char *world_name, char *buffer, size_t buffer_size)
+{
+    if (world_name == NULL || world_name[0] == '\0' || buffer == NULL || buffer_size == 0u)
+        return false;
+
+    const Uint64 name_hash = brush_artifact_hash_string(world_name);
+    char suffix[24];
+    const int suffix_len = SDL_snprintf(suffix, sizeof(suffix), "-%016llx", (unsigned long long)name_hash);
+    if (suffix_len < 0 || (size_t)suffix_len >= sizeof(suffix) || (size_t)suffix_len + 1u >= buffer_size)
+        return false;
+
+    const size_t max_prefix = buffer_size - (size_t)suffix_len - 1u;
+    size_t offset = 0u;
+    bool last_was_separator = false;
+    for (const char *cursor = world_name; *cursor != '\0' && offset < max_prefix; ++cursor)
+    {
+        const char out = brush_artifact_safe_char(*cursor) ? *cursor : '_';
+        if (out == '_' && last_was_separator)
+            continue;
+        buffer[offset++] = out;
+        last_was_separator = out == '_';
+    }
+    while (offset > 0u && buffer[offset - 1u] == '_')
+        --offset;
+    if (offset == 0u)
+        buffer[offset++] = 'w';
+    if (offset + (size_t)suffix_len >= buffer_size)
+        return false;
+    SDL_memcpy(buffer + offset, suffix, (size_t)suffix_len + 1u);
+    return true;
+}
+
+static bool brush_artifact_copy_trimmed_root(const char *artifact_root, char *buffer, size_t buffer_size,
+                                             char *error_buffer, int error_buffer_size)
+{
+    if (artifact_root == NULL || artifact_root[0] == '\0' || SDL_strstr(artifact_root, "://") != NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "brush compile artifact layout requires a filesystem root path");
+        return false;
+    }
+
+    size_t len = SDL_strlen(artifact_root);
+    while (len > 1u && (artifact_root[len - 1u] == '/' || artifact_root[len - 1u] == '\\'))
+        --len;
+    if (len + 1u > buffer_size)
+    {
+        set_error(error_buffer, error_buffer_size, "brush compile artifact root path is too long");
+        return false;
+    }
+    SDL_memcpy(buffer, artifact_root, len);
+    buffer[len] = '\0';
+    return true;
+}
+
+static bool brush_artifact_snprintf_path(char *buffer, size_t buffer_size, char *error_buffer, int error_buffer_size,
+                                         const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    const int written = SDL_vsnprintf(buffer, buffer_size, format, args);
+    va_end(args);
+    if (written < 0 || (size_t)written >= buffer_size)
+    {
+        set_error(error_buffer, error_buffer_size, "brush compile artifact layout path is too long");
+        return false;
+    }
+    return true;
+}
+
+bool slayer3d_game_data_get_brush_world_compile_artifact_layout(
+    const slayer3d_game_data_runtime *runtime, const char *world_name, const char *artifact_root,
+    slayer3d_game_data_brush_compile_artifact_layout *out_layout, char *error_buffer, int error_buffer_size)
+{
+    if (out_layout != NULL)
+        SDL_zero(*out_layout);
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || out_layout == NULL)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "brush compile artifact layout requires runtime, world name, and output");
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    if (world_runtime == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "brush world '%s' not found", world_name);
+        return false;
+    }
+
+    char root[SLAYER3D_GAME_DATA_BRUSH_COMPILE_ARTIFACT_LAYOUT_PATH_MAX];
+    if (!brush_artifact_copy_trimmed_root(artifact_root, root, sizeof(root), error_buffer, error_buffer_size) ||
+        !brush_artifact_make_world_key(world_name, out_layout->world_key, sizeof(out_layout->world_key)))
+    {
+        if (error_buffer != NULL && error_buffer_size > 0 && error_buffer[0] == '\0')
+            set_error(error_buffer, error_buffer_size, "failed to build brush compile artifact layout key");
+        return false;
+    }
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    out_layout->source_hash = slayer3d_game_data_brush_world_compute_source_hash(world);
+    out_layout->compile_artifact_hash = world->compile_artifact_hash;
+    char source_hash[24];
+    char artifact_hash[24];
+    SDL_snprintf(source_hash, sizeof(source_hash), "%016llx", (unsigned long long)out_layout->source_hash);
+    SDL_snprintf(artifact_hash, sizeof(artifact_hash), "%016llx",
+                 (unsigned long long)out_layout->compile_artifact_hash);
+
+    return brush_artifact_snprintf_path(out_layout->directory, sizeof(out_layout->directory), error_buffer,
+                                        error_buffer_size, "%s/brush/v0/%s/%s/%s", root, out_layout->world_key,
+                                        source_hash, artifact_hash) &&
+           brush_artifact_snprintf_path(out_layout->manifest_path, sizeof(out_layout->manifest_path), error_buffer,
+                                        error_buffer_size, "%s/manifest.json", out_layout->directory) &&
+           brush_artifact_snprintf_path(out_layout->render_payload_path, sizeof(out_layout->render_payload_path),
+                                        error_buffer, error_buffer_size, "%s/render.payload.bin",
+                                        out_layout->directory) &&
+           brush_artifact_snprintf_path(out_layout->collision_payload_path, sizeof(out_layout->collision_payload_path),
+                                        error_buffer, error_buffer_size, "%s/collision.payload.bin",
+                                        out_layout->directory) &&
+           brush_artifact_snprintf_path(out_layout->visibility_payload_path,
+                                        sizeof(out_layout->visibility_payload_path), error_buffer, error_buffer_size,
+                                        "%s/visibility.payload.bin", out_layout->directory);
+}
+
 bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_game_data_runtime *runtime,
                                                                  const char *world_name, char **out_json,
                                                                  size_t *out_size, char *error_buffer,
@@ -2053,6 +2197,29 @@ bool slayer3d_game_data_save_brush_world_compile_artifact_file(const slayer3d_ga
     if (out_size != NULL)
         *out_size = size;
     return true;
+}
+
+bool slayer3d_game_data_save_brush_world_compile_artifact_layout(
+    const slayer3d_game_data_runtime *runtime, const char *world_name, const char *artifact_root,
+    slayer3d_game_data_brush_compile_artifact_layout *out_layout, size_t *out_size, char *error_buffer,
+    int error_buffer_size)
+{
+    if (out_size != NULL)
+        *out_size = 0u;
+
+    slayer3d_game_data_brush_compile_artifact_layout layout;
+    if (!slayer3d_game_data_get_brush_world_compile_artifact_layout(runtime, world_name, artifact_root, &layout,
+                                                                    error_buffer, error_buffer_size))
+    {
+        if (out_layout != NULL)
+            SDL_zero(*out_layout);
+        return false;
+    }
+
+    if (out_layout != NULL)
+        *out_layout = layout;
+    return slayer3d_game_data_save_brush_world_compile_artifact_file(runtime, world_name, layout.manifest_path,
+                                                                     out_size, error_buffer, error_buffer_size);
 }
 
 static bool export_add_player_start(yyjson_mut_doc *doc, yyjson_mut_val *starts,

--- a/src/game_data_world_queries.c
+++ b/src/game_data_world_queries.c
@@ -852,6 +852,107 @@ static bool compile_brush_world_chunk_models(brush_world_runtime *world_runtime,
     return true;
 }
 
+static void free_brush_world_model_array(slayer3d_model *models, int model_count)
+{
+    if (models == NULL)
+        return;
+    for (int i = 0; i < model_count; ++i)
+        slayer3d_free_model(&models[i]);
+    SDL_free(models);
+}
+
+bool rebuild_brush_world_runtime_artifacts(brush_world_runtime *world_runtime, char *error_buffer,
+                                           int error_buffer_size)
+{
+    if (world_runtime == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "missing brush world runtime");
+        return false;
+    }
+
+    slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    char compile_error[256] = {0};
+    if (!slayer3d_game_data_brush_world_build_acceleration_checked(world, compile_error, sizeof(compile_error)))
+    {
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' acceleration data: %s",
+                   world->name != NULL ? world->name : "<unnamed>",
+                   compile_error[0] != '\0' ? compile_error : "unknown compile error");
+        return false;
+    }
+
+    slayer3d_model render_model;
+    slayer3d_model *brush_render_models = NULL;
+    slayer3d_model *chunk_render_models = NULL;
+    int brush_render_model_count = 0;
+    int chunk_render_model_count = 0;
+    SDL_zero(render_model);
+
+    brush_world_runtime staged_grid;
+    SDL_zero(staged_grid);
+    staged_grid.desc = *world;
+
+    bool ok = slayer3d_game_data_brush_world_compile_render_model(world, &render_model);
+    if (!ok)
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' render mesh",
+                   world->name != NULL ? world->name : "<unnamed>");
+    if (ok && !compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count))
+    {
+        ok = false;
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility meshes",
+                   world->name != NULL ? world->name : "<unnamed>");
+    }
+    if (ok && !compile_brush_world_visibility_grid(&staged_grid))
+    {
+        ok = false;
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' visibility grid",
+                   world->name != NULL ? world->name : "<unnamed>");
+    }
+    if (ok && !slayer3d_game_data_brush_world_build_compile_chunks(world))
+    {
+        ok = false;
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' spatial chunks",
+                   world->name != NULL ? world->name : "<unnamed>");
+    }
+    if (ok && !compile_brush_world_chunk_models(world_runtime, &chunk_render_models, &chunk_render_model_count))
+    {
+        ok = false;
+        set_errorf(error_buffer, error_buffer_size, "failed to compile brush world '%s' chunk meshes",
+                   world->name != NULL ? world->name : "<unnamed>");
+    }
+
+    if (!ok)
+    {
+        slayer3d_free_model(&render_model);
+        free_brush_world_model_array(brush_render_models, brush_render_model_count);
+        free_brush_world_model_array(chunk_render_models, chunk_render_model_count);
+        free_brush_world_visibility_grid(&staged_grid);
+        return false;
+    }
+
+    slayer3d_free_model(&world_runtime->render_model);
+    free_brush_world_visibility_models(world_runtime);
+    free_brush_world_visibility_grid(world_runtime);
+
+    world_runtime->render_model = render_model;
+    world_runtime->brush_render_models = brush_render_models;
+    world_runtime->brush_render_model_count = brush_render_model_count;
+    world_runtime->chunk_render_models = chunk_render_models;
+    world_runtime->chunk_render_model_count = chunk_render_model_count;
+    world_runtime->visibility_grid_bounds = staged_grid.visibility_grid_bounds;
+    world_runtime->visibility_cell_size = staged_grid.visibility_cell_size;
+    world_runtime->visibility_grid_dim_x = staged_grid.visibility_grid_dim_x;
+    world_runtime->visibility_grid_dim_y = staged_grid.visibility_grid_dim_y;
+    world_runtime->visibility_grid_dim_z = staged_grid.visibility_grid_dim_z;
+    world_runtime->visibility_grid_cell_count = staged_grid.visibility_grid_cell_count;
+    world_runtime->visibility_grid_solid = staged_grid.visibility_grid_solid;
+    for (int i = 0; i < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++i)
+        world_runtime->visibility_grid_visible_cache_start[i] = -1;
+
+    world->render_model = &world_runtime->render_model;
+    world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
+    return true;
+}
+
 static bool editor_brush_world_name_exists(const brush_world_runtime *world_runtime, const char *brush_name)
 {
     if (world_runtime == NULL || brush_name == NULL || brush_name[0] == '\0')
@@ -1021,50 +1122,20 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     world->brushes = brushes;
     world->brush_count = old_count + 1;
 
-    slayer3d_model render_model;
-    slayer3d_model *brush_render_models = NULL;
-    slayer3d_model *chunk_render_models = NULL;
-    int brush_render_model_count = 0;
-    int chunk_render_model_count = 0;
-    char compile_error[256] = {0};
-    SDL_zero(render_model);
-    const bool rebuilt =
-        slayer3d_game_data_brush_world_build_acceleration_checked(world, compile_error, sizeof(compile_error)) &&
-        slayer3d_game_data_brush_world_compile_render_model(world, &render_model) &&
-        compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count) &&
-        compile_brush_world_visibility_grid(world_runtime) &&
-        slayer3d_game_data_brush_world_build_compile_chunks(world) &&
-        compile_brush_world_chunk_models(world_runtime, &chunk_render_models, &chunk_render_model_count);
-    if (!rebuilt)
+    char rebuild_error[256] = {0};
+    if (!rebuild_brush_world_runtime_artifacts(world_runtime, rebuild_error, sizeof(rebuild_error)))
     {
-        slayer3d_free_model(&render_model);
-        for (int i = 0; i < brush_render_model_count; ++i)
-            slayer3d_free_model(&brush_render_models[i]);
-        SDL_free(brush_render_models);
-        for (int i = 0; i < chunk_render_model_count; ++i)
-            slayer3d_free_model(&chunk_render_models[i]);
-        SDL_free(chunk_render_models);
         world->brushes = old_brushes;
         world->brush_count = old_count;
         free_editor_runtime_brush(&brushes[old_count]);
         SDL_free(brushes);
-        (void)slayer3d_game_data_brush_world_build_acceleration_checked(world, NULL, 0);
-        (void)slayer3d_game_data_brush_world_build_compile_chunks(world);
+        (void)rebuild_brush_world_runtime_artifacts(world_runtime, NULL, 0);
         set_errorf(error_buffer, error_buffer_size, "failed to rebuild brush world after box creation%s%s",
-                   compile_error[0] != '\0' ? ": " : "", compile_error[0] != '\0' ? compile_error : "");
+                   rebuild_error[0] != '\0' ? ": " : "", rebuild_error[0] != '\0' ? rebuild_error : "");
         return false;
     }
 
     SDL_free(old_brushes);
-    slayer3d_free_model(&world_runtime->render_model);
-    free_brush_world_visibility_models(world_runtime);
-    world_runtime->render_model = render_model;
-    world_runtime->brush_render_models = brush_render_models;
-    world_runtime->brush_render_model_count = brush_render_model_count;
-    world_runtime->chunk_render_models = chunk_render_models;
-    world_runtime->chunk_render_model_count = chunk_render_model_count;
-    world->render_model = &world_runtime->render_model;
-    world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
     editor_brush_world_mark_dirty(world_runtime);
     if (out_brush_name != NULL && out_brush_name_size > 0u)
         SDL_strlcpy(out_brush_name, brushes[old_count].name != NULL ? brushes[old_count].name : "",
@@ -4769,44 +4840,7 @@ static int find_editor_brush_material_index(const brush_world_runtime *world_run
 
 static bool rebuild_editor_brush_world(brush_world_runtime *world_runtime)
 {
-    if (world_runtime == NULL)
-        return false;
-    slayer3d_game_data_brush_world *world = &world_runtime->desc;
-    if (!slayer3d_game_data_brush_world_build_acceleration_checked(world, NULL, 0))
-        return false;
-
-    slayer3d_model render_model;
-    slayer3d_model *brush_render_models = NULL;
-    slayer3d_model *chunk_render_models = NULL;
-    int brush_render_model_count = 0;
-    int chunk_render_model_count = 0;
-    SDL_zero(render_model);
-    if (!slayer3d_game_data_brush_world_compile_render_model(world, &render_model) ||
-        !compile_brush_world_visibility_models(world_runtime, &brush_render_models, &brush_render_model_count) ||
-        !compile_brush_world_visibility_grid(world_runtime) ||
-        !slayer3d_game_data_brush_world_build_compile_chunks(world) ||
-        !compile_brush_world_chunk_models(world_runtime, &chunk_render_models, &chunk_render_model_count))
-    {
-        slayer3d_free_model(&render_model);
-        for (int i = 0; i < brush_render_model_count; ++i)
-            slayer3d_free_model(&brush_render_models[i]);
-        SDL_free(brush_render_models);
-        for (int i = 0; i < chunk_render_model_count; ++i)
-            slayer3d_free_model(&chunk_render_models[i]);
-        SDL_free(chunk_render_models);
-        return false;
-    }
-
-    slayer3d_free_model(&world_runtime->render_model);
-    free_brush_world_visibility_models(world_runtime);
-    world_runtime->render_model = render_model;
-    world_runtime->brush_render_models = brush_render_models;
-    world_runtime->brush_render_model_count = brush_render_model_count;
-    world_runtime->chunk_render_models = chunk_render_models;
-    world_runtime->chunk_render_model_count = chunk_render_model_count;
-    world->render_model = &world_runtime->render_model;
-    world->compile_artifact_hash = slayer3d_game_data_brush_world_compute_compile_artifact_hash(world);
-    return true;
+    return rebuild_brush_world_runtime_artifacts(world_runtime, NULL, 0);
 }
 
 static bool editor_brush_bounds_valid(const slayer3d_game_data_brush *brush)

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -3032,23 +3032,25 @@ static bool brush_visibility_grid_cell(const brush_world_runtime *world_runtime,
 {
     if (out_index != NULL)
         *out_index = -1;
-    if (world_runtime == NULL || world_runtime->visibility_grid_solid == NULL ||
-        world_runtime->visibility_grid_cell_count <= 0 || world_runtime->visibility_cell_size <= 0.0f)
+    if (world_runtime == NULL || world_runtime->artifacts.visibility_grid_solid == NULL ||
+        world_runtime->artifacts.visibility_grid_cell_count <= 0 ||
+        world_runtime->artifacts.visibility_cell_size <= 0.0f)
     {
         return false;
     }
-    const float cell_size = world_runtime->visibility_cell_size;
-    const int x = (int)SDL_floorf((point.x - world_runtime->visibility_grid_bounds.min.x) / cell_size);
-    const int y = (int)SDL_floorf((point.y - world_runtime->visibility_grid_bounds.min.y) / cell_size);
-    const int z = (int)SDL_floorf((point.z - world_runtime->visibility_grid_bounds.min.z) / cell_size);
-    if (x < 0 || y < 0 || z < 0 || x >= world_runtime->visibility_grid_dim_x ||
-        y >= world_runtime->visibility_grid_dim_y || z >= world_runtime->visibility_grid_dim_z)
+    const float cell_size = world_runtime->artifacts.visibility_cell_size;
+    const int x = (int)SDL_floorf((point.x - world_runtime->artifacts.visibility_grid_bounds.min.x) / cell_size);
+    const int y = (int)SDL_floorf((point.y - world_runtime->artifacts.visibility_grid_bounds.min.y) / cell_size);
+    const int z = (int)SDL_floorf((point.z - world_runtime->artifacts.visibility_grid_bounds.min.z) / cell_size);
+    if (x < 0 || y < 0 || z < 0 || x >= world_runtime->artifacts.visibility_grid_dim_x ||
+        y >= world_runtime->artifacts.visibility_grid_dim_y || z >= world_runtime->artifacts.visibility_grid_dim_z)
     {
         return false;
     }
-    const int index = x + y * world_runtime->visibility_grid_dim_x +
-                      z * world_runtime->visibility_grid_dim_x * world_runtime->visibility_grid_dim_y;
-    if (index < 0 || index >= world_runtime->visibility_grid_cell_count)
+    const int index =
+        x + y * world_runtime->artifacts.visibility_grid_dim_x +
+        z * world_runtime->artifacts.visibility_grid_dim_x * world_runtime->artifacts.visibility_grid_dim_y;
+    if (index < 0 || index >= world_runtime->artifacts.visibility_grid_cell_count)
         return false;
     if (out_index != NULL)
         *out_index = index;
@@ -3058,8 +3060,8 @@ static bool brush_visibility_grid_cell(const brush_world_runtime *world_runtime,
 static void brush_visibility_grid_cell_coords(const brush_world_runtime *world_runtime, int index, int *out_x,
                                               int *out_y, int *out_z)
 {
-    const int dim_x = world_runtime != NULL ? world_runtime->visibility_grid_dim_x : 1;
-    const int dim_y = world_runtime != NULL ? world_runtime->visibility_grid_dim_y : 1;
+    const int dim_x = world_runtime != NULL ? world_runtime->artifacts.visibility_grid_dim_x : 1;
+    const int dim_y = world_runtime != NULL ? world_runtime->artifacts.visibility_grid_dim_y : 1;
     const int z = index / (dim_x * dim_y);
     const int rem = index - z * dim_x * dim_y;
     const int y = rem / dim_x;
@@ -3074,22 +3076,22 @@ static void brush_visibility_grid_cell_coords(const brush_world_runtime *world_r
 
 static slayer3d_vec3 brush_visibility_grid_cell_center(const brush_world_runtime *world_runtime, int x, int y, int z)
 {
-    const float cell_size = world_runtime->visibility_cell_size;
-    return slayer3d_vec3_make(world_runtime->visibility_grid_bounds.min.x + ((float)x + 0.5f) * cell_size,
-                              world_runtime->visibility_grid_bounds.min.y + ((float)y + 0.5f) * cell_size,
-                              world_runtime->visibility_grid_bounds.min.z + ((float)z + 0.5f) * cell_size);
+    const float cell_size = world_runtime->artifacts.visibility_cell_size;
+    return slayer3d_vec3_make(world_runtime->artifacts.visibility_grid_bounds.min.x + ((float)x + 0.5f) * cell_size,
+                              world_runtime->artifacts.visibility_grid_bounds.min.y + ((float)y + 0.5f) * cell_size,
+                              world_runtime->artifacts.visibility_grid_bounds.min.z + ((float)z + 0.5f) * cell_size);
 }
 
 static bool brush_visibility_grid_ray_clear(const brush_world_runtime *world_runtime, int start_index,
                                             slayer3d_vec3 local_camera, slayer3d_vec3 target)
 {
-    if (world_runtime == NULL || world_runtime->visibility_grid_solid == NULL)
+    if (world_runtime == NULL || world_runtime->artifacts.visibility_grid_solid == NULL)
         return false;
     const slayer3d_vec3 delta = slayer3d_vec3_sub(target, local_camera);
     const float distance = slayer3d_vec3_length(delta);
     if (distance <= 0.0001f)
         return true;
-    const float cell_size = world_runtime->visibility_cell_size;
+    const float cell_size = world_runtime->artifacts.visibility_cell_size;
     const int steps = SDL_max(1, SDL_min(4096, (int)SDL_ceilf(distance / SDL_max(cell_size * 0.35f, 0.05f))));
     for (int step = 1; step <= steps; ++step)
     {
@@ -3100,7 +3102,7 @@ static bool brush_visibility_grid_ray_clear(const brush_world_runtime *world_run
             return false;
         if (index == start_index)
             continue;
-        if (world_runtime->visibility_grid_solid[index])
+        if (world_runtime->artifacts.visibility_grid_solid[index])
             return false;
     }
     return true;
@@ -3119,15 +3121,17 @@ static void brush_visibility_grid_mark_neighborhood_visible(const brush_world_ru
         {
             for (int x = sx - 1; x <= sx + 1; ++x)
             {
-                if (x < 0 || y < 0 || z < 0 || x >= world_runtime->visibility_grid_dim_x ||
-                    y >= world_runtime->visibility_grid_dim_y || z >= world_runtime->visibility_grid_dim_z)
+                if (x < 0 || y < 0 || z < 0 || x >= world_runtime->artifacts.visibility_grid_dim_x ||
+                    y >= world_runtime->artifacts.visibility_grid_dim_y ||
+                    z >= world_runtime->artifacts.visibility_grid_dim_z)
                 {
                     continue;
                 }
-                const int index = x + y * world_runtime->visibility_grid_dim_x +
-                                  z * world_runtime->visibility_grid_dim_x * world_runtime->visibility_grid_dim_y;
-                if (index >= 0 && index < world_runtime->visibility_grid_cell_count &&
-                    !world_runtime->visibility_grid_solid[index])
+                const int index =
+                    x + y * world_runtime->artifacts.visibility_grid_dim_x +
+                    z * world_runtime->artifacts.visibility_grid_dim_x * world_runtime->artifacts.visibility_grid_dim_y;
+                if (index >= 0 && index < world_runtime->artifacts.visibility_grid_cell_count &&
+                    !world_runtime->artifacts.visibility_grid_solid[index])
                 {
                     visible_cells[index] = 1u;
                 }
@@ -3142,20 +3146,20 @@ static bool brush_visibility_grid_mark_visible_los(const brush_world_runtime *wo
     int start = -1;
     if (world_runtime == NULL || visible_cells == NULL ||
         !brush_visibility_grid_cell(world_runtime, local_camera, &start) || start < 0 ||
-        world_runtime->visibility_grid_solid[start])
+        world_runtime->artifacts.visibility_grid_solid[start])
     {
         return false;
     }
 
     static const int max_los_cells = 131072;
-    if (world_runtime->visibility_grid_cell_count > max_los_cells)
+    if (world_runtime->artifacts.visibility_grid_cell_count > max_los_cells)
         return false;
 
     visible_cells[start] = 1u;
     brush_visibility_grid_mark_neighborhood_visible(world_runtime, start, visible_cells);
-    const int dim_x = world_runtime->visibility_grid_dim_x;
-    const int dim_y = world_runtime->visibility_grid_dim_y;
-    const int dim_z = world_runtime->visibility_grid_dim_z;
+    const int dim_x = world_runtime->artifacts.visibility_grid_dim_x;
+    const int dim_y = world_runtime->artifacts.visibility_grid_dim_y;
+    const int dim_z = world_runtime->artifacts.visibility_grid_dim_z;
     for (int z = 0; z < dim_z; ++z)
     {
         for (int y = 0; y < dim_y; ++y)
@@ -3163,7 +3167,7 @@ static bool brush_visibility_grid_mark_visible_los(const brush_world_runtime *wo
             for (int x = 0; x < dim_x; ++x)
             {
                 const int index = x + y * dim_x + z * dim_x * dim_y;
-                if (visible_cells[index] || world_runtime->visibility_grid_solid[index])
+                if (visible_cells[index] || world_runtime->artifacts.visibility_grid_solid[index])
                     continue;
                 const slayer3d_vec3 target = brush_visibility_grid_cell_center(world_runtime, x, y, z);
                 if (brush_visibility_grid_ray_clear(world_runtime, start, local_camera, target))
@@ -3186,8 +3190,8 @@ static int brush_visibility_grid_cache_slot_for_start(brush_world_runtime *world
         return -1;
     for (int slot = 0; slot < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++slot)
     {
-        if (world_runtime->visibility_grid_visible_cache[slot] != NULL &&
-            world_runtime->visibility_grid_visible_cache_start[slot] == start)
+        if (world_runtime->artifacts.visibility_grid_visible_cache[slot] != NULL &&
+            world_runtime->artifacts.visibility_grid_visible_cache_start[slot] == start)
         {
             return slot;
         }
@@ -3203,11 +3207,11 @@ static int brush_visibility_grid_cache_slot_for_write(brush_world_runtime *world
     Uint64 oldest_tick = ~(Uint64)0;
     for (int slot = 0; slot < SLAYER3D_BRUSH_VISIBILITY_CACHE_SLOTS; ++slot)
     {
-        if (world_runtime->visibility_grid_visible_cache[slot] == NULL)
+        if (world_runtime->artifacts.visibility_grid_visible_cache[slot] == NULL)
             return slot;
-        if (world_runtime->visibility_grid_visible_cache_tick[slot] < oldest_tick)
+        if (world_runtime->artifacts.visibility_grid_visible_cache_tick[slot] < oldest_tick)
         {
-            oldest_tick = world_runtime->visibility_grid_visible_cache_tick[slot];
+            oldest_tick = world_runtime->artifacts.visibility_grid_visible_cache_tick[slot];
             oldest_slot = slot;
         }
     }
@@ -3218,10 +3222,10 @@ static const Uint8 *brush_visibility_grid_visible_cells(brush_world_runtime *wor
                                                         slayer3d_game_data_brush_diagnostics *diagnostics)
 {
     int start = -1;
-    if (world_runtime == NULL || world_runtime->visibility_grid_solid == NULL ||
-        world_runtime->visibility_grid_cell_count <= 0 ||
+    if (world_runtime == NULL || world_runtime->artifacts.visibility_grid_solid == NULL ||
+        world_runtime->artifacts.visibility_grid_cell_count <= 0 ||
         !brush_visibility_grid_cell(world_runtime, local_camera, &start) || start < 0 ||
-        world_runtime->visibility_grid_solid[start])
+        world_runtime->artifacts.visibility_grid_solid[start])
     {
         return NULL;
     }
@@ -3231,9 +3235,9 @@ static const Uint8 *brush_visibility_grid_visible_cells(brush_world_runtime *wor
     {
         if (diagnostics != NULL)
             ++diagnostics->visibility_grid_cache_hits;
-        world_runtime->visibility_grid_visible_cache_tick[cache_slot] =
-            ++world_runtime->visibility_grid_visible_cache_clock;
-        return world_runtime->visibility_grid_visible_cache[cache_slot];
+        world_runtime->artifacts.visibility_grid_visible_cache_tick[cache_slot] =
+            ++world_runtime->artifacts.visibility_grid_visible_cache_clock;
+        return world_runtime->artifacts.visibility_grid_visible_cache[cache_slot];
     }
 
     if (diagnostics != NULL)
@@ -3241,25 +3245,25 @@ static const Uint8 *brush_visibility_grid_visible_cells(brush_world_runtime *wor
     cache_slot = brush_visibility_grid_cache_slot_for_write(world_runtime);
     if (cache_slot < 0)
         return NULL;
-    if (world_runtime->visibility_grid_visible_cache[cache_slot] == NULL)
+    if (world_runtime->artifacts.visibility_grid_visible_cache[cache_slot] == NULL)
     {
-        world_runtime->visibility_grid_visible_cache[cache_slot] =
-            (Uint8 *)SDL_calloc((size_t)world_runtime->visibility_grid_cell_count,
-                                sizeof(*world_runtime->visibility_grid_visible_cache[cache_slot]));
-        if (world_runtime->visibility_grid_visible_cache[cache_slot] == NULL)
+        world_runtime->artifacts.visibility_grid_visible_cache[cache_slot] =
+            (Uint8 *)SDL_calloc((size_t)world_runtime->artifacts.visibility_grid_cell_count,
+                                sizeof(*world_runtime->artifacts.visibility_grid_visible_cache[cache_slot]));
+        if (world_runtime->artifacts.visibility_grid_visible_cache[cache_slot] == NULL)
             return NULL;
     }
-    SDL_memset(world_runtime->visibility_grid_visible_cache[cache_slot], 0,
-               (size_t)world_runtime->visibility_grid_cell_count *
-                   sizeof(*world_runtime->visibility_grid_visible_cache[cache_slot]));
-    world_runtime->visibility_grid_visible_cache_start[cache_slot] = -1;
+    SDL_memset(world_runtime->artifacts.visibility_grid_visible_cache[cache_slot], 0,
+               (size_t)world_runtime->artifacts.visibility_grid_cell_count *
+                   sizeof(*world_runtime->artifacts.visibility_grid_visible_cache[cache_slot]));
+    world_runtime->artifacts.visibility_grid_visible_cache_start[cache_slot] = -1;
     if (!brush_visibility_grid_mark_visible(world_runtime, local_camera,
-                                            world_runtime->visibility_grid_visible_cache[cache_slot]))
+                                            world_runtime->artifacts.visibility_grid_visible_cache[cache_slot]))
         return NULL;
-    world_runtime->visibility_grid_visible_cache_start[cache_slot] = start;
-    world_runtime->visibility_grid_visible_cache_tick[cache_slot] =
-        ++world_runtime->visibility_grid_visible_cache_clock;
-    return world_runtime->visibility_grid_visible_cache[cache_slot];
+    world_runtime->artifacts.visibility_grid_visible_cache_start[cache_slot] = start;
+    world_runtime->artifacts.visibility_grid_visible_cache_tick[cache_slot] =
+        ++world_runtime->artifacts.visibility_grid_visible_cache_clock;
+    return world_runtime->artifacts.visibility_grid_visible_cache[cache_slot];
 }
 
 static bool brush_visibility_forced_visible(const slayer3d_game_data_brush *brush)
@@ -3277,32 +3281,38 @@ static bool brush_visible_from_visibility_grid(const brush_world_runtime *world_
                                                const slayer3d_game_data_brush *brush, const Uint8 *visible_cells)
 {
     if (world_runtime == NULL || brush == NULL || visible_cells == NULL || !brush->has_bounds ||
-        world_runtime->visibility_cell_size <= 0.0f)
+        world_runtime->artifacts.visibility_cell_size <= 0.0f)
     {
         return true;
     }
-    const float cell_size = world_runtime->visibility_cell_size;
+    const float cell_size = world_runtime->artifacts.visibility_cell_size;
     const float expand = cell_size * 0.5f;
     const int min_x = SDL_max(
-        0, (int)SDL_floorf((brush->bounds.min.x - expand - world_runtime->visibility_grid_bounds.min.x) / cell_size));
+        0, (int)SDL_floorf((brush->bounds.min.x - expand - world_runtime->artifacts.visibility_grid_bounds.min.x) /
+                           cell_size));
     const int min_y = SDL_max(
-        0, (int)SDL_floorf((brush->bounds.min.y - expand - world_runtime->visibility_grid_bounds.min.y) / cell_size));
+        0, (int)SDL_floorf((brush->bounds.min.y - expand - world_runtime->artifacts.visibility_grid_bounds.min.y) /
+                           cell_size));
     const int min_z = SDL_max(
-        0, (int)SDL_floorf((brush->bounds.min.z - expand - world_runtime->visibility_grid_bounds.min.z) / cell_size));
-    const int max_x = SDL_min(
-        world_runtime->visibility_grid_dim_x - 1,
-        (int)SDL_floorf((brush->bounds.max.x + expand - world_runtime->visibility_grid_bounds.min.x) / cell_size));
-    const int max_y = SDL_min(
-        world_runtime->visibility_grid_dim_y - 1,
-        (int)SDL_floorf((brush->bounds.max.y + expand - world_runtime->visibility_grid_bounds.min.y) / cell_size));
-    const int max_z = SDL_min(
-        world_runtime->visibility_grid_dim_z - 1,
-        (int)SDL_floorf((brush->bounds.max.z + expand - world_runtime->visibility_grid_bounds.min.z) / cell_size));
+        0, (int)SDL_floorf((brush->bounds.min.z - expand - world_runtime->artifacts.visibility_grid_bounds.min.z) /
+                           cell_size));
+    const int max_x =
+        SDL_min(world_runtime->artifacts.visibility_grid_dim_x - 1,
+                (int)SDL_floorf((brush->bounds.max.x + expand - world_runtime->artifacts.visibility_grid_bounds.min.x) /
+                                cell_size));
+    const int max_y =
+        SDL_min(world_runtime->artifacts.visibility_grid_dim_y - 1,
+                (int)SDL_floorf((brush->bounds.max.y + expand - world_runtime->artifacts.visibility_grid_bounds.min.y) /
+                                cell_size));
+    const int max_z =
+        SDL_min(world_runtime->artifacts.visibility_grid_dim_z - 1,
+                (int)SDL_floorf((brush->bounds.max.z + expand - world_runtime->artifacts.visibility_grid_bounds.min.z) /
+                                cell_size));
     if (min_x > max_x || min_y > max_y || min_z > max_z)
         return true;
 
-    const int dim_x = world_runtime->visibility_grid_dim_x;
-    const int dim_y = world_runtime->visibility_grid_dim_y;
+    const int dim_x = world_runtime->artifacts.visibility_grid_dim_x;
+    const int dim_y = world_runtime->artifacts.visibility_grid_dim_y;
     for (int z = min_z; z <= max_z; ++z)
     {
         for (int y = min_y; y <= max_y; ++y)
@@ -3310,7 +3320,7 @@ static bool brush_visible_from_visibility_grid(const brush_world_runtime *world_
             for (int x = min_x; x <= max_x; ++x)
             {
                 const int index = x + y * dim_x + z * dim_x * dim_y;
-                if (index >= 0 && index < world_runtime->visibility_grid_cell_count && visible_cells[index])
+                if (index >= 0 && index < world_runtime->artifacts.visibility_grid_cell_count && visible_cells[index])
                     return true;
             }
         }
@@ -3326,8 +3336,8 @@ static bool apply_brush_visibility_grid(brush_world_runtime *world_runtime,
     if (out_occluded_count != NULL)
         *out_occluded_count = 0;
     if (world_runtime == NULL || instance == NULL || camera == NULL || brush_visible == NULL ||
-        mutable_runtime == NULL || world_runtime->visibility_grid_solid == NULL ||
-        world_runtime->visibility_grid_cell_count <= 0)
+        mutable_runtime == NULL || world_runtime->artifacts.visibility_grid_solid == NULL ||
+        world_runtime->artifacts.visibility_grid_cell_count <= 0)
     {
         return false;
     }
@@ -3340,7 +3350,7 @@ static bool apply_brush_visibility_grid(brush_world_runtime *world_runtime,
     int occluded_count = 0;
     for (int brush_index = 0; brush_index < brush_count; ++brush_index)
     {
-        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_model *brush_model = &world_runtime->artifacts.brush_render_models[brush_index];
         const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
@@ -3399,7 +3409,7 @@ static int apply_brush_frustum_culling(brush_world_draw_context *context, brush_
     {
         if (!brush_visible[brush_index])
             continue;
-        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_model *brush_model = &world_runtime->artifacts.brush_render_models[brush_index];
         const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (brush == NULL || !brush->has_bounds || triangles == 0u)
@@ -3449,19 +3459,20 @@ static bool draw_visible_brush_chunks(brush_world_draw_context *context, brush_w
                                       bool *brush_visible, int brush_count)
 {
     if (context == NULL || context->renderer == NULL || context->runtime == NULL || world_runtime == NULL ||
-        world_runtime->chunk_render_models == NULL || world_runtime->desc.compile_chunks == NULL)
+        world_runtime->artifacts.chunk_render_models == NULL || world_runtime->desc.compile_chunks == NULL)
     {
         return true;
     }
 
     slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
-    const int chunk_count = SDL_min(world_runtime->desc.compile_chunk_count, world_runtime->chunk_render_model_count);
+    const int chunk_count =
+        SDL_min(world_runtime->desc.compile_chunk_count, world_runtime->artifacts.chunk_render_model_count);
     for (int chunk_index = 0; chunk_index < chunk_count; ++chunk_index)
     {
         const slayer3d_game_data_brush_compile_chunk *chunk = &world_runtime->desc.compile_chunks[chunk_index];
         if (!brush_render_chunk_all_visible(chunk, brush_visible, brush_count))
             continue;
-        const slayer3d_model *chunk_model = &world_runtime->chunk_render_models[chunk_index];
+        const slayer3d_model *chunk_model = &world_runtime->artifacts.chunk_render_models[chunk_index];
         if (brush_model_triangle_count(chunk_model) == 0u)
             continue;
         if (!slayer3d_draw_model_ex_with_assets(
@@ -3490,12 +3501,12 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
     slayer3d_game_data_runtime *mutable_runtime = (slayer3d_game_data_runtime *)context->runtime;
     brush_world_runtime *world_runtime =
         (brush_world_runtime *)find_brush_world_runtime(mutable_runtime, instance->world_name);
-    if (world_runtime == NULL || world_runtime->brush_render_models == NULL || instance->world->brushes == NULL ||
-        instance->world->brush_count <= 0)
+    if (world_runtime == NULL || world_runtime->artifacts.brush_render_models == NULL ||
+        instance->world->brushes == NULL || instance->world->brush_count <= 0)
     {
         return draw_brush_world_instance(userdata, instance);
     }
-    const int brush_count = SDL_min(instance->world->brush_count, world_runtime->brush_render_model_count);
+    const int brush_count = SDL_min(instance->world->brush_count, world_runtime->artifacts.brush_render_model_count);
     bool *brush_visible = (bool *)SDL_calloc((size_t)brush_count, sizeof(*brush_visible));
     if (brush_visible == NULL)
     {
@@ -3512,7 +3523,7 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
         world_runtime, instance, context->camera, brush_visible, brush_count, &occluded_count, mutable_runtime);
     for (int brush_index = 0; !used_visibility_grid && brush_index < brush_count; ++brush_index)
     {
-        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_model *brush_model = &world_runtime->artifacts.brush_render_models[brush_index];
         const slayer3d_game_data_brush *brush = &instance->world->brushes[brush_index];
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
@@ -3561,7 +3572,7 @@ static bool draw_brush_world_instance_with_visibility(void *userdata,
     {
         if (!brush_visible[brush_index])
             continue;
-        const slayer3d_model *brush_model = &world_runtime->brush_render_models[brush_index];
+        const slayer3d_model *brush_model = &world_runtime->artifacts.brush_render_models[brush_index];
         const Uint64 triangles = brush_model_triangle_count(brush_model);
         if (triangles == 0u)
             continue;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13932,6 +13932,43 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
         << error;
     EXPECT_TRUE(artifact_status.fresh);
 
+    const std::filesystem::path artifact_root_dir = dir / "compile_cache";
+    slayer3d_game_data_brush_compile_artifact_layout culled_layout{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_compile_artifact_layout(
+        culled_a, "brush.compile_options", artifact_root_dir.string().c_str(), &culled_layout, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(culled_layout.source_hash, source_hash);
+    EXPECT_EQ(culled_layout.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    EXPECT_NE(std::string(culled_layout.world_key).find("brush.compile_options-"), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.directory).find("/brush/v0/"), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.directory).find(culled_layout.world_key), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.manifest_path).find("/manifest.json"), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.render_payload_path).find("/render.payload.bin"), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.collision_payload_path).find("/collision.payload.bin"), std::string::npos);
+    EXPECT_NE(std::string(culled_layout.visibility_payload_path).find("/visibility.payload.bin"), std::string::npos);
+
+    slayer3d_game_data_brush_compile_artifact_layout repeated_layout{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_compile_artifact_layout(
+        culled_a, "brush.compile_options", artifact_root_dir.string().c_str(), &repeated_layout, error, sizeof(error)))
+        << error;
+    EXPECT_STREQ(repeated_layout.directory, culled_layout.directory);
+    EXPECT_STREQ(repeated_layout.manifest_path, culled_layout.manifest_path);
+
+    slayer3d_game_data_brush_compile_artifact_layout saved_layout{};
+    ASSERT_TRUE(slayer3d_game_data_save_brush_world_compile_artifact_layout(
+        culled_a, "brush.compile_options", artifact_root_dir.string().c_str(), &saved_layout, &artifact_size, error,
+        sizeof(error)))
+        << error;
+    EXPECT_STREQ(saved_layout.manifest_path, culled_layout.manifest_path);
+    EXPECT_TRUE(std::filesystem::exists(saved_layout.manifest_path));
+    EXPECT_GT(artifact_size, 0u);
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_file(
+        culled_a, "brush.compile_options", saved_layout.manifest_path, &artifact_status, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.fresh);
+    EXPECT_FALSE(slayer3d_game_data_get_brush_world_compile_artifact_layout(
+        culled_a, "brush.compile_options", "asset://cache", &repeated_layout, error, sizeof(error)));
+
     slayer3d_game_data_runtime *culled_b = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_culled.game.json").string().c_str(), session, &culled_b,
                                              error, sizeof(error)))
@@ -13982,6 +14019,14 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_EQ(unculled_world.compile_rendered_face_count, 12);
     EXPECT_EQ(unculled_world.compile_triangle_count, 24);
     EXPECT_NE(unculled_world.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    slayer3d_game_data_brush_compile_artifact_layout unculled_layout{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_compile_artifact_layout(
+        unculled, "brush.compile_options", artifact_root_dir.string().c_str(), &unculled_layout, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(unculled_layout.source_hash, culled_layout.source_hash);
+    EXPECT_NE(unculled_layout.compile_artifact_hash, culled_layout.compile_artifact_hash);
+    EXPECT_STREQ(unculled_layout.world_key, culled_layout.world_key);
+    EXPECT_STRNE(unculled_layout.manifest_path, culled_layout.manifest_path);
     ASSERT_TRUE(slayer3d_game_data_export_brush_world_compile_artifact_json(
         unculled, "brush.compile_options", &artifact_json, &artifact_size, error, sizeof(error)))
         << error;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -13904,8 +13904,33 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     ASSERT_NE(grid, nullptr);
     EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(grid, "present")));
     EXPECT_GT(yyjson_get_int(yyjson_obj_get(grid, "cell_count")), 0);
+    slayer3d_game_data_brush_compile_artifact_status artifact_status{};
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        culled_a, "brush.compile_options", artifact_json, artifact_size, &artifact_status, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.schema_matches);
+    EXPECT_TRUE(artifact_status.world_matches);
+    EXPECT_TRUE(artifact_status.source_hash_matches);
+    EXPECT_TRUE(artifact_status.policy_matches);
+    EXPECT_TRUE(artifact_status.compile_artifact_hash_matches);
+    EXPECT_TRUE(artifact_status.fresh);
+    EXPECT_EQ(artifact_status.expected_source_hash, source_hash);
+    EXPECT_EQ(artifact_status.artifact_source_hash, source_hash);
+    EXPECT_EQ(artifact_status.expected_compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    EXPECT_EQ(artifact_status.artifact_compile_artifact_hash, culled_world_a.compile_artifact_hash);
     yyjson_doc_free(artifact_doc);
     SDL_free(artifact_json);
+
+    const std::filesystem::path artifact_path = dir / "artifacts" / "compile.artifact.json";
+    ASSERT_TRUE(slayer3d_game_data_save_brush_world_compile_artifact_file(
+        culled_a, "brush.compile_options", artifact_path.string().c_str(), &artifact_size, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(std::filesystem::exists(artifact_path));
+    EXPECT_GT(artifact_size, 0u);
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_file(
+        culled_a, "brush.compile_options", artifact_path.string().c_str(), &artifact_status, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.fresh);
 
     slayer3d_game_data_runtime *culled_b = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_culled.game.json").string().c_str(), session, &culled_b,
@@ -13926,6 +13951,22 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
               culled_world_a.compile_artifact_hash);
     yyjson_doc_free(artifact_doc);
     SDL_free(artifact_json);
+
+    std::string tampered_artifact = read_text(artifact_path);
+    const std::string source_hash_field = "\"source_hash\": " + std::to_string(source_hash);
+    const size_t source_hash_pos = tampered_artifact.find(source_hash_field);
+    ASSERT_NE(source_hash_pos, std::string::npos);
+    tampered_artifact.replace(source_hash_pos, source_hash_field.size(), "\"source_hash\": 1");
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        culled_a, "brush.compile_options", tampered_artifact.c_str(), tampered_artifact.size(), &artifact_status, error,
+        sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.schema_matches);
+    EXPECT_TRUE(artifact_status.world_matches);
+    EXPECT_FALSE(artifact_status.source_hash_matches);
+    EXPECT_TRUE(artifact_status.policy_matches);
+    EXPECT_TRUE(artifact_status.compile_artifact_hash_matches);
+    EXPECT_FALSE(artifact_status.fresh);
 
     slayer3d_game_data_runtime *unculled = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_unculled.game.json").string().c_str(), session, &unculled,
@@ -13956,10 +13997,22 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "culled_face_count")), 0);
     yyjson_doc_free(artifact_doc);
     SDL_free(artifact_json);
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_file(
+        unculled, "brush.compile_options", artifact_path.string().c_str(), &artifact_status, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.schema_matches);
+    EXPECT_TRUE(artifact_status.world_matches);
+    EXPECT_TRUE(artifact_status.source_hash_matches);
+    EXPECT_FALSE(artifact_status.policy_matches);
+    EXPECT_FALSE(artifact_status.compile_artifact_hash_matches);
+    EXPECT_FALSE(artifact_status.fresh);
 
     EXPECT_FALSE(slayer3d_game_data_export_brush_world_compile_artifact_json(unculled, "brush.missing", &artifact_json,
                                                                              &artifact_size, error, sizeof(error)));
     EXPECT_EQ(artifact_json, nullptr);
+    EXPECT_FALSE(slayer3d_game_data_verify_brush_world_compile_artifact_file(
+        unculled, "brush.compile_options", (dir / "artifacts" / "missing.artifact.json").string().c_str(),
+        &artifact_status, error, sizeof(error)));
 
     char *exported_json = nullptr;
     size_t exported_size = 0u;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14120,6 +14120,9 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
     EXPECT_EQ(world.brush_count, 1);
+    ASSERT_NE(world.render_model, nullptr);
+    ASSERT_NE(world.compile_artifact_hash, 0u);
+    const Uint64 initial_compile_hash = world.compile_artifact_hash;
     slayer3d_game_data_brush_world_editor_state editor_state{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
     EXPECT_FALSE(editor_state.dirty);
@@ -14138,6 +14141,10 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
 
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
     ASSERT_EQ(world.brush_count, 2);
+    ASSERT_NE(world.render_model, nullptr);
+    ASSERT_NE(world.compile_artifact_hash, 0u);
+    EXPECT_NE(world.compile_artifact_hash, initial_compile_hash);
+    const Uint64 signal_create_compile_hash = world.compile_artifact_hash;
     const slayer3d_game_data_brush &created = world.brushes[1];
     EXPECT_STREQ(created.name, "brush.created.wall");
     EXPECT_TRUE(created.has_bounds);
@@ -14161,6 +14168,11 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     EXPECT_TRUE(editor_state.dirty);
     EXPECT_EQ(editor_state.revision, 2U);
     EXPECT_EQ(editor_state.saved_revision, 0U);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_NE(world.render_model, nullptr);
+    ASSERT_NE(world.compile_artifact_hash, 0u);
+    EXPECT_NE(world.compile_artifact_hash, signal_create_compile_hash);
+    const Uint64 direct_create_compile_hash = world.compile_artifact_hash;
 
     slayer3d_game_data_resize_brush_face_desc resize_desc{};
     resize_desc.world_name = "brush.editor.level";
@@ -14170,6 +14182,10 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     ASSERT_TRUE(slayer3d_game_data_resize_brush_face(runtime, &resize_desc, error, sizeof(error))) << error;
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
     ASSERT_EQ(world.brush_count, 3);
+    ASSERT_NE(world.render_model, nullptr);
+    ASSERT_NE(world.compile_artifact_hash, 0u);
+    EXPECT_NE(world.compile_artifact_hash, direct_create_compile_hash);
+    const Uint64 resized_compile_hash = world.compile_artifact_hash;
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
     EXPECT_EQ(editor_state.revision, 3U);
@@ -14178,6 +14194,7 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     resize_desc.distance = -3.0f;
     EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize_desc, error, sizeof(error)));
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_EQ(world.compile_artifact_hash, resized_compile_hash);
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     EXPECT_NEAR(world.brushes[1].bounds.min.x, 2.0f, 0.001f);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
@@ -14210,6 +14227,8 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     slayer3d_game_data_brush_world roundtrip_world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(roundtrip_runtime, "brush.editor.level", &roundtrip_world));
     ASSERT_EQ(roundtrip_world.brush_count, 3);
+    ASSERT_NE(roundtrip_world.render_model, nullptr);
+    EXPECT_EQ(roundtrip_world.compile_artifact_hash, resized_compile_hash);
     EXPECT_STREQ(roundtrip_world.brushes[1].name, "brush.created.wall");
     EXPECT_NEAR(roundtrip_world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     EXPECT_STREQ(roundtrip_world.brushes[2].name, "brush.editor.level.box.1");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -12628,6 +12628,9 @@ TEST(GameDataRuntime, LoadsAuthoredBrushWorlds)
     EXPECT_STREQ(world.units, "meters");
     EXPECT_FLOAT_EQ(world.meters_per_unit, 1.0f);
     EXPECT_FLOAT_EQ(world.visibility_cell_size, 1.5f);
+    EXPECT_TRUE(world.compile_hidden_face_culling);
+    EXPECT_FLOAT_EQ(world.compile_chunk_cell_size_hint, 0.0f);
+    EXPECT_NE(world.compile_artifact_hash, 0u);
     EXPECT_STREQ(world.editor.stable_id, "brush_world.test.v1");
     EXPECT_STREQ(world.editor.display_name, "Brush Test World");
     EXPECT_STREQ(world.editor.category, "tests/brush");
@@ -12815,6 +12818,56 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
 })json",
             nullptr,
             "brush world visibility_cell_size must be positive",
+        },
+        {
+            "bad_compile",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "compile": "fast",
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush world compile must be an object",
+        },
+        {
+            "bad_compile_chunk_cell_size",
+            R"json({
+  "brush_worlds": [
+    {
+      "name": "brush.bad",
+      "compile": { "chunk_cell_size": 0.0 },
+      "materials": [{ "name": "mat.good" }],
+      "brushes": [
+        {
+          "name": "brush.box",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.good" },
+            { "plane": { "normal": [0, -1, 0], "distance": 1 }, "material": "mat.good" }
+          ]
+        }
+      ]
+    }
+  ]
+})json",
+            nullptr,
+            "brush world compile chunk_cell_size must be positive",
         },
         {
             "bad_visibility",
@@ -13723,6 +13776,128 @@ TEST(GameDataRuntime, BrushRenderCompileCullsFullyHiddenAdjacentSolidFaces)
     EXPECT_EQ(diagnostics.compile_degenerate_face_count, 0u);
 
     slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
+{
+    const std::filesystem::path dir = unique_test_dir("brush_compile_options");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "world": { "brush_worlds": [{ "world": "brush.compile_options" }] }
+})json");
+
+    auto write_game = [&](const char *filename, bool hidden_face_culling) {
+        std::ostringstream json;
+        json << R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Brush Compile Options Test" },
+  "world": { "name": "world.compile_options", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.compile_options",
+      "compile": { "hidden_face_culling": )json"
+             << (hidden_face_culling ? "true" : "false") << R"json(, "chunk_cell_size": 1.0 },
+      "materials": [
+        { "name": "mat.wall", "albedo": [0.6, 0.6, 0.6, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.left",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        },
+        {
+          "name": "brush.right",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  2 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance": -1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json";
+        write_text(dir / filename, json.str().c_str());
+    };
+    write_game("compile_culled.game.json", true);
+    write_game("compile_unculled.game.json", false);
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *culled_a = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_culled.game.json").string().c_str(), session, &culled_a,
+                                             error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world culled_world_a{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(culled_a, "brush.compile_options", &culled_world_a));
+    EXPECT_TRUE(culled_world_a.compile_hidden_face_culling);
+    EXPECT_FLOAT_EQ(culled_world_a.compile_chunk_cell_size_hint, 1.0f);
+    EXPECT_FLOAT_EQ(culled_world_a.compile_chunk_cell_size, 1.0f);
+    EXPECT_EQ(culled_world_a.compile_face_count, 12);
+    EXPECT_EQ(culled_world_a.compile_culled_face_count, 2);
+    EXPECT_EQ(culled_world_a.compile_rendered_face_count, 10);
+    EXPECT_EQ(culled_world_a.compile_triangle_count, 20);
+    EXPECT_NE(culled_world_a.compile_artifact_hash, 0u);
+
+    slayer3d_game_data_runtime *culled_b = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_culled.game.json").string().c_str(), session, &culled_b,
+                                             error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world culled_world_b{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(culled_b, "brush.compile_options", &culled_world_b));
+    EXPECT_EQ(culled_world_b.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+
+    slayer3d_game_data_runtime *unculled = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_unculled.game.json").string().c_str(), session, &unculled,
+                                             error, sizeof(error)))
+        << error;
+    slayer3d_game_data_brush_world unculled_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(unculled, "brush.compile_options", &unculled_world));
+    EXPECT_FALSE(unculled_world.compile_hidden_face_culling);
+    EXPECT_FLOAT_EQ(unculled_world.compile_chunk_cell_size_hint, 1.0f);
+    EXPECT_FLOAT_EQ(unculled_world.compile_chunk_cell_size, 1.0f);
+    EXPECT_EQ(unculled_world.compile_face_count, 12);
+    EXPECT_EQ(unculled_world.compile_culled_face_count, 0);
+    EXPECT_EQ(unculled_world.compile_rendered_face_count, 12);
+    EXPECT_EQ(unculled_world.compile_triangle_count, 24);
+    EXPECT_NE(unculled_world.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+
+    char *exported_json = nullptr;
+    size_t exported_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_fragment_json(unculled, "brush.compile_options", &exported_json,
+                                                                    &exported_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(exported_json, nullptr);
+    EXPECT_GT(exported_size, 0u);
+    const std::string export_text(exported_json);
+    EXPECT_NE(export_text.find("\"compile\""), std::string::npos);
+    EXPECT_NE(export_text.find("\"hidden_face_culling\""), std::string::npos);
+    EXPECT_NE(export_text.find("false"), std::string::npos);
+    EXPECT_NE(export_text.find("\"chunk_cell_size\""), std::string::npos);
+    EXPECT_NE(export_text.find("1.0"), std::string::npos);
+    SDL_free(exported_json);
+
+    slayer3d_game_data_destroy(unculled);
+    slayer3d_game_data_destroy(culled_b);
+    slayer3d_game_data_destroy(culled_a);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -21,6 +21,7 @@ extern "C"
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_stdinc.h>
 
+#include "../vendor/yyjson/yyjson.h"
 #include "slayer3d/asset.h"
 #include "slayer3d/data_game.h"
 #include "slayer3d/game.h"
@@ -13857,6 +13858,55 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_EQ(culled_world_a.compile_triangle_count, 20);
     EXPECT_NE(culled_world_a.compile_artifact_hash, 0u);
 
+    char *artifact_json = nullptr;
+    size_t artifact_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_compile_artifact_json(
+        culled_a, "brush.compile_options", &artifact_json, &artifact_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(artifact_json, nullptr);
+    EXPECT_GT(artifact_size, 0u);
+    yyjson_doc *artifact_doc = yyjson_read(artifact_json, artifact_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(artifact_doc, nullptr);
+    yyjson_val *artifact_root = yyjson_doc_get_root(artifact_doc);
+    ASSERT_NE(artifact_root, nullptr);
+    EXPECT_STREQ(yyjson_get_str(yyjson_obj_get(artifact_root, "schema")), "slayer3d.brush_compile_artifact.v0");
+    EXPECT_STREQ(yyjson_get_str(yyjson_obj_get(artifact_root, "world")), "brush.compile_options");
+    const Uint64 source_hash = yyjson_get_uint(yyjson_obj_get(artifact_root, "source_hash"));
+    EXPECT_NE(source_hash, 0u);
+    EXPECT_EQ(yyjson_get_uint(yyjson_obj_get(artifact_root, "compile_artifact_hash")),
+              culled_world_a.compile_artifact_hash);
+    yyjson_val *policy = yyjson_obj_get(artifact_root, "policy");
+    ASSERT_NE(policy, nullptr);
+    EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(policy, "hidden_face_culling")));
+    EXPECT_DOUBLE_EQ(yyjson_get_real(yyjson_obj_get(policy, "chunk_cell_size_hint")), 1.0);
+    EXPECT_DOUBLE_EQ(yyjson_get_real(yyjson_obj_get(policy, "chunk_cell_size")), 1.0);
+    yyjson_val *source = yyjson_obj_get(artifact_root, "source");
+    ASSERT_NE(source, nullptr);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(source, "brush_count")), 2);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(source, "material_count")), 1);
+    yyjson_val *render = yyjson_obj_get(artifact_root, "render");
+    ASSERT_NE(render, nullptr);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "face_count")), culled_world_a.compile_face_count);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "rendered_face_count")),
+              culled_world_a.compile_rendered_face_count);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "culled_face_count")), culled_world_a.compile_culled_face_count);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "triangle_count")), culled_world_a.compile_triangle_count);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "mesh_count")), culled_world_a.render_model->mesh_count);
+    yyjson_val *chunks = yyjson_obj_get(artifact_root, "chunks");
+    ASSERT_NE(chunks, nullptr);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(chunks, "count")), culled_world_a.compile_chunk_count);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(chunks, "brush_index_count")),
+              culled_world_a.compile_chunk_brush_index_count);
+    yyjson_val *chunk_items = yyjson_obj_get(chunks, "items");
+    ASSERT_TRUE(yyjson_is_arr(chunk_items));
+    EXPECT_EQ(yyjson_arr_size(chunk_items), static_cast<size_t>(culled_world_a.compile_chunk_count));
+    yyjson_val *grid = yyjson_obj_get(artifact_root, "visibility_grid");
+    ASSERT_NE(grid, nullptr);
+    EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(grid, "present")));
+    EXPECT_GT(yyjson_get_int(yyjson_obj_get(grid, "cell_count")), 0);
+    yyjson_doc_free(artifact_doc);
+    SDL_free(artifact_json);
+
     slayer3d_game_data_runtime *culled_b = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_culled.game.json").string().c_str(), session, &culled_b,
                                              error, sizeof(error)))
@@ -13864,6 +13914,18 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     slayer3d_game_data_brush_world culled_world_b{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(culled_b, "brush.compile_options", &culled_world_b));
     EXPECT_EQ(culled_world_b.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_compile_artifact_json(
+        culled_b, "brush.compile_options", &artifact_json, &artifact_size, error, sizeof(error)))
+        << error;
+    artifact_doc = yyjson_read(artifact_json, artifact_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(artifact_doc, nullptr);
+    artifact_root = yyjson_doc_get_root(artifact_doc);
+    ASSERT_NE(artifact_root, nullptr);
+    EXPECT_EQ(yyjson_get_uint(yyjson_obj_get(artifact_root, "source_hash")), source_hash);
+    EXPECT_EQ(yyjson_get_uint(yyjson_obj_get(artifact_root, "compile_artifact_hash")),
+              culled_world_a.compile_artifact_hash);
+    yyjson_doc_free(artifact_doc);
+    SDL_free(artifact_json);
 
     slayer3d_game_data_runtime *unculled = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file((dir / "compile_unculled.game.json").string().c_str(), session, &unculled,
@@ -13879,6 +13941,25 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_EQ(unculled_world.compile_rendered_face_count, 12);
     EXPECT_EQ(unculled_world.compile_triangle_count, 24);
     EXPECT_NE(unculled_world.compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_compile_artifact_json(
+        unculled, "brush.compile_options", &artifact_json, &artifact_size, error, sizeof(error)))
+        << error;
+    artifact_doc = yyjson_read(artifact_json, artifact_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(artifact_doc, nullptr);
+    artifact_root = yyjson_doc_get_root(artifact_doc);
+    ASSERT_NE(artifact_root, nullptr);
+    EXPECT_EQ(yyjson_get_uint(yyjson_obj_get(artifact_root, "source_hash")), source_hash);
+    EXPECT_EQ(yyjson_get_uint(yyjson_obj_get(artifact_root, "compile_artifact_hash")),
+              unculled_world.compile_artifact_hash);
+    render = yyjson_obj_get(artifact_root, "render");
+    ASSERT_NE(render, nullptr);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "culled_face_count")), 0);
+    yyjson_doc_free(artifact_doc);
+    SDL_free(artifact_json);
+
+    EXPECT_FALSE(slayer3d_game_data_export_brush_world_compile_artifact_json(unculled, "brush.missing", &artifact_json,
+                                                                             &artifact_size, error, sizeof(error)));
+    EXPECT_EQ(artifact_json, nullptr);
 
     char *exported_json = nullptr;
     size_t exported_size = 0u;


### PR DESCRIPTION
## Summary
- Add a data-authored `brush_worlds[].compile` policy object for hidden face culling and deterministic chunk cell sizing.
- Expose compile policy and `compile_artifact_hash` on brush-world runtime descriptors for future offline compile cache/invalidation workflows.
- Preserve compile policy during brush-world fragment export and document the new schema.
- Consolidate brush-world source-to-runtime rebuilds behind a shared helper used by initial load, editor box creation, and editor mutation commands.
- Group renderer-facing brush runtime models and visibility-grid state under an internal compile artifact container, leaving authored/source descriptor state separate.
- Add `slayer3d_game_data_export_brush_world_compile_artifact_json()` for deterministic inspection manifests with source hash, compile policy, render summaries, chunk metadata, and visibility-grid metadata.
- Add filesystem-facing manifest save and verification helpers so tools can atomically write descriptors and reject stale/tampered manifests before any future binary cache payload is trusted.
- Add canonical `brush/v0/<world-key>/<source-hash>/<compile-artifact-hash>/` layout helpers, reserved binary payload names, and layout-based manifest saving for editor/offline compiler tooling.

## Correctness
- Added validation for invalid compile objects and invalid chunk cell sizes.
- Added deterministic compile artifact coverage: same authored data produces the same source and artifact hashes; changing compile hidden-face culling keeps the source hash stable while changing emitted geometry and artifact hash.
- Verified compile options preserve source data while changing optimized render artifacts.
- Added editor mutation coverage proving create/resize rebuild compiled render artifacts and deterministic hashes, failed edits leave artifacts unchanged, and exported/imported fragments rebuild to the same hash.
- Rebuild failures restore the prior public `render_model` pointer instead of leaving descriptor state pointed at staged compile storage.
- Manifest export rejects missing worlds and uses an explicit descriptor schema rather than pretending to be a loadable binary cache payload.
- Manifest verification reports fresh vs stale status instead of treating stale descriptors as hard API errors; tests cover fresh files, tampered source hashes, stale policy/artifact hashes, and missing files.
- Consolidated duplicated atomic editor file-writing code behind one helper used by fragment, editable-level, and artifact-manifest saves.
- Layout tests prove deterministic paths for identical artifacts, stable world keys across policy changes, source-hash stability across compile policy changes, artifact path divergence when compile policy changes, and rejection of virtual URI cache roots.

## Tests
- `cmake --build build/debug -j4`
- `cmake --build build/debug --target slayer3d_game_data_test -j4`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.BrushCompileOptionsProduceDeterministicArtifacts'`
- `ctest --test-dir build/debug --output-on-failure -R 'Brush|brush|Editor.*Brush|GLRendererTest.BrushVisibility'`
- `ctest --test-dir build/debug --output-on-failure`

## Next slice
- Add serialized binary payload writers for the first reusable cache artifact, likely visibility/chunk metadata before render meshes, and keep runtime loading gated behind manifest freshness checks.