### PR TITLE
Use source-brush operations for editor prefab placement

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1840,6 +1840,27 @@
       ]
     }
   ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": [
+        {
+          "stable_id": "editor.brush.target_cube",
+          "name": "brush.target.cube",
+          "prefab": "prefab.editor_shell.cube",
+          "material": "mat.editor.wall",
+          "face_materials": {
+            "ny": "mat.editor.floor"
+          },
+          "min": [0, 0, 0],
+          "max": [2000, 2000, 2000],
+          "contents": ["solid", "player_clip"]
+        }
+      ]
+    }
+  ],
   "world": {
     "name": "world.editor_shell_dojo",
     "kind": "brush",

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -1678,41 +1678,8 @@
               },
               {
                 "type": "branch",
-                "if": { "type": "scene_state.compare", "key": "editor.leak.valid", "op": "==", "value": true },
+                "if": { "type": "scene_state.compare", "key": "editor.leak.valid", "op": "==", "value": false },
                 "then": [
-                  {
-                    "type": "editor.player_start.apply",
-                    "name": "player_start.editor_shell",
-                    "message": "test run player start applied",
-                    "outputs": {
-                      "valid_key": "editor.test_run.enter.valid",
-                      "message_key": "editor.test_run.enter.message",
-                      "player_start_key": "editor.test_run.enter.player_start",
-                      "scene_key": "editor.test_run.enter.scene",
-                      "target_key": "editor.test_run.enter.target",
-                      "position_key": "editor.test_run.enter.position",
-                      "yaw_key": "editor.test_run.enter.yaw",
-                      "pitch_key": "editor.test_run.enter.pitch"
-                    }
-                  },
-                  {
-                    "type": "branch",
-                    "if": { "type": "scene_state.compare", "key": "editor.test_run.enter.valid", "op": "==", "value": true },
-                    "then": [
-                      { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "entered playable test run" },
-                      { "type": "scene.set", "scene": "scene.editor_shell.test_run" }
-                    ],
-                    "else": [
-                      {
-                        "type": "scene_state.set",
-                        "key": "editor.tool.last_action",
-                        "value": "player start required before playable test run"
-                      }
-                    ]
-                  }
-                ],
-                "else": [
-                  { "type": "scene_state.set", "key": "editor.test_run.enter.valid", "value": false },
                   {
                     "type": "editor.selection.select_brush",
                     "world": "brush.editor_shell.target",
@@ -1724,16 +1691,49 @@
                       "valid_key": "editor.leak.candidate_selected",
                       "message_key": "editor.leak.candidate_select_message"
                     }
-                  },
+                  }
+                ]
+              },
+              {
+                "type": "editor.player_start.apply",
+                "name": "player_start.editor_shell",
+                "message": "test run player start applied",
+                "outputs": {
+                  "valid_key": "editor.test_run.enter.valid",
+                  "message_key": "editor.test_run.enter.message",
+                  "player_start_key": "editor.test_run.enter.player_start",
+                  "scene_key": "editor.test_run.enter.scene",
+                  "target_key": "editor.test_run.enter.target",
+                  "position_key": "editor.test_run.enter.position",
+                  "yaw_key": "editor.test_run.enter.yaw",
+                  "pitch_key": "editor.test_run.enter.pitch"
+                }
+              },
+              {
+                "type": "branch",
+                "if": { "type": "scene_state.compare", "key": "editor.test_run.enter.valid", "op": "==", "value": true },
+                "then": [
                   {
-                    "type": "scene_state.set",
-                    "key": "editor.test_run.enter.message",
-                    "value": "brush source model leaks to outside"
+                    "type": "branch",
+                    "if": { "type": "scene_state.compare", "key": "editor.leak.valid", "op": "==", "value": false },
+                    "then": [
+                      {
+                        "type": "scene_state.set",
+                        "key": "editor.tool.last_action",
+                        "value": "entered playable test run with leak warning"
+                      }
+                    ],
+                    "else": [
+                      { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "entered playable test run" }
+                    ]
                   },
+                  { "type": "scene.set", "scene": "scene.editor_shell.test_run" }
+                ],
+                "else": [
                   {
                     "type": "scene_state.set",
                     "key": "editor.tool.last_action",
-                    "value": "fix brush source leaks before playable test run"
+                    "value": "player start required before playable test run"
                   }
                 ]
               }
