### PR TITLE
Editor grid size widget

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -193,6 +193,10 @@
             "bindings": [{ "device": "mouse", "button": "RIGHT" }]
           },
           {
+            "name": "action.editor.camera.pan",
+            "bindings": [{ "device": "mouse", "button": "MIDDLE" }]
+          },
+          {
             "name": "action.editor.camera.fast",
             "bindings": [{ "device": "keyboard", "key": "LSHIFT" }]
           },
@@ -1830,6 +1834,8 @@
             "zoom_in": "action.editor.ortho.zoom.in",
             "zoom_out": "action.editor.ortho.zoom.out",
             "zoom_wheel": "action.editor.ortho.zoom.wheel",
+            "look": "action.editor.camera.look",
+            "mouse_pan": "action.editor.camera.pan",
             "fast": "action.editor.camera.fast"
           },
           "mode_key": "editor.view.mode",
@@ -1846,6 +1852,8 @@
           "orthographic_wheel_zoom_step": 0.12,
           "orthographic_min_size": 4.0,
           "orthographic_max_size": 256.0,
+          "mouse_pan_sensitivity": 0.012,
+          "perspective_wheel_zoom_step": 1.25,
           "mouse_sensitivity": 0.002,
           "pitch_min": -1.45,
           "pitch_max": 1.45

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -510,14 +510,14 @@
             "key": "editor.grid.size",
             "default": 8.0,
             "direction": -1,
-            "values": [2.0, 4.0, 8.0, 16.0]
+            "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           {
             "type": "scene_state.cycle",
             "key": "editor.brush.grid_size",
             "default": 8.0,
             "direction": -1,
-            "values": [2.0, 4.0, 8.0, 16.0]
+            "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "grid size decreased" }
         ]
@@ -530,14 +530,14 @@
             "key": "editor.grid.size",
             "default": 8.0,
             "direction": 1,
-            "values": [2.0, 4.0, 8.0, 16.0]
+            "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           {
             "type": "scene_state.cycle",
             "key": "editor.brush.grid_size",
             "default": 8.0,
             "direction": 1,
-            "values": [2.0, 4.0, 8.0, 16.0]
+            "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "grid size increased" }
         ]

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -6,8 +6,6 @@
   "renders_world": true,
   "on_enter_signal": "signal.editor.scene.enter",
   "input": {
-    "mouse_capture": "unpaused",
-    "mouse_capture_if": { "type": "scene_state.compare", "key": "editor.view.mode", "op": "==", "value": "flyby_3d" },
     "actions": [
       "action.exit",
       "action.editor.tool.cycle",
@@ -47,6 +45,7 @@
       "action.editor.camera.up",
       "action.editor.camera.down",
       "action.editor.camera.look",
+      "action.editor.camera.pan",
       "action.editor.camera.fast"
     ]
   },
