### PR TITLE
Improve editor viewport picking and zoom

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1454,6 +1454,10 @@
             "fast": "action.editor.camera.fast"
           },
           "mode_key": "editor.view.mode",
+          "quad_mode": "quad_view",
+          "top_camera": "camera.editor_shell.ortho_top",
+          "front_camera": "camera.editor_shell.ortho_front",
+          "side_camera": "camera.editor_shell.ortho_side",
           "orthographic_size_key": "editor.ortho.size",
           "orthographic_controls_if": { "type": "scene_state.compare", "key": "editor.palette.active", "op": "==", "value": "", "default": "" },
           "move_speed": 8.0,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -320,6 +320,12 @@
     },
     "debug_overlay": {
       "enabled": true,
+      "hover_selection_if": {
+        "type": "scene_state.compare",
+        "key": "editor.view.mode",
+        "op": "==",
+        "value": "flyby_3d"
+      },
       "flags": [
         "work_plane_grid",
         "world_bounds",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -107,6 +107,18 @@
             }
           },
           {
+            "camera": "camera.editor_shell.viewport",
+            "rect": [0, 0, 1280, 720],
+            "screen": "center",
+            "active_if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "flyby_3d" },
+            "work_plane": {
+              "enabled": true,
+              "normal": [0.0, 1.0, 0.0],
+              "distance": 0.0,
+              "distance_key": "editor.work_plane.distance"
+            }
+          },
+          {
             "camera": "camera.editor_shell.ortho_top",
             "rect": [640, 0, 640, 360],
             "active_if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "quad_view", "default": "quad_view" },

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -80,7 +80,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
 | `Enter` | palette closed | commit the current preview placement |
 | `+` / `-` | palette closed | increase or decrease grid size |
 | arrow keys | full-screen orthographic, palette closed | pan the active canvas |
-| `Z` / `X` or mouse wheel | full-screen orthographic | zoom the active canvas in or out |
+| `Z` / `X` or mouse wheel | orthographic view | zoom the active canvas in or out; in four-view layout, the mouse cursor must be over an orthographic pane |
 | `R` | palette closed | toggle wall axis |
 | `C` | palette closed | cycle tools for debug/testing |
 | `WASD` | 3D flyby | move camera |
@@ -139,6 +139,9 @@ The following should be true during a good test drive:
   perspective, top/XY, front/XZ, or side/YZ.
 - Full-screen orthographic views pan with the arrow keys and zoom with `Z`,
   `X`, or the mouse wheel while keeping a visible work grid.
+- In the four-view layout, mouse wheel zoom works when the cursor is over the
+  top, front, or side orthographic pane. The 3D perspective pane does not
+  consume orthographic zoom.
 - Top/front/side orthographic views plot on their authored work planes;
   perspective preview uses the 3D editor camera.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds` and `editor_player_starts` and

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -54,6 +54,9 @@ quick toggle between the four-viewport layout and full-screen 3D flyby.
 The editor uses normal hardware cursor positioning in the four-viewport layout.
 In full-screen 3D flyby mode the runtime captures relative mouse motion for
 mouse-look, then releases it again when returning to orthographic editing.
+Flyby brush feedback is reticle-driven: the highlighted brush, hit marker, and
+placement preview should remain pinned to the screen center instead of following
+the last clicked selection.
 
 ## Keybindings
 
@@ -146,7 +149,9 @@ The following should be true during a good test drive:
   perspective preview uses the 3D editor camera.
 - In full-screen 3D flyby mode, brush picking and placement trace from the
   screen center. The highlighted brush should be the brush under the crosshair;
-  if no brush is hit, placement falls back to the ground work plane.
+  if no brush is hit, placement falls back to the ground work plane. After
+  clicking one brush, look away and confirm the selection cursor follows the
+  reticle rather than staying offset on the previous brush.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds` and `editor_player_starts` and
   writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -144,6 +144,9 @@ The following should be true during a good test drive:
   consume orthographic zoom.
 - Top/front/side orthographic views plot on their authored work planes;
   perspective preview uses the 3D editor camera.
+- In full-screen 3D flyby mode, brush picking and placement trace from the
+  screen center. The highlighted brush should be the brush under the crosshair;
+  if no brush is hit, placement falls back to the ground work plane.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds` and `editor_player_starts` and
   writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -886,6 +886,12 @@ face normal through the normal 3D presentation path:
     },
     "debug_overlay": {
       "enabled": true,
+      "hover_selection_if": {
+        "type": "scene_state.compare",
+        "key": "editor.view.mode",
+        "op": "==",
+        "value": "flyby_3d"
+      },
       "flags": [
         "work_plane_grid",
         "world_bounds",
@@ -918,6 +924,12 @@ plane described by `dot(normal, point) = distance` and publishes that as a hit
 with `selection_type: "none"`. This is intended for blockout tools: a blank
 scene can still place the first floor on the ground plane, while later clicks on
 real brush faces keep returning normal brush-world selections.
+
+`editor.debug_overlay.hover_selection_if` can be used when the overlay should
+draw the live hover trace instead of the last clicked active selection. Full
+screen 3D flyby editors should usually enable this while flyby mode is active so
+selection bounds, hit markers, and trace feedback stay pinned to the center
+reticle.
 `normal_key` and `distance_key` may point at scene-state values, allowing a
 single editor scene to switch between top/front/side orthographic plotting
 planes with data-authored `scene_state.set` and `camera.set` actions.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -906,10 +906,11 @@ Selection traces default to `source: "world"`, where `start` and `end` are
 authored world-space vec3 values. `source: "camera_screen"` derives the ray
 from a camera and screen point using the latest live mouse position by default.
 Tooling can override that point with `screen`, `screen_x`/`screen_y`, or
-`screen_x_key`/`screen_y_key`; viewport dimensions can likewise be authored
-with `viewport`, `viewport_width`/`viewport_height`, or scene-state keys. This
-lets editor dojos and future editor hosts share the same data-authored picking
-primitive.
+`screen_x_key`/`screen_y_key`; `screen` may be a vec2 or the string `"center"`
+for crosshair-style 3D editor picking. Viewport dimensions can likewise be
+authored with `viewport`, `viewport_width`/`viewport_height`, or scene-state
+keys. This lets editor dojos and future editor hosts share the same
+data-authored picking primitive.
 
 Selection traces may also author `work_plane` as a fallback placement plane.
 When the ray misses world geometry, the editor intersects the same ray with the
@@ -1550,7 +1551,10 @@ falls inside a viewport rect, the trace uses that viewport's camera, local
 screen coordinates, dimensions, and optional viewport-specific `work_plane`.
 This keeps floor/wall/ceiling placement correct in orthographic quadrants while
 still allowing a perspective preview in the same scene. Traces that omit
-`viewports` fall back to the trace camera or active camera.
+`viewports` fall back to the trace camera or active camera. A viewport entry may
+set `"screen": "center"` to trace from the viewport center instead of the live
+mouse position, which is the expected shape for full-screen 3D editor flyby
+placement.
 
 Use `controller.fps_brush` on an actor to drive first-person movement through
 the active scene's brush-world instances:

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -310,6 +310,64 @@ static bool editor_camera_mode_is_orthographic(const char *mode, yyjson_val *com
            editor_camera_mode_equals(mode, json_string(component, "side_mode", "orthographic_side"));
 }
 
+static const char *editor_camera_mode_for_camera(yyjson_val *component, const char *camera)
+{
+    if (component == NULL || camera == NULL)
+        return NULL;
+    const char *top_camera = json_string(component, "top_camera", NULL);
+    const char *front_camera = json_string(component, "front_camera", NULL);
+    const char *side_camera = json_string(component, "side_camera", NULL);
+    if (top_camera != NULL && SDL_strcmp(camera, top_camera) == 0)
+        return json_string(component, "top_mode", "orthographic_top");
+    if (front_camera != NULL && SDL_strcmp(camera, front_camera) == 0)
+        return json_string(component, "front_mode", "orthographic_front");
+    if (side_camera != NULL && SDL_strcmp(camera, side_camera) == 0)
+        return json_string(component, "side_mode", "orthographic_side");
+    return NULL;
+}
+
+static bool editor_camera_rect_contains_mouse(yyjson_val *viewport, float mouse_x, float mouse_y)
+{
+    yyjson_val *rect = obj_get(viewport, "rect");
+    if (!yyjson_is_arr(rect) || yyjson_arr_size(rect) < 4)
+        return false;
+    const float x = (float)yyjson_get_num(yyjson_arr_get(rect, 0));
+    const float y = (float)yyjson_get_num(yyjson_arr_get(rect, 1));
+    const float w = (float)yyjson_get_num(yyjson_arr_get(rect, 2));
+    const float h = (float)yyjson_get_num(yyjson_arr_get(rect, 3));
+    return w > 0.0f && h > 0.0f && mouse_x >= x && mouse_y >= y && mouse_x < x + w && mouse_y < y + h;
+}
+
+static const char *editor_camera_hovered_orthographic_mode(slayer3d_game_data_runtime *runtime, yyjson_val *component,
+                                                           const slayer3d_input_manager *input, const char *mode)
+{
+    if (runtime == NULL || component == NULL || input == NULL ||
+        !editor_camera_mode_equals(mode, json_string(component, "quad_mode", "quad_view")))
+    {
+        return NULL;
+    }
+
+    float mouse_x = 0.0f;
+    float mouse_y = 0.0f;
+    if (!slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+        return NULL;
+
+    const scene_entry *scene = active_scene_entry_const(runtime);
+    yyjson_val *viewports = obj_get(scene != NULL ? scene->root : NULL, "world_viewports");
+    for (size_t i = 0; yyjson_is_arr(viewports) && i < yyjson_arr_size(viewports); ++i)
+    {
+        yyjson_val *viewport = yyjson_arr_get(viewports, i);
+        yyjson_val *active_if = obj_get(viewport, "active_if");
+        if (active_if != NULL && !eval_data_condition(runtime, active_if, NULL))
+            continue;
+        if (!editor_camera_rect_contains_mouse(viewport, mouse_x, mouse_y))
+            continue;
+        return editor_camera_mode_for_camera(component, json_string(viewport, "camera", NULL));
+    }
+
+    return NULL;
+}
+
 static void editor_camera_orthographic_basis(const char *mode, yyjson_val *component, slayer3d_vec3 *out_right,
                                              slayer3d_vec3 *out_up)
 {
@@ -408,6 +466,15 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
         if (orthographic_controls_if != NULL && !eval_data_condition(runtime, orthographic_controls_if, NULL))
             return;
         update_editor_camera_orthographic_controller(runtime, component, actor, input, dt, mode);
+        return;
+    }
+    const char *hovered_orthographic_mode = editor_camera_hovered_orthographic_mode(runtime, component, input, mode);
+    if (hovered_orthographic_mode != NULL)
+    {
+        yyjson_val *orthographic_controls_if = obj_get(component, "orthographic_controls_if");
+        if (orthographic_controls_if != NULL && !eval_data_condition(runtime, orthographic_controls_if, NULL))
+            return;
+        update_editor_camera_orthographic_controller(runtime, component, actor, input, dt, hovered_orthographic_mode);
         return;
     }
     if (mode != NULL && !editor_camera_mode_equals(mode, json_string(component, "flyby_mode", "flyby_3d")))

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -76,6 +76,11 @@ typedef struct editor_trace_viewport_config
     yyjson_val *work_plane;
 } editor_trace_viewport_config;
 
+static bool editor_trace_screen_value_is_center(yyjson_val *value)
+{
+    return yyjson_is_str(value) && SDL_strcmp(yyjson_get_str(value), "center") == 0;
+}
+
 static void editor_default_viewport(const slayer3d_game_data_runtime *runtime, float *out_width, float *out_height)
 {
     if (out_width == NULL || out_height == NULL)
@@ -102,16 +107,20 @@ static bool editor_trace_screen_point(const slayer3d_game_data_runtime *runtime,
     *out_x = viewport_width * 0.5f;
     *out_y = viewport_height * 0.5f;
 
-    slayer3d_input_manager *input = runtime_input(runtime);
-    float mouse_x = 0.0f;
-    float mouse_y = 0.0f;
-    if (slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+    yyjson_val *screen = obj_get(trace, "screen");
+    if (!editor_trace_screen_value_is_center(screen))
     {
-        *out_x = mouse_x;
-        *out_y = mouse_y;
+        slayer3d_input_manager *input = runtime_input(runtime);
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        if (slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+        {
+            *out_x = mouse_x;
+            *out_y = mouse_y;
+        }
     }
 
-    if (!json_vec2_value(obj_get(trace, "screen"), *out_x, *out_y, out_x, out_y))
+    if (!editor_trace_screen_value_is_center(screen) && !json_vec2_value(screen, *out_x, *out_y, out_x, out_y))
         return false;
 
     *out_x = json_float(trace, "screen_x", *out_x);
@@ -180,8 +189,15 @@ static bool editor_trace_select_viewport(const slayer3d_game_data_runtime *runti
         float height = 0.0f;
         if (!editor_trace_viewport_rect(viewport, &x, &y, &width, &height))
             continue;
-        if (screen_x < x || screen_y < y || screen_x >= x + width || screen_y >= y + height)
+
+        const bool center_screen = editor_trace_screen_value_is_center(obj_get(viewport, "screen"));
+        const float candidate_screen_x = center_screen ? x + width * 0.5f : screen_x;
+        const float candidate_screen_y = center_screen ? y + height * 0.5f : screen_y;
+        if (candidate_screen_x < x || candidate_screen_y < y || candidate_screen_x >= x + width ||
+            candidate_screen_y >= y + height)
+        {
             continue;
+        }
 
         SDL_zero(*out_viewport);
         out_viewport->camera = json_string(viewport, "camera", NULL);
@@ -189,8 +205,14 @@ static bool editor_trace_select_viewport(const slayer3d_game_data_runtime *runti
         out_viewport->y = y;
         out_viewport->width = width;
         out_viewport->height = height;
-        out_viewport->screen_x = screen_x - x;
-        out_viewport->screen_y = screen_y - y;
+        out_viewport->screen_x = candidate_screen_x - x;
+        out_viewport->screen_y = candidate_screen_y - y;
+        if (!center_screen &&
+            !json_vec2_value(obj_get(viewport, "screen"), out_viewport->screen_x, out_viewport->screen_y,
+                             &out_viewport->screen_x, &out_viewport->screen_y))
+        {
+            return false;
+        }
         out_viewport->work_plane = obj_get(viewport, "work_plane");
         return out_viewport->camera != NULL;
     }

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -103,7 +103,8 @@ static bool active_editor_debug_desc_from_json(const slayer3d_game_data_runtime 
         out_desc->trace = out_trace;
         out_desc->has_work_plane_grid = editor_work_plane_desc_from_trace_json(
             runtime, obj_get(selection_json, "trace"), &out_desc->work_plane_normal, &out_desc->work_plane_distance);
-        if (out_selection != NULL && editor_selection_mode_is_click(selection_json) &&
+        const bool prefer_hover_selection = eval_data_condition(runtime, obj_get(overlay, "hover_selection_if"), NULL);
+        if (out_selection != NULL && !prefer_hover_selection && editor_selection_mode_is_click(selection_json) &&
             editor_selection_active_for_scene(runtime) && runtime->editor_active_selection.hit)
         {
             *out_selection = runtime->editor_active_selection;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -44,8 +44,7 @@ typedef struct import_validation_stack
     int count;
 } import_validation_stack;
 
-static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
-                                    validation_names *names);
+bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path, validation_names *names);
 static bool validate_storage(validation_context *ctx, yyjson_val *root);
 static bool require_network_string_entry(validation_context *ctx, yyjson_val *map, const char *path, const char *label,
                                          const char *name);
@@ -9270,8 +9269,7 @@ static bool validate_world_metadata(validation_context *ctx, yyjson_val *root)
     return true;
 }
 
-static bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path,
-                                    validation_names *names)
+bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path, validation_names *names)
 {
     if (condition == NULL)
         return true;

--- a/src/game_data_validation_controller_components.c
+++ b/src/game_data_validation_controller_components.c
@@ -139,13 +139,20 @@ bool validate_editor_camera_component(validation_context *ctx, yyjson_val *compo
         return validation_error(ctx, path, "controller.editor_camera actions must reference at least one input action");
 
     const char *property_keys[] = {
-        "yaw_property", "pitch_property", "forward_property", "mode_key", "orthographic_size_key",
-        "flyby_mode",   "top_mode",       "front_mode",       "side_mode"};
+        "yaw_property", "pitch_property", "forward_property", "mode_key",   "orthographic_size_key",
+        "flyby_mode",   "quad_mode",      "top_mode",         "front_mode", "side_mode"};
     for (size_t i = 0; i < SDL_arraysize(property_keys); ++i)
     {
         yyjson_val *value = obj_get(component, property_keys[i]);
         if (value != NULL && (!yyjson_is_str(value) || yyjson_get_str(value)[0] == '\0'))
             return validation_error(ctx, path, "controller.editor_camera property names must be non-empty strings");
+    }
+    const char *camera_keys[] = {"top_camera", "front_camera", "side_camera"};
+    for (size_t i = 0; i < SDL_arraysize(camera_keys); ++i)
+    {
+        yyjson_val *value = obj_get(component, camera_keys[i]);
+        if (value != NULL && !require_ref(ctx, &names->cameras, "camera", json_string(component, camera_keys[i]), path))
+            return false;
     }
 
     const char *numeric_keys[] = {"move_speed",

--- a/src/game_data_validation_internal.h
+++ b/src/game_data_validation_internal.h
@@ -104,6 +104,7 @@ bool validate_editor_player_starts(validation_context *ctx, yyjson_val *root, va
 bool require_unique_editor_stable_id(validation_context *ctx, name_table *stable_ids, yyjson_val *json,
                                      const char *json_path);
 bool validation_mouse_button_name_valid(const char *name);
+bool validate_data_condition(validation_context *ctx, yyjson_val *condition, const char *path, validation_names *names);
 
 bool is_vec_array(yyjson_val *value, size_t min_count);
 bool is_exact_vec_array(yyjson_val *value, size_t count);

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -613,6 +613,10 @@ bool validate_scene_editor_tooling(validation_context *ctx, yyjson_val *scene_ro
         if (!validate_string_or_string_array_names(ctx, obj_get(overlay, "flags"), flags_path, "editor debug flag",
                                                    editor_debug_flag_name_valid))
             return false;
+        char hover_selection_path[PATH_BUFFER_SIZE];
+        format_path(hover_selection_path, sizeof(hover_selection_path), "%s.hover_selection_if", overlay_path);
+        if (!validate_data_condition(ctx, obj_get(overlay, "hover_selection_if"), hover_selection_path, names))
+            return false;
         static const char *const color_keys[] = {
             "world_bounds_color", "selection_bounds_color", "trace_color",           "face_normal_color",
             "hit_marker_color",   "command_preview_color",  "work_plane_grid_color", "player_start_color"};

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -132,6 +132,17 @@ static bool validate_optional_non_negative_number(validation_context *ctx, yyjso
 
 static bool validate_scene_editor_work_plane(validation_context *ctx, yyjson_val *trace, const char *trace_path);
 
+static bool validate_scene_editor_trace_screen(validation_context *ctx, yyjson_val *screen, const char *json_path)
+{
+    if (screen == NULL)
+        return true;
+    if (yyjson_is_arr(screen) && is_exact_vec_array(screen, 2))
+        return true;
+    if (yyjson_is_str(screen) && SDL_strcmp(yyjson_get_str(screen), "center") == 0)
+        return true;
+    return validation_error(ctx, json_path, "scene editor camera_screen trace screen must be a vec2 or 'center'");
+}
+
 static bool validate_scene_editor_camera_screen_trace(validation_context *ctx, yyjson_val *trace,
                                                       const char *trace_path, validation_names *names)
 {
@@ -142,15 +153,16 @@ static bool validate_scene_editor_camera_screen_trace(validation_context *ctx, y
     if (camera != NULL && !require_ref(ctx, &names->cameras, "camera", camera, trace_path))
         return false;
 
+    char field_path[PATH_BUFFER_SIZE];
     yyjson_val *screen = obj_get(trace, "screen");
-    if (screen != NULL && !is_exact_vec_array(screen, 2))
-        return validation_error(ctx, trace_path, "scene editor camera_screen trace screen must be a vec2");
+    format_path(field_path, sizeof(field_path), "%s.screen", trace_path);
+    if (!validate_scene_editor_trace_screen(ctx, screen, field_path))
+        return false;
     yyjson_val *viewport = obj_get(trace, "viewport");
     if (viewport != NULL &&
         (!is_exact_vec_array(viewport, 2) || !numeric_array_values_in_range(viewport, 0.000001, DBL_MAX)))
         return validation_error(ctx, trace_path, "scene editor camera_screen trace viewport must be a positive vec2");
 
-    char field_path[PATH_BUFFER_SIZE];
     static const char *const numeric_keys[] = {"screen_x", "screen_y"};
     for (size_t i = 0; i < SDL_arraysize(numeric_keys); ++i)
     {
@@ -212,6 +224,9 @@ static bool validate_scene_editor_camera_screen_trace(validation_context *ctx, y
                                         "with positive dimensions");
             }
             if (!validate_scene_editor_work_plane(ctx, viewport_entry, viewport_path))
+                return false;
+            format_path(field_path, sizeof(field_path), "%s.screen", viewport_path);
+            if (!validate_scene_editor_trace_screen(ctx, obj_get(viewport_entry, "screen"), field_path))
                 return false;
         }
     }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16086,6 +16086,20 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.hover.element", ""),
                  "brush.target.cube");
 
+    SDL_Event flyby_click{};
+    flyby_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    flyby_click.button.button = SDL_BUTTON_LEFT;
+    flyby_click.button.x = 640.0f;
+    flyby_click.button.y = 360.0f;
+    slayer3d_input_process_event(input, &flyby_click);
+    slayer3d_input_update(input, 7);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(
+        slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.selection.element", ""),
+        "brush.target.cube");
+    flyby_click.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &flyby_click);
+
     slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "floor");
     slayer3d_properties_set_float(camera_actor->props, "yaw", -1.0f);
     slayer3d_properties_set_float(camera_actor->props, "pitch", -0.25f);
@@ -16095,6 +16109,24 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
                                              false));
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.hover.element", ""),
                  "");
+    struct FlybyDebugCapture
+    {
+        int selection_edges = 0;
+        int hit_markers = 0;
+    } flyby_debug;
+    auto capture_flyby_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<FlybyDebugCapture *>(userdata);
+        if (primitive == nullptr)
+            return true;
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
+            capture->selection_edges++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER)
+            capture->hit_markers++;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_flyby_debug, &flyby_debug));
+    EXPECT_EQ(flyby_debug.selection_edges, 0);
+    EXPECT_GT(flyby_debug.hit_markers, 0);
     slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "select");
     slayer3d_properties_set_float(camera_actor->props, "yaw", start_yaw);
     slayer3d_properties_set_float(camera_actor->props, "pitch", -0.29566f);
@@ -16102,7 +16134,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_W;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 7);
+    slayer3d_input_update(input, 8);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.25f));
     EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, start_position)), 0.1f);
 
@@ -16114,7 +16146,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     motion.motion.xrel = 60.0f;
     motion.motion.yrel = -15.0f;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 8);
+    slayer3d_input_update(input, 9);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
 
     const float yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16072,6 +16072,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
     EXPECT_LT(ortho.fovy, quad_zoom_start);
 
+    camera_actor->position = start_position;
     slayer3d_signal_emit(bus, view_perspective_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.view.mode", ""),
@@ -16079,6 +16080,24 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_TRUE(visible_view_label("3D Perspective / Flyby"));
     EXPECT_TRUE(slayer3d_game_data_active_scene_mouse_capture(runtime, false));
     EXPECT_FALSE(slayer3d_game_data_active_scene_mouse_capture(runtime, true));
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(slayer3d_game_data_scene_state(runtime), "editor.hover.hit", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.hover.element", ""),
+                 "brush.target.cube");
+
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "floor");
+    slayer3d_properties_set_float(camera_actor->props, "yaw", -1.0f);
+    slayer3d_properties_set_float(camera_actor->props, "pitch", -0.25f);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(slayer3d_game_data_scene_state(runtime), "editor.placement_preview.active",
+                                             false));
+    EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.hover.element", ""),
+                 "");
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "select");
+    slayer3d_properties_set_float(camera_actor->props, "yaw", start_yaw);
+    slayer3d_properties_set_float(camera_actor->props, "pitch", -0.29566f);
 
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_W;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16050,6 +16050,28 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_TRUE(visible_view_label("Top / XY"));
     EXPECT_TRUE(visible_view_label("Side / YZ"));
     EXPECT_FALSE(slayer3d_game_data_active_scene_mouse_capture(runtime, false));
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
+    const float quad_zoom_start = ortho.fovy;
+    SDL_Event wheel{};
+    wheel.type = SDL_EVENT_MOUSE_WHEEL;
+    wheel.wheel.mouse_x = 100.0f;
+    wheel.wheel.mouse_y = 100.0f;
+    wheel.wheel.y = 1.0f;
+    slayer3d_input_process_event(input, &wheel);
+    slayer3d_input_update(input, 5);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
+    EXPECT_NEAR(ortho.fovy, quad_zoom_start, 0.001f);
+
+    wheel.wheel.mouse_x = 700.0f;
+    wheel.wheel.mouse_y = 100.0f;
+    wheel.wheel.y = 1.0f;
+    slayer3d_input_process_event(input, &wheel);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.ortho_top", &ortho));
+    EXPECT_LT(ortho.fovy, quad_zoom_start);
+
     slayer3d_signal_emit(bus, view_perspective_signal, nullptr);
     EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.view.mode", ""),
@@ -16061,7 +16083,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_W;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 3);
+    slayer3d_input_update(input, 7);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.25f));
     EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, start_position)), 0.1f);
 
@@ -16073,7 +16095,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     motion.motion.xrel = 60.0f;
     motion.motion.yrel = -15.0f;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 4);
+    slayer3d_input_update(input, 8);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
 
     const float yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);


### PR DESCRIPTION
## Summary
- let controller.editor_camera resolve hovered orthographic panes from authored world_viewports in quad view
- add explicit orthographic camera mappings to the editor shell dojo
- add data-authored screen center support for editor camera-screen traces and validation
- make full-screen 3D flyby picking/placement trace from the viewport center, with work-plane fallback when no brush is hit
- keep full-screen flyby debug selection feedback pinned to the live reticle trace instead of stale clicked selections
- document quad-view zoom and center-screen 3D editor picking behavior

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ctest --test-dir build/debug --output-on-failure -R 'GameDataRuntime\\.EditorShellDojoCameraNavigation|GameDataRuntime\\.EditorShellDojoCreatesBlockoutPrefabTools|GameDataRuntime\\.EditorShellDojoOpenLoadsEditableLevelOnEnter'
