### PR TITLE
Add structural box brush source checks

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1041,7 +1041,11 @@ blockout tools: floors, walls, ceilings, platforms, and simple room pieces. It
 validates the target world and bounds at load time, resolves the material at
 runtime, rebuilds brush collision/render data atomically, then marks the world
 dirty only after the rebuild succeeds. If `name` is omitted, the runtime
-generates a unique brush name under the target world. The editor shell dojo
+generates a unique brush name under the target world. Runtime-created box
+brushes are structural editor source brushes: they receive stable editor ids for
+the brush and all six faces, exact face/edge/vertex contact with existing
+structural brushes is allowed, and positive-volume overlap with an existing
+structural brush is rejected before the world is marked dirty. The editor shell dojo
 demonstrates the current blockout palette pattern: modal palette signals write
 scene-state selection strings, and the shared commit signal branches to
 prefab-specific `editor.brush_world.create_box` or

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2227,8 +2227,11 @@ extern "C"
      * The operation is atomic from the runtime caller's perspective: the brush
      * is visible only after allocations, acceleration rebuild, and render-model
      * compilation all succeed. Success marks the brush world dirty and
-     * increments its editor revision. @p out_brush_name receives the final
-     * runtime brush name when non-NULL.
+     * increments its editor revision. Structural box brushes may touch existing
+     * structural brushes exactly, but positive-volume overlap is rejected.
+     * Runtime-created boxes receive stable editor metadata on the brush and
+     * generated faces. @p out_brush_name receives the final runtime brush name
+     * when non-NULL.
      */
     bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
                                              const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,

--- a/src/game_data_brush_editor_mutation.c
+++ b/src/game_data_brush_editor_mutation.c
@@ -54,6 +54,41 @@ static bool editor_brush_world_name_exists(const brush_world_runtime *world_runt
     return false;
 }
 
