### PR TITLE
Add grid-sized editor placement prefabs

### DIFF
--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -5,6 +5,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - a normal Slayer3D runtime viewport
 - a data-authored editor camera controller: arrow keys move horizontally,
   `Q`/`E` move down/up, and right mouse button + drag looks around
+- data-authored editor view switching: `Tab` toggles between perspective and
+  top orthographic, while `F1`-`F4` select perspective/top/front/side cameras
 - authored brush-world selection trace metadata with a ground work-plane
   fallback for placing the first brush in empty space
 - data-authored world/selection/normal/hit debug overlay drawing, including a
@@ -12,7 +14,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
 - reusable `ui.panels` and `ui.inspectors` populated from scene state
 - a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
   `4` player start, then click a brush face or the ground work plane and press
-  `Enter` to place the selected prefab at that point
+  `Enter` to place the selected prefab at that point; `C` still cycles the
+  broader tool modes used by command previews
 - live snapped placement previews for floor, wall, ceiling, and player-start
   tools using the same renderer-agnostic editor debug primitive path; `-`/`+`
   change the active grid size and `R` toggles wall orientation between grid axes

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -14,8 +14,8 @@ This data-only dojo demonstrates the first reusable editor shell pieces:
   `4` player start, then click a brush face or the ground work plane and press
   `Enter` to place the selected prefab at that point
 - live snapped placement previews for floor, wall, ceiling, and player-start
-  tools using the same renderer-agnostic editor debug primitive path; `[`/`]`
-  change snap size and `R` toggles wall orientation between grid axes
+  tools using the same renderer-agnostic editor debug primitive path; `-`/`+`
+  change the active grid size and `R` toggles wall orientation between grid axes
 - unified editable-level save/export: `S` saves and publishes one fragment
   containing the brush world and player starts
 - test-run handoff manifest: `T` publishes and saves runner arguments for the

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -838,6 +838,28 @@
         "signal": "signal.editor.test_run.prepare",
         "actions": [
           {
+            "type": "editor.level.save",
+            "world": "brush.editor_shell.target",
+            "path_from_state": "editor.save.path",
+            "message": "editable level saved for test run",
+            "outputs": {
+              "valid_key": "editor.save.valid",
+              "message_key": "editor.save.message",
+              "path_key": "editor.save.path",
+              "size_key": "editor.save.size",
+              "brush_world_key": "editor.brush_world.name",
+              "brush_dirty_key": "editor.brush_world.dirty",
+              "brush_revision_key": "editor.brush_world.revision",
+              "brush_saved_revision_key": "editor.brush_world.saved_revision",
+              "brush_source_path_key": "editor.brush_world.source_path",
+              "player_start_count_key": "editor.player_start.count",
+              "player_start_dirty_key": "editor.player_start.dirty",
+              "player_start_revision_key": "editor.player_start.revision",
+              "player_start_saved_revision_key": "editor.player_start.saved_revision",
+              "player_start_source_path_key": "editor.player_start.source_path"
+            }
+          },
+          {
             "type": "editor.test_run.prepare",
             "data_asset": "asset://editor_shell_dojo.game.json",
             "player_start": "player_start.editor_shell",
@@ -877,7 +899,7 @@
               "command_key": "editor.test_run.command"
             }
           },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "test run handoff prepared" }
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "test run saved and prepared" }
         ]
       }
     ]

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -77,12 +77,18 @@
             "bindings": [{ "device": "keyboard", "key": "4" }]
           },
           {
-            "name": "action.editor.snap.finer",
-            "bindings": [{ "device": "keyboard", "key": "LEFTBRACKET" }]
+            "name": "action.editor.grid.decrease",
+            "bindings": [
+              { "device": "keyboard", "key": "MINUS" },
+              { "device": "keyboard", "key": "KP_MINUS" }
+            ]
           },
           {
-            "name": "action.editor.snap.coarser",
-            "bindings": [{ "device": "keyboard", "key": "RIGHTBRACKET" }]
+            "name": "action.editor.grid.increase",
+            "bindings": [
+              { "device": "keyboard", "key": "EQUALS" },
+              { "device": "keyboard", "key": "KP_PLUS" }
+            ]
           },
           {
             "name": "action.editor.wall_axis.toggle",
@@ -156,8 +162,8 @@
     "signal.editor.tool.wall",
     "signal.editor.tool.ceiling",
     "signal.editor.tool.player_start",
-    "signal.editor.snap.finer",
-    "signal.editor.snap.coarser",
+    "signal.editor.grid.decrease",
+    "signal.editor.grid.increase",
     "signal.editor.wall_axis.toggle",
     "signal.editor.export",
     "signal.editor.test_run.prepare"
@@ -231,13 +237,13 @@
       },
       {
         "type": "sensor.input_pressed",
-        "action": "action.editor.snap.finer",
-        "on_pressed": "signal.editor.snap.finer"
+        "action": "action.editor.grid.decrease",
+        "on_pressed": "signal.editor.grid.decrease"
       },
       {
         "type": "sensor.input_pressed",
-        "action": "action.editor.snap.coarser",
-        "on_pressed": "signal.editor.snap.coarser"
+        "action": "action.editor.grid.increase",
+        "on_pressed": "signal.editor.grid.increase"
       },
       {
         "type": "sensor.input_pressed",
@@ -286,29 +292,29 @@
         ]
       },
       {
-        "signal": "signal.editor.snap.finer",
+        "signal": "signal.editor.grid.decrease",
         "actions": [
           {
             "type": "scene_state.cycle",
-            "key": "editor.placement.snap",
-            "default": 0.5,
+            "key": "editor.grid.size",
+            "default": 8.0,
             "direction": -1,
-            "values": [0.25, 0.5, 1.0, 2.0]
+            "values": [2.0, 4.0, 8.0, 16.0]
           },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "placement snap decreased" }
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "grid size decreased" }
         ]
       },
       {
-        "signal": "signal.editor.snap.coarser",
+        "signal": "signal.editor.grid.increase",
         "actions": [
           {
             "type": "scene_state.cycle",
-            "key": "editor.placement.snap",
-            "default": 0.5,
+            "key": "editor.grid.size",
+            "default": 8.0,
             "direction": 1,
-            "values": [0.25, 0.5, 1.0, 2.0]
+            "values": [2.0, 4.0, 8.0, 16.0]
           },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "placement snap increased" }
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "grid size increased" }
         ]
       },
       {

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -61,6 +61,10 @@
             "bindings": [{ "device": "keyboard", "key": "T" }]
           },
           {
+            "name": "action.editor.test_run.enter",
+            "bindings": [{ "device": "keyboard", "key": "F5" }]
+          },
+          {
             "name": "action.editor.tool.floor",
             "bindings": [{ "device": "keyboard", "key": "1" }]
           },
@@ -192,7 +196,8 @@
     "signal.editor.grid.increase",
     "signal.editor.wall_axis.toggle",
     "signal.editor.export",
-    "signal.editor.test_run.prepare"
+    "signal.editor.test_run.prepare",
+    "signal.editor.test_run.enter"
   ],
   "logic": {
     "sensors": [
@@ -240,6 +245,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.test_run.prepare",
         "on_pressed": "signal.editor.test_run.prepare"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.test_run.enter",
+        "on_pressed": "signal.editor.test_run.enter"
       },
       {
         "type": "sensor.input_pressed",
@@ -900,6 +910,41 @@
             }
           },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "test run saved and prepared" }
+        ]
+      },
+      {
+        "signal": "signal.editor.test_run.enter",
+        "actions": [
+          {
+            "type": "editor.player_start.apply",
+            "name": "player_start.editor_shell",
+            "message": "test run player start applied",
+            "outputs": {
+              "valid_key": "editor.test_run.enter.valid",
+              "message_key": "editor.test_run.enter.message",
+              "player_start_key": "editor.test_run.enter.player_start",
+              "scene_key": "editor.test_run.enter.scene",
+              "target_key": "editor.test_run.enter.target",
+              "position_key": "editor.test_run.enter.position",
+              "yaw_key": "editor.test_run.enter.yaw",
+              "pitch_key": "editor.test_run.enter.pitch"
+            }
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.test_run.enter.valid", "op": "==", "value": true },
+            "then": [
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "entered playable test run" },
+              { "type": "scene.set", "scene": "scene.editor_shell.test_run" }
+            ],
+            "else": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "player start required before playable test run"
+              }
+            ]
+          }
         ]
       }
     ]

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -26,7 +26,7 @@
           },
           {
             "name": "action.editor.tool.cycle",
-            "bindings": [{ "device": "keyboard", "key": "TAB" }]
+            "bindings": [{ "device": "keyboard", "key": "C" }]
           },
           {
             "name": "action.editor.selection.clear",
@@ -75,6 +75,26 @@
           {
             "name": "action.editor.tool.player_start",
             "bindings": [{ "device": "keyboard", "key": "4" }]
+          },
+          {
+            "name": "action.editor.view.toggle",
+            "bindings": [{ "device": "keyboard", "key": "TAB" }]
+          },
+          {
+            "name": "action.editor.view.perspective",
+            "bindings": [{ "device": "keyboard", "key": "F1" }]
+          },
+          {
+            "name": "action.editor.view.top",
+            "bindings": [{ "device": "keyboard", "key": "F2" }]
+          },
+          {
+            "name": "action.editor.view.front",
+            "bindings": [{ "device": "keyboard", "key": "F3" }]
+          },
+          {
+            "name": "action.editor.view.side",
+            "bindings": [{ "device": "keyboard", "key": "F4" }]
           },
           {
             "name": "action.editor.grid.decrease",
@@ -162,6 +182,11 @@
     "signal.editor.tool.wall",
     "signal.editor.tool.ceiling",
     "signal.editor.tool.player_start",
+    "signal.editor.view.toggle",
+    "signal.editor.view.perspective",
+    "signal.editor.view.top",
+    "signal.editor.view.front",
+    "signal.editor.view.side",
     "signal.editor.grid.decrease",
     "signal.editor.grid.increase",
     "signal.editor.wall_axis.toggle",
@@ -237,6 +262,31 @@
       },
       {
         "type": "sensor.input_pressed",
+        "action": "action.editor.view.toggle",
+        "on_pressed": "signal.editor.view.toggle"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.view.perspective",
+        "on_pressed": "signal.editor.view.perspective"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.view.top",
+        "on_pressed": "signal.editor.view.top"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.view.front",
+        "on_pressed": "signal.editor.view.front"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.view.side",
+        "on_pressed": "signal.editor.view.side"
+      },
+      {
+        "type": "sensor.input_pressed",
         "action": "action.editor.grid.decrease",
         "on_pressed": "signal.editor.grid.decrease"
       },
@@ -289,6 +339,61 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.tool.mode", "value": "player_start" },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start tool selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.view.toggle",
+        "actions": [
+          {
+            "type": "scene_state.cycle",
+            "key": "editor.view.mode",
+            "default": "perspective_3d",
+            "values": ["perspective_3d", "orthographic_top"]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "orthographic_top" },
+            "then": [
+              { "type": "camera.set", "camera": "camera.editor_shell.ortho_top" },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "top orthographic view" }
+            ],
+            "else": [
+              { "type": "camera.set", "camera": "camera.editor_shell.viewport" },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "perspective editor view" }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.view.perspective",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.view.mode", "value": "perspective_3d" },
+          { "type": "camera.set", "camera": "camera.editor_shell.viewport" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "perspective editor view" }
+        ]
+      },
+      {
+        "signal": "signal.editor.view.top",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_top" },
+          { "type": "camera.set", "camera": "camera.editor_shell.ortho_top" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "top orthographic view" }
+        ]
+      },
+      {
+        "signal": "signal.editor.view.front",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_front" },
+          { "type": "camera.set", "camera": "camera.editor_shell.ortho_front" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "front orthographic view" }
+        ]
+      },
+      {
+        "signal": "signal.editor.view.side",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_side" },
+          { "type": "camera.set", "camera": "camera.editor_shell.ortho_side" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "side orthographic view" }
         ]
       },
       {
@@ -756,6 +861,33 @@
         "fov": 70.0,
         "fov_axis": "horizontal",
         "active": true
+      },
+      {
+        "name": "camera.editor_shell.ortho_top",
+        "type": "orthographic",
+        "position_entity": "entity.editor_shell.camera",
+        "position_offset": [0.0, 40.0, 0.0],
+        "target_entity": "entity.editor_shell.camera",
+        "up": [0.0, 0.0, -1.0],
+        "size": 48.0
+      },
+      {
+        "name": "camera.editor_shell.ortho_front",
+        "type": "orthographic",
+        "position_entity": "entity.editor_shell.camera",
+        "position_offset": [0.0, 0.0, 40.0],
+        "target_entity": "entity.editor_shell.camera",
+        "up": [0.0, 1.0, 0.0],
+        "size": 32.0
+      },
+      {
+        "name": "camera.editor_shell.ortho_side",
+        "type": "orthographic",
+        "position_entity": "entity.editor_shell.camera",
+        "position_offset": [40.0, 0.0, 0.0],
+        "target_entity": "entity.editor_shell.camera",
+        "up": [0.0, 1.0, 0.0],
+        "size": 32.0
       },
       {
         "name": "camera.editor_shell.player",

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -841,6 +841,8 @@
             "type": "editor.test_run.prepare",
             "data_asset": "asset://editor_shell_dojo.game.json",
             "player_start": "player_start.editor_shell",
+            "runner": "./build/debug/slayer3d_runner",
+            "root": "demos/editor_shell_dojo/data",
             "message": "test run handoff prepared",
             "outputs": {
               "valid_key": "editor.test_run.valid",
@@ -850,7 +852,8 @@
               "data_asset_key": "editor.test_run.data_asset",
               "scene_key": "editor.test_run.scene",
               "player_start_key": "editor.test_run.player_start",
-              "target_key": "editor.test_run.target"
+              "target_key": "editor.test_run.target",
+              "command_key": "editor.test_run.command"
             }
           },
           {
@@ -858,6 +861,8 @@
             "data_asset": "asset://editor_shell_dojo.game.json",
             "player_start": "player_start.editor_shell",
             "path_from_state": "editor.test_run.path",
+            "runner": "./build/debug/slayer3d_runner",
+            "root": "demos/editor_shell_dojo/data",
             "message": "test run manifest saved",
             "outputs": {
               "valid_key": "editor.test_run.saved",
@@ -868,7 +873,8 @@
               "data_asset_key": "editor.test_run.data_asset",
               "scene_key": "editor.test_run.scene",
               "player_start_key": "editor.test_run.player_start",
-              "target_key": "editor.test_run.target"
+              "target_key": "editor.test_run.target",
+              "command_key": "editor.test_run.command"
             }
           },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "test run handoff prepared" }

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -355,10 +355,14 @@
             "if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "orthographic_top" },
             "then": [
               { "type": "camera.set", "camera": "camera.editor_shell.ortho_top" },
+              { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+              { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
               { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "top orthographic view" }
             ],
             "else": [
               { "type": "camera.set", "camera": "camera.editor_shell.viewport" },
+              { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+              { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
               { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "perspective editor view" }
             ]
           }
@@ -369,6 +373,8 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.view.mode", "value": "perspective_3d" },
           { "type": "camera.set", "camera": "camera.editor_shell.viewport" },
+          { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+          { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "perspective editor view" }
         ]
       },
@@ -377,6 +383,8 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_top" },
           { "type": "camera.set", "camera": "camera.editor_shell.ortho_top" },
+          { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+          { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "top orthographic view" }
         ]
       },
@@ -385,6 +393,8 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_front" },
           { "type": "camera.set", "camera": "camera.editor_shell.ortho_front" },
+          { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 0.0, 1.0] },
+          { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "front orthographic view" }
         ]
       },