@@ -1480,7 +1479,7 @@
       },
       {
         "name": "ui.editor_shell.help",
-        "text": "3D editor: WASD move, mouse look, Q/E down/up. Modes: Space select, B brush, M texture, G objects. Brush: +/- grid, Enter commit. Select: Shift-click multi, [ and ] height, Delete/Backspace remove.",
+        "text": "3D editor: WASD move, RMB drag look, MMB drag pan, wheel zoom, Q/E down/up. Modes: Space select, B brush, M texture, G objects. Brush: +/- grid, Enter commit. Select: Shift-click multi, [ and ] height, Delete/Backspace remove.",
         "font": "font.editor_shell.ui",
         "x": 0.98,
         "y": 0.17,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -66,7 +66,6 @@
     "selection": {
       "mode": "click",
       "select_button": "LEFT",
-      "secondary_select_button": "RIGHT",
       "clear_on_miss": true,
       "trace": {
         "source": "camera_screen",
@@ -125,8 +124,7 @@
         "face_rendered_key": "editor.hover.face_rendered",
         "compiled_face_index_key": "editor.hover.compiled_face_index"
       },
-      "on_select": "signal.editor.pointer.primary",
-      "on_secondary_select": "signal.editor.delete_selected"
+      "on_select": "signal.editor.pointer.primary"
     },
     "placement": {
       "tool_key": "editor.tool.mode",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -507,6 +507,16 @@
         "border_thickness": 1
       },
       {
+        "name": "ui.editor_shell.tool_toolbar.grid.button",
+        "x": 735,
+        "y": 45,
+        "w": 110,
+        "h": 28,
+        "color": [24, 34, 48, 245],
+        "border_color": [120, 165, 205, 235],
+        "border_thickness": 1
+      },
+      {
         "name": "ui.editor_shell.left_inspector.panel",
         "x": 12,
         "y": 92,
@@ -1064,6 +1074,17 @@
         "y": 54,
         "align": "center",
         "color": [220, 236, 255, 245],
+        "scale": 0.54
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.label",
+        "format": "Grid %.3g",
+        "bindings": [{ "type": "scene_state", "key": "editor.grid.size", "default": 8.0 }],
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 54,
+        "align": "center",
+        "color": [230, 245, 255, 250],
         "scale": 0.54
       },
       {

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -269,9 +269,6 @@
         "player_starts",
         "selection_bounds",
         "selection_face",
-        "trace_ray",
-        "face_normal",
-        "hit_marker",
         "command_preview",
         "markers"
       ],

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -74,7 +74,6 @@
           {
             "camera": "camera.editor_shell.viewport",
             "rect": [0, 80, 1280, 520],
-            "screen": "center",
             "work_plane": {
               "enabled": true,
               "normal": [0.0, 1.0, 0.0],

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -66,10 +66,10 @@ SDL logging. The Issues tab is a placeholder for map findings such as leaks and
 validation warnings.
 
 The old number-key and `Tab` view switching shortcuts are intentionally
-unbound. The editor viewport uses relative mouse motion for mouse-look. Brush
-feedback is reticle-driven: the highlighted brush, hit marker, and placement
-preview should remain pinned to the screen center instead of following the last
-clicked selection.
+unbound. The editor viewport keeps the hardware cursor free for toolbar and
+panel interaction. Brush feedback is cursor-driven: the highlighted brush and
+placement preview should follow the OS cursor without drawing a second virtual
+hit cursor.
 
 ## Keybindings
 
@@ -193,17 +193,16 @@ The following should be true during a good test drive:
 - `M` opens the placeholder Material palette. `G` opens the Game Objects
   palette, and `Enter` selects Player Start for placement.
 - Placed player starts render as bright green cylinder markers in the editor
-  canvas, can be highlighted by hovering, and can be removed with right click.
+  canvas, can be highlighted by hovering, and can be removed after selection
+  with `Delete` or `Backspace`.
 - The top menu toolbar and second tool toolbar are visible above every view
   mode, and the editor viewport starts below them instead of rendering
   underneath the toolbar chrome.
 - The editor viewport displays a small label identifying the active 3D
   perspective view.
-- Brush picking and placement trace from the screen center. The highlighted
-  brush should be the brush under the crosshair; if no brush is hit, placement
-  falls back to the ground work plane. After clicking one brush, look away and
-  confirm the selection cursor follows the reticle rather than staying offset
-  on the previous brush.
+- Brush picking and placement trace from the hardware cursor. The highlighted
+  brush should be the brush under the cursor; if no brush is hit, placement
+  falls back to the ground work plane.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds`, `editor_brush_sources`, and
   `editor_player_starts`, then writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -51,7 +51,9 @@ menus such as File > Save without changing the viewport layout.
 A second placeholder tool toolbar sits directly underneath it with the first
 editor tool buttons: Select, Brush Tool, Clip Tool, Face Tool, Vertex Tool,
 Entity Tool, and Texture Tool. These are also visual placeholders; keyboard
-shortcuts still drive the active tools in this slice.
+shortcuts still drive the active tools in this slice. The same toolbar also
+shows the current grid size so placement and future transform operations have
+an obvious snap reference.
 
 The left Inspector panel is visible by default. It currently contains
 placeholder Map, Entity, and Face tabs so the editor has a stable destination
@@ -92,7 +94,7 @@ shortcuts do not shadow camera movement.
 | `Delete` / `Backspace` | Select Mode | delete all selected brushes |
 | `Delete` / `Backspace` | other editor modes | delete the active highlighted tile or game object |
 | `Enter` | palette closed | commit the current preview placement |
-| `+` / `-` | palette closed | increase or decrease grid size |
+| `+` / `-` | palette closed | increase or decrease grid size through the fixed ladder: 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256 |
 | `R` | palette closed | toggle wall axis for manual wall placement |
 | `C` | palette closed | cycle tools for debug/testing |
 | `WASD` | 3D flyby | move camera |
@@ -146,7 +148,7 @@ shortcuts do not shadow camera movement.
 The following should be true during a good test drive:
 
 - Placement previews snap to the active grid size and resize when `+` / `-` is
-  pressed.
+  pressed. The second toolbar's Grid widget should update to the same value.
 - The old left-side debug dump is no longer visible. The new left Inspector
   panel is visible with Map, Entity, and Face placeholder tabs, and `I`
   collapses it to a small strip.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -68,8 +68,8 @@ validation warnings.
 The old number-key and `Tab` view switching shortcuts are intentionally
 unbound. The editor viewport keeps the hardware cursor free for toolbar and
 panel interaction. Brush feedback is cursor-driven: the highlighted brush and
-placement preview should follow the OS cursor without drawing a second virtual
-hit cursor.
+flashing placement preview should follow the OS cursor without drawing a second
+virtual hit cursor.
 
 ## Keybindings
 
@@ -202,7 +202,8 @@ The following should be true during a good test drive:
   perspective view.
 - Brush picking and placement trace from the hardware cursor. The highlighted
   brush should be the brush under the cursor; if no brush is hit, placement
-  falls back to the ground work plane.
+  falls back to the ground work plane. In brush mode, the flashing preview
+  bounds should move as the cursor moves.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds`, `editor_brush_sources`, and
   `editor_player_starts`, then writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -98,7 +98,9 @@ shortcuts do not shadow camera movement.
 | `R` | palette closed | toggle wall axis for manual wall placement |
 | `C` | palette closed | cycle tools for debug/testing |
 | `WASD` | 3D flyby | move camera |
-| mouse look | 3D flyby | rotate camera |
+| right mouse drag | 3D flyby | rotate camera without capturing the hardware cursor |
+| middle mouse drag | 3D flyby | pan camera left/right/up/down |
+| mouse wheel | 3D flyby | dolly camera forward/back |
 | `Q` / `E` | 3D flyby | move camera down/up |
 | `Left Shift` | 3D flyby | move faster |
 | `Ctrl+S` / `Command+S` | palette closed | export editable level JSON in memory and save it to the CLI output path |

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -399,6 +399,49 @@ static void source_box_candidate_collect_warnings(const brush_world_runtime *wor
     }
 }
 
+static bool source_optional_string_equal(const char *a, const char *b)
+{
+    const bool a_empty = a == NULL || a[0] == '\0';
+    const bool b_empty = b == NULL || b[0] == '\0';
+    if (a_empty || b_empty)
+        return a_empty && b_empty;
+    return SDL_strcmp(a, b) == 0;
+}
+
+static bool source_box_matches_prefab_cell(const editor_brush_source_box_runtime *a,
+                                           const editor_brush_source_box_runtime *b)
+{
+    if (a == NULL || b == NULL || a->contents != b->contents || !source_optional_string_equal(a->prefab, b->prefab) ||
+        !source_optional_string_equal(a->material, b->material))
+    {
+        return false;
+    }
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        if (a->min[axis] != b->min[axis] || a->max[axis] != b->max[axis])
+            return false;
+    }
+    for (size_t i = 0; i < SDL_arraysize(a->face_materials); ++i)
+    {
+        if (!source_optional_string_equal(a->face_materials[i], b->face_materials[i]))
+            return false;
+    }
+    return true;
+}
+
+static int find_matching_source_prefab_cell(const brush_world_runtime *world_runtime,
+                                            const editor_brush_source_box_runtime *candidate)
+{
+    if (world_runtime == NULL || candidate == NULL)
+        return -1;
+    for (int i = 0; i < world_runtime->editor_source_box_count; ++i)
+    {
+        if (source_box_matches_prefab_cell(candidate, &world_runtime->editor_source_boxes[i]))
+            return i;
+    }
+    return -1;
+}
+
 static bool source_box_candidate_valid(const brush_world_runtime *world_runtime,
                                        const editor_brush_source_box_runtime *candidate, int exclude_index,
                                        char *error_buffer, int error_buffer_size)
@@ -1852,7 +1895,30 @@ bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_run
     bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
                                                                error_buffer_size);
     if (ok && out_result != NULL)