+static bool editor_metadata_stable_id_matches(const slayer3d_game_data_editor_metadata *metadata, const char *stable_id)
+{
+    return metadata != NULL && metadata->stable_id != NULL && stable_id != NULL &&
+           SDL_strcmp(metadata->stable_id, stable_id) == 0;
+}
+
+static bool editor_brush_world_stable_id_exists(const brush_world_runtime *world_runtime, const char *stable_id)
+{
+    if (world_runtime == NULL || stable_id == NULL || stable_id[0] == '\0')
+        return false;
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    if (editor_metadata_stable_id_matches(&world->editor, stable_id))
+        return true;
+    for (int i = 0; i < world->material_count; ++i)
+    {
+        if (editor_metadata_stable_id_matches(&world->materials[i].editor, stable_id))
+            return true;
+    }
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[i];
+        if (editor_metadata_stable_id_matches(&brush->editor, stable_id))
+            return true;
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            if (editor_metadata_stable_id_matches(&brush->faces[face_index].editor, stable_id))
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool editor_brush_world_box_stable_ids_available(const brush_world_runtime *world_runtime,
+                                                        const char *brush_name);
+
 static bool editor_brush_world_generate_brush_name(const brush_world_runtime *world_runtime, char *buffer,
                                                    size_t buffer_size)
 {
@@ -65,10 +100,42 @@ static bool editor_brush_world_generate_brush_name(const brush_world_runtime *wo
         SDL_snprintf(buffer, buffer_size, "%s.box.%d", world_name, i + 1);
         if (buffer[0] == '\0')
             return false;
-        if (!editor_brush_world_name_exists(world_runtime, buffer))
+        if (!editor_brush_world_name_exists(world_runtime, buffer) &&
+            editor_brush_world_box_stable_ids_available(world_runtime, buffer))
+        {
             return true;
+        }
     }
     return false;
+}
+
+static bool editor_metadata_set_string(const char **field, const char *value)
+{
+    if (field == NULL)
+        return false;
+    if (value == NULL || value[0] == '\0')
+        return true;
+    char *copy = SDL_strdup(value);
+    if (copy == NULL)
+        return false;
+    *field = copy;
+    return true;
+}
+
+static bool editor_brush_world_box_stable_ids_available(const brush_world_runtime *world_runtime,
+                                                        const char *brush_name)
+{
+    if (editor_brush_world_stable_id_exists(world_runtime, brush_name))
+        return false;
+    static const char *const face_suffixes[] = {"px", "nx", "py", "ny", "pz", "nz"};
+    for (size_t i = 0; i < SDL_arraysize(face_suffixes); ++i)
+    {
+        char stable_id[320];
+        SDL_snprintf(stable_id, sizeof(stable_id), "%s.face.%s", brush_name, face_suffixes[i]);
+        if (editor_brush_world_stable_id_exists(world_runtime, stable_id))
+            return false;
+    }
+    return true;
 }
 
 static int find_editor_brush_material_index(const brush_world_runtime *world_runtime, const char *material_name)
@@ -128,6 +195,29 @@ static void init_box_brush_face(slayer3d_game_data_brush_face *face, slayer3d_ve
     face->uv_scale[1] = 1.0f;
 }
 
+static bool init_editor_box_brush_metadata(slayer3d_game_data_brush *brush)
+{
+    if (brush == NULL || brush->name == NULL)
+        return false;
+    if (!editor_metadata_set_string(&brush->editor.stable_id, brush->name) ||
+        !editor_metadata_set_string(&brush->editor.prefab, "editor.box"))
+    {
+        return false;
+    }
+
+    static const char *const face_suffixes[] = {"px", "nx", "py", "ny", "pz", "nz"};
+    for (int i = 0; i < brush->face_count; ++i)
+    {
+        char stable_id[320];
+        SDL_snprintf(stable_id, sizeof(stable_id), "%s.face.%s", brush->name,
+                     i >= 0 && i < (int)SDL_arraysize(face_suffixes) ? face_suffixes[i] : "unknown");
+        slayer3d_game_data_brush_face *face = (slayer3d_game_data_brush_face *)&brush->faces[i];
+        if (!editor_metadata_set_string(&face->editor.stable_id, stable_id))
+            return false;
+    }
+    return true;
+}
+
 static bool init_editor_box_brush(const brush_world_runtime *world_runtime,
                                   const slayer3d_game_data_create_box_brush_desc *desc, const char *brush_name,
                                   int material_index, slayer3d_game_data_brush *out_brush)
@@ -157,7 +247,53 @@ static bool init_editor_box_brush(const brush_world_runtime *world_runtime,
     init_box_brush_face(&faces[3], slayer3d_vec3_make(0.0f, -1.0f, 0.0f), -desc->min.y, material_index, material_name);
     init_box_brush_face(&faces[4], slayer3d_vec3_make(0.0f, 0.0f, 1.0f), desc->max.z, material_index, material_name);
     init_box_brush_face(&faces[5], slayer3d_vec3_make(0.0f, 0.0f, -1.0f), -desc->min.z, material_index, material_name);
+    if (!init_editor_box_brush_metadata(out_brush))
+    {
+        free_editor_runtime_brush(out_brush);
+        return false;
+    }
     return true;
+}
+
+static bool editor_brush_contents_are_structural(unsigned int contents)
+{
+    if (contents == 0u)
+        contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    return (contents & (SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+                        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY)) != 0u;
+}
+
+static bool editor_bounds_overlap_positive_volume(slayer3d_bounding_box a, slayer3d_bounding_box b)
+{
+    const float epsilon = 0.00001f;
+    return a.min.x < b.max.x - epsilon && b.min.x < a.max.x - epsilon && a.min.y < b.max.y - epsilon &&
+           b.min.y < a.max.y - epsilon && a.min.z < b.max.z - epsilon && b.min.z < a.max.z - epsilon;
+}
+
+static bool editor_brush_world_box_overlaps_structural_brush(const brush_world_runtime *world_runtime,
+                                                             slayer3d_bounding_box bounds, unsigned int contents,
+                                                             const slayer3d_game_data_brush *exclude,
+                                                             const char **out_existing_name)
+{
+    if (out_existing_name != NULL)
+        *out_existing_name = NULL;
+    if (world_runtime == NULL || !editor_brush_contents_are_structural(contents))
+        return false;
+
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[i];
+        if (brush == exclude || !brush->has_bounds || !editor_brush_contents_are_structural(brush->contents))
+            continue;
+        if (editor_bounds_overlap_positive_volume(bounds, brush->bounds))
+        {
+            if (out_existing_name != NULL)
+                *out_existing_name = brush->name;
+            return true;
+        }
+    }
+    return false;
 }
 
 bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