@@ -393,6 +403,8 @@
         "actions": [
           { "type": "scene_state.set", "key": "editor.view.mode", "value": "orthographic_side" },
           { "type": "camera.set", "camera": "camera.editor_shell.ortho_side" },
+          { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [1.0, 0.0, 0.0] },
+          { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "side orthographic view" }
         ]
       },

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -176,6 +176,7 @@
     "signal.editor.selection.inspect",
     "signal.editor.command.preview",
     "signal.editor.command.commit",
+    "signal.editor.pointer.primary",
     "signal.editor.command.undo",
     "signal.editor.command.redo",
     "signal.editor.tool.floor",
@@ -528,6 +529,22 @@
                 }
               }
             ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.pointer.primary",
+        "actions": [
+          {
+            "type": "branch",
+            "if": {
+              "type": "scene_state.compare",
+              "key": "editor.tool.mode",
+              "op": "!=",
+              "value": "select",
+              "default": "select"
+            },
+            "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
           }
         ]
       },

--- a/demos/editor_shell_dojo/data/generated/editable_level.fragment.json
+++ b/demos/editor_shell_dojo/data/generated/editable_level.fragment.json
@@ -21,29 +21,29 @@
       "materials": [
         {
           "name": "mat.editor.wall",
-          "albedo": [0.58, 0.18, 0.16, 1.0],
+          "albedo": [0.50, 0.52, 0.56, 1.0],
           "roughness": 0.8,
           "editor": {
             "stable_id": "editor.material.wall",
-            "display_name": "Red Wall Material"
+            "display_name": "Mid Gray Wall Material"
           }
         },
         {
           "name": "mat.editor.floor",
-          "albedo": [0.22, 0.24, 0.28, 1.0],
+          "albedo": [0.30, 0.31, 0.33, 1.0],
           "roughness": 0.9,
           "editor": {
             "stable_id": "editor.material.floor",
-            "display_name": "Dark Floor Material"
+            "display_name": "Dark Gray Floor Material"
           }
         },
         {
           "name": "mat.editor.ceiling",
-          "albedo": [0.42, 0.44, 0.48, 1.0],
+          "albedo": [0.68, 0.69, 0.71, 1.0],
           "roughness": 0.85,
           "editor": {
             "stable_id": "editor.material.ceiling",
-            "display_name": "Soft Ceiling Material"
+            "display_name": "Light Gray Ceiling Material"
           }
         }
       ],

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -30,6 +30,7 @@
       "action.editor.command.redo",
       "action.editor.export",
       "action.editor.test_run.prepare",