@@ -1743,7 +1743,7 @@
               {
                 "type": "scene_state.set",
                 "key": "editor.test_run.enter.message",
-                "value": "brush source model has overlaps or near gaps"
+                "value": "brush source model has blocking errors"
               },
               {
                 "type": "scene_state.set",

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -125,14 +125,15 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
    file should contain `brush_worlds`, `editor_brush_sources`, and `editor_player_starts`.
 10. Press `F5`; the editor should validate the brush source model, then switch
    into the playable test scene using the current in-memory map and player
-   start. If the source model has overlaps, near-gaps, or a reachable leak to
-   outside from the player start, the editor should stay in edit mode and report
-   the source issue in the inspector. Reachable leaks also draw a bright
-   magenta diagnostic marker at the first outside-boundary cell so you have a
-   concrete place to inspect, plus an orange candidate marker on the nearest
-   source-box face associated with that leak boundary. The candidate brush face
-   should also become the active selection, making the suspected source face
-   obvious in the selection outline and inspector.
+   start. Source overlaps, near-gaps, and reachable leaks are warning-level
+   diagnostics during this MVP iteration: the inspector should still report
+   them, but they should not block entering the playable test scene. Reachable
+   leaks also draw a bright magenta diagnostic marker at the first
+   outside-boundary cell so you have a concrete place to inspect, plus an
+   orange candidate marker on the nearest source-box face associated with that
+   leak boundary. The candidate brush face should also become the active
+   selection, making the suspected source face obvious in the selection outline
+   and inspector.
 11. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
 
@@ -203,9 +204,10 @@ The following should be true during a good test drive:
   `editor_player_starts`, then writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.
 - `F5` validates source-backed brush structure, then applies the stored player
-  start before entering the playable scene. Source overlaps and near-gaps block
-  the transition. Source-backed maps that leak from the player start to outside
-  also block the transition.
+  start before entering the playable scene. Source overlaps, near-gaps, and
+  leaks are surfaced as warnings while this foundation is still being built;
+  hard source defects such as invalid geometry, duplicate identifiers, or
+  off-snap coordinates still prevent source edits from committing.
 
 Current limitations are expected: this is not yet a polished TrenchBroom-style
 frontend, there is no file picker, and texture/face painting remains outside

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -133,7 +133,7 @@ go through palettes so level-authoring shortcuts do not shadow view controls.
    source-box face associated with that leak boundary. The candidate brush face
    should also become the active selection, making the suspected source face
    obvious in the selection outline and inspector.
-10. In the playable scene, use `WASD` and mouse look to verify the player starts
+11. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
 
 ## Correctness Checks
@@ -163,9 +163,9 @@ The following should be true during a good test drive:
   bottoms sit directly on the connected floor elevation; authored blockout
   seams should be watertight rather than relying on visual offsets.
 - Floor, wall, ceiling, and sky placements commit as canonical source-box
-  operations. In source-backed maps, wall spans can be trimmed to the available
-  snapped interval at endpoint contacts; true invalid intersections report a
-  source-model diagnostic instead of a vague runtime overlap failure.
+  operations. Preview and commit use the same source candidate; valid previews
+  should commit with matching bounds, and true invalid intersections should
+  report a source-model diagnostic instead of a vague runtime overlap failure.
 - In full-screen 3D flyby mode, wall placement auto-rotates to the nearest
   cardinal axis from the camera direction. Orthographic placement keeps the
   explicit `R` wall-axis toggle for drafting control.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -162,6 +162,10 @@ The following should be true during a good test drive:
   visible gaps while adjacent hallways can pass close to one another. Wall
   bottoms sit directly on the connected floor elevation; authored blockout
   seams should be watertight rather than relying on visual offsets.
+- Floor, wall, ceiling, and sky placements commit as canonical source-box
+  operations. In source-backed maps, wall spans can be trimmed to the available
+  snapped interval at endpoint contacts; true invalid intersections report a
+  source-model diagnostic instead of a vague runtime overlap failure.
 - In full-screen 3D flyby mode, wall placement auto-rotates to the nearest
   cardinal axis from the camera direction. Orthographic placement keeps the
   explicit `R` wall-axis toggle for drafting control.

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1263,20 +1263,21 @@ target actor's position, `yaw`, and `pitch` are applied before camera setup and
 before the first scene-enter signal runs.
 
 Use `editor.brush_world.create_box` to append a new axis-aligned convex box
-brush to a runtime brush world. The action is intended for first-pass editor
-blockout tools: floors, walls, ceilings, sky seals, platforms, and simple room pieces. It
-validates the target world and bounds at load time, resolves the material at
-runtime, rebuilds brush collision/render data atomically, then marks the world
-dirty only after the rebuild succeeds. If `name` is omitted, the runtime
-generates a unique brush name under the target world. Source-backed worlds
-commit a canonical source box first, then compile runtime brushes from the
-source model; runtime-only worlds append the derived brush directly. Created
-structural boxes receive stable editor ids, exact face/edge/vertex contact with
-existing structural brushes is allowed, and positive-volume overlap with an
-existing structural brush is rejected before the world is marked dirty. The editor shell dojo
-demonstrates the current blockout palette pattern: modal palette signals write
-scene-state selection strings, and the shared commit signal branches to
-prefab-specific `editor.brush_world.create_box` or
+brush to a brush world. For placement-preview commits in source-backed editor
+worlds, the action only commits the canonical source candidate produced by the
+live preview command; it does not recompute runtime bounds or use a second
+runtime-overlap path. The source model is the truth: validation runs against the
+source box, runtime brush geometry is compiled output, and the world is marked
+dirty only after source insertion and rebuild succeed. Generic non-preview
+creation can still append a direct box for tests and low-level tooling, but the
+editor floor/wall/ceiling/sky workflow uses source-backed prefab recipes.
+
+Created structural boxes receive stable editor ids, exact face/edge/vertex
+contact with existing structural brushes is allowed, and positive-volume overlap
+with an existing structural brush is rejected before the world is marked dirty.
+The editor shell dojo demonstrates the current blockout palette pattern: modal
+palette signals write scene-state selection strings, and the shared commit
+signal branches to source-backed `editor.brush_world.create_box` or
 `editor.player_start.place` actions. That keeps the first editor workflow
 data-authored while a dedicated editor frontend is still evolving.
 `editor.brush_world.validate_source` reports exact face, edge, and vertex
@@ -1336,16 +1337,15 @@ to either a `box` ghost or a `player_start` marker. Box previews can use
 `axis_key` with `axis` `x` or `z` to rotate wall-like prefabs between
 horizontal grid axes. A box preview must author exactly one bounds
 source: fixed `min`/`max`, or grid-scaled `grid_min`/`grid_max`. For
-source-backed brush worlds, the preview uses the same source-box candidate
-validator as creation, so overlap and invalid-geometry messages match committed
-edits. Wall previews in source-backed worlds are also normalized as source-box
-operations: endpoint contacts against existing structural source brushes may
-trim the wall span to the free snapped interval before validation, while true
-positive-volume intersections are rejected with source-model diagnostics. This
-keeps floor, wall, ceiling, and sky prefabs on the same durable fixed-grid model
-instead of relying on runtime brush-overlap hacks. The preview reuses the
-editor debug overlay's `command_preview` flag and color, so editor hosts do not
-need a second rendering path.
+source-backed brush worlds, the preview and commit both use the same source
+prefab command. Preview runs it in dry-run mode and publishes the exact source
+candidate bounds; commit applies that candidate. If preview succeeds and no
+other edit changes the source model before commit, the commit succeeds with the
+same geometry. Floor, wall, ceiling, and sky are recipes that emit snapped source
+boxes; runtime brush geometry is generated only after the source candidate
+passes validation. The preview reuses the editor debug overlay's
+`command_preview` flag and color, so editor hosts do not need a second rendering
+path.
 
 ```json
 {

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1338,8 +1338,14 @@ horizontal grid axes. A box preview must author exactly one bounds
 source: fixed `min`/`max`, or grid-scaled `grid_min`/`grid_max`. For
 source-backed brush worlds, the preview uses the same source-box candidate
 validator as creation, so overlap and invalid-geometry messages match committed
-edits. The preview reuses the editor debug overlay's `command_preview` flag and
-color, so editor hosts do not need a second rendering path.
+edits. Wall previews in source-backed worlds are also normalized as source-box
+operations: endpoint contacts against existing structural source brushes may
+trim the wall span to the free snapped interval before validation, while true
+positive-volume intersections are rejected with source-model diagnostics. This
+keeps floor, wall, ceiling, and sky prefabs on the same durable fixed-grid model
+instead of relying on runtime brush-overlap hacks. The preview reuses the
+editor debug overlay's `command_preview` flag and color, so editor hosts do not
+need a second rendering path.
 
 ```json
 {
@@ -1372,8 +1378,8 @@ color, so editor hosts do not need a second rendering path.
           "material": "mat.stone_wall",
           "axis_key": "editor.wall_axis",
           "axis": "z",
-          "grid_min": [0.0, 0.0, 0.0],
-          "grid_max": [1.0, 1.0, 1.0]
+          "grid_min": [0.0, 0.0, -0.0125],
+          "grid_max": [1.0, 1.0, 0.0125]
         },
         {
           "mode": "sky",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1133,10 +1133,10 @@ again. This makes source boxes the durable editing truth and keeps generated
 `brush_worlds` as load-time/runtime derived data.
 
 Source-backed editor mutations validate candidate source boxes before they are
-committed. Exact snapped face, edge, or vertex contact is legal; positive-volume
-overlap between structural source boxes is rejected at the source-model boundary.
-This keeps placement, translate, and resize tools from introducing hidden
-runtime-only overlap states.
+committed. Exact snapped face, edge, or vertex contact is legal. Positive-volume
+overlap between structural source boxes is allowed in the editable source model
+and reported as a warning diagnostic; the brush compiler is responsible for
+removing hidden/internal faces from runtime render output.
 Structural checks consider solid, player/projectile clip, and sky source boxes
 as map-sealing architecture. Non-structural content such as trigger-only boxes
 may overlap structural brushes for gameplay volumes; those boxes do not report
@@ -1147,14 +1147,13 @@ Use `editor.brush_world.validate_source` or the native
 boxes before save or test-run. The pass runs on fixed source coordinates and
 reports off-snap coordinates, positive-volume overlaps, and tiny non-zero near
 gaps between boxes that otherwise overlap on the other two axes. Exact face
-contact is counted as structural adjacency. This is the first source-level
-correctness gate for watertight brush editing; future leak tracing can build on
-the same source model without relying on visual offsets.
+contact is counted as structural adjacency. Off-snap source coordinates are
+blocking source-model defects. Overlaps and near-gaps are warning diagnostics
+while the editor foundation is still evolving.
 
 The action form may set `allow_missing_source: true` when a workflow still needs
 to support legacy/runtime-only brush worlds. In that mode, worlds without an
-`editor_brush_sources` model are treated as valid for gating purposes while
-source-backed worlds still fail on overlaps and near gaps.
+`editor_brush_sources` model are treated as valid for gating purposes.
 
 Use `editor.brush_world.validate_enclosure` or
 `slayer3d_game_data_validate_editor_brush_source_enclosure()` to run the first
@@ -1162,9 +1161,10 @@ source-backed leak diagnostic. This pass derives an exact interval grid from
 the fixed source box coordinates, marks structural source boxes as solid, and
 flood-fills empty cells from an `editor_player_starts` marker. If the flood
 reaches the expanded outside boundary, the playable space leaks. The editor
-shell runs both validation actions before entering playable test-run mode so
-source defects block F5 instead of becoming game-runtime surprises. The `leak_point_key`
-output can feed an `editor.debug_overlay.markers` entry so the editor shows the
+shell runs both validation actions before entering playable test-run mode.
+During the current graybox-editor milestone, leak findings are warning-level:
+they are visible in the inspector and debug overlay, but they do not block F5.
+The `leak_point_key` output can feed an `editor.debug_overlay.markers` entry so the editor shows the
 first reachable outside-boundary cell directly in the 3D view. The candidate
 outputs identify the nearest source-box face on the same leak boundary axis,
 giving editor UI a second point to highlight while the user decides which
@@ -1282,7 +1282,7 @@ signal branches to source-backed `editor.brush_world.create_box` or
 data-authored while a dedicated editor frontend is still evolving.
 `editor.brush_world.validate_source` reports exact face, edge, and vertex
 contacts separately, so editor tools can distinguish legal snapped contact from
-suspicious near gaps or invalid positive-volume overlap.
+warning-level near gaps or positive-volume overlap.
 
 `contents` is optional and accepts the same brush-content string or string array
 as authored brush JSON. If omitted, created boxes default to `solid`. Sky

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -2260,7 +2260,7 @@ extern "C"
         int source_snap_units;
         /** @brief Source boxes whose min/max coordinates are not aligned to source_snap_units. */
         int off_snap_count;
-        /** @brief Positive-volume overlaps between structural source boxes. These are invalid. */
+        /** @brief Positive-volume overlaps between structural source boxes. These are compile-time warnings. */
         int positive_overlap_count;
         /** @brief Tiny non-zero gaps between otherwise adjacent structural source boxes. These indicate seams/leaks. */
         int near_gap_count;
@@ -2272,7 +2272,7 @@ extern "C"
         int vertex_contact_count;
         /** @brief Exact face contacts where only part of a structural source-box face is covered. */
         int partial_face_contact_count;
-        /** @brief First blocking issue, or an empty string when the source model is structurally valid. */
+        /** @brief First source diagnostic issue or warning, or an empty string when none was found. */
         char first_issue[SLAYER3D_GAME_DATA_EDITOR_DIAGNOSTIC_TEXT_MAX];
     } slayer3d_game_data_editor_brush_source_diagnostics;
 

--- a/src/game_data_brush.c
+++ b/src/game_data_brush.c
@@ -915,9 +915,13 @@ static bool brush_face_visible_rects_after_neighbor_covers(const slayer3d_game_d
             float other_distance = 0.0f;
             if (!brush_plane_normalized(other_face, &other_normal, &other_distance))
                 continue;
-            if (slayer3d_vec3_dot(normal, other_normal) > -1.0f + normal_epsilon)
-                continue;
-            if (SDL_fabsf(distance + other_distance) > distance_epsilon)
+            const float normal_alignment = slayer3d_vec3_dot(normal, other_normal);
+            const bool opposite_internal_cover =
+                normal_alignment <= -1.0f + normal_epsilon && SDL_fabsf(distance + other_distance) <= distance_epsilon;
+            const bool prior_same_plane_cover = other_brush_index < brush_index &&
+                                                normal_alignment >= 1.0f - normal_epsilon &&
+                                                SDL_fabsf(distance - other_distance) <= distance_epsilon;
+            if (!opposite_internal_cover && !prior_same_plane_cover)
                 continue;
 
             const int other_count =
@@ -1104,6 +1108,117 @@ static bool brush_face_hidden_by_neighbor(const slayer3d_game_data_brush_world *
     return false;
 }
 
+static bool brush_point_inside_brush(const slayer3d_game_data_brush *brush, slayer3d_vec3 point, bool *out_strict)
+{
+    if (brush == NULL)
+        return false;
+    bool strict = false;
+    const float epsilon = 0.001f;
+    for (int face_index = 0; face_index < brush->face_count; ++face_index)
+    {
+        slayer3d_vec3 normal;
+        float distance = 0.0f;
+        if (!brush_plane_normalized(&brush->faces[face_index], &normal, &distance))
+            return false;
+        const float signed_distance = slayer3d_vec3_dot(normal, point) - distance;
+        if (signed_distance > epsilon)
+            return false;
+        if (signed_distance < -epsilon)
+            strict = true;
+    }
+    if (out_strict != NULL)
+        *out_strict = strict;
+    return true;
+}
+
+static bool brush_polygon_inside_solid_neighbor(const slayer3d_game_data_brush_world *world, int brush_index,
+                                                int face_index, const slayer3d_vec3 *polygon, int polygon_count)
+{
+    if (world == NULL || polygon == NULL || polygon_count < 3 || brush_index < 0 || brush_index >= world->brush_count)
+        return false;
+
+    const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+    const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+    if (!brush_face_can_be_compile_culled(world, brush, face))
+        return false;
+
+    for (int other_brush_index = 0; other_brush_index < world->brush_count; ++other_brush_index)
+    {
+        if (other_brush_index == brush_index)
+            continue;
+        const slayer3d_game_data_brush *other = &world->brushes[other_brush_index];
+        if ((other->contents & SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID) == 0u)
+            continue;
+
+        bool any_strict = false;
+        bool all_inside = true;
+        for (int vertex_index = 0; vertex_index < polygon_count; ++vertex_index)
+        {
+            bool strict = false;
+            if (!brush_point_inside_brush(other, polygon[vertex_index], &strict))
+            {
+                all_inside = false;
+                break;
+            }
+            any_strict = any_strict || strict;
+        }
+        if (all_inside && any_strict)
+            return true;
+    }
+    return false;
+}
+
+static bool brush_face_duplicate_by_prior_neighbor(const slayer3d_game_data_brush_world *world, int brush_index,
+                                                   int face_index, const slayer3d_vec3 *polygon, int polygon_count,
+                                                   slayer3d_vec3 normal, slayer3d_vec3 basis_u, slayer3d_vec3 basis_v,
+                                                   float distance, slayer3d_vec3 *scratch, int scratch_capacity)
+{
+    if (world == NULL || polygon == NULL || polygon_count < 3 || scratch == NULL || brush_index <= 0 ||
+        brush_index >= world->brush_count)
+    {
+        return false;
+    }
+
+    const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
+    const slayer3d_game_data_brush_face *face = &brush->faces[face_index];
+    if (!brush_face_can_be_compile_culled(world, brush, face))
+        return false;
+
+    const float normal_epsilon = 0.001f;
+    const float distance_epsilon = 0.001f;
+    for (int other_brush_index = 0; other_brush_index < brush_index; ++other_brush_index)
+    {
+        const slayer3d_game_data_brush *other = &world->brushes[other_brush_index];
+        if ((other->contents & SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID) == 0u)
+            continue;
+
+        for (int other_face_index = 0; other_face_index < other->face_count; ++other_face_index)
+        {
+            const slayer3d_game_data_brush_face *other_face = &other->faces[other_face_index];
+            if (!brush_material_is_opaque(world, other_face->material_index))
+                continue;
+
+            slayer3d_vec3 other_normal;
+            float other_distance = 0.0f;
+            if (!brush_plane_normalized(other_face, &other_normal, &other_distance))
+                continue;
+            if (slayer3d_vec3_dot(normal, other_normal) < 1.0f - normal_epsilon)
+                continue;
+            if (SDL_fabsf(distance - other_distance) > distance_epsilon)
+                continue;
+
+            const int other_count =
+                brush_build_face_polygon(other, other_face_index, scratch, scratch_capacity, NULL, NULL, NULL);
+            if (other_count >= 3 &&
+                brush_polygon_covers_polygon(scratch, other_count, polygon, polygon_count, basis_u, basis_v))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_world *world, slayer3d_model *model,
                                                       const int *filter_indices, int filter_count,
                                                       bool update_compile_counters)
@@ -1183,19 +1298,32 @@ static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_w
                 int visible_triangle_count = count - 2;
                 brush_rect_2d *visible_rects = NULL;
                 int visible_rect_count = 0;
-                const bool has_split_visible_rects =
-                    cull_hidden_faces && brush_face_visible_rects_after_neighbor_covers(
-                                             world, brush_index, face_index, polygon, count, normal, u, v, distance,
-                                             neighbor_polygon, polygon_capacity, &visible_rects, &visible_rect_count);
-                if (has_split_visible_rects)
-                {
-                    visible_triangle_count = visible_rect_count * 2;
-                }
-                else if (cull_hidden_faces &&
-                         brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
-                                                       distance, neighbor_polygon, polygon_capacity))
+                const bool hidden_by_solid = cull_hidden_faces && brush_polygon_inside_solid_neighbor(
+                                                                      world, brush_index, face_index, polygon, count);
+                const bool duplicate_by_prior =
+                    cull_hidden_faces &&
+                    brush_face_duplicate_by_prior_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
+                                                           distance, neighbor_polygon, polygon_capacity);
+                bool has_split_visible_rects = false;
+                if (hidden_by_solid || duplicate_by_prior)
                 {
                     visible_triangle_count = 0;
+                }
+                else
+                {
+                    has_split_visible_rects =
+                        cull_hidden_faces &&
+                        brush_face_visible_rects_after_neighbor_covers(
+                            world, brush_index, face_index, polygon, count, normal, u, v, distance, neighbor_polygon,
+                            polygon_capacity, &visible_rects, &visible_rect_count);
+                    if (has_split_visible_rects)
+                        visible_triangle_count = visible_rect_count * 2;
+                    else if (cull_hidden_faces &&
+                             brush_face_hidden_by_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
+                                                           distance, neighbor_polygon, polygon_capacity))
+                    {
+                        visible_triangle_count = 0;
+                    }
                 }
                 SDL_free(visible_rects);
                 if (visible_triangle_count <= 0)
@@ -1342,6 +1470,14 @@ static bool brush_world_compile_render_model_filtered(slayer3d_game_data_brush_w
             }
             brush_rect_2d *visible_rects = NULL;
             int visible_rect_count = 0;
+            const bool hidden_by_solid = cull_hidden_faces && brush_polygon_inside_solid_neighbor(
+                                                                  world, brush_index, face_index, polygon, count);
+            const bool duplicate_by_prior =
+                cull_hidden_faces &&
+                brush_face_duplicate_by_prior_neighbor(world, brush_index, face_index, polygon, count, normal, u, v,
+                                                       distance, neighbor_polygon, polygon_capacity);
+            if (hidden_by_solid || duplicate_by_prior)
+                continue;
             const bool has_split_visible_rects =
                 cull_hidden_faces && brush_face_visible_rects_after_neighbor_covers(
                                          world, brush_index, face_index, polygon, count, normal, u, v, distance,

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -1373,6 +1373,113 @@ static const char *source_prefab_for_material(const char *material)
     return NULL;
 }
 
+static bool source_prefab_name_supported(const char *prefab)
+{
+    return prefab != NULL && (SDL_strcmp(prefab, "floor") == 0 || SDL_strcmp(prefab, "wall") == 0 ||
+                              SDL_strcmp(prefab, "ceiling") == 0 || SDL_strcmp(prefab, "sky") == 0);
+}
+
+static unsigned int source_prefab_default_contents(const char *prefab, unsigned int authored_contents)
+{
+    if (authored_contents != 0u)
+        return authored_contents;
+    if (prefab != NULL && SDL_strcmp(prefab, "sky") == 0)
+    {
+        return SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+               SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP;
+    }
+    return SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+}
+
+static slayer3d_vec3 source_prefab_oriented_offset(slayer3d_vec3 value, const char *axis)
+{
+    if (axis != NULL && SDL_strcmp(axis, "x") == 0)
+        return slayer3d_vec3_make(value.z, value.y, value.x);
+    return value;
+}
+
+static void source_prefab_set_axis_bounds(int *out_min, int *out_max, int a, int b)
+{
+    if (out_min != NULL)
+        *out_min = SDL_min(a, b);
+    if (out_max != NULL)
+        *out_max = SDL_max(a, b);
+}
+
+bool editor_brush_world_build_source_prefab_candidate(const brush_world_runtime *world_runtime,
+                                                      const editor_brush_source_prefab_desc *desc,
+                                                      const char *candidate_name,
+                                                      editor_brush_source_box_runtime *out_box, char *error_buffer,
+                                                      int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model || desc == NULL || out_box == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a source-backed brush world");
+        return false;
+    }
+
+    const char *material_prefab = source_prefab_for_material(desc->material);
+    const char *prefab = desc->prefab != NULL && desc->prefab[0] != '\0'
+                             ? desc->prefab
+                             : (material_prefab != NULL ? material_prefab : "");
+    if (!source_prefab_name_supported(prefab))
+    {
+        set_errorf(error_buffer, error_buffer_size, "unsupported source prefab '%s'",
+                   prefab != NULL && prefab[0] != '\0' ? prefab : "<empty>");
+        return false;
+    }
+    if (desc->material == NULL || desc->material[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a material");
+        return false;
+    }
+    if (desc->use_grid_bounds && desc->grid_size <= 0.0f)
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a positive grid size");
+        return false;
+    }
+    if (candidate_name == NULL || candidate_name[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a candidate name");
+        return false;
+    }
+
+    const slayer3d_vec3 recipe_min =
+        desc->use_grid_bounds ? slayer3d_vec3_scale(desc->grid_min, desc->grid_size) : desc->min;
+    const slayer3d_vec3 recipe_max =
+        desc->use_grid_bounds ? slayer3d_vec3_scale(desc->grid_max, desc->grid_size) : desc->max;
+    const slayer3d_vec3 oriented_min = source_prefab_oriented_offset(recipe_min, desc->axis);
+    const slayer3d_vec3 oriented_max = source_prefab_oriented_offset(recipe_max, desc->axis);
+
+    SDL_zero(*out_box);
+    if (!copy_source_string(&out_box->stable_id, candidate_name) ||
+        !copy_source_string(&out_box->name, candidate_name) || !copy_source_string(&out_box->prefab, prefab) ||
+        !copy_source_string(&out_box->material, desc->material))
+    {
+        free_editor_brush_source_box(out_box);
+        set_error(error_buffer, error_buffer_size, "failed to allocate source prefab candidate");
+        return false;
+    }
+
+    source_prefab_set_axis_bounds(&out_box->min[0], &out_box->max[0],
+                                  source_units_from_meters(world_runtime, desc->anchor.x + oriented_min.x),
+                                  source_units_from_meters(world_runtime, desc->anchor.x + oriented_max.x));
+    source_prefab_set_axis_bounds(&out_box->min[1], &out_box->max[1],
+                                  source_units_from_meters(world_runtime, desc->anchor.y + oriented_min.y),
+                                  source_units_from_meters(world_runtime, desc->anchor.y + oriented_max.y));
+    source_prefab_set_axis_bounds(&out_box->min[2], &out_box->max[2],
+                                  source_units_from_meters(world_runtime, desc->anchor.z + oriented_min.z),
+                                  source_units_from_meters(world_runtime, desc->anchor.z + oriented_max.z));
+    out_box->contents = source_prefab_default_contents(prefab, desc->contents);
+    if (!source_box_extents_valid(out_box))
+    {
+        free_editor_brush_source_box(out_box);
+        set_error(error_buffer, error_buffer_size, "source prefab placement would create invalid geometry");
+        return false;
+    }
+    return true;
+}
+
 static const char *source_prefab_for_brush(const slayer3d_game_data_brush *brush, const char *material)
 {
     if (brush != NULL && brush->editor.prefab != NULL && SDL_strcmp(brush->editor.prefab, "editor.box") != 0)
@@ -1427,6 +1534,67 @@ slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_ru
                                     source_meters_from_units(world_runtime, box->max[1]),
                                     source_meters_from_units(world_runtime, box->max[2]));
     return bounds;
+}
+
+bool editor_brush_world_place_source_prefab_candidate(brush_world_runtime *world_runtime, const char *brush_name,
+                                                      const char *prefab, const char *material, unsigned int contents,
+                                                      const int min_values[3], const int max_values[3],
+                                                      char *out_brush_name, size_t out_brush_name_size,
+                                                      char *error_buffer, int error_buffer_size)
+{
+    if (out_brush_name != NULL && out_brush_name_size > 0u)
+        out_brush_name[0] = '\0';
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model || min_values == NULL || max_values == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a source-backed brush world");
+        return false;
+    }
+    if (!source_prefab_name_supported(prefab))
+    {
+        set_errorf(error_buffer, error_buffer_size, "unsupported source prefab '%s'",
+                   prefab != NULL && prefab[0] != '\0' ? prefab : "<empty>");
+        return false;
+    }
+    if (material == NULL || material[0] == '\0')
+    {
+        set_error(error_buffer, error_buffer_size, "source prefab placement requires a material");
+        return false;
+    }
+
+    char generated_name[256];
+    const char *name = brush_name;
+    if (name == NULL || name[0] == '\0')
+    {
+        if (!editor_brush_world_generate_brush_name(world_runtime, generated_name, sizeof(generated_name)))
+        {
+            set_error(error_buffer, error_buffer_size, "failed to generate source prefab brush name");
+            return false;
+        }
+        name = generated_name;
+    }
+
+    editor_brush_source_box_runtime source_box;
+    SDL_zero(source_box);
+    if (!copy_source_string(&source_box.stable_id, name) || !copy_source_string(&source_box.name, name) ||
+        !copy_source_string(&source_box.prefab, prefab) || !copy_source_string(&source_box.material, material))
+    {
+        free_editor_brush_source_box(&source_box);
+        set_error(error_buffer, error_buffer_size, "failed to allocate source prefab brush");
+        return false;
+    }
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        source_box.min[axis] = min_values[axis];
+        source_box.max[axis] = max_values[axis];
+    }
+    source_box.contents = source_prefab_default_contents(prefab, contents);
+
+    const bool ok = editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,
+                                                                  &source_box, error_buffer, error_buffer_size);
+    if (ok && out_brush_name != NULL && out_brush_name_size > 0u)
+        SDL_strlcpy(out_brush_name, name, out_brush_name_size);
+    free_editor_brush_source_box(&source_box);
+    return ok;
 }
 
 static bool source_box_from_runtime_brush(const brush_world_runtime *world_runtime,

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -1406,11 +1406,11 @@ static void source_prefab_set_axis_bounds(int *out_min, int *out_max, int a, int
         *out_max = SDL_max(a, b);
 }
 
-bool editor_brush_world_build_source_prefab_candidate(const brush_world_runtime *world_runtime,
-                                                      const editor_brush_source_prefab_desc *desc,
-                                                      const char *candidate_name,
-                                                      editor_brush_source_box_runtime *out_box, char *error_buffer,
-                                                      int error_buffer_size)
+static bool editor_brush_world_build_source_prefab_candidate(const brush_world_runtime *world_runtime,
+                                                             const editor_brush_source_prefab_desc *desc,
+                                                             const char *candidate_name,
+                                                             editor_brush_source_box_runtime *out_box,
+                                                             char *error_buffer, int error_buffer_size)
 {
     if (world_runtime == NULL || !world_runtime->editor_has_source_model || desc == NULL || out_box == NULL)
     {
@@ -1536,26 +1536,31 @@ slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_ru
     return bounds;
 }
 
-bool editor_brush_world_place_source_prefab_candidate(brush_world_runtime *world_runtime, const char *brush_name,
-                                                      const char *prefab, const char *material, unsigned int contents,
-                                                      const int min_values[3], const int max_values[3],
-                                                      char *out_brush_name, size_t out_brush_name_size,
-                                                      char *error_buffer, int error_buffer_size)
+bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_runtime,
+                                                  const editor_brush_source_prefab_desc *desc, const char *brush_name,
+                                                  const int *source_min, const int *source_max, bool apply,
+                                                  editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                  int error_buffer_size)
 {
-    if (out_brush_name != NULL && out_brush_name_size > 0u)
-        out_brush_name[0] = '\0';
-    if (world_runtime == NULL || !world_runtime->editor_has_source_model || min_values == NULL || max_values == NULL)
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model || desc == NULL)
     {
         set_error(error_buffer, error_buffer_size, "source prefab placement requires a source-backed brush world");
         return false;
     }
+
+    const char *material_prefab = source_prefab_for_material(desc->material);
+    const char *prefab = desc->prefab != NULL && desc->prefab[0] != '\0'
+                             ? desc->prefab
+                             : (material_prefab != NULL ? material_prefab : "");
     if (!source_prefab_name_supported(prefab))
     {
         set_errorf(error_buffer, error_buffer_size, "unsupported source prefab '%s'",
                    prefab != NULL && prefab[0] != '\0' ? prefab : "<empty>");
         return false;
     }
-    if (material == NULL || material[0] == '\0')
+    if (desc->material == NULL || desc->material[0] == '\0')
     {
         set_error(error_buffer, error_buffer_size, "source prefab placement requires a material");
         return false;
@@ -1574,25 +1579,48 @@ bool editor_brush_world_place_source_prefab_candidate(brush_world_runtime *world
     }
 
     editor_brush_source_box_runtime source_box;
-    SDL_zero(source_box);
-    if (!copy_source_string(&source_box.stable_id, name) || !copy_source_string(&source_box.name, name) ||
-        !copy_source_string(&source_box.prefab, prefab) || !copy_source_string(&source_box.material, material))
+    if (source_min != NULL && source_max != NULL)
     {
-        free_editor_brush_source_box(&source_box);
-        set_error(error_buffer, error_buffer_size, "failed to allocate source prefab brush");
+        SDL_zero(source_box);
+        if (!copy_source_string(&source_box.stable_id, name) || !copy_source_string(&source_box.name, name) ||
+            !copy_source_string(&source_box.prefab, prefab) ||
+            !copy_source_string(&source_box.material, desc->material))
+        {
+            free_editor_brush_source_box(&source_box);
+            set_error(error_buffer, error_buffer_size, "failed to allocate source prefab brush");
+            return false;
+        }
+        for (int axis = 0; axis < 3; ++axis)
+        {
+            source_box.min[axis] = source_min[axis];
+            source_box.max[axis] = source_max[axis];
+        }
+        source_box.contents = source_prefab_default_contents(prefab, desc->contents);
+    }
+    else if (!editor_brush_world_build_source_prefab_candidate(world_runtime, desc, name, &source_box, error_buffer,
+                                                               error_buffer_size))
+    {
         return false;
     }
-    for (int axis = 0; axis < 3; ++axis)
-    {
-        source_box.min[axis] = min_values[axis];
-        source_box.max[axis] = max_values[axis];
-    }
-    source_box.contents = source_prefab_default_contents(prefab, contents);
 
-    const bool ok = editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,
-                                                                  &source_box, error_buffer, error_buffer_size);
-    if (ok && out_brush_name != NULL && out_brush_name_size > 0u)
-        SDL_strlcpy(out_brush_name, name, out_brush_name_size);
+    bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
+                                                               error_buffer_size);
+    if (ok && apply)
+    {
+        ok = editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,
+                                                           &source_box, error_buffer, error_buffer_size);
+    }
+    if (ok && out_result != NULL)
+    {
+        out_result->valid = true;
+        SDL_strlcpy(out_result->brush_name, name, sizeof(out_result->brush_name));
+        out_result->bounds = editor_brush_source_box_bounds_meters(world_runtime, &source_box);
+        for (int axis = 0; axis < 3; ++axis)
+        {
+            out_result->source_min[axis] = source_box.min[axis];
+            out_result->source_max[axis] = source_box.max[axis];
+        }
+    }
     free_editor_brush_source_box(&source_box);
     return ok;
 }

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -392,17 +392,6 @@ static bool source_box_candidate_valid(const brush_world_runtime *world_runtime,
             set_errorf(error_buffer, error_buffer_size, "duplicate editor brush source name '%s'", candidate->name);
             return false;
         }