@@ -194,6 +330,16 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
         set_error(error_buffer, error_buffer_size, "box brush material not found");
         return false;
     }
+    const slayer3d_bounding_box new_bounds = {desc->min, desc->max};
+    const char *overlapping_brush = NULL;
+    if (editor_brush_world_box_overlaps_structural_brush(
+            world_runtime, new_bounds, desc->contents != 0u ? desc->contents : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+            NULL, &overlapping_brush))
+    {
+        set_errorf(error_buffer, error_buffer_size, "box brush overlaps existing brush '%s'",
+                   overlapping_brush != NULL ? overlapping_brush : "");
+        return false;
+    }
 
     char generated_name[256];
     const char *brush_name = desc->brush_name;
@@ -209,6 +355,11 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
     else if (editor_brush_world_name_exists(world_runtime, brush_name))
     {
         set_error(error_buffer, error_buffer_size, "box brush name already exists");
+        return false;
+    }
+    if (!editor_brush_world_box_stable_ids_available(world_runtime, brush_name))
+    {
+        set_error(error_buffer, error_buffer_size, "box brush stable id already exists");
         return false;
     }
 
@@ -340,7 +491,12 @@ bool slayer3d_game_data_resize_brush_face(slayer3d_game_data_runtime *runtime,
         return false;
     }
 