+      "action.editor.test_run.enter",
       "action.editor.tool.floor",
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
@@ -499,7 +500,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. Arrows move, Q/E down/up, RMB look. Tab view, F1-F4 cameras. 1 floor 2 wall 3 ceiling 4 start. +/- grid, R axis. Enter commit. S save.",
+        "text": "Click select. Arrows move, Q/E down/up, RMB look. Tab view, F1-F4 cameras. 1 floor 2 wall 3 ceiling 4 start. +/- grid, R axis. Enter commit. S save. T handoff. F5 play.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -12,6 +12,7 @@
     },
     { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" },
     { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
+    { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
     { "type": "scene_state.set", "key": "editor.view.mode", "value": "perspective_3d" },
     { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
     { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
@@ -157,6 +158,47 @@
         }
       ]
     },
+    "palette": {
+      "selected_key": "editor.tool.mode",
+      "entries": [
+        {
+          "mode": "floor",
+          "preview": "floor",
+          "kind": "box",
+          "label": "Floor",
+          "shortcut": "1",
+          "category": "blockout",
+          "description": "8m gray floor tile"
+        },
+        {
+          "mode": "wall",
+          "preview": "wall",
+          "kind": "box",
+          "label": "Wall",
+          "shortcut": "2",
+          "category": "blockout",
+          "description": "8m gray wall tile"
+        },
+        {
+          "mode": "ceiling",
+          "preview": "ceiling",
+          "kind": "box",
+          "label": "Ceiling",
+          "shortcut": "3",
+          "category": "blockout",
+          "description": "8m gray ceiling tile"
+        },
+        {
+          "mode": "player_start",
+          "preview": "player_start",
+          "kind": "player_start",
+          "label": "Player",
+          "shortcut": "4",
+          "category": "things",
+          "description": "play-test spawn marker"
+        }
+      ]
+    },
     "debug_overlay": {
       "enabled": true,
       "flags": [
@@ -188,7 +230,7 @@
         "x": 18,
         "y": 18,
         "w": 340,
-        "h": 320,
+        "h": 370,
         "color": [10, 14, 22, 215],
         "border_color": [80, 140, 230, 230],
         "border_thickness": 2
@@ -286,6 +328,105 @@
       }
     ],
     "text": [
+      {
+        "name": "ui.editor_shell.palette.title",
+        "text": "Blockout Prefabs",
+        "font": "font.editor_shell.ui",
+        "x": 34,
+        "y": 246,
+        "color": [235, 245, 255, 255],
+        "scale": 0.64
+      },
+      {
+        "name": "ui.editor_shell.palette.floor",
+        "text": "  1 Floor",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 274,
+        "color": [205, 215, 225, 220],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "floor" }
+      },
+      {
+        "name": "ui.editor_shell.palette.floor.active",
+        "text": "> 1 Floor",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 274,
+        "color": [120, 220, 255, 255],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "floor" }
+      },
+      {
+        "name": "ui.editor_shell.palette.wall",
+        "text": "  2 Wall",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 298,
+        "color": [205, 215, 225, 220],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "wall" }
+      },
+      {
+        "name": "ui.editor_shell.palette.wall.active",
+        "text": "> 2 Wall",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 298,
+        "color": [120, 220, 255, 255],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "wall" }
+      },
+      {
+        "name": "ui.editor_shell.palette.ceiling",
+        "text": "  3 Ceiling",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 322,
+        "color": [205, 215, 225, 220],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "ceiling" }
+      },
+      {
+        "name": "ui.editor_shell.palette.ceiling.active",
+        "text": "> 3 Ceiling",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 322,
+        "color": [120, 220, 255, 255],
+        "scale": 0.58,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "ceiling" }
+      },
+      {
+        "name": "ui.editor_shell.palette.player",
+        "text": "  4 Player",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 346,
+        "color": [205, 215, 225, 220],
+        "scale": 0.58,
+        "visible_if": {
+          "type": "scene_state.compare",
+          "key": "editor.tool.mode",
+          "op": "!=",
+          "value": "player_start"
+        }
+      },
+      {
+        "name": "ui.editor_shell.palette.player.active",
+        "text": "> 4 Player",
+        "font": "font.editor_shell.ui",
+        "x": 42,
+        "y": 346,
+        "color": [120, 220, 255, 255],
+        "scale": 0.58,
+        "visible_if": {
+          "type": "scene_state.compare",
+          "key": "editor.tool.mode",
+          "op": "==",
+          "value": "player_start"
+        }
+      },
       {
         "name": "ui.editor_shell.title",
         "text": "Editor Shell Dojo",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -98,7 +98,8 @@
         "hit_key": "editor.hover.hit",
         "element_key": "editor.hover.element",
         "face_stable_id_key": "editor.hover.face_stable_id"
-      }
+      },
+      "on_select": "signal.editor.pointer.primary"
     },
     "placement": {
       "tool_key": "editor.tool.mode",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -13,6 +13,8 @@
     { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" },
     { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
     { "type": "scene_state.set", "key": "editor.view.mode", "value": "perspective_3d" },
+    { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+    { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
     { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
   ],
   "input": {
@@ -70,7 +72,9 @@
         "work_plane": {
           "enabled": true,
           "normal": [0.0, 1.0, 0.0],
-          "distance": 0.0
+          "normal_key": "editor.work_plane.normal",
+          "distance": 0.0,
+          "distance_key": "editor.work_plane.distance"
         }
       },
       "outputs": {

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -235,6 +235,17 @@
         "color": [10, 14, 22, 215],
         "border_color": [80, 140, 230, 230],
         "border_thickness": 2
+      },
+      {
+        "name": "ui.editor_shell.handoff.panel",
+        "x": 18,
+        "y": 610,
+        "w": 1244,
+        "h": 92,
+        "color": [8, 10, 16, 210],
+        "border_color": [80, 170, 170, 190],
+        "border_thickness": 1,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.test_run.command", "op": "!=", "value": "" }
       }
     ],
     "inspectors": [
@@ -442,6 +453,49 @@
         "align": "right",
         "color": [235, 242, 255, 230],
         "scale": 0.8
+      },
+      {
+        "name": "ui.editor_shell.handoff.title",
+        "text": "Test Run Handoff",
+        "font": "font.editor_shell.ui",
+        "x": 34,
+        "y": 620,
+        "color": [160, 230, 230, 240],
+        "scale": 0.56,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.test_run.command", "op": "!=", "value": "" }
+      },
+      {
+        "name": "ui.editor_shell.handoff.level",
+        "font": "font.editor_shell.ui",
+        "format": "Level: %s",
+        "bindings": [{ "type": "scene_state", "key": "editor.save.path", "default": "none" }],
+        "x": 34,
+        "y": 644,
+        "color": [220, 232, 245, 225],
+        "scale": 0.46,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.test_run.command", "op": "!=", "value": "" }
+      },
+      {
+        "name": "ui.editor_shell.handoff.manifest",
+        "font": "font.editor_shell.ui",
+        "format": "Manifest: %s",
+        "bindings": [{ "type": "scene_state", "key": "editor.test_run.path", "default": "none" }],
+        "x": 34,
+        "y": 666,
+        "color": [220, 232, 245, 225],
+        "scale": 0.46,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.test_run.command", "op": "!=", "value": "" }
+      },
+      {
+        "name": "ui.editor_shell.handoff.command",
+        "font": "font.editor_shell.ui",
+        "format": "Command: %s",
+        "bindings": [{ "type": "scene_state", "key": "editor.test_run.command", "default": "none" }],
+        "x": 34,
+        "y": 688,
+        "color": [235, 245, 255, 235],
+        "scale": 0.42,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.test_run.command", "op": "!=", "value": "" }
       },
       {
         "name": "ui.editor_shell.help",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -302,6 +302,10 @@
             "binding": { "type": "scene_state", "key": "editor.test_run.message", "default": "none" }
           },
           {
+            "label": "Cmd",
+            "binding": { "type": "scene_state", "key": "editor.test_run.command", "default": "none" }
+          },
+          {
             "label": "Saved",
             "binding": { "type": "scene_state", "key": "editor.save.path", "default": "none" }
           },

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -12,6 +12,7 @@
     },
     { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" },
     { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
+    { "type": "scene_state.set", "key": "editor.view.mode", "value": "perspective_3d" },
     { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
   ],
   "input": {
@@ -30,6 +31,11 @@
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
       "action.editor.tool.player_start",
+      "action.editor.view.toggle",
+      "action.editor.view.perspective",
+      "action.editor.view.top",
+      "action.editor.view.front",
+      "action.editor.view.side",
       "action.editor.grid.decrease",
       "action.editor.grid.increase",
       "action.editor.wall_axis.toggle",
@@ -56,7 +62,6 @@
       "clear_on_miss": true,
       "trace": {
         "source": "camera_screen",
-        "camera": "camera.editor_shell.viewport",
         "viewport": [1280.0, 720.0],
         "near": 0.05,
         "far": 100.0,
@@ -230,6 +235,10 @@
             "binding": { "type": "scene_state", "key": "editor.tool.mode", "default": "select" }
           },
           {
+            "label": "View",
+            "binding": { "type": "scene_state", "key": "editor.view.mode", "default": "perspective_3d" }
+          },
+          {
             "label": "Action",
             "binding": { "type": "scene_state", "key": "editor.tool.last_action", "default": "none" }
           },
@@ -286,7 +295,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. +/- grid, R axis. Enter commit. S save.",
+        "text": "Click select. Arrows move, Q/E down/up, RMB look. Tab view, F1-F4 cameras. 1 floor 2 wall 3 ceiling 4 start. +/- grid, R axis. Enter commit. S save.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -11,7 +11,7 @@
       "value": "demos/editor_shell_dojo/data/generated/editable_level.fragment.json"
     },
     { "type": "scene_state.set", "key": "editor.test_run.path", "value": "build/editor_shell_dojo/test-run.json" },
-    { "type": "scene_state.set", "key": "editor.placement.snap", "value": 0.5 },
+    { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
     { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
   ],
   "input": {
@@ -30,8 +30,8 @@
       "action.editor.tool.wall",
       "action.editor.tool.ceiling",
       "action.editor.tool.player_start",
-      "action.editor.snap.finer",
-      "action.editor.snap.coarser",
+      "action.editor.grid.decrease",
+      "action.editor.grid.increase",
       "action.editor.wall_axis.toggle",
       "action.editor.camera.forward",
       "action.editor.camera.back",
@@ -92,8 +92,10 @@
     },
     "placement": {
       "tool_key": "editor.tool.mode",
-      "snap_key": "editor.placement.snap",
-      "default_snap": 0.5,
+      "snap_key": "editor.grid.size",
+      "grid_size_key": "editor.grid.size",
+      "default_snap": 8.0,
+      "default_grid_size": 8.0,
       "outputs": {
         "active_key": "editor.placement_preview.active",
         "valid_key": "editor.placement_preview.valid",
@@ -114,9 +116,8 @@
           "kind": "box",
           "world": "brush.editor_shell.target",
           "material": "mat.editor.floor",
-          "snap": 0.5,
-          "min": [-3.0, -0.2, -3.0],
-          "max": [3.0, 0.0, 3.0],
+          "grid_min": [-0.5, -0.025, -0.5],
+          "grid_max": [0.5, 0.0, 0.5],
           "message": "floor prefab preview"
         },
         {
@@ -126,9 +127,8 @@
           "material": "mat.editor.wall",
           "axis_key": "editor.placement.wall_axis",
           "axis": "z",
-          "snap": 0.5,
-          "min": [-0.125, 0.0, -3.0],
-          "max": [0.125, 2.5, 3.0],
+          "grid_min": [-0.03125, 0.0, -0.5],
+          "grid_max": [0.03125, 1.0, 0.5],
           "message": "wall prefab preview"
         },
         {
@@ -136,15 +136,13 @@
           "kind": "box",
           "world": "brush.editor_shell.target",
           "material": "mat.editor.ceiling",
-          "snap": 0.5,
-          "min": [-3.0, 2.5, -3.0],
-          "max": [3.0, 2.7, 3.0],
+          "grid_min": [-0.5, 1.0, -0.5],
+          "grid_max": [0.5, 1.025, 0.5],
           "message": "ceiling prefab preview"
         },
         {
           "mode": "player_start",
           "kind": "player_start",
-          "snap": 0.5,
           "size": [0.5, 1.8, 0.5],
           "message": "player start preview"
         }
@@ -260,8 +258,8 @@
             "binding": { "type": "scene_state", "key": "editor.placement_preview.message", "default": "none" }
           },
           {
-            "label": "Snap",
-            "binding": { "type": "scene_state", "key": "editor.placement_preview.snap", "default": 0.5 }
+            "label": "Grid",
+            "binding": { "type": "scene_state", "key": "editor.placement_preview.snap", "default": 8.0 }
           },
           {
             "label": "Axis",
@@ -288,7 +286,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. [/] snap, R axis. Enter commit. S save.",
+        "text": "Click select. Arrows move, Q/E down/up, RMB look. 1 floor 2 wall 3 ceiling 4 start. +/- grid, R axis. Enter commit. S save.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.075,

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -1,0 +1,75 @@
+# Editor Test Drive
+
+This is the current graybox-editor milestone. It is still an alpha editor shell,
+but it should prove the core loop: place floor/wall/ceiling blocks, place a
+player start, save the authored level fragment, and run the result through the
+same data-driven runtime used by games.
+
+## Launch
+
+Build the editor and open the default editor shell dojo:
+
+```sh
+cmake --build build/debug --target slayer3d_editor -j4
+./build/debug/slayer3d_editor
+```
+
+The default editor project writes:
+
+- level fragment: `demos/editor_shell_dojo/data/generated/editable_level.fragment.json`
+- test-run manifest: `build/editor_shell_dojo/test-run.json`
+
+## Controls
+
+- `1`, `2`, `3`, `4`: select floor, wall, ceiling, or player-start prefab
+- mouse click: place the selected prefab at the snapped preview position
+- `Enter`: commit the current preview placement
+- `+` / `-`: increase or decrease grid size
+- `R`: toggle wall axis
+- `Tab`: toggle editor view
+- `F1`, `F2`, `F3`, `F4`: perspective, top, front, side views
+- arrow keys: move the editor camera
+- `Q` / `E`: move camera down/up
+- hold right mouse: look around in the perspective editor camera
+- `S`: save the editable level fragment
+- `T`: save the level, write the test-run manifest, and show the runner command
+- `F5`: enter the playable test scene in the editor from the placed player start
+- `Esc`: quit
+
+## Suggested Pass
+
+1. Select floor with `1` and place a floor tile.
+2. Select wall with `2`, press `R` if needed, and place at least one wall.
+3. Select ceiling with `3` and place a ceiling tile.
+4. Select player start with `4` and place it on the floor.
+5. Press `S` and confirm the inspector reports a saved level path.
+6. Press `T` and confirm the bottom handoff strip appears with level path,
+   manifest path, and a copy/paste runner command.
+7. Press `F5`; the editor should switch into the playable test scene.
+8. In the playable scene, use `WASD` and mouse look to verify the player starts
+   where you placed the marker and collides with the graybox geometry.
+
+You can also run the handoff through the generic runner:
+
+```sh
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
+```
+
+## Correctness Checks
+
+The following should be true during a good test drive:
+
+- Placement previews snap to the active grid size and resize when `+` / `-` is
+  pressed.
+- Floor, wall, and ceiling prefabs are distinct gray blockout brushes.
+- Top/front/side views plot on the correct work plane; perspective view uses the
+  3D editor camera.
+- `S` writes a JSON fragment containing `brush_worlds` and
+  `editor_player_starts`.
+- `T` saves the latest dirty level before writing the test-run manifest.
+- `F5` applies the stored player start before entering the playable scene.
+- The standalone runner command loads the same saved geometry and player start.
+
+Current limitations are expected: this is not yet a polished TrenchBroom-style
+frontend, there is no file picker, and texture/face painting remains outside
+this first graybox milestone.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1090,6 +1090,42 @@ flag and color, so editor hosts do not need a second rendering path.
 }
 ```
 
+Scenes may pair placement previews with `editor.palette` metadata. The palette
+is intentionally data-only: it gives editor hosts and authored sidebar UI a
+stable list of selectable tools without hard-coding project-specific prefab
+names in C. `selected_key` usually matches `editor.placement.tool_key`.
+Each entry has a `mode`, `label`, optional `shortcut`, optional
+`category`/`description`, and an optional `preview` reference. When omitted,
+`preview` defaults to `mode`. Validation requires every palette preview to
+match an authored placement preview, so stale sidebar entries fail at load time.
+
+```json
+{
+  "editor": {
+    "palette": {
+      "selected_key": "editor.tool.mode",
+      "entries": [
+        {
+          "mode": "floor",
+          "preview": "floor",
+          "kind": "box",
+          "label": "Floor",
+          "shortcut": "1",
+          "category": "blockout"
+        },
+        {
+          "mode": "player_start",
+          "kind": "player_start",
+          "label": "Player",
+          "shortcut": "4",
+          "category": "things"
+        }
+      ]
+    }
+  }
+}
+```
+
 `editor.brush_world.create_box` and `editor.player_start.place` may use
 `"position_from": "placement_preview"` to commit exactly the active preview.
 Set `preview_mode` on the action to fail closed if the active preview belongs
@@ -2909,8 +2945,11 @@ as a float so fractional damage, timers, and meters can accumulate correctly:
 `branch` executes `then` actions when its `if` condition passes and `else`
 actions when it does not. Either side may be omitted, which makes that branch a
 successful no-op. Conditions normally read scene state or actor properties.
-Actions that receive a runtime payload, such as `weapon.hitscan` or sensors,
-can also use `payload.compare` with the same comparison operators:
+`scene_state.compare`, `property.compare`, and `payload.compare` support
+`==`, `!=`, `<`, `<=`, `>`, and `>=` for numeric values, and `==` / `!=` for
+boolean and string values. Actions that receive a runtime payload, such as
+`weapon.hitscan` or sensors, can also use `payload.compare` with the same
+comparison operators:
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1322,6 +1322,10 @@ scene, player start, target actor, and runner argument array excluding mount
 flags. Editor hosts combine those arguments with their current `--root`,
 `--pack`, embedded, or fused launch context. The generic runner can consume the
 manifest directly with `--test-run-manifest <path-or-asset>`.
+For UI copy/paste affordances, `editor.test_run.prepare` and
+`editor.test_run.save_manifest` can also author `runner`, one mount option
+(`root`, `pack`, or `embedded`), and optional `media`. When `command_key` is
+present in `outputs`, the action publishes a quoted runner command string.
 
 ```json
 {
@@ -1333,7 +1337,8 @@ manifest directly with `--test-run-manifest <path-or-asset>`.
     "message_key": "editor.test_run.message",
     "manifest_json_key": "editor.test_run.manifest_json",
     "scene_key": "editor.test_run.scene",
-    "player_start_key": "editor.test_run.player_start"
+    "player_start_key": "editor.test_run.player_start",
+    "command_key": "editor.test_run.command"
   }
 }
 ```
@@ -1349,10 +1354,13 @@ the same `data_asset`, `scene`, and `player_start` fields as
   "data_asset": "asset://game.game.json",
   "player_start": "player_start.level_01",
   "path_from_state": "editor.test_run.path",
+  "runner": "./build/debug/slayer3d_runner",
+  "root": "path/to/game/data",
   "outputs": {
     "valid_key": "editor.test_run.saved",
     "message_key": "editor.test_run.save_message",
-    "path_key": "editor.test_run.path"
+    "path_key": "editor.test_run.path",
+    "command_key": "editor.test_run.command"
   }
 }
 ```

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1326,6 +1326,9 @@ For UI copy/paste affordances, `editor.test_run.prepare` and
 `editor.test_run.save_manifest` can also author `runner`, one mount option
 (`root`, `pack`, or `embedded`), and optional `media`. When `command_key` is
 present in `outputs`, the action publishes a quoted runner command string.
+Authored editor shells should usually run `editor.level.save` immediately before
+test-run preparation so the runner sees the latest blockout fragment rather than
+the last manually saved revision.
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1374,6 +1374,14 @@ is omitted, mouse-look is active whenever `mouse_look` is true. The controller
 writes `yaw`, `pitch`, and `camera_forward` by default; override those names
 with `yaw_property`, `pitch_property`, and `forward_property`.
 
+Editor scenes can pair one free-flight camera actor with multiple authored
+cameras. A typical graybox editor uses an `fps` or perspective camera for 3D
+inspection and orthographic cameras for top/front/side plotting. Bind UI or
+keyboard shortcuts to `camera.set` plus a scene-state `editor.view.mode` value
+so the active view is explicit and visible in inspector widgets. Selection
+traces that omit their `camera` field automatically use the active camera, so
+the same placement path works from perspective and orthographic views.
+
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -929,7 +929,12 @@ Selection mode defaults to `hover`, where `outputs` receives the current pick
 every frame. In `mode: "click"`, `outputs` receives the pinned selection and
 `hover_outputs` can publish the live hover independently. `select_button`
 defaults to `LEFT`; clicking empty space clears the pinned selection unless
-`clear_on_miss` is false.
+`clear_on_miss` is false. `on_select` may reference a signal to emit after a
+click updates the active selection and placement preview. The signal receives
+the same selection payload used by `editor.selection.run`, which lets authored
+editor tools turn one pointer click into a project-specific operation such as
+"place the active prefab" while keeping selection, placement preview, and
+command commits general-purpose.
 
 Editor selections can also drive generic logic actions:
 

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -860,7 +860,9 @@ face normal through the normal 3D presentation path:
         "work_plane": {
           "enabled": true,
           "normal": [0, 1, 0],
-          "distance": 0.0
+          "normal_key": "editor.work_plane.normal",
+          "distance": 0.0,
+          "distance_key": "editor.work_plane.distance"
         }
       },
       "outputs": {
@@ -909,12 +911,19 @@ plane described by `dot(normal, point) = distance` and publishes that as a hit
 with `selection_type: "none"`. This is intended for blockout tools: a blank
 scene can still place the first floor on the ground plane, while later clicks on
 real brush faces keep returning normal brush-world selections.
+`normal_key` and `distance_key` may point at scene-state values, allowing a
+single editor scene to switch between top/front/side orthographic plotting
+planes with data-authored `scene_state.set` and `camera.set` actions.
 
 Add `work_plane_grid` (or `grid`) to `editor.debug_overlay.flags` to visualize
 the authored work plane with reusable debug lines. `work_plane_grid_size` is the
 grid half-extent in world units, and `work_plane_grid_spacing` controls line
 spacing. The grid uses the same `work_plane.normal` and `work_plane.distance`
 as placement, so visual feedback and picking stay aligned.
+
+`scene_state.set` accepts boolean, numeric, string, and vec3-array values. Vec3
+scene-state values are useful for editor work-plane normals, runtime placement
+offsets, and other authored tool state that should not require Lua.
 
 Selection mode defaults to `hover`, where `outputs` receives the current pick
 every frame. In `mode: "click"`, `outputs` receives the pinned selection and

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1171,6 +1171,22 @@ current player-start collection as a `slayer3d.fragment.v0` document containing
 `editor_player_starts`. File writing remains host-owned, matching brush-world
 exports.
 
+Use `editor.player_start.apply` to move a stored player-start target actor back
+to its marker. This is useful for in-editor playable previews: apply the marker,
+then switch to the authored play/test scene with `scene.set`.
+
+```json
+{
+  "type": "editor.player_start.apply",
+  "name": "player_start.level_01",
+  "outputs": {
+    "valid_key": "editor.test_run.enter.valid",
+    "message_key": "editor.test_run.enter.message",
+    "target_key": "editor.test_run.enter.target"
+  }
+}
+```
+
 Use `editor.command.preview` to declare a non-mutating command intent against
 the active selection. This is the safe scaffolding layer for editor tools:
 commands can publish UI state and draw preview bounds without modifying the

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1025,19 +1025,26 @@ Scenes can also author `editor.placement` to show a live placement preview while
 the mouse hovers over a brush or work plane. `tool_key` names the scene-state
 property that selects the active tool. `snap_key` can point at a runtime
 scene-state float so UI or keyboard shortcuts can change grid size without
-reloading data. Each preview entry maps a tool `mode` to either a `box` ghost or
-a `player_start` marker. Box previews can use `axis_key` with `axis` `x` or `z`
-to rotate wall-like prefabs between horizontal grid axes. The preview reuses
-the editor debug overlay's `command_preview` flag and color, so editor hosts do
-not need a second rendering path.
+reloading data. `grid_size_key` can point at the same scene-state float when box
+previews use `grid_min` and `grid_max` instead of fixed `min` and `max` bounds.
+Those grid bounds are multipliers, so a floor authored from `[-0.5, 0, -0.5]`
+to `[0.5, 0.025, 0.5]` becomes one active grid cell wide at any configured grid
+size. Each preview entry maps a tool `mode` to either a `box` ghost or a
+`player_start` marker. Box previews can use `axis_key` with `axis` `x` or `z` to
+rotate wall-like prefabs between horizontal grid axes. A box preview must author
+exactly one bounds source: fixed `min`/`max`, or grid-scaled `grid_min`/
+`grid_max`. The preview reuses the editor debug overlay's `command_preview`
+flag and color, so editor hosts do not need a second rendering path.
 
 ```json
 {
   "editor": {
     "placement": {
       "tool_key": "editor.tool.mode",
-      "snap_key": "editor.placement.snap",
-      "default_snap": 0.5,
+      "snap_key": "editor.grid.size",
+      "grid_size_key": "editor.grid.size",
+      "default_snap": 8.0,
+      "default_grid_size": 8.0,
       "outputs": {
         "active_key": "editor.placement_preview.active",
         "mode_key": "editor.placement_preview.mode",
@@ -1050,9 +1057,8 @@ not need a second rendering path.
           "kind": "box",
           "world": "brush.level.blockout",
           "material": "mat.stone_floor",
-          "min": [-4.0, -0.25, -4.0],
-          "max": [4.0, 0.0, 4.0],
-          "snap": 0.5
+          "grid_min": [-0.5, -0.025, -0.5],
+          "grid_max": [0.5, 0.0, 0.5]
         },
         {
           "mode": "wall",
@@ -1061,8 +1067,8 @@ not need a second rendering path.
           "material": "mat.stone_wall",
           "axis_key": "editor.wall_axis",
           "axis": "z",
-          "min": [-0.125, 0.0, -3.0],
-          "max": [0.125, 2.5, 3.0]
+          "grid_min": [-0.03125, 0.0, -0.5],
+          "grid_max": [0.03125, 1.0, 0.5]
         },
         {
           "mode": "player_start",

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ data-authored games running on a generic SDL-powered runtime.
   actors, input, logic, arcade shooter primitives, networking, and validation.
 - [Gameplay Lua API](game-data-lua.md): Lua adapter model and runtime helper
   surface.
+- [Editor Test Drive](editor-test-drive.md): current graybox editor workflow,
+  controls, save/test-run loop, and correctness checks.
 - [Standard Options Package](standard-options.md): reusable display, audio,
   keyboard, mouse, and gamepad options screens.
 - [Storage](storage.md): `user://` and `cache://` writable data policy.

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -426,6 +426,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.player_start.place") == 0)
         return slayer3d_game_data_place_editor_player_start_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.player_start.apply") == 0)
+        return slayer3d_game_data_apply_editor_player_start_action(runtime, action);
+
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         const char *name = json_string(action, "name", NULL);

--- a/src/game_data_conditions_presentation.c
+++ b/src/game_data_conditions_presentation.c
@@ -28,6 +28,8 @@ static bool compare_value(const slayer3d_value *left, const char *op, yyjson_val
             return left->as_int < value;
         if (SDL_strcmp(op, "==") == 0)
             return left->as_int == value;
+        if (SDL_strcmp(op, "!=") == 0)
+            return left->as_int != value;
     }
     if (left->type == SLAYER3D_VALUE_FLOAT && yyjson_is_num(right))
     {
@@ -42,11 +44,24 @@ static bool compare_value(const slayer3d_value *left, const char *op, yyjson_val
             return left->as_float < value;
         if (SDL_strcmp(op, "==") == 0)
             return left->as_float == value;
+        if (SDL_strcmp(op, "!=") == 0)
+            return left->as_float != value;
     }
-    if (left->type == SLAYER3D_VALUE_BOOL && yyjson_is_bool(right) && SDL_strcmp(op, "==") == 0)
-        return left->as_bool == yyjson_get_bool(right);
-    if (left->type == SLAYER3D_VALUE_STRING && yyjson_is_str(right) && SDL_strcmp(op, "==") == 0)
-        return SDL_strcmp(left->as_string, yyjson_get_str(right)) == 0;
+    if (left->type == SLAYER3D_VALUE_BOOL && yyjson_is_bool(right))
+    {
+        if (SDL_strcmp(op, "==") == 0)
+            return left->as_bool == yyjson_get_bool(right);
+        if (SDL_strcmp(op, "!=") == 0)
+            return left->as_bool != yyjson_get_bool(right);
+    }
+    if (left->type == SLAYER3D_VALUE_STRING && yyjson_is_str(right))
+    {
+        const bool equal = SDL_strcmp(left->as_string, yyjson_get_str(right)) == 0;
+        if (SDL_strcmp(op, "==") == 0)
+            return equal;
+        if (SDL_strcmp(op, "!=") == 0)
+            return !equal;
+    }
     return false;
 }
 

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -57,6 +57,13 @@ static float editor_scene_state_float(const slayer3d_game_data_runtime *runtime,
                                           : fallback;
 }
 
+static slayer3d_vec3 editor_scene_state_vec3(const slayer3d_game_data_runtime *runtime, const char *key,
+                                             slayer3d_vec3 fallback)
+{
+    return runtime != NULL && key != NULL ? slayer3d_properties_get_vec3(runtime->scene_state, key, fallback)
+                                          : fallback;
+}
+
 static void editor_default_viewport(const slayer3d_game_data_runtime *runtime, float *out_width, float *out_height)
 {
     if (out_width == NULL || out_height == NULL)
@@ -167,29 +174,47 @@ bool editor_trace_desc_from_json(const slayer3d_game_data_runtime *runtime, yyjs
     return true;
 }
 
-static bool editor_work_plane_selection_from_trace(yyjson_val *selection,
-                                                   const slayer3d_game_data_world_trace_desc *trace,
-                                                   slayer3d_game_data_editor_selection *out_selection)
+static bool editor_work_plane_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *work_plane,
+                                        slayer3d_vec3 *out_normal, float *out_distance)
 {
-    init_editor_selection(out_selection);
-    yyjson_val *work_plane = obj_get(obj_get(selection, "trace"), "work_plane");
-    if (!yyjson_is_obj(work_plane) || !json_bool(work_plane, "enabled", true) || trace == NULL || out_selection == NULL)
+    if (!yyjson_is_obj(work_plane) || !json_bool(work_plane, "enabled", true) || out_normal == NULL ||
+        out_distance == NULL)
     {
         return false;
     }
 
     slayer3d_vec3 normal = json_vec3(work_plane, "normal", slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
-    const float normal_length_squared = slayer3d_vec3_length_squared(normal);
-    if (normal_length_squared <= 0.000001f)
+    normal = editor_scene_state_vec3(runtime, json_string(work_plane, "normal_key", NULL), normal);
+    if (slayer3d_vec3_length_squared(normal) <= 0.000001f)
         return false;
-    normal = slayer3d_vec3_normalize(normal);
+
+    *out_normal = slayer3d_vec3_normalize(normal);
+    *out_distance = editor_scene_state_float(runtime, json_string(work_plane, "distance_key", NULL),
+                                             json_float(work_plane, "distance", 0.0f));
+    return true;
+}
+
+static bool editor_work_plane_selection_from_trace(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
+                                                   const slayer3d_game_data_world_trace_desc *trace,
+                                                   slayer3d_game_data_editor_selection *out_selection)
+{
+    init_editor_selection(out_selection);
+    yyjson_val *work_plane = obj_get(obj_get(selection, "trace"), "work_plane");
+    if (trace == NULL || out_selection == NULL)
+    {
+        return false;
+    }
+
+    slayer3d_vec3 normal;
+    float distance = 0.0f;
+    if (!editor_work_plane_from_json(runtime, work_plane, &normal, &distance))
+        return false;
 
     const slayer3d_vec3 direction = slayer3d_vec3_sub(trace->end, trace->start);
     const float denominator = slayer3d_vec3_dot(normal, direction);
     if (SDL_fabsf(denominator) <= 0.000001f)
         return false;
 
-    const float distance = json_float(work_plane, "distance", 0.0f);
     const float fraction = (distance - slayer3d_vec3_dot(normal, trace->start)) / denominator;
     if (fraction < 0.0f || fraction > 1.0f)
         return false;
@@ -204,20 +229,10 @@ static bool editor_work_plane_selection_from_trace(yyjson_val *selection,
     return true;
 }
 
-bool editor_work_plane_desc_from_trace_json(yyjson_val *trace, slayer3d_vec3 *out_normal, float *out_distance)
+bool editor_work_plane_desc_from_trace_json(const slayer3d_game_data_runtime *runtime, yyjson_val *trace,
+                                            slayer3d_vec3 *out_normal, float *out_distance)
 {
-    yyjson_val *work_plane = obj_get(trace, "work_plane");
-    if (!yyjson_is_obj(work_plane) || !json_bool(work_plane, "enabled", true) || out_normal == NULL ||
-        out_distance == NULL)
-    {
-        return false;
-    }
-    slayer3d_vec3 normal = json_vec3(work_plane, "normal", slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
-    if (slayer3d_vec3_length_squared(normal) <= 0.000001f)
-        return false;
-    *out_normal = slayer3d_vec3_normalize(normal);
-    *out_distance = json_float(work_plane, "distance", 0.0f);
-    return true;
+    return editor_work_plane_from_json(runtime, obj_get(trace, "work_plane"), out_normal, out_distance);
 }
 
 bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
@@ -229,10 +244,10 @@ bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, 
         return false;
 
     if (!slayer3d_game_data_pick_editor_world_model(runtime, trace, out_selection))
-        return editor_work_plane_selection_from_trace(selection, trace, out_selection);
+        return editor_work_plane_selection_from_trace(runtime, selection, trace, out_selection);
     if (out_selection->hit)
         return true;
-    if (editor_work_plane_selection_from_trace(selection, trace, out_selection))
+    if (editor_work_plane_selection_from_trace(runtime, selection, trace, out_selection))
         return true;
     return true;
 }

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -287,6 +287,26 @@ static bool editor_selection_select_requested(const slayer3d_game_data_runtime *
     return button != 0 && slayer3d_input_get_pressed_mouse_button(input) == button;
 }
 
+static bool emit_editor_selection_signal(slayer3d_game_data_runtime *runtime, yyjson_val *selection_json,
+                                         const char *signal_key, const slayer3d_game_data_editor_selection *selection)
+{
+    const char *signal = json_string(selection_json, signal_key, NULL);
+    if (signal == NULL)
+        return true;
+
+    slayer3d_signal_bus *bus = runtime_bus(runtime);
+    const int signal_id = slayer3d_game_data_find_signal(runtime, signal);
+    if (bus == NULL || signal_id < 0)
+        return false;
+
+    slayer3d_properties *payload = slayer3d_game_data_create_editor_selection_payload(selection);
+    if (payload == NULL)
+        return false;
+    slayer3d_signal_emit(bus, signal_id, payload);
+    slayer3d_properties_destroy(payload);
+    return true;
+}
+
 static const char *editor_selection_type_name(slayer3d_game_data_world_model_type type)
 {
     if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_SECTOR_LEVEL)
@@ -365,7 +385,8 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
 
     publish_editor_selection(runtime, obj_get(selection_json, "hover_outputs"), &hover_selection);
     update_editor_placement_preview(runtime, editor, &hover_selection);
-    if (editor_selection_select_requested(runtime, selection_json))
+    const bool select_requested = editor_selection_select_requested(runtime, selection_json);
+    if (select_requested)
     {
         if (hover_selection.hit)
             runtime->editor_active_selection = hover_selection;
@@ -375,6 +396,11 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     }
 
     publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+    if (select_requested &&
+        !emit_editor_selection_signal(runtime, selection_json, "on_select", &runtime->editor_active_selection))
+    {
+        return false;
+    }
     return true;
 }
 

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -94,7 +94,7 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
     {
         out_desc->trace = out_trace;
         out_desc->has_work_plane_grid = editor_work_plane_desc_from_trace_json(
-            obj_get(selection_json, "trace"), &out_desc->work_plane_normal, &out_desc->work_plane_distance);
+            runtime, obj_get(selection_json, "trace"), &out_desc->work_plane_normal, &out_desc->work_plane_distance);
         if (out_selection != NULL && editor_selection_mode_is_click(selection_json) &&
             editor_selection_active_for_scene(runtime) && runtime->editor_active_selection.hit)
         {

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -52,6 +52,108 @@ static const char *editor_action_path(slayer3d_game_data_runtime *runtime, yyjso
     return json_string(action, "path", fallback);
 }
 
+static bool append_command_text(char *buffer, size_t buffer_size, size_t *offset, const char *text)
+{
+    if (buffer == NULL || buffer_size == 0u || offset == NULL || text == NULL)
+        return false;
+    if (*offset >= buffer_size)
+    {
+        buffer[buffer_size - 1u] = '\0';
+        return false;
+    }
+    const int written = SDL_snprintf(buffer + *offset, buffer_size - *offset, "%s", text);
+    if (written < 0 || (size_t)written >= buffer_size - *offset)
+    {
+        buffer[buffer_size - 1u] = '\0';
+        return false;
+    }
+    *offset += (size_t)written;
+    return true;
+}
+
+static bool append_command_arg(char *buffer, size_t buffer_size, size_t *offset, const char *arg)
+{
+    if (arg == NULL || arg[0] == '\0')
+        return true;
+    if (!append_command_text(buffer, buffer_size, offset, " \""))
+        return false;
+    for (const char *cursor = arg; *cursor != '\0'; ++cursor)
+    {
+        char escaped[3] = {*cursor, '\0', '\0'};
+        if (*cursor == '"' || *cursor == '\\')
+        {
+            escaped[0] = '\\';
+            escaped[1] = *cursor;
+        }
+        if (!append_command_text(buffer, buffer_size, offset, escaped))
+            return false;
+    }
+    return append_command_text(buffer, buffer_size, offset, "\"");
+}
+
+static bool append_test_run_mount_args(char *buffer, size_t buffer_size, size_t *offset, yyjson_val *action)
+{
+    const char *root = json_string(action, "root", NULL);
+    const char *pack = json_string(action, "pack", NULL);
+    if (root != NULL && (!append_command_text(buffer, buffer_size, offset, " --root") ||
+                         !append_command_arg(buffer, buffer_size, offset, root)))
+    {
+        return false;
+    }
+    if (pack != NULL && (!append_command_text(buffer, buffer_size, offset, " --pack") ||
+                         !append_command_arg(buffer, buffer_size, offset, pack)))
+    {
+        return false;
+    }
+    if (json_bool(action, "embedded", false) && !append_command_text(buffer, buffer_size, offset, " --embedded"))
+        return false;
+    const char *media = json_string(action, "media", NULL);
+    if (media != NULL && (!append_command_text(buffer, buffer_size, offset, " --media") ||
+                          !append_command_arg(buffer, buffer_size, offset, media)))
+    {
+        return false;
+    }
+    return true;
+}
+
+static bool format_test_run_direct_command(char *buffer, size_t buffer_size, yyjson_val *action,
+                                           const slayer3d_game_data_editor_test_run_desc *desc,
+                                           const char *resolved_scene)
+{
+    size_t offset = 0u;
+    const char *runner = json_string(action, "runner", "slayer3d_runner");
+    if (!append_command_text(buffer, buffer_size, &offset, runner) ||
+        !append_test_run_mount_args(buffer, buffer_size, &offset, action) ||
+        !append_command_text(buffer, buffer_size, &offset, " --data") ||
+        !append_command_arg(buffer, buffer_size, &offset, desc != NULL ? desc->data_asset_path : NULL))
+    {
+        return false;
+    }
+    if (resolved_scene != NULL && resolved_scene[0] != '\0' &&
+        (!append_command_text(buffer, buffer_size, &offset, " --scene") ||
+         !append_command_arg(buffer, buffer_size, &offset, resolved_scene)))
+    {
+        return false;
+    }
+    if (desc != NULL && desc->player_start != NULL && desc->player_start[0] != '\0' &&
+        (!append_command_text(buffer, buffer_size, &offset, " --player-start") ||
+         !append_command_arg(buffer, buffer_size, &offset, desc->player_start)))
+    {
+        return false;
+    }
+    return true;
+}
+
+static bool format_test_run_manifest_command(char *buffer, size_t buffer_size, yyjson_val *action, const char *path)
+{
+    size_t offset = 0u;
+    const char *runner = json_string(action, "runner", "slayer3d_runner");
+    return append_command_text(buffer, buffer_size, &offset, runner) &&
+           append_test_run_mount_args(buffer, buffer_size, &offset, action) &&
+           append_command_text(buffer, buffer_size, &offset, " --test-run-manifest") &&
+           append_command_arg(buffer, buffer_size, &offset, path);
+}
+
 bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, const char *world_name,
                                        const char *message, bool publish_result)
 {
@@ -219,6 +321,10 @@ bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtim
     const char *resolved_scene = desc.scene != NULL && desc.scene[0] != '\0'
                                      ? desc.scene
                                      : (has_start && start.scene != NULL ? start.scene : "");
+    char command[1024];
+    command[0] = '\0';
+    const bool command_ok =
+        ok && format_test_run_direct_command(command, sizeof(command), action, &desc, resolved_scene);
 
     slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     editor_set_bool_output(scene_state, outputs, "valid_key", ok);
@@ -232,6 +338,7 @@ bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtim
     editor_set_string_output(scene_state, outputs, "player_start_key",
                              ok && desc.player_start != NULL ? desc.player_start : "");
     editor_set_string_output(scene_state, outputs, "target_key", has_start && start.target != NULL ? start.target : "");
+    editor_set_string_output(scene_state, outputs, "command_key", command_ok ? command : "");
     SDL_free(json);
     return true;
 }
@@ -262,6 +369,9 @@ bool slayer3d_game_data_save_editor_test_run_manifest_action(slayer3d_game_data_
     const char *resolved_scene = desc.scene != NULL && desc.scene[0] != '\0'
                                      ? desc.scene
                                      : (has_start && start.scene != NULL ? start.scene : "");
+    char command[1024];
+    command[0] = '\0';
+    const bool command_ok = ok && format_test_run_manifest_command(command, sizeof(command), action, path);
 
     slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     editor_set_bool_output(scene_state, outputs, "valid_key", ok);
@@ -276,6 +386,7 @@ bool slayer3d_game_data_save_editor_test_run_manifest_action(slayer3d_game_data_
     editor_set_string_output(scene_state, outputs, "player_start_key",
                              ok && desc.player_start != NULL ? desc.player_start : "");
     editor_set_string_output(scene_state, outputs, "target_key", has_start && start.target != NULL ? start.target : "");
+    editor_set_string_output(scene_state, outputs, "command_key", command_ok ? command : "");
     SDL_free(json);
     return true;
 }

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -449,3 +449,19 @@ bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runt
     publish_editor_player_start_state(runtime, outputs, ok ? find_editor_player_start(runtime, desc.name) : NULL);
     return true;
 }
+
+bool slayer3d_game_data_apply_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    const char *name = json_string(action, "name", NULL);
+    char error[256];
+    error[0] = '\0';
+    const bool ok = slayer3d_game_data_apply_editor_player_start(runtime, name, error, (int)sizeof(error));
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? json_string(action, "message", "player start applied")
+                                : (error[0] != '\0' ? error : "player start apply failed"));
+    publish_editor_player_start_state(runtime, outputs, ok ? find_editor_player_start(runtime, name) : NULL);
+    return true;
+}

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -67,6 +67,20 @@ static float editor_placement_snap(slayer3d_game_data_runtime *runtime, yyjson_v
     return authored_snap;
 }
 
+static float editor_placement_grid_size(slayer3d_game_data_runtime *runtime, yyjson_val *placement, yyjson_val *preview,
+                                        float fallback)
+{
+    const float authored_grid_size =
+        json_float(preview, "grid_size", json_float(placement, "default_grid_size", fallback));
+    const char *grid_size_key = json_string(preview, "grid_size_key", json_string(placement, "grid_size_key", NULL));
+    if (runtime != NULL && grid_size_key != NULL && grid_size_key[0] != '\0')
+    {
+        return slayer3d_properties_get_float(slayer3d_game_data_scene_state(runtime), grid_size_key,
+                                             authored_grid_size);
+    }
+    return authored_grid_size;
+}
+
 static const char *editor_placement_axis(slayer3d_game_data_runtime *runtime, yyjson_val *preview)
 {
     const char *authored_axis = json_string(preview, "axis", "z");
@@ -76,11 +90,24 @@ static const char *editor_placement_axis(slayer3d_game_data_runtime *runtime, yy
     return authored_axis;
 }
 
-static slayer3d_bounding_box editor_placement_oriented_box_bounds(yyjson_val *preview_json, slayer3d_vec3 anchor,
-                                                                  const char *axis)
+static slayer3d_vec3 editor_grid_scaled_vec3(yyjson_val *obj, const char *key, float grid_size)
 {
-    const slayer3d_vec3 source_min = json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
-    const slayer3d_vec3 source_max = json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return slayer3d_vec3_scale(json_vec3(obj, key, slayer3d_vec3_make(0.0f, 0.0f, 0.0f)), grid_size);
+}
+
+static slayer3d_bounding_box editor_placement_oriented_box_bounds(slayer3d_game_data_runtime *runtime,
+                                                                  yyjson_val *placement, yyjson_val *preview_json,
+                                                                  slayer3d_vec3 anchor, const char *axis, float snap)
+{
+    const bool uses_grid_bounds =
+        obj_get(preview_json, "grid_min") != NULL || obj_get(preview_json, "grid_max") != NULL;
+    const float grid_size = editor_placement_grid_size(runtime, placement, preview_json, snap);
+    const slayer3d_vec3 source_min = uses_grid_bounds
+                                         ? editor_grid_scaled_vec3(preview_json, "grid_min", grid_size)
+                                         : json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const slayer3d_vec3 source_max = uses_grid_bounds
+                                         ? editor_grid_scaled_vec3(preview_json, "grid_max", grid_size)
+                                         : json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
     slayer3d_bounding_box bounds;
     if (axis != NULL && SDL_strcmp(axis, "x") == 0)
     {
@@ -157,7 +184,8 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     }
     else
     {
-        preview->bounds = editor_placement_oriented_box_bounds(preview_json, anchor, preview->axis);
+        preview->bounds =
+            editor_placement_oriented_box_bounds(runtime, placement, preview_json, anchor, preview->axis, snap);
     }
     publish_editor_placement_preview(runtime, outputs, true, preview_json, preview,
                                      json_string(preview_json, "message", "placement preview"));

--- a/src/game_data_input_device_helpers.c
+++ b/src/game_data_input_device_helpers.c
@@ -31,6 +31,14 @@ SDL_Scancode scancode_from_json(const char *name)
         return SDL_SCANCODE_COMMA;
     if (SDL_strcmp(name, "PERIOD") == 0)
         return SDL_SCANCODE_PERIOD;
+    if (SDL_strcmp(name, "MINUS") == 0)
+        return SDL_SCANCODE_MINUS;
+    if (SDL_strcmp(name, "EQUALS") == 0)
+        return SDL_SCANCODE_EQUALS;
+    if (SDL_strcmp(name, "KP_MINUS") == 0)
+        return SDL_SCANCODE_KP_MINUS;
+    if (SDL_strcmp(name, "KP_PLUS") == 0)
+        return SDL_SCANCODE_KP_PLUS;
     if (SDL_strlen(name) == 1)
         return SDL_GetScancodeFromKey(SDL_GetKeyFromName(name), NULL);
     return SDL_GetScancodeFromName(name);

--- a/src/game_data_input_device_helpers.c
+++ b/src/game_data_input_device_helpers.c
@@ -39,6 +39,14 @@ SDL_Scancode scancode_from_json(const char *name)
         return SDL_SCANCODE_KP_MINUS;
     if (SDL_strcmp(name, "KP_PLUS") == 0)
         return SDL_SCANCODE_KP_PLUS;
+    if (SDL_strcmp(name, "F1") == 0)
+        return SDL_SCANCODE_F1;
+    if (SDL_strcmp(name, "F2") == 0)
+        return SDL_SCANCODE_F2;
+    if (SDL_strcmp(name, "F3") == 0)
+        return SDL_SCANCODE_F3;
+    if (SDL_strcmp(name, "F4") == 0)
+        return SDL_SCANCODE_F4;
     if (SDL_strlen(name) == 1)
         return SDL_GetScancodeFromKey(SDL_GetKeyFromName(name), NULL);
     return SDL_GetScancodeFromName(name);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -913,6 +913,7 @@ bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_d
                                                                  yyjson_val *action);
 bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_apply_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 bool eval_data_condition_with_payload(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -1058,7 +1058,8 @@ bool editor_command_preview_active_for_scene(const slayer3d_game_data_runtime *r
 bool editor_placement_preview_active_for_scene(const slayer3d_game_data_runtime *runtime);
 bool editor_trace_desc_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
                                  slayer3d_game_data_world_trace_desc *out_trace);
-bool editor_work_plane_desc_from_trace_json(yyjson_val *trace, slayer3d_vec3 *out_normal, float *out_distance);
+bool editor_work_plane_desc_from_trace_json(const slayer3d_game_data_runtime *runtime, yyjson_val *trace,
+                                            slayer3d_vec3 *out_normal, float *out_distance);
 bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
                                      const slayer3d_game_data_world_trace_desc *trace,
                                      slayer3d_game_data_editor_selection *out_selection);

--- a/src/game_data_menu_ui.c
+++ b/src/game_data_menu_ui.c
@@ -1127,6 +1127,12 @@ bool set_property_from_json(slayer3d_properties *props, const char *key, yyjson_
 {
     if (props == NULL || key == NULL || value == NULL)
         return false;
+    if (yyjson_is_arr(value) && yyjson_arr_size(value) == 3 && yyjson_is_num(yyjson_arr_get(value, 0)) &&
+        yyjson_is_num(yyjson_arr_get(value, 1)) && yyjson_is_num(yyjson_arr_get(value, 2)))
+    {
+        slayer3d_properties_set_vec3(props, key, json_vec3_value(value, slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
+        return true;
+    }
     if (yyjson_is_bool(value))
     {
         slayer3d_properties_set_bool(props, key, yyjson_get_bool(value));

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7386,8 +7386,11 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (!is_non_empty_string(action, "key"))
             return validation_error(ctx, json_path, "scene_state.set requires a non-empty key");
         yyjson_val *value = obj_get(action, "value");
-        if (value == NULL || !(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value)))
-            return validation_error(ctx, json_path, "scene_state.set requires a scalar value");
+        if (value == NULL ||
+            !(yyjson_is_bool(value) || yyjson_is_num(value) || yyjson_is_str(value) || is_exact_vec_array(value, 3)))
+        {
+            return validation_error(ctx, json_path, "scene_state.set requires a scalar or vec3 value");
+        }
         return true;
     }
     if (SDL_strcmp(type, "scene_state.toggle") == 0)

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7631,6 +7631,22 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     {
         if (!is_non_empty_string(action, "data_asset"))
             return validation_error(ctx, json_path, "editor.test_run.prepare requires a non-empty data_asset");
+        static const char *const string_fields[] = {"runner", "root", "pack", "media"};
+        for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+        {
+            yyjson_val *field = obj_get(action, string_fields[i]);
+            if (field != NULL && (!yyjson_is_str(field) || yyjson_get_str(field)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.test_run.prepare command fields must be non-empty strings");
+        }
+        yyjson_val *embedded = obj_get(action, "embedded");
+        if (embedded != NULL && !yyjson_is_bool(embedded))
+            return validation_error(ctx, json_path, "editor.test_run.prepare embedded must be a boolean");
+        const int mount_count = (obj_get(action, "root") != NULL ? 1 : 0) + (obj_get(action, "pack") != NULL ? 1 : 0) +
+                                (embedded != NULL && yyjson_get_bool(embedded) ? 1 : 0);
+        if (mount_count > 1)
+            return validation_error(ctx, json_path,
+                                    "editor.test_run.prepare accepts at most one of root, pack, or embedded");
         const char *scene = json_string(action, "scene");
         if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, json_path))
             return false;
@@ -7647,8 +7663,9 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *outputs = obj_get(action, "outputs");
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "editor.test_run.prepare outputs must be an object");
-        static const char *const output_keys[] = {"valid_key",      "message_key", "manifest_json_key", "size_key",
-                                                  "data_asset_key", "scene_key",   "player_start_key",  "target_key"};
+        static const char *const output_keys[] = {"valid_key",        "message_key",    "manifest_json_key",
+                                                  "size_key",         "data_asset_key", "scene_key",
+                                                  "player_start_key", "target_key",     "command_key"};
         for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
         {
             yyjson_val *output = obj_get(outputs, output_keys[i]);
@@ -7662,6 +7679,22 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
     {
         if (!is_non_empty_string(action, "data_asset"))
             return validation_error(ctx, json_path, "editor.test_run.save_manifest requires a non-empty data_asset");
+        static const char *const string_fields[] = {"runner", "root", "pack", "media"};
+        for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+        {
+            yyjson_val *field = obj_get(action, string_fields[i]);
+            if (field != NULL && (!yyjson_is_str(field) || yyjson_get_str(field)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.test_run.save_manifest command fields must be non-empty strings");
+        }
+        yyjson_val *embedded = obj_get(action, "embedded");
+        if (embedded != NULL && !yyjson_is_bool(embedded))
+            return validation_error(ctx, json_path, "editor.test_run.save_manifest embedded must be a boolean");
+        const int mount_count = (obj_get(action, "root") != NULL ? 1 : 0) + (obj_get(action, "pack") != NULL ? 1 : 0) +
+                                (embedded != NULL && yyjson_get_bool(embedded) ? 1 : 0);
+        if (mount_count > 1)
+            return validation_error(ctx, json_path,
+                                    "editor.test_run.save_manifest accepts at most one of root, pack, or embedded");
         yyjson_val *path = obj_get(action, "path");
         yyjson_val *path_from_state = obj_get(action, "path_from_state");
         if ((path == NULL && path_from_state == NULL) || (path != NULL && path_from_state != NULL))
@@ -7689,9 +7722,9 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *outputs = obj_get(action, "outputs");
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "editor.test_run.save_manifest outputs must be an object");
-        static const char *const output_keys[] = {"valid_key",         "message_key",      "path_key",
-                                                  "manifest_json_key", "size_key",         "data_asset_key",
-                                                  "scene_key",         "player_start_key", "target_key"};
+        static const char *const output_keys[] = {"valid_key",  "message_key",    "path_key",  "manifest_json_key",
+                                                  "size_key",   "data_asset_key", "scene_key", "player_start_key",
+                                                  "target_key", "command_key"};
         for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
         {
             yyjson_val *output = obj_get(outputs, output_keys[i]);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7861,6 +7861,28 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.player_start.apply") == 0)
+    {
+        if (!is_non_empty_string(action, "name"))
+            return validation_error(ctx, json_path, "editor.player_start.apply requires a non-empty name");
+        const char *name = json_string(action, "name");
+        if (!require_ref(ctx, &names->editor_player_starts, "editor player start", name, json_path))
+            return false;
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.player_start.apply outputs must be an object");
+        static const char *const output_keys[] = {"valid_key",  "message_key",  "player_start_key",  "scene_key",
+                                                  "target_key", "position_key", "yaw_key",           "pitch_key",
+                                                  "dirty_key",  "revision_key", "saved_revision_key"};
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path,
+                                        "editor.player_start.apply output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {
         if (!is_non_empty_string(action, "name"))

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -2724,7 +2724,7 @@ static bool is_side_name(const char *side)
 static bool is_compare_op(const char *op)
 {
     return op != NULL && (SDL_strcmp(op, ">=") == 0 || SDL_strcmp(op, ">") == 0 || SDL_strcmp(op, "<=") == 0 ||
-                          SDL_strcmp(op, "<") == 0 || SDL_strcmp(op, "==") == 0);
+                          SDL_strcmp(op, "<") == 0 || SDL_strcmp(op, "==") == 0 || SDL_strcmp(op, "!=") == 0);
 }
 
 bool is_vec_array(yyjson_val *value, size_t min_count)

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -214,6 +214,16 @@ static bool validate_scene_editor_work_plane(validation_context *ctx, yyjson_val
     {
         return false;
     }
+
+    char key_path[PATH_BUFFER_SIZE];
+    static const char *const string_keys[] = {"normal_key", "distance_key"};
+    for (size_t i = 0; i < SDL_arraysize(string_keys); ++i)
+    {
+        format_path(key_path, sizeof(key_path), "%s.%s", work_plane_path, string_keys[i]);
+        if (!validate_optional_non_empty_string(ctx, obj_get(work_plane, string_keys[i]), key_path,
+                                                "scene editor selection work_plane key"))
+            return false;
+    }
     return true;
 }
 

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -517,6 +517,16 @@ bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_ro
         format_path(hover_outputs_path, sizeof(hover_outputs_path), "%s.hover_outputs", selection_path);
         if (!validate_scene_editor_outputs(ctx, obj_get(selection, "hover_outputs"), hover_outputs_path))
             return false;
+        yyjson_val *on_select = obj_get(selection, "on_select");
+        if (on_select != NULL)
+        {
+            char on_select_path[PATH_BUFFER_SIZE];
+            format_path(on_select_path, sizeof(on_select_path), "%s.on_select", selection_path);
+            if (!yyjson_is_str(on_select) || yyjson_get_str(on_select)[0] == '\0')
+                return validation_error(ctx, on_select_path, "scene editor selection on_select must be a signal");
+            if (!require_ref(ctx, &names->signals, "signal", yyjson_get_str(on_select), on_select_path))
+                return false;
+        }
     }
 
     char placement_path[PATH_BUFFER_SIZE];

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -291,7 +291,7 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     if (!yyjson_is_obj(placement))
         return validation_error(ctx, placement_path, "scene editor placement must be an object");
 
-    const char *string_fields[] = {"tool_key", "snap_key", "default_tool"};
+    const char *string_fields[] = {"tool_key", "snap_key", "grid_size_key", "default_tool"};
     for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
     {
         char field_path[PATH_BUFFER_SIZE];
@@ -303,6 +303,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     yyjson_val *default_snap = obj_get(placement, "default_snap");
     if (default_snap != NULL && (!yyjson_is_num(default_snap) || yyjson_get_num(default_snap) <= 0.0))
         return validation_error(ctx, placement_path, "scene editor placement default_snap must be positive");
+    yyjson_val *default_grid_size = obj_get(placement, "default_grid_size");
+    if (default_grid_size != NULL && (!yyjson_is_num(default_grid_size) || yyjson_get_num(default_grid_size) <= 0.0))
+        return validation_error(ctx, placement_path, "scene editor placement default_grid_size must be positive");
 
     yyjson_val *outputs = obj_get(placement, "outputs");
     if (outputs != NULL && !yyjson_is_obj(outputs))
@@ -339,6 +342,10 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         yyjson_val *axis_key = obj_get(preview, "axis_key");
         if (axis_key != NULL && (!yyjson_is_str(axis_key) || yyjson_get_str(axis_key)[0] == '\0'))
             return validation_error(ctx, preview_path, "scene editor placement preview axis_key must be non-empty");
+        yyjson_val *grid_size_key = obj_get(preview, "grid_size_key");
+        if (grid_size_key != NULL && (!yyjson_is_str(grid_size_key) || yyjson_get_str(grid_size_key)[0] == '\0'))
+            return validation_error(ctx, preview_path,
+                                    "scene editor placement preview grid_size_key must be non-empty");
         const char *axis = json_string(preview, "axis");
         if (axis != NULL && SDL_strcmp(axis, "x") != 0 && SDL_strcmp(axis, "z") != 0)
             return validation_error(ctx, preview_path, "scene editor placement preview axis must be x or z");
@@ -348,6 +355,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         yyjson_val *snap = obj_get(preview, "snap");
         if (snap != NULL && (!yyjson_is_num(snap) || yyjson_get_num(snap) <= 0.0))
             return validation_error(ctx, preview_path, "scene editor placement preview snap must be positive");
+        yyjson_val *grid_size = obj_get(preview, "grid_size");
+        if (grid_size != NULL && (!yyjson_is_num(grid_size) || yyjson_get_num(grid_size) <= 0.0))
+            return validation_error(ctx, preview_path, "scene editor placement preview grid_size must be positive");
         if (SDL_strcmp(kind, "player_start") == 0)
         {
             yyjson_val *size = obj_get(preview, "size");
@@ -366,11 +376,28 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
             return validation_error(ctx, preview_path, "scene editor placement box preview requires a material");
         yyjson_val *min = obj_get(preview, "min");
         yyjson_val *max = obj_get(preview, "max");
-        if (!is_exact_vec_array(min, 3) || !is_exact_vec_array(max, 3))
-            return validation_error(ctx, preview_path, "scene editor placement box preview requires min and max vec3");
-        if (!(yyjson_get_num(yyjson_arr_get(min, 0)) < yyjson_get_num(yyjson_arr_get(max, 0)) &&
-              yyjson_get_num(yyjson_arr_get(min, 1)) < yyjson_get_num(yyjson_arr_get(max, 1)) &&
-              yyjson_get_num(yyjson_arr_get(min, 2)) < yyjson_get_num(yyjson_arr_get(max, 2))))
+        yyjson_val *grid_min = obj_get(preview, "grid_min");
+        yyjson_val *grid_max = obj_get(preview, "grid_max");
+        const bool has_static_bounds = min != NULL || max != NULL;
+        const bool has_grid_bounds = grid_min != NULL || grid_max != NULL;
+        if (has_static_bounds == has_grid_bounds)
+        {
+            return validation_error(ctx, preview_path,
+                                    "scene editor placement box preview requires exactly one of min/max or "
+                                    "grid_min/grid_max bounds");
+        }
+        yyjson_val *bounds_min = has_grid_bounds ? grid_min : min;
+        yyjson_val *bounds_max = has_grid_bounds ? grid_max : max;
+        if (!is_exact_vec_array(bounds_min, 3) || !is_exact_vec_array(bounds_max, 3))
+        {
+            return validation_error(ctx, preview_path,
+                                    has_grid_bounds
+                                        ? "scene editor placement box preview requires grid_min and grid_max vec3"
+                                        : "scene editor placement box preview requires min and max vec3");
+        }
+        if (!(yyjson_get_num(yyjson_arr_get(bounds_min, 0)) < yyjson_get_num(yyjson_arr_get(bounds_max, 0)) &&
+              yyjson_get_num(yyjson_arr_get(bounds_min, 1)) < yyjson_get_num(yyjson_arr_get(bounds_max, 1)) &&
+              yyjson_get_num(yyjson_arr_get(bounds_min, 2)) < yyjson_get_num(yyjson_arr_get(bounds_max, 2))))
         {
             return validation_error(ctx, preview_path, "scene editor placement box preview bounds require min < max");
         }

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -19,6 +19,12 @@ static const char *json_string(yyjson_val *object, const char *key)
     return validation_json_string(object, key);
 }
 
+static const char *json_string_default(yyjson_val *object, const char *key, const char *default_value)
+{
+    const char *value = validation_json_string(object, key);
+    return value != NULL ? value : default_value;
+}
+
 static bool is_non_empty_string(yyjson_val *object, const char *key)
 {
     const char *value = json_string(object, key);
@@ -415,6 +421,69 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     return true;
 }
 
+static bool scene_editor_placement_has_preview_mode(yyjson_val *placement, const char *mode)
+{
+    yyjson_val *previews = obj_get(placement, "previews");
+    for (size_t i = 0; yyjson_is_arr(previews) && i < yyjson_arr_size(previews); ++i)
+    {
+        yyjson_val *preview = yyjson_arr_get(previews, i);
+        if (SDL_strcmp(json_string_default(preview, "mode", ""), mode != NULL ? mode : "") == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool validate_scene_editor_palette(validation_context *ctx, yyjson_val *palette, yyjson_val *placement,
+                                          const char *palette_path)
+{
+    if (palette == NULL)
+        return true;
+    if (!yyjson_is_obj(palette))
+        return validation_error(ctx, palette_path, "scene editor palette must be an object");
+
+    char field_path[PATH_BUFFER_SIZE];
+    format_path(field_path, sizeof(field_path), "%s.selected_key", palette_path);
+    if (!validate_optional_non_empty_string(ctx, obj_get(palette, "selected_key"), field_path,
+                                            "scene editor palette selected_key"))
+        return false;
+
+    yyjson_val *entries = obj_get(palette, "entries");
+    if (!yyjson_is_arr(entries) || yyjson_arr_size(entries) == 0)
+        return validation_error(ctx, palette_path, "scene editor palette entries must be a non-empty array");
+
+    for (size_t i = 0; i < yyjson_arr_size(entries); ++i)
+    {
+        char entry_path[PATH_BUFFER_SIZE];
+        format_path(entry_path, sizeof(entry_path), "%s.entries[%zu]", palette_path, i);
+        yyjson_val *entry = yyjson_arr_get(entries, i);
+        if (!yyjson_is_obj(entry))
+            return validation_error(ctx, entry_path, "scene editor palette entry must be an object");
+        if (!is_non_empty_string(entry, "mode"))
+            return validation_error(ctx, entry_path, "scene editor palette entry requires a non-empty mode");
+        if (!is_non_empty_string(entry, "label"))
+            return validation_error(ctx, entry_path, "scene editor palette entry requires a non-empty label");
+
+        static const char *const optional_string_fields[] = {"shortcut", "category", "description"};
+        for (size_t field_index = 0; field_index < SDL_arraysize(optional_string_fields); ++field_index)
+        {
+            format_path(field_path, sizeof(field_path), "%s.%s", entry_path, optional_string_fields[field_index]);
+            if (!validate_optional_non_empty_string(ctx, obj_get(entry, optional_string_fields[field_index]),
+                                                    field_path, "scene editor palette entry field"))
+                return false;
+        }
+
+        const char *kind = json_string_default(entry, "kind", "box");
+        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0 && SDL_strcmp(kind, "thing") != 0)
+            return validation_error(ctx, entry_path,
+                                    "scene editor palette entry kind must be box, player_start, or thing");
+
+        const char *preview = json_string_default(entry, "preview", json_string(entry, "mode"));
+        if (!scene_editor_placement_has_preview_mode(placement, preview))
+            return validation_error(ctx, entry_path, "scene editor palette entry references unknown placement preview");
+    }
+    return true;
+}
+
 bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_root, const char *json_path,
                                    validation_names *names)
 {
@@ -452,7 +521,13 @@ bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_ro
 
     char placement_path[PATH_BUFFER_SIZE];
     format_path(placement_path, sizeof(placement_path), "%s.editor.placement", json_path);
-    if (!validate_scene_editor_placement(ctx, obj_get(editor, "placement"), placement_path, names))
+    yyjson_val *placement = obj_get(editor, "placement");
+    if (!validate_scene_editor_placement(ctx, placement, placement_path, names))
+        return false;
+
+    char palette_path[PATH_BUFFER_SIZE];
+    format_path(palette_path, sizeof(palette_path), "%s.editor.palette", json_path);
+    if (!validate_scene_editor_palette(ctx, obj_get(editor, "palette"), placement, palette_path))
         return false;
 
     yyjson_val *overlay = obj_get(editor, "debug_overlay");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8996,6 +8996,64 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
                                                   placement_error, sizeof(placement_error)));
     EXPECT_NE(std::string(placement_error).find("preview kind must be box or player_start"), std::string::npos)
         << placement_error;
+
+    write_text(dir / "bad_grid_placement.game.json", R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Grid Scene Editor Placement" },
+  "world": {
+    "name": "world.bad_grid_scene_editor_placement",
+    "kind": "brush",
+    "cameras": [
+      { "name": "camera.valid", "type": "perspective", "position": [0, 0, 5], "target": [0, 0, 0], "up": [0, 1, 0] }
+    ]
+  },
+  "brush_worlds": [
+    {
+      "name": "brush.editor.target",
+      "materials": [{ "name": "mat.gray", "albedo": [0.5, 0.5, 0.5, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.valid",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 0 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 0, 1], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.gray" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json", R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.valid",
+  "editor": {
+    "placement": {
+      "previews": [
+        {
+          "mode": "wall",
+          "kind": "box",
+          "world": "brush.editor.target",
+          "material": "mat.gray",
+          "min": [-1.0, 0.0, -1.0],
+          "max": [1.0, 1.0, 1.0],
+          "grid_min": [-0.5, 0.0, -0.5],
+          "grid_max": [0.5, 1.0, 0.5]
+        }
+      ]
+    }
+  }
+})json");
+    char grid_placement_error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_grid_placement.game.json").string().c_str(), nullptr,
+                                                  grid_placement_error, sizeof(grid_placement_error)));
+    EXPECT_NE(std::string(grid_placement_error).find("exactly one of min/max or grid_min/grid_max"), std::string::npos)
+        << grid_placement_error;
     remove_test_dir(dir);
 }
 
@@ -15162,8 +15220,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int wall_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.wall");
     const int ceiling_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.ceiling");
     const int player_start_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start");
-    const int snap_finer_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.snap.finer");
-    const int snap_coarser_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.snap.coarser");
+    const int grid_decrease_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.grid.decrease");
+    const int grid_increase_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.grid.increase");
     const int wall_axis_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.wall_axis.toggle");
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
     const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
@@ -15172,8 +15230,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GE(wall_signal, 0);
     ASSERT_GE(ceiling_signal, 0);
     ASSERT_GE(player_start_signal, 0);
-    ASSERT_GE(snap_finer_signal, 0);
-    ASSERT_GE(snap_coarser_signal, 0);
+    ASSERT_GE(grid_decrease_signal, 0);
+    ASSERT_GE(grid_increase_signal, 0);
     ASSERT_GE(wall_axis_signal, 0);
     ASSERT_GE(commit_signal, 0);
     ASSERT_GE(export_signal, 0);
@@ -15214,9 +15272,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &placement_selection));
     ASSERT_TRUE(placement_selection.hit);
     EXPECT_EQ(placement_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID);
-    const slayer3d_vec3 placement_origin = slayer3d_vec3_make(SDL_roundf(placement_selection.point.x / 0.5f) * 0.5f,
-                                                              SDL_roundf(placement_selection.point.y / 0.5f) * 0.5f,
-                                                              SDL_roundf(placement_selection.point.z / 0.5f) * 0.5f);
+    const slayer3d_vec3 placement_origin = slayer3d_vec3_make(SDL_roundf(placement_selection.point.x / 8.0f) * 8.0f,
+                                                              SDL_roundf(placement_selection.point.y / 8.0f) * 8.0f,
+                                                              SDL_roundf(placement_selection.point.z / 8.0f) * 8.0f);
     auto world = [&]() {
         slayer3d_game_data_brush_world brush_world{};
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
@@ -15232,13 +15290,15 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
                  "mat.editor.floor");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
-    slayer3d_signal_emit(bus, snap_coarser_signal, nullptr);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
+    slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
-    slayer3d_signal_emit(bus, snap_finer_signal, nullptr);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 4.0f, 0.001f);
+    slayer3d_signal_emit(bus, grid_increase_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
     const slayer3d_value *placement_min =
         slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
     const slayer3d_value *placement_max =
@@ -15247,9 +15307,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_NE(placement_max, nullptr);
     ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
     ASSERT_EQ(placement_max->type, SLAYER3D_VALUE_VEC3);
-    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 3.0f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 4.0f, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y - 0.2f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 3.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 4.0f, 0.001f);
     struct PlacementPreviewDebug
     {
         int edges = 0;
@@ -15275,10 +15335,10 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GT(brush_world.brush_count, 0);
     const slayer3d_game_data_brush *brush = &brush_world.brushes[brush_world.brush_count - 1];
     EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.floor");
-    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 3.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 4.0f, 0.001f);
     EXPECT_NEAR(brush->bounds.min.y, placement_origin.y - 0.2f, 0.001f);
     EXPECT_NEAR(brush->bounds.max.y, placement_origin.y, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 3.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 4.0f, 0.001f);
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
@@ -15291,10 +15351,10 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
     ASSERT_NE(placement_min, nullptr);
     ASSERT_NE(placement_max, nullptr);
-    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 3.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 3.0f, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.125f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.125f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 4.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 4.0f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.25f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.25f, 0.001f);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
@@ -15304,11 +15364,11 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
     EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.wall");
-    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 3.0f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 3.0f, 0.001f);
-    EXPECT_NEAR(brush->bounds.min.z, placement_origin.z - 0.125f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 0.125f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 2.5f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 4.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 4.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.z, placement_origin.z - 0.25f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 0.25f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 8.0f, 0.001f);
 
     slayer3d_signal_emit(bus, ceiling_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "ceiling");
@@ -15322,8 +15382,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
     EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.ceiling");
-    EXPECT_NEAR(brush->bounds.min.y, placement_origin.y + 2.5f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 2.7f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.y, placement_origin.y + 8.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 8.2f, 0.001f);
     EXPECT_EQ(world().brush_count, 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 3);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -9054,6 +9054,67 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
                                                   grid_placement_error, sizeof(grid_placement_error)));
     EXPECT_NE(std::string(grid_placement_error).find("exactly one of min/max or grid_min/grid_max"), std::string::npos)
         << grid_placement_error;
+
+    write_text(dir / "bad_palette.game.json", R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Scene Editor Palette" },
+  "world": {
+    "name": "world.bad_scene_editor_palette",
+    "kind": "brush",
+    "cameras": [
+      { "name": "camera.valid", "type": "perspective", "position": [0, 0, 5], "target": [0, 0, 0], "up": [0, 1, 0] }
+    ]
+  },
+  "brush_worlds": [
+    {
+      "name": "brush.editor.target",
+      "materials": [{ "name": "mat.gray", "albedo": [0.5, 0.5, 0.5, 1.0] }],
+      "brushes": [
+        {
+          "name": "brush.valid",
+          "faces": [
+            { "plane": { "normal": [1, 0, 0], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [-1, 0, 0], "distance": 0 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 1, 0], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 0, 1], "distance": 1 }, "material": "mat.gray" },
+            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.gray" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    write_text(dir / "scenes" / "play.scene.json", R"json({
+  "schema": "slayer3d.scene.v0",
+  "name": "scene.play",
+  "camera": "camera.valid",
+  "editor": {
+    "placement": {
+      "previews": [
+        {
+          "mode": "floor",
+          "kind": "box",
+          "world": "brush.editor.target",
+          "material": "mat.gray",
+          "grid_min": [-0.5, -0.025, -0.5],
+          "grid_max": [0.5, 0.0, 0.5]
+        }
+      ]
+    },
+    "palette": {
+      "entries": [
+        { "mode": "wall", "preview": "wall", "kind": "box", "label": "Wall" }
+      ]
+    }
+  }
+})json");
+    char palette_error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_palette.game.json").string().c_str(), nullptr,
+                                                  palette_error, sizeof(palette_error)));
+    EXPECT_NE(std::string(palette_error).find("palette entry references unknown placement preview"), std::string::npos)
+        << palette_error;
     remove_test_dir(dir);
 }
 
@@ -15280,12 +15341,47 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
+    struct UiCapture
+    {
+        const slayer3d_game_data_runtime *runtime = nullptr;
+        std::vector<std::string> *values = nullptr;
+    };
+    auto visible_ui_text = [&]() {
+        std::vector<std::string> values;
+        auto capture = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+            auto *capture = static_cast<UiCapture *>(userdata);
+            if (text != nullptr && text->name != nullptr &&
+                std::string(text->name).rfind("ui.editor_shell.palette.", 0) == 0 &&
+                slayer3d_game_data_ui_text_is_visible(capture->runtime, text, nullptr))
+            {
+                capture->values->emplace_back(text->text != nullptr ? text->text : "");
+            }
+            return true;
+        };
+        UiCapture capture_state{runtime, &values};
+        slayer3d_game_data_ui_metrics metrics{};
+        EXPECT_TRUE(slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture, &capture_state));
+        return values;
+    };
+    auto contains_ui_text = [](const std::vector<std::string> &values, const char *expected) {
+        for (const std::string &value : values)
+        {
+            if (value == expected)
+                return true;
+        }
+        return false;
+    };
     EXPECT_EQ(world().brush_count, 1);
 
     slayer3d_signal_emit(bus, floor_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "floor prefab selected");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    std::vector<std::string> palette_text = visible_ui_text();
+    EXPECT_TRUE(contains_ui_text(palette_text, "Blockout Prefabs"));
+    EXPECT_TRUE(contains_ui_text(palette_text, "> 1 Floor"));
+    EXPECT_TRUE(contains_ui_text(palette_text, "  2 Wall"));
+    EXPECT_FALSE(contains_ui_text(palette_text, "  1 Floor"));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
@@ -15343,6 +15439,10 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    palette_text = visible_ui_text();
+    EXPECT_TRUE(contains_ui_text(palette_text, "> 2 Wall"));
+    EXPECT_TRUE(contains_ui_text(palette_text, "  1 Floor"));
+    EXPECT_FALSE(contains_ui_text(palette_text, "  2 Wall"));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
     slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -9341,6 +9341,38 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
         (dir / "bad_test_run_save_manifest_action.game.json").string().c_str(), nullptr, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("requires exactly one of path or path_from_state"), std::string::npos) << error;
 
+    write_text(dir / "bad_test_run_mount_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Test Run Mount Action" },
+  "world": { "name": "world.bad_editor_test_run_mount_action", "kind": "fixed_screen" },
+  "editor_player_starts": [{ "name": "player_start.test", "scene": "scene.play", "target": "entity.player", "position": [0, 1, 0] }],
+  "entities": [{ "name": "entity.player" }],
+  "signals": ["signal.editor.test_run"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.test_run",
+        "actions": [
+          {
+            "type": "editor.test_run.save_manifest",
+            "data_asset": "asset://bad.game.json",
+            "player_start": "player_start.test",
+            "path": "/tmp/test-run.json",
+            "root": "game/data",
+            "pack": "game.slayer3dpak"
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_test_run_mount_action.game.json").string().c_str(),
+                                                  nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("accepts at most one of root, pack, or embedded"), std::string::npos) << error;
+
     write_text(dir / "bad_status_action.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
@@ -15569,6 +15601,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
                  "player_start.editor_shell");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.target", ""),
                  "entity.editor_shell.player");
+    const char *test_run_command = slayer3d_properties_get_string(scene_state, "editor.test_run.command", "");
+    ASSERT_NE(test_run_command, nullptr);
+    EXPECT_NE(std::string(test_run_command).find("./build/debug/slayer3d_runner"), std::string::npos);
+    EXPECT_NE(std::string(test_run_command).find("--root \"demos/editor_shell_dojo/data\""), std::string::npos);
+    EXPECT_NE(std::string(test_run_command).find("--test-run-manifest"), std::string::npos);
+    EXPECT_NE(std::string(test_run_command).find(manifest_path.string()), std::string::npos);
     const char *manifest_json = slayer3d_properties_get_string(scene_state, "editor.test_run.manifest_json", "");
     ASSERT_NE(manifest_json, nullptr);
     EXPECT_NE(std::string(manifest_json).find("\"schema\": \"slayer3d.editor_test_run.v0\""), std::string::npos);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15554,10 +15554,47 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     ASSERT_GE(view_front_signal, 0);
     ASSERT_GE(view_side_signal, 0);
     ASSERT_GE(view_perspective_signal, 0);
+    auto expect_work_plane_grid_axis = [&](char axis) {
+        struct GridCapture
+        {
+            char axis = 'y';
+            int lines = 0;
+        } capture{axis, 0};
+        auto capture_grid = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+            auto *capture = static_cast<GridCapture *>(userdata);
+            if (primitive == nullptr || primitive->type != SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID)
+                return true;
+            capture->lines++;
+            if (capture->axis == 'x')
+            {
+                EXPECT_NEAR(primitive->start.x, 0.0f, 0.001f);
+                EXPECT_NEAR(primitive->end.x, 0.0f, 0.001f);
+            }
+            else if (capture->axis == 'z')
+            {
+                EXPECT_NEAR(primitive->start.z, 0.0f, 0.001f);
+                EXPECT_NEAR(primitive->end.z, 0.0f, 0.001f);
+            }
+            else
+            {
+                EXPECT_NEAR(primitive->start.y, 0.0f, 0.001f);
+                EXPECT_NEAR(primitive->end.y, 0.0f, 0.001f);
+            }
+            return true;
+        };
+        ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_grid, &capture));
+        EXPECT_GT(capture.lines, 0);
+    };
     slayer3d_signal_emit(bus, view_top_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_top");
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.view.mode", ""),
                  "orthographic_top");
+    const slayer3d_value *work_plane_normal =
+        slayer3d_properties_get_value(slayer3d_game_data_scene_state(runtime), "editor.work_plane.normal");
+    ASSERT_NE(work_plane_normal, nullptr);
+    ASSERT_EQ(work_plane_normal->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(work_plane_normal->as_vec3.y, 1.0f, 0.001f);
+    expect_work_plane_grid_axis('y');
     slayer3d_camera3d ortho{};
     ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
     EXPECT_EQ(ortho.projection, SLAYER3D_CAMERA_ORTHOGRAPHIC);
@@ -15566,8 +15603,20 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_NEAR(ortho.target.x, camera_actor->position.x, 0.001f);
     slayer3d_signal_emit(bus, view_front_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_front");
+    work_plane_normal =
+        slayer3d_properties_get_value(slayer3d_game_data_scene_state(runtime), "editor.work_plane.normal");
+    ASSERT_NE(work_plane_normal, nullptr);
+    ASSERT_EQ(work_plane_normal->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(work_plane_normal->as_vec3.z, 1.0f, 0.001f);
+    expect_work_plane_grid_axis('z');
     slayer3d_signal_emit(bus, view_side_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_side");
+    work_plane_normal =
+        slayer3d_properties_get_value(slayer3d_game_data_scene_state(runtime), "editor.work_plane.normal");
+    ASSERT_NE(work_plane_normal, nullptr);
+    ASSERT_EQ(work_plane_normal->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(work_plane_normal->as_vec3.x, 1.0f, 0.001f);
+    expect_work_plane_grid_axis('x');
     slayer3d_signal_emit(bus, view_perspective_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -9455,6 +9455,32 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
                                                   error, sizeof(error)));
     EXPECT_NE(std::string(error).find("unknown scene reference"), std::string::npos) << error;
 
+    write_text(dir / "bad_player_start_apply_action.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Player Start Apply Action" },
+  "world": { "name": "world.bad_editor_player_start_apply_action", "kind": "fixed_screen" },
+  "signals": ["signal.editor.apply_player_start"],
+  "logic": {
+    "bindings": [
+      {
+        "signal": "signal.editor.apply_player_start",
+        "actions": [
+          {
+            "type": "editor.player_start.apply",
+            "name": "player_start.missing"
+          }
+        ]
+      }
+    ]
+  },
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_player_start_apply_action.game.json").string().c_str(),
+                                                  nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unknown editor player start reference"), std::string::npos) << error;
+
     write_text(dir / "bad_player_start_section.game.json",
                R"json({
   "schema": "slayer3d.game.v0",
@@ -15324,6 +15350,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
     const int export_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.export");
     const int test_run_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.test_run.prepare");
+    const int test_run_enter_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.test_run.enter");
     ASSERT_GE(floor_signal, 0);
     ASSERT_GE(wall_signal, 0);
     ASSERT_GE(ceiling_signal, 0);
@@ -15334,6 +15361,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GE(commit_signal, 0);
     ASSERT_GE(export_signal, 0);
     ASSERT_GE(test_run_signal, 0);
+    ASSERT_GE(test_run_enter_signal, 0);
 
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
@@ -15683,6 +15711,22 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
 
     slayer3d_game_data_destroy(roundtrip_runtime);
     slayer3d_game_session_destroy(roundtrip_session);
+
+    slayer3d_signal_emit(bus, test_run_enter_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
+                 "test run player start applied");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.player");
+    EXPECT_TRUE(slayer3d_game_data_active_scene_has_entity(runtime, "entity.editor_shell.player"));
+    slayer3d_registered_actor *test_player = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.player");
+    ASSERT_NE(test_player, nullptr);
+    EXPECT_NEAR(test_player->position.x, placement_origin.x, 0.001f);
+    EXPECT_NEAR(test_player->position.y, placement_origin.y, 0.001f);
+    EXPECT_NEAR(test_player->position.z, placement_origin.z, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "yaw", 0.0f), 3.14159f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "pitch", 1.0f), 0.0f, 0.001f);
+
     remove_test_dir(save_dir);
 
     slayer3d_game_data_destroy(runtime);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15554,20 +15554,14 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.dirty", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.revision", 0), 1);
 
-    slayer3d_signal_emit(bus, export_signal, nullptr);
+    slayer3d_signal_emit(bus, test_run_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""), "editable level saved");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""),
+                 "editable level saved for test run");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.path", ""), saved_path.string().c_str());
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.save.size", 0), 0);
     EXPECT_TRUE(std::filesystem::exists(saved_path));
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.player_start.count", 0), 1);
-    const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
-    ASSERT_NE(export_json, nullptr);
-    EXPECT_NE(std::string(export_json).find("\"brush_worlds\""), std::string::npos);
-    EXPECT_NE(std::string(export_json).find("\"editor_player_starts\""), std::string::npos);
-    EXPECT_NE(std::string(export_json).find("\"mat.editor.ceiling\""), std::string::npos);
-    EXPECT_NE(std::string(export_json).find("\"player_start.editor_shell\""), std::string::npos);
     slayer3d_game_data_brush_world_editor_state brush_state{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &brush_state));
     EXPECT_FALSE(brush_state.dirty);