+    {
+        const int existing_index = find_matching_source_prefab_cell(world_runtime, &source_box);
+        if (existing_index >= 0)
+        {
+            const editor_brush_source_box_runtime *existing = &world_runtime->editor_source_boxes[existing_index];
+            out_result->valid = true;
+            out_result->no_op = true;
+            SDL_strlcpy(out_result->brush_name,
+                        existing->name != NULL && existing->name[0] != '\0' ? existing->name : name,
+                        sizeof(out_result->brush_name));
+            out_result->bounds = editor_brush_source_box_bounds_meters(world_runtime, existing);
+            for (int axis = 0; axis < 3; ++axis)
+            {
+                out_result->source_min[axis] = existing->min[axis];
+                out_result->source_max[axis] = existing->max[axis];
+            }
+            SDL_snprintf(out_result->warning, sizeof(out_result->warning),
+                         "source brush '%s' already occupies this prefab cell",
+                         out_result->brush_name[0] != '\0' ? out_result->brush_name : "<unnamed>");
+            free_editor_brush_source_box(&source_box);
+            return true;
+        }
         source_box_candidate_collect_warnings(world_runtime, &source_box, -1, out_result);
+    }
     if (ok && apply)
     {
         ok = editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -499,6 +499,34 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
     const float pitch_max = json_float(component, "pitch_max", 1.4f);
     pitch = editor_camera_clampf(pitch, SDL_min(pitch_min, pitch_max), SDL_max(pitch_min, pitch_max));
 
+    const float cos_pitch = SDL_cosf(pitch);
+    const slayer3d_vec3 camera_forward =
+        slayer3d_vec3_make(SDL_sinf(yaw) * cos_pitch, SDL_sinf(pitch), -SDL_cosf(yaw) * cos_pitch);
+    const slayer3d_vec3 camera_right = slayer3d_vec3_make(SDL_cosf(yaw), 0.0f, SDL_sinf(yaw));
+    const slayer3d_vec3 camera_up = slayer3d_vec3_normalize(slayer3d_vec3_cross(camera_right, camera_forward));
+
+    const int mouse_pan_action = fps_controller_action_id(runtime, component, "mouse_pan");
+    if (input != NULL && mouse_pan_action >= 0 && fps_controller_action_value(runtime, input, mouse_pan_action) > 0.0f)
+    {
+        const float pan_sensitivity = json_float(component, "mouse_pan_sensitivity", 0.012f);
+        const slayer3d_vec3 pan_delta =
+            slayer3d_vec3_scale(slayer3d_vec3_sub(slayer3d_vec3_scale(camera_right, slayer3d_input_get_mouse_dx(input)),
+                                                  slayer3d_vec3_scale(camera_up, slayer3d_input_get_mouse_dy(input))),
+                                pan_sensitivity);
+        if (slayer3d_vec3_length_squared(pan_delta) > 0.0000001f)
+            actor_set_position(actor, slayer3d_vec3_add(actor->position, pan_delta));
+    }
+
+    const float wheel_zoom =
+        fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "zoom_wheel"));
+    if (SDL_fabsf(wheel_zoom) > 0.0001f)
+    {
+        const float wheel_step = json_float(component, "perspective_wheel_zoom_step", 1.25f);
+        const slayer3d_vec3 dolly_delta = slayer3d_vec3_scale(camera_forward, wheel_zoom * wheel_step);
+        if (slayer3d_vec3_length_squared(dolly_delta) > 0.0000001f)
+            actor_set_position(actor, slayer3d_vec3_add(actor->position, dolly_delta));
+    }
+
     float forward =
         fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "forward")) -
         fps_controller_action_value(runtime, input, fps_controller_action_id(runtime, component, "back"));

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -968,25 +968,14 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
         return true;
     }
 