-    if (rebuild_brush_world_runtime_artifacts(world_runtime, NULL, 0) && editor_brush_bounds_valid(brush))
+    const char *overlapping_brush = NULL;
+    const bool resize_valid =
+        rebuild_brush_world_runtime_artifacts(world_runtime, NULL, 0) && editor_brush_bounds_valid(brush) &&
+        !editor_brush_world_box_overlaps_structural_brush(world_runtime, brush->bounds, brush->contents, brush,
+                                                          &overlapping_brush);
+    if (resize_valid)
     {
         editor_brush_world_mark_dirty(world_runtime);
         return true;
@@ -348,6 +504,10 @@ bool slayer3d_game_data_resize_brush_face(slayer3d_game_data_runtime *runtime,
 
     (void)resize_editor_brush_face_plane(brush, desc->face_index, -desc->distance);
     (void)rebuild_brush_world_runtime_artifacts(world_runtime, NULL, 0);
-    set_error(error_buffer, error_buffer_size, "brush face resize would create invalid geometry");
+    if (overlapping_brush != NULL)
+        set_errorf(error_buffer, error_buffer_size, "brush face resize would overlap existing brush '%s'",
+                   overlapping_brush);
+    else
+        set_error(error_buffer, error_buffer_size, "brush face resize would create invalid geometry");
     return false;
 }

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1185,24 +1185,30 @@ static slayer3d_bounding_box editor_floor_fill_bounds(slayer3d_bounding_box floo
 {
     slayer3d_bounding_box bounds = floor_bounds;
     bounds.min.y = low_y;
-    bounds.max.y = floor_bounds.min.y > low_y + 0.001f ? floor_bounds.min.y : high_y;
+    bounds.max.y = high_y;
+    const float inset_x = SDL_min(thickness, SDL_max((floor_bounds.max.x - floor_bounds.min.x) * 0.5f, 0.001f));
+    const float inset_z = SDL_min(thickness, SDL_max((floor_bounds.max.z - floor_bounds.min.z) * 0.5f, 0.001f));
     switch (side_index)
     {
     case 0:
-        bounds.max.x = floor_bounds.min.x;
-        bounds.min.x = floor_bounds.min.x - thickness;
+        bounds.min.x = floor_bounds.min.x;
+        bounds.max.x = floor_bounds.min.x + inset_x;
         break;
     case 1:
-        bounds.min.x = floor_bounds.max.x;
-        bounds.max.x = floor_bounds.max.x + thickness;
+        bounds.min.x = floor_bounds.max.x - inset_x;
+        bounds.max.x = floor_bounds.max.x;
         break;
     case 2:
-        bounds.max.z = floor_bounds.min.z;
-        bounds.min.z = floor_bounds.min.z - thickness;
+        bounds.min.x = floor_bounds.min.x + inset_x;
+        bounds.max.x = floor_bounds.max.x - inset_x;
+        bounds.min.z = floor_bounds.min.z;
+        bounds.max.z = floor_bounds.min.z + inset_z;
         break;
     default:
-        bounds.min.z = floor_bounds.max.z;
-        bounds.max.z = floor_bounds.max.z + thickness;
+        bounds.min.x = floor_bounds.min.x + inset_x;
+        bounds.max.x = floor_bounds.max.x - inset_x;
+        bounds.min.z = floor_bounds.max.z - inset_z;
+        bounds.max.z = floor_bounds.max.z;
         break;
     }
     return bounds;

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -175,6 +175,10 @@ static float editor_placement_connected_grid_elevation(slayer3d_game_data_runtim
         elevation = selection->bounds.max.y;
     else if (ceiling_material != NULL && ceiling_material[0] != '\0' && SDL_strcmp(material, ceiling_material) == 0)
         elevation = selection->bounds.min.y - grid_size;
+    else if (selection->normal.y > 0.5f)
+        elevation = selection->bounds.max.y;
+    else if (selection->normal.y < -0.5f)
+        elevation = selection->bounds.min.y - grid_size;
     else
         elevation = selection->bounds.min.y;
     return elevation;

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -166,6 +166,16 @@ static float editor_placement_connected_grid_elevation(slayer3d_game_data_runtim
 {
     float elevation = editor_placement_elevation(runtime, placement);
     if (selection == NULL || !selection->hit || !selection->has_bounds)
+    {
+        if (selection != NULL && selection->hit && !selection->has_bounds &&
+            selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID && selection->normal.y > 0.5f)
+        {
+            elevation = selection->point.y;
+        }
+        return elevation;
+    }
+
+    if (selection->type != SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
         return elevation;
 
     const char *material = selection->material_name != NULL ? selection->material_name : "";
@@ -222,6 +232,137 @@ static slayer3d_bounding_box editor_placement_oriented_box_bounds(slayer3d_game_
     {
         bounds.min = slayer3d_vec3_add(anchor, source_min);
         bounds.max = slayer3d_vec3_add(anchor, source_max);
+    }
+    return bounds;
+}
+
+static float *editor_bounds_min_axis(slayer3d_bounding_box *bounds, int axis)
+{
+    if (axis == 0)
+        return &bounds->min.x;
+    if (axis == 1)
+        return &bounds->min.y;
+    return &bounds->min.z;
+}
+
+static float *editor_bounds_max_axis(slayer3d_bounding_box *bounds, int axis)
+{
+    if (axis == 0)
+        return &bounds->max.x;
+    if (axis == 1)
+        return &bounds->max.y;
+    return &bounds->max.z;
+}
+
+static float editor_bounds_axis_min(slayer3d_bounding_box bounds, int axis)
+{
+    if (axis == 0)
+        return bounds.min.x;
+    if (axis == 1)
+        return bounds.min.y;
+    return bounds.min.z;
+}
+
+static float editor_bounds_axis_max(slayer3d_bounding_box bounds, int axis)
+{
+    if (axis == 0)
+        return bounds.max.x;
+    if (axis == 1)
+        return bounds.max.y;
+    return bounds.max.z;
+}
+
+static bool editor_bounds_overlap_positive_volume(slayer3d_bounding_box a, slayer3d_bounding_box b)
+{
+    const float epsilon = 0.00001f;
+    return a.min.x < b.max.x - epsilon && b.min.x < a.max.x - epsilon && a.min.y < b.max.y - epsilon &&
+           b.min.y < a.max.y - epsilon && a.min.z < b.max.z - epsilon && b.min.z < a.max.z - epsilon;
+}
+
+static bool editor_preview_brush_contents_are_structural(unsigned int contents)
+{
+    if (contents == 0u)
+        contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    return (contents & (SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+                        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY)) != 0u;
+}
+
+static bool editor_bounds_overlap_on_axis(slayer3d_bounding_box a, slayer3d_bounding_box b, int axis)
+{
+    const float epsilon = 0.00001f;
+    return editor_bounds_axis_min(a, axis) < editor_bounds_axis_max(b, axis) - epsilon &&
+           editor_bounds_axis_min(b, axis) < editor_bounds_axis_max(a, axis) - epsilon;
+}
+
+static bool editor_placement_trim_wall_overlap(slayer3d_bounding_box *bounds, slayer3d_bounding_box existing,
+                                               int run_axis, int thin_axis, float max_trim)
+{
+    if (bounds == NULL || !editor_bounds_overlap_positive_volume(*bounds, existing))
+        return true;
+
+    if (!editor_bounds_overlap_on_axis(*bounds, existing, 1) ||
+        !editor_bounds_overlap_on_axis(*bounds, existing, thin_axis))
+        return false;
+
+    const float candidate_min = editor_bounds_axis_min(*bounds, run_axis);
+    const float candidate_max = editor_bounds_axis_max(*bounds, run_axis);
+    const float existing_min = editor_bounds_axis_min(existing, run_axis);
+    const float existing_max = editor_bounds_axis_max(existing, run_axis);
+    const float overlap_min = SDL_max(candidate_min, existing_min);
+    const float overlap_max = SDL_min(candidate_max, existing_max);
+    const float overlap = overlap_max - overlap_min;
+    const float epsilon = 0.0001f;
+    if (overlap <= epsilon || overlap > max_trim + epsilon)
+        return false;
+
+    if (existing_min <= candidate_min + epsilon && existing_max > candidate_min + epsilon &&
+        existing_max < candidate_max - epsilon)
+    {
+        *editor_bounds_min_axis(bounds, run_axis) = SDL_max(*editor_bounds_min_axis(bounds, run_axis), existing_max);
+        return *editor_bounds_min_axis(bounds, run_axis) < *editor_bounds_max_axis(bounds, run_axis) - epsilon;
+    }
+
+    if (existing_max >= candidate_max - epsilon && existing_min < candidate_max - epsilon &&
+        existing_min > candidate_min + epsilon)
+    {
+        *editor_bounds_max_axis(bounds, run_axis) = SDL_min(*editor_bounds_max_axis(bounds, run_axis), existing_min);
+        return *editor_bounds_min_axis(bounds, run_axis) < *editor_bounds_max_axis(bounds, run_axis) - epsilon;
+    }
+
+    return false;
+}
+
+static slayer3d_bounding_box editor_placement_trim_wall_endpoint_overlaps(slayer3d_game_data_runtime *runtime,
+                                                                          yyjson_val *preview_json,
+                                                                          const editor_placement_preview_state *preview)
+{
+    slayer3d_bounding_box bounds = preview != NULL ? preview->bounds
+                                                   : (slayer3d_bounding_box){slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                                             slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
+    if (runtime == NULL || preview_json == NULL || preview == NULL || SDL_strcmp(preview->kind, "box") != 0 ||
+        SDL_strcmp(preview->mode, "wall") != 0 || preview->world_name == NULL)
+    {
+        return bounds;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, preview->world_name);
+    if (world_runtime == NULL)
+        return bounds;
+
+    const int thin_axis = preview->axis != NULL && SDL_strcmp(preview->axis, "x") == 0 ? 0 : 2;
+    const int run_axis = thin_axis == 0 ? 2 : 0;
+    const float wall_thickness = editor_bounds_axis_max(bounds, thin_axis) - editor_bounds_axis_min(bounds, thin_axis);
+    const float max_trim = SDL_max(wall_thickness * 1.25f, 0.001f);
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        const slayer3d_game_data_brush *brush = &world->brushes[i];
+        if (brush == NULL || !brush->has_bounds || !editor_preview_brush_contents_are_structural(brush->contents))
+            continue;
+        if (!editor_bounds_overlap_positive_volume(bounds, brush->bounds))
+            continue;
+        if (!editor_placement_trim_wall_overlap(&bounds, brush->bounds, run_axis, thin_axis, max_trim))
+            return preview->bounds;
     }
     return bounds;
 }
@@ -295,6 +436,7 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     {
         preview->bounds =
             editor_placement_oriented_box_bounds(runtime, placement, preview_json, anchor, preview->axis, snap);
+        preview->bounds = editor_placement_trim_wall_endpoint_overlaps(runtime, preview_json, preview);
     }
     publish_editor_placement_preview(runtime, outputs, true, preview_json, preview,
                                      json_string(preview_json, "message", "placement preview"));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15960,7 +15960,15 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(floor_bounds_below_plane.max.y, floor_bounds_before_lower.max.y - 8.0f, 0.001f);
     const slayer3d_bounding_box west_fill_bounds = brush_bounds(floor_brush_name + ".auto_fill.n8000_p0.west");
     EXPECT_NEAR(west_fill_bounds.min.y, floor_bounds_before_lower.max.y - 8.0f, 0.001f);
-    EXPECT_NEAR(west_fill_bounds.max.y, floor_bounds_before_lower.min.y, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.max.y, floor_bounds_before_lower.max.y, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.min.x, floor_bounds_before_lower.min.x, 0.001f);
+    EXPECT_NEAR(west_fill_bounds.max.x, floor_bounds_before_lower.min.x + 0.2f, 0.001f);
+    const slayer3d_bounding_box north_fill_bounds = brush_bounds(floor_brush_name + ".auto_fill.n8000_p0.north");
+    EXPECT_NEAR(north_fill_bounds.min.x, floor_bounds_before_lower.min.x + 0.2f, 0.001f);
+    EXPECT_NEAR(north_fill_bounds.max.x, floor_bounds_before_lower.max.x - 0.2f, 0.001f);
+    EXPECT_NEAR(north_fill_bounds.min.z, floor_bounds_before_lower.min.z, 0.001f);
+    EXPECT_NEAR(north_fill_bounds.max.z, floor_bounds_before_lower.min.z + 0.2f, 0.001f);
+    EXPECT_NEAR(north_fill_bounds.max.y, floor_bounds_before_lower.max.y, 0.001f);
 
     slayer3d_signal_emit(bus, wall_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14834,12 +14834,21 @@ TEST(GameDataRuntime, EditorCreateBoxBrushRejectsPositiveOverlapButAllowsContact
     touching.max = slayer3d_vec3_make(2.0f, 1.0f, 1.0f);
     ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &touching, nullptr, 0, error, sizeof(error))) << error;
 
+    slayer3d_game_data_create_box_brush_desc vertical_contact{};
+    vertical_contact.world_name = "brush.editor.level";
+    vertical_contact.brush_name = "brush.above.seed";
+    vertical_contact.material_name = "mat.wall";
+    vertical_contact.min = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    vertical_contact.max = slayer3d_vec3_make(1.0f, 2.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &vertical_contact, nullptr, 0, error, sizeof(error)))
+        << error;
+
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
-    ASSERT_EQ(world.brush_count, 2);
+    ASSERT_EQ(world.brush_count, 3);
     slayer3d_game_data_brush_world_editor_state editor_state{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
-    EXPECT_EQ(editor_state.revision, 1U);
+    EXPECT_EQ(editor_state.revision, 2U);
 
     slayer3d_game_data_create_box_brush_desc overlapping{};
     overlapping.world_name = "brush.editor.level";
@@ -14850,9 +14859,9 @@ TEST(GameDataRuntime, EditorCreateBoxBrushRejectsPositiveOverlapButAllowsContact
     EXPECT_FALSE(slayer3d_game_data_create_box_brush(runtime, &overlapping, nullptr, 0, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("overlaps existing brush 'brush.seed'"), std::string::npos);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
-    EXPECT_EQ(world.brush_count, 2);
+    EXPECT_EQ(world.brush_count, 3);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
-    EXPECT_EQ(editor_state.revision, 1U);
+    EXPECT_EQ(editor_state.revision, 2U);
 
     slayer3d_game_data_resize_brush_face_desc resize{};
     resize.world_name = "brush.editor.level";
@@ -14862,7 +14871,7 @@ TEST(GameDataRuntime, EditorCreateBoxBrushRejectsPositiveOverlapButAllowsContact
     EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("overlap existing brush 'brush.seed'"), std::string::npos);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
-    ASSERT_EQ(world.brush_count, 2);
+    ASSERT_EQ(world.brush_count, 3);
     EXPECT_NEAR(world.brushes[1].bounds.min.x, 1.0f, 0.001f);
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 2.0f, 0.001f);
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16290,6 +16290,97 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoTrimsPerpendicularWallEndpointPreview)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int floor_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.floor");
+    const int wall_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.tool.wall");
+    const int wall_axis_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.wall_axis.toggle");
+    const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
+    ASSERT_GE(floor_signal, 0);
+    ASSERT_GE(wall_signal, 0);
+    ASSERT_GE(wall_axis_signal, 0);
+    ASSERT_GE(commit_signal, 0);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 660.0f;
+    motion.motion.y = 20.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+
+    const int initial_brush_count = world().brush_count;
+    slayer3d_signal_emit(bus, floor_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const slayer3d_value *floor_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *floor_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(floor_min, nullptr);
+    ASSERT_NE(floor_max, nullptr);
+    ASSERT_EQ(floor_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(floor_max->type, SLAYER3D_VALUE_VEC3);
+    const slayer3d_vec3 placement_origin =
+        slayer3d_vec3_make(floor_min->as_vec3.x, floor_max->as_vec3.y, floor_min->as_vec3.z);
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+
+    slayer3d_signal_emit(bus, wall_signal, nullptr);
+    slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "x");
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
+
+    slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
+    const slayer3d_value *placement_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *placement_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(placement_min, nullptr);
+    ASSERT_NE(placement_max, nullptr);
+    ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(placement_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x + 0.1f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.1f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 8.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.y, placement_origin.y + 8.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.1f, 0.001f);
+
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
+    EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditableLevelFragmentLoadsIntoEditorRuntime)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14680,9 +14680,17 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     EXPECT_TRUE(created.has_bounds);
     EXPECT_NEAR(created.bounds.min.x, 2.0f, 0.001f);
     EXPECT_NEAR(created.bounds.max.y, 2.0f, 0.001f);
+    ASSERT_NE(created.editor.stable_id, nullptr);
+    EXPECT_STREQ(created.editor.stable_id, "brush.created.wall");
+    ASSERT_NE(created.editor.prefab, nullptr);
+    EXPECT_STREQ(created.editor.prefab, "editor.box");
     ASSERT_EQ(created.face_count, 6);
     for (int i = 0; i < created.face_count; ++i)
+    {
         EXPECT_STREQ(created.faces[i].material_name, "mat.wall");
+        ASSERT_NE(created.faces[i].editor.stable_id, nullptr);
+    }
+    EXPECT_STREQ(created.faces[0].editor.stable_id, "brush.created.wall.face.px");
 
     slayer3d_game_data_create_box_brush_desc desc{};
     desc.world_name = "brush.editor.level";
@@ -14760,12 +14768,104 @@ TEST(GameDataRuntime, EditorCreateBoxBrushAppendsAndRoundTrips)
     ASSERT_NE(roundtrip_world.render_model, nullptr);
     EXPECT_EQ(roundtrip_world.compile_artifact_hash, resized_compile_hash);
     EXPECT_STREQ(roundtrip_world.brushes[1].name, "brush.created.wall");
+    EXPECT_STREQ(roundtrip_world.brushes[1].editor.stable_id, "brush.created.wall");
+    EXPECT_STREQ(roundtrip_world.brushes[1].editor.prefab, "editor.box");
+    EXPECT_STREQ(roundtrip_world.brushes[1].faces[0].editor.stable_id, "brush.created.wall.face.px");
     EXPECT_NEAR(roundtrip_world.brushes[1].bounds.max.x, 4.75f, 0.001f);
     EXPECT_STREQ(roundtrip_world.brushes[2].name, "brush.editor.level.box.1");
+    EXPECT_STREQ(roundtrip_world.brushes[2].editor.stable_id, "brush.editor.level.box.1");
     EXPECT_STREQ(roundtrip_world.brushes[2].faces[0].material_name, "mat.floor");
 
     slayer3d_game_data_destroy(roundtrip_runtime);
     slayer3d_game_session_destroy(roundtrip_session);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(dir);
+}
+
+TEST(GameDataRuntime, EditorCreateBoxBrushRejectsPositiveOverlapButAllowsContact)
+{
+    const std::filesystem::path dir = unique_test_dir("editor_create_box_overlap");
+    write_text(dir / "scenes" / "play.scene.json",
+               R"json({ "schema": "slayer3d.scene.v0", "name": "scene.play" })json");
+    write_text(dir / "create_box_overlap.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Editor Create Box Brush Overlap Test" },
+  "world": { "name": "world.editor_create_box_overlap", "kind": "brush" },
+  "brush_worlds": [
+    {
+      "name": "brush.editor.level",
+      "materials": [
+        { "name": "mat.wall", "albedo": [0.7, 0.7, 0.7, 1.0] }
+      ],
+      "brushes": [
+        {
+          "name": "brush.seed",
+          "contents": "solid",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file((dir / "create_box_overlap.game.json").string().c_str(), session, &runtime,
+                                             error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_create_box_brush_desc touching{};
+    touching.world_name = "brush.editor.level";
+    touching.brush_name = "brush.touching.seed";
+    touching.material_name = "mat.wall";
+    touching.min = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    touching.max = slayer3d_vec3_make(2.0f, 1.0f, 1.0f);
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &touching, nullptr, 0, error, sizeof(error))) << error;
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_EQ(world.brush_count, 2);
+    slayer3d_game_data_brush_world_editor_state editor_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_EQ(editor_state.revision, 1U);
+
+    slayer3d_game_data_create_box_brush_desc overlapping{};
+    overlapping.world_name = "brush.editor.level";
+    overlapping.brush_name = "brush.overlapping.seed";
+    overlapping.material_name = "mat.wall";
+    overlapping.min = slayer3d_vec3_make(0.5f, 0.0f, 0.0f);
+    overlapping.max = slayer3d_vec3_make(1.5f, 1.0f, 1.0f);
+    EXPECT_FALSE(slayer3d_game_data_create_box_brush(runtime, &overlapping, nullptr, 0, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("overlaps existing brush 'brush.seed'"), std::string::npos);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    EXPECT_EQ(world.brush_count, 2);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor.level", &editor_state));
+    EXPECT_EQ(editor_state.revision, 1U);
+
+    slayer3d_game_data_resize_brush_face_desc resize{};
+    resize.world_name = "brush.editor.level";
+    resize.brush_name = "brush.touching.seed";
+    resize.face_index = 1;
+    resize.distance = 0.5f;
+    EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("overlap existing brush 'brush.seed'"), std::string::npos);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor.level", &world));
+    ASSERT_EQ(world.brush_count, 2);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 1.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.max.x, 2.0f, 0.001f);
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
     remove_test_dir(dir);


### PR DESCRIPTION
## Summary
- treat editor-created box brushes as structural source brushes with stable brush and face editor metadata
- reject positive-volume overlap with existing structural brushes during create and face resize while allowing exact contact
- document the create-box structural behavior and add regression coverage for contact vs overlap

Refs #409

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorCreateBoxBrushAppendsAndRoundTrips:GameDataRuntime.EditorCreateBoxBrushRejectsPositiveOverlapButAllowsContact'
- ./build/debug/tests/slayer3d_game_data_test