-        if (source_box_contents_are_structural(candidate->contents) &&
-            source_box_contents_are_structural(existing->contents) &&
-            source_box_positive_volume_overlap(candidate, existing))
-        {
-            set_errorf(error_buffer, error_buffer_size,
-                       "source brush '%s' overlaps existing brush '%s' with positive volume; use an adjacent snapped "
-                       "cell or a source operation that trims, splits, or merges the candidate",
-                       candidate->name != NULL ? candidate->name : "<unnamed>",
-                       existing->name != NULL ? existing->name : "<unnamed>");
-            return false;
-        }
     }
     return true;
 }
@@ -705,9 +694,7 @@ bool slayer3d_game_data_validate_editor_brush_source_model(
         }
     }
 
-    out_diagnostics->structurally_valid = out_diagnostics->off_snap_count == 0 &&
-                                          out_diagnostics->positive_overlap_count == 0 &&
-                                          out_diagnostics->near_gap_count == 0;
+    out_diagnostics->structurally_valid = out_diagnostics->off_snap_count == 0;
     return true;
 }
 

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -18,6 +18,14 @@ static int source_units_from_meters(const brush_world_runtime *world_runtime, fl
     return (int)SDL_lroundf(value / meters_per_unit);
 }
 
+static float source_meters_from_units(const brush_world_runtime *world_runtime, int value)
+{
+    const float meters_per_unit = world_runtime != NULL && world_runtime->editor_source_meters_per_unit > 0.0f
+                                      ? world_runtime->editor_source_meters_per_unit
+                                      : 0.001f;
+    return (float)value * meters_per_unit;
+}
+
 static const char *const source_box_face_keys[6] = {"px", "nx", "py", "ny", "pz", "nz"};
 
 static bool source_vec3i(yyjson_val *object, const char *key, int out_values[3])
@@ -388,7 +396,9 @@ static bool source_box_candidate_valid(const brush_world_runtime *world_runtime,
             source_box_contents_are_structural(existing->contents) &&
             source_box_positive_volume_overlap(candidate, existing))
         {
-            set_errorf(error_buffer, error_buffer_size, "source brush '%s' overlaps existing brush '%s'",
+            set_errorf(error_buffer, error_buffer_size,
+                       "source brush '%s' overlaps existing brush '%s' with positive volume; use an adjacent snapped "
+                       "cell or a source operation that trims, splits, or merges the candidate",
                        candidate->name != NULL ? candidate->name : "<unnamed>",
                        existing->name != NULL ? existing->name : "<unnamed>");
             return false;
@@ -1357,6 +1367,8 @@ static const char *source_prefab_for_material(const char *material)
             return "wall";
         if (SDL_strstr(material, ".ceiling") != NULL)
             return "ceiling";
+        if (SDL_strstr(material, ".sky") != NULL)
+            return "sky";
     }
     return NULL;
 }
@@ -1397,6 +1409,24 @@ bool editor_brush_source_box_from_create_desc(const brush_world_runtime *world_r
     out_box->max[2] = source_units_from_meters(world_runtime, desc->max.z);
     out_box->contents = desc->contents != 0u ? desc->contents : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
     return true;
+}
+
+slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_runtime *world_runtime,
+                                                            const editor_brush_source_box_runtime *box)
+{
+    slayer3d_bounding_box bounds;
+    bounds.min = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    bounds.max = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (box == NULL)
+        return bounds;
+
+    bounds.min = slayer3d_vec3_make(source_meters_from_units(world_runtime, box->min[0]),
+                                    source_meters_from_units(world_runtime, box->min[1]),
+                                    source_meters_from_units(world_runtime, box->min[2]));
+    bounds.max = slayer3d_vec3_make(source_meters_from_units(world_runtime, box->max[0]),
+                                    source_meters_from_units(world_runtime, box->max[1]),
+                                    source_meters_from_units(world_runtime, box->max[2]));
+    return bounds;
 }
 
 static bool source_box_from_runtime_brush(const brush_world_runtime *world_runtime,

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1241,6 +1241,7 @@ static void update_active_editor_selection_material_for_transaction(slayer3d_gam
                                                                     const editor_command_transaction_entry *entry,
                                                                     bool forward, bool active_matches)
 {
+    (void)forward;
     if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit || !active_matches)
         return;
     slayer3d_game_data_editor_selection *selection = &runtime->editor_active_selection;
@@ -1253,12 +1254,8 @@ static void update_active_editor_selection_material_for_transaction(slayer3d_gam
     }
 
     const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, entry->world_name);
-    const int material_index = forward ? entry->material_index : entry->previous_material_index;
-    selection->material_name = forward ? entry->material_name : entry->previous_material_name;
-    selection->material_editor =
-        world_runtime != NULL && material_index >= 0 && material_index < world_runtime->desc.material_count
-            ? &world_runtime->desc.materials[material_index].editor
-            : NULL;
+    refresh_editor_brush_selection_for_identity(world_runtime, selection, entry->element_name, entry->element_stable_id,
+                                                entry->face_index, entry->face_stable_id);
 
     yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
     publish_editor_selection(runtime, obj_get(selection_json, "outputs"), selection);

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1000,17 +1000,25 @@ static slayer3d_bounding_box editor_floor_fill_bounds(slayer3d_bounding_box floo
                                                       float thickness, int side_index);
 static void translate_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
                                                               const editor_command_transaction_entry *entry,
-                                                              slayer3d_vec3 offset);
+                                                              slayer3d_vec3 offset, bool active_matches);
 
-static void refresh_editor_brush_selection_for_transaction(const brush_world_runtime *world_runtime,
-                                                           slayer3d_game_data_editor_selection *selection)
+static void refresh_editor_brush_selection_for_identity(const brush_world_runtime *world_runtime,
+                                                        slayer3d_game_data_editor_selection *selection,
+                                                        const char *brush_name, const char *brush_stable_id,
+                                                        int face_index, const char *face_stable_id)
 {
-    if (world_runtime == NULL || selection == NULL || selection->world_name == NULL || selection->element_name == NULL)
+    if (world_runtime == NULL || selection == NULL ||
+        ((brush_name == NULL || brush_name[0] == '\0') && (brush_stable_id == NULL || brush_stable_id[0] == '\0')))
+    {
         return;
+    }
 
     const slayer3d_game_data_brush_world *world = &world_runtime->desc;
+    selection->hit = false;
     selection->world_name = world->name;
     selection->world_editor = &world->editor;
+    selection->element_name = NULL;
+    selection->material_name = NULL;
     selection->element_index = -1;
     selection->element_editor = NULL;
     selection->face_editor = NULL;
@@ -1019,9 +1027,10 @@ static void refresh_editor_brush_selection_for_transaction(const brush_world_run
     for (int brush_index = 0; brush_index < world->brush_count; ++brush_index)
     {
         const slayer3d_game_data_brush *brush = &world->brushes[brush_index];
-        if (!editor_brush_matches_identity(brush, selection->element_name, NULL))
+        if (!editor_brush_matches_identity(brush, brush_name, brush_stable_id))
             continue;
 
+        selection->hit = true;
         selection->element_name = brush->name;
         selection->element_index = brush_index;
         selection->element_editor = &brush->editor;
@@ -1029,9 +1038,11 @@ static void refresh_editor_brush_selection_for_transaction(const brush_world_run
         if (brush->has_bounds)
             selection->bounds = brush->bounds;
 
-        if (selection->face_index >= 0 && selection->face_index < brush->face_count)
+        const int resolved_face_index = editor_face_index_for_identity(brush, face_index, face_stable_id);
+        selection->face_index = resolved_face_index;
+        if (resolved_face_index >= 0 && resolved_face_index < brush->face_count)
         {
-            const slayer3d_game_data_brush_face *face = &brush->faces[selection->face_index];
+            const slayer3d_game_data_brush_face *face = &brush->faces[resolved_face_index];
             selection->face_editor = &face->editor;
             selection->material_name = face->material_name;
             if (face->material_index >= 0 && face->material_index < world->material_count)
@@ -1132,6 +1143,9 @@ static bool apply_editor_brush_sector_floor(slayer3d_game_data_runtime *runtime,
     if (fill_material_index < 0)
         return false;
 
+    const bool active_matches = runtime->editor_active_selection.hit &&
+                                editor_selection_matches_transaction_element(&runtime->editor_active_selection, entry);
+
     if (offset.y > 0.0f && !delete_editor_floor_fill_brushes(world_runtime, entry->element_name, low_y, high_y))
         return false;
 
@@ -1146,22 +1160,21 @@ static bool apply_editor_brush_sector_floor(slayer3d_game_data_runtime *runtime,
         return false;
     }
 
-    translate_active_editor_selection_for_transaction(runtime, entry, offset);
+    translate_active_editor_selection_for_transaction(runtime, entry, offset, active_matches);
     return true;
 }
 
 static void translate_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
                                                               const editor_command_transaction_entry *entry,
-                                                              slayer3d_vec3 offset)
+                                                              slayer3d_vec3 offset, bool active_matches)
 {
-    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit)
+    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit || !active_matches)
         return;
     slayer3d_game_data_editor_selection *selection = &runtime->editor_active_selection;
     const char *active_scene = slayer3d_game_data_active_scene(runtime);
     if (active_scene == NULL || entry->scene == NULL || SDL_strcmp(active_scene, entry->scene) != 0 ||
         selection->world_name == NULL || entry->world_name == NULL ||
-        SDL_strcmp(selection->world_name, entry->world_name) != 0 || selection->element_name == NULL ||
-        !editor_selection_matches_transaction_element(selection, entry))
+        SDL_strcmp(selection->world_name, entry->world_name) != 0)
     {
         return;
     }
@@ -1172,22 +1185,23 @@ static void translate_active_editor_selection_for_transaction(slayer3d_game_data
         selection->bounds = translated_bounds(selection->bounds, offset);
 
     const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, entry->world_name);
-    refresh_editor_brush_selection_for_transaction(world_runtime, selection);
+    refresh_editor_brush_selection_for_identity(world_runtime, selection, entry->element_name, entry->element_stable_id,
+                                                selection->face_index, entry->face_stable_id);
     yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
     publish_editor_selection(runtime, obj_get(selection_json, "outputs"), selection);
 }
 
 static void resize_active_editor_selection_for_transaction(slayer3d_game_data_runtime *runtime,
-                                                           const editor_command_transaction_entry *entry, bool forward)
+                                                           const editor_command_transaction_entry *entry, bool forward,
+                                                           bool active_matches)
 {
-    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit)
+    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit || !active_matches)
         return;
     slayer3d_game_data_editor_selection *selection = &runtime->editor_active_selection;
     const char *active_scene = slayer3d_game_data_active_scene(runtime);
     if (active_scene == NULL || entry->scene == NULL || SDL_strcmp(active_scene, entry->scene) != 0 ||
         selection->world_name == NULL || entry->world_name == NULL ||
-        SDL_strcmp(selection->world_name, entry->world_name) != 0 || selection->element_name == NULL ||
-        !editor_selection_matches_transaction_face(selection, entry))
+        SDL_strcmp(selection->world_name, entry->world_name) != 0)
     {
         return;
     }