-    if (select_requested || secondary_select_requested)
-    {
-        clear_editor_selected_brushes(runtime);
-        if (hover_selection.hit)
-            runtime->editor_active_selection = hover_selection;
-        else if (json_bool(selection_json, "clear_on_miss", true))
-            init_editor_selection(&runtime->editor_active_selection);
-        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
-    }
-
     publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
     publish_editor_selected_brush_count(runtime);
-    if (secondary_select_requested && !emit_editor_selection_signal(runtime, selection_json, "on_secondary_select",
-                                                                    &runtime->editor_active_selection))
+    if (secondary_select_requested &&
+        !emit_editor_selection_signal(runtime, selection_json, "on_secondary_select", &hover_selection))
     {
         return false;
     }
-    if (select_requested &&
-        !emit_editor_selection_signal(runtime, selection_json, "on_select", &runtime->editor_active_selection))
+    if (select_requested && !emit_editor_selection_signal(runtime, selection_json, "on_select", &hover_selection))
     {
         return false;
     }

--- a/src/game_data_editor_create_box_actions.c
+++ b/src/game_data_editor_create_box_actions.c
@@ -97,7 +97,7 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
                                                               error, (int)sizeof(error));
             if (ok)
             {
-                source_command_applied = true;
+                source_command_applied = !result.no_op;
                 SDL_strlcpy(brush_name, result.brush_name, sizeof(brush_name));
                 SDL_strlcpy(source_warning, result.warning, sizeof(source_warning));
                 desc.world_name = preview->world_name;
@@ -105,7 +105,8 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
                 desc.contents = preview->contents;
                 desc.min = result.bounds.min;
                 desc.max = result.bounds.max;
-                editor_brush_world_mark_dirty(world_runtime);
+                if (!result.no_op)
+                    editor_brush_world_mark_dirty(world_runtime);
             }
         }
         else if (error[0] == '\0')

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -682,8 +682,8 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
         editor_placement_preview_active_for_scene(runtime) && runtime->editor_placement_preview.has_bounds)
     {
         const editor_placement_preview_state *preview = &runtime->editor_placement_preview;
-        const slayer3d_color color =
-            editor_debug_color_or_default(desc->command_preview_color, (slayer3d_color){80, 255, 255, 220});
+        const slayer3d_color color = editor_debug_selection_flash_color(
+            editor_debug_color_or_default(desc->command_preview_color, (slayer3d_color){80, 255, 255, 220}));
         editor_debug_iteration_context context;
         SDL_zero(context);
         context.callback = callback;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -218,6 +218,7 @@ typedef struct editor_brush_source_prefab_desc
 typedef struct editor_brush_source_prefab_result
 {
     bool valid;
+    bool no_op;
     char brush_name[256];
     slayer3d_bounding_box bounds;
     int source_min[3];

--- a/src/game_data_validation_controller_components.c
+++ b/src/game_data_validation_controller_components.c
@@ -122,9 +122,9 @@ bool validate_editor_camera_component(validation_context *ctx, yyjson_val *compo
     if (!yyjson_is_obj(actions))
         return validation_error(ctx, path, "controller.editor_camera requires an actions object");
 
-    const char *action_keys[] = {"forward", "back",     "left",    "right",    "up",
-                                 "down",    "look",     "fast",    "pan_left", "pan_right",
-                                 "pan_up",  "pan_down", "zoom_in", "zoom_out", "zoom_wheel"};
+    const char *action_keys[] = {"forward",  "back",      "left",     "right",     "up",        "down",
+                                 "look",     "mouse_pan", "fast",     "pan_left",  "pan_right", "pan_up",
+                                 "pan_down", "zoom_in",   "zoom_out", "zoom_wheel"};
     bool has_action = false;
     for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
     {
@@ -167,7 +167,9 @@ bool validate_editor_camera_component(validation_context *ctx, yyjson_val *compo
                                   "orthographic_zoom_speed",
                                   "orthographic_wheel_zoom_step",
                                   "orthographic_min_size",
-                                  "orthographic_max_size"};
+                                  "orthographic_max_size",
+                                  "mouse_pan_sensitivity",
+                                  "perspective_wheel_zoom_step"};
     for (size_t i = 0; i < SDL_arraysize(numeric_keys); ++i)
     {
         yyjson_val *value = obj_get(component, numeric_keys[i]);
@@ -182,7 +184,9 @@ bool validate_editor_camera_component(validation_context *ctx, yyjson_val *compo
                                   "orthographic_zoom_speed",
                                   "orthographic_wheel_zoom_step",
                                   "orthographic_min_size",
-                                  "orthographic_max_size"};
+                                  "orthographic_max_size",
+                                  "mouse_pan_sensitivity",
+                                  "perspective_wheel_zoom_step"};
     for (size_t i = 0; i < SDL_arraysize(non_negative); ++i)
     {
         yyjson_val *value = obj_get(component, non_negative[i]);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15771,8 +15771,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
 
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
-    motion.motion.x = 282.4f;
-    motion.motion.y = 254.6f;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
     motion.motion.xrel = 0.0f;
     motion.motion.yrel = 0.0f;
     SDL_Event click{};
@@ -16284,7 +16284,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
     motion.motion.x = 660.0f;
-    motion.motion.y = 20.0f;
+    motion.motion.y = 360.0f;
     SDL_Event click{};
     click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     click.button.button = SDL_BUTTON_LEFT;
@@ -16500,13 +16500,43 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(
         slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_placement_preview, &placement_debug));
     EXPECT_EQ(placement_debug.edges, 24);
+    const slayer3d_vec3 original_preview_min = placement_min->as_vec3;
+    const slayer3d_value *placement_anchor =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.anchor");
+    ASSERT_NE(placement_anchor, nullptr);
+    ASSERT_EQ(placement_anchor->type, SLAYER3D_VALUE_VEC3);
+    const slayer3d_vec3 original_preview_anchor = placement_anchor->as_vec3;
+    motion.motion.x = 1180.0f;
+    motion.motion.y = 580.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    placement_anchor = slayer3d_properties_get_value(scene_state, "editor.placement_preview.anchor");
+    ASSERT_NE(placement_anchor, nullptr);
+    ASSERT_EQ(placement_anchor->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(placement_anchor->as_vec3, original_preview_anchor)), 0.001f);
+    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(placement_min, nullptr);
+    ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(placement_min->as_vec3, original_preview_min)), 0.001f);
+    motion.motion.x = click.button.x;
+    motion.motion.y = click.button.y;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(placement_min, nullptr);
+    ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(placement_min->as_vec3.x, original_preview_min.x, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.y, original_preview_min.y, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.z, original_preview_min.z, 0.001f);
     click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     slayer3d_input_process_event(input, &click);