@@ -15583,7 +15577,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_NE(player_start_state.source_path, nullptr);
     EXPECT_EQ(std::string(player_start_state.source_path), saved_path.string());
 
-    slayer3d_signal_emit(bus, test_run_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.valid", false));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.saved", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.message", ""),
@@ -15613,6 +15606,18 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NE(std::string(manifest_json).find("\"--player-start\""), std::string::npos);
     EXPECT_NE(std::string(manifest_json).find("\"player_start.editor_shell\""), std::string::npos);
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.test_run.size", 0), 0);
+
+    slayer3d_signal_emit(bus, export_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""), "editable level saved");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.path", ""), saved_path.string().c_str());
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
+    const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
+    ASSERT_NE(export_json, nullptr);
+    EXPECT_NE(std::string(export_json).find("\"brush_worlds\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"editor_player_starts\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"mat.editor.ceiling\""), std::string::npos);
+    EXPECT_NE(std::string(export_json).find("\"player_start.editor_shell\""), std::string::npos);
 
     write_text(save_dir / "scenes" / "play.scene.json",
                R"json({ "schema": "slayer3d.scene.v0", "name": "scene.editor_shell.dojo" })json");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15378,26 +15378,35 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
-    struct UiCapture
-    {
-        const slayer3d_game_data_runtime *runtime = nullptr;
-        std::vector<std::string> *values = nullptr;
-    };
-    auto visible_ui_text = [&]() {
+    auto visible_ui_text = [&](const char *prefix) {
         std::vector<std::string> values;
-        auto capture = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
-            auto *capture = static_cast<UiCapture *>(userdata);
-            if (text != nullptr && text->name != nullptr &&
-                std::string(text->name).rfind("ui.editor_shell.palette.", 0) == 0 &&
-                slayer3d_game_data_ui_text_is_visible(capture->runtime, text, nullptr))
+        slayer3d_game_data_ui_metrics metrics{};
+        struct PrefixCapture
+        {
+            const slayer3d_game_data_runtime *runtime = nullptr;
+            const slayer3d_game_data_ui_metrics *metrics = nullptr;
+            std::vector<std::string> *values = nullptr;
+            const char *prefix = nullptr;
+        };
+        auto capture_with_prefix = [](void *userdata, const slayer3d_game_data_ui_text *text) -> bool {
+            auto *capture = static_cast<PrefixCapture *>(userdata);
+            if (text == nullptr || text->name == nullptr || capture->values == nullptr || capture->prefix == nullptr ||
+                std::string(text->name).rfind(capture->prefix, 0) != 0 ||
+                !slayer3d_game_data_ui_text_is_visible(capture->runtime, text, capture->metrics))
             {
-                capture->values->emplace_back(text->text != nullptr ? text->text : "");
+                return true;
             }
+            char formatted[768]{};
+            if (slayer3d_game_data_format_ui_text(capture->runtime, text, capture->metrics, formatted,
+                                                  sizeof(formatted)))
+                capture->values->emplace_back(formatted);
+            else
+                capture->values->emplace_back(text->text != nullptr ? text->text : "");
             return true;
         };
-        UiCapture capture_state{runtime, &values};
-        slayer3d_game_data_ui_metrics metrics{};
-        EXPECT_TRUE(slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture, &capture_state));
+        PrefixCapture capture_state{runtime, &metrics, &values, prefix};
+        EXPECT_TRUE(
+            slayer3d_game_data_for_each_ui_text_for_metrics(runtime, &metrics, capture_with_prefix, &capture_state));
         return values;
     };
     auto contains_ui_text = [](const std::vector<std::string> &values, const char *expected) {
@@ -15414,7 +15423,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "floor prefab selected");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    std::vector<std::string> palette_text = visible_ui_text();
+    std::vector<std::string> palette_text = visible_ui_text("ui.editor_shell.palette.");
     EXPECT_TRUE(contains_ui_text(palette_text, "Blockout Prefabs"));
     EXPECT_TRUE(contains_ui_text(palette_text, "> 1 Floor"));
     EXPECT_TRUE(contains_ui_text(palette_text, "  2 Wall"));