@@ -1216,7 +1230,8 @@ static void resize_active_editor_selection_for_transaction(slayer3d_game_data_ru
         selection->bounds = editor_resized_preview_bounds(selection->bounds, selection->normal,
                                                           slayer3d_vec3_dot(selection->normal, offset));
     selection->has_bounds = brush != NULL ? brush->has_bounds : selection->has_bounds;
-    refresh_editor_brush_selection_for_transaction(world_runtime, selection);
+    refresh_editor_brush_selection_for_identity(world_runtime, selection, entry->element_name, entry->element_stable_id,
+                                                entry->face_index, entry->face_stable_id);
 
     yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
     publish_editor_selection(runtime, obj_get(selection_json, "outputs"), selection);
@@ -1224,16 +1239,15 @@ static void resize_active_editor_selection_for_transaction(slayer3d_game_data_ru
 
 static void update_active_editor_selection_material_for_transaction(slayer3d_game_data_runtime *runtime,
                                                                     const editor_command_transaction_entry *entry,
-                                                                    bool forward)
+                                                                    bool forward, bool active_matches)
 {
-    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit)
+    if (runtime == NULL || entry == NULL || !runtime->editor_active_selection.hit || !active_matches)
         return;
     slayer3d_game_data_editor_selection *selection = &runtime->editor_active_selection;
     const char *active_scene = slayer3d_game_data_active_scene(runtime);
     if (active_scene == NULL || entry->scene == NULL || SDL_strcmp(active_scene, entry->scene) != 0 ||
         selection->world_name == NULL || entry->world_name == NULL ||
-        SDL_strcmp(selection->world_name, entry->world_name) != 0 || selection->element_name == NULL ||
-        !editor_selection_matches_transaction_face(selection, entry))
+        SDL_strcmp(selection->world_name, entry->world_name) != 0)
     {
         return;
     }
@@ -1271,6 +1285,14 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
 {
     if (!editor_transaction_has_brush_mutation(entry))
         return true;
+
+    const bool active_element_matches =
+        runtime != NULL && runtime->editor_active_selection.hit &&
+        editor_selection_matches_transaction_element(&runtime->editor_active_selection, entry);
+    const bool active_face_matches =
+        runtime != NULL && runtime->editor_active_selection.hit &&
+        editor_selection_matches_transaction_face(&runtime->editor_active_selection, entry);
+
     if (SDL_strcmp(entry->command, "delete") == 0)
         return apply_editor_brush_delete(runtime, entry, forward);
     if (SDL_strcmp(entry->command, "create") == 0)
@@ -1281,21 +1303,21 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
     {
         if (!apply_editor_brush_paint(runtime, entry, forward))
             return false;
-        update_active_editor_selection_material_for_transaction(runtime, entry, forward);
+        update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_face_matches);
         return true;
     }
     if (SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0)
     {
         if (!apply_editor_brush_face_resize(runtime, entry, forward))
             return false;
-        resize_active_editor_selection_for_transaction(runtime, entry, forward);
+        resize_active_editor_selection_for_transaction(runtime, entry, forward, active_face_matches);
         return true;
     }
 
     const slayer3d_vec3 offset = forward ? entry->offset : slayer3d_vec3_scale(entry->offset, -1.0f);
     if (!apply_editor_brush_translate(runtime, entry, offset))
         return false;
-    translate_active_editor_selection_for_transaction(runtime, entry, offset);
+    translate_active_editor_selection_for_transaction(runtime, entry, offset, active_element_matches);
     return true;
 }
 
@@ -1402,22 +1424,19 @@ static bool selected_editor_brush_can_resize_y(const brush_world_runtime *world_
 }
 
 static void refresh_selected_editor_brush_bounds_for_transaction(slayer3d_game_data_runtime *runtime,
-                                                                 const editor_command_transaction_entry *entry)
+                                                                 const editor_command_transaction_entry *entry,
+                                                                 int selected_index)
 {
-    if (runtime == NULL || entry == NULL || entry->world_name == NULL || entry->element_name == NULL)
+    if (runtime == NULL || entry == NULL || entry->world_name == NULL || entry->element_name == NULL ||
+        selected_index < 0 || selected_index >= runtime->editor_selected_brush_count)
+    {
         return;
+    }
 
     const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, entry->world_name);
-    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
-    {
-        slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
-        if (selection->world_name != NULL && selection->element_name != NULL &&
-            SDL_strcmp(selection->world_name, entry->world_name) == 0 &&
-            editor_selection_matches_transaction_element(selection, entry))
-        {
-            refresh_editor_brush_selection_for_transaction(world_runtime, selection);
-        }
-    }
+    refresh_editor_brush_selection_for_identity(
+        world_runtime, &runtime->editor_selected_brushes[selected_index], entry->element_name, entry->element_stable_id,
+        runtime->editor_selected_brushes[selected_index].face_index, entry->face_stable_id);
 }
 
 static bool editor_brush_uses_material(const slayer3d_game_data_brush *brush, const char *material_name)
@@ -1759,7 +1778,7 @@ bool slayer3d_game_data_resize_selected_editor_brushes_y(slayer3d_game_data_runt
             return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "commit", false, NULL,
                                                        message);
         }
-        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry);
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
         last_entry = entry;
         resized_count++;
         applied_count++;

--- a/src/game_data_editor_create_box_actions.c
+++ b/src/game_data_editor_create_box_actions.c
@@ -76,8 +76,23 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
 
     char brush_name[256];
     brush_name[0] = '\0';
-    const bool ok = error[0] == '\0' && slayer3d_game_data_create_box_brush(
-                                            runtime, &desc, brush_name, sizeof(brush_name), error, (int)sizeof(error));
+    bool ok = false;
+    if (error[0] == '\0' && position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0 &&
+        runtime != NULL && runtime->editor_placement_preview.has_source_candidate)
+    {
+        const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, preview->world_name);
+        ok = editor_brush_world_place_source_prefab_candidate(
+            world_runtime, desc.brush_name, preview->mode, preview->material_name, preview->contents,
+            preview->source_min, preview->source_max, brush_name, sizeof(brush_name), error, (int)sizeof(error));
+        if (ok)
+            editor_brush_world_mark_dirty(world_runtime);
+    }
+    else
+    {
+        ok = error[0] == '\0' && slayer3d_game_data_create_box_brush(runtime, &desc, brush_name, sizeof(brush_name),
+                                                                     error, (int)sizeof(error));
+    }
     slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     editor_set_bool_output(scene_state, outputs, "valid_key", ok);
     editor_set_string_output(scene_state, outputs, "message_key",

--- a/src/game_data_editor_create_box_actions.c
+++ b/src/game_data_editor_create_box_actions.c
@@ -77,6 +77,7 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
     char brush_name[256];
     brush_name[0] = '\0';
     bool ok = false;
+    bool source_command_applied = false;
     if (position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0)
     {
         if (error[0] == '\0' && runtime != NULL && runtime->editor_placement_preview.has_source_candidate)
@@ -94,6 +95,7 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
                                                               error, (int)sizeof(error));
             if (ok)
             {
+                source_command_applied = true;
                 SDL_strlcpy(brush_name, result.brush_name, sizeof(brush_name));
                 desc.world_name = preview->world_name;
                 desc.material_name = preview->material_name;
@@ -125,5 +127,7 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
     editor_set_vec3_output(scene_state, outputs, "bounds_max_key",
                            ok ? desc.max : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
     (void)publish_editor_brush_world_status(runtime, outputs, desc.world_name, NULL, false);
+    if (source_command_applied)
+        (void)slayer3d_game_data_clear_active_editor_selection(runtime);
     return true;
 }

--- a/src/game_data_editor_create_box_actions.c
+++ b/src/game_data_editor_create_box_actions.c
@@ -77,16 +77,37 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
     char brush_name[256];
     brush_name[0] = '\0';
     bool ok = false;
-    if (error[0] == '\0' && position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0 &&
-        runtime != NULL && runtime->editor_placement_preview.has_source_candidate)
+    if (position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0)
     {
-        const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
-        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, preview->world_name);
-        ok = editor_brush_world_place_source_prefab_candidate(
-            world_runtime, desc.brush_name, preview->mode, preview->material_name, preview->contents,
-            preview->source_min, preview->source_max, brush_name, sizeof(brush_name), error, (int)sizeof(error));
-        if (ok)
-            editor_brush_world_mark_dirty(world_runtime);
+        if (error[0] == '\0' && runtime != NULL && runtime->editor_placement_preview.has_source_candidate)
+        {
+            const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+            brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, preview->world_name);
+            editor_brush_source_prefab_desc source_desc;
+            SDL_zero(source_desc);
+            source_desc.prefab = preview->mode;
+            source_desc.material = preview->material_name;
+            source_desc.contents = preview->contents;
+            editor_brush_source_prefab_result result;
+            ok = editor_brush_world_run_source_prefab_command(world_runtime, &source_desc, desc.brush_name,
+                                                              preview->source_min, preview->source_max, true, &result,
+                                                              error, (int)sizeof(error));
+            if (ok)
+            {
+                SDL_strlcpy(brush_name, result.brush_name, sizeof(brush_name));
+                desc.world_name = preview->world_name;
+                desc.material_name = preview->material_name;
+                desc.contents = preview->contents;
+                desc.min = result.bounds.min;
+                desc.max = result.bounds.max;
+                editor_brush_world_mark_dirty(world_runtime);
+            }
+        }
+        else if (error[0] == '\0')
+        {
+            set_error(error, (int)sizeof(error),
+                      "box brush placement requires a valid source-backed placement preview");
+        }
     }
     else
     {

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -448,6 +448,8 @@ bool slayer3d_game_data_validate_editor_brush_source_action(slayer3d_game_data_r
     const char *message = NULL;
     if (missing_allowed)
         message = error[0] != '\0' ? error : "brush world has no editor brush source model";
+    else if (valid && ok && diagnostics.first_issue[0] != '\0')
+        message = diagnostics.first_issue;
     else if (valid)
         message = json_string(action, "message", "editor brush source model is structurally valid");
     else if (ok && diagnostics.first_issue[0] != '\0')

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -246,8 +246,8 @@ static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime
     return anchor;
 }
 
-static bool editor_placement_preview_validate_source_box(const slayer3d_game_data_runtime *runtime,
-                                                         yyjson_val *placement, yyjson_val *preview_json,
+static bool editor_placement_preview_validate_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                                         yyjson_val *preview_json,
                                                          editor_placement_preview_state *preview, char *error_buffer,
                                                          int error_buffer_size)
 {
@@ -257,42 +257,28 @@ static bool editor_placement_preview_validate_source_box(const slayer3d_game_dat
         return true;
     }
 
-    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, preview->world_name);
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, preview->world_name);
     if (world_runtime == NULL || !world_runtime->editor_has_source_model)
     {
         set_error(error_buffer, error_buffer_size, "brush prefab placement requires a source-backed brush world");
         return false;
     }
 
-    char generated_name[256];
-    if (!editor_brush_world_generate_brush_name(world_runtime, generated_name, sizeof(generated_name)))
-    {
-        set_error(error_buffer, error_buffer_size, "failed to generate placement preview brush name");
-        return false;
-    }
-
     const editor_brush_source_prefab_desc desc =
-        editor_placement_source_prefab_desc((slayer3d_game_data_runtime *)runtime, placement, preview_json, preview);
-    editor_brush_source_box_runtime source_box;
-    if (!editor_brush_world_build_source_prefab_candidate(world_runtime, &desc, generated_name, &source_box,
-                                                          error_buffer, error_buffer_size))
-    {
-        return false;
-    }
-
-    const bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
-                                                                     error_buffer_size);
+        editor_placement_source_prefab_desc(runtime, placement, preview_json, preview);
+    editor_brush_source_prefab_result result;
+    const bool ok = editor_brush_world_run_source_prefab_command(world_runtime, &desc, NULL, NULL, NULL, false, &result,
+                                                                 error_buffer, error_buffer_size);
     if (ok)
     {
-        preview->bounds = editor_brush_source_box_bounds_meters(world_runtime, &source_box);
+        preview->bounds = result.bounds;
         preview->has_source_candidate = true;
         for (int axis = 0; axis < 3; ++axis)
         {
-            preview->source_min[axis] = source_box.min[axis];
-            preview->source_max[axis] = source_box.max[axis];
+            preview->source_min[axis] = result.source_min[axis];
+            preview->source_max[axis] = result.source_max[axis];
         }
     }
-    free_editor_brush_source_box_runtime(&source_box);
     return ok;
 }
 

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -138,11 +138,6 @@ static const char *editor_placement_axis(slayer3d_game_data_runtime *runtime, yy
     return authored_axis;
 }
 