-    slayer3d_input_update(input, 3);
+    slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     release.type = SDL_EVENT_MOUSE_BUTTON_UP;
     slayer3d_input_process_event(input, &release);
-    slayer3d_input_update(input, 4);
+    slayer3d_input_update(input, 6);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
     const std::string floor_brush_name = "brush.editor_shell.target.box." + std::to_string(initial_brush_count);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16551,6 +16551,19 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 8.0f, 0.001f);
     EXPECT_NEAR(brush->bounds.max.y, placement_origin.y, 0.001f);
     EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 8.0f, 0.001f);
+    const int brush_count_after_first_floor = world().brush_count;
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 7);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    release.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &release);
+    slayer3d_input_update(input, 8);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
+    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.create.message", ""))
+                  .find("already occupies this prefab cell"),
+              std::string::npos);
+    EXPECT_EQ(world().brush_count, brush_count_after_first_floor);
 
     auto press_editor_key = [&](SDL_Scancode scancode, Uint64 frame) {
         SDL_Event key{};
@@ -16606,12 +16619,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     };
 
     slayer3d_signal_emit(bus, mode_select_signal, nullptr);
-    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
+    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 9);
     ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), floor_brush_name.c_str());
     const int brush_count_before_floor_lower = world().brush_count;
     const slayer3d_bounding_box floor_bounds_before_lower = brush_bounds(floor_brush_name);