@@ -15482,7 +15491,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "wall");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    palette_text = visible_ui_text();
+    palette_text = visible_ui_text("ui.editor_shell.palette.");
     EXPECT_TRUE(contains_ui_text(palette_text, "> 2 Wall"));
     EXPECT_TRUE(contains_ui_text(palette_text, "  1 Floor"));
     EXPECT_FALSE(contains_ui_text(palette_text, "  2 Wall"));
@@ -15606,6 +15615,11 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NE(std::string(manifest_json).find("\"--player-start\""), std::string::npos);
     EXPECT_NE(std::string(manifest_json).find("\"player_start.editor_shell\""), std::string::npos);
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.test_run.size", 0), 0);
+    const std::vector<std::string> handoff_text = visible_ui_text("ui.editor_shell.handoff.");
+    EXPECT_TRUE(contains_ui_text(handoff_text, "Test Run Handoff"));
+    EXPECT_TRUE(contains_ui_text(handoff_text, ("Level: " + saved_path.string()).c_str()));
+    EXPECT_TRUE(contains_ui_text(handoff_text, ("Manifest: " + manifest_path.string()).c_str()));
+    EXPECT_TRUE(contains_ui_text(handoff_text, ("Command: " + std::string(test_run_command)).c_str()));
 
     slayer3d_signal_emit(bus, export_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", false));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -8894,6 +8894,11 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
             R"json({ "select_button": "PRIMARY", "trace": { "source": "camera_screen", "camera": "camera.valid" }, "outputs": { "hit_key": "editor.hit" } })json",
             "scene editor selection select_button must be a mouse button",
         },