-static slayer3d_vec3 editor_grid_scaled_vec3(yyjson_val *obj, const char *key, float grid_size)
-{
-    return slayer3d_vec3_scale(json_vec3(obj, key, slayer3d_vec3_make(0.0f, 0.0f, 0.0f)), grid_size);
-}
-
 static float editor_placement_snap_floor(float value, float snap)
 {
     return SDL_floorf(value / snap) * snap;
@@ -209,142 +204,24 @@ static void publish_editor_placement_elevation(slayer3d_game_data_runtime *runti
         slayer3d_properties_set_float(scene_state, work_plane_distance_key, elevation);
 }
 
-static slayer3d_bounding_box editor_placement_oriented_box_bounds(slayer3d_game_data_runtime *runtime,
-                                                                  yyjson_val *placement, yyjson_val *preview_json,
-                                                                  slayer3d_vec3 anchor, const char *axis, float snap)
+static editor_brush_source_prefab_desc editor_placement_source_prefab_desc(
+    slayer3d_game_data_runtime *runtime, yyjson_val *placement, yyjson_val *preview_json,
+    const editor_placement_preview_state *preview)
 {
-    const bool uses_grid_bounds =
-        obj_get(preview_json, "grid_min") != NULL || obj_get(preview_json, "grid_max") != NULL;
-    const float grid_size = editor_placement_grid_size(runtime, placement, preview_json, snap);
-    const slayer3d_vec3 source_min = uses_grid_bounds
-                                         ? editor_grid_scaled_vec3(preview_json, "grid_min", grid_size)
-                                         : json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
-    const slayer3d_vec3 source_max = uses_grid_bounds
-                                         ? editor_grid_scaled_vec3(preview_json, "grid_max", grid_size)
-                                         : json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
-    slayer3d_bounding_box bounds;
-    if (axis != NULL && SDL_strcmp(axis, "x") == 0)
-    {
-        bounds.min = slayer3d_vec3_make(anchor.x + source_min.z, anchor.y + source_min.y, anchor.z + source_min.x);
-        bounds.max = slayer3d_vec3_make(anchor.x + source_max.z, anchor.y + source_max.y, anchor.z + source_max.x);
-    }
-    else
-    {
-        bounds.min = slayer3d_vec3_add(anchor, source_min);
-        bounds.max = slayer3d_vec3_add(anchor, source_max);
-    }
-    return bounds;
-}
-
-static bool editor_source_contents_are_structural(unsigned int contents)
-{
-    if (contents == 0u)
-        contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
-    return (contents & (SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
-                        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY)) != 0u;
-}
-
-static bool editor_source_intervals_overlap_positive(int a_min, int a_max, int b_min, int b_max)
-{
-    return SDL_max(a_min, b_min) < SDL_min(a_max, b_max);
-}
-
-static bool editor_source_boxes_overlap_positive(const editor_brush_source_box_runtime *a,
-                                                 const editor_brush_source_box_runtime *b)
-{
-    return a != NULL && b != NULL &&
-           editor_source_intervals_overlap_positive(a->min[0], a->max[0], b->min[0], b->max[0]) &&
-           editor_source_intervals_overlap_positive(a->min[1], a->max[1], b->min[1], b->max[1]) &&
-           editor_source_intervals_overlap_positive(a->min[2], a->max[2], b->min[2], b->max[2]);
-}
-
-static int editor_source_box_extent(const editor_brush_source_box_runtime *box, int axis)
-{
-    return box != NULL && axis >= 0 && axis < 3 ? box->max[axis] - box->min[axis] : 0;
-}
-
-static bool editor_placement_adjust_wall_source_overlap(editor_brush_source_box_runtime *candidate,
-                                                        const editor_brush_source_box_runtime *existing, int run_axis,
-                                                        int thin_axis, int max_trim_units)
-{
-    if (candidate == NULL || existing == NULL || !editor_source_boxes_overlap_positive(candidate, existing))
-        return true;
-
-    if (!editor_source_intervals_overlap_positive(candidate->min[1], candidate->max[1], existing->min[1],
-                                                  existing->max[1]) ||
-        !editor_source_intervals_overlap_positive(candidate->min[thin_axis], candidate->max[thin_axis],
-                                                  existing->min[thin_axis], existing->max[thin_axis]))
-    {
-        return false;
-    }
-
-    const int overlap_min = SDL_max(candidate->min[run_axis], existing->min[run_axis]);
-    const int overlap_max = SDL_min(candidate->max[run_axis], existing->max[run_axis]);
-    const int overlap = overlap_max - overlap_min;
-    if (overlap <= 0 || overlap > max_trim_units)
-        return false;
-
-    if (existing->min[run_axis] <= candidate->min[run_axis] && existing->max[run_axis] > candidate->min[run_axis] &&
-        existing->max[run_axis] < candidate->max[run_axis])
-    {
-        candidate->min[run_axis] = existing->max[run_axis];
-        return candidate->min[run_axis] < candidate->max[run_axis];
-    }
-
-    if (existing->max[run_axis] >= candidate->max[run_axis] && existing->min[run_axis] < candidate->max[run_axis] &&
-        existing->min[run_axis] > candidate->min[run_axis])
-    {
-        candidate->max[run_axis] = existing->min[run_axis];
-        return candidate->min[run_axis] < candidate->max[run_axis];
-    }
-
-    return false;
-}
-
-static bool editor_placement_fit_wall_source_candidate(const brush_world_runtime *world_runtime,
-                                                       editor_brush_source_box_runtime *candidate, char *error_buffer,
-                                                       int error_buffer_size)
-{
-    if (world_runtime == NULL || candidate == NULL ||
-        SDL_strcmp(candidate->prefab != NULL ? candidate->prefab : "", "wall") != 0)
-    {
-        return true;
-    }
-
-    const int x_extent = editor_source_box_extent(candidate, 0);
-    const int z_extent = editor_source_box_extent(candidate, 2);
-    const int thin_axis = x_extent <= z_extent ? 0 : 2;
-    const int run_axis = thin_axis == 0 ? 2 : 0;
-    const int max_trim_units = SDL_max(editor_source_box_extent(candidate, thin_axis) * 2, 1);
-
-    bool adjusted = true;
-    while (adjusted)
-    {
-        adjusted = false;
-        for (int i = 0; i < world_runtime->editor_source_box_count; ++i)
-        {
-            const editor_brush_source_box_runtime *existing = &world_runtime->editor_source_boxes[i];
-            if (!editor_source_contents_are_structural(existing->contents) ||
-                !editor_source_contents_are_structural(candidate->contents) ||
-                !editor_source_boxes_overlap_positive(candidate, existing))
-            {
-                continue;
-            }
-
-            const int before_min = candidate->min[run_axis];
-            const int before_max = candidate->max[run_axis];
-            if (!editor_placement_adjust_wall_source_overlap(candidate, existing, run_axis, thin_axis, max_trim_units))
-            {
-                set_errorf(error_buffer, error_buffer_size,
-                           "source wall candidate overlaps existing brush '%s' beyond an endpoint contact; use a "
-                           "free snapped cell or split the wall span",
-                           existing->name != NULL ? existing->name : "<unnamed>");
-                return false;
-            }
-            adjusted = adjusted || before_min != candidate->min[run_axis] || before_max != candidate->max[run_axis];
-        }
-    }
-    return true;
+    editor_brush_source_prefab_desc desc;
+    SDL_zero(desc);
+    desc.prefab = preview != NULL ? preview->mode : json_string(preview_json, "mode", NULL);
+    desc.material = preview != NULL ? preview->material_name : json_string(preview_json, "material", NULL);
+    desc.axis = preview != NULL ? preview->axis : json_string(preview_json, "axis", "z");
+    desc.contents = preview != NULL ? preview->contents : 0u;
+    desc.anchor = preview != NULL ? preview->anchor : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    desc.grid_size = editor_placement_grid_size(runtime, placement, preview_json, desc.grid_size);
+    desc.use_grid_bounds = obj_get(preview_json, "grid_min") != NULL || obj_get(preview_json, "grid_max") != NULL;
+    desc.grid_min = json_vec3(preview_json, "grid_min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.grid_max = json_vec3(preview_json, "grid_max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.min = json_vec3(preview_json, "min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.max = json_vec3(preview_json, "max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return desc;
 }
 
 static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
@@ -370,6 +247,7 @@ static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime
 }
 
 static bool editor_placement_preview_validate_source_box(const slayer3d_game_data_runtime *runtime,
+                                                         yyjson_val *placement, yyjson_val *preview_json,
                                                          editor_placement_preview_state *preview, char *error_buffer,
                                                          int error_buffer_size)
 {
@@ -381,7 +259,10 @@ static bool editor_placement_preview_validate_source_box(const slayer3d_game_dat
 
     const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, preview->world_name);
     if (world_runtime == NULL || !world_runtime->editor_has_source_model)
-        return true;
+    {
+        set_error(error_buffer, error_buffer_size, "brush prefab placement requires a source-backed brush world");
+        return false;
+    }
 
     char generated_name[256];
     if (!editor_brush_world_generate_brush_name(world_runtime, generated_name, sizeof(generated_name)))
@@ -390,32 +271,27 @@ static bool editor_placement_preview_validate_source_box(const slayer3d_game_dat
         return false;
     }
 
-    slayer3d_game_data_create_box_brush_desc desc;
-    SDL_zero(desc);
-    desc.world_name = preview->world_name;
-    desc.brush_name = generated_name;
-    desc.material_name = preview->material_name;
-    desc.contents = preview->contents != 0u ? preview->contents : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
-    desc.min = preview->bounds.min;
-    desc.max = preview->bounds.max;
-
+    const editor_brush_source_prefab_desc desc =
+        editor_placement_source_prefab_desc((slayer3d_game_data_runtime *)runtime, placement, preview_json, preview);
     editor_brush_source_box_runtime source_box;
-    if (!editor_brush_source_box_from_create_desc(world_runtime, &desc, generated_name, &source_box))
+    if (!editor_brush_world_build_source_prefab_candidate(world_runtime, &desc, generated_name, &source_box,
+                                                          error_buffer, error_buffer_size))
     {
-        set_error(error_buffer, error_buffer_size, "failed to allocate placement preview source brush");
-        return false;
-    }
-
-    if (!editor_placement_fit_wall_source_candidate(world_runtime, &source_box, error_buffer, error_buffer_size))
-    {
-        free_editor_brush_source_box_runtime(&source_box);
         return false;
     }
 
     const bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
                                                                      error_buffer_size);
     if (ok)
+    {
         preview->bounds = editor_brush_source_box_bounds_meters(world_runtime, &source_box);
+        preview->has_source_candidate = true;
+        for (int axis = 0; axis < 3; ++axis)
+        {
+            preview->source_min[axis] = source_box.min[axis];
+            preview->source_max[axis] = source_box.max[axis];
+        }
+    }
     free_editor_brush_source_box_runtime(&source_box);
     return ok;
 }
@@ -467,11 +343,12 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     }
     else
     {
-        preview->bounds =
-            editor_placement_oriented_box_bounds(runtime, placement, preview_json, anchor, preview->axis, snap);
+        preview->bounds.min = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        preview->bounds.max = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
     }
     char validation_error[256] = {0};
-    if (!editor_placement_preview_validate_source_box(runtime, preview, validation_error, sizeof(validation_error)))
+    if (!editor_placement_preview_validate_source_box(runtime, placement, preview_json, preview, validation_error,
+                                                      sizeof(validation_error)))
     {
         clear_editor_placement_preview(runtime);
         publish_editor_placement_preview(runtime, outputs, false, preview_json, NULL,

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -236,50 +236,7 @@ static slayer3d_bounding_box editor_placement_oriented_box_bounds(slayer3d_game_
     return bounds;
 }
 
-static float *editor_bounds_min_axis(slayer3d_bounding_box *bounds, int axis)
-{
-    if (axis == 0)
-        return &bounds->min.x;
-    if (axis == 1)
-        return &bounds->min.y;
-    return &bounds->min.z;
-}
-
-static float *editor_bounds_max_axis(slayer3d_bounding_box *bounds, int axis)
-{
-    if (axis == 0)
-        return &bounds->max.x;
-    if (axis == 1)
-        return &bounds->max.y;
-    return &bounds->max.z;
-}
-
-static float editor_bounds_axis_min(slayer3d_bounding_box bounds, int axis)
-{
-    if (axis == 0)
-        return bounds.min.x;
-    if (axis == 1)
-        return bounds.min.y;
-    return bounds.min.z;
-}
-
-static float editor_bounds_axis_max(slayer3d_bounding_box bounds, int axis)
-{
-    if (axis == 0)
-        return bounds.max.x;
-    if (axis == 1)
-        return bounds.max.y;
-    return bounds.max.z;
-}
-
-static bool editor_bounds_overlap_positive_volume(slayer3d_bounding_box a, slayer3d_bounding_box b)
-{
-    const float epsilon = 0.00001f;
-    return a.min.x < b.max.x - epsilon && b.min.x < a.max.x - epsilon && a.min.y < b.max.y - epsilon &&
-           b.min.y < a.max.y - epsilon && a.min.z < b.max.z - epsilon && b.min.z < a.max.z - epsilon;
-}
-
-static bool editor_preview_brush_contents_are_structural(unsigned int contents)
+static bool editor_source_contents_are_structural(unsigned int contents)
 {
     if (contents == 0u)
         contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
@@ -287,84 +244,107 @@ static bool editor_preview_brush_contents_are_structural(unsigned int contents)
                         SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY)) != 0u;
 }
 
-static bool editor_bounds_overlap_on_axis(slayer3d_bounding_box a, slayer3d_bounding_box b, int axis)
+static bool editor_source_intervals_overlap_positive(int a_min, int a_max, int b_min, int b_max)
 {
-    const float epsilon = 0.00001f;
-    return editor_bounds_axis_min(a, axis) < editor_bounds_axis_max(b, axis) - epsilon &&
-           editor_bounds_axis_min(b, axis) < editor_bounds_axis_max(a, axis) - epsilon;
+    return SDL_max(a_min, b_min) < SDL_min(a_max, b_max);
 }
 
-static bool editor_placement_trim_wall_overlap(slayer3d_bounding_box *bounds, slayer3d_bounding_box existing,
-                                               int run_axis, int thin_axis, float max_trim)
+static bool editor_source_boxes_overlap_positive(const editor_brush_source_box_runtime *a,
+                                                 const editor_brush_source_box_runtime *b)
 {
-    if (bounds == NULL || !editor_bounds_overlap_positive_volume(*bounds, existing))
+    return a != NULL && b != NULL &&
+           editor_source_intervals_overlap_positive(a->min[0], a->max[0], b->min[0], b->max[0]) &&
+           editor_source_intervals_overlap_positive(a->min[1], a->max[1], b->min[1], b->max[1]) &&
+           editor_source_intervals_overlap_positive(a->min[2], a->max[2], b->min[2], b->max[2]);
+}
+
+static int editor_source_box_extent(const editor_brush_source_box_runtime *box, int axis)
+{
+    return box != NULL && axis >= 0 && axis < 3 ? box->max[axis] - box->min[axis] : 0;
+}
+
+static bool editor_placement_adjust_wall_source_overlap(editor_brush_source_box_runtime *candidate,
+                                                        const editor_brush_source_box_runtime *existing, int run_axis,
+                                                        int thin_axis, int max_trim_units)
+{
+    if (candidate == NULL || existing == NULL || !editor_source_boxes_overlap_positive(candidate, existing))
         return true;
 
-    if (!editor_bounds_overlap_on_axis(*bounds, existing, 1) ||
-        !editor_bounds_overlap_on_axis(*bounds, existing, thin_axis))
-        return false;
-
-    const float candidate_min = editor_bounds_axis_min(*bounds, run_axis);
-    const float candidate_max = editor_bounds_axis_max(*bounds, run_axis);
-    const float existing_min = editor_bounds_axis_min(existing, run_axis);
-    const float existing_max = editor_bounds_axis_max(existing, run_axis);
-    const float overlap_min = SDL_max(candidate_min, existing_min);
-    const float overlap_max = SDL_min(candidate_max, existing_max);
-    const float overlap = overlap_max - overlap_min;
-    const float epsilon = 0.0001f;
-    if (overlap <= epsilon || overlap > max_trim + epsilon)
-        return false;
-
-    if (existing_min <= candidate_min + epsilon && existing_max > candidate_min + epsilon &&
-        existing_max < candidate_max - epsilon)
+    if (!editor_source_intervals_overlap_positive(candidate->min[1], candidate->max[1], existing->min[1],
+                                                  existing->max[1]) ||
+        !editor_source_intervals_overlap_positive(candidate->min[thin_axis], candidate->max[thin_axis],
+                                                  existing->min[thin_axis], existing->max[thin_axis]))
     {
-        *editor_bounds_min_axis(bounds, run_axis) = SDL_max(*editor_bounds_min_axis(bounds, run_axis), existing_max);
-        return *editor_bounds_min_axis(bounds, run_axis) < *editor_bounds_max_axis(bounds, run_axis) - epsilon;
+        return false;
     }
 
-    if (existing_max >= candidate_max - epsilon && existing_min < candidate_max - epsilon &&
-        existing_min > candidate_min + epsilon)
+    const int overlap_min = SDL_max(candidate->min[run_axis], existing->min[run_axis]);
+    const int overlap_max = SDL_min(candidate->max[run_axis], existing->max[run_axis]);
+    const int overlap = overlap_max - overlap_min;
+    if (overlap <= 0 || overlap > max_trim_units)
+        return false;
+
+    if (existing->min[run_axis] <= candidate->min[run_axis] && existing->max[run_axis] > candidate->min[run_axis] &&
+        existing->max[run_axis] < candidate->max[run_axis])
     {
-        *editor_bounds_max_axis(bounds, run_axis) = SDL_min(*editor_bounds_max_axis(bounds, run_axis), existing_min);
-        return *editor_bounds_min_axis(bounds, run_axis) < *editor_bounds_max_axis(bounds, run_axis) - epsilon;
+        candidate->min[run_axis] = existing->max[run_axis];
+        return candidate->min[run_axis] < candidate->max[run_axis];
+    }
+
+    if (existing->max[run_axis] >= candidate->max[run_axis] && existing->min[run_axis] < candidate->max[run_axis] &&
+        existing->min[run_axis] > candidate->min[run_axis])
+    {
+        candidate->max[run_axis] = existing->min[run_axis];
+        return candidate->min[run_axis] < candidate->max[run_axis];
     }
 
     return false;
 }
 