-    press_editor_key(SDL_SCANCODE_LEFTBRACKET, 7);
+    press_editor_key(SDL_SCANCODE_LEFTBRACKET, 11);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.message", ""),
                  "lowered 1 selected brush");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -15971,9 +15971,9 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(debug.selection_edges, 12);
     EXPECT_EQ(debug.selection_face_edges, 4);
     EXPECT_EQ(debug.command_preview_edges, 12);
-    EXPECT_EQ(debug.rays, 1);
-    EXPECT_EQ(debug.normals, 1);
-    EXPECT_EQ(debug.markers, 3);
+    EXPECT_EQ(debug.rays, 0);
+    EXPECT_EQ(debug.normals, 0);
+    EXPECT_EQ(debug.markers, 0);
 
     struct RemovedInspectorText
     {
@@ -20644,7 +20644,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     };
     ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_flyby_debug, &flyby_debug));
     EXPECT_EQ(flyby_debug.selection_edges, 0);
-    EXPECT_GT(flyby_debug.hit_markers, 0);
+    EXPECT_EQ(flyby_debug.hit_markers, 0);
     slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "select");
     slayer3d_properties_set_float(camera_actor->props, "yaw", start_yaw);
     slayer3d_properties_set_float(camera_actor->props, "pitch", -0.29566f);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16700,11 +16700,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_input_process_event(input, &right_click);
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "delete");
-    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
-    slayer3d_signal_emit(bus, undo_signal, nullptr);
     EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+    EXPECT_STRNE(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "delete");
 
     SDL_Event right_release{};
     right_release.type = SDL_EVENT_MOUSE_BUTTON_UP;
@@ -16713,6 +16710,16 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     right_release.button.y = right_click.button.y;
     slayer3d_input_process_event(input, &right_release);
     slayer3d_input_update(input, 7);
+
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 8);
+    ASSERT_GE(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    press_editor_key(SDL_SCANCODE_DELETE, 10);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "delete");
+    EXPECT_EQ(world().brush_count, initial_brush_count + 2);
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
+    EXPECT_EQ(world().brush_count, initial_brush_count + 3);
 
     slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "game_object");
@@ -16776,11 +16783,17 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_input_process_event(input, &right_click);
     slayer3d_input_update(input, 18);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 19);
+    press_editor_key(SDL_SCANCODE_BACKSPACE, 20);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.message", ""),
                  "player start deleted");
     EXPECT_FALSE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
 
+    slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
+    slayer3d_signal_emit(bus, palette_accept_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16187,6 +16187,13 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
 
     slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
     ASSERT_NE(bus, nullptr);
@@ -16430,27 +16437,39 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.material", ""), "mat.editor.floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "floor prefab selected");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    std::vector<std::string> palette_text = visible_ui_text("ui.editor_shell.palette.");
-    EXPECT_TRUE(contains_ui_text(palette_text, "Active Tool"));
-    EXPECT_TRUE(contains_ui_text(palette_text, "> Floor"));
-    EXPECT_TRUE(contains_ui_text(palette_text, "  Wall"));
-    EXPECT_TRUE(contains_ui_text(palette_text, "  Sky"));
-    EXPECT_FALSE(contains_ui_text(palette_text, "  Floor"));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
                  "mat.editor.floor");
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
+    std::vector<std::string> grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 8"));
     slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 4.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 4.0f, 0.001f);
-    slayer3d_signal_emit(bus, grid_increase_signal, nullptr);
+    grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 4"));
+    for (int i = 0; i < 5; ++i)
+        slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 0.125f, 0.001f);
+    grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 0.125"));
+    slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 256.0f, 0.001f);
+    grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 256"));
+    for (int i = 0; i < 7; ++i)
+        slayer3d_signal_emit(bus, grid_increase_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 8.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 8.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
+    grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 8"));
     const slayer3d_value *placement_min =
         slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
     const slayer3d_value *placement_max =
@@ -16615,24 +16634,20 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.prefab", ""), "wall");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.material", ""), "mat.editor.wall");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    palette_text = visible_ui_text("ui.editor_shell.palette.");
-    EXPECT_TRUE(contains_ui_text(palette_text, "> Wall"));
-    EXPECT_TRUE(contains_ui_text(palette_text, "  Floor"));
-    EXPECT_FALSE(contains_ui_text(palette_text, "  Wall"));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
     slayer3d_signal_emit(bus, wall_axis_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "x");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
     placement_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
     placement_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
     ASSERT_NE(placement_min, nullptr);
     ASSERT_NE(placement_max, nullptr);
