### PR TITLE
Add editor new and open CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ target_sources(
         src/game.c
         src/game_data_brush_artifacts.c
         src/game_data_brush_editor_export.c
+        src/game_data_brush_editor_import.c
         src/game_data_brush_editor_mutation.c
         src/game_data_brush_trace_queries.c
         src/game_data_brush_visibility_runtime.c
@@ -397,16 +398,16 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     )
     target_link_libraries(slayer3d_editor PRIVATE Slayer3D::slayer3d slayer3d_argtable3)
     target_compile_features(slayer3d_editor PRIVATE c_std_17)
-    target_include_directories(slayer3d_editor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+    target_include_directories(
+        slayer3d_editor
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/tools
+    )
     target_compile_definitions(
         slayer3d_editor
         PRIVATE
             SLAYER3D_MEDIA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/media"
             SLAYER3D_RUNNER_NO_MAIN
-            SLAYER3D_EDITOR_DEFAULT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/demos/editor_shell_dojo/data"
-            SLAYER3D_EDITOR_DEFAULT_DATA="asset://editor_shell_dojo.game.json"
-            SLAYER3D_EDITOR_DEFAULT_SAVE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/demos/editor_shell_dojo/data/generated/editable_level.fragment.json"
-            SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH="${CMAKE_CURRENT_BINARY_DIR}/editor_shell_dojo/test-run.json"
     )
     slayer3d_enable_warnings(slayer3d_editor)
     slayer3d_enable_sanitizers(slayer3d_editor)

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -18,9 +18,9 @@ Reopen that saved level:
 ```
 
 `--project` points at a directory containing `slayer3d.project.json`; the
-manifest defines the data root and editor entry point. Press `S` in the editor
-to atomically save an editable fragment containing `brush_worlds` and
-`editor_player_starts`.
+manifest defines the data root and editor entry point. Press `Ctrl+S` or
+`Command+S` in the editor to atomically save an editable fragment containing
+`brush_worlds` and `editor_player_starts`.
 
 The equivalent raw runner command remains useful for data/runtime debugging:
 

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -18,14 +18,19 @@ Reopen that saved level:
 ```
 
 `--project` points at a directory containing `slayer3d.project.json`; the
-manifest defines the data root and editor entry point. Press `Ctrl+S` or
-`Command+S` in the editor to atomically save an editable fragment containing
-`brush_worlds` and `editor_player_starts`.
+manifest defines the data root, editor entry point, optional media root, and
+optional test-run manifest path. `new` requires `--output`. `open` requires
+`--input` and saves back to that same file unless `--output` is supplied. Pass
+`--overwrite` only when replacing an existing output file is intentional.
+
+Press `Ctrl+S` or `Command+S` in the editor to atomically save an editable
+fragment containing `brush_worlds` and `editor_player_starts`. Press `F5` to
+enter the in-runtime playable test scene from the current in-memory level.
 
 The equivalent raw runner command remains useful for data/runtime debugging:
 
 ```sh
-./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --state editor.command=open --state editor.input.path=/tmp/slayer3d-editor-level.fragment.json --state editor.save.path=/tmp/slayer3d-editor-level.fragment.json
 ```
 
 See [docs/editor-test-drive.md](../../docs/editor-test-drive.md) for the current

--- a/demos/editor_shell_dojo/README.md
+++ b/demos/editor_shell_dojo/README.md
@@ -1,63 +1,32 @@
 # Editor Shell Dojo
 
-This data-only dojo demonstrates the first reusable editor shell pieces:
+This data-only dojo demonstrates the reusable graybox editor shell: multiple
+viewports, orthographic grid placement, brush/game-object palettes, editable
+brush-world export, player-start placement, and an in-runtime playable test
+scene.
 
-- a normal Slayer3D runtime viewport
-- a data-authored editor camera controller: arrow keys move horizontally,
-  `Q`/`E` move down/up, and right mouse button + drag looks around
-- data-authored editor view switching: `Tab` toggles between perspective and
-  top orthographic, while `F1`-`F4` select perspective/top/front/side cameras
-- authored brush-world selection trace metadata with a ground work-plane
-  fallback for placing the first brush in empty space
-- data-authored world/selection/normal/hit debug overlay drawing, including a
-  visible work-plane grid for empty-space placement
-- reusable `ui.panels` and `ui.inspectors` populated from scene state
-- a first blockout tool palette: `1` floor, `2` wall, `3` ceiling,
-  `4` player start, then click a brush face or the ground work plane and press
-  `Enter` to place the selected prefab at that point; `C` still cycles the
-  broader tool modes used by command previews
-- live snapped placement previews for floor, wall, ceiling, and player-start
-  tools using the same renderer-agnostic editor debug primitive path; `-`/`+`
-  change the active grid size and `R` toggles wall orientation between grid axes
-- unified editable-level save/export: `S` saves and publishes one fragment
-  containing the brush world and player starts
-- test-run handoff manifest: `T` publishes and saves runner arguments for the
-  authored player start
-- generic runner test-run support: `--player-start player_start.editor_shell`
-  enters the playable FPS scene through the same runtime path a data-only game
-  uses
-
-Run it with:
+Run a new editing session:
 
 ```sh
-./build/debug/slayer3d_editor
+./build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/slayer3d-editor-level.fragment.json --overwrite
 ```
 
-The editor host is a thin wrapper around the generic runner. In the build tree it
-defaults to this dojo, injects `editor.save.path` and `editor.test_run.path`,
-and leaves all editor behavior data-authored. The equivalent runner command is:
+Reopen that saved level:
+
+```sh
+./build/debug/slayer3d_editor open --project demos/editor_shell_dojo --input /tmp/slayer3d-editor-level.fragment.json
+```
+
+`--project` points at a directory containing `slayer3d.project.json`; the
+manifest defines the data root and editor entry point. Press `S` in the editor
+to atomically save an editable fragment containing `brush_worlds` and
+`editor_player_starts`.
+
+The equivalent raw runner command remains useful for data/runtime debugging:
 
 ```sh
 ./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json
 ```
 
-Test-run the authored player start directly:
-
-```sh
-./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --player-start player_start.editor_shell
-```
-
-By default, `S` writes
-`demos/editor_shell_dojo/data/generated/editable_level.fragment.json`, which is
-imported by the dojo on the next launch. `T` writes
-`build/editor_shell_dojo/test-run.json`. Launch that saved manifest with:
-
-```sh
-./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --test-run-manifest build/editor_shell_dojo/test-run.json
-```
-
-For another editor project, pass explicit paths:
-
-```sh
-./build/debug/slayer3d_editor --root path/to/editor/data --data asset://editor.game.json --save path/to/generated/editable_level.fragment.json --test-run-output build/editor/test-run.json
-```
+See [docs/editor-test-drive.md](../../docs/editor-test-drive.md) for the current
+keybindings and manual validation checklist.

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1161,9 +1161,40 @@
               "player_start_source_path_key": "editor.player_start.source_path"
             }
           },