+        {
+            "bad_on_select",
+            R"json({ "trace": { "source": "camera_screen", "camera": "camera.valid" }, "outputs": { "hit_key": "editor.hit" }, "on_select": "signal.editor.missing" })json",
+            "unknown signal",
+        },
     };
 
     const std::filesystem::path dir = unique_test_dir("scene_editor_tooling");
@@ -15422,7 +15427,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(
         slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_placement_preview, &placement_debug));
     EXPECT_EQ(placement_debug.edges, 12);
-    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    release.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &release);
+    slayer3d_input_update(input, 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""),

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14939,7 +14939,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
                  "inspect brush.target.cube face editor.face.target_cube.left");
 
-    press_key(SDL_SCANCODE_TAB, 5);
+    press_key(SDL_SCANCODE_C, 5);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "move");
 
@@ -15062,7 +15062,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_NEAR(target_cube_min_y(), 0.35f, 0.001f);
 
-    press_key(SDL_SCANCODE_TAB, 10);
+    press_key(SDL_SCANCODE_C, 10);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "paint");
 
@@ -15542,12 +15542,54 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
 
     slayer3d_camera3d before{};
     ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &before));
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int view_top_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.view.top");
+    const int view_front_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.view.front");
+    const int view_side_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.view.side");
+    const int view_perspective_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.view.perspective");
+    ASSERT_GE(view_top_signal, 0);
+    ASSERT_GE(view_front_signal, 0);
+    ASSERT_GE(view_side_signal, 0);
+    ASSERT_GE(view_perspective_signal, 0);
+    slayer3d_signal_emit(bus, view_top_signal, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_top");
+    EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.view.mode", ""),
+                 "orthographic_top");
+    slayer3d_camera3d ortho{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
+    EXPECT_EQ(ortho.projection, SLAYER3D_CAMERA_ORTHOGRAPHIC);
+    EXPECT_NEAR(ortho.fovy, 48.0f, 0.001f);
+    EXPECT_NEAR(ortho.position.y, camera_actor->position.y + 40.0f, 0.001f);
+    EXPECT_NEAR(ortho.target.x, camera_actor->position.x, 0.001f);
+    slayer3d_signal_emit(bus, view_front_signal, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_front");
+    slayer3d_signal_emit(bus, view_side_signal, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_side");
+    slayer3d_signal_emit(bus, view_perspective_signal, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
+
+    SDL_Event tab{};
+    tab.type = SDL_EVENT_KEY_DOWN;
+    tab.key.scancode = SDL_SCANCODE_TAB;
+    slayer3d_input_process_event(input, &tab);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.ortho_top");
+    tab.type = SDL_EVENT_KEY_UP;
+    slayer3d_input_process_event(input, &tab);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    slayer3d_signal_emit(bus, view_perspective_signal, nullptr);
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
 
     SDL_Event key{};
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_UP;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 1);
+    slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.25f));
     EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, start_position)), 0.1f);
 
