### PR TITLE
Enforce source brush snap invariants

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1125,8 +1125,9 @@ by transient compiled-surface indexes.
 `min` and `max` coordinate must remain aligned to that source-unit increment.
 For example, with `meters_per_unit: 0.001` and `snap_units: 100`, source edits
 are constrained to a 0.1 meter structural grid. The editor can still use larger
-placement grids, but malformed off-grid source coordinates are reported as
-source-model defects and rejected by source-backed mutation tools.
+placement grids, but malformed off-grid source coordinates are invalid source
+data: validation, editable-fragment import, and source-backed mutation tools all
+reject them.
 
 For source-backed editor worlds, the runtime keeps `editor_brush_sources` as an
 in-memory source model. Successful editor mutations synchronize that source

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -636,6 +636,12 @@ bool load_editor_brush_source_boxes(brush_world_runtime *world_runtime, yyjson_v
             free_editor_brush_source_model(world_runtime);
             return false;
         }
+        if (!source_box_candidate_valid(world_runtime, &source_boxes[i], -1, error_buffer, error_buffer_size))
+        {
+            free_editor_brush_source_box(&source_boxes[i]);
+            free_editor_brush_source_model(world_runtime);
+            return false;
+        }
         world_runtime->editor_source_box_count++;
     }
     return true;

--- a/src/game_data_validation_editor_metadata.c
+++ b/src/game_data_validation_editor_metadata.c
@@ -378,6 +378,23 @@ static bool editor_brush_source_box_has_positive_extent(yyjson_val *min_value, y
     return true;
 }
 
+static bool editor_brush_source_box_aligned_to_snap(yyjson_val *min_value, yyjson_val *max_value, int snap_units)
+{
+    if (snap_units <= 1)
+        return true;
+    if (!is_exact_int_vec3_array(min_value) || !is_exact_int_vec3_array(max_value))
+        return false;
+    for (size_t i = 0; i < 3u; ++i)
+    {
+        if ((yyjson_get_sint(yyjson_arr_get(min_value, i)) % snap_units) != 0 ||
+            (yyjson_get_sint(yyjson_arr_get(max_value, i)) % snap_units) != 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool editor_brush_source_face_key_valid(const char *key)
 {
     static const char *const valid[] = {"px", "nx", "py", "ny", "pz", "nz"};
@@ -479,6 +496,8 @@ bool validate_editor_brush_sources(validation_context *ctx, yyjson_val *root, va
         yyjson_val *meters_per_unit = obj_get(source, "meters_per_unit");
         yyjson_val *snap_units = obj_get(source, "snap_units");
         yyjson_val *boxes = obj_get(source, "boxes");
+        const int source_snap_units =
+            snap_units != NULL && yyjson_is_int(snap_units) ? (int)yyjson_get_int(snap_units) : 1;
         const char *coordinate_system = json_string(source, "coordinate_system");
         const char *source_world = json_string(source, "world");
         name_table material_names;
@@ -523,11 +542,14 @@ bool validate_editor_brush_sources(validation_context *ctx, yyjson_val *root, va
             const char *explicit_name = json_string(box, "name");
             const char *name = explicit_name != NULL ? explicit_name : stable_id;
             yyjson_val *contents = obj_get(box, "contents");
+            yyjson_val *min_value = obj_get(box, "min");
+            yyjson_val *max_value = obj_get(box, "max");
             ok = require_unique_name(ctx, &box_ids, "editor brush source stable id", stable_id, box_path) &&
                  require_unique_name(ctx, &box_names, "editor brush source name", name, box_path) &&
                  (kind == NULL || SDL_strcmp(kind, "box") == 0) && (prefab == NULL || prefab[0] != '\0') &&
                  material != NULL && material[0] != '\0' && name_table_contains(&material_names, material) &&
-                 editor_brush_source_box_has_positive_extent(obj_get(box, "min"), obj_get(box, "max")) &&
+                 editor_brush_source_box_has_positive_extent(min_value, max_value) &&
+                 editor_brush_source_box_aligned_to_snap(min_value, max_value, source_snap_units) &&
                  validate_brush_string_or_string_array(ctx, contents, box_path, "editor brush source contents",
                                                        brush_content_name_valid, false) &&
                  validate_editor_brush_source_face_materials(ctx, obj_get(box, "face_materials"), box_path,
@@ -536,7 +558,8 @@ bool validate_editor_brush_sources(validation_context *ctx, yyjson_val *root, va
             {
                 ok = validation_error(ctx, box_path,
                                       "editor brush source box requires stable_id, kind 'box', material ref, integer "
-                                      "min/max vec3 with positive extent, valid contents, and valid face_materials");
+                                      "min/max vec3 with positive snap-aligned extent, valid contents, and valid "
+                                      "face_materials");
             }
         }
         name_table_destroy(&box_names);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -10057,6 +10057,55 @@ TEST(GameDataRuntime, RejectsInvalidEditorSelectionActions)
     EXPECT_FALSE(slayer3d_game_data_validate_file(
         (dir / "bad_editor_brush_source_snap_units.game.json").string().c_str(), nullptr, error, sizeof(error)));
     EXPECT_NE(std::string(error).find("positive snap_units"), std::string::npos) << error;
+
+    write_text(dir / "bad_editor_brush_source_off_snap.game.json",
+               R"json({
+  "schema": "slayer3d.game.v0",
+  "metadata": { "name": "Bad Editor Brush Source Off Snap" },
+  "world": { "name": "world.bad_editor_brush_source_off_snap", "kind": "fixed_screen" },
+  "brush_worlds": [
+    {
+      "name": "brush.bad_source_off_snap",
+      "materials": [{ "name": "mat.wall" }],
+      "brushes": [
+        {
+          "name": "brush.seed",
+          "faces": [
+            { "plane": { "normal": [ 1,  0,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [-1,  0,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  1,  0], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0, -1,  0], "distance":  0 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0,  1], "distance":  1 }, "material": "mat.wall" },
+            { "plane": { "normal": [ 0,  0, -1], "distance":  0 }, "material": "mat.wall" }
+          ]
+        }
+      ]
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.bad_source_off_snap",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "snap_units": 100,
+      "boxes": [
+        {
+          "stable_id": "box.off_snap",
+          "kind": "box",
+          "material": "mat.wall",
+          "min": [0, 0, 0],
+          "max": [1050, 1000, 1000],
+          "contents": ["solid"]
+        }
+      ]
+    }
+  ],
+  "scenes": { "initial": "scene.play", "files": ["scenes/play.scene.json"] }
+})json");
+    SDL_zeroa(error);
+    EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_editor_brush_source_off_snap.game.json").string().c_str(),
+                                                  nullptr, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("positive snap-aligned extent"), std::string::npos) << error;
     remove_test_dir(dir);
 }
 
@@ -18978,7 +19027,7 @@ TEST(GameDataRuntime, EditableLevelFragmentReportsSourceModelDiagnostics)
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditableLevelFragmentReportsSourceSnapDiagnostics)
+TEST(GameDataRuntime, EditableLevelFragmentRejectsOffSnapSourceCoordinates)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19031,24 +19080,14 @@ TEST(GameDataRuntime, EditableLevelFragmentReportsSourceSnapDiagnostics)
   ],
   "editor_player_starts": []
 })json";