-          { "type": "scene_state.set", "key": "editor.save.valid", "value": false },
-          { "type": "scene_state.set", "key": "editor.save.message", "value": "disk save disabled for MVP iteration" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "exported level JSON in memory" }
+          {
+            "type": "editor.level.save",
+            "world": "brush.editor_shell.target",
+            "path_from_state": "editor.save.path",
+            "message": "editable level saved",
+            "outputs": {
+              "valid_key": "editor.save.valid",
+              "message_key": "editor.save.message",
+              "path_key": "editor.save.path",
+              "size_key": "editor.save.size",
+              "brush_world_key": "editor.brush_world.name",
+              "brush_dirty_key": "editor.brush_world.dirty",
+              "brush_revision_key": "editor.brush_world.revision",
+              "brush_saved_revision_key": "editor.brush_world.saved_revision",
+              "brush_source_path_key": "editor.brush_world.source_path",
+              "player_start_count_key": "editor.player_start.count",
+              "player_start_dirty_key": "editor.player_start.dirty",
+              "player_start_revision_key": "editor.player_start.revision",
+              "player_start_saved_revision_key": "editor.player_start.saved_revision",
+              "player_start_source_path_key": "editor.player_start.source_path"
+            }
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.save.valid", "op": "==", "value": true },
+            "then": [{ "type": "scene_state.set", "key": "editor.tool.last_action", "value": "saved level to disk" }],
+            "else": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "save failed: {editor.save.message}"
+              }
+            ]
+          }
         ]
       },
       {

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -56,7 +56,10 @@
           },
           {
             "name": "action.editor.export",
-            "bindings": [{ "device": "keyboard", "key": "S" }]
+            "bindings": [
+              { "device": "keyboard", "key": "S", "modifiers": ["ctrl"] },
+              { "device": "keyboard", "key": "S", "modifiers": ["gui"] }
+            ]
           },
           {
             "name": "action.editor.test_run.prepare",

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -230,6 +230,7 @@
     ]
   },
   "signals": [
+    "signal.editor.scene.enter",
     "signal.editor.tool.cycle",
     "signal.editor.selection.clear",
     "signal.editor.selection.inspect",
@@ -397,6 +398,43 @@
       }
     ],
     "bindings": [
+      {
+        "signal": "signal.editor.scene.enter",
+        "actions": [
+          {
+            "type": "editor.level.load",
+            "world": "brush.editor_shell.target",
+            "path_from_state": "editor.input.path",
+            "optional": true,
+            "outputs": {
+              "valid_key": "editor.load.valid",
+              "message_key": "editor.load.message",
+              "path_key": "editor.load.path",
+              "brush_world_key": "editor.brush_world.name",
+              "brush_dirty_key": "editor.brush_world.dirty",
+              "brush_revision_key": "editor.brush_world.revision",
+              "brush_saved_revision_key": "editor.brush_world.saved_revision",
+              "brush_source_path_key": "editor.brush_world.source_path",
+              "player_start_count_key": "editor.player_start.count",
+              "player_start_dirty_key": "editor.player_start.dirty",
+              "player_start_revision_key": "editor.player_start.revision",
+              "player_start_saved_revision_key": "editor.player_start.saved_revision",
+              "player_start_source_path_key": "editor.player_start.source_path"
+            }
+          },
+          { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
+          { "type": "scene_state.set", "key": "editor.ortho.size", "value": 48.0 },
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
+          { "type": "scene_state.set", "key": "editor.palette.active", "value": "" },
+          { "type": "scene_state.set", "key": "editor.palette.brush.cursor", "value": "floor" },
+          { "type": "scene_state.set", "key": "editor.palette.material.cursor", "value": "mat.editor.floor" },
+          { "type": "scene_state.set", "key": "editor.palette.game_object.cursor", "value": "player_start" },
+          { "type": "scene_state.set", "key": "editor.view.mode", "value": "quad_view" },
+          { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
+          { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
+          { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
+        ]
+      },
       {
         "signal": "signal.editor.tool.cycle",
         "actions": [

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -4,40 +4,7 @@
   "camera": "camera.editor_shell.viewport",
   "updates_game": true,
   "renders_world": true,
-  "on_enter": [
-    {
-      "type": "editor.level.load",
-      "world": "brush.editor_shell.target",
-      "path_from_state": "editor.input.path",
-      "optional": true,
-      "outputs": {
-        "valid_key": "editor.load.valid",
-        "message_key": "editor.load.message",
-        "path_key": "editor.load.path",
-        "brush_world_key": "editor.brush_world.name",
-        "brush_dirty_key": "editor.brush_world.dirty",
-        "brush_revision_key": "editor.brush_world.revision",
-        "brush_saved_revision_key": "editor.brush_world.saved_revision",
-        "brush_source_path_key": "editor.brush_world.source_path",
-        "player_start_count_key": "editor.player_start.count",
-        "player_start_dirty_key": "editor.player_start.dirty",
-        "player_start_revision_key": "editor.player_start.revision",
-        "player_start_saved_revision_key": "editor.player_start.saved_revision",
-        "player_start_source_path_key": "editor.player_start.source_path"
-      }
-    },
-    { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
-    { "type": "scene_state.set", "key": "editor.ortho.size", "value": 48.0 },
-    { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
-    { "type": "scene_state.set", "key": "editor.palette.active", "value": "" },
-    { "type": "scene_state.set", "key": "editor.palette.brush.cursor", "value": "floor" },
-    { "type": "scene_state.set", "key": "editor.palette.material.cursor", "value": "mat.editor.floor" },
-    { "type": "scene_state.set", "key": "editor.palette.game_object.cursor", "value": "player_start" },
-    { "type": "scene_state.set", "key": "editor.view.mode", "value": "quad_view" },
-    { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
-    { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
-    { "type": "scene_state.set", "key": "editor.placement.wall_axis", "value": "z" }
-  ],
+  "on_enter_signal": "signal.editor.scene.enter",
   "input": {
     "mouse_capture": "unpaused",
     "mouse_capture_if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "flyby_3d" },

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -5,8 +5,27 @@
   "updates_game": true,
   "renders_world": true,
   "on_enter": [
-    { "type": "scene_state.set", "key": "editor.save.path", "value": "" },
-    { "type": "scene_state.set", "key": "editor.test_run.path", "value": "" },
+    {
+      "type": "editor.level.load",
+      "world": "brush.editor_shell.target",
+      "path_from_state": "editor.input.path",
+      "optional": true,
+      "outputs": {
+        "valid_key": "editor.load.valid",
+        "message_key": "editor.load.message",
+        "path_key": "editor.load.path",
+        "brush_world_key": "editor.brush_world.name",
+        "brush_dirty_key": "editor.brush_world.dirty",
+        "brush_revision_key": "editor.brush_world.revision",
+        "brush_saved_revision_key": "editor.brush_world.saved_revision",
+        "brush_source_path_key": "editor.brush_world.source_path",
+        "player_start_count_key": "editor.player_start.count",
+        "player_start_dirty_key": "editor.player_start.dirty",
+        "player_start_revision_key": "editor.player_start.revision",
+        "player_start_saved_revision_key": "editor.player_start.saved_revision",
+        "player_start_source_path_key": "editor.player_start.source_path"
+      }
+    },
     { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
     { "type": "scene_state.set", "key": "editor.ortho.size", "value": 48.0 },
     { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },

--- a/demos/editor_shell_dojo/slayer3d.project.json
+++ b/demos/editor_shell_dojo/slayer3d.project.json
@@ -1,0 +1,8 @@
+{
+  "schema": "slayer3d.project.v0",
+  "name": "Editor Shell Dojo",
+  "data_root": "data",
+  "editor_entry": "asset://editor_shell_dojo.game.json",
+  "media_root": "../../media",
+  "test_run_output": "../../build/editor_shell_dojo/test-run.json"
+}

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -172,22 +172,19 @@ build/MyGame
 ## Generic Editor Host
 
 `slayer3d_editor` is a thin host over the same managed runtime and renderer. It
-launches a data-authored editor project, injects editor output paths as scene
-state, and leaves the actual tool behavior in JSON/Lua. The build-tree default
-opens the editor shell dojo:
+launches a data-authored editor project, injects editor input/output paths as
+scene state, and leaves the actual tool behavior in JSON/Lua.
 
 ```sh
-build/debug/slayer3d_editor
+build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/level.fragment.json --overwrite
 ```
 
-For another editor project, pass explicit paths:
+Projects are described by `slayer3d.project.json` manifests. `new` starts from
+the project's empty editor scene; `open` loads an existing editable fragment and
+saves back to `--input` unless `--output` is supplied:
 
 ```sh
-build/debug/slayer3d_editor \
-  --root path/to/editor/data \
-  --data asset://editor.game.json \
-  --save path/to/generated/editable_level.fragment.json \
-  --test-run-output build/editor/test-run.json
+build/debug/slayer3d_editor open --project path/to/project --input path/to/level.fragment.json
 ```
 
 The fused executable path is still the same generic runner. The game data is

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -187,6 +187,26 @@ saves back to `--input` unless `--output` is supplied:
 build/debug/slayer3d_editor open --project path/to/project --input path/to/level.fragment.json
 ```
 
+The manifest currently carries `data_root`, `editor_entry`, optional
+`media_root`, and optional `test_run_output`. The editor host translates those
+fields into a normal runner launch and injects `editor.command`,
+`editor.input.path`, `editor.save.path`, and `editor.test_run.path` as scene
+state. This keeps the shell data-authored while still giving users a stable CLI:
+`--project` selects the editor project, `--input` selects the editable fragment
+for `open`, and `--output` selects the save target.
+
+For low-level debugging, the same launch can be written directly with the
+generic runner:
+
+```sh
+build/debug/slayer3d_runner \
+  --root demos/editor_shell_dojo/data \
+  --data asset://editor_shell_dojo.game.json \
+  --state editor.command=open \
+  --state editor.input.path=/tmp/level.fragment.json \
+  --state editor.save.path=/tmp/level.fragment.json
+```
+
 The fused executable path is still the same generic runner. The game data is
 stored as an appended `.slayer3dpak`, and the runner auto-mounts it only when no
 explicit mount flags are provided.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -75,7 +75,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 | mouse look | 3D flyby | rotate camera |
 | `Space` / `Left Ctrl` | 3D flyby | move camera up/down |
 | `Left Shift` | 3D flyby | move faster |
-| `S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
+| `Ctrl+S` / `Command+S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
 | `T` | palette closed | report that disk test-run handoff is disabled for this MVP iteration |
 | `F5` | palette closed | enter the playable test scene from the placed player start |
 | `Esc` | palette closed | quit |
@@ -90,7 +90,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 4. Press `G`, press `Enter` to select Player Start, and place it on the floor.
 5. Hover a placed tile and right click, or select it and press `Delete`; the
    tile should disappear.
-6. Press `S` and confirm the inspector reports a successful save. The output
+6. Press `Ctrl+S` or `Command+S` and confirm the inspector reports a successful save. The output
    file should contain `brush_worlds` and `editor_player_starts`.
 7. Press `F5`; the editor should switch into the playable test scene.
 8. In the playable scene, use `WASD` and mouse look to verify the player starts
@@ -128,7 +128,7 @@ The following should be true during a good test drive:
   `X`, or the mouse wheel while keeping a visible work grid.
 - Top/front/side orthographic views plot on their authored work planes;
   perspective preview uses the 3D editor camera.
-- `S` exports JSON containing `brush_worlds` and `editor_player_starts` and
+- `Ctrl+S` and `Command+S` export JSON containing `brush_worlds` and `editor_player_starts` and
   writes the same fragment to the CLI output path.
 - `T` does not write a manifest during this MVP iteration.
 - `F5` applies the stored player start before entering the playable scene.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -23,7 +23,19 @@ template, and `open` loads an existing editable level fragment:
 
 The project path points at a directory containing `slayer3d.project.json`.
 Saving uses an atomic same-directory temporary file and rename; `open` without
-`--output` saves back to `--input`.
+`--output` saves back to `--input`. Use `--output` with `open` when you want to
+fork an existing editable fragment into a different file, and pass
+`--overwrite` only when replacing an existing output path is intentional.
+
+The editor host is a thin wrapper around the generic runner. For runtime/data
+debugging, the equivalent raw runner command for opening a saved level is:
+
+```sh
+./build/debug/slayer3d_runner --root demos/editor_shell_dojo/data --data asset://editor_shell_dojo.game.json --state editor.command=open --state editor.input.path=/tmp/slayer3d-test-level.fragment.json --state editor.save.path=/tmp/slayer3d-test-level.fragment.json
+```
+
+The raw runner path is useful for debugging state injection, but normal editing
+should use `slayer3d_editor new` or `slayer3d_editor open`.
 
 ## Default Layout
 
@@ -76,7 +88,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 | `Space` / `Left Ctrl` | 3D flyby | move camera up/down |
 | `Left Shift` | 3D flyby | move faster |
 | `Ctrl+S` / `Command+S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
-| `T` | palette closed | report that disk test-run handoff is disabled for this MVP iteration |
+| `T` | palette closed | report that disk test-run manifest handoff is disabled for this MVP iteration |
 | `F5` | palette closed | enter the playable test scene from the placed player start |
 | `Esc` | palette closed | quit |
 
@@ -92,7 +104,8 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
    tile should disappear.
 6. Press `Ctrl+S` or `Command+S` and confirm the inspector reports a successful save. The output
    file should contain `brush_worlds` and `editor_player_starts`.
-7. Press `F5`; the editor should switch into the playable test scene.
+7. Press `F5`; the editor should switch into the playable test scene using the
+   current in-memory map and player start.
 8. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
 
@@ -130,7 +143,7 @@ The following should be true during a good test drive:
   perspective preview uses the 3D editor camera.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds` and `editor_player_starts` and
   writes the same fragment to the CLI output path.
-- `T` does not write a manifest during this MVP iteration.
+- `T` does not write a test-run manifest during this MVP iteration.
 - `F5` applies the stored player start before entering the playable scene.
 
 Current limitations are expected: this is not yet a polished TrenchBroom-style

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -11,12 +11,19 @@ Build the editor and open the default editor shell dojo:
 
 ```sh
 cmake --build build/debug --target slayer3d_editor -j4
-./build/debug/slayer3d_editor
+./build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/slayer3d-test-level.fragment.json --overwrite
 ```
 
-Disk save and runner handoff are intentionally disabled while the blockout UX is
-still changing quickly. The shell can export the current level JSON into scene
-state for inspection, but it does not write generated maps to disk.
+The editor now uses explicit subcommands. `new` starts from the project
+template, and `open` loads an existing editable level fragment:
+
+```sh
+./build/debug/slayer3d_editor open --project demos/editor_shell_dojo --input /tmp/slayer3d-test-level.fragment.json
+```
+
+The project path points at a directory containing `slayer3d.project.json`.
+Saving uses an atomic same-directory temporary file and rename; `open` without
+`--output` saves back to `--input`.
 
 ## Default Layout
 
@@ -68,7 +75,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 | mouse look | 3D flyby | rotate camera |
 | `Space` / `Left Ctrl` | 3D flyby | move camera up/down |
 | `Left Shift` | 3D flyby | move faster |
-| `S` | palette closed | export editable level JSON in memory without writing it to disk |
+| `S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
 | `T` | palette closed | report that disk test-run handoff is disabled for this MVP iteration |
 | `F5` | palette closed | enter the playable test scene from the placed player start |
 | `Esc` | palette closed | quit |
@@ -83,8 +90,8 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 4. Press `G`, press `Enter` to select Player Start, and place it on the floor.
 5. Hover a placed tile and right click, or select it and press `Delete`; the
    tile should disappear.
-6. Press `S` and confirm the inspector reports an in-memory JSON export and a
-   disabled disk-save message.
+6. Press `S` and confirm the inspector reports a successful save. The output
+   file should contain `brush_worlds` and `editor_player_starts`.
 7. Press `F5`; the editor should switch into the playable test scene.
 8. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
@@ -121,11 +128,11 @@ The following should be true during a good test drive:
   `X`, or the mouse wheel while keeping a visible work grid.
 - Top/front/side orthographic views plot on their authored work planes;
   perspective preview uses the 3D editor camera.
-- `S` exports JSON containing `brush_worlds` and `editor_player_starts` in
-  memory only.
+- `S` exports JSON containing `brush_worlds` and `editor_player_starts` and
+  writes the same fragment to the CLI output path.
 - `T` does not write a manifest during this MVP iteration.
 - `F5` applies the stored player start before entering the playable scene.
 
 Current limitations are expected: this is not yet a polished TrenchBroom-style
-frontend, there is no file picker, disk persistence is disabled, and
-texture/face painting remains outside this first graybox milestone.
+frontend, there is no file picker, and texture/face painting remains outside
+this first graybox milestone.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1359,6 +1359,28 @@ revision state as `editor.level.export`.
 }
 ```
 
+Use `editor.level.load` to replace an editor runtime's authored starter level
+with an editable fragment from disk. This is intended for editor hosts that pass
+`editor.input.path` at launch time. The fragment must use
+`schema: "slayer3d.fragment.v0"` and contain a `brush_worlds` entry whose name
+matches `world`; its `editor_player_starts` collection replaces the runtime
+player-start collection. Set `optional: true` when the same editor scene should
+also support new/blank sessions with no input file.
+
+```json
+{
+  "type": "editor.level.load",
+  "world": "brush.level.blockout",
+  "path_from_state": "editor.input.path",
+  "optional": true,
+  "outputs": {
+    "valid_key": "editor.load.valid",
+    "message_key": "editor.load.message",
+    "path_key": "editor.load.path"
+  }
+}
+```
+
 Use `editor.test_run.prepare` to publish a game-agnostic handoff manifest for
 launching the generic runner from an editor-selected scene or player start. The
 action does not spawn a process and does not write files. It produces

--- a/docs/game-data-model.md
+++ b/docs/game-data-model.md
@@ -137,6 +137,11 @@ Use C for:
 - asset loaders and pack primitives
 - high-performance primitives that should be available to future games
 
+Keyboard bindings may require modifier chords with `modifiers` or
+`required_modifiers`, and may reject modifier states with `excluded_modifiers`.
+Supported modifier names are `shift`, `ctrl`/`control`, `alt`/`option`, and
+`gui`/`cmd`/`command`/`meta`.
+
 ## Promotion Rule
 
 When the same Lua or host-code pattern appears in multiple games, consider

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2524,6 +2524,19 @@ extern "C"
                                                               size_t *out_size, char *error_buffer,
                                                               int error_buffer_size);
 
+    /**
+     * @brief Load an editable level fragment file into an existing editor runtime.
+     *
+     * The input must be a `slayer3d.fragment.v0` document containing a
+     * `brush_worlds` entry whose name matches @p world_name. The matching world
+     * replaces the runtime world in place, and `editor_player_starts` from the
+     * fragment replaces the runtime player-start collection. On success both
+     * collections are marked clean and @p path becomes their editor source path.
+     */
+    bool slayer3d_game_data_load_editable_level_fragment_file(slayer3d_game_data_runtime *runtime,
+                                                              const char *world_name, const char *path,
+                                                              char *error_buffer, int error_buffer_size);
+
     /** @brief Descriptor for creating an editor test-run handoff manifest. */
     typedef struct slayer3d_game_data_editor_test_run_desc
     {

--- a/src/drawing3d.c
+++ b/src/drawing3d.c
@@ -1906,7 +1906,7 @@ static bool slayer3d_draw_model_node(slayer3d_render_context *context, const sla
     }
 
     /* Recurse into children. */
-    for (int c = 0; ok && c < node->child_count; ++c)
+    for (int c = 0; ok && node->children != NULL && c < node->child_count; ++c)
     {
         ok = slayer3d_draw_model_node(context, assets, model, node->children[c], tint_modulate, joint_matrices,
                                       joint_count);
@@ -1918,6 +1918,12 @@ static bool slayer3d_draw_model_node(slayer3d_render_context *context, const sla
     }
 
     return ok;
+}
+
+static bool slayer3d_model_has_node_roots(const slayer3d_model *model)
+{
+    return model != NULL && model->nodes != NULL && model->node_count > 0 && model->root_nodes != NULL &&
+           model->root_count > 0;
 }
 
 bool slayer3d_draw_model(slayer3d_render_context *context, const slayer3d_model *model, slayer3d_vec3 position,
@@ -1970,7 +1976,7 @@ bool slayer3d_draw_model_ex_with_assets(slayer3d_render_context *context, const 
         ok = slayer3d_scale(context, scale.x, scale.y, scale.z);
     }
 
-    if (ok && model->nodes != NULL && model->root_count > 0)
+    if (ok && slayer3d_model_has_node_roots(model))
     {
         for (int r = 0; ok && r < model->root_count; ++r)
         {
@@ -2020,7 +2026,7 @@ bool slayer3d_draw_model_euler_with_assets(slayer3d_render_context *context, con
     if (ok)
         ok = slayer3d_scale(context, scale.x, scale.y, scale.z);
 
-    if (ok && model->nodes != NULL && model->root_count > 0)
+    if (ok && slayer3d_model_has_node_roots(model))
     {
         for (int r = 0; ok && r < model->root_count; ++r)
             ok = slayer3d_draw_model_node(context, assets, model, model->root_nodes[r], tint_modulate, NULL, 0);
@@ -2088,7 +2094,7 @@ bool slayer3d_draw_model_skinned_with_assets(slayer3d_render_context *context, c
         ok = slayer3d_scale(context, scale.x, scale.y, scale.z);
     }
 
-    if (ok && model->nodes != NULL && model->root_count > 0)
+    if (ok && slayer3d_model_has_node_roots(model))
     {
         for (int r = 0; ok && r < model->root_count; ++r)
         {

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -89,6 +89,74 @@ bool append_format(char *buffer, size_t buffer_size, size_t *offset, const char 
     return true;
 }
 
+void free_brush_world_runtime(brush_world_runtime *world_runtime)
+{
+    if (world_runtime == NULL)
+        return;
+    slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    slayer3d_free_model(&world_runtime->artifacts.render_model);
+    for (int brush_model_index = 0; brush_model_index < world_runtime->artifacts.brush_render_model_count;
+         ++brush_model_index)
+    {
+        slayer3d_free_model(&world_runtime->artifacts.brush_render_models[brush_model_index]);
+    }
+    for (int chunk_model_index = 0; chunk_model_index < world_runtime->artifacts.chunk_render_model_count;
+         ++chunk_model_index)
+    {
+        slayer3d_free_model(&world_runtime->artifacts.chunk_render_models[chunk_model_index]);
+    }
+    SDL_free(world_runtime->artifacts.brush_render_models);
+    SDL_free(world_runtime->artifacts.chunk_render_models);
+    free_brush_world_visibility_grid(world_runtime);
+    slayer3d_game_data_brush_world_free_compile_chunks(world);
+    SDL_free(world_runtime->editor_source_path);
+    free_editor_metadata(&world->editor);
+    SDL_free((void *)world->name);
+    SDL_free((void *)world->units);
+    for (int material_index = 0; material_index < world->material_count; ++material_index)
+    {
+        slayer3d_game_data_brush_material *material =
+            (slayer3d_game_data_brush_material *)&world->materials[material_index];
+        free_editor_metadata(&material->editor);
+        SDL_free((void *)material->name);
+        SDL_free((void *)material->texture);
+    }
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        slayer3d_game_data_brush *brush = (slayer3d_game_data_brush *)&world->brushes[brush_index];
+        SDL_free((void *)brush->name);
+        free_editor_metadata(&brush->editor);
+        for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
+            SDL_free((void *)brush->tags[tag_index]);
+        SDL_free((void *)brush->tags);
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[face_index];
+            free_editor_metadata(&face->editor);
+        }
+        SDL_free((void *)brush->faces);
+    }
+    SDL_free((void *)world->materials);
+    SDL_free((void *)world->brushes);
+    SDL_zero(*world_runtime);
+}
+
+void free_editor_player_starts_runtime(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    for (int i = 0; i < runtime->editor_player_start_count; ++i)
+    {
+        SDL_free(runtime->editor_player_starts[i].name);
+        SDL_free(runtime->editor_player_starts[i].scene);
+        SDL_free(runtime->editor_player_starts[i].target);
+    }
+    SDL_free(runtime->editor_player_starts);
+    runtime->editor_player_starts = NULL;
+    runtime->editor_player_start_count = 0;
+    runtime->editor_player_start_capacity = 0;
+}
+
 bool eval_data_condition(const slayer3d_game_data_runtime *runtime, yyjson_val *condition,
                          const slayer3d_game_data_ui_metrics *metrics);
 bool runtime_actor_is_active(const slayer3d_game_data_runtime *runtime, const slayer3d_registered_actor *actor);
@@ -297,59 +365,8 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
         slayer3d_free_level(&runtime->sector_levels[i].unlit_without_sector_lighting);
     }
     for (int i = 0; i < runtime->brush_world_count; ++i)
-    {
-        slayer3d_game_data_brush_world *world = &runtime->brush_worlds[i].desc;
-        slayer3d_free_model(&runtime->brush_worlds[i].artifacts.render_model);
-        for (int brush_model_index = 0; brush_model_index < runtime->brush_worlds[i].artifacts.brush_render_model_count;
-             ++brush_model_index)
-        {
-            slayer3d_free_model(&runtime->brush_worlds[i].artifacts.brush_render_models[brush_model_index]);
-        }
-        for (int chunk_model_index = 0; chunk_model_index < runtime->brush_worlds[i].artifacts.chunk_render_model_count;
-             ++chunk_model_index)
-        {
-            slayer3d_free_model(&runtime->brush_worlds[i].artifacts.chunk_render_models[chunk_model_index]);
-        }
-        SDL_free(runtime->brush_worlds[i].artifacts.brush_render_models);
-        SDL_free(runtime->brush_worlds[i].artifacts.chunk_render_models);
-        free_brush_world_visibility_grid(&runtime->brush_worlds[i]);
-        slayer3d_game_data_brush_world_free_compile_chunks(world);
-        SDL_free(runtime->brush_worlds[i].editor_source_path);
-        free_editor_metadata(&world->editor);
-        SDL_free((void *)world->name);
-        SDL_free((void *)world->units);
-        for (int material_index = 0; material_index < world->material_count; ++material_index)
-        {
-            slayer3d_game_data_brush_material *material =
-                (slayer3d_game_data_brush_material *)&world->materials[material_index];
-            free_editor_metadata(&material->editor);
-            SDL_free((void *)material->name);
-            SDL_free((void *)material->texture);
-        }
-        for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
-        {
-            slayer3d_game_data_brush *brush = (slayer3d_game_data_brush *)&world->brushes[brush_index];
-            SDL_free((void *)brush->name);
-            free_editor_metadata(&brush->editor);
-            for (int tag_index = 0; tag_index < brush->tag_count; ++tag_index)
-                SDL_free((void *)brush->tags[tag_index]);
-            SDL_free((void *)brush->tags);
-            for (int face_index = 0; face_index < brush->face_count; ++face_index)
-            {
-                slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[face_index];
-                free_editor_metadata(&face->editor);
-            }
-            SDL_free((void *)brush->faces);
-        }
-        SDL_free((void *)world->materials);
-        SDL_free((void *)world->brushes);
-    }
-    for (int i = 0; i < runtime->editor_player_start_count; ++i)
-    {
-        SDL_free(runtime->editor_player_starts[i].name);
-        SDL_free(runtime->editor_player_starts[i].scene);
-        SDL_free(runtime->editor_player_starts[i].target);
-    }
+        free_brush_world_runtime(&runtime->brush_worlds[i]);
+    free_editor_player_starts_runtime(runtime);
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {
         SDL_free(runtime->actor_pools[i].name);
@@ -413,7 +430,6 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     SDL_free(runtime->grid_pickup_layers);
     SDL_free(runtime->sector_levels);
     SDL_free(runtime->brush_worlds);
-    SDL_free(runtime->editor_player_starts);
     SDL_free(runtime->editor_player_start_source_path);
     SDL_free(runtime->sector_doors);
     SDL_free(runtime->sector_platforms);

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -411,6 +411,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.level.save") == 0)
         return slayer3d_game_data_save_editor_level_action(runtime, action);
 
+    if (SDL_strcmp(type, "editor.level.load") == 0)
+        return slayer3d_game_data_load_editor_level_action(runtime, action);
+
     if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
         return slayer3d_game_data_prepare_editor_test_run_action(runtime, action);
 

--- a/src/game_data_actors_input.c
+++ b/src/game_data_actors_input.c
@@ -714,6 +714,113 @@ static void bind_input_spec(slayer3d_input_manager *input, const input_binding_s
     }
 }
 
+static int input_modifier_from_json_name(const char *name)
+{
+    if (name == NULL)
+        return -1;
+    if (SDL_strcasecmp(name, "shift") == 0)
+        return SLAYER3D_INPUT_MOD_SHIFT;
+    if (SDL_strcasecmp(name, "ctrl") == 0 || SDL_strcasecmp(name, "control") == 0)
+        return SLAYER3D_INPUT_MOD_CTRL;
+    if (SDL_strcasecmp(name, "alt") == 0 || SDL_strcasecmp(name, "option") == 0)
+        return SLAYER3D_INPUT_MOD_ALT;
+    if (SDL_strcasecmp(name, "gui") == 0 || SDL_strcasecmp(name, "cmd") == 0 || SDL_strcasecmp(name, "command") == 0 ||
+        SDL_strcasecmp(name, "meta") == 0)
+    {
+        return SLAYER3D_INPUT_MOD_GUI;
+    }
+    return -1;
+}
+
+static bool input_modifier_mask_from_json(yyjson_val *value, int *out_mask, const char *label, char *error_buffer,
+                                          int error_buffer_size)
+{
+    int mask = SLAYER3D_INPUT_MOD_NONE;
+    if (value == NULL)
+    {
+        if (out_mask != NULL)
+            *out_mask = mask;
+        return true;
+    }
+
+    if (yyjson_is_str(value))
+    {
+        const int modifier = input_modifier_from_json_name(yyjson_get_str(value));
+        if (modifier < 0)
+        {
+            set_errorf(error_buffer, error_buffer_size, "%s contains unsupported modifier '%s'", label,
+                       yyjson_get_str(value) != NULL ? yyjson_get_str(value) : "<missing>");
+            return false;
+        }
+        mask |= modifier;
+    }
+    else if (yyjson_is_arr(value))
+    {
+        for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+        {
+            yyjson_val *entry = yyjson_arr_get(value, i);
+            if (!yyjson_is_str(entry))
+            {
+                set_errorf(error_buffer, error_buffer_size, "%s entries must be modifier strings", label);
+                return false;
+            }
+            const int modifier = input_modifier_from_json_name(yyjson_get_str(entry));
+            if (modifier < 0)
+            {
+                set_errorf(error_buffer, error_buffer_size, "%s contains unsupported modifier '%s'", label,
+                           yyjson_get_str(entry) != NULL ? yyjson_get_str(entry) : "<missing>");
+                return false;
+            }
+            mask |= modifier;
+        }
+    }
+    else
+    {
+        set_errorf(error_buffer, error_buffer_size, "%s must be a modifier string or array", label);
+        return false;
+    }
+
+    if (out_mask != NULL)
+        *out_mask = mask;
+    return true;
+}
+
+static bool keyboard_modifier_masks_from_json(yyjson_val *binding, int *required_modifiers, int *excluded_modifiers,
+                                              char *error_buffer, int error_buffer_size)
+{
+    yyjson_val *modifiers = obj_get(binding, "modifiers");
+    yyjson_val *required = obj_get(binding, "required_modifiers");
+    yyjson_val *excluded = obj_get(binding, "excluded_modifiers");
+    int required_mask = SLAYER3D_INPUT_MOD_NONE;
+    int excluded_mask = SLAYER3D_INPUT_MOD_NONE;
+
+    if (modifiers != NULL && required != NULL)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "keyboard binding must not define both modifiers and required_modifiers");
+        return false;
+    }
+    if (!input_modifier_mask_from_json(modifiers != NULL ? modifiers : required, &required_mask,
+                                       "keyboard binding required_modifiers", error_buffer, error_buffer_size) ||
+        !input_modifier_mask_from_json(excluded, &excluded_mask, "keyboard binding excluded_modifiers", error_buffer,
+                                       error_buffer_size))
+    {
+        return false;
+    }
+    if ((required_mask & excluded_mask) != 0)
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "keyboard binding required_modifiers and excluded_modifiers must not overlap");
+        return false;
+    }
+
+    if (required_modifiers != NULL)
+        *required_modifiers = required_mask;
+    if (excluded_modifiers != NULL)
+        *excluded_modifiers = excluded_mask;
+    return true;
+}
+
 static void rebind_action_from_specs(slayer3d_game_data_runtime *runtime, int action_id)
 {
     slayer3d_input_manager *input = runtime_input(runtime);
@@ -877,6 +984,13 @@ bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *err
                     SDL_Scancode code = scancode_from_json(json_string(binding, "key", NULL));
                     if (code != SDL_SCANCODE_UNKNOWN)
                     {
+                        int required_modifiers = SLAYER3D_INPUT_MOD_NONE;
+                        int excluded_modifiers = SLAYER3D_INPUT_MOD_NONE;
+                        if (!keyboard_modifier_masks_from_json(binding, &required_modifiers, &excluded_modifiers,
+                                                               error_buffer, error_buffer_size))
+                        {
+                            return false;
+                        }
                         input_binding_spec spec;
                         SDL_zero(spec);
                         spec.action = name;
@@ -884,6 +998,8 @@ bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *err
                         spec.source = SLAYER3D_INPUT_KEYBOARD;
                         spec.gamepad_index = -1;
                         spec.scancode = code;
+                        spec.required_modifiers = required_modifiers;
+                        spec.excluded_modifiers = excluded_modifiers;
                         spec.scale = 1.0f;
                         if (!append_input_binding_spec(runtime, &spec))
                             return false;
@@ -1022,6 +1138,11 @@ static bool input_profile_binding_to_spec(const slayer3d_game_data_runtime *runt
         }
         out_spec->source = SLAYER3D_INPUT_KEYBOARD;
         out_spec->scancode = code;
+        if (!keyboard_modifier_masks_from_json(binding, &out_spec->required_modifiers, &out_spec->excluded_modifiers,
+                                               error_buffer, error_buffer_size))
+        {
+            return false;
+        }
         out_spec->scale = 1.0f;
         return true;
     }
@@ -1112,6 +1233,11 @@ static bool input_assignment_binding_to_spec(const slayer3d_game_data_runtime *r
         }
         out_spec->source = SLAYER3D_INPUT_KEYBOARD;
         out_spec->scancode = code;
+        if (!keyboard_modifier_masks_from_json(binding, &out_spec->required_modifiers, &out_spec->excluded_modifiers,
+                                               error_buffer, error_buffer_size))
+        {
+            return false;
+        }
         out_spec->scale = 1.0f;
         return true;
     }

--- a/src/game_data_brush_editor_import.c
+++ b/src/game_data_brush_editor_import.c
@@ -1,0 +1,131 @@
+/**
+ * @file game_data_brush_editor_import.c
+ * @brief Editable-level JSON import helpers for editor tooling.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_stdinc.h>
+
+static bool editable_fragment_schema_valid(yyjson_val *root)
+{
+    const char *schema = json_string(root, "schema", NULL);
+    return yyjson_is_obj(root) && schema != NULL && SDL_strcmp(schema, "slayer3d.fragment.v0") == 0;
+}
+
+static int find_loaded_brush_world_index(const slayer3d_game_data_runtime *runtime, const char *world_name)
+{
+    if (runtime == NULL || world_name == NULL)
+        return -1;
+    for (int i = 0; i < runtime->brush_world_count; ++i)
+    {
+        const char *name = runtime->brush_worlds[i].desc.name;
+        if (name != NULL && SDL_strcmp(name, world_name) == 0)
+            return i;
+    }
+    return -1;
+}
+
+static void free_staged_import_runtime(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    for (int i = 0; i < runtime->brush_world_count; ++i)
+        free_brush_world_runtime(&runtime->brush_worlds[i]);
+    SDL_free(runtime->brush_worlds);
+    runtime->brush_worlds = NULL;
+    runtime->brush_world_count = 0;
+    free_editor_player_starts_runtime(runtime);
+    SDL_free(runtime->editor_player_start_source_path);
+    runtime->editor_player_start_source_path = NULL;
+}
+
+bool slayer3d_game_data_load_editable_level_fragment_file(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                          const char *path, char *error_buffer, int error_buffer_size)
+{
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || path == NULL || path[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "editable level load requires runtime, world name, and non-empty file path");
+        return false;
+    }
+
+    size_t size = 0u;
+    void *bytes = SDL_LoadFile(path, &size);
+    if (bytes == NULL || size == 0u)
+    {
+        set_errorf(error_buffer, error_buffer_size, "failed to read editable level '%s'", path);
+        SDL_free(bytes);
+        return false;
+    }
+
+    yyjson_read_err read_error;
+    SDL_zero(read_error);
+    yyjson_doc *doc = yyjson_read_opts((char *)bytes, size, 0, NULL, &read_error);
+    SDL_free(bytes);
+    yyjson_val *root = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    if (!editable_fragment_schema_valid(root))
+    {
+        set_error(error_buffer, error_buffer_size,
+                  "editable level must be a JSON object with schema 'slayer3d.fragment.v0'");
+        yyjson_doc_free(doc);
+        return false;
+    }
+    if (!yyjson_is_arr(obj_get(root, "brush_worlds")))
+    {
+        set_error(error_buffer, error_buffer_size, "editable level requires a brush_worlds array");
+        yyjson_doc_free(doc);
+        return false;
+    }
+
+    slayer3d_game_data_runtime staged;
+    SDL_zero(staged);
+    if (!load_brush_worlds(&staged, root, error_buffer, error_buffer_size) ||
+        !load_editor_player_starts(&staged, root, error_buffer, error_buffer_size))
+    {
+        free_staged_import_runtime(&staged);
+        yyjson_doc_free(doc);
+        return false;
+    }
+
+    const int staged_index = find_loaded_brush_world_index(&staged, world_name);
+    if (staged_index < 0)
+    {
+        set_errorf(error_buffer, error_buffer_size, "editable level does not contain brush world '%s'", world_name);
+        free_staged_import_runtime(&staged);
+        yyjson_doc_free(doc);
+        return false;
+    }
+    brush_world_runtime *target = find_brush_world_runtime_mutable(runtime, world_name);
+    if (target == NULL)
+    {
+        set_errorf(error_buffer, error_buffer_size, "runtime brush world '%s' not found", world_name);
+        free_staged_import_runtime(&staged);
+        yyjson_doc_free(doc);
+        return false;
+    }
+
+    brush_world_runtime replacement = staged.brush_worlds[staged_index];
+    SDL_zero(staged.brush_worlds[staged_index]);
+    free_brush_world_runtime(target);
+    *target = replacement;
+
+    free_editor_player_starts_runtime(runtime);
+    runtime->editor_player_starts = staged.editor_player_starts;
+    runtime->editor_player_start_count = staged.editor_player_start_count;
+    runtime->editor_player_start_capacity = staged.editor_player_start_capacity;
+    staged.editor_player_starts = NULL;
+    staged.editor_player_start_count = 0;
+    staged.editor_player_start_capacity = 0;
+
+    free_staged_import_runtime(&staged);
+    yyjson_doc_free(doc);
+
+    if (!slayer3d_game_data_mark_brush_world_saved(runtime, world_name, path, error_buffer, error_buffer_size) ||
+        !slayer3d_game_data_mark_player_starts_saved(runtime, path, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/game_data_brush_editor_import.c
+++ b/src/game_data_brush_editor_import.c
@@ -110,6 +110,7 @@ bool slayer3d_game_data_load_editable_level_fragment_file(slayer3d_game_data_run
     SDL_zero(staged.brush_worlds[staged_index]);
     free_brush_world_runtime(target);
     *target = replacement;
+    target->desc.render_model = &target->artifacts.render_model;
 
     free_editor_player_starts_runtime(runtime);
     runtime->editor_player_starts = staged.editor_player_starts;

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -298,6 +298,40 @@ bool slayer3d_game_data_save_editor_level_action(slayer3d_game_data_runtime *run
     return true;
 }
 
+bool slayer3d_game_data_load_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    const char *world_name = json_string(action, "world", NULL);
+    const char *path = editor_action_path(runtime, action, NULL);
+    const bool optional = json_bool(action, "optional", false);
+    char error[256];
+    error[0] = '\0';
+
+    bool ok = true;
+    bool skipped = false;
+    if (path == NULL || path[0] == '\0')
+    {
+        ok = optional;
+        skipped = optional;
+        if (!ok)
+            SDL_snprintf(error, sizeof(error), "editable level load path is required");
+    }
+    else
+    {
+        ok = slayer3d_game_data_load_editable_level_fragment_file(runtime, world_name, path, error, (int)sizeof(error));
+    }
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key",
+                             ok ? (skipped ? json_string(action, "skipped_message", "no editable level input")
+                                           : json_string(action, "message", "editable level loaded"))
+                                : (error[0] != '\0' ? error : "editable level load failed"));
+    editor_set_string_output(scene_state, outputs, "path_key", ok && path != NULL ? path : "");
+    publish_editor_level_state_outputs(runtime, outputs, world_name);
+    return true;
+}
+
 bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
 {
     yyjson_val *outputs = obj_get(action, "outputs");

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -910,6 +910,7 @@ bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime,
 bool slayer3d_game_data_export_editor_brush_world_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_export_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_save_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_load_editor_level_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_prepare_editor_test_run_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_save_editor_test_run_manifest_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_publish_editor_brush_world_status_action(slayer3d_game_data_runtime *runtime,
@@ -1085,6 +1086,8 @@ void editor_set_float_output(slayer3d_properties *props, yyjson_val *outputs, co
 void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, slayer3d_vec3 value);
 bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, const char *world_name,
                                        const char *message, bool publish_result);
+void free_brush_world_runtime(brush_world_runtime *world_runtime);
+void free_editor_player_starts_runtime(slayer3d_game_data_runtime *runtime);
 void free_editor_command_history(editor_command_history_state *history);
 slayer3d_bounding_box editor_resized_preview_bounds(slayer3d_bounding_box bounds, slayer3d_vec3 normal, float distance);
 void publish_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -132,6 +132,98 @@ static bool validation_key_name_valid(const char *name)
     return SDL_GetScancodeFromName(name) != SDL_SCANCODE_UNKNOWN;
 }
 
+static bool validation_input_modifier_name_valid(const char *name)
+{
+    return name != NULL && (SDL_strcasecmp(name, "shift") == 0 || SDL_strcasecmp(name, "ctrl") == 0 ||
+                            SDL_strcasecmp(name, "control") == 0 || SDL_strcasecmp(name, "alt") == 0 ||
+                            SDL_strcasecmp(name, "option") == 0 || SDL_strcasecmp(name, "gui") == 0 ||
+                            SDL_strcasecmp(name, "cmd") == 0 || SDL_strcasecmp(name, "command") == 0 ||
+                            SDL_strcasecmp(name, "meta") == 0);
+}
+
+static int validation_input_modifier_mask(const char *name)
+{
+    if (name == NULL)
+        return -1;
+    if (SDL_strcasecmp(name, "shift") == 0)
+        return SLAYER3D_INPUT_MOD_SHIFT;
+    if (SDL_strcasecmp(name, "ctrl") == 0 || SDL_strcasecmp(name, "control") == 0)
+        return SLAYER3D_INPUT_MOD_CTRL;
+    if (SDL_strcasecmp(name, "alt") == 0 || SDL_strcasecmp(name, "option") == 0)
+        return SLAYER3D_INPUT_MOD_ALT;
+    if (SDL_strcasecmp(name, "gui") == 0 || SDL_strcasecmp(name, "cmd") == 0 || SDL_strcasecmp(name, "command") == 0 ||
+        SDL_strcasecmp(name, "meta") == 0)
+    {
+        return SLAYER3D_INPUT_MOD_GUI;
+    }
+    return -1;
+}
+
+static bool validate_keyboard_modifier_mask(validation_context *ctx, yyjson_val *value, const char *path,
+                                            const char *field, int *out_mask)
+{
+    int mask = SLAYER3D_INPUT_MOD_NONE;
+    if (value == NULL)
+    {
+        if (out_mask != NULL)
+            *out_mask = mask;
+        return true;
+    }
+
+    if (yyjson_is_str(value))
+    {
+        const char *modifier = yyjson_get_str(value);
+        if (!validation_input_modifier_name_valid(modifier))
+            return validation_error(ctx, path, "%s contains unsupported modifier '%s'", field,
+                                    modifier != NULL ? modifier : "<missing>");
+        mask |= validation_input_modifier_mask(modifier);
+    }
+    else if (yyjson_is_arr(value))
+    {
+        for (size_t i = 0; i < yyjson_arr_size(value); ++i)
+        {
+            yyjson_val *entry = yyjson_arr_get(value, i);
+            if (!yyjson_is_str(entry))
+                return validation_error(ctx, path, "%s entries must be modifier strings", field);
+            const char *modifier = yyjson_get_str(entry);
+            if (!validation_input_modifier_name_valid(modifier))
+                return validation_error(ctx, path, "%s contains unsupported modifier '%s'", field,
+                                        modifier != NULL ? modifier : "<missing>");
+            mask |= validation_input_modifier_mask(modifier);
+        }
+    }
+    else
+    {
+        return validation_error(ctx, path, "%s must be a modifier string or array", field);
+    }
+
+    if (out_mask != NULL)
+        *out_mask = mask;
+    return true;
+}
+
+static bool validate_keyboard_modifiers(validation_context *ctx, yyjson_val *binding, const char *path)
+{
+    yyjson_val *modifiers = obj_get(binding, "modifiers");
+    yyjson_val *required = obj_get(binding, "required_modifiers");
+    yyjson_val *excluded = obj_get(binding, "excluded_modifiers");
+    int required_mask = SLAYER3D_INPUT_MOD_NONE;
+    int excluded_mask = SLAYER3D_INPUT_MOD_NONE;
+
+    if (modifiers != NULL && required != NULL)
+        return validation_error(ctx, path, "keyboard binding must not define both modifiers and required_modifiers");
+    if (!validate_keyboard_modifier_mask(ctx, modifiers != NULL ? modifiers : required, path,
+                                         "keyboard binding required_modifiers", &required_mask) ||
+        !validate_keyboard_modifier_mask(ctx, excluded, path, "keyboard binding excluded_modifiers", &excluded_mask))
+    {
+        return false;
+    }
+    if ((required_mask & excluded_mask) != 0)
+        return validation_error(ctx, path,
+                                "keyboard binding required_modifiers and excluded_modifiers must not overlap");
+    return true;
+}
+
 bool validation_mouse_button_name_valid(const char *name)
 {
     return name != NULL &&
@@ -4130,6 +4222,8 @@ static bool validate_input_bindings(validation_context *ctx, yyjson_val *root)
                 {
                     if (!is_non_empty_string(binding, "key"))
                         return validation_error(ctx, path, "keyboard binding requires a non-empty key");
+                    if (!validate_keyboard_modifiers(ctx, binding, path))
+                        return false;
                 }
                 else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
                 {
@@ -4171,6 +4265,8 @@ static bool validate_input_profile_binding(validation_context *ctx, yyjson_val *
         const char *key = json_string(binding, "key");
         if (!validation_key_name_valid(key))
             return validation_error(ctx, path, "keyboard input profile binding requires a valid key");
+        if (!validate_keyboard_modifiers(ctx, binding, path))
+            return false;
     }
     else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
     {
@@ -4246,6 +4342,8 @@ static bool validate_input_assignment_set_binding(validation_context *ctx, yyjso
     {
         if (!validation_key_name_valid(json_string(binding, "key")))
             return validation_error(ctx, path, "keyboard input device assignment binding requires a valid key");
+        if (!validate_keyboard_modifiers(ctx, binding, path))
+            return false;
     }
     else if (SDL_strcmp(device != NULL ? device : "", "gamepad") == 0)
     {

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7632,6 +7632,48 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         }
         return true;
     }
+    if (SDL_strcmp(type, "editor.level.load") == 0)
+    {
+        if (!require_ref(ctx, &names->brush_worlds, "brush world", json_string(action, "world"), json_path))
+            return false;
+        yyjson_val *path = obj_get(action, "path");
+        yyjson_val *path_from_state = obj_get(action, "path_from_state");
+        if ((path == NULL && path_from_state == NULL) || (path != NULL && path_from_state != NULL))
+            return validation_error(ctx, json_path,
+                                    "editor.level.load requires exactly one of path or path_from_state");
+        if (path != NULL && (!yyjson_is_str(path) || yyjson_get_str(path)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.level.load path must be a non-empty string");
+        if (path_from_state != NULL && (!yyjson_is_str(path_from_state) || yyjson_get_str(path_from_state)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.level.load path_from_state must be a non-empty string");
+        yyjson_val *optional = obj_get(action, "optional");
+        if (optional != NULL && !yyjson_is_bool(optional))
+            return validation_error(ctx, json_path, "editor.level.load optional must be a boolean");
+        yyjson_val *outputs = obj_get(action, "outputs");
+        if (outputs != NULL && !yyjson_is_obj(outputs))
+            return validation_error(ctx, json_path, "editor.level.load outputs must be an object");
+        static const char *const output_keys[] = {
+            "valid_key",
+            "message_key",
+            "path_key",
+            "brush_world_key",
+            "brush_source_path_key",
+            "brush_dirty_key",
+            "brush_revision_key",
+            "brush_saved_revision_key",
+            "player_start_source_path_key",
+            "player_start_count_key",
+            "player_start_dirty_key",
+            "player_start_revision_key",
+            "player_start_saved_revision_key",
+        };
+        for (size_t i = 0; yyjson_is_obj(outputs) && i < SDL_arraysize(output_keys); ++i)
+        {
+            yyjson_val *output = obj_get(outputs, output_keys[i]);
+            if (output != NULL && (!yyjson_is_str(output) || yyjson_get_str(output)[0] == '\0'))
+                return validation_error(ctx, json_path, "editor.level.load output keys must be non-empty strings");
+        }
+        return true;
+    }
     if (SDL_strcmp(type, "editor.test_run.prepare") == 0)
     {
         if (!is_non_empty_string(action, "data_asset"))

--- a/src/gltf_loader.c
+++ b/src/gltf_loader.c
@@ -646,125 +646,150 @@ bool slayer3d_load_model_gltf(const char *path, slayer3d_model *out)
          * Our mesh array is ordered: for each cgltf mesh, its triangle
          * primitives appear consecutively starting at mesh_start[m]. */
         int *mesh_start = (int *)SDL_calloc(data->meshes_count, sizeof(int));
-        if (mesh_start != NULL)
+        if (mesh_start == NULL)
         {
-            int running = 0;
-            for (cgltf_size m = 0; m < data->meshes_count; ++m)
+            cgltf_free(data);
+            slayer3d_free_model(out);
+            return SDL_OutOfMemory();
+        }
+
+        int running = 0;
+        for (cgltf_size m = 0; m < data->meshes_count; ++m)
+        {
+            mesh_start[m] = running;
+            for (cgltf_size p = 0; p < data->meshes[m].primitives_count; ++p)
             {
-                mesh_start[m] = running;
-                for (cgltf_size p = 0; p < data->meshes[m].primitives_count; ++p)
+                if (data->meshes[m].primitives[p].type == cgltf_primitive_type_triangles)
                 {
-                    if (data->meshes[m].primitives[p].type == cgltf_primitive_type_triangles)
-                    {
-                        ++running;
-                    }
+                    ++running;
                 }
             }
+        }
 
-            out->node_count = (int)data->nodes_count;
-            out->nodes = (slayer3d_model_node *)SDL_calloc(data->nodes_count, sizeof(slayer3d_model_node));
-            if (out->nodes != NULL)
+        out->nodes = (slayer3d_model_node *)SDL_calloc(data->nodes_count, sizeof(slayer3d_model_node));
+        if (out->nodes == NULL)
+        {
+            SDL_free(mesh_start);
+            cgltf_free(data);
+            slayer3d_free_model(out);
+            return SDL_OutOfMemory();
+        }
+        out->node_count = (int)data->nodes_count;
+
+        for (cgltf_size n = 0; n < data->nodes_count; ++n)
+        {
+            const cgltf_node *src = &data->nodes[n];
+            slayer3d_model_node *dst = &out->nodes[n];
+
+            /* Default TRS. */
+            dst->translation[0] = dst->translation[1] = dst->translation[2] = 0.0f;
+            dst->rotation[0] = dst->rotation[1] = dst->rotation[2] = 0.0f;
+            dst->rotation[3] = 1.0f;
+            dst->scale[0] = dst->scale[1] = dst->scale[2] = 1.0f;
+            dst->mesh_index = -1;
+
+            if (src->has_matrix)
             {
+                dst->has_matrix = true;
+                cgltf_node_transform_local(src, dst->local_matrix);
+            }
+            if (src->has_translation)
+            {
+                dst->translation[0] = src->translation[0];
+                dst->translation[1] = src->translation[1];
+                dst->translation[2] = src->translation[2];
+            }
+            if (src->has_rotation)
+            {
+                dst->rotation[0] = src->rotation[0];
+                dst->rotation[1] = src->rotation[1];
+                dst->rotation[2] = src->rotation[2];
+                dst->rotation[3] = src->rotation[3];
+            }
+            if (src->has_scale)
+            {
+                dst->scale[0] = src->scale[0];
+                dst->scale[1] = src->scale[1];
+                dst->scale[2] = src->scale[2];
+            }
+
+            /* Map mesh reference. */
+            if (src->mesh != NULL)
+            {
+                cgltf_size mi = (cgltf_size)(src->mesh - data->meshes);
+                dst->mesh_index = mesh_start[mi];
+            }
+
+            /* Children. */
+            if (src->children_count > 0)
+            {
+                dst->children = (int *)SDL_malloc(src->children_count * sizeof(int));
+                if (dst->children == NULL)
+                {
+                    SDL_free(mesh_start);
+                    cgltf_free(data);
+                    slayer3d_free_model(out);
+                    return SDL_OutOfMemory();
+                }
+                dst->child_count = (int)src->children_count;
+                for (cgltf_size c = 0; c < src->children_count; ++c)
+                {
+                    dst->children[c] = (int)(src->children[c] - data->nodes);
+                }
+            }
+        }
+
+        /* Identify root nodes from the default scene (or all parentless nodes). */
+        if (data->scene != NULL && data->scene->nodes_count > 0)
+        {
+            const int root_count = (int)data->scene->nodes_count;
+            out->root_nodes = (int *)SDL_malloc((size_t)root_count * sizeof(int));
+            if (out->root_nodes == NULL)
+            {
+                SDL_free(mesh_start);
+                cgltf_free(data);
+                slayer3d_free_model(out);
+                return SDL_OutOfMemory();
+            }
+            out->root_count = root_count;
+            for (cgltf_size r = 0; r < data->scene->nodes_count; ++r)
+            {
+                out->root_nodes[r] = (int)(data->scene->nodes[r] - data->nodes);
+            }
+        }
+        else
+        {
+            /* Fallback: nodes with no parent are roots. */
+            int rc = 0;
+            for (cgltf_size n = 0; n < data->nodes_count; ++n)
+            {
+                if (data->nodes[n].parent == NULL)
+                {
+                    ++rc;
+                }
+            }
+            if (rc > 0)
+            {
+                out->root_nodes = (int *)SDL_malloc((size_t)rc * sizeof(int));
+                if (out->root_nodes == NULL)
+                {
+                    SDL_free(mesh_start);
+                    cgltf_free(data);
+                    slayer3d_free_model(out);
+                    return SDL_OutOfMemory();
+                }
+                out->root_count = rc;
+                int ri = 0;
                 for (cgltf_size n = 0; n < data->nodes_count; ++n)
                 {
-                    const cgltf_node *src = &data->nodes[n];
-                    slayer3d_model_node *dst = &out->nodes[n];
-
-                    /* Default TRS. */
-                    dst->translation[0] = dst->translation[1] = dst->translation[2] = 0.0f;
-                    dst->rotation[0] = dst->rotation[1] = dst->rotation[2] = 0.0f;
-                    dst->rotation[3] = 1.0f;
-                    dst->scale[0] = dst->scale[1] = dst->scale[2] = 1.0f;
-                    dst->mesh_index = -1;
-
-                    if (src->has_matrix)
+                    if (data->nodes[n].parent == NULL)
                     {
-                        dst->has_matrix = true;
-                        cgltf_node_transform_local(src, dst->local_matrix);
-                    }
-                    if (src->has_translation)
-                    {
-                        dst->translation[0] = src->translation[0];
-                        dst->translation[1] = src->translation[1];
-                        dst->translation[2] = src->translation[2];
-                    }
-                    if (src->has_rotation)
-                    {
-                        dst->rotation[0] = src->rotation[0];
-                        dst->rotation[1] = src->rotation[1];
-                        dst->rotation[2] = src->rotation[2];
-                        dst->rotation[3] = src->rotation[3];
-                    }
-                    if (src->has_scale)
-                    {
-                        dst->scale[0] = src->scale[0];
-                        dst->scale[1] = src->scale[1];
-                        dst->scale[2] = src->scale[2];
-                    }
-
-                    /* Map mesh reference. */
-                    if (src->mesh != NULL)
-                    {
-                        cgltf_size mi = (cgltf_size)(src->mesh - data->meshes);
-                        dst->mesh_index = mesh_start[mi];
-                    }
-
-                    /* Children. */
-                    if (src->children_count > 0)
-                    {
-                        dst->child_count = (int)src->children_count;
-                        dst->children = (int *)SDL_malloc(src->children_count * sizeof(int));
-                        if (dst->children != NULL)
-                        {
-                            for (cgltf_size c = 0; c < src->children_count; ++c)
-                            {
-                                dst->children[c] = (int)(src->children[c] - data->nodes);
-                            }
-                        }
-                    }
-                }
-
-                /* Identify root nodes from the default scene (or all parentless nodes). */
-                if (data->scene != NULL && data->scene->nodes_count > 0)
-                {
-                    out->root_count = (int)data->scene->nodes_count;
-                    out->root_nodes = (int *)SDL_malloc(data->scene->nodes_count * sizeof(int));
-                    if (out->root_nodes != NULL)
-                    {
-                        for (cgltf_size r = 0; r < data->scene->nodes_count; ++r)
-                        {
-                            out->root_nodes[r] = (int)(data->scene->nodes[r] - data->nodes);
-                        }
-                    }
-                }
-                else
-                {
-                    /* Fallback: nodes with no parent are roots. */
-                    int rc = 0;
-                    for (cgltf_size n = 0; n < data->nodes_count; ++n)
-                    {
-                        if (data->nodes[n].parent == NULL)
-                        {
-                            ++rc;
-                        }
-                    }
-                    out->root_nodes = (int *)SDL_malloc((size_t)rc * sizeof(int));
-                    if (out->root_nodes != NULL)
-                    {
-                        out->root_count = rc;
-                        int ri = 0;
-                        for (cgltf_size n = 0; n < data->nodes_count; ++n)
-                        {
-                            if (data->nodes[n].parent == NULL)
-                            {
-                                out->root_nodes[ri++] = (int)n;
-                            }
-                        }
+                        out->root_nodes[ri++] = (int)n;
                     }
                 }
             }
-            SDL_free(mesh_start);
         }
+        SDL_free(mesh_start);
     }
 
     cgltf_free(data);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -295,7 +295,11 @@ else()
             ${CMAKE_SOURCE_DIR}/tools/slayer3d_runner_state.c
     )
     target_link_libraries(slayer3d_tool_cli_test PRIVATE slayer3d_argtable3)
-    target_include_directories(slayer3d_tool_cli_test PRIVATE ${CMAKE_SOURCE_DIR}/tools)
+    target_include_directories(
+        slayer3d_tool_cli_test
+        PRIVATE
+            ${CMAKE_SOURCE_DIR}/tools
+    )
 
     if(NOT EMSCRIPTEN)
         slayer3d_add_test(slayer3d_asset_test test_asset.cpp unit)

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -350,6 +350,41 @@ TEST_F(SLAYER3DDrawingFixture, RenderStatsTrackModelMeshCulling)
     slayer3d_destroy_render_context(ctx);
 }
 
+TEST_F(SLAYER3DDrawingFixture, ModelDrawFallsBackToMeshesWhenRootNodeArrayMissing)
+{
+    WindowRenderer wr;
+    ASSERT_TRUE(wr.ok());
+    slayer3d_render_context *ctx = nullptr;
+    ASSERT_TRUE(slayer3d_create_render_context(wr.window(), wr.renderer(), nullptr, &ctx)) << SDL_GetError();
+
+    slayer3d_mesh mesh{};
+    FillTriangleMesh(mesh, 0.0f, 0.0f);
+    slayer3d_model_node node{};
+    node.mesh_index = 0;
+
+    slayer3d_model model{};
+    model.meshes = &mesh;
+    model.mesh_count = 1;
+    model.nodes = &node;
+    model.node_count = 1;
+    model.root_nodes = nullptr;
+    model.root_count = 1;
+
+    ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, MakeCamera())) << SDL_GetError();
+    ASSERT_TRUE(slayer3d_draw_model_ex(ctx, &model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                       slayer3d_vec3_make(0.0f, 1.0f, 0.0f), 0.0f, slayer3d_vec3_make(1.0f, 1.0f, 1.0f),
+                                       kRed))
+        << SDL_GetError();
+    ASSERT_TRUE(slayer3d_end_mode_3d(ctx)) << SDL_GetError();
+
+    slayer3d_render_stats stats{};
+    ASSERT_TRUE(slayer3d_get_render_stats(ctx, &stats));
+    EXPECT_EQ(stats.model_mesh_submissions, 1u);
+    EXPECT_EQ(stats.model_mesh_draws, 1u);
+
+    slayer3d_destroy_render_context(ctx);
+}
+
 TEST_F(SLAYER3DDrawingFixture, SetDepthPlanesRejectedWhileInMode)
 {
     WindowRenderer wr;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15870,6 +15870,11 @@ TEST(GameDataRuntime, EditorShellDojoOpenLoadsEditableLevelOnEnter)
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(data, "brush.editor_shell.target", &world));
     ASSERT_GT(world.brush_count, 1);
+    ASSERT_NE(world.render_model, nullptr);
+    if (world.render_model->root_count > 0)
+    {
+        EXPECT_NE(world.render_model->root_nodes, nullptr);
+    }
     bool found_probe = false;
     for (int i = 0; i < world.brush_count; ++i)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15710,10 +15710,14 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.save_message", ""),
                  "test-run manifest disabled");
 
+    const std::filesystem::path save_dir = unique_test_dir("editor_shell_dojo_save");
+    const std::filesystem::path save_path = save_dir / "level.fragment.json";
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.save.path",
+                                   save_path.string().c_str());
     slayer3d_signal_emit(bus, export_signal, nullptr);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", true));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""),
-                 "disk save disabled for MVP iteration");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.save.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.save.message", ""), "editable level saved");
+    EXPECT_TRUE(std::filesystem::exists(save_path));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.export.valid", false));
     const char *export_json = slayer3d_properties_get_string(scene_state, "editor.export.json", "");
     ASSERT_NE(export_json, nullptr);
@@ -15736,6 +15740,49 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(test_player->position.z, player_start_origin.z, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "yaw", 0.0f), 3.14159f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "pitch", 1.0f), 0.0f, 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditableLevelFragmentLoadsIntoEditorRuntime)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    const std::filesystem::path save_dir = unique_test_dir("editable_level_reload");
+    const std::filesystem::path save_path = save_dir / "level.fragment.json";
+    const std::string save_path_string = save_path.string();
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    size_t saved_size = 0;
+    ASSERT_TRUE(slayer3d_game_data_save_editable_level_fragment_file(
+        runtime, "brush.editor_shell.target", save_path_string.c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    EXPECT_GT(saved_size, 0u);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_file(runtime, "brush.editor_shell.target",
+                                                                     save_path_string.c_str(), error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_brush_world_editor_state brush_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &brush_state));
+    EXPECT_STREQ(brush_state.source_path, save_path_string.c_str());
+    EXPECT_FALSE(brush_state.dirty);
+    slayer3d_game_data_player_start_editor_state start_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_player_start_editor_state(runtime, &start_state));
+    EXPECT_STREQ(start_state.source_path, save_path_string.c_str());
+    EXPECT_EQ(start_state.count, 1);
+    EXPECT_FALSE(start_state.dirty);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15384,6 +15384,26 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_NE(scene_state, nullptr);
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
+    const int export_action_id = slayer3d_game_data_find_action(runtime, "action.editor.export");
+    ASSERT_GE(export_action_id, 0);
+    auto press_save_chord = [&](SDL_Keymod modifiers, Uint64 frame) {
+        SDL_SetModState(modifiers);
+        SDL_Event key{};
+        key.type = SDL_EVENT_KEY_DOWN;
+        key.key.scancode = SDL_SCANCODE_S;
+        key.key.mod = modifiers;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, frame);
+        const bool pressed = slayer3d_input_is_pressed(input, export_action_id);
+        key.type = SDL_EVENT_KEY_UP;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, frame + 1U);
+        SDL_SetModState(SDL_KMOD_NONE);
+        return pressed;
+    };
+    EXPECT_FALSE(press_save_chord(SDL_KMOD_NONE, 100));
+    EXPECT_TRUE(press_save_chord(SDL_KMOD_CTRL, 102));
+    EXPECT_TRUE(press_save_chord(SDL_KMOD_GUI, 104));
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
     motion.motion.x = 660.0f;
@@ -21815,6 +21835,71 @@ TEST(GameDataRuntime, ValidatesAuthoredStorageConfig)
                                                  sizeof(error)))
         << error;
     EXPECT_EQ(error[0], '\0');
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, ValidatesKeyboardBindingModifiers)
+{
+    const std::filesystem::path dir = unique_test_dir("input_modifier_validation");
+    write_text(dir / "bad_input_modifier.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Input Modifier", "id": "test.bad_input_modifier", "version": "0.1.0" },
+  "world": { "name": "world.bad_input_modifier", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.test",
+        "actions": [
+          {
+            "name": "action.save",
+            "bindings": [{ "device": "keyboard", "key": "S", "modifiers": ["hyper"] }]
+          }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    char error[512]{};
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_input_modifier.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("unsupported modifier 'hyper'"), std::string::npos) << error;
+
+    write_text(dir / "overlap_input_modifier.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Overlap Input Modifier", "id": "test.overlap_input_modifier", "version": "0.1.0" },
+  "world": { "name": "world.overlap_input_modifier", "kind": "fixed_screen" },
+  "input": {
+    "contexts": [
+      {
+        "name": "input.test",
+        "actions": [
+          {
+            "name": "action.save",
+            "bindings": [
+              {
+                "device": "keyboard",
+                "key": "S",
+                "required_modifiers": ["ctrl"],
+                "excluded_modifiers": ["control"]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "entities": []
+})json");
+
+    error[0] = '\0';
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "overlap_input_modifier.game.json").string().c_str(), nullptr,
+                                                  error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("must not overlap"), std::string::npos) << error;
+
     remove_test_dir(dir);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15871,6 +15871,7 @@ TEST(GameDataRuntime, EditorShellDojoOpenLoadsEditableLevelOnEnter)
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(data, "brush.editor_shell.target", &world));
     ASSERT_GT(world.brush_count, 1);
     ASSERT_NE(world.render_model, nullptr);
+    EXPECT_GT(world.render_model->mesh_count, 0);
     if (world.render_model->root_count > 0)
     {
         EXPECT_NE(world.render_model->root_nodes, nullptr);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15808,6 +15808,90 @@ TEST(GameDataRuntime, EditableLevelFragmentLoadsIntoEditorRuntime)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoOpenLoadsEditableLevelOnEnter)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    const std::string root = dojo_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + dojo_path.filename().string();
+    const std::filesystem::path save_dir = unique_test_dir("editor_shell_open_load");
+    const std::filesystem::path save_path = save_dir / "level.fragment.json";
+    const std::string save_path_string = save_path.string();
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *source = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &source, error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_create_box_brush_desc box{};
+    box.world_name = "brush.editor_shell.target";
+    box.brush_name = "brush.editor_shell.target.open_load_probe";
+    box.material_name = "mat.editor.floor";
+    box.min = slayer3d_vec3_make(16.0f, -0.2f, 16.0f);
+    box.max = slayer3d_vec3_make(24.0f, 0.0f, 24.0f);
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(source, &box, nullptr, 0, error, sizeof(error))) << error;
+    size_t saved_size = 0;
+    ASSERT_TRUE(slayer3d_game_data_save_editable_level_fragment_file(
+        source, "brush.editor_shell.target", save_path_string.c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    slayer3d_game_data_destroy(source);
+    slayer3d_game_session_destroy(session);
+
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_properties *initial_state = slayer3d_properties_create();
+    ASSERT_NE(initial_state, nullptr);
+    slayer3d_properties_set_string(initial_state, "editor.command", "open");
+    slayer3d_properties_set_string(initial_state, "editor.input.path", save_path_string.c_str());
+    slayer3d_properties_set_string(initial_state, "editor.save.path", save_path_string.c_str());
+
+    slayer3d_data_game_runtime_desc desc{};
+    slayer3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SLAYER3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+    desc.initial_scene_state = initial_state;
+    desc.initial_scene_payload = initial_state;
+
+    slayer3d_data_game_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
+    slayer3d_properties_destroy(initial_state);
+    slayer3d_game_data_runtime *data = slayer3d_data_game_runtime_data(runtime);
+    ASSERT_NE(data, nullptr);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(data);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.load.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.load.message", ""), "editable level loaded");
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(data, "brush.editor_shell.target", &world));
+    ASSERT_GT(world.brush_count, 1);
+    bool found_probe = false;
+    for (int i = 0; i < world.brush_count; ++i)
+    {
+        if (world.brushes[i].name != nullptr &&
+            std::string(world.brushes[i].name) == "brush.editor_shell.target.open_load_probe")
+        {
+            found_probe = true;
+            EXPECT_NEAR(world.brushes[i].bounds.min.x, 16.0f, 0.001f);
+            EXPECT_NEAR(world.brushes[i].bounds.max.z, 24.0f, 0.001f);
+        }
+    }
+    EXPECT_TRUE(found_probe);
+    slayer3d_game_data_brush_world_editor_state brush_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(data, "brush.editor_shell.target", &brush_state));
+    EXPECT_STREQ(brush_state.source_path, save_path_string.c_str());
+    EXPECT_FALSE(brush_state.dirty);
+
+    slayer3d_data_game_runtime_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(save_dir);
+}
+
 TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_tool_cli.cpp
+++ b/tests/test_tool_cli.cpp
@@ -148,20 +148,39 @@ TEST(ToolCli, RunnerRejectsEmptyTestRunManifestPath)
     slayer3d_runner_args_destroy(&args);
 }
 
-TEST(ToolCli, EditorParsesDefaultsAndBuildsRunnerInvocation)
+TEST(ToolCli, EditorNewLoadsProjectAndBuildsRunnerInvocation)
 {
-    std::vector<char *> argv = argv_from({"slayer3d_editor", "--state", "editor.tool.mode=floor"});
+    const std::filesystem::path project_dir = unique_cli_test_dir("editor_project");
+    std::filesystem::create_directories(project_dir / "data");
+    write_text(project_dir / "slayer3d.project.json",
+               R"json({
+  "schema": "slayer3d.project.v0",
+  "data_root": "data",
+  "editor_entry": "asset://editor.game.json",
+  "media_root": "media",
+  "test_run_output": "build/test-run.json"
+})json");
+    const std::string project = project_dir.string();
+    const std::string output = (project_dir / "levels" / "new.json").string();
+    std::vector<char *> argv =
+        argv_from({"slayer3d_editor", "new", "--project", project.c_str(), "--output", output.c_str()});
     slayer3d_editor_args args;
     ASSERT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
-    slayer3d_editor_args_apply_defaults(&args, "editor/data", "asset://editor.game.json", "build/editor/level.json",
-                                        "build/editor/run.json");
+    EXPECT_EQ(args.command, SLAYER3D_EDITOR_COMMAND_NEW);
+
+    char error[512]{};
+    slayer3d_editor_project loaded_project;
+    ASSERT_TRUE(slayer3d_editor_project_load(args.project, &loaded_project, error, sizeof(error))) << error;
+    slayer3d_editor_launch launch;
+    ASSERT_TRUE(slayer3d_editor_prepare_launch(&args, &loaded_project, &launch, error, sizeof(error))) << error;
+    ASSERT_TRUE(slayer3d_editor_validate_paths(&args, &launch, error, sizeof(error))) << error;
 
     slayer3d_editor_runner_invocation invocation;
-    ASSERT_TRUE(slayer3d_editor_build_runner_invocation(&args, "slayer3d_editor", &invocation));
-    ASSERT_GE(invocation.argc, 11);
+    ASSERT_TRUE(slayer3d_editor_build_runner_invocation(&launch, "slayer3d_editor", &invocation));
+    ASSERT_GE(invocation.argc, 15);
     EXPECT_STREQ(invocation.argv[0], "slayer3d_editor");
     EXPECT_STREQ(invocation.argv[1], "--root");
-    EXPECT_STREQ(invocation.argv[2], "editor/data");
+    EXPECT_STREQ(invocation.argv[2], (project_dir / "data").string().c_str());
     EXPECT_STREQ(invocation.argv[3], "--data");
     EXPECT_STREQ(invocation.argv[4], "asset://editor.game.json");
     std::string joined;
@@ -171,21 +190,97 @@ TEST(ToolCli, EditorParsesDefaultsAndBuildsRunnerInvocation)
             joined += "\n";
         joined += invocation.argv[i];
     }
-    EXPECT_NE(joined.find("editor.save.path=build/editor/level.json"), std::string::npos);
-    EXPECT_NE(joined.find("editor.test_run.path=build/editor/run.json"), std::string::npos);
-    EXPECT_NE(joined.find("editor.tool.mode=floor"), std::string::npos);
+    EXPECT_NE(joined.find("editor.command=new"), std::string::npos);
+    EXPECT_NE(joined.find("editor.input.path="), std::string::npos);
+    EXPECT_NE(joined.find("editor.save.path=" + output), std::string::npos);
+    EXPECT_NE(joined.find("editor.test_run.path=" + (project_dir / "build" / "test-run.json").string()),
+              std::string::npos);
     slayer3d_editor_runner_invocation_destroy(&invocation);
+    slayer3d_editor_launch_destroy(&launch);
+    slayer3d_editor_project_destroy(&loaded_project);
     slayer3d_editor_args_destroy(&args);
+    std::filesystem::remove_all(project_dir);
 }
 
-TEST(ToolCli, EditorRequiresProjectAndOutputPathsAfterDefaults)
+TEST(ToolCli, EditorOpenDefaultsOutputToInput)
+{
+    const std::filesystem::path project_dir = unique_cli_test_dir("editor_open_project");
+    std::filesystem::create_directories(project_dir / "data");
+    write_text(project_dir / "slayer3d.project.json",
+               R"json({
+  "schema": "slayer3d.project.v0",
+  "data_root": "data",
+  "editor_entry": "asset://editor.game.json"
+})json");
+    const std::filesystem::path level_path = project_dir / "level.json";
+    write_text(level_path, R"json({ "schema": "slayer3d.fragment.v0", "brush_worlds": [] })json");
+    const std::string project = project_dir.string();
+    const std::string input = level_path.string();
+    std::vector<char *> argv =
+        argv_from({"slayer3d_editor", "open", "--project", project.c_str(), "--input", input.c_str()});
+    slayer3d_editor_args args;
+    ASSERT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
+
+    char error[512]{};
+    slayer3d_editor_project loaded_project;
+    ASSERT_TRUE(slayer3d_editor_project_load(args.project, &loaded_project, error, sizeof(error))) << error;
+    slayer3d_editor_launch launch;
+    ASSERT_TRUE(slayer3d_editor_prepare_launch(&args, &loaded_project, &launch, error, sizeof(error))) << error;
+    ASSERT_TRUE(slayer3d_editor_validate_paths(&args, &launch, error, sizeof(error))) << error;
+    EXPECT_STREQ(launch.input_path, input.c_str());
+    EXPECT_STREQ(launch.save_path, input.c_str());
+
+    slayer3d_editor_launch_destroy(&launch);
+    slayer3d_editor_project_destroy(&loaded_project);
+    slayer3d_editor_args_destroy(&args);
+    std::filesystem::remove_all(project_dir);
+}
+
+TEST(ToolCli, EditorRejectsMissingSubcommand)
 {
     std::vector<char *> argv = argv_from({"slayer3d_editor"});
     slayer3d_editor_args args;
+    EXPECT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
+}
+
+TEST(ToolCli, EditorRejectsNewWithoutOutput)
+{
+    std::vector<char *> argv = argv_from({"slayer3d_editor", "new", "--project", "project"});
+    slayer3d_editor_args args;
+    EXPECT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_ERROR);
+}
+
+TEST(ToolCli, EditorRejectsMalformedOpenInputBeforeLaunch)
+{
+    const std::filesystem::path project_dir = unique_cli_test_dir("editor_bad_open_project");
+    std::filesystem::create_directories(project_dir / "data");
+    write_text(project_dir / "slayer3d.project.json",
+               R"json({
+  "schema": "slayer3d.project.v0",
+  "data_root": "data",
+  "editor_entry": "asset://editor.game.json"
+})json");
+    const std::filesystem::path level_path = project_dir / "level.json";
+    write_text(level_path, R"json({ "schema": "slayer3d.game.v0" })json");
+    const std::string project = project_dir.string();
+    const std::string input = level_path.string();
+    std::vector<char *> argv =
+        argv_from({"slayer3d_editor", "open", "--project", project.c_str(), "--input", input.c_str()});
+    slayer3d_editor_args args;
     ASSERT_EQ(slayer3d_editor_args_parse((int)argv.size(), argv.data(), &args, nullptr), SLAYER3D_TOOL_CLI_OK);
-    slayer3d_editor_runner_invocation invocation;
-    EXPECT_FALSE(slayer3d_editor_build_runner_invocation(&args, "slayer3d_editor", &invocation));
+
+    char error[512]{};
+    slayer3d_editor_project loaded_project;
+    ASSERT_TRUE(slayer3d_editor_project_load(args.project, &loaded_project, error, sizeof(error))) << error;
+    slayer3d_editor_launch launch;
+    ASSERT_TRUE(slayer3d_editor_prepare_launch(&args, &loaded_project, &launch, error, sizeof(error))) << error;
+    EXPECT_FALSE(slayer3d_editor_validate_paths(&args, &launch, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("slayer3d.fragment.v0"), std::string::npos) << error;
+
+    slayer3d_editor_launch_destroy(&launch);
+    slayer3d_editor_project_destroy(&loaded_project);
     slayer3d_editor_args_destroy(&args);
+    std::filesystem::remove_all(project_dir);
 }
 
 TEST(ToolCli, PackParsesRepeatedFiles)

--- a/tools/slayer3d_editor.c
+++ b/tools/slayer3d_editor.c
@@ -11,22 +11,6 @@
 #include "slayer3d_editor_cli.h"
 #include "slayer3d_runner_cli.h"
 
-#if !defined(SLAYER3D_EDITOR_DEFAULT_ROOT)
-#define SLAYER3D_EDITOR_DEFAULT_ROOT ""
-#endif
-
-#if !defined(SLAYER3D_EDITOR_DEFAULT_DATA)
-#define SLAYER3D_EDITOR_DEFAULT_DATA ""
-#endif
-
-#if !defined(SLAYER3D_EDITOR_DEFAULT_SAVE_PATH)
-#define SLAYER3D_EDITOR_DEFAULT_SAVE_PATH ""
-#endif
-
-#if !defined(SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH)
-#define SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH ""
-#endif
-
 int main(int argc, char **argv)
 {
     slayer3d_editor_args args;
@@ -34,23 +18,45 @@ int main(int argc, char **argv)
     if (cli_result != SLAYER3D_TOOL_CLI_OK)
         return cli_result == SLAYER3D_TOOL_CLI_HELP ? 0 : 2;
 
-    slayer3d_editor_args_apply_defaults(&args, SLAYER3D_EDITOR_DEFAULT_ROOT, SLAYER3D_EDITOR_DEFAULT_DATA,
-                                        SLAYER3D_EDITOR_DEFAULT_SAVE_PATH, SLAYER3D_EDITOR_DEFAULT_TEST_RUN_PATH);
-    slayer3d_editor_runner_invocation invocation;
-    if (!slayer3d_editor_build_runner_invocation(&args, argc > 0 && argv != NULL ? argv[0] : "slayer3d_editor",
-                                                 &invocation))
+    char error[512];
+    error[0] = '\0';
+    slayer3d_editor_project project;
+    if (!slayer3d_editor_project_load(args.project, &project, error, (int)sizeof(error)))
     {
-        fprintf(stderr,
-                "slayer3d_editor: --root, --data, --save, and --test-run-output are required unless build defaults "
-                "provide them\n");
+        fprintf(stderr, "slayer3d_editor: %s\n", error[0] != '\0' ? error : "failed to load project manifest");
         slayer3d_editor_args_destroy(&args);
         return 2;
     }
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor save path: %s", args.save_path);
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor test-run manifest: %s", args.test_run_path);
+    slayer3d_editor_launch launch;
+    if (!slayer3d_editor_prepare_launch(&args, &project, &launch, error, (int)sizeof(error)) ||
+        !slayer3d_editor_validate_paths(&args, &launch, error, (int)sizeof(error)))
+    {
+        fprintf(stderr, "slayer3d_editor: %s\n", error[0] != '\0' ? error : "invalid editor launch configuration");
+        slayer3d_editor_project_destroy(&project);
+        slayer3d_editor_args_destroy(&args);
+        return 2;
+    }
+
+    slayer3d_editor_runner_invocation invocation;
+    if (!slayer3d_editor_build_runner_invocation(&launch, argc > 0 && argv != NULL ? argv[0] : "slayer3d_editor",
+                                                 &invocation))
+    {
+        fprintf(stderr, "slayer3d_editor: failed to build runner invocation\n");
+        slayer3d_editor_launch_destroy(&launch);
+        slayer3d_editor_project_destroy(&project);
+        slayer3d_editor_args_destroy(&args);
+        return 2;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor project: %s", project.project_dir);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor save path: %s", launch.save_path);
+    if (launch.input_path != NULL && launch.input_path[0] != '\0')
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D editor input path: %s", launch.input_path);
     const int result = slayer3d_runner_main(invocation.argc, invocation.argv);
     slayer3d_editor_runner_invocation_destroy(&invocation);
+    slayer3d_editor_launch_destroy(&launch);
+    slayer3d_editor_project_destroy(&project);
     slayer3d_editor_args_destroy(&args);
     return result;
 }

--- a/tools/slayer3d_editor_cli.c
+++ b/tools/slayer3d_editor_cli.c
@@ -5,53 +5,177 @@
 
 #include "slayer3d_editor_cli.h"
 
+#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_stdinc.h>
 
 #include <argtable3.h>
+
+#include "../vendor/yyjson/yyjson.h"
+
+static void editor_set_error(char *buffer, int buffer_size, const char *message)
+{
+    if (buffer != NULL && buffer_size > 0)
+        SDL_snprintf(buffer, (size_t)buffer_size, "%s", message != NULL ? message : "unknown editor CLI error");
+}
+
+static void editor_set_errorf(char *buffer, int buffer_size, const char *format, const char *value)
+{
+    if (buffer != NULL && buffer_size > 0)
+        SDL_snprintf(buffer, (size_t)buffer_size, format != NULL ? format : "%s", value != NULL ? value : "");
+}
 
 void slayer3d_editor_args_print_usage(const char *argv0, FILE *stream)
 {
     FILE *out = stream != NULL ? stream : stderr;
     const char *program = argv0 != NULL ? argv0 : "slayer3d_editor";
-    fprintf(out,
-            "Usage:\n"
-            "  %s [--root <asset-root>] [--data <asset://editor.game.json>] [--media <media-dir>] "
-            "[--scene <scene>] [--save <path>] [--test-run-output <path>] [--state <key=value> ...]\n",
-            program);
+    fprintf(
+        out,
+        "Usage:\n"
+        "  %s new --project <project-dir-or-json> --output <level.json> [--overwrite]\n"
+        "  %s open --project <project-dir-or-json> --input <level.json> [--output <level.json>] [--overwrite]\n"
+        "\n"
+        "Commands:\n"
+        "  new    Start from the project's empty editor level and save to --output.\n"
+        "  open   Load an editable level fragment from --input and save to --output, or back to --input if omitted.\n"
+        "\n"
+        "Project manifests use schema slayer3d.project.v0 and define data_root plus editor_entry.\n",
+        program, program);
 }
 
-static bool copy_string_list(const char ***out_values, int *out_count, const char **values, int count)
+static bool path_is_absolute_tool(const char *path)
 {
-    if (out_values == NULL || out_count == NULL)
+    if (path == NULL || path[0] == '\0')
         return false;
-    *out_values = NULL;
-    *out_count = 0;
-    if (count <= 0)
+    if (path[0] == '/' || path[0] == '\\')
         return true;
+    return SDL_strlen(path) > 2u && path[1] == ':';
+}
 
-    const char **copy = (const char **)SDL_calloc((size_t)count, sizeof(*copy));
-    if (copy == NULL)
+static char *path_dirname_tool(const char *path)
+{
+    if (path == NULL || path[0] == '\0')
+        return SDL_strdup(".");
+    const char *last = NULL;
+    for (const char *p = path; *p != '\0'; ++p)
+    {
+        if (*p == '/' || *p == '\\')
+            last = p;
+    }
+    if (last == NULL)
+        return SDL_strdup(".");
+    const size_t length = (size_t)(last - path);
+    if (length == 0u)
+        return SDL_strdup(path[0] == '\\' ? "\\" : "/");
+    char *dir = (char *)SDL_malloc(length + 1u);
+    if (dir == NULL)
+        return NULL;
+    SDL_memcpy(dir, path, length);
+    dir[length] = '\0';
+    return dir;
+}
+
+static char *path_join_tool(const char *base, const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    if (path_is_absolute_tool(path) || base == NULL || base[0] == '\0')
+        return SDL_strdup(path);
+    const size_t base_len = SDL_strlen(base);
+    const size_t path_len = SDL_strlen(path);
+    const bool needs_sep = base_len > 0u && base[base_len - 1u] != '/' && base[base_len - 1u] != '\\';
+    char *joined = (char *)SDL_malloc(base_len + (needs_sep ? 1u : 0u) + path_len + 1u);
+    if (joined == NULL)
+        return NULL;
+    SDL_memcpy(joined, base, base_len);
+    size_t offset = base_len;
+    if (needs_sep)
+        joined[offset++] = '/';
+    SDL_memcpy(joined + offset, path, path_len + 1u);
+    return joined;
+}
+
+static bool file_exists_tool(const char *path, bool *out_is_file)
+{
+    if (out_is_file != NULL)
+        *out_is_file = false;
+    SDL_PathInfo info;
+    SDL_zero(info);
+    if (path == NULL || path[0] == '\0' || !SDL_GetPathInfo(path, &info))
         return false;
-    for (int i = 0; i < count; ++i)
-        copy[i] = values[i];
-    *out_values = copy;
-    *out_count = count;
+    if (out_is_file != NULL)
+        *out_is_file = info.type == SDL_PATHTYPE_FILE;
     return true;
+}
+
+static const char *manifest_string(yyjson_val *root, const char *key)
+{
+    yyjson_val *value = yyjson_obj_get(root, key);
+    return yyjson_is_str(value) ? yyjson_get_str(value) : NULL;
+}
+
+static bool validate_editable_level_fragment_file(const char *path, char *error_buffer, int error_buffer_size)
+{
+    yyjson_read_err read_error;
+    SDL_zero(read_error);
+    yyjson_doc *doc = yyjson_read_file(path, 0, NULL, &read_error);
+    yyjson_val *root = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    const char *schema = manifest_string(root, "schema");
+    if (doc == NULL || !yyjson_is_obj(root))
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "input level '%s' is not valid JSON", path);
+        yyjson_doc_free(doc);
+        return false;
+    }
+    if (SDL_strcmp(schema != NULL ? schema : "", "slayer3d.fragment.v0") != 0)
+    {
+        editor_set_error(error_buffer, error_buffer_size, "input level must use schema 'slayer3d.fragment.v0'");
+        yyjson_doc_free(doc);
+        return false;
+    }
+    if (!yyjson_is_arr(yyjson_obj_get(root, "brush_worlds")))
+    {
+        editor_set_error(error_buffer, error_buffer_size, "input level must contain a brush_worlds array");
+        yyjson_doc_free(doc);
+        return false;
+    }
+    yyjson_doc_free(doc);
+    return true;
+}
+
+static char *project_manifest_path(const char *project_arg, char *error_buffer, int error_buffer_size)
+{
+    if (project_arg == NULL || project_arg[0] == '\0')
+    {
+        editor_set_error(error_buffer, error_buffer_size, "--project is required");
+        return NULL;
+    }
+
+    SDL_PathInfo info;
+    SDL_zero(info);
+    if (!SDL_GetPathInfo(project_arg, &info))
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "project path '%s' does not exist", project_arg);
+        return NULL;
+    }
+    if (info.type == SDL_PATHTYPE_DIRECTORY)
+        return path_join_tool(project_arg, "slayer3d.project.json");
+    if (info.type == SDL_PATHTYPE_FILE)
+        return SDL_strdup(project_arg);
+
+    editor_set_errorf(error_buffer, error_buffer_size, "project path '%s' must be a directory or manifest file",
+                      project_arg);
+    return NULL;
 }
 
 slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slayer3d_editor_args *args, FILE *stream)
 {
-    struct arg_str *root = arg_str0(NULL, "root", "<asset-root>", "mount an editor project asset root");
-    struct arg_str *data = arg_str0(NULL, "data", "<asset://editor.game.json>", "editor game-data asset path");
-    struct arg_str *media = arg_str0(NULL, "media", "<media-dir>", "built-in media directory");
-    struct arg_str *scene = arg_str0(NULL, "scene", "<scene>", "start directly in an editor scene");
-    struct arg_str *save = arg_str0(NULL, "save", "<path>", "editable level fragment output path");
-    struct arg_str *test_run_output =
-        arg_str0(NULL, "test-run-output", "<path>", "runner test-run manifest output path");
-    struct arg_str *state = arg_strn(NULL, "state", "<key=value>", 0, argc > 0 ? argc : 1, "scene-state override");
+    struct arg_str *project = arg_str0(NULL, "project", "<project>", "project directory or slayer3d.project.json");
+    struct arg_str *input = arg_str0(NULL, "input", "<level.json>", "editable level fragment to open");
+    struct arg_str *output = arg_str0(NULL, "output", "<level.json>", "editable level fragment save target");
+    struct arg_lit *overwrite = arg_lit0(NULL, "overwrite", "allow new/open to replace an existing output path");
     struct arg_lit *help = arg_lit0("h", "help", "print this help and exit");
     struct arg_end *end = arg_end(20);
-    void *argtable[] = {root, data, media, scene, save, test_run_output, state, help, end};
+    void *argtable[] = {project, input, output, overwrite, help, end};
     const char *program = argc > 0 && argv != NULL && argv[0] != NULL ? argv[0] : "slayer3d_editor";
     FILE *out = stream != NULL ? stream : stderr;
 
@@ -64,7 +188,43 @@ slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slaye
     }
 
     SDL_zero(*args);
-    const int errors = arg_parse(argc, argv, argtable);
+    if (argc <= 1 || argv == NULL || argv[1] == NULL)
+    {
+        slayer3d_editor_args_print_usage(program, out);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+    if (SDL_strcmp(argv[1], "--help") == 0 || SDL_strcmp(argv[1], "-h") == 0)
+    {
+        slayer3d_editor_args_print_usage(program, out);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_HELP;
+    }
+
+    if (SDL_strcmp(argv[1], "new") == 0)
+        args->command = SLAYER3D_EDITOR_COMMAND_NEW;
+    else if (SDL_strcmp(argv[1], "open") == 0)
+        args->command = SLAYER3D_EDITOR_COMMAND_OPEN;
+    else if (SDL_strcmp(argv[1], "check") == 0)
+        args->command = SLAYER3D_EDITOR_COMMAND_CHECK;
+    else
+    {
+        fprintf(out, "%s: unknown editor command '%s'\n", program, argv[1]);
+        fprintf(out, "Try '%s --help' for more information.\n", program);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+
+    if (args->command == SLAYER3D_EDITOR_COMMAND_CHECK)
+    {
+        fprintf(out, "%s: 'check' is not implemented yet; use 'new' or 'open'.\n", program);
+        arg_freetable(argtable, SDL_arraysize(argtable));
+        return SLAYER3D_TOOL_CLI_ERROR;
+    }
+
+    const int parse_argc = argc - 1;
+    char **parse_argv = argv + 1;
+    const int errors = arg_parse(parse_argc, parse_argv, argtable);
     if (help->count > 0)
     {
         slayer3d_editor_args_print_usage(program, out);
@@ -79,23 +239,46 @@ slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slaye
         return SLAYER3D_TOOL_CLI_ERROR;
     }
 
-    args->root = root->count > 0 ? root->sval[0] : NULL;
-    args->data_asset_path = data->count > 0 ? data->sval[0] : NULL;
-    args->media_dir = media->count > 0 ? media->sval[0] : NULL;
-    args->scene = scene->count > 0 ? scene->sval[0] : NULL;
-    args->save_path = save->count > 0 ? save->sval[0] : NULL;
-    args->test_run_path = test_run_output->count > 0 ? test_run_output->sval[0] : NULL;
+    args->project = project->count > 0 ? project->sval[0] : NULL;
+    args->input_path = input->count > 0 ? input->sval[0] : NULL;
+    args->output_path = output->count > 0 ? output->sval[0] : NULL;
+    args->overwrite = overwrite->count > 0;
 
-    if ((args->root != NULL && args->root[0] == '\0') ||
-        (args->data_asset_path != NULL && args->data_asset_path[0] == '\0') ||
-        (args->scene != NULL && args->scene[0] == '\0') || (args->save_path != NULL && args->save_path[0] == '\0') ||
-        (args->test_run_path != NULL && args->test_run_path[0] == '\0') ||
-        !copy_string_list(&args->state_assignments, &args->state_assignment_count, state->sval, state->count))
+    if (args->project == NULL || args->project[0] == '\0')
     {
-        fprintf(out, "%s: invalid or out-of-memory editor arguments\n", program);
+        fprintf(out, "%s: --project is required for '%s'.\n", program, argv[1]);
         arg_freetable(argtable, SDL_arraysize(argtable));
-        slayer3d_editor_args_destroy(args);
         return SLAYER3D_TOOL_CLI_ERROR;
+    }
+    if (args->command == SLAYER3D_EDITOR_COMMAND_NEW)
+    {
+        if (args->input_path != NULL)
+        {
+            fprintf(out, "%s: 'new' does not accept --input; use 'open' to edit an existing level.\n", program);
+            arg_freetable(argtable, SDL_arraysize(argtable));
+            return SLAYER3D_TOOL_CLI_ERROR;
+        }
+        if (args->output_path == NULL || args->output_path[0] == '\0')
+        {
+            fprintf(out, "%s: 'new' requires --output <level.json>.\n", program);
+            arg_freetable(argtable, SDL_arraysize(argtable));
+            return SLAYER3D_TOOL_CLI_ERROR;
+        }
+    }
+    if (args->command == SLAYER3D_EDITOR_COMMAND_OPEN)
+    {
+        if (args->input_path == NULL || args->input_path[0] == '\0')
+        {
+            fprintf(out, "%s: 'open' requires --input <level.json>.\n", program);
+            arg_freetable(argtable, SDL_arraysize(argtable));
+            return SLAYER3D_TOOL_CLI_ERROR;
+        }
+        if (args->output_path != NULL && args->output_path[0] == '\0')
+        {
+            fprintf(out, "%s: --output must be non-empty when present.\n", program);
+            arg_freetable(argtable, SDL_arraysize(argtable));
+            return SLAYER3D_TOOL_CLI_ERROR;
+        }
     }
 
     arg_freetable(argtable, SDL_arraysize(argtable));
@@ -104,44 +287,197 @@ slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slaye
 
 void slayer3d_editor_args_destroy(slayer3d_editor_args *args)
 {
-    if (args == NULL)
-        return;
-    SDL_free(args->state_assignments);
-    args->state_assignments = NULL;
-    args->state_assignment_count = 0;
+    if (args != NULL)
+        SDL_zero(*args);
 }
 
-void slayer3d_editor_args_apply_defaults(slayer3d_editor_args *args, const char *root, const char *data_asset_path,
-                                         const char *save_path, const char *test_run_path)
+bool slayer3d_editor_project_load(const char *project_arg, slayer3d_editor_project *out_project, char *error_buffer,
+                                  int error_buffer_size)
 {
-    if (args == NULL)
+    if (out_project != NULL)
+        SDL_zero(*out_project);
+    if (out_project == NULL)
+    {
+        editor_set_error(error_buffer, error_buffer_size, "project output is required");
+        return false;
+    }
+
+    char *manifest = project_manifest_path(project_arg, error_buffer, error_buffer_size);
+    if (manifest == NULL)
+        return false;
+
+    bool is_file = false;
+    if (!file_exists_tool(manifest, &is_file) || !is_file)
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "project manifest '%s' does not exist", manifest);
+        SDL_free(manifest);
+        return false;
+    }
+
+    yyjson_read_err read_error;
+    SDL_zero(read_error);
+    yyjson_doc *doc = yyjson_read_file(manifest, 0, NULL, &read_error);
+    yyjson_val *root = doc != NULL ? yyjson_doc_get_root(doc) : NULL;
+    const char *schema = manifest_string(root, "schema");
+    const char *data_root = manifest_string(root, "data_root");
+    const char *editor_entry = manifest_string(root, "editor_entry");
+    const char *media_root = manifest_string(root, "media_root");
+    const char *test_run_output = manifest_string(root, "test_run_output");
+    if (doc == NULL || !yyjson_is_obj(root))
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "failed to parse project manifest '%s'", manifest);
+        yyjson_doc_free(doc);
+        SDL_free(manifest);
+        return false;
+    }
+    if (SDL_strcmp(schema != NULL ? schema : "", "slayer3d.project.v0") != 0)
+    {
+        editor_set_error(error_buffer, error_buffer_size, "project manifest must use schema 'slayer3d.project.v0'");
+        yyjson_doc_free(doc);
+        SDL_free(manifest);
+        return false;
+    }
+    if (data_root == NULL || data_root[0] == '\0' || editor_entry == NULL || editor_entry[0] == '\0')
+    {
+        editor_set_error(error_buffer, error_buffer_size,
+                         "project manifest requires non-empty data_root and editor_entry fields");
+        yyjson_doc_free(doc);
+        SDL_free(manifest);
+        return false;
+    }
+
+    char *project_dir = path_dirname_tool(manifest);
+    char *resolved_data_root = path_join_tool(project_dir, data_root);
+    char *resolved_media_root =
+        media_root != NULL && media_root[0] != '\0' ? path_join_tool(project_dir, media_root) : NULL;
+    char *resolved_test_run =
+        test_run_output != NULL && test_run_output[0] != '\0' ? path_join_tool(project_dir, test_run_output) : NULL;
+    char *entry_copy = SDL_strdup(editor_entry);
+    if (project_dir == NULL || resolved_data_root == NULL || entry_copy == NULL ||
+        (media_root != NULL && media_root[0] != '\0' && resolved_media_root == NULL) ||
+        (test_run_output != NULL && test_run_output[0] != '\0' && resolved_test_run == NULL))
+    {
+        editor_set_error(error_buffer, error_buffer_size, "failed to allocate project manifest paths");
+        SDL_free(project_dir);
+        SDL_free(resolved_data_root);
+        SDL_free(resolved_media_root);
+        SDL_free(resolved_test_run);
+        SDL_free(entry_copy);
+        yyjson_doc_free(doc);
+        SDL_free(manifest);
+        return false;
+    }
+
+    out_project->project_dir = project_dir;
+    out_project->data_root = resolved_data_root;
+    out_project->editor_entry = entry_copy;
+    out_project->owned_media_dir = resolved_media_root;
+    out_project->media_dir = out_project->owned_media_dir;
+    out_project->test_run_path = resolved_test_run;
+    yyjson_doc_free(doc);
+    SDL_free(manifest);
+    return true;
+}
+
+void slayer3d_editor_project_destroy(slayer3d_editor_project *project)
+{
+    if (project == NULL)
         return;
-    if ((args->root == NULL || args->root[0] == '\0') && root != NULL && root[0] != '\0')
-        args->root = root;
-    if ((args->data_asset_path == NULL || args->data_asset_path[0] == '\0') && data_asset_path != NULL &&
-        data_asset_path[0] != '\0')
+    SDL_free(project->project_dir);
+    SDL_free(project->data_root);
+    SDL_free(project->editor_entry);
+    SDL_free(project->owned_media_dir);
+    SDL_free(project->test_run_path);
+    SDL_zero(*project);
+}
+
+bool slayer3d_editor_prepare_launch(const slayer3d_editor_args *args, const slayer3d_editor_project *project,
+                                    slayer3d_editor_launch *out_launch, char *error_buffer, int error_buffer_size)
+{
+    if (out_launch != NULL)
+        SDL_zero(*out_launch);
+    if (args == NULL || project == NULL || out_launch == NULL)
     {
-        args->data_asset_path = data_asset_path;
+        editor_set_error(error_buffer, error_buffer_size, "editor launch requires parsed args and project");
+        return false;
     }
-    if ((args->save_path == NULL || args->save_path[0] == '\0') && save_path != NULL && save_path[0] != '\0')
-        args->save_path = save_path;
-    if ((args->test_run_path == NULL || args->test_run_path[0] == '\0') && test_run_path != NULL &&
-        test_run_path[0] != '\0')
+    const char *save_path = args->output_path;
+    if (args->command == SLAYER3D_EDITOR_COMMAND_OPEN && (save_path == NULL || save_path[0] == '\0'))
+        save_path = args->input_path;
+    if (project->data_root == NULL || project->editor_entry == NULL || save_path == NULL || save_path[0] == '\0')
     {
-        args->test_run_path = test_run_path;
+        editor_set_error(error_buffer, error_buffer_size, "project and editor command did not resolve launch paths");
+        return false;
     }
+
+    out_launch->root = project->data_root;
+    out_launch->data_asset_path = project->editor_entry;
+    out_launch->media_dir = project->media_dir;
+    out_launch->input_path = args->command == SLAYER3D_EDITOR_COMMAND_OPEN ? args->input_path : "";
+    out_launch->save_path = save_path;
+    out_launch->test_run_path = project->test_run_path;
+    return true;
+}
+
+void slayer3d_editor_launch_destroy(slayer3d_editor_launch *launch)
+{
+    if (launch == NULL)
+        return;
+    SDL_zero(*launch);
+}
+
+bool slayer3d_editor_validate_paths(const slayer3d_editor_args *args, const slayer3d_editor_launch *launch,
+                                    char *error_buffer, int error_buffer_size)
+{
+    if (args == NULL || launch == NULL)
+    {
+        editor_set_error(error_buffer, error_buffer_size, "editor path validation requires args and launch");
+        return false;
+    }
+    bool is_file = false;
+    if (args->command == SLAYER3D_EDITOR_COMMAND_OPEN && (!file_exists_tool(args->input_path, &is_file) || !is_file))
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "input level '%s' does not exist", args->input_path);
+        return false;
+    }
+    if (args->command == SLAYER3D_EDITOR_COMMAND_OPEN &&
+        !validate_editable_level_fragment_file(args->input_path, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+
+    if (launch->save_path == NULL || launch->save_path[0] == '\0')
+    {
+        editor_set_error(error_buffer, error_buffer_size, "output save path is required");
+        return false;
+    }
+    const bool output_exists = file_exists_tool(launch->save_path, &is_file);
+    const bool saving_back_to_input = args->command == SLAYER3D_EDITOR_COMMAND_OPEN && args->input_path != NULL &&
+                                      SDL_strcmp(args->input_path, launch->save_path) == 0;
+    if (output_exists && !is_file)
+    {
+        editor_set_errorf(error_buffer, error_buffer_size, "output path '%s' is not a regular file", launch->save_path);
+        return false;
+    }
+    if (output_exists && !saving_back_to_input && !args->overwrite)
+    {
+        editor_set_errorf(error_buffer, error_buffer_size,
+                          "output path '%s' already exists; pass --overwrite to replace it", launch->save_path);
+        return false;
+    }
+    return true;
 }
 
 static char *editor_state_assignment(const char *key, const char *value)
 {
     const size_t key_len = SDL_strlen(key);
-    const size_t value_len = SDL_strlen(value);
+    const size_t value_len = SDL_strlen(value != NULL ? value : "");
     char *assignment = (char *)SDL_malloc(key_len + 1u + value_len + 1u);
     if (assignment == NULL)
         return NULL;
     SDL_memcpy(assignment, key, key_len);
     assignment[key_len] = '=';
-    SDL_memcpy(assignment + key_len + 1u, value, value_len);
+    SDL_memcpy(assignment + key_len + 1u, value != NULL ? value : "", value_len);
     assignment[key_len + 1u + value_len] = '\0';
     return assignment;
 }
@@ -155,23 +491,20 @@ static bool editor_add_arg(slayer3d_editor_runner_invocation *invocation, int *i
     return true;
 }
 
-bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_args *args, const char *program,
+bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_launch *launch, const char *program,
                                              slayer3d_editor_runner_invocation *out_invocation)
 {
     if (out_invocation == NULL)
         return false;
     SDL_zero(*out_invocation);
-    if (args == NULL || args->root == NULL || args->root[0] == '\0' || args->data_asset_path == NULL ||
-        args->data_asset_path[0] == '\0' || args->save_path == NULL || args->save_path[0] == '\0' ||
-        args->test_run_path == NULL || args->test_run_path[0] == '\0')
+    if (launch == NULL || launch->root == NULL || launch->root[0] == '\0' || launch->data_asset_path == NULL ||
+        launch->data_asset_path[0] == '\0' || launch->save_path == NULL || launch->save_path[0] == '\0')
     {
         return false;
     }
 
-    int argc = 9 + args->state_assignment_count * 2;
-    if (args->media_dir != NULL && args->media_dir[0] != '\0')
-        argc += 2;
-    if (args->scene != NULL && args->scene[0] != '\0')
+    int argc = 13;
+    if (launch->media_dir != NULL && launch->media_dir[0] != '\0')
         argc += 2;
 
     char **argv = (char **)SDL_calloc((size_t)argc + 1u, sizeof(*argv));
@@ -180,60 +513,45 @@ bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_args *args, c
 
     out_invocation->argv = argv;
     out_invocation->argc = argc;
-    int index = 0;
-    char *save_assignment = editor_state_assignment("editor.save.path", args->save_path);
-    char *test_run_assignment = editor_state_assignment("editor.test_run.path", args->test_run_path);
-    if (save_assignment == NULL || test_run_assignment == NULL)
+    out_invocation->owned_command_assignment = editor_state_assignment(
+        "editor.command", launch->input_path != NULL && launch->input_path[0] != '\0' ? "open" : "new");
+    out_invocation->owned_input_assignment = editor_state_assignment("editor.input.path", launch->input_path);
+    out_invocation->owned_save_assignment = editor_state_assignment("editor.save.path", launch->save_path);
+    out_invocation->owned_test_run_assignment =
+        editor_state_assignment("editor.test_run.path", launch->test_run_path != NULL ? launch->test_run_path : "");
+    if (out_invocation->owned_command_assignment == NULL || out_invocation->owned_input_assignment == NULL ||
+        out_invocation->owned_save_assignment == NULL || out_invocation->owned_test_run_assignment == NULL)
     {
-        SDL_free(save_assignment);
-        SDL_free(test_run_assignment);
         slayer3d_editor_runner_invocation_destroy(out_invocation);
         return false;
     }
-    out_invocation->owned_save_assignment = save_assignment;
-    out_invocation->owned_test_run_assignment = test_run_assignment;
 
+    int index = 0;
     if (!editor_add_arg(out_invocation, &index, (char *)(program != NULL ? program : "slayer3d_editor")) ||
         !editor_add_arg(out_invocation, &index, "--root") ||
-        !editor_add_arg(out_invocation, &index, (char *)args->root) ||
+        !editor_add_arg(out_invocation, &index, (char *)launch->root) ||
         !editor_add_arg(out_invocation, &index, "--data") ||
-        !editor_add_arg(out_invocation, &index, (char *)args->data_asset_path))
+        !editor_add_arg(out_invocation, &index, (char *)launch->data_asset_path))
     {
         slayer3d_editor_runner_invocation_destroy(out_invocation);
         return false;
     }
-    if (args->media_dir != NULL && args->media_dir[0] != '\0')
+    if (launch->media_dir != NULL && launch->media_dir[0] != '\0')
     {
         if (!editor_add_arg(out_invocation, &index, "--media") ||
-            !editor_add_arg(out_invocation, &index, (char *)args->media_dir))
-        {
-            slayer3d_editor_runner_invocation_destroy(out_invocation);
-            return false;
-        }
-    }
-    if (args->scene != NULL && args->scene[0] != '\0')
-    {
-        if (!editor_add_arg(out_invocation, &index, "--scene") ||
-            !editor_add_arg(out_invocation, &index, (char *)args->scene))
+            !editor_add_arg(out_invocation, &index, (char *)launch->media_dir))
         {
             slayer3d_editor_runner_invocation_destroy(out_invocation);
             return false;
         }
     }
 
-    if (!editor_add_arg(out_invocation, &index, "--state") ||
-        !editor_add_arg(out_invocation, &index, save_assignment) ||
-        !editor_add_arg(out_invocation, &index, "--state") ||
-        !editor_add_arg(out_invocation, &index, test_run_assignment))
-    {
-        slayer3d_editor_runner_invocation_destroy(out_invocation);
-        return false;
-    }
-
-    for (int i = 0; i < args->state_assignment_count; ++i)
+    char *owned_state[] = {out_invocation->owned_command_assignment, out_invocation->owned_input_assignment,
+                           out_invocation->owned_save_assignment, out_invocation->owned_test_run_assignment};
+    for (size_t i = 0; i < SDL_arraysize(owned_state); ++i)
     {
         if (!editor_add_arg(out_invocation, &index, "--state") ||
-            !editor_add_arg(out_invocation, &index, (char *)args->state_assignments[i]))
+            !editor_add_arg(out_invocation, &index, owned_state[i]))
         {
             slayer3d_editor_runner_invocation_destroy(out_invocation);
             return false;
@@ -251,11 +569,10 @@ void slayer3d_editor_runner_invocation_destroy(slayer3d_editor_runner_invocation
 {
     if (invocation == NULL)
         return;
+    SDL_free(invocation->owned_command_assignment);
+    SDL_free(invocation->owned_input_assignment);
     SDL_free(invocation->owned_save_assignment);
     SDL_free(invocation->owned_test_run_assignment);
     SDL_free(invocation->argv);
-    invocation->argv = NULL;
-    invocation->argc = 0;
-    invocation->owned_save_assignment = NULL;
-    invocation->owned_test_run_assignment = NULL;
+    SDL_zero(*invocation);
 }

--- a/tools/slayer3d_editor_cli.c
+++ b/tools/slayer3d_editor_cli.c
@@ -51,6 +51,30 @@ static bool path_is_absolute_tool(const char *path)
     return SDL_strlen(path) > 2u && path[1] == ':';
 }
 
+static void path_normalize_host_separators_tool(char *path)
+{
+#if defined(_WIN32)
+    if (path == NULL)
+        return;
+    for (char *p = path; *p != '\0'; ++p)
+    {
+        if (*p == '/')
+            *p = '\\';
+    }
+#else
+    (void)path;
+#endif
+}
+
+static char path_separator_tool(void)
+{
+#if defined(_WIN32)
+    return '\\';
+#else
+    return '/';
+#endif
+}
+
 static char *path_dirname_tool(const char *path)
 {
     if (path == NULL || path[0] == '\0')
@@ -79,7 +103,11 @@ static char *path_join_tool(const char *base, const char *path)
     if (path == NULL)
         return NULL;
     if (path_is_absolute_tool(path) || base == NULL || base[0] == '\0')
-        return SDL_strdup(path);
+    {
+        char *copy = SDL_strdup(path);
+        path_normalize_host_separators_tool(copy);
+        return copy;
+    }
     const size_t base_len = SDL_strlen(base);
     const size_t path_len = SDL_strlen(path);
     const bool needs_sep = base_len > 0u && base[base_len - 1u] != '/' && base[base_len - 1u] != '\\';
@@ -89,8 +117,9 @@ static char *path_join_tool(const char *base, const char *path)
     SDL_memcpy(joined, base, base_len);
     size_t offset = base_len;
     if (needs_sep)
-        joined[offset++] = '/';
+        joined[offset++] = path_separator_tool();
     SDL_memcpy(joined + offset, path, path_len + 1u);
+    path_normalize_host_separators_tool(joined);
     return joined;
 }
 

--- a/tools/slayer3d_editor_cli.h
+++ b/tools/slayer3d_editor_cli.h
@@ -16,22 +16,49 @@ extern "C"
 {
 #endif
 
+    typedef enum slayer3d_editor_command
+    {
+        SLAYER3D_EDITOR_COMMAND_NONE = 0,
+        SLAYER3D_EDITOR_COMMAND_NEW,
+        SLAYER3D_EDITOR_COMMAND_OPEN,
+        SLAYER3D_EDITOR_COMMAND_CHECK
+    } slayer3d_editor_command;
+
     typedef struct slayer3d_editor_args
+    {
+        slayer3d_editor_command command;
+        const char *project;
+        const char *input_path;
+        const char *output_path;
+        bool overwrite;
+    } slayer3d_editor_args;
+
+    typedef struct slayer3d_editor_project
+    {
+        char *project_dir;
+        char *data_root;
+        char *editor_entry;
+        const char *media_dir;
+        char *owned_media_dir;
+        char *test_run_path;
+    } slayer3d_editor_project;
+
+    typedef struct slayer3d_editor_launch
     {
         const char *root;
         const char *data_asset_path;
         const char *media_dir;
-        const char *scene;
+        const char *input_path;
         const char *save_path;
         const char *test_run_path;
-        const char **state_assignments;
-        int state_assignment_count;
-    } slayer3d_editor_args;
+    } slayer3d_editor_launch;
 
     typedef struct slayer3d_editor_runner_invocation
     {
         char **argv;
         int argc;
+        char *owned_command_assignment;
+        char *owned_input_assignment;
         char *owned_save_assignment;
         char *owned_test_run_assignment;
     } slayer3d_editor_runner_invocation;
@@ -39,9 +66,15 @@ extern "C"
     slayer3d_tool_cli_result slayer3d_editor_args_parse(int argc, char **argv, slayer3d_editor_args *args,
                                                         FILE *stream);
     void slayer3d_editor_args_destroy(slayer3d_editor_args *args);
-    void slayer3d_editor_args_apply_defaults(slayer3d_editor_args *args, const char *root, const char *data_asset_path,
-                                             const char *save_path, const char *test_run_path);
-    bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_args *args, const char *program,
+    bool slayer3d_editor_project_load(const char *project_arg, slayer3d_editor_project *out_project, char *error_buffer,
+                                      int error_buffer_size);
+    void slayer3d_editor_project_destroy(slayer3d_editor_project *project);
+    bool slayer3d_editor_prepare_launch(const slayer3d_editor_args *args, const slayer3d_editor_project *project,
+                                        slayer3d_editor_launch *out_launch, char *error_buffer, int error_buffer_size);
+    void slayer3d_editor_launch_destroy(slayer3d_editor_launch *launch);
+    bool slayer3d_editor_validate_paths(const slayer3d_editor_args *args, const slayer3d_editor_launch *launch,
+                                        char *error_buffer, int error_buffer_size);
+    bool slayer3d_editor_build_runner_invocation(const slayer3d_editor_launch *launch, const char *program,
                                                  slayer3d_editor_runner_invocation *out_invocation);
     void slayer3d_editor_runner_invocation_destroy(slayer3d_editor_runner_invocation *invocation);
     void slayer3d_editor_args_print_usage(const char *argv0, FILE *stream);


### PR DESCRIPTION
## Summary
- replaces the editor host flags with explicit `new` and `open` subcommands backed by `slayer3d.project.json`
- adds runtime editable-level loading so `open` can load a saved fragment before editing, while `Ctrl+S` / `Command+S` saves atomically through the existing editor action path
- adds JSON-authored keyboard modifier bindings (`modifiers`, `required_modifiers`, `excluded_modifiers`) so shortcut chords are reusable engine input data
- updates the editor shell dojo project/docs and adds CLI/runtime tests for new/open, malformed input rejection, save, reload, and modifier validation

## Tests
- `cmake --build build/debug --target slayer3d_editor slayer3d_tool_cli_test slayer3d_game_data_test -j 8`
- `./build/debug/tests/slayer3d_tool_cli_test --gtest_filter='ToolCli.Editor*'`\n- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.Editor*Dojo*:GameDataRuntime.EditableLevelFragmentLoadsIntoEditorRuntime:GameDataRuntime.*Editable*:GameDataRuntime.*Editor*Level*'`\n- `ctest --test-dir build/debug --output-on-failure -R 'GameDataRuntime\\.(EditorShellDojoCreatesBlockoutPrefabTools|ValidatesKeyboardBindingModifiers)'`\n- `git diff --check`