-    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x - 0.1f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y, 0.001f);
-    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 0.1f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z - 0.1f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.x, placement_origin.x + 8.0f, 0.001f);
     EXPECT_NEAR(placement_max->as_vec3.y, placement_origin.y + 8.0f, 0.001f);
-    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 8.0f, 0.001f);
+    EXPECT_NEAR(placement_max->as_vec3.z, placement_origin.z + 0.1f, 0.001f);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
@@ -16642,11 +16657,11 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
     EXPECT_STREQ(brush->faces[0].material_name, "mat.editor.wall");
-    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x - 0.1f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.x, placement_origin.x, 0.001f);
     EXPECT_NEAR(brush->bounds.min.y, placement_origin.y, 0.001f);
-    EXPECT_NEAR(brush->bounds.min.z, placement_origin.z, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 0.1f, 0.001f);
-    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 8.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.min.z, placement_origin.z - 0.1f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.x, placement_origin.x + 8.0f, 0.001f);
+    EXPECT_NEAR(brush->bounds.max.z, placement_origin.z + 0.1f, 0.001f);
     EXPECT_NEAR(brush->bounds.max.y, placement_origin.y + 8.0f, 0.001f);
 
     slayer3d_signal_emit(bus, ceiling_signal, nullptr);
@@ -16698,55 +16713,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     right_release.button.y = right_click.button.y;
     slayer3d_input_process_event(input, &right_release);
     slayer3d_input_update(input, 7);
-
-    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
-    click_editor(282.4f, 196.45f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 8);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), "brush.target.cube");
-    click_editor(282.4f, 196.45f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 10);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
-    click_editor(282.4f, 196.45f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 12);
-    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_SHIFT, 14);
-    const int selected_brushes = slayer3d_properties_get_int(scene_state, "editor.selection.count", 0);
-    EXPECT_EQ(selected_brushes, 2);
-    struct MultiSelectionDebug
-    {
-        int edges = 0;
-    } multi_selection_debug;
-    auto count_multi_selection_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) {
-        auto *debug = static_cast<MultiSelectionDebug *>(userdata);
-        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE)
-            debug->edges++;
-        return true;
-    };
-    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_multi_selection_debug,
-                                                                          &multi_selection_debug));
-    EXPECT_EQ(multi_selection_debug.edges, 24);
-
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), selected_brushes);
-
-    slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
-    click_editor(282.4f, 196.45f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 26);
-    click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_SHIFT, 28);
-    ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), selected_brushes);
-
-    const int brush_count_before_multi_delete = world().brush_count;
-    SDL_Event backspace{};
-    backspace.type = SDL_EVENT_KEY_DOWN;
-    backspace.key.scancode = SDL_SCANCODE_BACKSPACE;
-    slayer3d_input_process_event(input, &backspace);
-    slayer3d_input_update(input, 30);
-    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
-    backspace.type = SDL_EVENT_KEY_UP;
-    slayer3d_input_process_event(input, &backspace);
-    slayer3d_input_update(input, 31);
-    EXPECT_EQ(world().brush_count, brush_count_before_multi_delete - selected_brushes);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
-                 "deleted 2 selected brushes");
 
     slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "game_object");
@@ -20324,6 +20290,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
         bool tool_background = false;
         bool tool_buttons[7]{};
         bool tool_labels[7]{};
+        bool grid_widget = false;
+        bool grid_label = false;
         bool inspector_panel = false;
         bool inspector_header = false;
         bool inspector_tabs[3]{};
@@ -20348,6 +20316,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
             capture->background = true;
         if (SDL_strcmp(rect->name, "ui.editor_shell.tool_toolbar") == 0)
             capture->tool_background = true;
+        if (SDL_strcmp(rect->name, "ui.editor_shell.tool_toolbar.grid.button") == 0)
+            capture->grid_widget = true;
         if (SDL_strcmp(rect->name, "ui.editor_shell.left_inspector.panel") == 0)
             capture->inspector_panel = true;
         if (SDL_strcmp(rect->name, "ui.editor_shell.left_inspector.header") == 0)
@@ -20458,6 +20428,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
             capture->inspector_collapsed_label = true;
         if (name == "ui.editor_shell.console.console.label")
             capture->console_tab_labels[0] = true;