@@ -15563,7 +15605,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     motion.motion.xrel = 60.0f;
     motion.motion.yrel = -15.0f;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 2);
+    slayer3d_input_update(input, 6);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
 
     const float yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);


### PR DESCRIPTION
## Summary
- Add grid-scaled editor placement preview bounds driven by authored scene-state keys.
- Update the editor shell dojo to use an 8m grid with +/- grid-size controls and gray blockout materials.
- Add data-authored editor view modes with perspective/top/front/side cameras and Tab/F1-F4 switching.
- Let editor selection traces follow the active camera so placement works from perspective or orthographic views.
- Add scene-state-driven editor work planes so top/front/side views switch their plotting/debug grid plane from JSON actions.
- Allow scene_state.set to write vec3 values for reusable editor/tool state.
- Add data-authored editor palette metadata and sidebar rows for floor/wall/ceiling/player-start prefab tools.
- Add `!=` support to scene/property/payload compare conditions so authored UI can express selected-vs-unselected states.
- Add a generic `editor.selection.on_select` signal hook and use it in the editor shell so clicking places the active prefab tool.
- Publish copy/pasteable editor test-run commands from data-authored test-run manifest actions, including root/pack/embedded mount hints.
- Save the editable level before editor test-run handoff so `T` runs the latest graybox output without requiring a separate save.
- Add a bottom handoff strip that shows the saved level path, test-run manifest path, and copy/paste runner command after `T`.
- Add reusable `editor.player_start.apply` and wire F5 in the editor shell to enter the playable test scene from the placed start.
- Add an editor test-drive doc covering launch, controls, save/test-run workflow, and correctness checks.
- Document grid-sized placement previews, editor palettes, editor selection signals, editor test-run commands, editor player-start apply, editor view switching, and dynamic work-plane keys; extend editor tests/validation coverage.

## Tests
- python3 -m json.tool demos/editor_shell_dojo/data/editor_shell_dojo.game.json >/tmp/editor_shell_dojo.game.json.checked
- python3 -m json.tool demos/editor_shell_dojo/data/scenes/editor_shell.scene.json >/tmp/editor_shell.scene.json.checked
- cmake --build build/debug --target slayer3d_game_data_test -j4
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j4
- ctest --test-dir build/debug -R "GameDataRuntime\.(RejectsInvalidSceneEditorTooling|EditorShellDojoCreatesBlockoutPrefabTools)" --output-on-failure
- ctest --test-dir build/debug -R "GameDataRuntime\.EditorShellDojo|GameDataRuntime\.RejectsInvalidSceneEditor|GameDataRuntime\.EditorCreateBox" --output-on-failure
- ctest --test-dir build/debug -R "GameDataRuntime\.EditorShellDojo|GameDataRuntime\.RejectsInvalidSceneEditor|GameDataRuntime\.RejectsInvalidEditorSelectionActions|GameDataRuntime\.EditorCreateBox" --output-on-failure
- cmake --build build/debug --target slayer3d_editor -j4
- git diff --check

Refs #401