-static slayer3d_bounding_box editor_placement_trim_wall_endpoint_overlaps(slayer3d_game_data_runtime *runtime,
-                                                                          yyjson_val *preview_json,
-                                                                          const editor_placement_preview_state *preview)
+static bool editor_placement_fit_wall_source_candidate(const brush_world_runtime *world_runtime,
+                                                       editor_brush_source_box_runtime *candidate, char *error_buffer,
+                                                       int error_buffer_size)
 {
-    slayer3d_bounding_box bounds = preview != NULL ? preview->bounds
-                                                   : (slayer3d_bounding_box){slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                                                             slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
-    if (runtime == NULL || preview_json == NULL || preview == NULL || SDL_strcmp(preview->kind, "box") != 0 ||
-        SDL_strcmp(preview->mode, "wall") != 0 || preview->world_name == NULL)
+    if (world_runtime == NULL || candidate == NULL ||
+        SDL_strcmp(candidate->prefab != NULL ? candidate->prefab : "", "wall") != 0)
     {
-        return bounds;
+        return true;
     }
 
-    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, preview->world_name);
-    if (world_runtime == NULL)
-        return bounds;
-
-    const int thin_axis = preview->axis != NULL && SDL_strcmp(preview->axis, "x") == 0 ? 0 : 2;
+    const int x_extent = editor_source_box_extent(candidate, 0);
+    const int z_extent = editor_source_box_extent(candidate, 2);
+    const int thin_axis = x_extent <= z_extent ? 0 : 2;
     const int run_axis = thin_axis == 0 ? 2 : 0;
-    const float wall_thickness = editor_bounds_axis_max(bounds, thin_axis) - editor_bounds_axis_min(bounds, thin_axis);
-    const float max_trim = SDL_max(wall_thickness * 1.25f, 0.001f);
-    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
-    for (int i = 0; i < world->brush_count; ++i)
+    const int max_trim_units = SDL_max(editor_source_box_extent(candidate, thin_axis) * 2, 1);
+
+    bool adjusted = true;
+    while (adjusted)
     {
-        const slayer3d_game_data_brush *brush = &world->brushes[i];
-        if (brush == NULL || !brush->has_bounds || !editor_preview_brush_contents_are_structural(brush->contents))
-            continue;
-        if (!editor_bounds_overlap_positive_volume(bounds, brush->bounds))
-            continue;
-        if (!editor_placement_trim_wall_overlap(&bounds, brush->bounds, run_axis, thin_axis, max_trim))
-            return preview->bounds;
+        adjusted = false;
+        for (int i = 0; i < world_runtime->editor_source_box_count; ++i)
+        {
+            const editor_brush_source_box_runtime *existing = &world_runtime->editor_source_boxes[i];
+            if (!editor_source_contents_are_structural(existing->contents) ||
+                !editor_source_contents_are_structural(candidate->contents) ||
+                !editor_source_boxes_overlap_positive(candidate, existing))
+            {
+                continue;
+            }
+
+            const int before_min = candidate->min[run_axis];
+            const int before_max = candidate->max[run_axis];
+            if (!editor_placement_adjust_wall_source_overlap(candidate, existing, run_axis, thin_axis, max_trim_units))
+            {
+                set_errorf(error_buffer, error_buffer_size,
+                           "source wall candidate overlaps existing brush '%s' beyond an endpoint contact; use a "
+                           "free snapped cell or split the wall span",
+                           existing->name != NULL ? existing->name : "<unnamed>");
+                return false;
+            }
+            adjusted = adjusted || before_min != candidate->min[run_axis] || before_max != candidate->max[run_axis];
+        }
     }
-    return bounds;
+    return true;
 }
 
 static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
@@ -390,8 +370,8 @@ static slayer3d_vec3 editor_placement_anchor(slayer3d_game_data_runtime *runtime
 }
 
 static bool editor_placement_preview_validate_source_box(const slayer3d_game_data_runtime *runtime,
-                                                         const editor_placement_preview_state *preview,
-                                                         char *error_buffer, int error_buffer_size)
+                                                         editor_placement_preview_state *preview, char *error_buffer,
+                                                         int error_buffer_size)
 {
     if (runtime == NULL || preview == NULL || SDL_strcmp(preview->kind, "box") != 0 || !preview->has_bounds ||
         preview->world_name == NULL || preview->world_name[0] == '\0')
@@ -426,8 +406,16 @@ static bool editor_placement_preview_validate_source_box(const slayer3d_game_dat
         return false;
     }
 
+    if (!editor_placement_fit_wall_source_candidate(world_runtime, &source_box, error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box_runtime(&source_box);
+        return false;
+    }
+
     const bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
                                                                      error_buffer_size);
+    if (ok)
+        preview->bounds = editor_brush_source_box_bounds_meters(world_runtime, &source_box);
     free_editor_brush_source_box_runtime(&source_box);
     return ok;
 }
@@ -481,7 +469,6 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     {
         preview->bounds =
             editor_placement_oriented_box_bounds(runtime, placement, preview_json, anchor, preview->axis, snap);
-        preview->bounds = editor_placement_trim_wall_endpoint_overlaps(runtime, preview_json, preview);
     }
     char validation_error[256] = {0};
     if (!editor_placement_preview_validate_source_box(runtime, preview, validation_error, sizeof(validation_error)))

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -213,6 +213,15 @@ typedef struct editor_brush_source_prefab_desc
     float grid_size;
 } editor_brush_source_prefab_desc;
 
+typedef struct editor_brush_source_prefab_result
+{
+    bool valid;
+    char brush_name[256];
+    slayer3d_bounding_box bounds;
+    int source_min[3];
+    int source_max[3];
+} editor_brush_source_prefab_result;
+
 #define SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY 32
 #define SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY 512
 
@@ -1173,19 +1182,14 @@ bool editor_brush_source_box_from_create_desc(const brush_world_runtime *world_r
                                               const char *brush_name, editor_brush_source_box_runtime *out_box);
 slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_runtime *world_runtime,
                                                             const editor_brush_source_box_runtime *box);
-bool editor_brush_world_build_source_prefab_candidate(const brush_world_runtime *world_runtime,
-                                                      const editor_brush_source_prefab_desc *desc,
-                                                      const char *candidate_name,
-                                                      editor_brush_source_box_runtime *out_box, char *error_buffer,
-                                                      int error_buffer_size);
 bool editor_brush_world_validate_source_box_candidate(const brush_world_runtime *world_runtime,
                                                       const editor_brush_source_box_runtime *box, int exclude_index,
                                                       char *error_buffer, int error_buffer_size);
-bool editor_brush_world_place_source_prefab_candidate(brush_world_runtime *world_runtime, const char *brush_name,
-                                                      const char *prefab, const char *material, unsigned int contents,
-                                                      const int min_values[3], const int max_values[3],
-                                                      char *out_brush_name, size_t out_brush_name_size,
-                                                      char *error_buffer, int error_buffer_size);
+bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_runtime,
+                                                  const editor_brush_source_prefab_desc *desc, const char *brush_name,
+                                                  const int *source_min, const int *source_max, bool apply,
+                                                  editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                  int error_buffer_size);
 bool editor_brush_world_insert_source_box_at_index(brush_world_runtime *world_runtime, int box_index,
                                                    const editor_brush_source_box_runtime *box, char *error_buffer,
                                                    int error_buffer_size);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -1153,6 +1153,8 @@ bool editor_brush_world_copy_source_box_by_identity(const brush_world_runtime *w
 bool editor_brush_source_box_from_create_desc(const brush_world_runtime *world_runtime,
                                               const slayer3d_game_data_create_box_brush_desc *desc,
                                               const char *brush_name, editor_brush_source_box_runtime *out_box);
+slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_runtime *world_runtime,
+                                                            const editor_brush_source_box_runtime *box);
 bool editor_brush_world_validate_source_box_candidate(const brush_world_runtime *world_runtime,
                                                       const editor_brush_source_box_runtime *box, int exclude_index,
                                                       char *error_buffer, int error_buffer_size);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -181,6 +181,9 @@ typedef struct editor_placement_preview_state
     float snap;
     bool has_bounds;
     slayer3d_bounding_box bounds;
+    bool has_source_candidate;
+    int source_min[3];
+    int source_max[3];
 } editor_placement_preview_state;
 
 typedef struct editor_brush_source_box_runtime
@@ -194,6 +197,21 @@ typedef struct editor_brush_source_box_runtime
     int max[3];
     unsigned int contents;
 } editor_brush_source_box_runtime;
+
+typedef struct editor_brush_source_prefab_desc
+{
+    const char *prefab;
+    const char *material;
+    const char *axis;
+    unsigned int contents;
+    slayer3d_vec3 anchor;
+    bool use_grid_bounds;
+    slayer3d_vec3 min;
+    slayer3d_vec3 max;
+    slayer3d_vec3 grid_min;
+    slayer3d_vec3 grid_max;
+    float grid_size;
+} editor_brush_source_prefab_desc;
 
 #define SLAYER3D_EDITOR_COMMAND_HISTORY_CAPACITY 32
 #define SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY 512
@@ -1155,8 +1173,18 @@ bool editor_brush_source_box_from_create_desc(const brush_world_runtime *world_r
                                               const char *brush_name, editor_brush_source_box_runtime *out_box);
 slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_runtime *world_runtime,
                                                             const editor_brush_source_box_runtime *box);
+bool editor_brush_world_build_source_prefab_candidate(const brush_world_runtime *world_runtime,
+                                                      const editor_brush_source_prefab_desc *desc,
+                                                      const char *candidate_name,
+                                                      editor_brush_source_box_runtime *out_box, char *error_buffer,
+                                                      int error_buffer_size);
 bool editor_brush_world_validate_source_box_candidate(const brush_world_runtime *world_runtime,
                                                       const editor_brush_source_box_runtime *box, int exclude_index,
+                                                      char *error_buffer, int error_buffer_size);
+bool editor_brush_world_place_source_prefab_candidate(brush_world_runtime *world_runtime, const char *brush_name,
+                                                      const char *prefab, const char *material, unsigned int contents,
+                                                      const int min_values[3], const int max_values[3],
+                                                      char *out_brush_name, size_t out_brush_name_size,
                                                       char *error_buffer, int error_buffer_size);
 bool editor_brush_world_insert_source_box_at_index(brush_world_runtime *world_runtime, int box_index,
                                                    const editor_brush_source_box_runtime *box, char *error_buffer,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -17821,6 +17821,152 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxPrefabOperationsAllowGridCor
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoCommitsPrefabPreviewSourceCandidate)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [
+        { "name": "mat.editor.floor", "albedo": [0.30, 0.31, 0.33, 1.0] },
+        { "name": "mat.editor.wall", "albedo": [0.50, 0.52, 0.56, 1.0] },
+        { "name": "mat.editor.ceiling", "albedo": [0.68, 0.69, 0.71, 1.0] },
+        { "name": "mat.editor.sky", "albedo": [0.20, 0.42, 0.78, 1.0] }
+      ],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": []
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u, "/tmp/source-preview-commit.json",
+        error, sizeof(error)))
+        << error;
+
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    ASSERT_NE(editor, nullptr);
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
+    ASSERT_GE(commit_signal, 0);
+
+    struct PrefabCase
+    {
+        const char *mode;
+        slayer3d_vec3 point;
+    };
+    const PrefabCase cases[] = {
+        {"floor", slayer3d_vec3_make(0.0f, 0.0f, 0.0f)},
+        {"wall", slayer3d_vec3_make(16.0f, 0.0f, 0.0f)},
+        {"ceiling", slayer3d_vec3_make(32.0f, 0.0f, 0.0f)},
+        {"sky", slayer3d_vec3_make(48.0f, 0.0f, 0.0f)},
+    };
+
+    auto export_source_prefab_for_name = [&](const char *brush_name) {
+        std::string prefab;
+        char *json = nullptr;
+        size_t json_size = 0u;
+        EXPECT_TRUE(slayer3d_game_data_export_editable_level_fragment_json(runtime, "brush.editor_shell.target", &json,
+                                                                           &json_size, error, sizeof(error)))
+            << error;
+        if (json == nullptr)
+            return prefab;
+        yyjson_doc *doc = yyjson_read(json, json_size, 0);
+        EXPECT_NE(doc, nullptr);
+        if (doc != nullptr)
+        {
+            yyjson_val *root = yyjson_doc_get_root(doc);
+            yyjson_val *sources = yyjson_obj_get(root, "editor_brush_sources");
+            yyjson_val *source = yyjson_arr_get(sources, 0);
+            yyjson_val *boxes = source != nullptr ? yyjson_obj_get(source, "boxes") : nullptr;
+            const size_t count = yyjson_is_arr(boxes) ? yyjson_arr_size(boxes) : 0u;
+            for (size_t i = 0; i < count; ++i)
+            {
+                yyjson_val *box = yyjson_arr_get(boxes, i);
+                const char *name = yyjson_get_str(yyjson_obj_get(box, "name"));
+                if (name != nullptr && brush_name != nullptr && SDL_strcmp(name, brush_name) == 0)
+                {
+                    const char *box_prefab = yyjson_get_str(yyjson_obj_get(box, "prefab"));
+                    prefab = box_prefab != nullptr ? box_prefab : "";
+                    break;
+                }
+            }
+            yyjson_doc_free(doc);
+        }
+        SDL_free(json);
+        return prefab;
+    };
+
+    for (const PrefabCase &test_case : cases)
+    {
+        slayer3d_properties_set_string(scene_state, "editor.tool.mode", test_case.mode);
+        slayer3d_game_data_editor_selection hover{};
+        hover.hit = true;
+        hover.type = SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+        hover.point = test_case.point;
+        hover.normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+        hover.world_name = "brush.editor_shell.target";
+        hover.material_name = "";
+        update_editor_placement_preview(runtime, editor, &hover);
+        ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false))
+            << test_case.mode << ": "
+            << slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", "");
+        const slayer3d_value *preview_min =
+            slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+        const slayer3d_value *preview_max =
+            slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+        ASSERT_NE(preview_min, nullptr);
+        ASSERT_NE(preview_max, nullptr);
+        ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+        ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+        const slayer3d_vec3 expected_min = preview_min->as_vec3;
+        const slayer3d_vec3 expected_max = preview_max->as_vec3;
+
+        slayer3d_signal_emit(bus, commit_signal, nullptr);
+        ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false))
+            << test_case.mode << ": " << slayer3d_properties_get_string(scene_state, "editor.create.message", "");
+        const char *brush_name = slayer3d_properties_get_string(scene_state, "editor.create.brush", "");
+        ASSERT_STRNE(brush_name, "");
+        const slayer3d_value *created_min = slayer3d_properties_get_value(scene_state, "editor.create.bounds_min");
+        const slayer3d_value *created_max = slayer3d_properties_get_value(scene_state, "editor.create.bounds_max");
+        ASSERT_NE(created_min, nullptr);
+        ASSERT_NE(created_max, nullptr);
+        ASSERT_EQ(created_min->type, SLAYER3D_VALUE_VEC3);
+        ASSERT_EQ(created_max->type, SLAYER3D_VALUE_VEC3);
+        EXPECT_NEAR(created_min->as_vec3.x, expected_min.x, 0.001f) << test_case.mode;
+        EXPECT_NEAR(created_min->as_vec3.y, expected_min.y, 0.001f) << test_case.mode;
+        EXPECT_NEAR(created_min->as_vec3.z, expected_min.z, 0.001f) << test_case.mode;
+        EXPECT_NEAR(created_max->as_vec3.x, expected_max.x, 0.001f) << test_case.mode;
+        EXPECT_NEAR(created_max->as_vec3.y, expected_max.y, 0.001f) << test_case.mode;
+        EXPECT_NEAR(created_max->as_vec3.z, expected_max.z, 0.001f) << test_case.mode;
+        EXPECT_EQ(export_source_prefab_for_name(brush_name), test_case.mode);
+    }
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditableLevelFragmentSourceBoxTranslateRejectsOverlapButAllowsContact)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15589,6 +15589,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
     ASSERT_GE(preview_signal, 0);
     ASSERT_GE(clear_selection_signal, 0);