-    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+    EXPECT_FALSE(slayer3d_game_data_load_editable_level_fragment_json(
         runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u,
-        "/tmp/source-snap-diagnostics.json", error, sizeof(error)))
-        << error;
+        "/tmp/source-snap-diagnostics.json", error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("not aligned to 100-unit source snap"), std::string::npos) << error;
 
-    slayer3d_game_data_editor_brush_source_diagnostics diagnostics{};
-    ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
-                                                                      &diagnostics, error, sizeof(error)))
-        << error;
-    EXPECT_TRUE(diagnostics.has_source_model);
-    EXPECT_FALSE(diagnostics.structurally_valid);
-    EXPECT_EQ(diagnostics.source_box_count, 2);
-    EXPECT_EQ(diagnostics.source_snap_units, 100);
-    EXPECT_EQ(diagnostics.off_snap_count, 1);
-    EXPECT_EQ(diagnostics.positive_overlap_count, 0);
-    EXPECT_EQ(diagnostics.near_gap_count, 0);
-    EXPECT_NE(std::string(diagnostics.first_issue).find("not aligned to 100-unit source snap"), std::string::npos)
-        << diagnostics.first_issue;
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    EXPECT_GT(world.brush_count, 0);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- reject off-snap editor brush source boxes during game-data validation
- reject off-snap editable level imports before replacing the current source model
- document source snap alignment as a hard source-data invariant

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test

## Manual verification
No new UI behavior is expected. Existing source-backed editor placement should feel unchanged for valid grid-aligned brushes. Malformed off-snap source fragments should now fail early with a clear diagnostic instead of loading as structurally invalid data.