+        else if (name == "ui.editor_shell.tool_toolbar.grid.label")
+            capture->grid_label = true;
         else if (name == "ui.editor_shell.console.issues.label")
             capture->console_tab_labels[1] = true;
         else if (name == "ui.editor_shell.console.line0")
@@ -20540,6 +20512,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
         EXPECT_TRUE(toolbar_capture.tool_buttons[i]) << i;
         EXPECT_TRUE(toolbar_capture.tool_labels[i]) << i;
     }
+    EXPECT_TRUE(toolbar_capture.grid_widget);
+    EXPECT_TRUE(toolbar_capture.grid_label);
     EXPECT_TRUE(toolbar_capture.inspector_panel);
     EXPECT_TRUE(toolbar_capture.inspector_header);
     EXPECT_TRUE(toolbar_capture.inspector_title);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -20543,7 +20543,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.view.mode", ""),
                  "flyby_3d");
     EXPECT_TRUE(visible_view_label("3D Perspective / Flyby"));
-    EXPECT_TRUE(slayer3d_game_data_active_scene_mouse_capture(runtime, false));
+    EXPECT_FALSE(slayer3d_game_data_active_scene_mouse_capture(runtime, false));
     EXPECT_FALSE(slayer3d_game_data_active_scene_mouse_capture(runtime, true));
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
@@ -20647,6 +20647,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     key.type = SDL_EVENT_KEY_UP;
     slayer3d_input_process_event(input, &key);
 
+    const float yaw_before_free_mouse = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
     motion.motion.xrel = 60.0f;
@@ -20654,12 +20655,53 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 17);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_NEAR(slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw), yaw_before_free_mouse, 0.0001f);
+
+    SDL_Event right_down{};
+    right_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    right_down.button.button = SDL_BUTTON_RIGHT;
+    slayer3d_input_process_event(input, &right_down);
+    motion.motion.xrel = 60.0f;
+    motion.motion.yrel = -15.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 18);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
 
     const float yaw = slayer3d_properties_get_float(camera_actor->props, "yaw", start_yaw);
-    EXPECT_GT(SDL_fabsf(yaw - start_yaw), 0.01f);
+    EXPECT_GT(SDL_fabsf(yaw - yaw_before_free_mouse), 0.01f);
     slayer3d_camera3d after{};
     ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &after));
     EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(after.target, before.target)), 0.01f);
+    right_down.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &right_down);
+    slayer3d_input_update(input, 19);
+
+    const slayer3d_vec3 before_pan = camera_actor->position;
+    SDL_Event middle_down{};
+    middle_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    middle_down.button.button = SDL_BUTTON_MIDDLE;
+    slayer3d_input_process_event(input, &middle_down);
+    motion.motion.xrel = 30.0f;
+    motion.motion.yrel = -20.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 20);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, before_pan)), 0.01f);
+    middle_down.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &middle_down);
+    slayer3d_input_update(input, 21);
+
+    const slayer3d_vec3 before_wheel = camera_actor->position;
+    SDL_Event wheel{};
+    wheel.type = SDL_EVENT_MOUSE_WHEEL;
+    wheel.wheel.y = 1.0f;
+    wheel.wheel.mouse_x = 640.0f;
+    wheel.wheel.mouse_y = 360.0f;
+    wheel.wheel.direction = SDL_MOUSEWHEEL_NORMAL;
+    slayer3d_input_process_event(input, &wheel);
+    slayer3d_input_update(input, 22);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(camera_actor->position, before_wheel)), 0.01f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- Add a TrenchBroom-style grid size readout to the editor tool toolbar
- Expand editor grid cycling to the fixed ladder from 0.125 through 256
- Keep the editor hardware cursor free in 3D view so toolbar/menu buttons remain selectable
- Move 3D camera mouse controls to RMB drag look, MMB drag pan, and mouse-wheel dolly/zoom
- Remove right-click deletion from editor selection; deletion now stays on explicit Delete/Backspace after selection
- Remove the default virtual hit cursor/face-normal marker from the editor overlay so the hardware cursor is the only pointer
- Drive brush placement preview from the hardware cursor and flash the preview bounds where the prefab will be placed
- Make brush-mode clicks selection-neutral and make repeated placement on the same source prefab cell idempotent instead of inserting a duplicate/hiding the tile
- Update editor test-drive docs and focused editor tests for the grid ladder, cursor-friendly camera controls, cursor-driven placement preview, and repeated brush placement

## Tests
- jq empty demos/editor_shell_dojo/data/editor_shell_dojo.game.json
- jq empty demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
- cmake --build build/debug --target slayer3d_game_data_test -j4
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoCreatesBlockoutPrefabTools:GameDataRuntime.EditorShellDojoPublishesSelectionAndDebugOverlay'
- cmake --build build/debug --target slayer3d_editor -j4
- git diff --check

Closes #422 for slice 1 only; selected-brush grid nudge remains the next slice.