+    const char *target_cube_left_face_stable_id = "editor.brush.target_cube.face.nx";
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.type", ""), "brush_world");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.world", ""),
@@ -15596,7 +15597,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.material", ""), "mat.editor.wall");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.face_stable_id", ""),
-                 "editor.face.target_cube.left");
+                 target_cube_left_face_stable_id);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.face_index", -1), 1);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.face_rendered", false));
     EXPECT_GE(slayer3d_properties_get_int(scene_state, "editor.selection.compiled_face_index", -1), 0);
@@ -15695,8 +15696,9 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
 
     press_key(SDL_SCANCODE_I, 4);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
-                 "inspect brush.target.cube face editor.face.target_cube.left");
+    const std::string expected_inspect_action =
+        std::string("inspect brush.target.cube face ").append(target_cube_left_face_stable_id);
+    EXPECT_EQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), expected_inspect_action);
 
     press_key(SDL_SCANCODE_C, 5);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
@@ -15843,7 +15845,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.element_stable_id", ""),
                  "editor.brush.target_cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.face_stable_id", ""),
-                 "editor.face.target_cube.left");
+                 target_cube_left_face_stable_id);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.message", ""),
                  "preview paint brush.target.cube");
 
@@ -15853,7 +15855,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.event", ""), "commit");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""), "committed paint #2");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.face_stable_id", ""),
-                 "editor.face.target_cube.left");
+                 target_cube_left_face_stable_id);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 2);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_EQ(target_cube_face_material(), "mat.editor.floor");
@@ -16658,17 +16660,18 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.leak.valid", true));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.leak.message", ""),
                  "player-start reachable space leaks to outside");
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
-                 "brush source model leaks to outside");
-    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.dojo");
-    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
+                 "test run player start applied");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "entered playable test run with leak warning");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoRejectsOverlappingWallPreviewWithSourceModel)
+TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -16760,15 +16763,10 @@ TEST(GameDataRuntime, EditorShellDojoRejectsOverlappingWallPreviewWithSourceMode
 
     slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
-    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""))
-                  .find("overlaps existing brush"),
-              std::string::npos);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
     slayer3d_signal_emit(bus, commit_signal, nullptr);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", true));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""),
-                 "box brush placement requires an active placement preview");
-    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_EQ(world().brush_count, initial_brush_count + 3);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -17366,7 +17364,102 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxesSplitMultipleCoveredFaceRe
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditableLevelFragmentSourceBoxResizeRejectsPositiveOverlap)
+TEST(GameDataRuntime, EditableLevelFragmentOverlappingSourceBoxesCompileWithoutDuplicateSurfaces)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "compile": { "hidden_face_culling": true },
+      "materials": [
+        { "name": "mat.editor.floor", "albedo": [0.25, 0.5, 0.75, 1.0] }
+      ],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 1.0,
+      "boxes": [
+        {
+          "stable_id": "source.box.left",
+          "name": "brush.source.left",
+          "kind": "box",
+          "prefab": "floor",
+          "material": "mat.editor.floor",
+          "min": [0, 0, 0],
+          "max": [8, 1, 8],
+          "contents": ["solid"]
+        },
+        {
+          "stable_id": "source.box.right",
+          "name": "brush.source.right",
+          "kind": "box",
+          "prefab": "floor",
+          "material": "mat.editor.floor",
+          "min": [4, 0, 0],
+          "max": [12, 1, 8],
+          "contents": ["solid"]
+        }
+      ]
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u, "/tmp/source-overlap-level.json",
+        error, sizeof(error)))
+        << error;
+
+    slayer3d_game_data_editor_brush_source_diagnostics diagnostics{};
+    ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
+                                                                      &diagnostics, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(diagnostics.structurally_valid) << diagnostics.first_issue;
+    EXPECT_EQ(diagnostics.positive_overlap_count, 1);
+    EXPECT_EQ(diagnostics.near_gap_count, 0);
+    EXPECT_NE(std::string(diagnostics.first_issue).find("overlap"), std::string::npos) << diagnostics.first_issue;
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    EXPECT_EQ(world.brush_count, 2);
+    EXPECT_EQ(world.compile_face_count, 12);
+    EXPECT_EQ(world.compile_culled_face_count, 2);
+    EXPECT_EQ(world.compile_rendered_face_count, 10);
+    EXPECT_EQ(world.compile_triangle_count, 20);
+    ASSERT_NE(world.compile_rendered_faces, nullptr);
+    ASSERT_EQ(world.compile_rendered_face_metadata_count, 10);
+
+    bool rendered_left_internal = false;
+    bool rendered_right_internal = false;
+    for (int i = 0; i < world.compile_rendered_face_metadata_count; ++i)
+    {
+        const slayer3d_game_data_brush_compiled_face &face = world.compile_rendered_faces[i];
+        const std::string face_id = face.source_face_stable_id != nullptr ? face.source_face_stable_id : "";
+        rendered_left_internal = rendered_left_internal || face_id == "source.box.left.face.px";
+        rendered_right_internal = rendered_right_internal || face_id == "source.box.right.face.nx";
+    }
+    EXPECT_FALSE(rendered_left_internal);
+    EXPECT_FALSE(rendered_right_internal);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditableLevelFragmentSourceBoxResizeAllowsPositiveOverlap)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -17438,25 +17531,24 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxResizeRejectsPositiveOverlap
     resize.brush_name = "brush.source.right";
     resize.face_index = 1;
     resize.distance = 1.0f;
-    EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize, error, sizeof(error)));
-    EXPECT_NE(std::string(error).find("overlaps existing brush"), std::string::npos) << error;
+    EXPECT_TRUE(slayer3d_game_data_resize_brush_face(runtime, &resize, error, sizeof(error))) << error;
 
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 2);
     ASSERT_TRUE(world.brushes[1].has_bounds);
-    EXPECT_NEAR(world.brushes[1].bounds.min.x, 8.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 7.0f, 0.001f);
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 16.0f, 0.001f);
-    EXPECT_EQ(world.compile_rendered_face_count, initial_rendered_faces);
+    EXPECT_LE(world.compile_rendered_face_count, initial_rendered_faces + 6);
 
     SDL_zeroa(error);
     resize.face_index = 1;
-    resize.distance = -8.0f;
+    resize.distance = -10.0f;
     EXPECT_FALSE(slayer3d_game_data_resize_brush_face(runtime, &resize, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("invalid geometry"), std::string::npos) << error;
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 2);
     ASSERT_TRUE(world.brushes[1].has_bounds);
-    EXPECT_NEAR(world.brushes[1].bounds.min.x, 8.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 7.0f, 0.001f);
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 16.0f, 0.001f);
 
     SDL_zeroa(error);
@@ -17466,14 +17558,14 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxResizeRejectsPositiveOverlap
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 2);
     ASSERT_TRUE(world.brushes[1].has_bounds);
-    EXPECT_NEAR(world.brushes[1].bounds.min.x, 8.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 7.0f, 0.001f);
     EXPECT_NEAR(world.brushes[1].bounds.max.x, 17.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateRejectsOverlapButAllowsContact)
+TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateAllowsOverlapAndContact)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -17528,13 +17620,13 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateRejectsOverlapButAllow
     box.material_name = "mat.editor.floor";
     box.min = slayer3d_vec3_make(7.0f, -0.2f, 0.0f);
     box.max = slayer3d_vec3_make(15.0f, 0.0f, 8.0f);
-    EXPECT_FALSE(slayer3d_game_data_create_box_brush(runtime, &box, nullptr, 0, error, sizeof(error)));
-    EXPECT_NE(std::string(error).find("overlaps existing brush"), std::string::npos) << error;
+    EXPECT_TRUE(slayer3d_game_data_create_box_brush(runtime, &box, nullptr, 0, error, sizeof(error))) << error;
 
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
-    ASSERT_EQ(world.brush_count, 1);
+    ASSERT_EQ(world.brush_count, 2);
     EXPECT_STREQ(world.brushes[0].name, "brush.source.left");
+    EXPECT_STREQ(world.brushes[1].name, "brush.source.overlap");
 
     SDL_zeroa(error);
     box.brush_name = "brush.source.right";
@@ -17542,8 +17634,8 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateRejectsOverlapButAllow
     box.max = slayer3d_vec3_make(16.0f, 0.0f, 8.0f);
     ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &box, nullptr, 0, error, sizeof(error))) << error;
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
-    ASSERT_EQ(world.brush_count, 2);
-    EXPECT_STREQ(world.brushes[1].name, "brush.source.right");
+    ASSERT_EQ(world.brush_count, 3);
+    EXPECT_STREQ(world.brushes[2].name, "brush.source.right");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -17611,13 +17703,12 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxPlacementPreviewUsesSourceVa
     hover.world_name = "brush.editor_shell.target";
     hover.material_name = "mat.editor.floor";
     update_editor_placement_preview(runtime, editor, &hover);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
-    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""))
-                  .find("source brush"),
-              std::string::npos);
-    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""))
-                  .find("overlaps existing brush 'brush.source.left'"),
-              std::string::npos);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    const slayer3d_value *overlap_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(overlap_min, nullptr);
+    ASSERT_EQ(overlap_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(overlap_min->as_vec3.x, 0.0f, 0.001f);
 
     hover.point = slayer3d_vec3_make(8.0f, 0.0f, 0.0f);
     update_editor_placement_preview(runtime, editor, &hover);
@@ -17883,7 +17974,7 @@ TEST(GameDataRuntime, EditorShellDojoCommitsPrefabPreviewSourceCandidate)
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditableLevelFragmentSourceBoxTranslateRejectsOverlapButAllowsContact)
+TEST(GameDataRuntime, EditableLevelFragmentSourceBoxTranslateAllowsOverlapAndContact)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -17951,18 +18042,18 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxTranslateRejectsOverlapButAl
     ASSERT_TRUE(world.brushes[1].has_bounds);
     EXPECT_NEAR(world.brushes[1].bounds.min.x, 16.0f, 0.001f);
 
-    EXPECT_FALSE(editor_brush_world_translate_source_box(world_runtime, "brush.source.right",
-                                                         slayer3d_vec3_make(-9.0f, 0.0f, 0.0f), error, sizeof(error)));
-    EXPECT_NE(std::string(error).find("overlaps existing brush"), std::string::npos) << error;
+    EXPECT_TRUE(editor_brush_world_translate_source_box(world_runtime, "brush.source.right",
+                                                        slayer3d_vec3_make(-9.0f, 0.0f, 0.0f), error, sizeof(error)))
+        << error;
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 2);
     ASSERT_TRUE(world.brushes[1].has_bounds);
-    EXPECT_NEAR(world.brushes[1].bounds.min.x, 16.0f, 0.001f);
-    EXPECT_NEAR(world.brushes[1].bounds.max.x, 24.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.min.x, 7.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[1].bounds.max.x, 15.0f, 0.001f);
 
     SDL_zeroa(error);
     ASSERT_TRUE(editor_brush_world_translate_source_box(world_runtime, "source.box.right",
-                                                        slayer3d_vec3_make(-8.0f, 0.0f, 0.0f), error, sizeof(error)))
+                                                        slayer3d_vec3_make(1.0f, 0.0f, 0.0f), error, sizeof(error)))
         << error;
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 2);
@@ -18413,7 +18504,7 @@ TEST(GameDataRuntime, EditableLevelFragmentReportsSourceModelDiagnostics)
     ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
                                                                       &diagnostics, error, sizeof(error)))
         << error;
-    EXPECT_FALSE(diagnostics.structurally_valid);
+    EXPECT_TRUE(diagnostics.structurally_valid) << diagnostics.first_issue;
     EXPECT_EQ(diagnostics.positive_overlap_count, 0);
     EXPECT_EQ(diagnostics.near_gap_count, 1);
     EXPECT_EQ(diagnostics.edge_contact_count, 0);
@@ -18446,7 +18537,7 @@ TEST(GameDataRuntime, EditableLevelFragmentReportsSourceModelDiagnostics)
     ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
                                                                       &diagnostics, error, sizeof(error)))
         << error;
-    EXPECT_FALSE(diagnostics.structurally_valid);
+    EXPECT_TRUE(diagnostics.structurally_valid) << diagnostics.first_issue;
     EXPECT_EQ(diagnostics.positive_overlap_count, 1);
     EXPECT_EQ(diagnostics.near_gap_count, 0);
     EXPECT_EQ(diagnostics.edge_contact_count, 0);
@@ -19064,24 +19155,23 @@ TEST(GameDataRuntime, EditorShellDojoBlocksPlayableTestRunOnInvalidSourceModel)
     slayer3d_signal_emit(bus, test_run_enter_signal, nullptr);
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.source.valid", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.source.valid", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.source.overlaps", -1), 0);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.source.near_gaps", 0), 1);
     EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.source.message", "")).find("near gap"),
               std::string::npos);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
-                 "brush source model has overlaps or near gaps");
+                 "test run player start applied");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
-                 "fix brush source errors before playable test run");
-    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.dojo");
-    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
+                 "entered playable test run with leak warning");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoBlocksPlayableTestRunOnLeakingSourceModel)
+TEST(GameDataRuntime, EditorShellDojoWarnsOnLeakingSourceModel)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19154,41 +19244,15 @@ TEST(GameDataRuntime, EditorShellDojoBlocksPlayableTestRunOnLeakingSourceModel)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.leak.candidate_select_message", ""),
                  "selected leak candidate");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
-    slayer3d_game_data_editor_selection leak_selection{};
-    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &leak_selection));
-    EXPECT_EQ(leak_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
-    EXPECT_STREQ(leak_selection.world_name, "brush.editor_shell.target");
-    EXPECT_STREQ(leak_selection.element_name, slayer3d_properties_get_string(scene_state, "editor.leak.candidate", ""));
-    EXPECT_EQ(leak_selection.face_index, 0);
-    ASSERT_NE(leak_selection.face_editor, nullptr);
-    const std::string expected_face_stable =
-        std::string(slayer3d_properties_get_string(scene_state, "editor.leak.candidate_stable", "")) + ".face.px";
-    EXPECT_STREQ(leak_selection.face_editor->stable_id, expected_face_stable.c_str());
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
-                 "brush source model leaks to outside");
-    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.dojo");
+                 "test run player start applied");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "entered playable test run with leak warning");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
     const slayer3d_value *leak_point = slayer3d_properties_get_value(scene_state, "editor.leak.point");
     ASSERT_NE(leak_point, nullptr);
     ASSERT_EQ(leak_point->type, SLAYER3D_VALUE_VEC3);
