### PR TITLE
Track editor source metadata in brush artifacts

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -753,14 +753,20 @@ cache invalidation. Tools can also call
 `slayer3d_game_data_export_brush_world_compile_artifact_json()` to write an
 inspection manifest using `schema: "slayer3d.brush_compile_artifact.v0"`. The
 manifest records a deterministic source hash for authored brush inputs, the
-compile policy, source brush totals, render mesh totals, visible source-face
-mappings, spatial chunk summaries, and visibility-grid metadata. Source totals
-separate renderable brushes from non-renderable structural brushes such as
-`sky`, so tools can verify that sky seals are present for leak detection without
-being emitted into the opaque world mesh. It is intentionally a descriptor
-rather than a binary cache payload: use the source hash, policy, and compile
-artifact hash together to inspect, compare, and invalidate compiled artifacts
-before adding cache storage/loading.
+compile policy, source brush totals, editor source-model metadata when present,
+render mesh totals, visible source-face mappings, spatial chunk summaries, and
+visibility-grid metadata. Source totals separate renderable brushes from
+non-renderable structural brushes such as `sky`, so tools can verify that sky
+seals are present for leak detection without being emitted into the opaque world
+mesh. For editor-authored worlds, the `source.editor_source_model` object records
+whether the runtime was compiled from source boxes, plus the source box count,
+snap units, and source units. Artifact verification treats mismatched
+source-model metadata as stale even when the source and compile hashes are
+otherwise present, which gives editors and offline compilers a direct guard
+against trusting runtime-only or stale compiled payloads. It is intentionally a
+descriptor rather than a binary cache payload: use the source hash, policy,
+source-model status, and compile artifact hash together to inspect, compare, and
+invalidate compiled artifacts before adding cache storage/loading.
 Native editor/offline compiler hosts can call
 `slayer3d_game_data_save_brush_world_compile_artifact_file()` to atomically save
 that manifest beside authored brush fragments, then use

--- a/include/slayer3d/game_data.h
+++ b/include/slayer3d/game_data.h
@@ -608,6 +608,8 @@ extern "C"
         bool source_hash_matches;
         /** @brief True when the manifest compile policy matches the current authored compile policy. */
         bool policy_matches;
+        /** @brief True when the manifest editor source-model metadata matches the current runtime world. */
+        bool source_model_matches;
         /** @brief True when the manifest compiled artifact hash matches the current runtime artifact. */
         bool compile_artifact_hash_matches;
         /** @brief True when all fields required for artifact reuse match. */
@@ -620,6 +622,14 @@ extern "C"
         Uint64 expected_compile_artifact_hash;
         /** @brief Compiled artifact hash stored in the manifest. */
         Uint64 artifact_compile_artifact_hash;
+        /** @brief True when the current runtime world was compiled from editor source boxes. */
+        bool expected_source_model_present;
+        /** @brief True when the manifest reports editor source boxes. */
+        bool artifact_source_model_present;
+        /** @brief Current runtime editor source box count, or 0 for runtime-only worlds. */
+        int expected_source_box_count;
+        /** @brief Editor source box count stored in the manifest, or 0 when absent. */
+        int artifact_source_box_count;
     } slayer3d_game_data_brush_compile_artifact_status;
 
     /** @brief Maximum bytes, including the NUL terminator, for brush compile artifact layout paths. */
@@ -2594,11 +2604,11 @@ extern "C"
      * The exported document uses `schema:
      * "slayer3d.brush_compile_artifact.v0"` and records a deterministic source
      * hash for authored brush inputs, the compile policy, the compiled-artifact
-     * hash, render mesh totals, spatial chunk metadata, and visibility-grid
-     * metadata. This is an inspection and cache-invalidation descriptor; it does
-     * not contain the binary mesh or collision payloads needed to load a compiled
-     * artifact directly. The returned string is allocated with SDL_malloc and
-     * must be released with SDL_free().
+     * hash, editor source-model metadata when present, render mesh totals,
+     * spatial chunk metadata, and visibility-grid metadata. This is an inspection
+     * and cache-invalidation descriptor; it does not contain the binary mesh or
+     * collision payloads needed to load a compiled artifact directly. The returned
+     * string is allocated with SDL_malloc and must be released with SDL_free().
      */
     bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_game_data_runtime *runtime,
                                                                      const char *world_name, char **out_json,
@@ -2612,8 +2622,10 @@ extern "C"
      * @ref slayer3d_game_data_export_brush_world_compile_artifact_json without
      * loading any binary cache payload. A return value of true means the manifest
      * was parsed and compared; inspect @p out_status->fresh to decide whether an
