### PR TITLE
Add structural grid validation for editor brushes

### DIFF
--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -234,6 +234,7 @@
       "ceiling_material": "mat.editor.ceiling",
       "default_snap": 8.0,
       "default_grid_size": 8.0,
+      "default_structural_grid": 0.05,
       "default_elevation": 0.0,
       "outputs": {
         "active_key": "editor.placement_preview.active",

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -150,7 +150,10 @@ The following should be true during a good test drive:
   are thin grid-edge segments, so simple blockout maps can be tiled without
   visible gaps while adjacent hallways can pass close to one another. Wall
   bottoms sit directly on the connected floor elevation; authored blockout
-  seams should be watertight rather than relying on visual offsets.
+  seams should be watertight rather than relying on visual offsets. The shell
+  dojo also snaps generated floor/wall/ceiling bounds to a 0.05m structural
+  source grid, so accidental sub-millimeter hover offsets should not appear in
+  saved brush planes.
 - In full-screen 3D flyby mode, wall placement auto-rotates to the nearest
   cardinal axis from the camera direction. Orthographic placement keeps the
   explicit `R` wall-axis toggle for drafting control.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -141,8 +141,10 @@ The following should be true during a good test drive:
   default plane; the editor creates deterministic side-wall fill brushes for
   the exposed vertical space. Fill brushes sit on the lowered tile boundary
   and extend to the upper walk surface so the test-run view should not show a
-  dark slab-height seam around the pit. The matching fill segment is removed
-  when the floor is raised back up.
+  dark slab-height seam around the pit. Fill materials are selected per side:
+  adjacent wall context wins, deliberately painted floor side faces come next,
+  and the authored fallback fill material is used when no context exists. The
+  matching fill segment is removed when the floor is raised back up.
 - Game object placement uses its own tighter snap grid, so player starts can be
   placed precisely while floor/wall/ceiling brushes stay aligned to the larger
   blockout grid.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -142,9 +142,10 @@ The following should be true during a good test drive:
   the exposed vertical space. Fill brushes sit on the lowered tile boundary
   and extend to the upper walk surface so the test-run view should not show a
   dark slab-height seam around the pit. Fill materials are selected per side:
-  adjacent wall context wins, deliberately painted floor side faces come next,
-  and the authored fallback fill material is used when no context exists. The
-  matching fill segment is removed when the floor is raised back up.
+  adjacent wall-height brush context wins, and the authored fallback fill
+  material is used when no context exists. Thin floor-slab side faces do not
+  count as wall context. The matching fill segment is removed when the floor is
+  raised back up.
 - Game object placement uses its own tighter snap grid, so player starts can be
   placed precisely while floor/wall/ceiling brushes stay aligned to the larger
   blockout grid.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -139,8 +139,10 @@ The following should be true during a good test drive:
   Mode owns brush selection and multi-selection. `[` and `]` resize generic
   selected brushes by the active grid step. Thin floor slabs can move below the
   default plane; the editor creates deterministic side-wall fill brushes for
-  the exposed vertical space and removes the matching fill segment when raised
-  back up.
+  the exposed vertical space. Fill brushes sit on the lowered tile boundary
+  and extend to the upper walk surface so the test-run view should not show a
+  dark slab-height seam around the pit. The matching fill segment is removed
+  when the floor is raised back up.
 - Game object placement uses its own tighter snap grid, so player starts can be
   placed precisely while floor/wall/ceiling brushes stay aligned to the larger
   blockout grid.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1052,6 +1052,11 @@ For interactive placement, set `position_from` to `selection_point`. The action
 then treats `min` and `max` as offsets from the current active editor selection
 point. `position_offset` can move the prefab anchor before creation, and `snap`
 rounds the anchor to a grid size in world units before applying the offsets.
+`structural_grid` is an optional source-coordinate correctness guard: when it
+is present, every generated bounds component must land on that grid. This is
+separate from the visible placement grid. For example, an editor can place 8m
+floor tiles while validating thin floor and wall slabs on a 0.05m structural
+source grid.
 
 ```json
 {
@@ -1060,6 +1065,7 @@ rounds the anchor to a grid size in world units before applying the offsets.
   "material": "mat.stone_floor",
   "position_from": "selection_point",
   "snap": 0.5,
+  "structural_grid": 0.05,
   "min": [-4.0, -0.25, -4.0],
   "max": [4.0, 0.0, 4.0],
   "outputs": {
@@ -1084,11 +1090,15 @@ floor tiles. `grid_size_key` can point at the same scene-state float when box
 previews use `grid_min` and `grid_max` instead of fixed `min` and `max` bounds.
 Those grid bounds are multipliers from the snapped grid anchor, so a floor
 authored from `[0, 0, 0]` to `[1, 0.025, 1]` becomes one active grid cell wide
-at any configured grid size. For tile-like blockout tools, author floors,
-walls, and ceilings from grid-boundary anchors with matching horizontal
-footprints instead of centering them around the snap point; this keeps adjacent
-tiles aligned without gaps. Each preview entry maps a tool `mode` to either a
-`box` ghost or a `player_start` marker. Box
+at any configured grid size. `default_structural_grid`,
+`structural_grid_key`, and per-preview `structural_grid` apply a second snap to
+the preview anchor and bounds before the brush is created. Use this source grid
+to prevent tiny hit-test offsets such as `0.001` from becoming authored brush
+planes. For tile-like blockout tools, author floors, walls, and ceilings from
+grid-boundary anchors with matching horizontal footprints instead of centering
+them around the snap point; this keeps adjacent tiles aligned without gaps.
+Each preview entry maps a tool `mode` to either a `box` ghost or a
+`player_start` marker. Box
 previews can use `axis_key` with `axis` `x` or `z` to rotate wall-like prefabs
 between horizontal grid axes. A box preview must author exactly one bounds
 source: fixed `min`/`max`, or grid-scaled `grid_min`/`grid_max`. The preview

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2219,6 +2219,15 @@ extern "C"
         slayer3d_vec3 max;
         /** @brief Brush contents bitmask. Zero defaults to solid. */
         unsigned int contents;
+        /**
+         * @brief Optional source-coordinate snap step for structural brushes.
+         *
+         * When greater than zero, all min/max bounds components must align to
+         * this grid before the brush is appended. This is separate from the
+         * editor's visible placement grid: a level can place 8m tiles while
+         * still allowing 0.2m-thick walls on a 0.1m structural source grid.
+         */
+        float structural_grid;
     } slayer3d_game_data_create_box_brush_desc;
 
     /**

--- a/src/game_data_brush_editor_mutation.c
+++ b/src/game_data_brush_editor_mutation.c
@@ -128,6 +128,27 @@ static void init_box_brush_face(slayer3d_game_data_brush_face *face, slayer3d_ve
     face->uv_scale[1] = 1.0f;
 }
 
+static bool editor_box_brush_value_aligned_to_grid(float value, float structural_grid)
+{
+    if (structural_grid <= 0.0f)
+        return true;
+    const float snapped = SDL_roundf(value / structural_grid) * structural_grid;
+    const float epsilon = SDL_max(0.00001f, structural_grid * 0.0001f);
+    return SDL_fabsf(value - snapped) <= epsilon;
+}
+
+static bool editor_box_brush_bounds_aligned_to_grid(const slayer3d_game_data_create_box_brush_desc *desc)
+{
+    if (desc == NULL || desc->structural_grid <= 0.0f)
+        return true;
+    return editor_box_brush_value_aligned_to_grid(desc->min.x, desc->structural_grid) &&
+           editor_box_brush_value_aligned_to_grid(desc->min.y, desc->structural_grid) &&
+           editor_box_brush_value_aligned_to_grid(desc->min.z, desc->structural_grid) &&
+           editor_box_brush_value_aligned_to_grid(desc->max.x, desc->structural_grid) &&
+           editor_box_brush_value_aligned_to_grid(desc->max.y, desc->structural_grid) &&
+           editor_box_brush_value_aligned_to_grid(desc->max.z, desc->structural_grid);
+}
+
 static bool init_editor_box_brush(const brush_world_runtime *world_runtime,
                                   const slayer3d_game_data_create_box_brush_desc *desc, const char *brush_name,
                                   int material_index, slayer3d_game_data_brush *out_brush)
@@ -179,6 +200,16 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     if (!(desc->min.x < desc->max.x && desc->min.y < desc->max.y && desc->min.z < desc->max.z))
     {
         set_error(error_buffer, error_buffer_size, "box brush bounds must have min < max on all axes");
+        return false;
+    }
+    if (desc->structural_grid < 0.0f)
+    {
+        set_error(error_buffer, error_buffer_size, "box brush structural grid must be positive");
+        return false;
+    }
+    if (!editor_box_brush_bounds_aligned_to_grid(desc))
+    {
+        set_error(error_buffer, error_buffer_size, "box brush bounds must align to structural grid");
         return false;
     }
 

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -718,6 +718,7 @@ static bool editor_floor_fill_name(const char *brush_name, float low_y, float hi
                                    size_t buffer_size);
 static slayer3d_bounding_box editor_floor_fill_bounds(slayer3d_bounding_box floor_bounds, float low_y, float high_y,
                                                       float thickness, int side_index);
+static int editor_brush_top_y_face_index(const slayer3d_game_data_brush *brush);
 static void translate_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
                                                               const editor_command_transaction_entry *entry,
                                                               slayer3d_vec3 offset);
@@ -782,9 +783,121 @@ static bool delete_editor_floor_fill_brushes(brush_world_runtime *world_runtime,
     return true;
 }
 
+static bool editor_intervals_overlap(float a_min, float a_max, float b_min, float b_max, float epsilon)
+{
+    return SDL_min(a_max, b_max) > SDL_max(a_min, b_min) + epsilon;
+}
+
+static int editor_floor_side_face_index(const slayer3d_game_data_brush *brush, int side_index)
+{
+    if (brush == NULL)
+        return -1;
+
+    const slayer3d_vec3 expected[] = {
+        slayer3d_vec3_make(-1.0f, 0.0f, 0.0f),
+        slayer3d_vec3_make(1.0f, 0.0f, 0.0f),
+        slayer3d_vec3_make(0.0f, 0.0f, -1.0f),
+        slayer3d_vec3_make(0.0f, 0.0f, 1.0f),
+    };
+    const slayer3d_vec3 normal = side_index >= 0 && side_index < 4 ? expected[side_index] : expected[0];
+    for (int face_index = 0; face_index < brush->face_count; ++face_index)
+    {
+        const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+        if (slayer3d_vec3_dot(face->normal, normal) > 0.99f)
+            return face_index;
+    }
+    return -1;
+}
+
+static int editor_floor_top_face_material_index(const slayer3d_game_data_brush *brush)
+{
+    const int face_index = editor_brush_top_y_face_index(brush);
+    return face_index >= 0 ? brush->faces[face_index].material_index : -1;
+}
+
+static int editor_floor_painted_side_material_index(const slayer3d_game_data_brush *brush, int side_index)
+{
+    const int face_index = editor_floor_side_face_index(brush, side_index);
+    const int top_material_index = editor_floor_top_face_material_index(brush);
+    if (face_index < 0)
+        return -1;
+    const int side_material_index = brush->faces[face_index].material_index;
+    return side_material_index >= 0 && side_material_index != top_material_index ? side_material_index : -1;
+}
+
+static int editor_adjacent_fill_material_index(const brush_world_runtime *world_runtime, const char *brush_name,
+                                               slayer3d_bounding_box floor_bounds, int side_index)
+{
+    if (world_runtime == NULL)
+        return -1;
+
+    const float epsilon = 0.001f;
+    const bool x_side = side_index == 0 || side_index == 1;
+    const float side_coord = side_index == 0   ? floor_bounds.min.x
+                             : side_index == 1 ? floor_bounds.max.x
+                             : side_index == 2 ? floor_bounds.min.z
+                                               : floor_bounds.max.z;
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+        if (brush->name == NULL || (brush_name != NULL && SDL_strcmp(brush->name, brush_name) == 0) ||
+            !brush->has_bounds)
+        {
+            continue;
+        }
+
+        const bool horizontal_overlap = x_side
+                                            ? editor_intervals_overlap(brush->bounds.min.z, brush->bounds.max.z,
+                                                                       floor_bounds.min.z, floor_bounds.max.z, epsilon)
+                                            : editor_intervals_overlap(brush->bounds.min.x, brush->bounds.max.x,
+                                                                       floor_bounds.min.x, floor_bounds.max.x, epsilon);
+        if (!horizontal_overlap)
+            continue;
+
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+            if (face->material_index < 0)
+                continue;
+            if (x_side)
+            {
+                if (SDL_fabsf(face->normal.x) <= 0.99f)
+                    continue;
+                const float face_coord = face->normal.x > 0.0f ? face->distance : -face->distance;
+                if (SDL_fabsf(face_coord - side_coord) <= epsilon)
+                    return face->material_index;
+            }
+            else
+            {
+                if (SDL_fabsf(face->normal.z) <= 0.99f)
+                    continue;
+                const float face_coord = face->normal.z > 0.0f ? face->distance : -face->distance;
+                if (SDL_fabsf(face_coord - side_coord) <= epsilon)
+                    return face->material_index;
+            }
+        }
+    }
+    return -1;
+}
+
+static void editor_floor_fill_material_indices(const brush_world_runtime *world_runtime, const char *brush_name,
+                                               const slayer3d_game_data_brush *floor_brush,
+                                               slayer3d_bounding_box floor_bounds, int fallback_material_index,
+                                               int out_material_indices[4])
+{
+    for (int side = 0; side < 4; ++side)
+    {
+        int material_index = editor_adjacent_fill_material_index(world_runtime, brush_name, floor_bounds, side);
+        if (material_index < 0)
+            material_index = editor_floor_painted_side_material_index(floor_brush, side);
+        out_material_indices[side] = material_index >= 0 ? material_index : fallback_material_index;
+    }
+}
+
 static bool create_editor_floor_fill_brushes(brush_world_runtime *world_runtime, const char *brush_name,
                                              slayer3d_bounding_box floor_bounds, float low_y, float high_y,
-                                             float fill_thickness, int material_index)
+                                             float fill_thickness, const int material_indices[4])
 {
     static const char *const fill_side_names[] = {"west", "east", "north", "south"};
     int created_count = 0;
@@ -799,7 +912,8 @@ static bool create_editor_floor_fill_brushes(brush_world_runtime *world_runtime,
         slayer3d_game_data_brush fill_brush;
         const slayer3d_bounding_box fill_bounds =
             editor_floor_fill_bounds(floor_bounds, low_y, high_y, fill_thickness, side);
-        if (!create_editor_box_brush_snapshot(world_runtime, fill_name, fill_bounds, material_index, &fill_brush))
+        if (!create_editor_box_brush_snapshot(world_runtime, fill_name, fill_bounds, material_indices[side],
+                                              &fill_brush))
             goto fail;
         if (!insert_editor_brush_at_index(world_runtime, world_runtime->desc.brush_count, &fill_brush))
         {
@@ -852,6 +966,19 @@ static bool apply_editor_brush_sector_floor(slayer3d_game_data_runtime *runtime,
     if (fill_material_index < 0)
         return false;
 
+    int fill_material_indices[4] = {fill_material_index, fill_material_index, fill_material_index, fill_material_index};
+    if (entry->has_fill_material_indices)
+    {
+        for (int side = 0; side < 4; ++side)
+            fill_material_indices[side] =
+                entry->fill_material_indices[side] >= 0 ? entry->fill_material_indices[side] : fill_material_index;
+    }
+    else if (offset.y < 0.0f)
+    {
+        editor_floor_fill_material_indices(world_runtime, entry->element_name, brush, current_bounds,
+                                           fill_material_index, fill_material_indices);
+    }
+
     if (offset.y > 0.0f && !delete_editor_floor_fill_brushes(world_runtime, entry->element_name, low_y, high_y))
         return false;
 
@@ -859,7 +986,7 @@ static bool apply_editor_brush_sector_floor(slayer3d_game_data_runtime *runtime,
         return false;
 
     if (offset.y < 0.0f && !create_editor_floor_fill_brushes(world_runtime, entry->element_name, current_bounds, low_y,
-                                                             high_y, fill_thickness, fill_material_index))
+                                                             high_y, fill_thickness, fill_material_indices))
     {
         (void)apply_editor_brush_translate(runtime, entry, slayer3d_vec3_scale(offset, -1.0f));
         (void)delete_editor_floor_fill_brushes(world_runtime, entry->element_name, low_y, high_y);
@@ -1237,6 +1364,10 @@ static bool editor_append_sector_floor_transaction(slayer3d_game_data_runtime *r
     }
     entry->material_index = fill_material_index;
     entry->offset = slayer3d_vec3_make(fill_thickness, distance, 0.0f);
+    entry->has_fill_material_indices = true;
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, selection->world_name);
+    editor_floor_fill_material_indices(world_runtime, selection->element_name, brush, brush->bounds,
+                                       fill_material_index, entry->fill_material_indices);
     entry->has_bounds = brush != NULL && brush->has_bounds;
     entry->bounds = entry->has_bounds ? translated_bounds(brush->bounds, slayer3d_vec3_make(0.0f, distance, 0.0f))
                                       : (slayer3d_bounding_box){slayer3d_vec3_make(0.0f, 0.0f, 0.0f),

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -718,7 +718,6 @@ static bool editor_floor_fill_name(const char *brush_name, float low_y, float hi
                                    size_t buffer_size);
 static slayer3d_bounding_box editor_floor_fill_bounds(slayer3d_bounding_box floor_bounds, float low_y, float high_y,
                                                       float thickness, int side_index);
-static int editor_brush_top_y_face_index(const slayer3d_game_data_brush *brush);
 static void translate_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
                                                               const editor_command_transaction_entry *entry,
                                                               slayer3d_vec3 offset);
@@ -788,43 +787,6 @@ static bool editor_intervals_overlap(float a_min, float a_max, float b_min, floa
     return SDL_min(a_max, b_max) > SDL_max(a_min, b_min) + epsilon;
 }
 
-static int editor_floor_side_face_index(const slayer3d_game_data_brush *brush, int side_index)
-{
-    if (brush == NULL)
-        return -1;
-
-    const slayer3d_vec3 expected[] = {
-        slayer3d_vec3_make(-1.0f, 0.0f, 0.0f),
-        slayer3d_vec3_make(1.0f, 0.0f, 0.0f),
-        slayer3d_vec3_make(0.0f, 0.0f, -1.0f),
-        slayer3d_vec3_make(0.0f, 0.0f, 1.0f),
-    };
-    const slayer3d_vec3 normal = side_index >= 0 && side_index < 4 ? expected[side_index] : expected[0];
-    for (int face_index = 0; face_index < brush->face_count; ++face_index)
-    {
-        const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
-        if (slayer3d_vec3_dot(face->normal, normal) > 0.99f)
-            return face_index;
-    }
-    return -1;
-}
-
-static int editor_floor_top_face_material_index(const slayer3d_game_data_brush *brush)
-{
-    const int face_index = editor_brush_top_y_face_index(brush);
-    return face_index >= 0 ? brush->faces[face_index].material_index : -1;
-}
-
-static int editor_floor_painted_side_material_index(const slayer3d_game_data_brush *brush, int side_index)
-{
-    const int face_index = editor_floor_side_face_index(brush, side_index);
-    const int top_material_index = editor_floor_top_face_material_index(brush);
-    if (face_index < 0)
-        return -1;
-    const int side_material_index = brush->faces[face_index].material_index;
-    return side_material_index >= 0 && side_material_index != top_material_index ? side_material_index : -1;
-}
-
 static int editor_adjacent_fill_material_index(const brush_world_runtime *world_runtime, const char *brush_name,
                                                slayer3d_bounding_box floor_bounds, int side_index)
 {
@@ -846,6 +808,8 @@ static int editor_adjacent_fill_material_index(const brush_world_runtime *world_
         {
             continue;
         }
+        if (brush->bounds.max.y - brush->bounds.min.y <= 0.5f)
+            continue;
 
         const bool horizontal_overlap = x_side
                                             ? editor_intervals_overlap(brush->bounds.min.z, brush->bounds.max.z,
@@ -886,11 +850,10 @@ static void editor_floor_fill_material_indices(const brush_world_runtime *world_
                                                slayer3d_bounding_box floor_bounds, int fallback_material_index,
                                                int out_material_indices[4])
 {
+    (void)floor_brush;
     for (int side = 0; side < 4; ++side)
     {
         int material_index = editor_adjacent_fill_material_index(world_runtime, brush_name, floor_bounds, side);
-        if (material_index < 0)
-            material_index = editor_floor_painted_side_material_index(floor_brush, side);
         out_material_indices[side] = material_index >= 0 ? material_index : fallback_material_index;
     }
 }

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1184,25 +1184,27 @@ static slayer3d_bounding_box editor_floor_fill_bounds(slayer3d_bounding_box floo
                                                       float thickness, int side_index)
 {
     slayer3d_bounding_box bounds = floor_bounds;
+    const float x_thickness = SDL_min(thickness, (floor_bounds.max.x - floor_bounds.min.x) * 0.5f);
+    const float z_thickness = SDL_min(thickness, (floor_bounds.max.z - floor_bounds.min.z) * 0.5f);
     bounds.min.y = low_y;
-    bounds.max.y = floor_bounds.min.y > low_y + 0.001f ? floor_bounds.min.y : high_y;
+    bounds.max.y = high_y;
     switch (side_index)
     {
     case 0:
-        bounds.max.x = floor_bounds.min.x;
-        bounds.min.x = floor_bounds.min.x - thickness;
+        bounds.min.x = floor_bounds.min.x;
+        bounds.max.x = floor_bounds.min.x + x_thickness;
         break;
     case 1:
-        bounds.min.x = floor_bounds.max.x;
-        bounds.max.x = floor_bounds.max.x + thickness;
+        bounds.min.x = floor_bounds.max.x - x_thickness;
+        bounds.max.x = floor_bounds.max.x;
         break;
     case 2:
-        bounds.max.z = floor_bounds.min.z;
-        bounds.min.z = floor_bounds.min.z - thickness;
+        bounds.min.z = floor_bounds.min.z;
+        bounds.max.z = floor_bounds.min.z + z_thickness;
         break;
     default:
-        bounds.min.z = floor_bounds.max.z;
-        bounds.max.z = floor_bounds.max.z + thickness;
+        bounds.min.z = floor_bounds.max.z - z_thickness;
+        bounds.max.z = floor_bounds.max.z;
         break;
     }
     return bounds;

--- a/src/game_data_editor_create_box_actions.c
+++ b/src/game_data_editor_create_box_actions.c
@@ -19,6 +19,7 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
     desc.material_name = json_string(action, "material", NULL);
     desc.min = json_vec3(action, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
     desc.max = json_vec3(action, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.structural_grid = json_float(action, "structural_grid", 0.0f);
 
     char error[256];
     error[0] = '\0';
@@ -43,6 +44,8 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
                 desc.material_name = json_string(action, "material", preview->material_name);
                 desc.min = preview->bounds.min;
                 desc.max = preview->bounds.max;
+                if (desc.structural_grid <= 0.0f)
+                    desc.structural_grid = preview->structural_grid;
             }
         }
     }

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -83,6 +83,18 @@ static float editor_placement_grid_size(slayer3d_game_data_runtime *runtime, yyj
     return authored_grid_size;
 }
 
+static float editor_placement_structural_grid(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                              yyjson_val *preview)
+{
+    const float authored_grid =
+        json_float(preview, "structural_grid", json_float(placement, "default_structural_grid", 0.0f));
+    const char *grid_key =
+        json_string(preview, "structural_grid_key", json_string(placement, "structural_grid_key", NULL));
+    if (runtime != NULL && grid_key != NULL && grid_key[0] != '\0')
+        return slayer3d_properties_get_float(slayer3d_game_data_scene_state(runtime), grid_key, authored_grid);
+    return authored_grid;
+}
+
 static float editor_placement_elevation(slayer3d_game_data_runtime *runtime, yyjson_val *placement)
 {
     const float authored_elevation = json_float(placement, "default_elevation", 0.0f);
@@ -155,6 +167,29 @@ static float editor_placement_snap_value(float value, float snap, const char *mo
     return editor_placement_snap_floor(value, snap);
 }
 
+static float editor_placement_snap_source_value(float value, float structural_grid)
+{
+    if (structural_grid <= 0.0f)
+        return value;
+    const float snapped = SDL_roundf(value / structural_grid) * structural_grid;
+    return SDL_fabsf(snapped) <= 0.000001f ? 0.0f : snapped;
+}
+
+static slayer3d_vec3 editor_placement_snap_source_vec3(slayer3d_vec3 value, float structural_grid)
+{
+    value.x = editor_placement_snap_source_value(value.x, structural_grid);
+    value.y = editor_placement_snap_source_value(value.y, structural_grid);
+    value.z = editor_placement_snap_source_value(value.z, structural_grid);
+    return value;
+}
+
+static slayer3d_bounding_box editor_placement_snap_source_bounds(slayer3d_bounding_box bounds, float structural_grid)
+{
+    bounds.min = editor_placement_snap_source_vec3(bounds.min, structural_grid);
+    bounds.max = editor_placement_snap_source_vec3(bounds.max, structural_grid);
+    return bounds;
+}
+
 static bool editor_placement_uses_connected_grid(yyjson_val *preview)
 {
     return SDL_strcmp(json_string(preview, "elevation_mode", ""), "connected_grid") == 0;
@@ -224,7 +259,7 @@ static slayer3d_bounding_box editor_placement_oriented_box_bounds(slayer3d_game_
 
 static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
                                              yyjson_val *preview, const slayer3d_game_data_editor_selection *selection,
-                                             float snap)
+                                             float snap, float structural_grid)
 {
     slayer3d_vec3 anchor = selection != NULL ? selection->point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
     anchor = slayer3d_vec3_add(anchor, json_vec3(preview, "position_offset", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)));
@@ -239,8 +274,10 @@ static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime
     {
         const float grid_size = editor_placement_grid_size(runtime, placement, preview, snap);
         anchor.y = editor_placement_connected_grid_elevation(runtime, placement, selection, grid_size);
-        publish_editor_placement_elevation(runtime, placement, anchor.y);
     }
+    anchor = editor_placement_snap_source_vec3(anchor, structural_grid);
+    if (editor_placement_uses_connected_grid(preview))
+        publish_editor_placement_elevation(runtime, placement, anchor.y);
     return anchor;
 }
 
@@ -268,7 +305,9 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     }
 
     const float snap = editor_placement_snap(runtime, placement, preview_json);
-    const slayer3d_vec3 anchor = editor_placement_anchor(runtime, placement, preview_json, hover_selection, snap);
+    const float structural_grid = editor_placement_structural_grid(runtime, placement, preview_json);
+    const slayer3d_vec3 anchor =
+        editor_placement_anchor(runtime, placement, preview_json, hover_selection, snap, structural_grid);
     editor_placement_preview_state *preview = &runtime->editor_placement_preview;
     SDL_zero(*preview);
     preview->active = true;
@@ -280,6 +319,7 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     preview->material_name = json_string(preview_json, "material", hover_selection->material_name);
     preview->anchor = anchor;
     preview->snap = snap;
+    preview->structural_grid = structural_grid;
     preview->has_bounds = true;
     if (SDL_strcmp(preview->kind, "player_start") == 0)
     {
@@ -292,6 +332,7 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
         preview->bounds =
             editor_placement_oriented_box_bounds(runtime, placement, preview_json, anchor, preview->axis, snap);
     }
+    preview->bounds = editor_placement_snap_source_bounds(preview->bounds, structural_grid);
     publish_editor_placement_preview(runtime, outputs, true, preview_json, preview,
                                      json_string(preview_json, "message", "placement preview"));
 }

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -198,6 +198,8 @@ typedef struct editor_command_transaction_entry
     int material_index;
     int previous_material_index;
     slayer3d_vec3 offset;
+    bool has_fill_material_indices;
+    int fill_material_indices[4];
     bool has_bounds;
     slayer3d_bounding_box bounds;
     int brush_index;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -176,6 +176,7 @@ typedef struct editor_placement_preview_state
     const char *material_name;
     slayer3d_vec3 anchor;
     float snap;
+    float structural_grid;
     bool has_bounds;
     slayer3d_bounding_box bounds;
 } editor_placement_preview_state;

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -7997,6 +7997,10 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         yyjson_val *snap = obj_get(action, "snap");
         if (snap != NULL && (!yyjson_is_num(snap) || yyjson_get_num(snap) <= 0.0))
             return validation_error(ctx, json_path, "editor.brush_world.create_box snap must be a positive number");
+        yyjson_val *structural_grid = obj_get(action, "structural_grid");
+        if (structural_grid != NULL && (!yyjson_is_num(structural_grid) || yyjson_get_num(structural_grid) <= 0.0))
+            return validation_error(ctx, json_path,
+                                    "editor.brush_world.create_box structural_grid must be a positive number");
         if (!from_preview)
         {
             const double min_x = yyjson_get_num(yyjson_arr_get(min, 0));

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -355,9 +355,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     if (!yyjson_is_obj(placement))
         return validation_error(ctx, placement_path, "scene editor placement must be an object");
 
-    const char *string_fields[] = {"tool_key",       "snap_key",        "grid_size_key",
-                                   "default_tool",   "elevation_key",   "work_plane_distance_key",
-                                   "floor_material", "ceiling_material"};
+    const char *string_fields[] = {"tool_key",       "snap_key",         "grid_size_key",
+                                   "default_tool",   "elevation_key",    "work_plane_distance_key",
+                                   "floor_material", "ceiling_material", "structural_grid_key"};
     for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
     {
         char field_path[PATH_BUFFER_SIZE];
@@ -372,6 +372,10 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
     yyjson_val *default_grid_size = obj_get(placement, "default_grid_size");
     if (default_grid_size != NULL && (!yyjson_is_num(default_grid_size) || yyjson_get_num(default_grid_size) <= 0.0))
         return validation_error(ctx, placement_path, "scene editor placement default_grid_size must be positive");
+    yyjson_val *default_structural_grid = obj_get(placement, "default_structural_grid");
+    if (default_structural_grid != NULL &&
+        (!yyjson_is_num(default_structural_grid) || yyjson_get_num(default_structural_grid) <= 0.0))
+        return validation_error(ctx, placement_path, "scene editor placement default_structural_grid must be positive");
     char default_elevation_path[PATH_BUFFER_SIZE];
     format_path(default_elevation_path, sizeof(default_elevation_path), "%s.default_elevation", placement_path);
     if (!validate_optional_number(ctx, obj_get(placement, "default_elevation"), default_elevation_path,
@@ -410,8 +414,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0)
             return validation_error(ctx, preview_path,
                                     "scene editor placement preview kind must be box or player_start");
-        static const char *const preview_string_fields[] = {"axis_key", "grid_size_key", "auto_axis_camera",
-                                                            "auto_axis_view_key", "auto_axis_view"};
+        static const char *const preview_string_fields[] = {
+            "axis_key",         "grid_size_key",      "structural_grid_key",
+            "auto_axis_camera", "auto_axis_view_key", "auto_axis_view"};
         for (size_t field_index = 0; field_index < SDL_arraysize(preview_string_fields); ++field_index)
         {
             char field_path[PATH_BUFFER_SIZE];
@@ -456,6 +461,10 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         yyjson_val *grid_size = obj_get(preview, "grid_size");
         if (grid_size != NULL && (!yyjson_is_num(grid_size) || yyjson_get_num(grid_size) <= 0.0))
             return validation_error(ctx, preview_path, "scene editor placement preview grid_size must be positive");
+        yyjson_val *structural_grid = obj_get(preview, "structural_grid");
+        if (structural_grid != NULL && (!yyjson_is_num(structural_grid) || yyjson_get_num(structural_grid) <= 0.0))
+            return validation_error(ctx, preview_path,
+                                    "scene editor placement preview structural_grid must be positive");
         if (SDL_strcmp(kind, "player_start") == 0)
         {
             yyjson_val *size = obj_get(preview, "size");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15675,6 +15675,16 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         ADD_FAILURE() << "brush not found: " << name;
         return slayer3d_bounding_box{slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
     };
+    auto find_brush_by_name = [&](const std::string &name) -> const slayer3d_game_data_brush * {
+        const slayer3d_game_data_brush_world brush_world = world();
+        for (int i = 0; i < brush_world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &candidate = brush_world.brushes[i];
+            if (candidate.name != nullptr && name == candidate.name)
+                return &candidate;
+        }
+        return nullptr;
+    };
     auto visible_ui_text = [&](const char *prefix) {
         std::vector<std::string> values;
         slayer3d_game_data_ui_metrics metrics{};
@@ -15854,8 +15864,19 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
     ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), floor_brush_name.c_str());
-    const int brush_count_before_floor_lower = world().brush_count;
     const slayer3d_bounding_box floor_bounds_before_lower = brush_bounds(floor_brush_name);
+    slayer3d_game_data_create_box_brush_desc west_context_desc{};
+    west_context_desc.world_name = "brush.editor_shell.target";
+    west_context_desc.brush_name = "brush.editor_shell.context.west_wall";
+    west_context_desc.material_name = "mat.editor.ceiling";
+    west_context_desc.min = slayer3d_vec3_make(floor_bounds_before_lower.min.x - 0.2f,
+                                               floor_bounds_before_lower.max.y - 8.0f, floor_bounds_before_lower.min.z);
+    west_context_desc.max = slayer3d_vec3_make(floor_bounds_before_lower.min.x, floor_bounds_before_lower.max.y + 8.0f,
+                                               floor_bounds_before_lower.max.z);
+    west_context_desc.structural_grid = 0.05f;
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &west_context_desc, nullptr, 0, error, sizeof(error)))
+        << error;
+    const int brush_count_before_floor_lower = world().brush_count;
     press_editor_key(SDL_SCANCODE_LEFTBRACKET, 7);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
@@ -15869,6 +15890,14 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(west_fill_bounds.max.y, floor_bounds_before_lower.max.y, 0.001f);
     EXPECT_NEAR(west_fill_bounds.min.x, floor_bounds_before_lower.min.x, 0.001f);
     EXPECT_NEAR(west_fill_bounds.max.x, floor_bounds_before_lower.min.x + 0.2f, 0.001f);
+    const slayer3d_game_data_brush *west_fill = find_brush_by_name(floor_brush_name + ".auto_fill.n8000_p0.west");
+    ASSERT_NE(west_fill, nullptr);
+    ASSERT_GT(west_fill->face_count, 0);
+    EXPECT_STREQ(west_fill->faces[0].material_name, "mat.editor.ceiling");
+    const slayer3d_game_data_brush *east_fill = find_brush_by_name(floor_brush_name + ".auto_fill.n8000_p0.east");
+    ASSERT_NE(east_fill, nullptr);
+    ASSERT_GT(east_fill->face_count, 0);
+    EXPECT_STREQ(east_fill->faces[0].material_name, "mat.editor.wall");
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
@@ -15984,7 +16013,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(brush->bounds.max.x, ceiling_bounds_max.x, 0.001f);
     EXPECT_NEAR(brush->bounds.max.y, ceiling_bounds_max.y, 0.001f);
     EXPECT_NEAR(brush->bounds.max.z, ceiling_bounds_max.z, 0.001f);
-    EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+    EXPECT_EQ(world().brush_count, initial_brush_count + 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
     EXPECT_GE(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 3);
 
@@ -15998,9 +16027,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "delete");
-    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
-    slayer3d_signal_emit(bus, undo_signal, nullptr);
     EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
+    EXPECT_EQ(world().brush_count, initial_brush_count + 4);
 
     SDL_Event right_release{};
     right_release.type = SDL_EVENT_MOUSE_BUTTON_UP;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15866,7 +15866,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(floor_bounds_below_plane.max.y, floor_bounds_before_lower.max.y - 8.0f, 0.001f);
     const slayer3d_bounding_box west_fill_bounds = brush_bounds(floor_brush_name + ".auto_fill.n8000_p0.west");
     EXPECT_NEAR(west_fill_bounds.min.y, floor_bounds_before_lower.max.y - 8.0f, 0.001f);
-    EXPECT_NEAR(west_fill_bounds.max.y, floor_bounds_before_lower.min.y, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.max.y, floor_bounds_before_lower.max.y, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.min.x, floor_bounds_before_lower.min.x, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.max.x, floor_bounds_before_lower.min.x + 0.2f, 0.001f);
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14623,6 +14623,7 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
             "material": "mat.wall",
             "min": [2.0, 0.0, 0.0],
             "max": [4.0, 2.0, 0.5],
+            "structural_grid": 0.1,
             "outputs": {
               "valid_key": "editor.create.valid",
               "message_key": "editor.create.message",
@@ -14689,6 +14690,7 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     desc.material_name = "mat.floor";
     desc.min = slayer3d_vec3_make(0.0f, -0.25f, 2.0f);
     desc.max = slayer3d_vec3_make(3.0f, 0.0f, 4.0f);
+    desc.structural_grid = 0.25f;
     char generated_name[256]{};
     ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &desc, generated_name, sizeof(generated_name), error,
                                                     sizeof(error)))
@@ -14703,6 +14705,19 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     ASSERT_NE(world.compile_artifact_hash, 0u);
     EXPECT_NE(world.compile_artifact_hash, signal_create_compile_hash);
     const Uint64 direct_create_compile_hash = world.compile_artifact_hash;
+
+    slayer3d_game_data_create_box_brush_desc off_grid_desc = desc;
+    off_grid_desc.brush_name = "brush.off_grid";
+    off_grid_desc.min = slayer3d_vec3_make(0.03f, 0.0f, 0.0f);
+    off_grid_desc.max = slayer3d_vec3_make(1.03f, 1.0f, 1.0f);
+    off_grid_desc.structural_grid = 0.1f;
+    EXPECT_FALSE(slayer3d_game_data_create_box_brush(runtime, &off_grid_desc, nullptr, 0, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("structural grid"), std::string::npos) << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_EQ(world.brush_count, 3);
+    EXPECT_EQ(world.compile_artifact_hash, direct_create_compile_hash);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_EQ(editor_state.revision, 2U);
 
     slayer3d_game_data_resize_brush_face_desc resize_desc{};
     resize_desc.world_name = "brush.editor.level";


### PR DESCRIPTION
## Summary
- Adds an optional `structural_grid` source-coordinate guard to box-brush creation.
- Snaps editor placement preview anchors/bounds to a `default_structural_grid` before committing floor/wall/ceiling brushes.
- Enables a 0.05m structural source grid in the editor shell dojo so tiny hover offsets do not become authored brush planes.
- Documents the distinction between visible placement grid size and structural source-grid validation.

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j4`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorCreateBoxBrushAppendsAndRoundTrips:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools:GameDataRuntime.EditableLevelFragmentLoadsIntoEditorRuntime:GameDataRuntime.RejectsInvalidSceneEditorTooling'`
- `cmake --build --preset sanitizers --target slayer3d_game_data_test -j4`
- `ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1 ./build/sanitizers/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorCreateBoxBrushAppendsAndRoundTrips:GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools:GameDataRuntime.EditableLevelFragmentLoadsIntoEditorRuntime'`
- `git diff --check`

## Manual Verification
Run:

```sh
./build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/slayer3d-structural-test.fragment.json --overwrite
```

Inspect:
- Place floor, wall, and ceiling brushes at default grid size and after changing grid size with `+` / `-`.
- In flyby/orthographic views, confirm generated blockout brushes no longer show tiny `0.001`-style elevation offsets in the inspector.
- Lower a floor brush, then place floor/wall/ceiling brushes from the lowered area; placement should stay connected to the lowered floor elevation.
- Save and inspect `/tmp/slayer3d-structural-test.fragment.json`; brush plane distances should be clean multiples of 0.05 for editor shell blockout brushes.

Refs #409