-
-    struct LeakMarkerCapture
-    {
-        int marker_lines = 0;
-        bool named = false;
-    } leak_debug;
-    auto capture_leak_marker = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
-        auto *capture = static_cast<LeakMarkerCapture *>(userdata);
-        if (primitive == nullptr || primitive->type != SLAYER3D_GAME_DATA_EDITOR_DEBUG_DIAGNOSTIC_MARKER)
-            return true;
-        capture->marker_lines++;
-        if (primitive->element_name != nullptr && std::string(primitive->element_name) == "editor.leak.point")
-            capture->named = true;
-        return true;
-    };
-    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_leak_marker, &leak_debug));
-    EXPECT_EQ(leak_debug.marker_lines, 10);
-    EXPECT_TRUE(leak_debug.named);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16739,7 +16739,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoTrimsPerpendicularWallEndpointPreview)
+TEST(GameDataRuntime, EditorShellDojoFitsPerpendicularWallEndpointPreviewWithSourceModel)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -16749,6 +16749,34 @@ TEST(GameDataRuntime, EditorShellDojoTrimsPerpendicularWallEndpointPreview)
     char error[512]{};
     slayer3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    const char empty_source_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [
+        { "name": "mat.editor.floor", "albedo": [0.30, 0.31, 0.33, 1.0] },
+        { "name": "mat.editor.wall", "albedo": [0.50, 0.52, 0.56, 1.0] },
+        { "name": "mat.editor.ceiling", "albedo": [0.68, 0.69, 0.71, 1.0] },
+        { "name": "mat.editor.sky", "albedo": [0.20, 0.42, 0.78, 1.0] }
+      ],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": []
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", empty_source_json, sizeof(empty_source_json) - 1u,
+        "/tmp/empty-source-level.json", error, sizeof(error)))
         << error;
 
     slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
@@ -17683,6 +17711,111 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxPlacementPreviewUsesSourceVa
     ASSERT_NE(placement_min, nullptr);
     ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
     EXPECT_NEAR(placement_min->as_vec3.x, 8.0f, 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditableLevelFragmentSourceBoxPrefabOperationsAllowGridCorrectBlockouts)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [
+        { "name": "mat.editor.floor", "albedo": [0.30, 0.31, 0.33, 1.0] },
+        { "name": "mat.editor.wall", "albedo": [0.50, 0.52, 0.56, 1.0] },
+        { "name": "mat.editor.ceiling", "albedo": [0.68, 0.69, 0.71, 1.0] },
+        { "name": "mat.editor.sky", "albedo": [0.20, 0.42, 0.78, 1.0] }
+      ],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": []
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u, "/tmp/source-grid-blockout.json",
+        error, sizeof(error)))
+        << error;
+
+    auto create_box = [&](const char *name, const char *material, unsigned int contents, slayer3d_vec3 min,
+                          slayer3d_vec3 max) {
+        slayer3d_game_data_create_box_brush_desc box{};
+        box.world_name = "brush.editor_shell.target";
+        box.brush_name = name;
+        box.material_name = material;
+        box.contents = contents;
+        box.min = min;
+        box.max = max;
+        SDL_zeroa(error);
+        ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &box, nullptr, 0, error, sizeof(error))) << error;
+    };
+
+    create_box("floor.0.0", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.0f, -0.2f, 0.0f), slayer3d_vec3_make(8.0f, 0.0f, 8.0f));
+    create_box("floor.1.0", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(8.0f, -0.2f, 0.0f), slayer3d_vec3_make(16.0f, 0.0f, 8.0f));
+    create_box("wall.between.floors", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(7.9f, 0.0f, 0.0f), slayer3d_vec3_make(8.1f, 8.0f, 8.0f));
+
+    create_box("pit.floor", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.0f, -8.2f, 8.0f), slayer3d_vec3_make(8.0f, -8.0f, 16.0f));
+    create_box("pit.wall.west", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(-0.2f, -8.0f, 8.0f), slayer3d_vec3_make(0.0f, 0.0f, 16.0f));
+    create_box("pit.wall.east", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(8.0f, -8.0f, 8.0f), slayer3d_vec3_make(8.2f, 0.0f, 16.0f));
+    create_box("pit.wall.south", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.0f, -8.0f, 16.0f), slayer3d_vec3_make(8.0f, 0.0f, 16.2f));
+    create_box("pit.wall.north", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.2f, -8.0f, 7.8f), slayer3d_vec3_make(7.8f, -0.2f, 8.0f));
+    create_box("lower.room.ceiling", "mat.editor.ceiling", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.0f, 0.0f, 8.0f), slayer3d_vec3_make(8.0f, 0.2f, 16.0f));
+    create_box("upper.wall.over.ceiling", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(0.0f, 0.2f, 16.0f), slayer3d_vec3_make(8.0f, 8.2f, 16.2f));
+
+    create_box("sky.window.seal", "mat.editor.sky",
+               SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+                   SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP,
+               slayer3d_vec3_make(16.0f, 0.0f, 0.0f), slayer3d_vec3_make(24.0f, 0.2f, 8.0f));
+
+    create_box("h.wall.left", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(24.0f, 0.0f, 0.0f), slayer3d_vec3_make(24.2f, 8.0f, 24.0f));
+    create_box("h.wall.right", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(32.0f, 0.0f, 0.0f), slayer3d_vec3_make(32.2f, 8.0f, 24.0f));
+    create_box("h.wall.crossbar", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID,
+               slayer3d_vec3_make(24.2f, 0.0f, 11.9f), slayer3d_vec3_make(32.0f, 8.0f, 12.1f));
+
+    slayer3d_game_data_editor_brush_source_diagnostics diagnostics{};
+    ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
+                                                                      &diagnostics, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(diagnostics.structurally_valid) << diagnostics.first_issue;
+    EXPECT_EQ(diagnostics.positive_overlap_count, 0);
+    EXPECT_EQ(diagnostics.near_gap_count, 0);
+    EXPECT_GT(diagnostics.face_contact_count, 0);
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 14);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16389,46 +16389,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_TRUE(source_box_name_exists(source_names, floor_brush_name + ".auto_fill.n8000_p0.north"));
     EXPECT_TRUE(source_box_name_exists(source_names, floor_brush_name + ".auto_fill.n8000_p0.south"));
 
-    slayer3d_signal_emit(bus, wall_signal, nullptr);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
-    placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
-    ASSERT_NE(placement_min, nullptr);
-    ASSERT_NE(placement_max, nullptr);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.elevation", 0.0f),
-                floor_bounds_below_plane.max.y, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.work_plane.distance", 0.0f),
-                floor_bounds_below_plane.max.y, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.y, floor_bounds_below_plane.max.y, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.1f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.y, floor_bounds_below_plane.max.y + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.1f, 0.001f);
-
-    slayer3d_signal_emit(bus, ceiling_signal, nullptr);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
-    placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
-    ASSERT_NE(placement_min, nullptr);
-    ASSERT_NE(placement_max, nullptr);
-    EXPECT_NEAR(placement_min->as_vec3.y, floor_bounds_below_plane.max.y + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.y, floor_bounds_below_plane.max.y + 8.2f, 0.001f);
-
-    slayer3d_signal_emit(bus, floor_signal, nullptr);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
-    placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
-    ASSERT_NE(placement_min, nullptr);
-    ASSERT_NE(placement_max, nullptr);
-    EXPECT_NEAR(placement_min->as_vec3.y, floor_bounds_below_plane.max.y - 0.2f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.y, floor_bounds_below_plane.max.y, 0.001f);
-
-    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
-    press_editor_key(SDL_SCANCODE_RIGHTBRACKET, 9);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
-                 "raised 1 selected brush");
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
     EXPECT_EQ(world().brush_count, brush_count_before_floor_lower);
     const slayer3d_bounding_box floor_bounds_restored = brush_bounds(floor_brush_name);
     EXPECT_NEAR(floor_bounds_restored.min.y, floor_bounds_before_lower.min.y, 0.001f);
@@ -16436,13 +16397,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     source_names = exported_source_box_names();
     EXPECT_EQ((int)source_names.size(), brush_count_before_floor_lower);
     EXPECT_FALSE(source_box_name_exists(source_names, floor_brush_name + ".auto_fill.n8000_p0.west"));
-    slayer3d_signal_emit(bus, undo_signal, nullptr);
+    slayer3d_signal_emit(bus, redo_signal, nullptr);
     EXPECT_EQ(world().brush_count, brush_count_before_floor_lower + 4);
     EXPECT_NEAR(brush_bounds(floor_brush_name).min.y, floor_bounds_before_lower.min.y - 8.0f, 0.001f);
     source_names = exported_source_box_names();
     EXPECT_EQ((int)source_names.size(), brush_count_before_floor_lower + 4);
     EXPECT_TRUE(source_box_name_exists(source_names, floor_brush_name + ".auto_fill.n8000_p0.west"));
-    slayer3d_signal_emit(bus, redo_signal, nullptr);
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
     EXPECT_EQ(world().brush_count, brush_count_before_floor_lower);
     EXPECT_NEAR(brush_bounds(floor_brush_name).min.y, floor_bounds_before_lower.min.y, 0.001f);
     source_names = exported_source_box_names();
@@ -16564,30 +16525,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
                                                                           &multi_selection_debug));
     EXPECT_EQ(multi_selection_debug.edges, 24);
 
-    const int brush_count_before_resize = world().brush_count;
-    press_editor_key(SDL_SCANCODE_RIGHTBRACKET, 16);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "resize");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.target", ""), "face");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
-                 "raised 2 selected brushes");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
-                 "raised 2 selected brushes");
-    EXPECT_EQ(world().brush_count, brush_count_before_resize);
-    const std::string resized_brush_name =
-        slayer3d_properties_get_string(scene_state, "editor.transaction.element", "");
-    ASSERT_FALSE(resized_brush_name.empty());
-    const slayer3d_bounding_box bounds_after_raise = brush_bounds(resized_brush_name);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), selected_brushes);
-
-    press_editor_key(SDL_SCANCODE_LEFTBRACKET, 18);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
-                 "lowered 2 selected brushes");
-    EXPECT_EQ(world().brush_count, brush_count_before_resize);
-    const slayer3d_bounding_box bounds_after_lower = brush_bounds(resized_brush_name);
-    EXPECT_NEAR(bounds_after_lower.min.y, bounds_after_raise.min.y, 0.001f);
-    EXPECT_NEAR(bounds_after_lower.max.y, bounds_after_raise.max.y - 8.0f, 0.001f);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), selected_brushes);
 
     slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
@@ -16715,31 +16652,23 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, test_run_enter_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.source.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.source.message", ""),
-                 "brush world has no editor brush source model");
+                 "editor source model is structurally valid");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.source.overlaps", -1), 0);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.source.near_gaps", -1), 0);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.leak.valid", false));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.leak.valid", true));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.leak.message", ""),
-                 "brush world has no editor brush source model");
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
+                 "player-start reachable space leaks to outside");
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", true));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
-                 "test run player start applied");
-    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
-    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.player");
-    EXPECT_TRUE(slayer3d_game_data_active_scene_has_entity(runtime, "entity.editor_shell.player"));
-    slayer3d_registered_actor *test_player = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.player");
-    ASSERT_NE(test_player, nullptr);
-    EXPECT_NEAR(test_player->position.x, player_start_origin.x, 0.001f);
-    EXPECT_NEAR(test_player->position.y, player_start_origin.y, 0.001f);
-    EXPECT_NEAR(test_player->position.z, player_start_origin.z, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "yaw", 0.0f), 3.14159f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(test_player->props, "pitch", 1.0f), 0.0f, 0.001f);
+                 "brush source model leaks to outside");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.dojo");
+    EXPECT_STREQ(slayer3d_game_data_active_camera(runtime), "camera.editor_shell.viewport");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoFitsPerpendicularWallEndpointPreviewWithSourceModel)
+TEST(GameDataRuntime, EditorShellDojoRejectsOverlappingWallPreviewWithSourceModel)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -16818,8 +16747,6 @@ TEST(GameDataRuntime, EditorShellDojoFitsPerpendicularWallEndpointPreviewWithSou
     ASSERT_NE(floor_max, nullptr);
     ASSERT_EQ(floor_min->type, SLAYER3D_VALUE_VEC3);
     ASSERT_EQ(floor_max->type, SLAYER3D_VALUE_VEC3);
-    const slayer3d_vec3 placement_origin =
-        slayer3d_vec3_make(floor_min->as_vec3.x, floor_max->as_vec3.y, floor_min->as_vec3.z);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
 
@@ -16833,26 +16760,15 @@ TEST(GameDataRuntime, EditorShellDojoFitsPerpendicularWallEndpointPreviewWithSou
 
     slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
-    const slayer3d_value *placement_min =
-        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
-    const slayer3d_value *placement_max =
-        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
-    ASSERT_NE(placement_min, nullptr);
-    ASSERT_NE(placement_max, nullptr);
-    ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
-    ASSERT_EQ(placement_max->type, SLAYER3D_VALUE_VEC3);
-    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x + 0.1f, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.1f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.y, placement_origin.y + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.1f, 0.001f);
-
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""))
+                  .find("overlaps existing brush"),
+              std::string::npos);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
-    EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""),
+                 "box brush placement requires an active placement preview");
+    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -817,8 +817,8 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
       ],
       "brushes": [
 )json" << BrushVisibilityBoxJson("brush.front_marker", "mat.front", -0.5f, 0.5f, 0.5f, 1.5f, -2.5f, -2.0f)
-              << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f)
-              << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f)
+              << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, -0.25f, 0.75f)
+              << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.25f, 2.25f)
               << R"json(
       ]
     }
@@ -917,8 +917,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     runtime = nullptr;
 
     std::ostringstream override_game_json;
-    override_game_json
-        << R"json({
+    override_game_json << R"json({
   "schema": "slayer3d.game.v0",
   "metadata": { "name": "Brush Visibility Override Test" },
   "world": { "name": "world.visibility", "kind": "brush" },
@@ -933,9 +932,13 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
       ],
       "brushes": [
 )json" << BrushVisibilityBoxJson("brush.front_marker", "mat.front", -0.5f, 0.5f, 0.5f, 1.5f, -2.5f, -2.0f)
-        << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f, "always")
-        << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f, "always")
-        << R"json(
+                       << ","
+                       << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, -0.25f, 0.75f,
+                                                 "always")
+                       << ","
+                       << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.25f, 2.25f,
+                                                 "always")
+                       << R"json(
       ]
     }
   ],
@@ -993,8 +996,8 @@ TEST_F(GLRendererTest, BrushVisibilityDrawsFullyVisibleCompileChunks)
       "brushes": [
 )json" << BrushVisibilityBoxJson("brush.front_a", "mat.front", 0.1f, 0.3f, 0.5f, 1.5f, -2.5f, -2.0f)
               << "," << BrushVisibilityBoxJson("brush.front_b", "mat.front", 0.4f, 0.6f, 0.5f, 1.5f, -2.5f, -2.0f)
-              << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, 0.0f, 3.0f)
-              << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.0f, 2.0f)
+              << "," << BrushVisibilityBoxJson("brush.blocker", "mat.blocker", -2.0f, 2.0f, 0.0f, 2.0f, -0.25f, 0.75f)
+              << "," << BrushVisibilityBoxJson("brush.hidden", "mat.hidden", -1.0f, 1.0f, 0.5f, 1.5f, 1.25f, 2.25f)
               << R"json(
       ]
     }


### PR DESCRIPTION
## Summary
- replaces runtime wall-overlap trimming in placement preview with source-box candidate fitting and validation
- normalizes adjusted wall previews back to source-grid bounds before create_box commits
- makes source brushes the editable truth: positive overlap is now a warning diagnostic, while invalid/off-snap source geometry remains blocking
- moves visible-surface correctness into brush compile output by culling hidden/internal and duplicate coincident faces from overlapping source boxes
- relaxes F5 leak checks to warning level for the current editor foundation pass while keeping leak markers/diagnostics visible
- documents source-backed prefab placement and adds blockout coverage for floors, walls, pits, ceilings, sky seals, overlap warnings, and H-style hallway contacts

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test
- cmake --build build/debug --target slayer3d_editor -j4

## Manual verification
Run:
```sh
./build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/slayer3d-test-level.fragment.json --overwrite
```
Then verify adjacent floors, walls between floor cells, lowered pits with surrounding walls, ceiling above a lower room, wall placement near ceilings without false overlap rejection, sky/window sealing, and an H-shaped hallway with adjacent parallel walls. Overlaps/leaks should warn in the inspector/debug overlay instead of blocking basic graybox iteration.