-     * offline artifact is reusable. Stale manifests are reported through
-     * @p out_status rather than treated as API errors.
+     * offline artifact is reusable. Source-backed editable worlds also compare
+     * editor source-model metadata so tooling can detect runtime-only or stale
+     * source-box manifests before trusting cached output. Stale manifests are
+     * reported through @p out_status rather than treated as API errors.
      */
     bool slayer3d_game_data_verify_brush_world_compile_artifact_json(
         const slayer3d_game_data_runtime *runtime, const char *world_name, const char *json, size_t json_size,

--- a/src/game_data_brush_artifacts.c
+++ b/src/game_data_brush_artifacts.c
@@ -62,9 +62,25 @@ static bool artifact_brush_is_renderable(const slayer3d_game_data_brush *brush)
                                SLAYER3D_GAME_DATA_BRUSH_CONTENT_LAVA)) != 0u;
 }
 
-static bool artifact_export_add_source_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
-                                               const slayer3d_game_data_brush_world *world)
+static bool artifact_export_add_editor_source_model(yyjson_mut_doc *doc, yyjson_mut_val *source,
+                                                    const brush_world_runtime *world_runtime)
 {
+    const bool has_source_model = world_runtime != NULL && world_runtime->editor_has_source_model;
+    yyjson_mut_val *source_model = yyjson_mut_obj(doc);
+    return source_model != NULL && yyjson_mut_obj_add_val(doc, source, "editor_source_model", source_model) &&
+           yyjson_mut_obj_add_bool(doc, source_model, "present", has_source_model) &&
+           yyjson_mut_obj_add_int(doc, source_model, "box_count",
+                                  has_source_model ? world_runtime->editor_source_box_count : 0) &&
+           yyjson_mut_obj_add_int(doc, source_model, "snap_units",
+                                  has_source_model ? world_runtime->editor_source_snap_units : 0) &&
+           yyjson_mut_obj_add_real(doc, source_model, "meters_per_unit",
+                                   has_source_model ? world_runtime->editor_source_meters_per_unit : 0.0f);
+}
+
+static bool artifact_export_add_source_summary(yyjson_mut_doc *doc, yyjson_mut_val *root,
+                                               const brush_world_runtime *world_runtime)
+{
+    const slayer3d_game_data_brush_world *world = &world_runtime->desc;
     yyjson_mut_val *source = yyjson_mut_obj(doc);
     const char *units = world->units != NULL ? world->units : "meters";
     int solid_brush_count = 0;
@@ -90,6 +106,7 @@ static bool artifact_export_add_source_summary(yyjson_mut_doc *doc, yyjson_mut_v
            yyjson_mut_obj_add_int(doc, source, "sky_brush_count", sky_brush_count) &&
            yyjson_mut_obj_add_int(doc, source, "renderable_brush_count", renderable_brush_count) &&
            yyjson_mut_obj_add_int(doc, source, "nonrenderable_brush_count", nonrenderable_brush_count) &&
+           artifact_export_add_editor_source_model(doc, source, world_runtime) &&
            yyjson_mut_obj_add_bool(doc, source, "has_bounds", world->has_bounds) &&
            (!world->has_bounds || artifact_export_add_bounds(doc, source, "bounds", world->bounds));
 }
@@ -393,7 +410,7 @@ bool slayer3d_game_data_export_brush_world_compile_artifact_json(const slayer3d_
               yyjson_mut_obj_add_uint(doc, root, "source_hash", source_hash) &&
               yyjson_mut_obj_add_uint(doc, root, "compile_artifact_hash", world->compile_artifact_hash) &&
               artifact_export_add_compile_policy(doc, root, world) &&
-              artifact_export_add_source_summary(doc, root, world) &&
+              artifact_export_add_source_summary(doc, root, world_runtime) &&
               artifact_export_add_render_summary(doc, root, world) && artifact_export_add_chunks(doc, root, world) &&
               artifact_export_add_visibility_grid(doc, root, &world_runtime->artifacts);
     size_t size = 0u;
@@ -424,6 +441,33 @@ static bool artifact_json_real_matches(yyjson_val *obj, const char *key, float e
 {
     yyjson_val *value = yyjson_obj_get(obj, key);
     return yyjson_is_num(value) && SDL_fabsf((float)yyjson_get_num(value) - expected) <= 0.0001f;
+}
+
+static bool artifact_json_editor_source_model_matches(const brush_world_runtime *world_runtime, yyjson_val *root,
+                                                      slayer3d_game_data_brush_compile_artifact_status *status)
+{
+    const bool expected_present = world_runtime != NULL && world_runtime->editor_has_source_model;
+    const int expected_count = expected_present ? world_runtime->editor_source_box_count : 0;
+    const int expected_snap_units = expected_present ? world_runtime->editor_source_snap_units : 0;
+    const float expected_meters_per_unit = expected_present ? world_runtime->editor_source_meters_per_unit : 0.0f;
+    status->expected_source_model_present = expected_present;
+    status->expected_source_box_count = expected_count;
+
+    yyjson_val *source = yyjson_obj_get(root, "source");
+    yyjson_val *source_model = yyjson_is_obj(source) ? yyjson_obj_get(source, "editor_source_model") : NULL;
+    if (!yyjson_is_obj(source_model))
+        return false;
+
+    yyjson_val *present_value = yyjson_obj_get(source_model, "present");
+    yyjson_val *box_count_value = yyjson_obj_get(source_model, "box_count");
+    yyjson_val *snap_units_value = yyjson_obj_get(source_model, "snap_units");
+    status->artifact_source_model_present = yyjson_is_bool(present_value) && yyjson_get_bool(present_value);
+    status->artifact_source_box_count = yyjson_is_int(box_count_value) ? (int)yyjson_get_int(box_count_value) : 0;
+
+    return yyjson_is_bool(present_value) && status->artifact_source_model_present == expected_present &&
+           yyjson_is_int(box_count_value) && status->artifact_source_box_count == expected_count &&
+           yyjson_is_int(snap_units_value) && (int)yyjson_get_int(snap_units_value) == expected_snap_units &&
+           artifact_json_real_matches(source_model, "meters_per_unit", expected_meters_per_unit);
 }
 
 bool slayer3d_game_data_verify_brush_world_compile_artifact_json(
@@ -477,9 +521,11 @@ bool slayer3d_game_data_verify_brush_world_compile_artifact_json(
         artifact_json_real_matches(policy, "chunk_cell_size_hint", world->compile_chunk_cell_size_hint) &&
         artifact_json_real_matches(policy, "chunk_cell_size", world->compile_chunk_cell_size) &&
         artifact_json_real_matches(policy, "visibility_cell_size", world->visibility_cell_size);
+    out_status->source_model_matches = artifact_json_editor_source_model_matches(world_runtime, root, out_status);
 
     out_status->fresh = out_status->schema_matches && out_status->world_matches && out_status->source_hash_matches &&
-                        out_status->policy_matches && out_status->compile_artifact_hash_matches;
+                        out_status->policy_matches && out_status->source_model_matches &&
+                        out_status->compile_artifact_hash_matches;
     yyjson_doc_free(doc);
     return true;
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14687,6 +14687,12 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_EQ(yyjson_get_int(yyjson_obj_get(source, "sky_brush_count")), 0);
     EXPECT_EQ(yyjson_get_int(yyjson_obj_get(source, "renderable_brush_count")), 2);
     EXPECT_EQ(yyjson_get_int(yyjson_obj_get(source, "nonrenderable_brush_count")), 0);
+    yyjson_val *editor_source_model = yyjson_obj_get(source, "editor_source_model");
+    ASSERT_TRUE(yyjson_is_obj(editor_source_model));
+    EXPECT_FALSE(yyjson_get_bool(yyjson_obj_get(editor_source_model, "present")));
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(editor_source_model, "box_count")), 0);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(editor_source_model, "snap_units")), 0);
+    EXPECT_DOUBLE_EQ(yyjson_get_real(yyjson_obj_get(editor_source_model, "meters_per_unit")), 0.0);
     yyjson_val *render = yyjson_obj_get(artifact_root, "render");
     ASSERT_NE(render, nullptr);
     EXPECT_EQ(yyjson_get_int(yyjson_obj_get(render, "face_count")), culled_world_a.compile_face_count);
@@ -14761,12 +14767,17 @@ TEST(GameDataRuntime, BrushCompileOptionsProduceDeterministicArtifacts)
     EXPECT_TRUE(artifact_status.world_matches);
     EXPECT_TRUE(artifact_status.source_hash_matches);
     EXPECT_TRUE(artifact_status.policy_matches);
+    EXPECT_TRUE(artifact_status.source_model_matches);
     EXPECT_TRUE(artifact_status.compile_artifact_hash_matches);
     EXPECT_TRUE(artifact_status.fresh);
     EXPECT_EQ(artifact_status.expected_source_hash, source_hash);
     EXPECT_EQ(artifact_status.artifact_source_hash, source_hash);
     EXPECT_EQ(artifact_status.expected_compile_artifact_hash, culled_world_a.compile_artifact_hash);
     EXPECT_EQ(artifact_status.artifact_compile_artifact_hash, culled_world_a.compile_artifact_hash);
+    EXPECT_FALSE(artifact_status.expected_source_model_present);
+    EXPECT_FALSE(artifact_status.artifact_source_model_present);
+    EXPECT_EQ(artifact_status.expected_source_box_count, 0);
+    EXPECT_EQ(artifact_status.artifact_source_box_count, 0);
     yyjson_doc_free(artifact_doc);
     SDL_free(artifact_json);
 
@@ -17191,6 +17202,64 @@ TEST(GameDataRuntime, EditableLevelFragmentCompilesRuntimeBrushesFromSourceBoxes
     EXPECT_NEAR(resolved_normal.x, 0.0f, 0.001f);
     EXPECT_NEAR(resolved_normal.y, -1.0f, 0.001f);
     EXPECT_NEAR(resolved_normal.z, 0.0f, 0.001f);
+
+    char *artifact_json = nullptr;
+    size_t artifact_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_export_brush_world_compile_artifact_json(
+        runtime, "brush.editor_shell.target", &artifact_json, &artifact_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(artifact_json, nullptr);
+    yyjson_doc *artifact_doc = yyjson_read(artifact_json, artifact_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(artifact_doc, nullptr);
+    yyjson_val *artifact_root = yyjson_doc_get_root(artifact_doc);
+    ASSERT_NE(artifact_root, nullptr);
+    yyjson_val *source = yyjson_obj_get(artifact_root, "source");
+    ASSERT_TRUE(yyjson_is_obj(source));
+    yyjson_val *editor_source_model = yyjson_obj_get(source, "editor_source_model");
+    ASSERT_TRUE(yyjson_is_obj(editor_source_model));
+    EXPECT_TRUE(yyjson_get_bool(yyjson_obj_get(editor_source_model, "present")));
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(editor_source_model, "box_count")), 1);
+    EXPECT_EQ(yyjson_get_int(yyjson_obj_get(editor_source_model, "snap_units")), 1);
+    EXPECT_NEAR(yyjson_get_real(yyjson_obj_get(editor_source_model, "meters_per_unit")), 0.001, 0.000001);
+    yyjson_doc_free(artifact_doc);
+
+    slayer3d_game_data_brush_compile_artifact_status artifact_status{};
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        runtime, "brush.editor_shell.target", artifact_json, artifact_size, &artifact_status, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.schema_matches);
+    EXPECT_TRUE(artifact_status.world_matches);
+    EXPECT_TRUE(artifact_status.source_hash_matches);
+    EXPECT_TRUE(artifact_status.policy_matches);
+    EXPECT_TRUE(artifact_status.source_model_matches);
+    EXPECT_TRUE(artifact_status.compile_artifact_hash_matches);
+    EXPECT_TRUE(artifact_status.fresh);
+    EXPECT_TRUE(artifact_status.expected_source_model_present);
+    EXPECT_TRUE(artifact_status.artifact_source_model_present);
+    EXPECT_EQ(artifact_status.expected_source_box_count, 1);
+    EXPECT_EQ(artifact_status.artifact_source_box_count, 1);
+
+    std::string tampered_artifact(artifact_json, artifact_size);
+    SDL_free(artifact_json);
+    const std::string source_box_count_field = "\"box_count\": 1";
+    const size_t source_box_count_pos = tampered_artifact.find(source_box_count_field);
+    ASSERT_NE(source_box_count_pos, std::string::npos);
+    tampered_artifact.replace(source_box_count_pos, source_box_count_field.size(), "\"box_count\": 2");
+    ASSERT_TRUE(slayer3d_game_data_verify_brush_world_compile_artifact_json(
+        runtime, "brush.editor_shell.target", tampered_artifact.c_str(), tampered_artifact.size(), &artifact_status,
+        error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(artifact_status.schema_matches);
+    EXPECT_TRUE(artifact_status.world_matches);
+    EXPECT_TRUE(artifact_status.source_hash_matches);
+    EXPECT_TRUE(artifact_status.policy_matches);
+    EXPECT_FALSE(artifact_status.source_model_matches);
+    EXPECT_TRUE(artifact_status.compile_artifact_hash_matches);
+    EXPECT_FALSE(artifact_status.fresh);
+    EXPECT_TRUE(artifact_status.expected_source_model_present);
+    EXPECT_TRUE(artifact_status.artifact_source_model_present);
+    EXPECT_EQ(artifact_status.expected_source_box_count, 1);
+    EXPECT_EQ(artifact_status.artifact_source_box_count, 2);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- record editor source-model metadata in brush compile artifact manifests
- include source-model comparison fields in artifact verification status and freshness checks
- document the source-model cache guard and cover runtime-only/source-backed artifact cases in tests

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.BrushCompileOptionsProduceDeterministicArtifacts:GameDataRuntime.EditableLevelFragmentCompilesRuntimeBrushesFromSourceBoxes'
- ./build/debug/tests/slayer3d_game_data_test
- git diff --check